### PR TITLE
feat(tui): add YOLO mode toggle to Edit Session dialog

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -269,6 +269,7 @@ impl HomeView {
                         &data.title,
                         data.group.as_deref(),
                         data.profile.as_deref(),
+                        data.yolo_mode,
                     ) {
                         tracing::error!("Failed to rename session: {}", e);
                     }
@@ -467,11 +468,15 @@ impl HomeView {
                         let current_profile = self.storage.profile().to_string();
                         let profiles =
                             list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+                        let is_sandboxed = inst.is_sandboxed();
+                        let current_yolo = inst.is_yolo_mode();
                         self.rename_dialog = Some(RenameDialog::new(
                             &inst.title,
                             &inst.group_path,
                             &current_profile,
                             profiles,
+                            is_sandboxed,
+                            current_yolo,
                         ));
                     }
                 }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -163,6 +163,7 @@ impl HomeView {
         new_title: &str,
         new_group: Option<&str>,
         new_profile: Option<&str>,
+        new_yolo_mode: Option<bool>,
     ) -> anyhow::Result<()> {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
@@ -205,9 +206,14 @@ impl HomeView {
                         .cloned()
                         .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
 
-                    // Apply title and group changes to the instance
+                    // Apply title, group, and YOLO mode changes to the instance
                     instance.title = effective_title.clone();
                     instance.group_path = effective_group.clone();
+                    if let Some(yolo) = new_yolo_mode {
+                        if let Some(ref mut sandbox) = instance.sandbox_info {
+                            sandbox.yolo_mode = Some(yolo);
+                        }
+                    }
 
                     // Handle tmux rename if title changed
                     if let Some(orig_inst) = self.instance_map.get(&id) {
@@ -255,6 +261,11 @@ impl HomeView {
             if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
                 inst.title = effective_title.clone();
                 inst.group_path = effective_group.clone();
+                if let Some(yolo) = new_yolo_mode {
+                    if let Some(ref mut sandbox) = inst.sandbox_info {
+                        sandbox.yolo_mode = Some(yolo);
+                    }
+                }
             }
 
             // Handle tmux rename if title changed


### PR DESCRIPTION
## Summary
- Adds YOLO mode (`--dangerously-skip-permissions`) toggle to the Edit Session dialog
- Checkbox only appears for sandboxed sessions
- Use Space key to toggle, Tab/arrows to navigate between fields

## Test plan
- [ ] Create a sandboxed session
- [ ] Press `r` to open Edit Session dialog
- [ ] Verify YOLO mode checkbox appears at the bottom
- [ ] Toggle YOLO mode with Space key
- [ ] Submit and verify the session's YOLO mode is updated
- [ ] Verify non-sandboxed sessions don't show the YOLO checkbox