### PR TITLE
feat: offer to create non-existent directory on session submit

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -161,6 +161,9 @@ pub struct NewSessionDialog {
     pub(super) path_invalid_flash_until: Option<Instant>,
     /// Ghost text completion for the path field (fish-shell style).
     path_ghost: Option<PathGhostCompletion>,
+    /// Inline confirmation for creating a non-existent directory.
+    /// None = inactive, Some(true) = Yes selected, Some(false) = No selected.
+    pub(super) confirm_create_dir: Option<bool>,
 }
 
 /// Shared logic for handling key events in an editable list (env keys or env values).
@@ -363,6 +366,7 @@ impl NewSessionDialog {
             hook_output: Vec::new(),
             path_invalid_flash_until: None,
             path_ghost: None,
+            confirm_create_dir: None,
         }
     }
 
@@ -476,6 +480,7 @@ impl NewSessionDialog {
             hook_output: Vec::new(),
             path_invalid_flash_until: None,
             path_ghost: None,
+            confirm_create_dir: None,
         }
     }
 
@@ -524,6 +529,7 @@ impl NewSessionDialog {
             hook_output: Vec::new(),
             path_invalid_flash_until: None,
             path_ghost: None,
+            confirm_create_dir: None,
         }
     }
 
@@ -546,6 +552,10 @@ impl NewSessionDialog {
                 self.show_help = false;
             }
             return DialogResult::Continue;
