### PR TITLE
feat(nix): add shell completions and enriched meta to flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
             pkg-config
             perl
             cmake
+            installShellFiles
           ];
 
           buildInputs = with pkgs; [
@@ -43,9 +44,29 @@
           aoe = craneLib.buildPackage (commonArgs // {
             inherit cargoArtifacts;
             cargoExtraArgs = "--package agent-of-empires";
-            # Tests are run in the separate aoe-test check below
             doCheck = false;
-            meta.mainProgram = "aoe";
+            postInstall = ''
+              installShellCompletion --cmd aoe \
+                --bash <($out/bin/aoe completion bash) \
+                --fish <($out/bin/aoe completion fish) \
+                --zsh <($out/bin/aoe completion zsh)
+            '';
+
+            meta = with pkgs.lib; {
+              description = "Terminal session manager for AI coding agents";
+              longDescription = ''
+                Agent of Empires (AoE) is a terminal session manager for AI coding
+                agents on Linux and macOS. Built on tmux, it allows running multiple
+                AI agents in parallel across different branches of your codebase,
+                each in its own isolated session with optional Docker sandboxing.
+
+                Supports Claude Code, OpenCode, Mistral Vibe, Codex CLI, and Gemini CLI.
+              '';
+              homepage = "https://github.com/njbrake/agent-of-empires";
+              license = licenses.mit;
+              platforms = platforms.unix;
+              mainProgram = "aoe";
+            };
           });
         in
         {


### PR DESCRIPTION
## Description

Add shell completions (bash/fish/zsh) and enriched package metadata to the Nix flake.

The current flake lacks shell completions and has minimal metadata. This aligns the package with Nix best practices:
- Users get tab completion out of the box when installing via Nix
- `nix search` and `nix-env -qa` display useful information (description, license, homepage)

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude claude-4.5-opus via OpenCode

**Any Additional AI Details you'd like to share:** Based on comparison with existing Nix packaging in https://github.com/jerome-benoit/dotfiles/blob/main/home-manager/modules/development/aoe.nix

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)