### PR TITLE
feat(tui): color running terminal status different from running agent

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -52,7 +52,7 @@ impl Preview {
                         "Not started"
                     },
                     Style::default().fg(if terminal_running {
-                        theme.running
+                        theme.terminal_active
                     } else {
                         theme.dimmed
                     }),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -205,7 +205,7 @@ impl HomeView {
                                 .map(|s| s.exists())
                                 .unwrap_or(false);
                             let (icon, color) = if terminal_running {
-                                (ICON_RUNNING, theme.running)
+                                (ICON_RUNNING, theme.terminal_active)
                             } else {
                                 (ICON_IDLE, theme.dimmed)
                             };

--- a/src/tui/styles.rs
+++ b/src/tui/styles.rs
@@ -22,6 +22,7 @@ pub struct Theme {
     pub waiting: Color,
     pub idle: Color,
     pub error: Color,
+    pub terminal_active: Color,
 
     // UI elements
     pub group: Color,
@@ -53,6 +54,7 @@ impl Theme {
             waiting: Color::Rgb(255, 180, 60),
             idle: Color::Rgb(60, 100, 70),
             error: Color::Rgb(255, 100, 80),
+            terminal_active: Color::Rgb(130, 170, 255),
 
             group: Color::Rgb(100, 220, 160),
             search: Color::Rgb(180, 255, 200),
@@ -78,6 +80,7 @@ impl Theme {
             waiting: Color::Rgb(224, 175, 104),
             idle: Color::Rgb(86, 95, 137),
             error: Color::Rgb(247, 118, 142),
+            terminal_active: Color::Rgb(122, 162, 247),
 
             group: Color::Rgb(187, 154, 247),
             search: Color::Rgb(125, 207, 255),


### PR DESCRIPTION
## Description

Now:

<img width="1069" height="268" alt="Screenshot 2026-01-20 at 5 48 06 AM" src="https://github.com/user-attachments/assets/b46fce01-0a51-45e6-89ee-2751b7622d3f" />

was:

<img width="800" height="187" alt="Screenshot 2026-01-20 at 5 48 31 AM" src="https://github.com/user-attachments/assets/b08c8e28-b8cc-43c9-ba2a-6af168ca54f8" />

Which was the same coloring as the agent view so it made it harder to quickly see that it was the different view


## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Related Issues

<!-- Link any related issues: Fixes #123, Relates to #456 -->

## Checklist

- [ ] I understand the code I am submitting
- [ ] I have tested this locally (`cargo test`, manual TUI checks if applicable)
- [ ] New and existing tests pass
- [ ] I ran `cargo fmt` and `cargo clippy`
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

<!-- Note: When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI. -->
