### PR TITLE
docs: regenerate CLI reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,18 @@ jobs:
           components: clippy
       - run: cargo clippy -- -D warnings
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Check CLI docs are up-to-date
+        run: |
+          cargo xtask gen-docs
+          git diff --exit-code docs/cli/reference.md \
+            || (echo "::error::CLI docs are out of date. Run 'cargo xtask gen-docs' and commit." && exit 1)
+
   nix:
     name: Nix Eval
     runs-on: ubuntu-latest

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -27,6 +27,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe profile list`↴](#aoe-profile-list)
 * [`aoe profile create`↴](#aoe-profile-create)
 * [`aoe profile delete`↴](#aoe-profile-delete)
+* [`aoe profile rename`↴](#aoe-profile-rename)
 * [`aoe profile default`↴](#aoe-profile-default)
 * [`aoe worktree`↴](#aoe-worktree)
 * [`aoe worktree list`↴](#aoe-worktree-list)
@@ -43,7 +44,7 @@ This document contains the help content for the `aoe` command-line program.
 
 ## `aoe`
 
-Agent of Empires (aoe) is a terminal session manager that uses tmux to help you manage and monitor AI coding agents like Claude Code, OpenCode, and Cursor CLI.
+Agent of Empires (aoe) is a terminal session manager that uses tmux to help you manage and monitor AI coding agents like Claude Code and OpenCode.
 
 Run without arguments to launch the TUI dashboard.
 
@@ -94,6 +95,7 @@ Add a new session
 * `-b`, `--new-branch` — Create a new branch (use with --worktree)
 * `-s`, `--sandbox` — Run session in Docker sandbox
 * `--sandbox-image <SANDBOX_IMAGE>` — Custom Docker image for sandbox (implies --sandbox)
+* `-y`, `--yolo` — Enable YOLO mode (skip permission prompts)
 * `--trust-hooks` — Automatically trust repository hooks without prompting
 
 
@@ -138,6 +140,7 @@ Remove a session
 ###### **Options:**
 
 * `--delete-worktree` — Delete worktree directory (default: keep worktree)
+* `--force` — Force worktree removal even with untracked/modified files
 * `--keep-container` — Keep container instead of deleting it (default: delete per config)
 
 
@@ -351,6 +354,7 @@ Manage profiles (separate workspaces)
 * `list` — List all profiles
 * `create` — Create a new profile
 * `delete` — Delete a profile
+* `rename` — Rename a profile
 * `default` — Show or set default profile
 
 
@@ -384,6 +388,19 @@ Delete a profile
 ###### **Arguments:**
 
 * `<NAME>` — Profile name
+
+
+
+## `aoe profile rename`
+
+Rename a profile
+
+**Usage:** `aoe profile rename <OLD_NAME> <NEW_NAME>`
+
+###### **Arguments:**
+
+* `<OLD_NAME>` — Current profile name
+* `<NEW_NAME>` — New profile name
 
 
 


### PR DESCRIPTION
## Description

Regenerate CLI reference documentation and add a CI check to prevent future drift.

### Changes

1. **Regenerate `docs/cli/reference.md`** to sync with recent code changes:
   - Add `aoe profile rename` command (from #334)
   - Add `--yolo` flag to `aoe add`
   - Add `--force` flag to `aoe remove`
   - Update description text

2. **Add `docs` job to CI** (`.github/workflows/ci.yml`):
   - Runs `cargo xtask gen-docs` and fails if output differs from committed version
   - Prevents CLI documentation from getting out of sync in the future

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (anthropic--claude-4.5-opus via OpenCode)

**Any Additional AI Details you'd like to share:**
- Researched CI patterns from helix-editor, oxc-project, datafusion, and other Rust projects
- Used `git diff --exit-code` pattern as the standard approach for generated file drift detection

- [x] I am an AI Agent filling out this form (check box if true)