### PR TITLE
feat: debounce to stablize status reporting

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -324,10 +324,10 @@ pub fn detect_claude_status(content: &str) -> Status {
 
     for line in non_empty_lines.iter().rev().take(10) {
         let clean_line = strip_ansi(line).trim().to_string();
-        if clean_line == ">" || clean_line == "> " {
+        if clean_line == ">" || clean_line == "> " || clean_line == "❯" || clean_line == "❯ " {
             return Status::Waiting;
         }
-        if clean_line.starts_with("> ")
+        if (clean_line.starts_with("> ") || clean_line.starts_with("❯ "))
             && !clean_line.to_lowercase().contains("esc")
             && clean_line.len() < 100
         {


### PR DESCRIPTION
- Introduce a `status_history` field to track the last three detected statuses for improved status stability.
- Implement a debounce mechanism to update the session status only after three consecutive identical readings.
- Update the `detect_claude_status` function to recognize additional prompt characters for better status detection.