+        }
+
+        if self.confirm_create_dir.is_some() {
+            return self.handle_confirm_create_dir_key(key);
         }
 
         if self.group_picker.is_active() {
@@ -689,40 +699,12 @@ impl NewSessionDialog {
             }
             KeyCode::Enter => {
                 self.error_message = None;
-                let title_value = self.title.value().trim();
-                let final_title = if title_value.is_empty() {
-                    let refs: Vec<&str> = self.existing_titles.iter().map(|s| s.as_str()).collect();
-                    civilizations::generate_random_title(&refs)
-                } else {
-                    title_value.to_string()
-                };
-                let worktree_value = self.worktree_branch.value().trim();
-                let worktree_branch = if worktree_value.is_empty() {
-                    None
-                } else {
-                    Some(worktree_value.to_string())
-                };
-                DialogResult::Submit(NewSessionData {
-                    title: final_title,
-                    path: self.path.value().trim().to_string(),
-                    group: self.group.value().trim().to_string(),
-                    tool: self.available_tools[self.tool_index].to_string(),
-                    worktree_branch,
-                    create_new_branch: self.create_new_branch,
-                    sandbox: self.sandbox_enabled,
-                    sandbox_image: self.sandbox_image.value().trim().to_string(),
-                    yolo_mode: self.yolo_mode,
-                    extra_env_keys: if self.sandbox_enabled {
-                        self.extra_env_keys.clone()
-                    } else {
-                        Vec::new()
-                    },
-                    extra_env_values: if self.sandbox_enabled {
-                        self.extra_env_values.clone()
-                    } else {
-                        Vec::new()
-                    },
-                })
+                let path_str = self.path.value().trim().to_string();
+                if !std::path::Path::new(&path_str).exists() {
+                    self.confirm_create_dir = Some(false);
+                    return DialogResult::Continue;
+                }
+                self.build_submit_result()
             }
             KeyCode::Tab | KeyCode::Down => {
                 if self.focused_field == PATH_FIELD {
@@ -895,6 +877,93 @@ impl NewSessionDialog {
             n if n == sandbox_image_field => &mut self.sandbox_image,
             n if n == group_field => &mut self.group,
             _ => &mut self.title,
+        }
+    }
+
+    fn build_submit_result(&self) -> DialogResult<NewSessionData> {
+        let title_value = self.title.value().trim();
+        let final_title = if title_value.is_empty() {
+            let refs: Vec<&str> = self.existing_titles.iter().map(|s| s.as_str()).collect();
+            civilizations::generate_random_title(&refs)
+        } else {
+            title_value.to_string()
+        };
+        let worktree_value = self.worktree_branch.value().trim();
+        let worktree_branch = if worktree_value.is_empty() {
+            None
+        } else {
+            Some(worktree_value.to_string())
+        };
+        DialogResult::Submit(NewSessionData {
+            title: final_title,
+            path: self.path.value().trim().to_string(),
+            group: self.group.value().trim().to_string(),
+            tool: self.available_tools[self.tool_index].to_string(),
+            worktree_branch,
+            create_new_branch: self.create_new_branch,
+            sandbox: self.sandbox_enabled,
+            sandbox_image: self.sandbox_image.value().trim().to_string(),
+            yolo_mode: self.yolo_mode,
+            extra_env_keys: if self.sandbox_enabled {
+                self.extra_env_keys.clone()
+            } else {
+                Vec::new()
+            },
+            extra_env_values: if self.sandbox_enabled {
+                self.extra_env_values.clone()
+            } else {
+                Vec::new()
+            },
+        })
+    }
+
+    fn handle_confirm_create_dir_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
+        let selected = self.confirm_create_dir.as_mut().unwrap();
+        match key.code {
+            KeyCode::Left | KeyCode::Char('h') => {
+                *selected = true;
+                DialogResult::Continue
+            }
+            KeyCode::Right | KeyCode::Char('l') => {
+                *selected = false;
+                DialogResult::Continue
+            }
+            KeyCode::Tab => {
+                *selected = !*selected;
+                DialogResult::Continue
+            }
+            KeyCode::Char('y') | KeyCode::Char('Y') => {
+                self.confirm_create_dir = None;
+                self.try_create_dir_and_submit()
+            }
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+                self.confirm_create_dir = None;
+                self.focused_field = PATH_FIELD;
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                let yes = *selected;
+                self.confirm_create_dir = None;
+                if yes {
+                    self.try_create_dir_and_submit()
+                } else {
+                    self.focused_field = PATH_FIELD;
+                    DialogResult::Continue
+                }
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    fn try_create_dir_and_submit(&mut self) -> DialogResult<NewSessionData> {
+        let path_str = self.path.value().trim().to_string();
+        match std::fs::create_dir_all(&path_str) {
+            Ok(()) => self.build_submit_result(),
+            Err(e) => {
+                self.error_message = Some(format!("Failed to create directory: {}", e));
+                self.focused_field = PATH_FIELD;
+                DialogResult::Continue
+            }
         }
     }
 }

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -361,7 +361,29 @@ impl NewSessionDialog {
 
         // Hints/errors (last chunk)
         let hint_chunk = ci;
-        if let Some(error) = &self.error_message {
+        if self.confirm_create_dir.is_some() {
+            let selected = self.confirm_create_dir.unwrap_or(false);
+            let yes_style = if selected {
+                Style::default().fg(theme.error).bold()
+            } else {
+                Style::default().fg(theme.dimmed)
+            };
+            let no_style = if !selected {
+                Style::default().fg(theme.accent).bold()
+            } else {
+                Style::default().fg(theme.dimmed)
+            };
+            let line = Line::from(vec![
+                Span::styled(
+                    "⚠ Path does not exist. Create? ",
+                    Style::default().fg(theme.error),
+                ),
+                Span::styled("[y]es", yes_style),
+                Span::raw(" "),
+                Span::styled("[N]o", no_style),
+            ]);
+            frame.render_widget(Paragraph::new(line), chunks[hint_chunk]);
+        } else if let Some(error) = &self.error_message {
             let error_text = format!("✗ Error: {}", error);
             let error_paragraph = Paragraph::new(error_text)
                 .style(Style::default().fg(theme.error))

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -3,7 +3,7 @@ use crate::session::{merge_configs, Config, ProfileConfig, SessionConfigOverride
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::fs;
 
-const TEST_PATH: &str = "/__aoe_nonexistent__/project";
+const TEST_PATH: &str = ".";
 
 fn key(code: KeyCode) -> KeyEvent {
     KeyEvent::new(code, KeyModifiers::NONE)
@@ -883,4 +883,124 @@ fn test_profile_override_beats_global_default_tool() {
         "Profile override should select opencode over global claude"
     );
     assert_eq!(dialog.available_tools[dialog.tool_index], "opencode");
+}
+
+// --- confirm_create_dir tests ---
+
+fn nonexistent_dialog() -> NewSessionDialog {
+    NewSessionDialog::new_with_tools(vec!["claude"], "/__aoe_nonexistent__/project".to_string())
+}
+
+#[test]
+fn test_enter_with_nonexistent_path_enters_confirm() {
+    let mut dialog = nonexistent_dialog();
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(matches!(result, DialogResult::Continue));
+    assert_eq!(dialog.confirm_create_dir, Some(false));
+}
+
+#[test]
+fn test_enter_with_existing_path_submits_directly() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let mut dialog =
+        NewSessionDialog::new_with_tools(vec!["claude"], tmp.path().to_string_lossy().to_string());
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(matches!(result, DialogResult::Submit(_)));
+    assert!(dialog.confirm_create_dir.is_none());
+}
+
+#[test]
+fn test_confirm_esc_cancels() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(false);
+    let result = dialog.handle_key(key(KeyCode::Esc));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(dialog.confirm_create_dir.is_none());
+    assert_eq!(dialog.focused_field, PATH_FIELD);
+}
+
+#[test]
+fn test_confirm_n_cancels() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(true);
+    dialog.handle_key(key(KeyCode::Char('n')));
+    assert!(dialog.confirm_create_dir.is_none());
+    assert_eq!(dialog.focused_field, PATH_FIELD);
+}
+
+#[test]
+fn test_confirm_h_selects_yes() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(false);
+    dialog.handle_key(key(KeyCode::Char('h')));
+    assert_eq!(dialog.confirm_create_dir, Some(true));
+}
+
+#[test]
+fn test_confirm_l_selects_no() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(true);
+    dialog.handle_key(key(KeyCode::Char('l')));
+    assert_eq!(dialog.confirm_create_dir, Some(false));
+}
+
+#[test]
+fn test_confirm_tab_toggles() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(false);
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.confirm_create_dir, Some(true));
+    dialog.confirm_create_dir = Some(true);
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.confirm_create_dir, Some(false));
+}
+
+#[test]
+fn test_confirm_y_creates_dir_and_submits() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let new_path = tmp.path().join("new_project");
+    assert!(!new_path.exists());
+
+    let mut dialog =
+        NewSessionDialog::new_with_tools(vec!["claude"], new_path.to_string_lossy().to_string());
+    dialog.confirm_create_dir = Some(false);
+    let result = dialog.handle_key(key(KeyCode::Char('y')));
+    assert!(matches!(result, DialogResult::Submit(_)));
+    assert!(new_path.exists());
+}
+
+#[test]
+fn test_confirm_enter_yes_creates_dir_and_submits() {
+    let tmp = tempfile::tempdir().expect("temp dir");
+    let new_path = tmp.path().join("another_dir");
+
+    let mut dialog =
+        NewSessionDialog::new_with_tools(vec!["claude"], new_path.to_string_lossy().to_string());
+    dialog.confirm_create_dir = Some(true);
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(matches!(result, DialogResult::Submit(_)));
+    assert!(new_path.exists());
+}
+
+#[test]
+fn test_confirm_enter_no_cancels() {
+    let mut dialog = nonexistent_dialog();
+    dialog.confirm_create_dir = Some(false);
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(dialog.confirm_create_dir.is_none());
+    assert_eq!(dialog.focused_field, PATH_FIELD);
+}
+
+#[test]
+fn test_confirm_create_failure_shows_error() {
+    let mut dialog = NewSessionDialog::new_with_tools(
+        vec!["claude"],
+        "/proc/aoe_test_cannot_create".to_string(),
+    );
+    dialog.confirm_create_dir = Some(true);
+    let result = dialog.handle_key(key(KeyCode::Char('y')));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(dialog.error_message.is_some());
+    assert!(dialog.confirm_create_dir.is_none());
 }


