### PR TITLE
Attachbranch

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -9,7 +9,6 @@ use crate::tui::styles::Theme;
 pub struct Preview;
 
 impl Preview {
-    /// Render preview with pre-cached output content (avoids subprocess calls per frame)
     pub fn render_with_cache(
         frame: &mut Frame,
         area: Rect,
@@ -121,7 +120,6 @@ impl Preview {
         frame.render_widget(paragraph, area);
     }
 
-    /// Render output section using pre-cached content (avoids subprocess calls)
     fn render_output_cached(
         frame: &mut Frame,
         area: Rect,

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -45,13 +45,11 @@ impl StatusPoller {
         result_tx: mpsc::Sender<Vec<StatusUpdate>>,
     ) {
         while let Ok(instances) = request_rx.recv() {
-            // Refresh the tmux session cache once before checking all sessions
             crate::tmux::refresh_session_cache();
 
             let updates: Vec<StatusUpdate> = instances
                 .into_iter()
                 .map(|mut inst| {
-                    // Call the existing update_status method which handles all the logic
                     inst.update_status();
 
                     StatusUpdate {
@@ -70,10 +68,8 @@ impl StatusPoller {
         }
     }
 
-    /// Request a status refresh for all given instances.
-    /// This is non-blocking - the actual polling happens in the background thread.
+    /// Request a status refresh for all given instances (non-blocking).
     pub fn request_refresh(&self, instances: Vec<Instance>) {
-        // Use try_send semantics - if channel is full, skip this refresh
         let _ = self.request_tx.send(instances);
     }
 


### PR DESCRIPTION
  - Adds "New Branch" checkbox to the TUI new session dialog when creating a worktree
  - Default: checked (create new branch) - backwards compatible with existing behavior
  - Unchecked: attach to existing branch - enables reviewing/editing branches created elsewhere

  The checkbox only appears when a worktree branch name is entered. This matches the CLI behavior where aoe add --worktree <branch> (without -b)
attaches to an existing branch.