### PR TITLE
fix: skip migrations for completion command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@ async fn main() -> Result<()> {
     }
 
     let cli = Cli::parse();
+
+    // Handle completion before migrations - no database setup needed
+    if let Some(Commands::Completion { shell }) = cli.command {
+        generate(shell, &mut Cli::command(), "aoe", &mut std::io::stdout());
+        return Ok(());
+    }
+
     let profile = cli.profile.unwrap_or_default();
 
     // TUI mode handles migrations with a spinner; CLI runs them silently
@@ -41,10 +48,7 @@ async fn main() -> Result<()> {
         }
         Some(Commands::Sounds { command }) => cli::sounds::run(command).await,
         Some(Commands::Uninstall(args)) => cli::uninstall::run(args).await,
-        Some(Commands::Completion { shell }) => {
-            generate(shell, &mut Cli::command(), "aoe", &mut std::io::stdout());
-            Ok(())
-        }
+        Some(Commands::Completion { .. }) => unreachable!(),
         None => tui::run(&profile).await,
     }
 }


### PR DESCRIPTION
## Description

The `aoe completion <shell>` command fails in Nix sandbox environments because `run_migrations()` is called before the completion logic runs. Shell completion generation doesn't need database migrations - it only outputs completion scripts to stdout.

This fix handles the completion command **before** migrations run.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (opencode)

**Any Additional AI Details you'd like to share:** Used to identify root cause and implement fix

- [x] I am an AI Agent filling out this form (check box if true)