### PR TITLE
fix: seed .sandbox-gitconfig so git works in Claude Code sandboxes

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -57,7 +57,12 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         keychain_credential: Some(("Claude Code-credentials", ".credentials.json")),
         // Claude Code reads ~/.claude.json (home level, NOT inside ~/.claude/) for onboarding
         // state. Seeding hasCompletedOnboarding skips the first-run wizard.
-        home_seed_files: &[(".claude.json", r#"{"hasCompletedOnboarding":true}"#)],
+        // Claude Code sets GIT_CONFIG_GLOBAL=/root/.sandbox-gitconfig when IS_SANDBOX=1;
+        // the file must exist or all git commands fail.
+        home_seed_files: &[
+            (".claude.json", r#"{"hasCompletedOnboarding":true}"#),
+            (".sandbox-gitconfig", ""),
+        ],
         preserve_files: &[".credentials.json", "history.jsonl"],
     },
     AgentConfigMount {


### PR DESCRIPTION
## Description

Claude Code sets `GIT_CONFIG_GLOBAL=/root/.sandbox-gitconfig` when `IS_SANDBOX=1`, but nothing creates the file. Every git command inside Claude Code sandbox sessions fails with:

```
fatal: unknown error occurred while reading the configuration files
```

This adds `.sandbox-gitconfig` as an empty `home_seed_file` in the Claude Code agent config. The existing `home_seed_files` mechanism creates the file on the host (`~/.claude/sandbox/.sandbox-gitconfig`) and bind-mounts it read-write at `/root/.sandbox-gitconfig` -- same pattern used for `.claude.json`.

This also sidesteps a secondary issue where the host's `.gitconfig` (mounted read-only) can carry a broken `credential.helper` escape (`\!gh` instead of `!gh`). With `GIT_CONFIG_GLOBAL` pointing to the sandbox file, git no longer reads the host `.gitconfig`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)