### PR TITLE
refactor: improve table output and error handling in CLI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,8 +80,6 @@ git2 = { version = "0.19", features = ["vendored-openssl"] }
 
 [dev-dependencies]
 tempfile = "3.14"
-assert_cmd = "2.0"
-predicates = "3.1"
 serial_test = "3.2"
 cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"] }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -49,3 +49,11 @@ pub fn truncate(s: &str, max: usize) -> String {
         format!("{}...", &s[..max - 3])
     }
 }
+
+pub fn truncate_id(id: &str, max_len: usize) -> &str {
+    if id.len() > max_len {
+        &id[..max_len]
+    } else {
+        id
+    }
+}

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -91,7 +91,7 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
 
                     match GitWorktree::new(main_repo) {
                         Ok(git_wt) => {
-                            if let Err(e) = git_wt.remove_worktree(&worktree_path, false) {
+                            if let Err(e) = git_wt.remove_worktree(&worktree_path) {
                                 eprintln!("Warning: failed to remove worktree: {}", e);
                                 eprintln!(
                                     "You may need to remove it manually with: git worktree remove {}",

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -240,7 +240,7 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
         let git_wt = GitWorktree::new(main_repo)?;
 
         for wt in &orphaned_worktrees {
-            match git_wt.remove_worktree(&wt.path, false) {
+            match git_wt.remove_worktree(&wt.path) {
                 Ok(_) => {
                     println!("✓ Removed worktree: {}", wt.path.display());
                     removed_count += 1;

--- a/src/docker/container.rs
+++ b/src/docker/container.rs
@@ -1,4 +1,5 @@
 use super::error::{DockerError, Result};
+use crate::cli::truncate_id;
 use std::process::Command;
 
 pub struct VolumeMount {
@@ -37,12 +38,7 @@ impl DockerContainer {
     }
 
     pub fn generate_name(session_id: &str) -> String {
-        let short_id = if session_id.len() > 8 {
-            &session_id[..8]
-        } else {
-            session_id
-        };
-        format!("aoe-sandbox-{}", short_id)
+        format!("aoe-sandbox-{}", truncate_id(session_id, 8))
     }
 
     pub fn exists(&self) -> Result<bool> {

--- a/src/docker/error.rs
+++ b/src/docker/error.rs
@@ -1,66 +1,53 @@
-use std::fmt;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum DockerError {
+    #[error(
+        "Docker is not installed or not in PATH.\n\
+         Install Docker: https://docs.docker.com/get-docker/"
+    )]
     NotInstalled,
+
+    #[error(
+        "Docker daemon is not running.\n\
+         Start Docker Desktop or run: sudo systemctl start docker"
+    )]
     DaemonNotRunning,
+
+    #[error(
+        "Docker permission denied.\n\
+         On Linux, add your user to the docker group:\n\
+         sudo usermod -aG docker $USER\n\
+         Then log out and back in."
+    )]
     PermissionDenied,
+
+    #[error("Container not found: {0}")]
     ContainerNotFound(String),
+
+    #[error("Container already exists: {0}")]
     ContainerAlreadyExists(String),
+
+    #[error("Docker image not found: {0}")]
     ImageNotFound(String),
+
+    #[error("Failed to create container: {0}")]
     CreateFailed(String),
+
+    #[error("Failed to start container: {0}")]
     StartFailed(String),
+
+    #[error("Failed to stop container: {0}")]
     StopFailed(String),
+
+    #[error("Failed to remove container: {0}")]
     RemoveFailed(String),
+
+    #[error("Docker command failed: {0}")]
     CommandFailed(String),
-    IoError(std::io::Error),
-}
 
-impl fmt::Display for DockerError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            DockerError::NotInstalled => write!(
-                f,
-                "Docker is not installed or not in PATH.\n\
-                 Install Docker: https://docs.docker.com/get-docker/"
-            ),
-            DockerError::DaemonNotRunning => write!(
-                f,
-                "Docker daemon is not running.\n\
-                 Start Docker Desktop or run: sudo systemctl start docker"
-            ),
-            DockerError::PermissionDenied => write!(
-                f,
-                "Docker permission denied.\n\
-                 On Linux, add your user to the docker group:\n\
-                 sudo usermod -aG docker $USER\n\
-                 Then log out and back in."
-            ),
-            DockerError::ContainerNotFound(name) => {
-                write!(f, "Container not found: {}", name)
-            }
-            DockerError::ContainerAlreadyExists(name) => {
-                write!(f, "Container already exists: {}", name)
-            }
-            DockerError::ImageNotFound(image) => {
-                write!(f, "Docker image not found: {}", image)
-            }
-            DockerError::CreateFailed(msg) => write!(f, "Failed to create container: {}", msg),
-            DockerError::StartFailed(msg) => write!(f, "Failed to start container: {}", msg),
-            DockerError::StopFailed(msg) => write!(f, "Failed to stop container: {}", msg),
-            DockerError::RemoveFailed(msg) => write!(f, "Failed to remove container: {}", msg),
-            DockerError::CommandFailed(msg) => write!(f, "Docker command failed: {}", msg),
-            DockerError::IoError(err) => write!(f, "IO error: {}", err),
-        }
-    }
-}
-
-impl std::error::Error for DockerError {}
-
-impl From<std::io::Error> for DockerError {
-    fn from(err: std::io::Error) -> Self {
-        DockerError::IoError(err)
-    }
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, DockerError>;

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -1,46 +1,25 @@
-// Git error types
-
 use std::path::PathBuf;
+use thiserror::Error;
 
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum GitError {
+    #[error("Path is not in a git repository")]
     NotAGitRepo,
+
+    #[error("Worktree already exists at {}", .0.display())]
     WorktreeAlreadyExists(PathBuf),
+
+    #[error("Worktree not found at {}", .0.display())]
     WorktreeNotFound(PathBuf),
+
+    #[error("Branch '{0}' not found")]
     BranchNotFound(String),
-    Git2Error(git2::Error),
-    IoError(std::io::Error),
-}
 
-impl std::fmt::Display for GitError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            GitError::NotAGitRepo => write!(f, "Path is not in a git repository"),
-            GitError::WorktreeAlreadyExists(path) => {
-                write!(f, "Worktree already exists at {}", path.display())
-            }
-            GitError::WorktreeNotFound(path) => {
-                write!(f, "Worktree not found at {}", path.display())
-            }
-            GitError::BranchNotFound(branch) => write!(f, "Branch '{}' not found", branch),
-            GitError::Git2Error(err) => write!(f, "Git error: {}", err),
-            GitError::IoError(err) => write!(f, "IO error: {}", err),
-        }
-    }
-}
+    #[error("Git error: {0}")]
+    Git2Error(#[from] git2::Error),
 
-impl std::error::Error for GitError {}
-
-impl From<git2::Error> for GitError {
-    fn from(err: git2::Error) -> Self {
-        GitError::Git2Error(err)
-    }
-}
-
-impl From<std::io::Error> for GitError {
-    fn from(err: std::io::Error) -> Self {
-        GitError::IoError(err)
-    }
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
 }
 
 pub type Result<T> = std::result::Result<T, GitError>;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -91,7 +91,7 @@ impl GitWorktree {
         Ok(entries)
     }
 
-    pub fn remove_worktree(&self, path: &Path, _force: bool) -> Result<()> {
+    pub fn remove_worktree(&self, path: &Path) -> Result<()> {
         if !path.exists() {
             return Err(GitError::WorktreeNotFound(path.to_path_buf()));
         }
@@ -257,7 +257,7 @@ mod tests {
 
         assert!(wt_path.exists());
 
-        git_wt.remove_worktree(&wt_path, false).unwrap();
+        git_wt.remove_worktree(&wt_path).unwrap();
         assert!(!wt_path.exists());
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,10 +7,13 @@ mod groups;
 mod instance;
 mod storage;
 
-pub use config::*;
-pub use groups::*;
-pub use instance::*;
-pub use storage::*;
+pub use config::{
+    get_claude_config_dir, get_update_settings, load_config, save_config, ClaudeConfig, Config,
+    SandboxConfig, ThemeConfig, UpdatesConfig, WorktreeConfig,
+};
+pub use groups::{flatten_tree, Group, GroupTree, Item};
+pub use instance::{Instance, SandboxInfo, Status, WorktreeInfo, YOLO_SUPPORTED_TOOLS};
+pub use storage::Storage;
 
 use anyhow::Result;
 use std::fs;

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
+use tracing::warn;
 
 use super::{get_profile_dir, Group, GroupTree, Instance, DEFAULT_PROFILE};
 
@@ -69,7 +70,9 @@ impl Storage {
         // Create backup
         if self.sessions_path.exists() {
             let backup_path = self.sessions_path.with_extension("json.bak");
-            let _ = fs::copy(&self.sessions_path, &backup_path);
+            if let Err(e) = fs::copy(&self.sessions_path, &backup_path) {
+                warn!("Failed to create backup: {}", e);
+            }
         }
 
         let content = serde_json::to_string_pretty(instances)?;

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::{session_exists_from_cache, SESSION_PREFIX};
+use crate::cli::truncate_id;
 use crate::process;
 use crate::session::Status;
 
@@ -45,8 +46,7 @@ impl Session {
 
     pub fn generate_name(id: &str, title: &str) -> String {
         let safe_title = sanitize_session_name(title);
-        let short_id = if id.len() > 8 { &id[..8] } else { id };
-        format!("{}{}_{}", SESSION_PREFIX, safe_title, short_id)
+        format!("{}{}_{}", SESSION_PREFIX, safe_title, truncate_id(id, 8))
     }
 
     pub fn exists(&self) -> bool {

--- a/src/tui/home.rs
+++ b/src/tui/home.rs
@@ -726,7 +726,7 @@ impl HomeView {
                         let main_repo = PathBuf::from(&wt_info.main_repo_path);
 
                         if let Ok(git_wt) = GitWorktree::new(main_repo) {
-                            let _ = git_wt.remove_worktree(&worktree_path, false);
+                            let _ = git_wt.remove_worktree(&worktree_path);
                         }
                     }
                 }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use serde::Deserialize;
 use std::fs;
 use std::path::PathBuf;
+use tracing::warn;
 
 use crate::session::{get_app_dir, get_update_settings};
 
@@ -81,7 +82,9 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
         checked_at: chrono::Utc::now(),
         latest_version: latest_version.clone(),
     };
-    let _ = save_cache(&cache);
+    if let Err(e) = save_cache(&cache) {
+        warn!("Failed to save update cache: {}", e);
+    }
 
     let available = is_newer_version(&latest_version, current_version);
 

--- a/tests/sandbox_integration.rs
+++ b/tests/sandbox_integration.rs
@@ -26,7 +26,7 @@ fn test_sandbox_info_serialization() {
     let json = serde_json::to_string(&sandbox_info).unwrap();
     let deserialized: SandboxInfo = serde_json::from_str(&json).unwrap();
 
-    assert_eq!(deserialized.enabled, true);
+    assert!(deserialized.enabled);
     assert_eq!(deserialized.container_id, Some("abc123".to_string()));
     assert_eq!(deserialized.container_name, "aoe-sandbox-test1234");
 }

--- a/tests/tui_attach_detach.rs
+++ b/tests/tui_attach_detach.rs
@@ -97,7 +97,7 @@ fn test_terminal_mode_sequence_documented() {
     // This test documents the expected behavior rather than testing it directly
     // since testing terminal modes requires actual terminal interaction.
 
-    let expected_exit_sequence = vec![
+    let expected_exit_sequence = [
         "disable_raw_mode",
         "LeaveAlternateScreen",
         "DisableMouseCapture",
@@ -105,7 +105,7 @@ fn test_terminal_mode_sequence_documented() {
         "flush",
     ];
 
-    let expected_reenter_sequence = vec![
+    let expected_reenter_sequence = [
         "enable_raw_mode",
         "EnterAlternateScreen",
         "EnableMouseCapture",

--- a/tests/worktree_integration.rs
+++ b/tests/worktree_integration.rs
@@ -168,7 +168,7 @@ fn test_worktree_cleanup_on_session_removal() {
         cleanup_on_delete: true,
     });
 
-    git_wt.remove_worktree(&wt_path, false).unwrap();
+    git_wt.remove_worktree(&wt_path).unwrap();
 
     assert!(!wt_path.exists());
 }


### PR DESCRIPTION
- Refactored table printing in `list.rs` to use dedicated functions for header and row output.
- Updated `remove_worktree` method signatures in `git/mod.rs` and `remove.rs` to remove the unused force parameter.
- Enhanced error handling in `storage.rs` and `update/mod.rs` to log warnings on backup and cache save failures.
- Added `truncate_id` function to `cli/mod.rs` for consistent ID truncation across the codebase.
- Updated `DockerError` and `GitError` enums to use `thiserror` for better error handling and messaging.
- Cleaned up unused imports and improved code readability in various files.