### PR TITLE
fix: delete sandbox worktree contents via container to avoid permission denied

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -80,9 +80,34 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                     let worktree_path = PathBuf::from(&inst.project_path);
                     let main_repo = PathBuf::from(&wt_info.main_repo_path);
 
+                    // Sandbox containers run as root, so files they create
+                    // are root-owned on the host. Delete contents from inside
+                    // the container where root can remove them.
+                    let sandbox_cleaned = if inst.is_sandboxed() {
+                        let container = containers::DockerContainer::from_session_id(&inst.id);
+                        if container.exists().unwrap_or(false) {
+                            if !container.is_running().unwrap_or(false) {
+                                let _ = container.start();
+                            }
+                            container
+                                .exec(&["find", ".", "-mindepth", "1", "-delete"])
+                                .is_ok()
+                        } else {
+                            false
+                        }
+                    } else {
+                        false
+                    };
+
                     match GitWorktree::new(main_repo) {
                         Ok(git_wt) => {
-                            if let Err(e) = git_wt.remove_worktree(&worktree_path, args.force) {
+                            let result = if sandbox_cleaned {
+                                let _ = std::fs::remove_dir(&worktree_path);
+                                git_wt.prune_worktrees()
+                            } else {
+                                git_wt.remove_worktree(&worktree_path, args.force)
+                            };
+                            if let Err(e) = result {
                                 eprintln!("Warning: failed to remove worktree: {}", e);
                                 eprintln!(
                                     "You may need to remove it manually with: git worktree remove {}",

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -203,7 +203,7 @@ impl GitWorktree {
     }
 
     /// Prune stale worktree entries whose directories no longer exist on disk.
-    fn prune_worktrees(&self) -> Result<()> {
+    pub fn prune_worktrees(&self) -> Result<()> {
         let output = std::process::Command::new("git")
             .args(["worktree", "prune"])
             .current_dir(&self.repo_path)
@@ -252,36 +252,6 @@ impl GitWorktree {
             let new_content = format!("gitdir: {}\n", relative.display());
             std::fs::write(&git_file, new_content)?;
         }
-
-        Ok(())
-    }
-
-    /// Convert a worktree's .git file from relative back to absolute path.
-    ///
-    /// This reverses `convert_git_file_to_relative` so that `git worktree remove`
-    /// can validate the worktree. Git requires an absolute gitdir path for removal.
-    fn convert_git_file_to_absolute(worktree_path: &Path) -> Result<()> {
-        let git_file = worktree_path.join(".git");
-        if !git_file.exists() || !git_file.is_file() {
-            return Ok(());
-        }
-
-        let content = std::fs::read_to_string(&git_file)?;
-        let Some(gitdir_line) = content.lines().find(|l| l.starts_with("gitdir:")) else {
-            return Ok(());
-        };
-
-        let gitdir_value = gitdir_line.trim_start_matches("gitdir:").trim();
-        let gitdir_path = Path::new(gitdir_value);
-
-        if gitdir_path.is_absolute() {
-            return Ok(()); // Already absolute
-        }
-
-        // Resolve the relative path against the worktree directory
-        let absolute = worktree_path.join(gitdir_path).canonicalize()?;
-        let new_content = format!("gitdir: {}\n", absolute.display());
-        std::fs::write(&git_file, new_content)?;
 
         Ok(())
     }
@@ -351,11 +321,6 @@ impl GitWorktree {
         if !path.exists() {
             return Err(GitError::WorktreeNotFound(path.to_path_buf()));
         }
-
-        // Restore the .git file to an absolute path before removal.
-        // create_worktree() converts it to relative for Docker compatibility,
-        // but git worktree remove requires an absolute gitdir path for validation.
-        Self::convert_git_file_to_absolute(path)?;
 
         let path_str = path
             .to_str()

--- a/src/tui/deletion_poller.rs
+++ b/src/tui/deletion_poller.rs
@@ -81,8 +81,25 @@ impl DeletionPoller {
                     let worktree_path = PathBuf::from(&request.instance.project_path);
                     let main_repo = PathBuf::from(&wt_info.main_repo_path);
 
+                    // Sandbox containers run as root, so files they create are
+                    // root-owned on the host. On macOS Docker Desktop, chmod
+                    // inside the container doesn't propagate to the host, so
+                    // we delete the contents from inside the container instead.
+                    let sandbox_cleaned = if request.instance.is_sandboxed() {
+                        cleanup_sandbox_worktree(&request.instance)
+                    } else {
+                        false
+                    };
+
                     if let Ok(git_wt) = GitWorktree::new(main_repo) {
-                        if let Err(e) = git_wt.remove_worktree(&worktree_path, request.force_delete)
+                        if sandbox_cleaned {
+                            // Contents deleted by container; remove empty dir + prune
+                            let _ = std::fs::remove_dir(&worktree_path);
+                            if let Err(e) = git_wt.prune_worktrees() {
+                                errors.push(format!("Worktree: {}", e));
+                            }
+                        } else if let Err(e) =
+                            git_wt.remove_worktree(&worktree_path, request.force_delete)
                         {
                             errors.push(format!("Worktree: {}", e));
                         }
@@ -152,6 +169,21 @@ impl Default for DeletionPoller {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Delete worktree contents from inside the sandbox container.
+/// Returns true if the container successfully deleted the contents.
+fn cleanup_sandbox_worktree(instance: &Instance) -> bool {
+    let container = DockerContainer::from_session_id(&instance.id);
+    if !container.exists().unwrap_or(false) {
+        return false;
+    }
+    if !container.is_running().unwrap_or(false) && container.start().is_err() {
+        return false;
+    }
+    container
+        .exec(&["find", ".", "-mindepth", "1", "-delete"])
+        .is_ok()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description

Fixes "Permission denied" errors when deleting worktree sessions that use Docker sandbox mode.

**Root cause:** Sandbox containers run as root, so files created inside the container are root-owned on the host via the volume mount. On macOS Docker Desktop, the VirtioFS/gRPC FUSE file sharing layer does not propagate `chmod` changes from the container to the host, so `git worktree remove` fails with permission denied when trying to delete root-owned files.

**Fix:** Before removing the worktree via git, delete the worktree contents from inside the container (where root can delete root-owned files) using `find . -mindepth 1 -delete`. Then clean up the empty directory on the host and run `git worktree prune` to update git metadata. If the container is stopped, it is restarted temporarily for the cleanup.

Also removes the `convert_git_file_to_absolute` function (added in #400), which was a previous incorrect fix attempt targeting the same symptom but misidentifying the root cause as a path resolution issue.

**Changes:**
- `src/tui/deletion_poller.rs`: Added `cleanup_sandbox_worktree()` helper that execs `find . -mindepth 1 -delete` inside the container before worktree removal, with start-if-stopped logic
- `src/cli/remove.rs`: Same sandbox cleanup logic for the CLI `aoe remove` path
- `src/git/mod.rs`: Removed `convert_git_file_to_absolute` and its call in `remove_worktree()`; made `prune_worktrees` public

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Iterative debugging with user testing on macOS Docker Desktop to identify that chmod doesn't propagate through VirtioFS.

- [x] I am an AI Agent filling out this form (check box if true)