### PR TITLE
[Fix] Don't render delete option if there are no active sessions/groups

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -396,7 +396,7 @@ impl HomeView {
         };
         let mode_style = Style::default().fg(mode_color).bold();
 
-        let spans = vec![
+        let mut spans = vec![
             Span::styled(format!(" {} ", mode_indicator), mode_style),
             Span::styled("│", sep_style),
             Span::styled(" j/k", key_style),
@@ -410,9 +410,18 @@ impl HomeView {
             Span::styled("│", sep_style),
             Span::styled(" n", key_style),
             Span::styled(" New ", desc_style),
-            Span::styled("│", sep_style),
-            Span::styled(" d", key_style),
-            Span::styled(" Del ", desc_style),
+        ];
+
+        // Only show delete option if there are sessions or groups to delete
+        if !self.flat_items.is_empty() {
+            spans.extend([
+                Span::styled("│", sep_style),
+                Span::styled(" d", key_style),
+                Span::styled(" Del ", desc_style),
+            ]);
+        }
+
+        spans.extend([
             Span::styled("│", sep_style),
             Span::styled(" /", key_style),
             Span::styled(" Search ", desc_style),
@@ -422,7 +431,7 @@ impl HomeView {
             Span::styled("│", sep_style),
             Span::styled(" q", key_style),
             Span::styled(" Quit", desc_style),
-        ];
+        ]);
 
         let status = Paragraph::new(Line::from(spans)).style(Style::default().bg(theme.selection));
         frame.render_widget(status, area);


### PR DESCRIPTION
## Description
Only show the delete option where it's relevant: if there's at least one session or group.

Delete option no longer shows with no sessions + groups:
<img width="1526" height="1110" alt="image" src="https://github.com/user-attachments/assets/d11d545f-dfa8-4cc7-98cd-551f9bdddd89" />

Delete option still shows with a session:
<img width="1512" height="1119" alt="image" src="https://github.com/user-attachments/assets/92fd6b49-b449-43d2-b9ed-bf9b18030c74" />


Delete option still shows with a grouped session:
<img width="1520" height="1092" alt="image" src="https://github.com/user-attachments/assets/8a4a5e60-8736-4a36-895d-52ca6138ceb4" />


Delete option still shows with an empty group:
<img width="1536" height="1146" alt="image" src="https://github.com/user-attachments/assets/77bef906-205b-48cf-98bc-8d0100e9f4b3" />

## PR Type

- [ ] New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Related Issues

Fixes #37 

## Checklist

- [X] I understand the code I am submitting
- [X] I have tested this locally (`cargo test`, manual TUI checks if applicable)
- [X] New and existing tests pass
- [X] I ran `cargo fmt` and `cargo clippy`
- [N/A] Documentation was updated where necessary
- [X] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [X] This is fully AI-generated

Used CC to explain where the relevant TUI code was defined then make the actual change. I did grill it a bit about other options since I'm not that familiar with idiomatic Rust but this seemed easier to read than the other non-mutation options. Commit message and PR is 100% organic.

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
Claude Code + AOE 
<!-- Note: When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI. -->