### PR DESCRIPTION
## Description

When submitting the New Session dialog with a path that does not exist, instead of
failing with an error after creation, the dialog now shows an inline confirmation
prompt in the hint area: `⚠ Path does not exist. Create? [y]es [N]o`.

- Pressing `y`/`Y` runs `create_dir_all` and proceeds with session creation
- Pressing `n`/`N`/`Esc` dismisses the prompt and returns focus to the path field
- Standard vim-style navigation (`h`/`l`), `Tab` toggle, and `Enter` also work
- Default selection is No (safe by default)
- If directory creation fails (e.g. permissions), an error message is shown inline

This avoids having to open a separate terminal to `mkdir` before creating a session.

### Implementation

- Added `confirm_create_dir: Option<bool>` state to `NewSessionDialog`
- Extracted `build_submit_result()` to share submit logic between normal and create-dir paths
- Confirmation prompt reuses the existing hint area -- no new overlay or dialog added
- Key handling follows the same pattern as `ConfirmDialog` (`y`/`n`/`h`/`l`/`Tab`/`Enter`/`Esc`)

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

**Any Additional AI Details you'd like to share:** Codebase analysis, owner style analysis, implementation, and tests were all generated by Claude Code.

- [x] I am an AI Agent filling out this form (check box if true)

## Screenshot

<img width="833" height="458" alt="aoe-create-path" src="https://github.com/user-attachments/assets/bad12baf-7ae7-4a81-9854-4140dd30964c" />