### PR TITLE
feat: add profile rename command

### DIFF
--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -26,6 +26,15 @@ pub enum ProfileCommands {
         name: String,
     },
 
+    /// Rename a profile
+    #[command(alias = "mv")]
+    Rename {
+        /// Current profile name
+        old_name: String,
+        /// New profile name
+        new_name: String,
+    },
+
     /// Show or set default profile
     Default {
         /// Profile name (optional, shows current if not provided)
@@ -38,6 +47,9 @@ pub async fn run(command: Option<ProfileCommands>) -> Result<()> {
         Some(ProfileCommands::List) | None => list_profiles().await,
         Some(ProfileCommands::Create { name }) => create_profile(&name).await,
         Some(ProfileCommands::Delete { name }) => delete_profile(&name).await,
+        Some(ProfileCommands::Rename { old_name, new_name }) => {
+            rename_profile(&old_name, &new_name).await
+        }
         Some(ProfileCommands::Default { name }) => {
             if let Some(n) = name {
                 set_default_profile(&n).await
@@ -79,6 +91,12 @@ async fn create_profile(name: &str) -> Result<()> {
     session::create_profile(name)?;
     println!("✓ Created profile: {}", name);
     println!("  Use with: agent-of-empires -p {}", name);
+    Ok(())
+}
+
+async fn rename_profile(old_name: &str, new_name: &str) -> Result<()> {
+    session::rename_profile(old_name, new_name)?;
+    println!("✓ Renamed profile: {} -> {}", old_name, new_name);
     Ok(())
 }
 

--- a/tests/profile_management.rs
+++ b/tests/profile_management.rs
@@ -1,7 +1,8 @@
-//! Integration tests for profile management: create, delete, list, default, and isolation.
+//! Integration tests for profile management: create, delete, list, default, rename, and isolation.
 
 use agent_of_empires::session::{
-    create_profile, delete_profile, list_profiles, set_default_profile, Config, Instance, Storage,
+    create_profile, delete_profile, list_profiles, rename_profile, set_default_profile, Config,
+    Instance, Storage,
 };
 use anyhow::Result;
 use serial_test::serial;
@@ -107,6 +108,120 @@ fn test_profile_session_isolation() -> Result<()> {
     let loaded_a = storage_a.load()?;
     assert_eq!(loaded_a.len(), 1);
     assert_eq!(loaded_a[0].title, "Alpha Session");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("old_name")?;
+    // Add a session so we can verify data moves with the rename
+    let storage = Storage::new("old_name")?;
+    let instance = Instance::new("Test Session", "/path/test");
+    storage.save(&[instance])?;
+
+    rename_profile("old_name", "new_name")?;
+
+    let profiles = list_profiles()?;
+    assert!(!profiles.contains(&"old_name".to_string()));
+    assert!(profiles.contains(&"new_name".to_string()));
+
+    // Verify sessions moved with the profile
+    let new_storage = Storage::new("new_name")?;
+    let sessions = new_storage.load()?;
+    assert_eq!(sessions.len(), 1);
+    assert_eq!(sessions[0].title, "Test Session");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_updates_default() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("primary")?;
+    set_default_profile("primary")?;
+
+    rename_profile("primary", "renamed")?;
+
+    let config = Config::load()?;
+    assert_eq!(config.default_profile, "renamed");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_nondefault_keeps_default() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("main_profile")?;
+    create_profile("other")?;
+    set_default_profile("main_profile")?;
+
+    rename_profile("other", "renamed_other")?;
+
+    let config = Config::load()?;
+    assert_eq!(config.default_profile, "main_profile");
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_to_existing_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("first")?;
+    create_profile("second")?;
+
+    let result = rename_profile("first", "second");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("already exists"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_nonexistent_profile_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    let result = rename_profile("nonexistent", "new_name");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("does not exist"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_empty_name_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("valid")?;
+
+    let result = rename_profile("valid", "");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("cannot be empty"));
+
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_rename_profile_with_path_separator_fails() -> Result<()> {
+    let _temp = setup_temp_home();
+
+    create_profile("valid")?;
+
+    let result = rename_profile("valid", "bad/name");
+    assert!(result.is_err());
+    assert!(result.unwrap_err().to_string().contains("path separators"));
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Adds `aoe profile rename <old_name> <new_name>` (alias: `aoe profile mv`) to rename profiles. The rename moves the entire profile directory, preserving all sessions and groups. If the renamed profile was the default, the default config is updated automatically.

Fixes #328

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)