### PR TITLE
fix: update Claude Code spinner detection to match current UI

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1,6 +1,7 @@
 //! Status detection for agent sessions
 
 use crate::session::Status;
+use regex::Regex;
 
 use super::utils::strip_ansi;
 
@@ -47,7 +48,17 @@ pub fn detect_claude_status(content: &str) -> Status {
         return Status::Running;
     }
 
+    // Claude Code spinner: "<spinner> <verb>…" with optional stats after
+    // e.g. "✳ Twisting… (10m 6s · ↓ 18.3k tokens · thinking)"
+    // Must NOT match completion lines like "✻ Worked for 1m 52s"
+    const CLAUDE_SPINNER_CHARS: &[&str] = &["·", "✢", "✳", "✶", "✻", "✽", "●"];
+    let chars = CLAUDE_SPINNER_CHARS.join("");
+    let claude_spinner_re = Regex::new(&format!(r"^[{}] \S+…", chars)).unwrap();
     for line in &lines {
+        let trimmed = line.trim();
+        if claude_spinner_re.is_match(trimmed) {
+            return Status::Running;
+        }
         for spinner in SPINNER_CHARS {
             if line.contains(spinner) {
                 return Status::Running;
@@ -499,6 +510,21 @@ mod tests {
         );
         assert_eq!(detect_claude_status("Processing ⠋"), Status::Running);
         assert_eq!(detect_claude_status("Loading ⠹"), Status::Running);
+
+        // New Claude Code spinner patterns: <spinner> <verb>…
+        assert_eq!(detect_claude_status("✶ Hashing…"), Status::Running);
+        assert_eq!(detect_claude_status("✻ Reading…"), Status::Running);
+        assert_eq!(detect_claude_status("● Thinking…"), Status::Running);
+        assert_eq!(detect_claude_status("· Searching…"), Status::Running);
+        assert_eq!(detect_claude_status("✳ Writing…"), Status::Running);
+        assert_eq!(detect_claude_status("✽ Editing…"), Status::Running);
+        assert_eq!(detect_claude_status("✢ Running…"), Status::Running);
+
+        // Spinner with timing/token stats after ellipsis
+        assert_eq!(
+            detect_claude_status("✳ Twisting… (10m 6s · ↓ 18.3k tokens · thinking)"),
+            Status::Running
+        );
     }
 
     #[test]
@@ -525,6 +551,10 @@ mod tests {
     fn test_detect_claude_status_idle() {
         assert_eq!(detect_claude_status("completed the task"), Status::Idle);
         assert_eq!(detect_claude_status("some random output"), Status::Idle);
+
+        // Completion messages with spinner chars should NOT be Running
+        assert_eq!(detect_claude_status("✻ Worked for 1m 52s"), Status::Idle);
+        assert_eq!(detect_claude_status("✶ Completed in 30s"), Status::Idle);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Claude Code no longer uses braille spinners (⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏). It now uses spinner chars (· ✢ ✳ ✶ ✻ ✽ ●) with the pattern `<spinner> <verb>…` when active, e.g. `✳ Twisting… (10m 6s · ↓ 18.3k tokens · thinking)`.

This PR adds a regex-based detection for the new spinner pattern, distinguishing active spinners (which contain `…`) from completion messages like `✻ Worked for 1m 52s` (which don't). Braille spinner detection is kept as a fallback.

Closes #378

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Code (Opus 4.6)

**Any Additional AI Details you'd like to share:** Used Claude Code to implement the fix and write tests. I reviewed and tested the changes locally.