### PR TITLE
fix: use exec env for inline env vars (bash 3.2 compat)

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -704,7 +704,7 @@ fn generate_id() -> String {
 /// breaking out of the outer `bash -c '...'` wrapper.
 fn wrap_command_ignore_suspend(cmd: &str) -> String {
     let escaped = cmd.replace('\'', "'\\''");
-    format!("bash -c 'stty susp undef; exec {}'", escaped)
+    format!("bash -c 'stty susp undef; exec env {}'", escaped)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

PR #390 introduced `AOE_INSTANCE_ID=xxx` as an inline env var prefix prepended to the agent command. This gets wrapped by `wrap_command_ignore_suspend` into:

```
bash -c 'stty susp undef; exec AOE_INSTANCE_ID=xxx claude'
```

macOS ships bash 3.2 (stuck at this version due to GPLv3 licensing), which does not support `exec VAR=val cmd` -- it treats `AOE_INSTANCE_ID=xxx` as the command name, producing:

```
bash: line 0: exec: AOE_INSTANCE_ID=d0bdd19285914c73: not found
```

The fix adds `env` after `exec`, producing `exec env AOE_INSTANCE_ID=xxx claude`. `env(1)` is POSIX-standard and handles inline variable assignments on all bash versions. The `exec` still replaces the shell process (with `env`, which then execs the actual command).

One-line change in `wrap_command_ignore_suspend`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

**Any Additional AI Details you'd like to share:** AI identified the root cause (bash 3.2 on macOS not supporting `exec VAR=val cmd`) and proposed the minimal fix. Manually tested on macOS.

- [x] I am an AI Agent filling out this form (check box if true)