### PR TITLE
fix: correctly detect bare repos when running from worktree directory

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -83,7 +83,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         let session_id_short = &session_id[..8];
 
         // Choose appropriate template based on repo type (bare vs regular)
-        let template = if GitWorktree::is_bare_repo(&path) {
+        // Use main_repo_path (not path) to correctly detect bare repos when running from a worktree
+        let template = if GitWorktree::is_bare_repo(&main_repo_path) {
             &config.worktree.bare_repo_path_template
         } else {
             &config.worktree.path_template

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -76,7 +76,8 @@ pub fn build_instance(params: InstanceParams, existing_titles: &[&str]) -> Resul
         let git_wt = GitWorktree::new(main_repo_path.clone())?;
 
         // Choose appropriate template based on repo type (bare vs regular)
-        let is_bare = GitWorktree::is_bare_repo(&path);
+        // Use main_repo_path (not path) to correctly detect bare repos when running from a worktree
+        let is_bare = GitWorktree::is_bare_repo(&main_repo_path);
         let template = if is_bare {
             &config.worktree.bare_repo_path_template
         } else {


### PR DESCRIPTION


## Description
<!-- Describe your changes and the problem they solve -->
  When launching a new worktree from within an existing worktree of a bare
  repo setup (e.g., agent-of-empires/main/), the code was using the wrong
  path template, creating worktrees at main-worktrees/feature instead of
  feature/.

  Root cause: is_bare_repo() was called with the current directory path
  instead of the main repo path. When git2 discovers from a worktree,
  repo.is_bare() returns false because the worktree has a working directory.

  Additionally, find_main_repo() wasn't correctly handling worktrees of
  bare repos - it returned the worktree directory instead of the bare repo
  root.

  Changes:
  - Fix is_bare_repo() call sites in cli/add.rs and session/builder.rs to use main_repo_path instead of path
  - Enhance find_main_repo() to detect when gitdir is inside a worktrees/ directory and return the correct bare repo root
  - Add tests for bare repo detection from worktree directories

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] I understand the code I am submitting
- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
CC + Opus 4.5

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 
