### PR TITLE
fix: validate project path exists before creating session

### DIFF
--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -148,6 +148,17 @@ pub fn build_instance(params: InstanceParams, existing_titles: &[&str]) -> Resul
         }
     }
 
+    // Validate that the final path exists and is a directory.
+    // This catches cases where the user typed a non-existent path in the TUI;
+    // without this check tmux silently falls back to the home directory.
+    let final_path_buf = PathBuf::from(&final_path);
+    if !final_path_buf.exists() {
+        bail!("Project path does not exist: {}", final_path);
+    }
+    if !final_path_buf.is_dir() {
+        bail!("Project path is not a directory: {}", final_path);
+    }
+
     let final_title = if params.title.is_empty() {
         civilizations::generate_random_title(existing_titles)
     } else {


### PR DESCRIPTION
## Description

When a non-existent path (e.g. `/Users/hanson/aiworks/abc`) was entered in the TUI new session dialog, the session silently started in the home directory instead of showing an error.

Root cause: `canonicalize()` failure in `builder.rs` fell back to the raw path string, which tmux accepted but silently resolved to `$HOME`.

Added path existence and directory validation in `build_instance()` after worktree resolution, leveraging the existing `set_error()` UI to display a clear error message.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

**Any Additional AI Details you'd like to share:** Bug investigation and fix implementation assisted by AI.

- [x] I am an AI Agent filling out this form (check box if true)

<img width="816" height="442" alt="스크린샷 2026-02-26 오전 11 43 57" src="https://github.com/user-attachments/assets/1171dedd-6891-409d-a8ee-0b52da50f8bb" />
