### PR TITLE
feat: add profile picker and collapse sandbox options in new session dialog

### DIFF
--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -55,6 +55,8 @@ pub struct CreationPoller {
     progress_tx: mpsc::Sender<HookProgress>,
     _handle: thread::JoinHandle<()>,
     pending: bool,
+    /// Profile from the last creation request (for cross-profile saves)
+    last_profile: Option<String>,
 }
 
 impl CreationPoller {
@@ -80,6 +82,7 @@ impl CreationPoller {
             progress_tx,
             _handle: handle,
             pending: false,
+            last_profile: None,
         }
     }
 
@@ -214,6 +217,7 @@ impl CreationPoller {
 
     pub fn request_creation(&mut self, request: CreationRequest) {
         self.pending = true;
+        self.last_profile = Some(request.data.profile.clone());
         if self
             .request_tx
             .send((request, self.progress_tx.clone()))
@@ -222,6 +226,11 @@ impl CreationPoller {
             tracing::error!("Failed to send creation request: receiver thread died");
             self.pending = false;
         }
+    }
+
+    /// Get the profile from the last creation request
+    pub fn last_profile(&self) -> Option<String> {
+        self.last_profile.clone()
     }
 
     pub fn try_recv_result(&mut self) -> Option<CreationResult> {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -34,6 +34,10 @@ pub(super) const HELP_DIALOG_WIDTH: u16 = 85;
 
 pub(super) const FIELD_HELP: &[FieldHelp] = &[
     FieldHelp {
+        name: "Profile",
+        description: "Settings profile for session defaults (Left/Right to cycle)",
+    },
+    FieldHelp {
         name: "Title",
         description: "Session name (auto-generates if empty)",
     },
@@ -61,7 +65,7 @@ pub(super) const FIELD_HELP: &[FieldHelp] = &[
     },
     FieldHelp {
         name: "Sandbox",
-        description: "Run session in Docker container for isolation",
+        description: "Run session in Docker container for isolation (Ctrl+P to configure)",
     },
     FieldHelp {
         name: "Image",
@@ -87,6 +91,7 @@ pub(super) const FIELD_HELP: &[FieldHelp] = &[
 
 #[derive(Clone)]
 pub struct NewSessionData {
+    pub profile: String,
     pub title: String,
     pub path: String,
     pub group: String,
@@ -105,10 +110,11 @@ pub struct NewSessionData {
 
 /// Spinner frames for loading animation
 pub(super) const SPINNER_FRAMES: &[&str] = &["◐", "◓", "◑", "◒"];
-const PATH_FIELD: usize = 1;
 
 pub struct NewSessionDialog {
     pub(super) profile: String,
+    pub(super) available_profiles: Vec<String>,
+    pub(super) profile_index: usize,
     pub(super) title: Input,
     pub(super) path: Input,
     pub(super) group: Input,
@@ -142,6 +148,8 @@ pub struct NewSessionDialog {
     pub(super) inherited_expanded: bool,
     /// Pre-computed label/value pairs for non-default inherited sandbox settings.
     pub(super) inherited_settings: Vec<(String, String)>,
+    pub(super) sandbox_config_mode: bool,
+    pub(super) sandbox_focused_field: usize,
     pub(super) existing_groups: Vec<String>,
     pub(super) group_picker: ListPicker,
     pub(super) branch_picker: ListPicker,
@@ -289,6 +297,7 @@ impl NewSessionDialog {
         existing_titles: Vec<String>,
         existing_groups: Vec<String>,
         profile: &str,
+        available_profiles: Vec<String>,
     ) -> Self {
         let current_dir = std::env::current_dir()
             .map(|p| p.to_string_lossy().to_string())
@@ -328,8 +337,15 @@ impl NewSessionDialog {
             (Vec::new(), Vec::new(), Vec::new())
         };
 
+        let profile_index = available_profiles
+            .iter()
+            .position(|p| p == profile)
+            .unwrap_or(0);
+
         Self {
             profile: profile.to_string(),
+            available_profiles,
+            profile_index,
             title: Input::default(),
             path: Input::new(current_dir),
             group: Input::default(),
@@ -361,6 +377,8 @@ impl NewSessionDialog {
             env_values_adding_new: false,
             inherited_expanded: false,
             inherited_settings,
+            sandbox_config_mode: false,
+            sandbox_focused_field: 0,
             error_message: None,
             show_help: false,
             loading: false,
@@ -432,6 +450,74 @@ impl NewSessionDialog {
         changed
     }
 
+    pub(super) fn selected_profile(&self) -> &str {
+        &self.available_profiles[self.profile_index]
+    }
+
+    pub(super) fn has_profile_selection(&self) -> bool {
+        self.available_profiles.len() > 1
+    }
+
+    /// The field index of the path field (shifts based on whether profile picker is visible)
+    fn path_field(&self) -> usize {
+        if self.has_profile_selection() {
+            2
+        } else {
+            1
+        }
+    }
+
+    /// Re-resolve config defaults when the profile changes.
+    /// Resets tool, yolo, sandbox, and env settings but preserves user inputs
+    /// (title, path, group, worktree).
+    fn reload_config_defaults(&mut self) {
+        let profile = self.selected_profile().to_string();
+        self.profile = profile.clone();
+        let config = resolve_config(&profile).unwrap_or_default();
+
+        // Reset tool index
+        self.tool_index = if let Some(ref default_tool) = config.session.default_tool {
+            self.available_tools
+                .iter()
+                .position(|&t| t == default_tool.as_str())
+                .unwrap_or(0)
+        } else {
+            0
+        };
+
+        // Reset sandbox/yolo defaults
+        self.yolo_mode = config.session.yolo_mode_default;
+        self.sandbox_enabled = self.docker_available && config.sandbox.enabled_by_default;
+
+        // Reset sandbox image from resolved config (includes profile overrides)
+        self.sandbox_image = Input::new(config.sandbox.default_image.clone());
+
+        // Reset env keys, values, inherited settings
+        if self.sandbox_enabled {
+            self.extra_env_keys = config.sandbox.environment.clone();
+            self.extra_env_values = config
+                .sandbox
+                .environment_values
+                .iter()
+                .map(|(k, v)| format!("{}={}", k, v))
+                .collect();
+            self.inherited_settings = build_inherited_settings(&config.sandbox);
+        } else {
+            self.extra_env_keys.clear();
+            self.extra_env_values.clear();
+            self.inherited_settings.clear();
+        }
+
+        // Reset expanded states
+        self.env_list_expanded = false;
+        self.env_editing_input = None;
+        self.env_values_list_expanded = false;
+        self.env_values_editing_input = None;
+        self.inherited_expanded = false;
+        self.sandbox_config_mode = false;
+        self.sandbox_focused_field = 0;
+    }
+
     #[cfg(test)]
     pub(super) fn new_with_config(tools: Vec<&'static str>, path: String, config: Config) -> Self {
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
@@ -445,6 +531,8 @@ impl NewSessionDialog {
 
         Self {
             profile: "default".to_string(),
+            available_profiles: vec!["default".to_string()],
+            profile_index: 0,
             title: Input::default(),
             path: Input::new(path),
             group: Input::default(),
@@ -476,6 +564,8 @@ impl NewSessionDialog {
             env_values_adding_new: false,
             inherited_expanded: false,
             inherited_settings: Vec::new(),
+            sandbox_config_mode: false,
+            sandbox_focused_field: 0,
             error_message: None,
             show_help: false,
             loading: false,
@@ -495,6 +585,8 @@ impl NewSessionDialog {
     pub(super) fn new_with_tools(tools: Vec<&'static str>, path: String) -> Self {
         Self {
             profile: "default".to_string(),
+            available_profiles: vec!["default".to_string()],
+            profile_index: 0,
             title: Input::default(),
             path: Input::new(path),
             group: Input::default(),
@@ -526,6 +618,8 @@ impl NewSessionDialog {
             env_values_adding_new: false,
             inherited_expanded: false,
             inherited_settings: Vec::new(),
+            sandbox_config_mode: false,
+            sandbox_focused_field: 0,
             error_message: None,
             show_help: false,
             loading: false,
@@ -562,6 +656,11 @@ impl NewSessionDialog {
             return DialogResult::Continue;
         }
 
+        // Delegate to sandbox config mode handler when active
+        if self.sandbox_config_mode {
+            return self.handle_sandbox_config_key(key);
+        }
+
         if self.confirm_create_dir.is_some() {
             return self.handle_confirm_create_dir_key(key);
         }
@@ -592,17 +691,24 @@ impl NewSessionDialog {
             return DialogResult::Continue;
         }
 
+        let has_profile_selection = self.available_profiles.len() > 1;
         let has_tool_selection = self.available_tools.len() > 1;
         let has_sandbox = self.docker_available;
         let has_worktree = !self.worktree_branch.value().is_empty();
-        let sandbox_options_visible = has_sandbox && self.sandbox_enabled;
-        // Field order: title(0), path(1), [tool(2)], yolo, worktree,
-        //   [new_branch], [sandbox], [image, env, env_values, inherited], group
-        // INVARIANT: sandbox sub-options (image, env, env_values, inherited) must be
-        // contiguous and immediately after the sandbox checkbox. Toggling sandbox off
-        // hides them as a group and clamps focus to sandbox_field.
-        let tool_field = if has_tool_selection { 2 } else { usize::MAX };
-        let yolo_mode_field = if has_tool_selection { 3 } else { 2 };
+        // Field order: [profile], title, path, [tool], yolo, worktree,
+        //   [new_branch], [sandbox], group
+        // Sandbox sub-options are in a separate sandbox_config_mode overlay.
+        let profile_field = if has_profile_selection { 0 } else { usize::MAX };
+        let mut fi = if has_profile_selection { 1 } else { 0 }; // next field index
+        fi += 2; // title + path
+        let tool_field = if has_tool_selection {
+            let f = fi;
+            fi += 1;
+            f
+        } else {
+            usize::MAX
+        };
+        let yolo_mode_field = fi;
         let worktree_field = yolo_mode_field + 1;
         let new_branch_field = if has_worktree {
             worktree_field + 1
@@ -621,49 +727,13 @@ impl NewSessionDialog {
         } else {
             usize::MAX
         };
-        let _sandbox_image_field = if sandbox_options_visible {
-            let f = next;
-            next += 1;
-            f
-        } else {
-            usize::MAX
-        };
-        let env_field = if sandbox_options_visible {
-            let f = next;
-            next += 1;
-            f
-        } else {
-            usize::MAX
-        };
-        let env_values_field = if sandbox_options_visible {
-            let f = next;
-            next += 1;
-            f
-        } else {
-            usize::MAX
-        };
-        let inherited_field = if sandbox_options_visible {
-            let f = next;
-            next += 1;
-            f
-        } else {
-            usize::MAX
-        };
         let group_field = next;
         next += 1;
         let max_field = next;
 
-        // Handle env list editing mode
-        if self.env_list_expanded && self.focused_field == env_field {
-            return self.handle_env_list_key(key);
-        }
-        if self.env_values_list_expanded && self.focused_field == env_values_field {
-            return self.handle_env_values_list_key(key);
-        }
-
         // Ctrl+P opens a context-sensitive picker
         if key.code == KeyCode::Char('p') && key.modifiers.contains(KeyModifiers::CONTROL) {
-            if self.focused_field == PATH_FIELD {
+            if self.focused_field == self.path_field() {
                 let path_value = self.path.value().trim().to_string();
                 self.dir_picker.activate(&path_value);
                 return DialogResult::Continue;
@@ -679,6 +749,11 @@ impl NewSessionDialog {
                         self.branch_picker.activate(branches);
                     }
                 }
+                return DialogResult::Continue;
+            }
+            if self.focused_field == sandbox_field && self.sandbox_enabled {
+                self.sandbox_config_mode = true;
+                self.sandbox_focused_field = 0;
                 return DialogResult::Continue;
             }
         }
@@ -700,16 +775,6 @@ impl NewSessionDialog {
                 self.error_message = None;
                 DialogResult::Cancel
             }
-            KeyCode::Enter if self.focused_field == env_field => {
-                self.env_list_expanded = true;
-                self.env_selected_index = 0;
-                DialogResult::Continue
-            }
-            KeyCode::Enter if self.focused_field == env_values_field => {
-                self.env_values_list_expanded = true;
-                self.env_values_selected_index = 0;
-                DialogResult::Continue
-            }
             KeyCode::Enter => {
                 self.error_message = None;
                 let path_str = self.path.value().trim().to_string();
@@ -721,14 +786,14 @@ impl NewSessionDialog {
                 self.build_submit_result()
             }
             KeyCode::Tab | KeyCode::Down => {
-                if self.focused_field == PATH_FIELD {
+                if self.focused_field == self.path_field() {
                     self.clear_path_ghost();
                 }
                 if self.focused_field == group_field {
                     self.clear_group_ghost();
                 }
                 self.focused_field = (self.focused_field + 1) % max_field;
-                if self.focused_field == PATH_FIELD {
+                if self.focused_field == self.path_field() {
                     self.recompute_path_ghost();
                 }
                 if self.focused_field == group_field {
@@ -737,7 +802,7 @@ impl NewSessionDialog {
                 DialogResult::Continue
             }
             KeyCode::BackTab | KeyCode::Up => {
-                if self.focused_field == PATH_FIELD {
+                if self.focused_field == self.path_field() {
                     self.clear_path_ghost();
                 }
                 if self.focused_field == group_field {
@@ -748,11 +813,29 @@ impl NewSessionDialog {
                 } else {
                     self.focused_field - 1
                 };
-                if self.focused_field == PATH_FIELD {
+                if self.focused_field == self.path_field() {
                     self.recompute_path_ghost();
                 }
                 if self.focused_field == group_field {
                     self.recompute_group_ghost();
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if self.focused_field == profile_field =>
+            {
+                if self.available_profiles.len() > 1 {
+                    if key.code == KeyCode::Left {
+                        self.profile_index = if self.profile_index == 0 {
+                            self.available_profiles.len() - 1
+                        } else {
+                            self.profile_index - 1
+                        };
+                    } else {
+                        self.profile_index =
+                            (self.profile_index + 1) % self.available_profiles.len();
+                    }
+                    self.reload_config_defaults();
                 }
                 DialogResult::Continue
             }
@@ -775,7 +858,6 @@ impl NewSessionDialog {
             {
                 self.sandbox_enabled = !self.sandbox_enabled;
                 if self.sandbox_enabled {
-                    // Reload env keys/values from config
                     let config = resolve_config(&self.profile).unwrap_or_default();
                     self.extra_env_keys = config.sandbox.environment.clone();
                     self.extra_env_values = config
@@ -794,10 +876,7 @@ impl NewSessionDialog {
                     self.env_values_editing_input = None;
                     self.inherited_expanded = false;
                     self.inherited_settings.clear();
-                    // Clamp focused_field if we were on a sandbox sub-option
-                    if self.focused_field > sandbox_field {
-                        self.focused_field = sandbox_field;
-                    }
+                    self.sandbox_config_mode = false;
                 }
                 DialogResult::Continue
             }
@@ -807,31 +886,93 @@ impl NewSessionDialog {
                 self.yolo_mode = !self.yolo_mode;
                 DialogResult::Continue
             }
-            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
-                if self.focused_field == inherited_field =>
-            {
-                self.inherited_expanded = !self.inherited_expanded;
-                DialogResult::Continue
-            }
             _ => {
-                if self.focused_field != tool_field
+                if self.focused_field != profile_field
+                    && self.focused_field != tool_field
                     && self.focused_field != new_branch_field
                     && self.focused_field != sandbox_field
                     && self.focused_field != yolo_mode_field
-                    && self.focused_field != env_field
-                    && self.focused_field != env_values_field
-                    && self.focused_field != inherited_field
                 {
                     self.current_input_mut()
                         .handle_event(&crossterm::event::Event::Key(key));
                     self.error_message = None;
-                    if self.focused_field == PATH_FIELD {
+                    if self.focused_field == self.path_field() {
                         self.path_invalid_flash_until = None;
                         self.recompute_path_ghost();
                     }
                     if self.focused_field == group_field {
                         self.recompute_group_ghost();
                     }
+                }
+                DialogResult::Continue
+            }
+        }
+    }
+
+    /// Handle key events when in sandbox configuration mode.
+    fn handle_sandbox_config_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
+        // Sandbox config fields: 0=image, 1=env, 2=env_values, 3=inherited
+        const SANDBOX_IMAGE: usize = 0;
+        const SANDBOX_ENV: usize = 1;
+        const SANDBOX_ENV_VALUES: usize = 2;
+        const SANDBOX_INHERITED: usize = 3;
+        const SANDBOX_MAX: usize = 4;
+
+        // Handle env list editing when expanded
+        if self.env_list_expanded && self.sandbox_focused_field == SANDBOX_ENV {
+            return self.handle_env_list_key(key);
+        }
+        if self.env_values_list_expanded && self.sandbox_focused_field == SANDBOX_ENV_VALUES {
+            return self.handle_env_values_list_key(key);
+        }
+
+        match key.code {
+            KeyCode::Esc => {
+                self.sandbox_config_mode = false;
+                DialogResult::Continue
+            }
+            KeyCode::Char('?') => {
+                self.show_help = true;
+                DialogResult::Continue
+            }
+            KeyCode::Enter if self.sandbox_focused_field == SANDBOX_ENV => {
+                self.env_list_expanded = true;
+                self.env_selected_index = 0;
+                DialogResult::Continue
+            }
+            KeyCode::Enter if self.sandbox_focused_field == SANDBOX_ENV_VALUES => {
+                self.env_values_list_expanded = true;
+                self.env_values_selected_index = 0;
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                // Non-expandable fields: return to main dialog
+                self.sandbox_config_mode = false;
+                DialogResult::Continue
+            }
+            KeyCode::Tab | KeyCode::Down => {
+                self.sandbox_focused_field = (self.sandbox_focused_field + 1) % SANDBOX_MAX;
+                DialogResult::Continue
+            }
+            KeyCode::BackTab | KeyCode::Up => {
+                self.sandbox_focused_field = if self.sandbox_focused_field == 0 {
+                    SANDBOX_MAX - 1
+                } else {
+                    self.sandbox_focused_field - 1
+                };
+                DialogResult::Continue
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if self.sandbox_focused_field == SANDBOX_INHERITED =>
+            {
+                self.inherited_expanded = !self.inherited_expanded;
+                DialogResult::Continue
+            }
+            _ => {
+                // Text input for image field only
+                if self.sandbox_focused_field == SANDBOX_IMAGE {
+                    self.sandbox_image
+                        .handle_event(&crossterm::event::Event::Key(key));
                 }
                 DialogResult::Continue
             }
@@ -870,9 +1011,11 @@ impl NewSessionDialog {
     fn current_input_mut(&mut self) -> &mut Input {
         let has_tool_selection = self.available_tools.len() > 1;
         let has_worktree = !self.worktree_branch.value().is_empty();
-        let sandbox_options_visible = self.docker_available && self.sandbox_enabled;
+        let base = if self.has_profile_selection() { 1 } else { 0 };
 
-        let yolo_mode_field = if has_tool_selection { 3 } else { 2 };
+        // Field layout: [profile], title, path, [tool], yolo, worktree,
+        //   [new_branch], [sandbox], group
+        let yolo_mode_field = base + 2 + if has_tool_selection { 1 } else { 0 };
         let worktree_field = yolo_mode_field + 1;
         let new_branch_field = if has_worktree {
             worktree_field + 1
@@ -887,23 +1030,14 @@ impl NewSessionDialog {
         if self.docker_available {
             next += 1; // sandbox checkbox
         }
-        let sandbox_image_field = if sandbox_options_visible {
-            let f = next;
-            next += 1;
-            f
-        } else {
-            usize::MAX
-        };
-        if sandbox_options_visible {
-            next += 3; // env, env_values, inherited
-        }
         let group_field = next;
 
+        let path_field = self.path_field();
+        let title_field = if self.has_profile_selection() { 1 } else { 0 };
         match self.focused_field {
-            0 => &mut self.title,
-            PATH_FIELD => &mut self.path,
+            n if n == title_field => &mut self.title,
+            n if n == path_field => &mut self.path,
             n if n == worktree_field => &mut self.worktree_branch,
-            n if n == sandbox_image_field => &mut self.sandbox_image,
             n if n == group_field => &mut self.group,
             _ => &mut self.title,
         }
@@ -924,6 +1058,7 @@ impl NewSessionDialog {
             Some(worktree_value.to_string())
         };
         DialogResult::Submit(NewSessionData {
+            profile: self.selected_profile().to_string(),
             title: final_title,
             path: self.path.value().trim().to_string(),
             group: self.group.value().trim().to_string(),
@@ -967,7 +1102,7 @@ impl NewSessionDialog {
             }
             KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
                 self.confirm_create_dir = None;
-                self.focused_field = PATH_FIELD;
+                self.focused_field = self.path_field();
                 DialogResult::Continue
             }
             KeyCode::Enter => {
@@ -976,7 +1111,7 @@ impl NewSessionDialog {
                 if yes {
                     self.try_create_dir_and_submit()
                 } else {
-                    self.focused_field = PATH_FIELD;
+                    self.focused_field = self.path_field();
                     DialogResult::Continue
                 }
             }
@@ -991,7 +1126,7 @@ impl NewSessionDialog {
             Ok(()) => self.build_submit_result(),
             Err(e) => {
                 self.error_message = Some(format!("Failed to create directory: {}", e));
-                self.focused_field = PATH_FIELD;
+                self.focused_field = self.path_field();
                 DialogResult::Continue
             }
         }

--- a/src/tui/dialogs/new_session/path_input.rs
+++ b/src/tui/dialogs/new_session/path_input.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
-use super::{NewSessionDialog, PATH_FIELD};
+use super::NewSessionDialog;
 use crate::tui::components::longest_common_prefix;
 
 pub(super) struct PathGhostCompletion {
@@ -59,7 +59,7 @@ fn path_completion_base(parent_prefix: &str) -> Option<PathBuf> {
 
 impl NewSessionDialog {
     pub(super) fn handle_path_shortcuts(&mut self, key: KeyEvent) -> bool {
-        if self.focused_field != PATH_FIELD {
+        if self.focused_field != self.path_field() {
             return false;
         }
 

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -3,7 +3,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
-use super::{NewSessionDialog, FIELD_HELP, HELP_DIALOG_WIDTH, PATH_FIELD, SPINNER_FRAMES};
+use super::{NewSessionDialog, FIELD_HELP, HELP_DIALOG_WIDTH, SPINNER_FRAMES};
 use crate::tui::components::{render_text_field, render_text_field_with_ghost};
 use crate::tui::styles::Theme;
 
@@ -15,59 +15,35 @@ impl NewSessionDialog {
             return;
         }
 
+        // If in sandbox config mode, render that overlay instead
+        if self.sandbox_config_mode {
+            self.render_sandbox_config(frame, area, theme);
+            return;
+        }
+
+        let has_profile_selection = self.has_profile_selection();
         let has_tool_selection = self.available_tools.len() > 1;
         let has_sandbox = self.docker_available;
         let has_worktree = !self.worktree_branch.value().is_empty();
-        let sandbox_options_visible = has_sandbox && self.sandbox_enabled;
         let dialog_width = 80;
-        // Calculate env list heights based on expanded state and number of items
-        let env_list_height: u16 = if sandbox_options_visible {
-            if self.env_list_expanded {
-                (2 + self.extra_env_keys.len() as u16).clamp(4, 8)
-            } else {
-                2
-            }
-        } else {
-            0
-        };
-        let env_values_list_height: u16 = if sandbox_options_visible {
-            if self.env_values_list_expanded {
-                (2 + self.extra_env_values.len() as u16).clamp(4, 8)
-            } else {
-                2
-            }
-        } else {
-            0
-        };
-        let inherited_height: u16 = if sandbox_options_visible {
-            if self.inherited_expanded {
-                3 + self.inherited_settings.len().max(1) as u16
-            } else {
-                2
-            }
-        } else {
-            0
-        };
 
         // Build constraints dynamically based on visible fields only
-        let mut constraints = vec![
+        let mut constraints = Vec::new();
+        if has_profile_selection {
+            constraints.push(Constraint::Length(2)); // Profile
+        }
+        constraints.extend([
             Constraint::Length(2), // Title
             Constraint::Length(2), // Path
             Constraint::Length(2), // Tool (always shown, interactive or not)
             Constraint::Length(2), // YOLO mode checkbox (always visible)
             Constraint::Length(2), // Worktree Branch
-        ];
+        ]);
         if has_worktree {
             constraints.push(Constraint::Length(2)); // New Branch checkbox
         }
         if has_sandbox {
-            constraints.push(Constraint::Length(2)); // Sandbox checkbox
-        }
-        if sandbox_options_visible {
-            constraints.push(Constraint::Length(2)); // Image field
-            constraints.push(Constraint::Length(env_list_height)); // Env vars field
-            constraints.push(Constraint::Length(env_values_list_height)); // Env values field
-            constraints.push(Constraint::Length(inherited_height)); // Inherited settings
+            constraints.push(Constraint::Length(2)); // Sandbox checkbox (summary only)
         }
         constraints.push(Constraint::Length(2)); // Group (always, at the bottom)
 
@@ -84,7 +60,6 @@ impl NewSessionDialog {
         constraints.push(Constraint::Min(error_lines)); // Hints/errors
 
         // Compute dialog height from actual constraints
-        // border (2) + margin (2) + sum of field heights + hint line (2)
         let fields_height: u16 = constraints
             .iter()
             .map(|c| match c {
@@ -117,32 +92,56 @@ impl NewSessionDialog {
         // Render fields sequentially, tracking chunk index to match dynamic constraints
         let mut ci = 0; // chunk index
 
-        // Title, Path (always visible)
-        let path_placeholder = if self.focused_field == PATH_FIELD {
-            Some("(Ctrl+P to browse directories)")
+        // Field index calculations (must match handle_key)
+        let base = if has_profile_selection { 1 } else { 0 };
+        let title_field = base;
+        let yolo_mode_field = base + 2 + if has_tool_selection { 1 } else { 0 };
+        let worktree_field = yolo_mode_field + 1;
+        let new_branch_field = worktree_field + 1;
+        let mut next_field_idx = if has_worktree {
+            new_branch_field + 1
         } else {
-            None
+            worktree_field + 1
         };
+        let sandbox_field = if has_sandbox {
+            let f = next_field_idx;
+            next_field_idx += 1;
+            f
+        } else {
+            usize::MAX
+        };
+        let group_field = next_field_idx;
 
+        // Profile picker (only when multiple profiles)
+        if has_profile_selection {
+            self.render_profile_field(frame, chunks[ci], theme);
+            ci += 1;
+        }
+
+        // Title
         render_text_field(
             frame,
             chunks[ci],
             "Title:",
             &self.title,
-            self.focused_field == 0,
+            self.focused_field == title_field,
             Some("(random civ)"),
             theme,
         );
         ci += 1;
 
+        // Path
+        let path_placeholder = if self.focused_field == self.path_field() {
+            Some("(Ctrl+P to browse directories)")
+        } else {
+            None
+        };
         self.render_path_field(frame, chunks[ci], path_placeholder, theme);
         ci += 1;
 
         // Tool (always shown, interactive or read-only)
-        let yolo_mode_field = if has_tool_selection { 3 } else { 2 };
-        let worktree_field = yolo_mode_field + 1;
-        let is_tool_focused = self.focused_field == 2;
-
+        let tool_field = base + 2;
+        let is_tool_focused = has_tool_selection && self.focused_field == tool_field;
         if has_tool_selection {
             let label_style = if is_tool_focused {
                 Style::default().fg(theme.accent).underlined()
@@ -179,7 +178,7 @@ impl NewSessionDialog {
         }
         ci += 1;
 
-        // YOLO Mode checkbox (always visible, right after tool)
+        // YOLO Mode checkbox
         {
             let is_yolo_focused = self.focused_field == yolo_mode_field;
             let yolo_label_style = if is_yolo_focused {
@@ -212,7 +211,7 @@ impl NewSessionDialog {
             ci += 1;
         }
 
-        // Worktree Branch (always visible)
+        // Worktree Branch
         let worktree_placeholder = if self.focused_field == worktree_field {
             Some("(leave empty to skip | Ctrl+P to browse branches)")
         } else {
@@ -230,7 +229,6 @@ impl NewSessionDialog {
         ci += 1;
 
         // New Branch checkbox (only when worktree is set)
-        let new_branch_field = worktree_field + 1;
         if has_worktree {
             let is_nb_focused = self.focused_field == new_branch_field;
             let nb_label_style = if is_nb_focused {
@@ -266,15 +264,8 @@ impl NewSessionDialog {
             ci += 1;
         }
 
-        // Sandbox checkbox (only when Docker available)
-        let mut next_field_idx = if has_worktree {
-            new_branch_field + 1
-        } else {
-            worktree_field + 1
-        };
+        // Sandbox checkbox with summary (only when Docker available)
         if has_sandbox {
-            let sandbox_field = next_field_idx;
-            next_field_idx += 1;
             let is_sandbox_focused = self.focused_field == sandbox_field;
             let sandbox_label_style = if is_sandbox_focused {
                 Style::default().fg(theme.accent).underlined()
@@ -289,59 +280,32 @@ impl NewSessionDialog {
                 Style::default().fg(theme.dimmed)
             };
 
-            let sandbox_line = Line::from(vec![
+            let mut spans = vec![
                 Span::styled("Sandbox:", sandbox_label_style),
                 Span::raw(" "),
                 Span::styled(checkbox, checkbox_style),
                 Span::styled(
-                    " Run in Docker container",
+                    " Run in Docker",
                     if self.sandbox_enabled {
                         Style::default().fg(theme.accent)
                     } else {
                         Style::default().fg(theme.dimmed)
                     },
                 ),
-            ]);
-            frame.render_widget(Paragraph::new(sandbox_line), chunks[ci]);
-            ci += 1;
-        }
+            ];
 
-        if sandbox_options_visible {
-            // Image field
-            let sandbox_image_field = next_field_idx;
-            next_field_idx += 1;
-            render_text_field(
-                frame,
-                chunks[ci],
-                "  Image:",
-                &self.sandbox_image,
-                self.focused_field == sandbox_image_field,
-                None,
-                theme,
-            );
-            ci += 1;
+            if self.sandbox_enabled {
+                spans.push(Span::styled(
+                    "  (Ctrl+P to configure)",
+                    Style::default().fg(theme.dimmed),
+                ));
+            }
 
-            // Environment variables field
-            let env_field = next_field_idx;
-            next_field_idx += 1;
-            self.render_env_field(frame, chunks[ci], env_field, theme);
-            ci += 1;
-
-            // Environment values field (KEY=VALUE)
-            let env_values_field = next_field_idx;
-            next_field_idx += 1;
-            self.render_env_values_field(frame, chunks[ci], env_values_field, theme);
-            ci += 1;
-
-            // Inherited settings (read-only)
-            let inherited_field = next_field_idx;
-            next_field_idx += 1;
-            self.render_inherited_field(frame, chunks[ci], inherited_field, theme);
+            frame.render_widget(Paragraph::new(Line::from(spans)), chunks[ci]);
             ci += 1;
         }
 
         // Group (always visible, at the bottom before hints)
-        let group_field = next_field_idx;
         let group_placeholder =
             if !self.existing_groups.is_empty() && self.focused_field == group_field {
                 Some("(Ctrl+P to browse groups)")
@@ -398,7 +362,7 @@ impl NewSessionDialog {
                 hint_spans.push(Span::styled("←/→", Style::default().fg(theme.hint)));
                 hint_spans.push(Span::raw(" tool  "));
             }
-            if self.focused_field == PATH_FIELD {
+            if self.focused_field == self.path_field() {
                 if self.ghost_text().is_some() {
                     hint_spans.push(Span::styled("→", Style::default().fg(theme.hint)));
                     hint_spans.push(Span::raw(" accept  "));
@@ -448,6 +412,34 @@ impl NewSessionDialog {
         }
     }
 
+    fn render_profile_field(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let is_focused = self.focused_field == 0;
+        let label_style = if is_focused {
+            Style::default().fg(theme.accent).underlined()
+        } else {
+            Style::default().fg(theme.text)
+        };
+
+        let selected = self.selected_profile();
+        let profile_style = if is_focused {
+            Style::default().fg(theme.accent).bold()
+        } else {
+            Style::default().fg(theme.accent)
+        };
+
+        let mut spans = vec![Span::styled("Profile:", label_style), Span::raw(" ")];
+
+        if self.available_profiles.len() > 1 {
+            spans.push(Span::styled("< ", Style::default().fg(theme.dimmed)));
+            spans.push(Span::styled(selected, profile_style));
+            spans.push(Span::styled(" >", Style::default().fg(theme.dimmed)));
+        } else {
+            spans.push(Span::styled(selected, profile_style));
+        }
+
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
     fn render_path_field(
         &self,
         frame: &mut Frame,
@@ -455,7 +447,7 @@ impl NewSessionDialog {
         placeholder: Option<&str>,
         theme: &Theme,
     ) {
-        let is_focused = self.focused_field == PATH_FIELD;
+        let is_focused = self.focused_field == self.path_field();
         let flashing_invalid = self.is_path_invalid_flash_active();
 
         let label_color = if flashing_invalid {
@@ -520,8 +512,106 @@ impl NewSessionDialog {
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
     }
 
-    fn render_env_field(&self, frame: &mut Frame, area: Rect, env_field: usize, theme: &Theme) {
-        let is_focused = self.focused_field == env_field;
+    fn render_sandbox_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dialog_width: u16 = 72;
+
+        // Sandbox config fields: image, env vars, env values, inherited
+        let env_list_height: u16 = if self.env_list_expanded {
+            (2 + self.extra_env_keys.len() as u16).clamp(4, 8)
+        } else {
+            2
+        };
+        let env_values_list_height: u16 = if self.env_values_list_expanded {
+            (2 + self.extra_env_values.len() as u16).clamp(4, 8)
+        } else {
+            2
+        };
+        let inherited_height: u16 = if self.inherited_expanded {
+            3 + self.inherited_settings.len().max(1) as u16
+        } else {
+            2
+        };
+
+        let constraints = vec![
+            Constraint::Length(2),                      // Image
+            Constraint::Length(env_list_height),        // Env vars
+            Constraint::Length(env_values_list_height), // Env values
+            Constraint::Length(inherited_height),       // Inherited settings
+            Constraint::Min(1),                         // Hints
+        ];
+
+        let fields_height: u16 = constraints
+            .iter()
+            .map(|c| match c {
+                Constraint::Length(n) => *n,
+                Constraint::Min(n) => *n,
+                _ => 0,
+            })
+            .sum();
+        let dialog_height = fields_height + 4;
+
+        let dialog_area = crate::tui::dialogs::centered_rect(area, dialog_width, dialog_height);
+
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.accent))
+            .title(" Sandbox Configuration ")
+            .title_style(Style::default().fg(theme.title).bold());
+
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints(constraints)
+            .split(inner);
+
+        let mut ci = 0;
+
+        // Image field
+        render_text_field(
+            frame,
+            chunks[ci],
+            "Image:",
+            &self.sandbox_image,
+            self.sandbox_focused_field == 0,
+            None,
+            theme,
+        );
+        ci += 1;
+
+        // Env vars
+        self.render_env_field(frame, chunks[ci], self.sandbox_focused_field == 1, theme);
+        ci += 1;
+
+        // Env values
+        self.render_env_values_field(frame, chunks[ci], self.sandbox_focused_field == 2, theme);
+        ci += 1;
+
+        // Inherited settings
+        self.render_inherited_field(frame, chunks[ci], self.sandbox_focused_field == 3, theme);
+        ci += 1;
+
+        // Hints
+        let hint_spans = vec![
+            Span::styled("Tab", Style::default().fg(theme.hint)),
+            Span::raw(" next  "),
+            Span::styled("Enter", Style::default().fg(theme.hint)),
+            Span::raw(" edit  "),
+            Span::styled("Esc", Style::default().fg(theme.hint)),
+            Span::raw(" back"),
+        ];
+        frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[ci]);
+
+        if self.show_help {
+            self.render_help_overlay(frame, area, theme);
+        }
+    }
+
+    fn render_env_field(&self, frame: &mut Frame, area: Rect, is_focused: bool, theme: &Theme) {
         let label_style = if is_focused {
             Style::default().fg(theme.accent).underlined()
         } else {
@@ -543,7 +633,7 @@ impl NewSessionDialog {
             };
 
             let line = Line::from(vec![
-                Span::styled("  Env Vars:", label_style),
+                Span::styled("Env Vars:", label_style),
                 Span::raw(" "),
                 Span::styled(summary, summary_style),
             ]);
@@ -554,7 +644,7 @@ impl NewSessionDialog {
 
             // Header with controls hint
             let header = Line::from(vec![
-                Span::styled("  Env Vars:", label_style),
+                Span::styled("Env Vars:", label_style),
                 Span::styled(
                     " (a)dd (d)el (Enter)edit (Esc)close",
                     Style::default().fg(theme.dimmed),
@@ -639,10 +729,9 @@ impl NewSessionDialog {
         &self,
         frame: &mut Frame,
         area: Rect,
-        field_idx: usize,
+        is_focused: bool,
         theme: &Theme,
     ) {
-        let is_focused = self.focused_field == field_idx;
         let label_style = if is_focused {
             Style::default().fg(theme.accent).underlined()
         } else {
@@ -663,7 +752,7 @@ impl NewSessionDialog {
             };
 
             let line = Line::from(vec![
-                Span::styled("  Env Values:", label_style),
+                Span::styled("Env Values:", label_style),
                 Span::raw(" "),
                 Span::styled(summary, summary_style),
             ]);
@@ -672,7 +761,7 @@ impl NewSessionDialog {
             let mut lines: Vec<Line> = Vec::new();
 
             let header = Line::from(vec![
-                Span::styled("  Env Values:", label_style),
+                Span::styled("Env Values:", label_style),
                 Span::styled(
                     " (a)dd (d)el (Enter)edit (Esc)close",
                     Style::default().fg(theme.dimmed),
@@ -748,10 +837,9 @@ impl NewSessionDialog {
         &self,
         frame: &mut Frame,
         area: Rect,
-        field_idx: usize,
+        is_focused: bool,
         theme: &Theme,
     ) {
-        let is_focused = self.focused_field == field_idx;
         let label_style = if is_focused {
             Style::default().fg(theme.accent).underlined()
         } else {
@@ -777,7 +865,7 @@ impl NewSessionDialog {
                 Style::default().fg(theme.dimmed)
             };
             let line = Line::from(vec![
-                Span::styled(format!("  {} ", arrow), label_style),
+                Span::styled(format!("{} ", arrow), label_style),
                 Span::styled("Inherited Settings ", label_style),
                 Span::styled(summary, summary_style),
             ]);
@@ -786,7 +874,7 @@ impl NewSessionDialog {
             let mut lines: Vec<Line> = Vec::new();
 
             let header = Line::from(vec![
-                Span::styled(format!("  {} ", arrow), label_style),
+                Span::styled(format!("{} ", arrow), label_style),
                 Span::styled("Inherited Settings", label_style),
             ]);
             lines.push(header);
@@ -819,11 +907,14 @@ impl NewSessionDialog {
         let show_sandbox_options_help = has_sandbox && self.sandbox_enabled;
 
         let dialog_width: u16 = HELP_DIALOG_WIDTH;
-        let base_height: u16 = 20; // includes YOLO Mode and Group (always visible)
+        let has_profile_selection = self.has_profile_selection();
+        // Base fields: Title, Path, YOLO, Worktree, New Branch, Group + close hint
+        let base_height: u16 = 20;
         let dialog_height: u16 = base_height
+            + if has_profile_selection { 3 } else { 0 }
             + if has_tool_selection { 3 } else { 0 }
             + if has_sandbox { 3 } else { 0 }
-            + if show_sandbox_options_help { 12 } else { 0 }; // Image, Env, Env Values, Inherited
+            + if show_sandbox_options_help { 12 } else { 0 };
 
         let dialog_area = crate::tui::dialogs::centered_rect(area, dialog_width, dialog_height);
 
@@ -841,17 +932,21 @@ impl NewSessionDialog {
         let mut lines: Vec<Line> = Vec::new();
 
         for (idx, help) in FIELD_HELP.iter().enumerate() {
-            if idx == 2 && !has_tool_selection {
-                continue;
+            if idx == 0 && !has_profile_selection {
+                continue; // Profile
             }
-            // idx 3 (YOLO), 4 (Worktree), 5 (New Branch) are always shown
-            if idx == 6 && !has_sandbox {
-                continue;
+            // idx 1 (Title), idx 2 (Path) always shown
+            if idx == 3 && !has_tool_selection {
+                continue; // Tool
             }
-            if (7..=10).contains(&idx) && !show_sandbox_options_help {
-                continue;
+            // idx 4 (YOLO), 5 (Worktree), 6 (New Branch) always shown
+            if idx == 7 && !has_sandbox {
+                continue; // Sandbox
             }
-            // idx 11 (Group) is always shown
+            if (8..=11).contains(&idx) && !show_sandbox_options_help {
+                continue; // Image, Env, Env Values, Inherited
+            }
+            // idx 12 (Group) always shown
 
             lines.push(Line::from(Span::styled(
                 help.name,
@@ -888,7 +983,6 @@ impl NewSessionDialog {
             50
         };
         let dialog_height: u16 = if show_hook_output {
-            // spinner line + command line + output lines + cancel hint + padding
             (6 + max_output_lines as u16).min(area.height)
         } else if needs_extra_line {
             9
@@ -920,9 +1014,7 @@ impl NewSessionDialog {
         if show_hook_output {
             let mut lines = vec![];
 
-            // Status line with spinner
             let status_text = if let Some(ref cmd) = self.current_hook {
-                // Truncate long commands to fit the dialog
                 let max_cmd_len = (dialog_width as usize).saturating_sub(12);
                 if cmd.len() > max_cmd_len {
                     let truncated: String =
@@ -943,7 +1035,6 @@ impl NewSessionDialog {
                 Span::styled(status_text, Style::default().fg(theme.text)),
             ]));
 
-            // Show last N output lines
             let output_start = self.hook_output.len().saturating_sub(max_output_lines);
             let visible_lines = &self.hook_output[output_start..];
             let inner_width = (dialog_width as usize).saturating_sub(6);
@@ -961,9 +1052,8 @@ impl NewSessionDialog {
                 )));
             }
 
-            // Pad remaining lines so cancel hint stays at bottom
-            let used = 1 + visible_lines.len(); // status + output
-            let available = dialog_height.saturating_sub(4) as usize; // borders + cancel line
+            let used = 1 + visible_lines.len();
+            let available = dialog_height.saturating_sub(4) as usize;
             for _ in used..available {
                 lines.push(Line::from(""));
             }

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -37,6 +37,8 @@ fn test_initial_state() {
     assert_eq!(dialog.group.value(), "");
     assert_eq!(dialog.focused_field, 0);
     assert_eq!(dialog.tool_index, 0);
+    assert_eq!(dialog.profile_index, 0);
+    assert_eq!(dialog.selected_profile(), "default");
 }
 
 #[test]
@@ -62,6 +64,7 @@ fn test_enter_submits_with_auto_title() {
             assert_eq!(data.path, TEST_PATH);
             assert_eq!(data.group, "");
             assert_eq!(data.tool, "claude");
+            assert_eq!(data.profile, "default");
         }
         _ => panic!("Expected Submit"),
     }
@@ -83,10 +86,10 @@ fn test_enter_preserves_custom_title() {
 #[test]
 fn test_tab_cycles_fields_single_tool() {
     let mut dialog = single_tool_dialog();
-    assert_eq!(dialog.focused_field, 0);
+    assert_eq!(dialog.focused_field, 0); // title (single profile, no profile field)
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1);
+    assert_eq!(dialog.focused_field, 1); // path
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // yolo mode
@@ -105,10 +108,10 @@ fn test_tab_cycles_fields_single_tool() {
 fn test_tab_cycles_fields_single_tool_with_worktree() {
     let mut dialog = single_tool_dialog();
     dialog.worktree_branch = Input::new("feature".to_string());
-    assert_eq!(dialog.focused_field, 0);
+    assert_eq!(dialog.focused_field, 0); // title
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1);
+    assert_eq!(dialog.focused_field, 1); // path
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // yolo mode
@@ -129,10 +132,10 @@ fn test_tab_cycles_fields_single_tool_with_worktree() {
 #[test]
 fn test_tab_cycles_fields_multi_tool() {
     let mut dialog = multi_tool_dialog();
-    assert_eq!(dialog.focused_field, 0);
+    assert_eq!(dialog.focused_field, 0); // title
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1);
+    assert_eq!(dialog.focused_field, 1); // path
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // tool selection
@@ -153,7 +156,7 @@ fn test_tab_cycles_fields_multi_tool() {
 #[test]
 fn test_backtab_cycles_fields_reverse() {
     let mut dialog = single_tool_dialog();
-    assert_eq!(dialog.focused_field, 0);
+    assert_eq!(dialog.focused_field, 0); // title
 
     dialog.handle_key(shift_key(KeyCode::BackTab));
     assert_eq!(dialog.focused_field, 4); // group (last field without worktree/docker)
@@ -174,6 +177,7 @@ fn test_backtab_cycles_fields_reverse() {
 #[test]
 fn test_char_input_to_title() {
     let mut dialog = single_tool_dialog();
+    dialog.focused_field = 0; // title
     dialog.handle_key(key(KeyCode::Char('H')));
     dialog.handle_key(key(KeyCode::Char('i')));
     assert_eq!(dialog.title.value(), "Hi");
@@ -182,7 +186,7 @@ fn test_char_input_to_title() {
 #[test]
 fn test_char_input_to_path() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.handle_key(key(KeyCode::Char('/')));
     dialog.handle_key(key(KeyCode::Char('a')));
     assert_eq!(dialog.path.value(), format!("{TEST_PATH}/a"));
@@ -195,7 +199,7 @@ fn test_ghost_text_appears_for_single_match() {
     fs::write(tmp.path().join("project-file"), "not a directory").expect("failed to write file");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -209,7 +213,7 @@ fn test_ghost_text_shows_common_prefix_for_multiple_matches() {
     fs::create_dir(tmp.path().join("client-web")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/cl", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -221,7 +225,7 @@ fn test_ghost_text_none_when_no_matches() {
     let tmp = tempfile::tempdir().expect("failed to create temp dir");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/zzz_nonexistent", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -234,7 +238,7 @@ fn test_ghost_shows_slash_for_exact_directory_match() {
     fs::create_dir(tmp.path().join("alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/alpha", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -247,7 +251,7 @@ fn test_right_arrow_accepts_ghost_text() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -266,7 +270,7 @@ fn test_end_key_accepts_ghost_text() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -282,7 +286,7 @@ fn test_end_key_accepts_ghost_text() {
 #[test]
 fn test_right_arrow_at_mid_input_moves_cursor_normally() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
     // Move cursor to start
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -302,7 +306,7 @@ fn test_ghost_recomputes_after_accepting() {
     fs::create_dir(tmp.path().join("alpha").join("inner")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/alp", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert_eq!(dialog.ghost_text(), Some("ha/"));
@@ -323,7 +327,7 @@ fn test_tab_always_navigates_from_path_field() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -331,7 +335,7 @@ fn test_tab_always_navigates_from_path_field() {
     dialog.handle_key(key(KeyCode::Tab));
 
     // Tab should navigate to next field, not accept ghost
-    assert_eq!(dialog.focused_field, 2);
+    assert_eq!(dialog.focused_field, 2); // yolo mode
 }
 
 #[test]
@@ -340,7 +344,7 @@ fn test_ghost_cleared_when_leaving_path_field() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -356,7 +360,7 @@ fn test_ghost_not_shown_when_cursor_not_at_end() {
     fs::create_dir(tmp.path().join("alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new(format!("{}/alp", tmp.path().display()));
     // Move cursor to start
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -368,7 +372,7 @@ fn test_ghost_not_shown_when_cursor_not_at_end() {
 #[test]
 fn test_invalid_path_flash_expires_after_tick() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path_invalid_flash_until =
         Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
     assert!(dialog.tick());
@@ -378,7 +382,7 @@ fn test_invalid_path_flash_expires_after_tick() {
 #[test]
 fn test_ctrl_left_jumps_to_previous_path_segment() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(ctrl_key(KeyCode::Left));
@@ -390,7 +394,7 @@ fn test_ctrl_left_jumps_to_previous_path_segment() {
 #[test]
 fn test_alt_b_jumps_to_previous_path_segment() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(alt_key(KeyCode::Char('b')));
@@ -402,7 +406,7 @@ fn test_alt_b_jumps_to_previous_path_segment() {
 #[test]
 fn test_ctrl_a_jumps_to_start_of_path() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1;
+    dialog.focused_field = 1; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -414,7 +418,7 @@ fn test_ctrl_a_jumps_to_start_of_path() {
 #[test]
 fn test_char_input_to_group() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 4; // group is at the bottom (single tool: yolo=2, worktree=3, group=4)
+    dialog.focused_field = 4; // group (single tool, single profile: title=0, path=1, yolo=2, worktree=3, group=4)
     dialog.handle_key(key(KeyCode::Char('w')));
     dialog.handle_key(key(KeyCode::Char('o')));
     dialog.handle_key(key(KeyCode::Char('r')));
@@ -425,6 +429,7 @@ fn test_char_input_to_group() {
 #[test]
 fn test_backspace_removes_char() {
     let mut dialog = single_tool_dialog();
+    dialog.focused_field = 0; // title
     dialog.title = Input::new("Hello".to_string());
     dialog.handle_key(key(KeyCode::Backspace));
     assert_eq!(dialog.title.value(), "Hell");
@@ -433,6 +438,7 @@ fn test_backspace_removes_char() {
 #[test]
 fn test_backspace_on_empty_field() {
     let mut dialog = single_tool_dialog();
+    dialog.focused_field = 0; // title
     dialog.handle_key(key(KeyCode::Backspace));
     assert_eq!(dialog.title.value(), "");
 }
@@ -440,7 +446,7 @@ fn test_backspace_on_empty_field() {
 #[test]
 fn test_tool_selection_left_right() {
     let mut dialog = multi_tool_dialog();
-    dialog.focused_field = 2; // tool field
+    dialog.focused_field = 2; // tool field (single profile: title=0, path=1, tool=2)
     assert_eq!(dialog.tool_index, 0);
 
     dialog.handle_key(key(KeyCode::Right));
@@ -469,7 +475,7 @@ fn test_tool_selection_space() {
 #[test]
 fn test_tool_selection_ignored_on_text_field() {
     let mut dialog = multi_tool_dialog();
-    dialog.focused_field = 0;
+    dialog.focused_field = 0; // title
     dialog.handle_key(key(KeyCode::Char(' ')));
     assert_eq!(dialog.title.value(), " ");
     assert_eq!(dialog.tool_index, 0);
@@ -509,6 +515,7 @@ fn test_unknown_key_continues() {
 #[test]
 fn test_error_clears_on_input() {
     let mut dialog = single_tool_dialog();
+    dialog.focused_field = 0; // title
     dialog.error_message = Some("Some error".to_string());
 
     dialog.handle_key(key(KeyCode::Char('a')));
@@ -535,7 +542,8 @@ fn test_new_branch_checkbox_default_true() {
 fn test_new_branch_checkbox_toggle() {
     let mut dialog = single_tool_dialog();
     dialog.worktree_branch = Input::new("feature-branch".to_string());
-    dialog.focused_field = 4; // new_branch checkbox field (single tool, with worktree set: yolo=2, worktree=3, new_branch=4)
+    // new_branch checkbox (single profile): title=0, path=1, yolo=2, worktree=3, new_branch=4
+    dialog.focused_field = 4;
     assert!(dialog.create_new_branch);
 
     dialog.handle_key(key(KeyCode::Char(' ')));
@@ -549,7 +557,7 @@ fn test_new_branch_checkbox_toggle() {
 fn test_submit_respects_create_new_branch() {
     let mut dialog = single_tool_dialog();
     dialog.worktree_branch = Input::new("feature-branch".to_string());
-    dialog.focused_field = 4; // new_branch (yolo=2, worktree=3, new_branch=4)
+    dialog.focused_field = 4; // new_branch
     dialog.handle_key(key(KeyCode::Char(' '))); // Toggle off
 
     let result = dialog.handle_key(key(KeyCode::Enter));
@@ -566,8 +574,8 @@ fn test_new_branch_field_hidden_without_worktree() {
     let mut dialog = single_tool_dialog();
     assert_eq!(dialog.focused_field, 0);
 
-    // Tab through all fields: title(0) -> path(1) -> yolo(2) -> worktree(3) -> group(4) -> wrap to 0
-    dialog.handle_key(key(KeyCode::Tab)); // 1
+    // Tab through (single profile): title(0) -> path(1) -> yolo(2) -> worktree(3) -> group(4) -> wrap to 0
+    dialog.handle_key(key(KeyCode::Tab)); // 1 (path)
     dialog.handle_key(key(KeyCode::Tab)); // 2 (yolo)
     dialog.handle_key(key(KeyCode::Tab)); // 3 (worktree)
     dialog.handle_key(key(KeyCode::Tab)); // 4 (group)
@@ -593,45 +601,32 @@ fn test_sandbox_image_initialized_with_effective_default() {
 }
 
 #[test]
-fn test_tab_includes_sandbox_options_when_sandbox_enabled() {
+fn test_tab_skips_sandbox_options_in_main_form() {
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
     dialog.sandbox_enabled = true;
 
-    // Tab through all fields:
-    // 0: title, 1: path, 2: tool, 3: yolo, 4: worktree, 5: sandbox, 6: image, 7: env keys, 8: env values, 9: inherited, 10: group
+    // With sandbox enabled, sandbox sub-options are in separate mode now.
+    // Main form (single profile): title(0), path(1), tool(2), yolo(3), worktree(4), sandbox(5), group(6)
     for _ in 0..5 {
         dialog.handle_key(key(KeyCode::Tab));
     }
     assert_eq!(dialog.focused_field, 5); // sandbox field
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 6); // sandbox image field
-
-    dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 7); // env keys field
-
-    dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 8); // env values field
-
-    dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 9); // inherited settings field
-
-    dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 10); // group field
+    assert_eq!(dialog.focused_field, 6); // group field (no sandbox sub-options inline)
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 0); // wrap to start
 }
 
 #[test]
-fn test_tab_skips_sandbox_image_when_sandbox_disabled() {
+fn test_tab_skips_sandbox_when_disabled() {
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
     dialog.sandbox_enabled = false;
 
-    // Tab through all fields - should not include sandbox image
-    // 0: title, 1: path, 2: tool, 3: yolo, 4: worktree, 5: sandbox, 6: group
+    // Single profile: title(0), path(1), tool(2), yolo(3), worktree(4), sandbox(5), group(6)
     for _ in 0..5 {
         dialog.handle_key(key(KeyCode::Tab));
     }
@@ -720,12 +715,13 @@ fn test_submit_sandbox_image_always_included() {
 }
 
 #[test]
-fn test_sandbox_image_input_works() {
+fn test_sandbox_image_input_in_config_mode() {
     use crate::containers;
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
     dialog.sandbox_enabled = true;
-    dialog.focused_field = 6; // sandbox image field (yolo=3, worktree=4, sandbox=5, image=6)
+    dialog.sandbox_config_mode = true;
+    dialog.sandbox_focused_field = 0; // image field
 
     dialog.handle_key(key(KeyCode::Char('a')));
     dialog.handle_key(key(KeyCode::Char('b')));
@@ -749,7 +745,7 @@ fn test_yolo_mode_toggle() {
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
     dialog.sandbox_enabled = true;
-    dialog.focused_field = 3; // yolo mode field (tool=2, yolo=3)
+    dialog.focused_field = 3; // yolo mode field (single profile: title=0, path=1, tool=2, yolo=3)
     assert!(!dialog.yolo_mode);
 
     dialog.handle_key(key(KeyCode::Char(' ')));
@@ -801,7 +797,8 @@ fn test_disabling_sandbox_does_not_reset_yolo_mode() {
     dialog.docker_available = true;
     dialog.sandbox_enabled = true;
     dialog.yolo_mode = true;
-    dialog.focused_field = 5; // sandbox field (yolo=3, worktree=4, sandbox=5)
+    // sandbox field (single profile): title=0, path=1, tool=2, yolo=3, worktree=4, sandbox=5
+    dialog.focused_field = 5;
 
     dialog.handle_key(key(KeyCode::Char(' ')));
     assert!(!dialog.sandbox_enabled);
@@ -916,7 +913,7 @@ fn test_confirm_esc_cancels() {
     let result = dialog.handle_key(key(KeyCode::Esc));
     assert!(matches!(result, DialogResult::Continue));
     assert!(dialog.confirm_create_dir.is_none());
-    assert_eq!(dialog.focused_field, PATH_FIELD);
+    assert_eq!(dialog.focused_field, dialog.path_field());
 }
 
 #[test]
@@ -925,7 +922,7 @@ fn test_confirm_n_cancels() {
     dialog.confirm_create_dir = Some(true);
     dialog.handle_key(key(KeyCode::Char('n')));
     assert!(dialog.confirm_create_dir.is_none());
-    assert_eq!(dialog.focused_field, PATH_FIELD);
+    assert_eq!(dialog.focused_field, dialog.path_field());
 }
 
 #[test]
@@ -989,7 +986,7 @@ fn test_confirm_enter_no_cancels() {
     let result = dialog.handle_key(key(KeyCode::Enter));
     assert!(matches!(result, DialogResult::Continue));
     assert!(dialog.confirm_create_dir.is_none());
-    assert_eq!(dialog.focused_field, PATH_FIELD);
+    assert_eq!(dialog.focused_field, dialog.path_field());
 }
 
 #[test]
@@ -1003,4 +1000,143 @@ fn test_confirm_create_failure_shows_error() {
     assert!(matches!(result, DialogResult::Continue));
     assert!(dialog.error_message.is_some());
     assert!(dialog.confirm_create_dir.is_none());
+}
+
+// --- Profile picker tests ---
+
+#[test]
+fn test_profile_cycling() {
+    let mut dialog = single_tool_dialog();
+    dialog.available_profiles = vec![
+        "default".to_string(),
+        "work".to_string(),
+        "personal".to_string(),
+    ];
+    dialog.profile_index = 0;
+    dialog.focused_field = 0; // profile field
+
+    // Right cycles forward
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.selected_profile(), "work");
+
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.selected_profile(), "personal");
+
+    // Wraps around
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.selected_profile(), "default");
+
+    // Left cycles backward
+    dialog.handle_key(key(KeyCode::Left));
+    assert_eq!(dialog.selected_profile(), "personal");
+}
+
+#[test]
+fn test_profile_single_profile_no_cycle() {
+    let mut dialog = single_tool_dialog();
+    dialog.available_profiles = vec!["default".to_string()];
+    dialog.profile_index = 0;
+    dialog.focused_field = 0;
+
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.selected_profile(), "default");
+    assert_eq!(dialog.profile_index, 0);
+}
+
+#[test]
+fn test_profile_included_in_submit() {
+    let mut dialog = single_tool_dialog();
+    dialog.available_profiles = vec!["default".to_string(), "work".to_string()];
+    dialog.focused_field = 0;
+
+    dialog.handle_key(key(KeyCode::Right)); // switch to "work"
+    let result = dialog.handle_key(key(KeyCode::Enter));
+
+    match result {
+        DialogResult::Submit(data) => {
+            assert_eq!(data.profile, "work");
+        }
+        _ => panic!("Expected Submit"),
+    }
+}
+
+// --- Sandbox config mode tests ---
+
+#[test]
+fn test_ctrl_p_on_sandbox_enters_config_mode() {
+    let mut dialog = multi_tool_dialog();
+    dialog.docker_available = true;
+    dialog.sandbox_enabled = true;
+    // sandbox field (single profile): title=0, path=1, tool=2, yolo=3, worktree=4, sandbox=5
+    dialog.focused_field = 5;
+
+    let result = dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(dialog.sandbox_config_mode);
+    assert_eq!(dialog.sandbox_focused_field, 0);
+}
+
+#[test]
+fn test_enter_on_sandbox_submits() {
+    let mut dialog = multi_tool_dialog();
+    dialog.docker_available = true;
+    dialog.sandbox_enabled = true;
+    dialog.focused_field = 5; // sandbox field
+
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    // Enter should submit, not enter config mode
+    assert!(!dialog.sandbox_config_mode);
+    assert!(matches!(result, DialogResult::Submit(_)));
+}
+
+#[test]
+fn test_ctrl_p_on_disabled_sandbox_does_not_open_config() {
+    let mut dialog = multi_tool_dialog();
+    dialog.docker_available = true;
+    dialog.sandbox_enabled = false;
+    dialog.focused_field = 5; // sandbox field
+
+    dialog.handle_key(ctrl_key(KeyCode::Char('p')));
+    assert!(!dialog.sandbox_config_mode);
+}
+
+#[test]
+fn test_sandbox_config_mode_esc_returns_to_main() {
+    let mut dialog = multi_tool_dialog();
+    dialog.sandbox_config_mode = true;
+    dialog.sandbox_focused_field = 1;
+
+    let result = dialog.handle_key(key(KeyCode::Esc));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(!dialog.sandbox_config_mode);
+}
+
+#[test]
+fn test_sandbox_config_mode_tab_cycles() {
+    let mut dialog = multi_tool_dialog();
+    dialog.sandbox_config_mode = true;
+    dialog.sandbox_focused_field = 0;
+
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.sandbox_focused_field, 1);
+
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.sandbox_focused_field, 2);
+
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.sandbox_focused_field, 3);
+
+    dialog.handle_key(key(KeyCode::Tab));
+    assert_eq!(dialog.sandbox_focused_field, 0); // wrap
+}
+
+#[test]
+fn test_sandbox_config_mode_enter_on_image_returns_to_main() {
+    let mut dialog = multi_tool_dialog();
+    dialog.sandbox_config_mode = true;
+    dialog.sandbox_focused_field = 0; // image
+
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(matches!(result, DialogResult::Continue));
+    assert!(!dialog.sandbox_config_mode);
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -170,11 +170,12 @@ impl HomeView {
                                 ) {
                                     tracing::error!("Failed to trust repo: {}", e);
                                 }
-                                let merged = self.merge_repo_hooks_onto_config(hooks);
+                                let merged =
+                                    self.merge_repo_hooks_onto_config_for(&data.profile, hooks);
                                 return self.create_session_with_hooks(data, merged);
                             }
                             HookTrustAction::Skip => {
-                                let fallback = self.resolve_global_profile_hooks();
+                                let fallback = self.resolve_global_profile_hooks_for(&data.profile);
                                 return self.create_session_with_hooks(data, fallback);
                             }
                         }
@@ -210,17 +211,17 @@ impl HomeView {
                             self.pending_hook_trust_data = Some(data);
                         }
                         Ok(repo_config::HookTrustStatus::Trusted(repo_hooks)) => {
-                            // Merge repo hooks onto global+profile hooks (per-field override)
-                            let merged = self.merge_repo_hooks_onto_config(repo_hooks);
+                            let merged =
+                                self.merge_repo_hooks_onto_config_for(&data.profile, repo_hooks);
                             return self.create_session_with_hooks(data, merged);
                         }
                         Ok(repo_config::HookTrustStatus::NoHooks) => {
-                            let fallback = self.resolve_global_profile_hooks();
+                            let fallback = self.resolve_global_profile_hooks_for(&data.profile);
                             return self.create_session_with_hooks(data, fallback);
                         }
                         Err(e) => {
                             tracing::warn!("Failed to check repo hooks: {}", e);
-                            let fallback = self.resolve_global_profile_hooks();
+                            let fallback = self.resolve_global_profile_hooks_for(&data.profile);
                             return self.create_session_with_hooks(data, fallback);
                         }
                     }
@@ -394,11 +395,15 @@ impl HomeView {
                         .iter()
                         .map(|g| g.path.clone())
                         .collect();
+                    let current_profile = self.storage.profile().to_string();
+                    let profiles =
+                        list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
                     self.new_dialog = Some(NewSessionDialog::new(
                         self.available_tools.clone(),
                         existing_titles,
                         existing_groups,
-                        self.storage.profile(),
+                        &current_profile,
+                        profiles,
                     ));
                 }
             }
@@ -863,11 +868,12 @@ impl HomeView {
         None
     }
 
-    /// Resolve hooks from global+profile config. Returns `Some(hooks)` only if
-    /// at least one hook command is defined. Global/profile hooks are implicitly
-    /// trusted and skip the repo trust dialog.
-    fn resolve_global_profile_hooks(&self) -> Option<crate::session::HooksConfig> {
-        let config = resolve_config(self.storage.profile()).ok()?;
+    /// Resolve hooks from global+profile config for the given profile.
+    fn resolve_global_profile_hooks_for(
+        &self,
+        profile: &str,
+    ) -> Option<crate::session::HooksConfig> {
+        let config = resolve_config(profile).ok()?;
         if config.hooks.on_create.is_empty() && config.hooks.on_launch.is_empty() {
             None
         } else {
@@ -875,16 +881,13 @@ impl HomeView {
         }
     }
 
-    /// Merge trusted repo hooks onto the resolved global+profile config using
-    /// per-field override semantics: repo fields replace global/profile fields
-    /// only when the repo field is non-empty.
-    fn merge_repo_hooks_onto_config(
+    /// Merge trusted repo hooks onto the resolved config for the given profile.
+    fn merge_repo_hooks_onto_config_for(
         &self,
+        profile: &str,
         repo_hooks: crate::session::HooksConfig,
     ) -> Option<crate::session::HooksConfig> {
-        let mut base = resolve_config(self.storage.profile())
-            .map(|c| c.hooks)
-            .unwrap_or_default();
+        let mut base = resolve_config(profile).map(|c| c.hooks).unwrap_or_default();
 
         if !repo_hooks.on_create.is_empty() {
             base.on_create = repo_hooks.on_create;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -444,17 +444,52 @@ impl HomeView {
                 ..
             } => {
                 let instance = *instance;
-                self.instances.push(instance.clone());
-                self.group_tree = GroupTree::new_with_groups(&self.instances, &self.groups);
-                if !instance.group_path.is_empty() {
-                    self.group_tree.create_group(&instance.group_path);
-                }
 
-                if let Err(e) = self
-                    .storage
-                    .save_with_groups(&self.instances, &self.group_tree)
-                {
-                    tracing::error!("Failed to save after creation: {}", e);
+                // Check if this was created for a different profile
+                let target_profile = self
+                    .creation_poller
+                    .last_profile()
+                    .unwrap_or_else(|| self.storage.profile().to_string());
+                let is_cross_profile = target_profile != self.storage.profile();
+
+                if is_cross_profile {
+                    // Save to target profile's storage
+                    match Storage::new(&target_profile) {
+                        Ok(target_storage) => match target_storage.load_with_groups() {
+                            Ok((mut target_instances, target_groups)) => {
+                                target_instances.push(instance.clone());
+                                let mut target_tree =
+                                    GroupTree::new_with_groups(&target_instances, &target_groups);
+                                if !instance.group_path.is_empty() {
+                                    target_tree.create_group(&instance.group_path);
+                                }
+                                if let Err(e) =
+                                    target_storage.save_with_groups(&target_instances, &target_tree)
+                                {
+                                    tracing::error!("Failed to save to target profile: {}", e);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::error!("Failed to load target profile data: {}", e);
+                            }
+                        },
+                        Err(e) => {
+                            tracing::error!("Failed to open target profile storage: {}", e);
+                        }
+                    }
+                } else {
+                    self.instances.push(instance.clone());
+                    self.group_tree = GroupTree::new_with_groups(&self.instances, &self.groups);
+                    if !instance.group_path.is_empty() {
+                        self.group_tree.create_group(&instance.group_path);
+                    }
+
+                    if let Err(e) = self
+                        .storage
+                        .save_with_groups(&self.instances, &self.group_tree)
+                    {
+                        tracing::error!("Failed to save after creation: {}", e);
+                    }
                 }
 
                 if on_launch_hooks_ran {

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -9,7 +9,20 @@ use super::HomeView;
 
 impl HomeView {
     pub(super) fn create_session(&mut self, data: NewSessionData) -> anyhow::Result<String> {
-        let existing_titles: Vec<&str> = self.instances.iter().map(|i| i.title.as_str()).collect();
+        let target_profile = data.profile.clone();
+        let is_cross_profile = target_profile != self.storage.profile();
+
+        // For cross-profile creation, use the target profile's instances for title dedup
+        let target_instances = if is_cross_profile {
+            Storage::new(&target_profile)?.load()?
+        } else {
+            Vec::new()
+        };
+        let existing_titles: Vec<&str> = if is_cross_profile {
+            target_instances.iter().map(|i| i.title.as_str()).collect()
+        } else {
+            self.instances.iter().map(|i| i.title.as_str()).collect()
+        };
 
         let params = InstanceParams {
             title: data.title,
@@ -27,15 +40,27 @@ impl HomeView {
 
         let build_result = builder::build_instance(params, &existing_titles)?;
         let instance = build_result.instance;
-
         let session_id = instance.id.clone();
-        self.instances.push(instance.clone());
-        self.group_tree = GroupTree::new_with_groups(&self.instances, &self.groups);
-        if !instance.group_path.is_empty() {
-            self.group_tree.create_group(&instance.group_path);
+
+        if is_cross_profile {
+            // Save to target profile's storage
+            let target_storage = Storage::new(&target_profile)?;
+            let (mut target_instances, target_groups) = target_storage.load_with_groups()?;
+            target_instances.push(instance.clone());
+            let mut target_tree = GroupTree::new_with_groups(&target_instances, &target_groups);
+            if !instance.group_path.is_empty() {
+                target_tree.create_group(&instance.group_path);
+            }
+            target_storage.save_with_groups(&target_instances, &target_tree)?;
+        } else {
+            self.instances.push(instance.clone());
+            self.group_tree = GroupTree::new_with_groups(&self.instances, &self.groups);
+            if !instance.group_path.is_empty() {
+                self.group_tree.create_group(&instance.group_path);
+            }
+            self.storage
+                .save_with_groups(&self.instances, &self.group_tree)?;
         }
-        self.storage
-            .save_with_groups(&self.instances, &self.group_tree)?;
 
         self.reload()?;
         Ok(session_id)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -186,6 +186,7 @@ fn test_has_dialog_returns_true_for_new_dialog() {
         Vec::new(),
         Vec::new(),
         "default",
+        vec!["default".to_string()],
     ));
     assert!(env.view.has_dialog());
 }


### PR DESCRIPTION
## Description

Cleans up the new session dialog and adds a profile picker (#364):

1. **Profile picker**: When multiple profiles exist, a profile picker field appears at the top of the dialog. Left/Right/Space cycles profiles. Switching profiles reloads tool, yolo, sandbox, and environment defaults from that profile's config while preserving user inputs (title, path, group, worktree). Hidden when only one profile exists.

2. **Sandbox options collapsed**: Sandbox sub-options (image, env vars, env values, inherited settings) are moved into a separate "Sandbox Configuration" overlay, accessible via **Ctrl+P** on the sandbox checkbox -- consistent with path/branch/group pickers. Enter always submits the form regardless of focused field.

3. **Cross-profile session creation**: When a different profile is selected, the session is saved to that profile's storage (both synchronous and background/poller creation paths). Title deduplication correctly checks the target profile's sessions.

### Files changed
- `src/tui/dialogs/new_session/mod.rs` - Profile picker, sandbox config mode, dynamic field indices, `reload_config_defaults()`
- `src/tui/dialogs/new_session/render.rs` - Conditional profile field rendering, sandbox config overlay
- `src/tui/dialogs/new_session/tests.rs` - Updated all field indices, added 9 new tests (77 total)
- `src/tui/dialogs/new_session/path_input.rs` - Dynamic path field index
- `src/tui/home/input.rs` - Pass profiles to dialog, hook methods accept profile param
- `src/tui/home/operations.rs` - Cross-profile session creation with correct title dedup
- `src/tui/home/mod.rs` - Cross-profile creation results
- `src/tui/creation_poller.rs` - Track last_profile for background creation
- `src/tui/home/tests.rs` - Updated NewSessionDialog::new() call

Fixes #364

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)