### PR TITLE
feat: add Dracula theme

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -41,12 +41,12 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 
 ```toml
 [theme]
-name = "phosphor"   # phosphor, tokyo-night-storm, catppuccin-latte
+name = "phosphor"   # phosphor, tokyo-night-storm, catppuccin-latte, dracula
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `name` | `"phosphor"` | TUI color theme. Available: `phosphor` (default green), `tokyo-night-storm` (dark blue/purple), `catppuccin-latte` (light pastel). |
+| `name` | `"phosphor"` | TUI color theme. Available: `phosphor` (default green), `tokyo-night-storm` (dark blue/purple), `catppuccin-latte` (light pastel), `dracula` (dark purple/pink). |
 
 ## Session
 

--- a/src/tui/styles.rs
+++ b/src/tui/styles.rs
@@ -185,7 +185,7 @@ impl Theme {
         }
     }
 
-    /// Dracula theme - the most popular dark theme (23k+ GitHub stars)
+    /// Dracula theme
     /// Official palette: https://draculatheme.com/spec
     pub fn dracula() -> Self {
         Self {

--- a/src/tui/styles.rs
+++ b/src/tui/styles.rs
@@ -3,13 +3,19 @@
 use ratatui::style::Color;
 use tracing::warn;
 
-pub const AVAILABLE_THEMES: &[&str] = &["phosphor", "tokyo-night-storm", "catppuccin-latte"];
+pub const AVAILABLE_THEMES: &[&str] = &[
+    "phosphor",
+    "tokyo-night-storm",
+    "catppuccin-latte",
+    "dracula",
+];
 
 pub fn load_theme(name: &str) -> Theme {
     match name {
         "phosphor" => Theme::phosphor(),
         "tokyo-night-storm" => Theme::tokyo_night_storm(),
         "catppuccin-latte" => Theme::catppuccin_latte(),
+        "dracula" => Theme::dracula(),
         _ => {
             warn!("Unknown theme '{}', falling back to phosphor", name);
             Theme::phosphor()
@@ -178,6 +184,46 @@ impl Theme {
             worktree_manual: Color::Rgb(223, 142, 29),
         }
     }
+
+    /// Dracula theme - the most popular dark theme (23k+ GitHub stars)
+    /// Official palette: https://draculatheme.com/spec
+    pub fn dracula() -> Self {
+        Self {
+            background: Color::Rgb(40, 42, 54),
+            border: Color::Rgb(68, 71, 90),
+            terminal_border: Color::Rgb(139, 233, 253),
+            selection: Color::Rgb(68, 71, 90),
+            session_selection: Color::Rgb(98, 114, 164),
+
+            title: Color::Rgb(189, 147, 249),
+            text: Color::Rgb(248, 248, 242),
+            dimmed: Color::Rgb(98, 114, 164),
+            hint: Color::Rgb(98, 114, 164),
+
+            running: Color::Rgb(80, 250, 123),
+            waiting: Color::Rgb(255, 184, 108),
+            idle: Color::Rgb(98, 114, 164),
+            error: Color::Rgb(255, 85, 85),
+            terminal_active: Color::Rgb(139, 233, 253),
+
+            group: Color::Rgb(139, 233, 253),
+            search: Color::Rgb(241, 250, 140),
+            accent: Color::Rgb(255, 121, 198),
+
+            diff_add: Color::Rgb(80, 250, 123),
+            diff_delete: Color::Rgb(255, 85, 85),
+            diff_modified: Color::Rgb(255, 184, 108),
+            diff_context: Color::Rgb(98, 114, 164),
+            diff_header: Color::Rgb(189, 147, 249),
+
+            help_key: Color::Rgb(255, 121, 198),
+
+            branch: Color::Rgb(139, 233, 253),
+            sandbox: Color::Rgb(189, 147, 249),
+            worktree_managed: Color::Rgb(80, 250, 123),
+            worktree_manual: Color::Rgb(255, 184, 108),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -211,12 +257,19 @@ mod tests {
         assert_eq!(theme.title, Color::Rgb(122, 162, 247));
         assert_eq!(theme.background, Color::Rgb(36, 40, 59));
     }
+    #[test]
+    fn test_load_dracula() {
+        let theme = load_theme("dracula");
+        assert_eq!(theme.title, Color::Rgb(189, 147, 249));
+        assert_eq!(theme.background, Color::Rgb(40, 42, 54));
+    }
 
     #[test]
     fn test_available_themes_count() {
-        assert_eq!(AVAILABLE_THEMES.len(), 3);
+        assert_eq!(AVAILABLE_THEMES.len(), 4);
         assert!(AVAILABLE_THEMES.contains(&"phosphor"));
         assert!(AVAILABLE_THEMES.contains(&"tokyo-night-storm"));
         assert!(AVAILABLE_THEMES.contains(&"catppuccin-latte"));
+        assert!(AVAILABLE_THEMES.contains(&"dracula"));
     }
 }


### PR DESCRIPTION
## Description

Add the **Dracula** color theme, the most popular dark theme for terminals and editors with 23k+ GitHub stars.

This theme uses the official Dracula palette from [draculatheme.com/spec](https://draculatheme.com/spec), featuring the signature purple/pink aesthetic that complements the existing themes:
- `phosphor` (green, custom)
- `tokyo-night-storm` (blue/purple, dark)
- `catppuccin-latte` (pastel, light)
- **`dracula`** (purple/pink, dark) ← NEW

### Changes
- Add `dracula` to `AVAILABLE_THEMES` in `src/tui/styles.rs`
- Implement `Theme::dracula()` with official Dracula colors
- Add `test_load_dracula` unit test
- Update documentation in `docs/guides/configuration.md`

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (anthropic--claude-4.5-opus via OpenCode)

**Any Additional AI Details you'd like to share:**
- Researched popular themes using GitHub stars, web search, and official documentation
- Cross-verified implementation against official Dracula spec (draculatheme.com/spec)
- Harmonized code style with existing theme implementations (inline RGB values, no local variables)
- Followed project conventions from AGENTS.md

- [x] I am an AI Agent filling out this form (check box if true)