### PR TITLE
feat: add AI summary pane to preview panel

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -197,6 +197,12 @@ impl App {
                 refresh_needed = true;
             }
 
+            // AI summary polling
+            self.home.refresh_summary_if_needed();
+            if self.home.apply_summary_results() {
+                refresh_needed = true;
+            }
+
             // Tick the dialog spinner if loading
             if self.home.is_creation_pending() {
                 self.home.tick_dialog();

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -9,5 +9,5 @@ mod text_input;
 pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
-pub use preview::Preview;
+pub use preview::{Preview, SummaryDisplay};
 pub use text_input::render_text_field;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -528,6 +528,12 @@ impl HomeView {
                     self.toggle_group_collapsed(&path);
                 }
             }
+            KeyCode::Char('S') => {
+                // Manually trigger AI summary refresh (Agent view only)
+                if self.view_mode == ViewMode::Agent {
+                    self.force_summary_refresh();
+                }
+            }
             KeyCode::Char('H') => {
                 self.shrink_list();
             }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -9,7 +9,7 @@ use super::{
     ICON_EXPANDED, ICON_IDLE, ICON_RUNNING, ICON_STARTING, ICON_WAITING,
 };
 use crate::session::{Item, Status};
-use crate::tui::components::{HelpOverlay, Preview};
+use crate::tui::components::{HelpOverlay, Preview, SummaryDisplay};
 use crate::tui::styles::Theme;
 use crate::update::UpdateInfo;
 
@@ -447,12 +447,24 @@ impl HomeView {
 
                 if let Some(id) = &self.selected_session {
                     if let Some(inst) = self.instance_map.get(id) {
+                        let summary_display = if !self.summary_cache.summary.is_empty()
+                            || self.summary_cache.is_loading
+                        {
+                            Some(SummaryDisplay {
+                                text: self.summary_cache.summary.clone(),
+                                is_loading: self.summary_cache.is_loading,
+                                is_error: self.summary_cache.is_error,
+                            })
+                        } else {
+                            None
+                        };
                         Preview::render_with_cache(
                             frame,
                             inner,
                             inst,
                             &self.preview_cache.content,
                             theme,
+                            summary_display.as_ref(),
                         );
                     }
                 } else {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -10,6 +10,7 @@ mod home;
 pub mod settings;
 mod status_poller;
 mod styles;
+mod summary_poller;
 
 pub use app::*;
 

--- a/src/tui/summary_poller.rs
+++ b/src/tui/summary_poller.rs
@@ -1,0 +1,157 @@
+//! Background AI summary polling for terminal output
+//!
+//! Calls `claude -p` in a background thread to generate concise summaries
+//! of what's happening in a terminal session.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::thread;
+use std::time::Instant;
+
+pub struct SummaryRequest {
+    pub session_id: String,
+    pub terminal_output: String,
+}
+
+pub struct SummaryResult {
+    pub session_id: String,
+    pub summary: String,
+    pub is_error: bool,
+}
+
+pub struct SummaryCache {
+    pub session_id: Option<String>,
+    pub summary: String,
+    pub is_loading: bool,
+    pub is_error: bool,
+    pub last_request: Instant,
+}
+
+impl Default for SummaryCache {
+    fn default() -> Self {
+        Self {
+            session_id: None,
+            summary: String::new(),
+            is_loading: false,
+            is_error: false,
+            last_request: Instant::now(),
+        }
+    }
+}
+
+pub struct SummaryPoller {
+    request_tx: mpsc::Sender<SummaryRequest>,
+    result_rx: mpsc::Receiver<SummaryResult>,
+    _handle: thread::JoinHandle<()>,
+    in_flight: bool,
+}
+
+impl SummaryPoller {
+    pub fn new() -> Self {
+        let (request_tx, request_rx) = mpsc::channel::<SummaryRequest>();
+        let (result_tx, result_rx) = mpsc::channel::<SummaryResult>();
+
+        let handle = thread::spawn(move || {
+            Self::polling_loop(request_rx, result_tx);
+        });
+
+        Self {
+            request_tx,
+            result_rx,
+            _handle: handle,
+            in_flight: false,
+        }
+    }
+
+    fn polling_loop(
+        request_rx: mpsc::Receiver<SummaryRequest>,
+        result_tx: mpsc::Sender<SummaryResult>,
+    ) {
+        const SYSTEM_PROMPT: &str = "Summarize what is happening in this terminal session in 2-3 concise sentences. Focus on the current activity, any errors, and progress. Be terse.";
+
+        while let Ok(request) = request_rx.recv() {
+            // Truncate to last 150 lines
+            let lines: Vec<&str> = request.terminal_output.lines().collect();
+            let truncated = if lines.len() > 150 {
+                lines[lines.len() - 150..].join("\n")
+            } else {
+                request.terminal_output.clone()
+            };
+
+            let result = Command::new("claude")
+                .args([
+                    "-p",
+                    "--model",
+                    "claude-haiku-4-5-20251001",
+                    "--system-prompt",
+                    SYSTEM_PROMPT,
+                ])
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .and_then(|mut child| {
+                    if let Some(mut stdin) = child.stdin.take() {
+                        let _ = stdin.write_all(truncated.as_bytes());
+                    }
+                    child.wait_with_output()
+                });
+
+            let summary_result = match result {
+                Ok(output) if output.status.success() => {
+                    let summary = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                    SummaryResult {
+                        session_id: request.session_id,
+                        summary,
+                        is_error: false,
+                    }
+                }
+                Ok(output) => {
+                    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                    SummaryResult {
+                        session_id: request.session_id,
+                        summary: format!("Summary failed: {}", stderr),
+                        is_error: true,
+                    }
+                }
+                Err(e) => SummaryResult {
+                    session_id: request.session_id,
+                    summary: format!("Could not run claude: {}", e),
+                    is_error: true,
+                },
+            };
+
+            if result_tx.send(summary_result).is_err() {
+                break;
+            }
+        }
+    }
+
+    /// Request a summary (non-blocking). Skips if a request is already in-flight.
+    pub fn request_summary(&mut self, request: SummaryRequest) {
+        if self.in_flight {
+            return;
+        }
+        if self.request_tx.send(request).is_ok() {
+            self.in_flight = true;
+        }
+    }
+
+    /// Try to receive a result without blocking. Returns None if no result yet.
+    pub fn try_recv_result(&mut self) -> Option<SummaryResult> {
+        match self.result_rx.try_recv().ok() {
+            Some(result) => {
+                self.in_flight = false;
+                Some(result)
+            }
+            None => None,
+        }
+    }
+}
+
+impl Default for SummaryPoller {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an AI-generated summary box to the Agent view preview panel, powered by Claude Haiku via `claude -p` (headless pipe mode)
- Background thread polls summaries every 15s using the same mpsc channel pattern as `StatusPoller`
- Press `Shift+S` to manually trigger a summary refresh
- Summary box rendered between info and output sections with padding for readability

## Test plan

- [ ] Run `aoe`, select a running session in Agent view -- summary box should appear with "Generating summary..." then populate
- [ ] Switch between sessions -- summary should clear and regenerate for the new session
- [ ] Press `Shift+S` -- summary should refresh immediately regardless of 15s timer
- [ ] Switch to Terminal view -- summary box should not appear
- [ ] `cargo fmt`, `cargo clippy`, `cargo test` all pass

