### PR TITLE
fix(sandbox): apply extra_volumes config when creating containers

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -680,10 +680,21 @@ impl Instance {
             read_only: false,
         }];
 
-        let sandbox_config = super::config::Config::load()
-            .ok()
-            .map(|c| c.sandbox)
-            .unwrap_or_default();
+        let sandbox_config = match super::config::Config::load() {
+            Ok(c) => {
+                tracing::debug!(
+                    "Loaded sandbox config: extra_volumes={:?}, mount_ssh={}, volume_ignores={:?}",
+                    c.sandbox.extra_volumes,
+                    c.sandbox.mount_ssh,
+                    c.sandbox.volume_ignores
+                );
+                c.sandbox
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load config, using defaults: {}", e);
+                Default::default()
+            }
+        };
 
         const CONTAINER_HOME: &str = "/root";
 
@@ -781,6 +792,29 @@ impl Instance {
             .iter()
             .map(|ignore| format!("{}/{}", workspace_path, ignore))
             .collect();
+
+        tracing::debug!(
+            "extra_volumes from config: {:?}",
+            sandbox_config.extra_volumes
+        );
+        for entry in &sandbox_config.extra_volumes {
+            let parts: Vec<&str> = entry.splitn(3, ':').collect();
+            if parts.len() >= 2 {
+                tracing::info!(
+                    "Mounting extra volume: {} -> {} (ro: {})",
+                    parts[0],
+                    parts[1],
+                    parts.get(2) == Some(&"ro")
+                );
+                volumes.push(VolumeMount {
+                    host_path: parts[0].to_string(),
+                    container_path: parts[1].to_string(),
+                    read_only: parts.get(2) == Some(&"ro"),
+                });
+            } else {
+                tracing::warn!("Ignoring malformed extra_volume entry: {}", entry);
+            }
+        }
 
         Ok(ContainerConfig {
             working_dir: workspace_path,

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -475,6 +475,11 @@ impl SettingsView {
                     s.default_terminal_mode = None;
                 }
             }
+            FieldKey::ExtraVolumes => {
+                if let Some(ref mut s) = config.sandbox {
+                    s.extra_volumes = None;
+                }
+            }
             FieldKey::VolumeIgnores => {
                 if let Some(ref mut s) = config.sandbox {
                     s.volume_ignores = None;


### PR DESCRIPTION
## Summary

- Fixed `extra_volumes` sandbox config being parsed but never applied when creating containers
- Volumes are now properly mounted using standard Docker syntax (`host:container` or `host:container:ro`)
- Added `ExtraVolumes` field to TUI settings under Sandbox category for editing
- Added debug/info tracing for volume mount operations

## Problem

The `extra_volumes` field in `[sandbox]` config was silently ignored. Users could configure extra volumes in their config file, but they were never passed to the container.

## Changes

| File | Change |
|------|--------|
| `src/session/instance.rs` | Iterate `sandbox_config.extra_volumes` and append to volumes vec |
| `src/tui/settings/fields.rs` | Add `FieldKey::ExtraVolumes`, wire up build/apply functions |
| `src/tui/settings/input.rs` | Add `clear_profile_override()` case for ExtraVolumes |

## Test plan

- [x] `cargo clippy` passes
- [x] `cargo fmt --check` passes
- [x] Manual test: add `extra_volumes = ["/tmp/test:/mnt/test"]` to config and verify mount appears in container