### PR TITLE
feature: use tmux pane title to detect gemini status

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -183,11 +183,28 @@ impl Session {
         process::get_foreground_pid(pane_pid).or(Some(pane_pid))
     }
 
+    fn get_pane_title(&self) -> Result<String> {
+        let output = Command::new("tmux")
+            .args(["display-message", "-t", &self.name, "-p", "#{pane_title}"])
+            .output()?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+        } else {
+            Ok(String::new())
+        }
+    }
+
     pub fn detect_status(&self, tool: &str) -> Result<Status> {
         let content = self.capture_pane(50)?;
         let fg_pid = self.get_foreground_pid();
+        let pane_title = self.get_pane_title()?;
+
         Ok(super::status_detection::detect_status_from_content(
-            &content, tool, fg_pid,
+            &content,
+            &pane_title,
+            tool,
+            fg_pid,
         ))
     }
 }


### PR DESCRIPTION
## Description

gemini cli now sets its terminal window title to reflect its state. This patch will use it to provide simple and accurate gemini status detection. Changes are pretty straightforward so a GH issue is unnecessary I suppose?

## PR Type

- [X] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [X] I understand the code I am submitting
- [X] New and existing tests pass
- [X] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [X] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

AoE controlled gemini cli running in apple container

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 
