### PR TITLE
feat: add profile rename command

### DIFF
--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -26,6 +26,15 @@ pub enum ProfileCommands {
         name: String,
     },
 
+    /// Rename a profile
+    #[command(alias = "mv")]
+    Rename {
+        /// Current profile name
+        old_name: String,
+        /// New profile name
+        new_name: String,
+    },
+
     /// Show or set default profile
     Default {
         /// Profile name (optional, shows current if not provided)
@@ -38,6 +47,9 @@ pub async fn run(command: Option<ProfileCommands>) -> Result<()> {
         Some(ProfileCommands::List) | None => list_profiles().await,
         Some(ProfileCommands::Create { name }) => create_profile(&name).await,
         Some(ProfileCommands::Delete { name }) => delete_profile(&name).await,
+        Some(ProfileCommands::Rename { old_name, new_name }) => {
+            rename_profile(&old_name, &new_name).await
+        }
         Some(ProfileCommands::Default { name }) => {
             if let Some(n) = name {
                 set_default_profile(&n).await
@@ -79,6 +91,12 @@ async fn create_profile(name: &str) -> Result<()> {
     session::create_profile(name)?;
     println!("✓ Created profile: {}", name);
     println!("  Use with: agent-of-empires -p {}", name);
+    Ok(())
+}
+
+async fn rename_profile(old_name: &str, new_name: &str) -> Result<()> {
+    session::rename_profile(old_name, new_name)?;
+    println!("✓ Renamed profile: {} -> {}", old_name, new_name);
     Ok(())
 }
 

--- a/tests/profile_management.rs
+++ b/tests/profile_management.rs
@@ -1,7 +1,8 @@
-//! Integration tests for profile management: create, delete, list, default, and isolation.
+//! Integration tests for profile management: create, delete, list, default, rename, and isolation.
 
 use agent_of_empires::session::{
-    create_profile, delete_profile, list_profiles, set_default_profile, Config, Instance, Storage,
+    create_profile, delete_profile, list_profiles, rename_profile, set_default_profile, Config,
+    Instance, Storage,
 };
 use anyhow::Result;
 use serial_test::serial;
@@ -107,6 +108,120 @@ fn test_profile_session_isolation() -> Result<()> {
     let loaded_a = storage_a.load()?;
     assert_eq!(loaded_a.len(), 1);
     assert_eq!(loaded_a[0].title, "Alpha Session");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("old_name")?;
+    // Add a session so we can verify data moves with the rename
+    let storage = Storage::new("old_name")?;
+    let instance = Instance::new("Test Session", "/path/test");
+    storage.save(&[instance])?;
+
+    rename_profile("old_name", "new_name")?;
+
+    let profiles = list_profiles()?;
+    assert!(!profiles.contains(&"old_name".to_string()));
+    assert!(profiles.contains(&"new_name".to_string()));
+
+    // Verify sessions moved with the profile
+    let new_storage = Storage::new("new_name")?;
+    let sessions = new_storage.load()?;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].title, "Test Session");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_updates_default() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("primary")?;
+    set_default_profile("primary")?;
+
+    rename_profile("primary", "renamed")?;
+
+    let config = Config::load()?;
+    assert_eq!(config.default_profile, "renamed");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_nondefault_keeps_default() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("main_profile")?;
+    create_profile("other")?;
+    set_default_profile("main_profile")?;
+
+    rename_profile("other", "renamed_other")?;
+
+    let config = Config::load()?;
+    assert_eq!(config.default_profile, "main_profile");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_to_existing_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("first")?;
+    create_profile("second")?;
+
+    let result = rename_profile("first", "second");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("already exists"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_nonexistent_profile_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    let result = rename_profile("nonexistent", "new_name");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("does not exist"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_empty_name_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("valid")?;
+
+    let result = rename_profile("valid", "");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_with_path_separator_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("valid")?;
+
+    let result = rename_profile("valid", "bad/name");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("path separators"));
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- Adds `aoe profile rename <old_name> <new_name>` CLI command (with `mv` alias) to rename profiles
- Renames the profile directory on disk, moving all sessions, groups, and config with it
- Automatically updates the default profile setting if the renamed profile was the default
- Validates new name (non-empty, no path separators, doesn't already exist)

Fixes #328

## Test plan
- [x] 7 new integration tests covering: basic rename, default profile update, non-default preservation, rename to existing name, nonexistent profile, empty name, path separators
- [x] Full test suite passes (692 unit tests + 14 profile management tests + all integration tests)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [ ] Manual: `aoe profile create foo && aoe profile rename foo bar && aoe profile list`
- [ ] Manual: set default profile, rename it, verify default updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)