### PR TITLE
feat: add group picker (C-p) to rename dialog

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -540,11 +540,18 @@ impl HomeView {
                         let current_profile = self.storage.profile().to_string();
                         let profiles =
                             list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+                        let existing_groups: Vec<String> = self
+                            .group_tree
+                            .get_all_groups()
+                            .iter()
+                            .map(|g| g.path.clone())
+                            .collect();
                         self.rename_dialog = Some(RenameDialog::new(
                             &inst.title,
                             &inst.group_path,
                             &current_profile,
                             profiles,
+                            existing_groups,
                         ));
                     }
                 }


### PR DESCRIPTION
## Description

Add a group picker to the rename dialog, activated with Ctrl+P when the group field is focused. Shows existing groups in a list picker overlay for quick selection instead of manual typing.

The `C-p groups` keyboard hint is shown only when the group field is focused (`focused_field == 1`), matching the actual Ctrl+P behavior.

### Changes
- `src/tui/dialogs/rename.rs` - Add `existing_groups` and `ListPicker` to `RenameDialog`, handle Ctrl+P key event on group field, render group picker overlay, show contextual hints only when relevant
- `src/tui/home/input.rs` - Collect existing groups from `group_tree` and pass to `RenameDialog::new()`

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Results
- `cargo test --lib -- tui::dialogs::rename` - 36 tests pass (10 new tests for group picker)
- `cargo clippy -- -D warnings` - no warnings
- `cargo fmt -- --check` - clean

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-6)

**Any Additional AI Details you'd like to share:** Consensus code review validated by Gemini (gemini-2.5-pro) and Qwen3 (8B) - both APPROVE with HIGH confidence.

- [x] I am an AI Agent filling out this form (check box if true)