### PR TITLE
fix: aoe add respects config-driven agent defaults

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -191,17 +191,27 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
     instance.yolo_mode = args.yolo;
 
+    let config = Config::load()?;
+
+    // Apply extra_args and command override: CLI flags take priority, then config defaults
     if let Some(ref extra) = args.extra_args {
         instance.extra_args = extra.clone();
+    } else if let Some(extra) = config.session.agent_extra_args.get(&instance.tool) {
+        if !extra.is_empty() {
+            instance.extra_args = extra.clone();
+        }
     }
 
     if let Some(ref cmd) = args.cmd_override {
         instance.command = cmd.clone();
+    } else if let Some(cmd_override) = config.session.agent_command_override.get(&instance.tool) {
+        if !cmd_override.is_empty() {
+            instance.command = cmd_override.clone();
+        }
     }
 
     // Handle sandbox setup
     let use_sandbox = args.sandbox || args.sandbox_image.is_some();
-    let config = Config::load()?;
 
     let runtime = containers::get_container_runtime();
     if use_sandbox || config.sandbox.enabled_by_default {

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -2,6 +2,20 @@ use serial_test::serial;
 
 use crate::harness::TuiTestHarness;
 
+/// Helper to read a session field from the sessions.json in the harness's isolated home.
+fn read_sessions_json(h: &TuiTestHarness) -> serde_json::Value {
+    let sessions_path = if cfg!(target_os = "linux") {
+        h.home_path()
+            .join(".config/agent-of-empires/profiles/default/sessions.json")
+    } else {
+        h.home_path()
+            .join(".agent-of-empires/profiles/default/sessions.json")
+    };
+    let content = std::fs::read_to_string(&sessions_path)
+        .unwrap_or_else(|e| panic!("failed to read {}: {}", sessions_path.display(), e));
+    serde_json::from_str(&content).expect("invalid sessions JSON")
+}
+
 #[test]
 #[serial]
 fn test_cli_add_and_list() {
@@ -54,5 +68,150 @@ fn test_cli_add_invalid_path() {
         "expected error message about invalid path.\nstdout: {}\nstderr: {}",
         stdout,
         stderr
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_respects_config_extra_args() {
+    let h = TuiTestHarness::new("cli_add_config_extra_args");
+    let project = h.project_path();
+
+    // Write config with agent_extra_args for claude
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+agent_extra_args = {{ claude = "--verbose --debug" }}
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "ConfigExtraArgs"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["extra_args"].as_str().unwrap_or(""),
+        "--verbose --debug",
+        "extra_args should be populated from config"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_respects_config_command_override() {
+    let h = TuiTestHarness::new("cli_add_config_cmd_override");
+    let project = h.project_path();
+
+    // Write config with agent_command_override for claude
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+agent_command_override = {{ claude = "my-custom-claude" }}
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "ConfigCmdOverride"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["command"].as_str().unwrap_or(""),
+        "my-custom-claude",
+        "command should be populated from config agent_command_override"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_cli_flags_override_config() {
+    let h = TuiTestHarness::new("cli_add_flags_override");
+    let project = h.project_path();
+
+    // Write config with agent_extra_args for claude
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+agent_extra_args = {{ claude = "--from-config" }}
+agent_command_override = {{ claude = "config-claude" }}
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    // CLI flags should take priority over config
+    let add_output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "FlagsOverride",
+        "--extra-args",
+        "from-cli-extra",
+        "--cmd-override",
+        "cli-claude",
+    ]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["extra_args"].as_str().unwrap_or(""),
+        "from-cli-extra",
+        "CLI --extra-args should override config"
+    );
+    assert_eq!(
+        session["command"].as_str().unwrap_or(""),
+        "cli-claude",
+        "CLI --cmd-override should override config"
     );
 }


### PR DESCRIPTION
## Description

`aoe add` was constructing instances manually without consulting `SessionConfig` defaults for `agent_extra_args` and `agent_command_override`. This meant config-level overrides only worked through the TUI path (via `build_instance()`) but were silently ignored by the CLI.

Added the same config fallback logic from `build_instance()` into `cli/add.rs`: when `--extra-args` or `--cmd-override` are not passed, the resolved config values are used. CLI flags still take priority over config.

Fixes #374

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- [x] `cargo test` -- all unit/integration tests pass
- [x] `cargo test --test e2e -- cli` -- all CLI e2e tests pass including 3 new tests:
  - `test_cli_add_respects_config_extra_args` -- verifies config `agent_extra_args` are applied when no CLI flag
  - `test_cli_add_respects_config_command_override` -- verifies config `agent_command_override` is applied when no CLI flag
  - `test_cli_add_cli_flags_override_config` -- verifies CLI flags take priority over config
- [x] `cargo clippy` -- clean
- [x] `cargo fmt` -- clean

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)