### PR TITLE
fix(nix): remove deprecated darwin SDK deps and add flake eval to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: nixbuild/nix-quick-install-action@5bb6a3b74f2a36f7fe9d68ea5369671d8c8ce70e # v34
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
       - name: Evaluate flake outputs (all systems)
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,60 @@ jobs:
           components: clippy
       - run: cargo clippy -- -D warnings
 
+  nix:
+    name: Nix Eval
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b74f2a36f7fe9d68ea5369671d8c8ce70e # v34
+      - name: Evaluate flake outputs (all systems)
+        run: |
+          set -euo pipefail
+          nix --version
+
+          echo "=== Flake metadata ==="
+          nix flake metadata
+
+          echo ""
+          echo "=== Flake structure ==="
+          nix flake show --all-systems
+
+          SYSTEMS="x86_64-linux aarch64-linux x86_64-darwin aarch64-darwin"
+
+          echo ""
+          echo "=== Evaluating packages for all systems ==="
+          for system in $SYSTEMS; do
+            echo ""
+            echo "--- $system ---"
+            printf "  default: "
+            if output=$(nix eval ".#packages.$system.default.drvPath" --raw 2>&1); then
+              echo "✓"
+            else
+              echo "✗"
+              echo "::error::Evaluation failed for packages.$system.default"
+              echo "$output"
+              exit 1
+            fi
+          done
+
+          echo ""
+          echo "=== Evaluating devShells for all systems ==="
+          for system in $SYSTEMS; do
+            printf "%s: " "$system"
+            if output=$(nix eval ".#devShells.$system.default.drvPath" --raw 2>&1); then
+              echo "✓"
+            else
+              echo "✗"
+              echo "::error::Evaluation failed for devShells.$system.default"
+              echo "$output"
+              exit 1
+            fi
+          done
+
+          echo ""
+          echo "=== All evaluations passed ==="
+
   website:
     name: Website Build
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -26,10 +26,6 @@
 
           buildInputs = with pkgs; [
             zlib # required by vendored libgit2
-          ] ++ lib.optionals stdenv.hostPlatform.isDarwin [
-            libiconv
-            darwin.apple_sdk.frameworks.Security
-            darwin.apple_sdk.frameworks.SystemConfiguration
           ];
 
           commonArgs = {


### PR DESCRIPTION
## Description

Remove deprecated `darwin.apple_sdk.frameworks.{Security,SystemConfiguration}` and `libiconv` from flake buildInputs (fixes build on recent nixpkgs). Add CI job to evaluate flake outputs for all systems without building.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (claude-4.5-opus via opencode)

**Any Additional AI Details you'd like to share:** Diagnosed deprecated SDK issue, simplified Darwin deps, added nix eval CI job following project conventions.

- [x] I am an AI Agent filling out this form (check box if true)