### PR TITLE
fix: detect shell panes restored by tmux-resurrect and relaunch agent

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -622,13 +622,15 @@ impl Instance {
         );
         self.status = match detected {
             Status::Idle if self.has_custom_command() => {
-                if session.is_pane_dead() {
+                if session.is_pane_dead() || session.is_pane_running_shell() {
                     Status::Error
                 } else {
                     Status::Unknown
                 }
             }
-            Status::Idle if session.is_pane_dead() => Status::Error,
+            Status::Idle if session.is_pane_dead() || session.is_pane_running_shell() => {
+                Status::Error
+            }
             other => other,
         };
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -624,16 +624,16 @@ impl Instance {
             self.has_custom_command(),
             detected
         );
-        let shell_pane_is_stale = !self.expects_shell() && session.is_pane_running_shell();
+        let is_shell_stale = || !self.expects_shell() && session.is_pane_running_shell();
         self.status = match detected {
             Status::Idle if self.has_custom_command() => {
-                if session.is_pane_dead() || shell_pane_is_stale {
+                if session.is_pane_dead() || is_shell_stale() {
                     Status::Error
                 } else {
                     Status::Unknown
                 }
             }
-            Status::Idle if session.is_pane_dead() || shell_pane_is_stale => Status::Error,
+            Status::Idle if session.is_pane_dead() || is_shell_stale() => Status::Error,
             other => other,
         };
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -159,6 +159,10 @@ impl Instance {
             .unwrap_or(true)
     }
 
+    pub fn expects_shell(&self) -> bool {
+        crate::tmux::utils::is_shell_command(self.get_tool_command())
+    }
+
     pub fn get_tool_command(&self) -> &str {
         if self.command.is_empty() {
             crate::agents::get_agent(&self.tool)
@@ -620,17 +624,16 @@ impl Instance {
             self.has_custom_command(),
             detected
         );
+        let shell_pane_is_stale = !self.expects_shell() && session.is_pane_running_shell();
         self.status = match detected {
             Status::Idle if self.has_custom_command() => {
-                if session.is_pane_dead() || session.is_pane_running_shell() {
+                if session.is_pane_dead() || shell_pane_is_stale {
                     Status::Error
                 } else {
                     Status::Unknown
                 }
             }
-            Status::Idle if session.is_pane_dead() || session.is_pane_running_shell() => {
-                Status::Error
-            }
+            Status::Idle if session.is_pane_dead() || shell_pane_is_stale => Status::Error,
             other => other,
         };
 
@@ -1026,6 +1029,23 @@ mod tests {
         inst.tool = "unknown_agent".to_string();
         inst.command = "some-binary".to_string();
         assert!(inst.has_custom_command());
+    }
+
+    #[test]
+    fn test_expects_shell() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        assert!(!inst.expects_shell());
+
+        inst.tool = "unknown-tool".to_string();
+        inst.command = String::new();
+        assert!(inst.expects_shell());
+
+        inst.tool = "claude".to_string();
+        inst.command = "bash".to_string();
+        assert!(inst.expects_shell());
+
+        inst.command = "my-agent".to_string();
+        assert!(!inst.expects_shell());
     }
 
     #[test]

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -4,7 +4,7 @@ mod session;
 pub mod status_bar;
 pub(crate) mod status_detection;
 mod terminal_session;
-mod utils;
+pub(crate) mod utils;
 
 pub use session::Session;
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -467,6 +467,7 @@ mod tests {
                 "80",
                 "-y",
                 "24",
+                "sh",
             ])
             .output()
             .expect("tmux new-session");
@@ -476,7 +477,7 @@ mod tests {
 
         assert!(
             is_pane_running_shell(&session_name),
-            "Session running a bare shell should be detected"
+            "Session running sh should be detected as a shell"
         );
 
         let _ = Command::new("tmux")

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -4,7 +4,9 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::{
-    refresh_session_cache, session_exists_from_cache, utils::is_pane_dead, SESSION_PREFIX,
+    refresh_session_cache, session_exists_from_cache,
+    utils::{is_pane_dead, is_pane_running_shell},
+    SESSION_PREFIX,
 };
 use crate::cli::truncate_id;
 use crate::process;
@@ -77,6 +79,10 @@ impl Session {
 
     pub fn is_pane_dead(&self) -> bool {
         is_pane_dead(&self.name)
+    }
+
+    pub fn is_pane_running_shell(&self) -> bool {
+        is_pane_running_shell(&self.name)
     }
 
     pub fn kill(&self) -> Result<()> {
@@ -439,5 +445,81 @@ mod tests {
 
         // Command should be last
         assert_eq!(args.last().unwrap(), "claude");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_is_pane_running_shell_on_shell_session() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session_name = format!("aoe_test_shell_{}", std::process::id());
+
+        let output = Command::new("tmux")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        assert!(
+            is_pane_running_shell(&session_name),
+            "Session running a bare shell should be detected"
+        );
+
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &session_name])
+            .output();
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_is_pane_running_shell_on_non_shell_session() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session_name = format!("aoe_test_noshell_{}", std::process::id());
+
+        let output = Command::new("tmux")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep",
+                "30",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+
+        assert!(
+            !is_pane_running_shell(&session_name),
+            "Session running 'sleep' should not be detected as a shell"
+        );
+
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &session_name])
+            .output();
     }
 }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -48,8 +48,7 @@ pub fn is_pane_dead(session_name: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Returns the current command running in the session's active pane (e.g. "bash", "claude").
-pub fn pane_current_command(session_name: &str) -> Option<String> {
+fn pane_current_command(session_name: &str) -> Option<String> {
     Command::new("tmux")
         .args([
             "display-message",
@@ -65,17 +64,17 @@ pub fn pane_current_command(session_name: &str) -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
-/// Shells that indicate the agent is not running (the pane was restored by
-/// tmux-resurrect, the agent crashed back to a prompt, or the user exited).
+// Shells that indicate the agent is not running (the pane was restored by
+// tmux-resurrect, the agent crashed back to a prompt, or the user exited).
 const KNOWN_SHELLS: &[&str] = &[
     "bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh", "nu", "pwsh",
 ];
 
 fn is_shell_command(cmd: &str) -> bool {
-    KNOWN_SHELLS.contains(&cmd)
+    let normalized = cmd.strip_prefix('-').unwrap_or(cmd);
+    KNOWN_SHELLS.contains(&normalized)
 }
 
-/// Returns true if the pane is alive but running a plain shell instead of an agent.
 pub fn is_pane_running_shell(session_name: &str) -> bool {
     pane_current_command(session_name)
         .map(|cmd| is_shell_command(&cmd))
@@ -163,6 +162,16 @@ mod tests {
             assert!(
                 is_shell_command(shell),
                 "{shell} should be recognized as a shell"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_shell_command_recognizes_login_shells() {
+        for shell in ["-bash", "-zsh", "-sh", "-fish"] {
+            assert!(
+                is_shell_command(shell),
+                "{shell} should be recognized as a login shell"
             );
         }
     }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -70,7 +70,7 @@ const KNOWN_SHELLS: &[&str] = &[
     "bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh", "nu", "pwsh",
 ];
 
-fn is_shell_command(cmd: &str) -> bool {
+pub(crate) fn is_shell_command(cmd: &str) -> bool {
     let normalized = cmd.strip_prefix('-').unwrap_or(cmd);
     KNOWN_SHELLS.contains(&normalized)
 }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -48,6 +48,40 @@ pub fn is_pane_dead(session_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Returns the current command running in the session's active pane (e.g. "bash", "claude").
+pub fn pane_current_command(session_name: &str) -> Option<String> {
+    Command::new("tmux")
+        .args([
+            "display-message",
+            "-t",
+            session_name,
+            "-p",
+            "#{pane_current_command}",
+        ])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Shells that indicate the agent is not running (the pane was restored by
+/// tmux-resurrect, the agent crashed back to a prompt, or the user exited).
+const KNOWN_SHELLS: &[&str] = &[
+    "bash", "zsh", "sh", "fish", "dash", "ksh", "tcsh", "csh", "nu", "pwsh",
+];
+
+fn is_shell_command(cmd: &str) -> bool {
+    KNOWN_SHELLS.contains(&cmd)
+}
+
+/// Returns true if the pane is alive but running a plain shell instead of an agent.
+pub fn is_pane_running_shell(session_name: &str) -> bool {
+    pane_current_command(session_name)
+        .map(|cmd| is_shell_command(&cmd))
+        .unwrap_or(false)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -121,5 +155,27 @@ mod tests {
         assert!(result.starts_with("test"));
         assert!(result.contains('_'));
         assert!(!result.contains('😀'));
+    }
+
+    #[test]
+    fn test_is_shell_command_recognizes_common_shells() {
+        for shell in KNOWN_SHELLS {
+            assert!(
+                is_shell_command(shell),
+                "{shell} should be recognized as a shell"
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_shell_command_rejects_agent_binaries() {
+        for cmd in [
+            "claude", "opencode", "codex", "gemini", "cursor", "sleep", "python",
+        ] {
+            assert!(
+                !is_shell_command(cmd),
+                "{cmd} should not be recognized as a shell"
+            );
+        }
     }
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -383,7 +383,10 @@ impl App {
 
         let tmux_session = instance.tmux_session()?;
 
-        if !tmux_session.exists() || tmux_session.is_pane_dead() {
+        if !tmux_session.exists()
+            || tmux_session.is_pane_dead()
+            || tmux_session.is_pane_running_shell()
+        {
             if tmux_session.exists() {
                 let _ = tmux_session.kill();
             }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -385,7 +385,7 @@ impl App {
 
         if !tmux_session.exists()
             || tmux_session.is_pane_dead()
-            || tmux_session.is_pane_running_shell()
+            || (!instance.expects_shell() && tmux_session.is_pane_running_shell())
         {
             if tmux_session.exists() {
                 let _ = tmux_session.kill();

--- a/src/tui/styles.rs
+++ b/src/tui/styles.rs
@@ -257,6 +257,7 @@ mod tests {
         assert_eq!(theme.title, Color::Rgb(122, 162, 247));
         assert_eq!(theme.background, Color::Rgb(36, 40, 59));
     }
+
     #[test]
     fn test_load_dracula() {
         let theme = load_theme("dracula");


### PR DESCRIPTION
## Description

After `tmux kill-server`, tmux-resurrect/continuum restores `aoe_*` sessions with live shells instead of dead panes. AoE previously only checked `is_pane_dead()`, so it attached directly to empty shells instead of relaunching the agent.

This PR queries `#{pane_current_command}` from tmux to detect when a pane runs a known shell (bash, zsh, fish, etc.) instead of the expected agent binary. When detected, the session is killed and relaunched -- same as the existing dead pane path. Login shells (prefixed with `-`, e.g. `-bash`) are also handled.

Shell detection is gated by `Instance::expects_shell()`: sessions whose expected command is itself a shell (unknown tool fallback to `bash`, or explicit `--cmd-override bash`) skip the check entirely. This prevents infinite kill/relaunch loops for intentionally shell-based sessions.

This covers:
- **tmux-resurrect restores** -- the primary issue
- **Agent crashes** back to a shell prompt
- **Manual `Ctrl+C` exits** from the agent

### Changes

- **`src/tmux/utils.rs`**: Added `pane_current_command()`, `is_shell_command()` (with login shell prefix handling), `KNOWN_SHELLS` constant, and `is_pane_running_shell()` with unit tests
- **`src/tmux/session.rs`**: Added `is_pane_running_shell()` method on `Session` with integration tests
- **`src/tui/app.rs`**: Extended attach condition to check `is_pane_running_shell()`, gated by `expects_shell()`
- **`src/session/instance.rs`**: Added `expects_shell()` method; updated `update_status()` to detect shell panes as `Status::Error` only when the session is not expected to run a shell

Closes #385

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No documentation or UI changes needed -- behavior matches existing dead-pane recovery path.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (anthropic--claude-4.6-opus) via OpenCode

- [x] I am an AI Agent filling out this form (check box if true)