### PR TITLE
refactor: centralize instance access via get/set/mutate helpers

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -403,7 +403,7 @@ impl HomeView {
                 // Toggle container/host terminal mode (only in Terminal view for sandboxed sessions)
                 if self.view_mode == ViewMode::Terminal {
                     if let Some(id) = &self.selected_session {
-                        if let Some(inst) = self.instance_map.get(id) {
+                        if let Some(inst) = self.get_instance(id) {
                             if inst.is_sandboxed() {
                                 let id = id.clone();
                                 self.toggle_terminal_mode(&id);
@@ -464,7 +464,7 @@ impl HomeView {
                 let project_path = self
                     .selected_session
                     .as_ref()
-                    .and_then(|id| self.instance_map.get(id))
+                    .and_then(|id| self.get_instance(id))
                     .map(|inst| inst.project_path.clone());
                 match SettingsView::new(self.storage.profile(), project_path) {
                     Ok(view) => self.settings_view = Some(view),
@@ -487,7 +487,7 @@ impl HomeView {
                     return None;
                 };
 
-                let Some(inst) = self.instance_map.get(session_id) else {
+                let Some(inst) = self.get_instance(session_id) else {
                     self.info_dialog =
                         Some(InfoDialog::new("Error", "Could not find session data."));
                     return None;
@@ -507,7 +507,7 @@ impl HomeView {
             }
             KeyCode::Char('x') => {
                 if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.instance_map.get(session_id) {
+                    if let Some(inst) = self.get_instance(session_id) {
                         if inst.status == Status::Stopped || inst.status == Status::Deleting {
                             return None;
                         }
@@ -528,7 +528,7 @@ impl HomeView {
                     return None;
                 }
                 if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.instance_map.get(session_id) {
+                    if let Some(inst) = self.get_instance(session_id) {
                         if inst.status == Status::Deleting {
                             return None;
                         }
@@ -580,7 +580,7 @@ impl HomeView {
             }
             KeyCode::Char('r') if !key.modifiers.contains(KeyModifiers::SHIFT) => {
                 if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.instance_map.get(id) {
+                    if let Some(inst) = self.get_instance(id) {
                         if inst.status == Status::Deleting {
                             return None;
                         }
@@ -633,7 +633,7 @@ impl HomeView {
             }
             KeyCode::Enter => {
                 if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.instance_map.get(id) {
+                    if let Some(inst) = self.get_instance(id) {
                         if inst.status == Status::Deleting {
                             return None;
                         }
@@ -641,7 +641,7 @@ impl HomeView {
                     return match self.view_mode {
                         ViewMode::Agent => Some(Action::AttachSession(id.clone())),
                         ViewMode::Terminal => {
-                            let terminal_mode = if let Some(inst) = self.instance_map.get(id) {
+                            let terminal_mode = if let Some(inst) = self.get_instance(id) {
                                 if inst.is_sandboxed() {
                                     self.get_terminal_mode(id)
                                 } else {
@@ -774,7 +774,7 @@ impl HomeView {
         for (idx, item) in self.flat_items.iter().enumerate() {
             let haystack = match item {
                 Item::Session { id, .. } => {
-                    if let Some(inst) = self.instance_map.get(id) {
+                    if let Some(inst) = self.get_instance(id) {
                         format!("{} {}", inst.title, inst.project_path)
                     } else {
                         continue;
@@ -828,7 +828,7 @@ impl HomeView {
         for (idx, item) in self.flat_items.iter().enumerate() {
             let haystack = match item {
                 Item::Session { id, .. } => {
-                    if let Some(inst) = self.instance_map.get(id) {
+                    if let Some(inst) = self.get_instance(id) {
                         format!("{} {}", inst.title, inst.project_path)
                     } else {
                         continue;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -314,30 +314,30 @@ impl HomeView {
 
         if let Some(updates) = self.status_poller.try_recv_updates() {
             for update in updates {
-                if let Some(inst) = self.instances.iter_mut().find(|i| i.id == update.id) {
-                    if inst.status != Status::Deleting
-                        && inst.status != Status::Stopped
+                let old_status = self
+                    .instances
+                    .iter()
+                    .find(|i| i.id == update.id)
+                    .map(|i| i.status);
+
+                let should_update = old_status.is_some_and(|s| {
+                    s != Status::Deleting
+                        && s != Status::Stopped
                         && update.status != Status::Stopped
-                    {
-                        let old_status = inst.status;
-                        inst.status = update.status;
-                        inst.last_error = update.last_error.clone();
-                        if old_status != update.status {
-                            crate::sound::play_for_transition(
-                                old_status,
-                                update.status,
-                                &self.sound_config,
-                            );
+                });
+
+                if should_update {
+                    let new_status = update.status;
+                    let new_error = update.last_error;
+                    self.mutate_instance(&update.id, |inst| {
+                        inst.status = new_status;
+                        inst.last_error = new_error.clone();
+                    });
+
+                    if let Some(old) = old_status {
+                        if old != new_status {
+                            crate::sound::play_for_transition(old, new_status, &self.sound_config);
                         }
-                    }
-                }
-                if let Some(inst) = self.instance_map.get_mut(&update.id) {
-                    if inst.status != Status::Deleting
-                        && inst.status != Status::Stopped
-                        && update.status != Status::Stopped
-                    {
-                        inst.status = update.status;
-                        inst.last_error = update.last_error;
                     }
                 }
             }
@@ -361,18 +361,11 @@ impl HomeView {
                 }
                 let _ = self.reload();
             } else {
-                if let Some(inst) = self
-                    .instances
-                    .iter_mut()
-                    .find(|i| i.id == result.session_id)
-                {
+                let error = result.error;
+                self.mutate_instance(&result.session_id, |inst| {
                     inst.status = Status::Error;
-                    inst.last_error = result.error.clone();
-                }
-                if let Some(inst) = self.instance_map.get_mut(&result.session_id) {
-                    inst.status = Status::Error;
-                    inst.last_error = result.error;
-                }
+                    inst.last_error = error.clone();
+                });
             }
             return true;
         }
@@ -615,12 +608,7 @@ impl HomeView {
     }
 
     pub fn set_instance_status(&mut self, id: &str, status: crate::session::Status) {
-        if let Some(inst) = self.instance_map.get_mut(id) {
-            inst.status = status;
-        }
-        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            inst.status = status;
-        }
+        self.mutate_instance(id, |inst| inst.status = status);
     }
 
     pub fn save(&self) -> anyhow::Result<()> {
@@ -629,13 +617,19 @@ impl HomeView {
         Ok(())
     }
 
-    pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
+    /// Centralized instance mutation: applies `f` to both `instance_map` and
+    /// `instances` vec so the two copies stay in sync.
+    pub(super) fn mutate_instance(&mut self, id: &str, f: impl Fn(&mut Instance)) {
         if let Some(inst) = self.instance_map.get_mut(id) {
-            inst.last_error = error.clone();
+            f(inst);
         }
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            inst.last_error = error;
+            f(inst);
         }
+    }
+
+    pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
+        self.mutate_instance(id, |inst| inst.last_error = error.clone());
     }
 
     pub fn start_terminal_for_instance_with_size(
@@ -645,9 +639,10 @@ impl HomeView {
     ) -> anyhow::Result<()> {
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
             inst.start_terminal_with_size(size)?;
-        }
-        if let Some(inst) = self.instance_map.get_mut(id) {
-            inst.start_terminal_with_size(size)?;
+            let terminal_info = inst.terminal_info.clone();
+            if let Some(map_inst) = self.instance_map.get_mut(id) {
+                map_inst.terminal_info = terminal_info;
+            }
         }
         self.save()?;
         Ok(())
@@ -706,10 +701,6 @@ impl HomeView {
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
             inst.start_container_terminal_with_size(size)?;
         }
-        if let Some(inst) = self.instance_map.get_mut(id) {
-            inst.start_container_terminal_with_size(size)?;
-        }
-        // Don't save terminal info for container terminals - it's ephemeral
         Ok(())
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -314,11 +314,7 @@ impl HomeView {
 
         if let Some(updates) = self.status_poller.try_recv_updates() {
             for update in updates {
-                let old_status = self
-                    .instances
-                    .iter()
-                    .find(|i| i.id == update.id)
-                    .map(|i| i.status);
+                let old_status = self.get_instance(&update.id).map(|i| i.status);
 
                 let should_update = old_status.is_some_and(|s| {
                     s != Status::Deleting
@@ -331,7 +327,7 @@ impl HomeView {
                     let new_error = update.last_error;
                     self.mutate_instance(&update.id, |inst| {
                         inst.status = new_status;
-                        inst.last_error = new_error.clone();
+                        inst.last_error = new_error;
                     });
 
                     if let Some(old) = old_status {
@@ -364,7 +360,7 @@ impl HomeView {
                 let error = result.error;
                 self.mutate_instance(&result.session_id, |inst| {
                     inst.status = Status::Error;
-                    inst.last_error = error.clone();
+                    inst.last_error = error;
                 });
             }
             return true;
@@ -617,36 +613,35 @@ impl HomeView {
         Ok(())
     }
 
-    /// Centralized instance mutation: applies `f` to both `instance_map` and
-    /// `instances` vec so the two copies stay in sync.
-    pub(super) fn mutate_instance(&mut self, id: &str, f: impl Fn(&mut Instance)) {
-        if let Some(inst) = self.instance_map.get_mut(id) {
-            f(inst);
-        }
+    /// Centralized instance mutation: applies `f` once to the `instances` vec
+    /// entry, then clones the result into `instance_map`. This guarantees both
+    /// collections stay in sync even for non-idempotent closures.
+    pub(super) fn mutate_instance(&mut self, id: &str, f: impl FnOnce(&mut Instance)) {
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
             f(inst);
+            self.instance_map.insert(id.to_string(), inst.clone());
         }
     }
 
-    /// Like `mutate_instance`, but for fallible operations. Applies `f` to
-    /// both `instance_map` and `instances` vec. If the first call returns an
-    /// error, the second copy is left untouched and the error is propagated.
+    /// Like `mutate_instance`, but for fallible operations. Clones the entry,
+    /// applies `f` to the clone, and writes back to both collections only on
+    /// success -- neither collection is modified on error.
     pub(super) fn try_mutate_instance(
         &mut self,
         id: &str,
-        f: impl Fn(&mut Instance) -> anyhow::Result<()>,
+        f: impl FnOnce(&mut Instance) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        if let Some(inst) = self.instance_map.get_mut(id) {
-            f(inst)?;
-        }
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            f(inst)?;
+            let mut updated = inst.clone();
+            f(&mut updated)?;
+            *inst = updated.clone();
+            self.instance_map.insert(id.to_string(), updated);
         }
         Ok(())
     }
 
     pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
-        self.mutate_instance(id, |inst| inst.last_error = error.clone());
+        self.mutate_instance(id, |inst| inst.last_error = error);
     }
 
     pub fn start_terminal_for_instance_with_size(

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -628,6 +628,23 @@ impl HomeView {
         }
     }
 
+    /// Like `mutate_instance`, but for fallible operations. Applies `f` to
+    /// both `instance_map` and `instances` vec. If the first call returns an
+    /// error, the second copy is left untouched and the error is propagated.
+    pub(super) fn try_mutate_instance(
+        &mut self,
+        id: &str,
+        f: impl Fn(&mut Instance) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
+        if let Some(inst) = self.instance_map.get_mut(id) {
+            f(inst)?;
+        }
+        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
+            f(inst)?;
+        }
+        Ok(())
+    }
+
     pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
         self.mutate_instance(id, |inst| inst.last_error = error.clone());
     }
@@ -637,13 +654,7 @@ impl HomeView {
         id: &str,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<()> {
-        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            inst.start_terminal_with_size(size)?;
-            let terminal_info = inst.terminal_info.clone();
-            if let Some(map_inst) = self.instance_map.get_mut(id) {
-                map_inst.terminal_info = terminal_info;
-            }
-        }
+        self.try_mutate_instance(id, |inst| inst.start_terminal_with_size(size))?;
         self.save()?;
         Ok(())
     }
@@ -698,9 +709,6 @@ impl HomeView {
         id: &str,
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<()> {
-        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            inst.start_container_terminal_with_size(size)?;
-        }
-        Ok(())
+        self.try_mutate_instance(id, |inst| inst.start_container_terminal_with_size(size))
     }
 }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -183,8 +183,7 @@ impl HomeView {
 
             // Get current values for comparison
             let (current_title, current_group) = self
-                .instance_map
-                .get(&id)
+                .get_instance(&id)
                 .map(|i| (i.title.clone(), i.group_path.clone()))
                 .unwrap_or_default();
 

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -70,12 +70,7 @@ impl HomeView {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
 
-            if let Some(inst) = self.instance_map.get_mut(&id) {
-                inst.status = Status::Deleting;
-            }
-            if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-                inst.status = Status::Deleting;
-            }
+            self.mutate_instance(&id, |inst| inst.status = Status::Deleting);
 
             if let Some(inst) = self.instance_map.get(&id) {
                 let request = DeletionRequest {
@@ -125,16 +120,10 @@ impl HomeView {
                 .collect();
 
             for session_id in sessions_to_delete {
-                // Clear group_path when marking for deletion so these instances
-                // won't cause the group to be recreated during tree rebuilds
-                if let Some(inst) = self.instance_map.get_mut(&session_id) {
+                self.mutate_instance(&session_id, |inst| {
                     inst.status = Status::Deleting;
                     inst.group_path = String::new();
-                }
-                if let Some(inst) = self.instances.iter_mut().find(|i| i.id == session_id) {
-                    inst.status = Status::Deleting;
-                    inst.group_path = String::new();
-                }
+                });
 
                 if let Some(inst) = self.instance_map.get(&session_id) {
                     let delete_worktree = options.delete_worktrees

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -70,9 +70,9 @@ impl HomeView {
         if let Some(id) = &self.selected_session {
             let id = id.clone();
 
-            self.mutate_instance(&id, |inst| inst.status = Status::Deleting);
+            self.set_instance_status(&id, Status::Deleting);
 
-            if let Some(inst) = self.instance_map.get(&id) {
+            if let Some(inst) = self.get_instance(&id) {
                 let request = DeletionRequest {
                     session_id: id.clone(),
                     instance: inst.clone(),
@@ -125,7 +125,7 @@ impl HomeView {
                     inst.group_path = String::new();
                 });
 
-                if let Some(inst) = self.instance_map.get(&session_id) {
+                if let Some(inst) = self.get_instance(&session_id) {
                     let delete_worktree = options.delete_worktrees
                         && inst
                             .worktree_info
@@ -224,7 +224,7 @@ impl HomeView {
                     instance.group_path = effective_group.clone();
 
                     // Handle tmux rename if title changed
-                    if let Some(orig_inst) = self.instance_map.get(&id) {
+                    if let Some(orig_inst) = self.get_instance(&id) {
                         if orig_inst.title != effective_title {
                             let tmux_session = orig_inst.tmux_session()?;
                             if tmux_session.exists() {
@@ -271,7 +271,7 @@ impl HomeView {
             }
 
             // Handle tmux rename if title changed
-            if let Some(inst) = self.instance_map.get(&id) {
+            if let Some(inst) = self.get_instance(&id) {
                 if inst.title != effective_title {
                     let tmux_session = inst.tmux_session()?;
                     if tmux_session.exists() {

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -264,14 +264,17 @@ impl HomeView {
             }
 
             // No profile change - update in place
-            if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
+            // Read old title before mutation so we can detect renames
+            let old_title = self.get_instance(&id).map(|i| i.title.clone());
+
+            self.mutate_instance(&id, |inst| {
                 inst.title = effective_title.clone();
                 inst.group_path = effective_group.clone();
-            }
+            });
 
             // Handle tmux rename if title changed
-            if let Some(inst) = self.get_instance(&id) {
-                if inst.title != effective_title {
+            if old_title.is_some_and(|t| t != effective_title) {
+                if let Some(inst) = self.get_instance(&id) {
                     let tmux_session = inst.tmux_session()?;
                     if tmux_session.exists() {
                         let new_tmux_name =

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -241,7 +241,7 @@ impl HomeView {
                 (icon, text, style)
             }
             Item::Session { id, .. } => {
-                if let Some(inst) = self.instance_map.get(id) {
+                if let Some(inst) = self.get_instance(id) {
                     match self.view_mode {
                         ViewMode::Agent => {
                             let icon = match inst.status {
@@ -317,7 +317,7 @@ impl HomeView {
         ));
 
         if let Item::Session { id, .. } = item {
-            if let Some(inst) = self.instance_map.get(id) {
+            if let Some(inst) = self.get_instance(id) {
                 if let Some(wt_info) = &inst.worktree_info {
                     line_spans.push(Span::styled(
                         format!("  {}", wt_info.branch),
@@ -370,7 +370,7 @@ impl HomeView {
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {
-                if let Some(inst) = self.instance_map.get(id) {
+                if let Some(inst) = self.get_instance(id) {
                     self.preview_cache.content = inst
                         .capture_output_with_size(height as usize, width, height)
                         .unwrap_or_default();
@@ -402,7 +402,7 @@ impl HomeView {
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {
-                if let Some(inst) = self.instance_map.get(id) {
+                if let Some(inst) = self.get_instance(id) {
                     self.terminal_preview_cache.content = inst
                         .terminal_tmux_session()
                         .and_then(|s| s.capture_pane(height as usize))
@@ -435,7 +435,7 @@ impl HomeView {
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {
-                if let Some(inst) = self.instance_map.get(id) {
+                if let Some(inst) = self.get_instance(id) {
                     self.container_terminal_preview_cache.content = inst
                         .container_terminal_tmux_session()
                         .and_then(|s| s.capture_pane(height as usize))
@@ -472,7 +472,7 @@ impl HomeView {
                 self.refresh_preview_cache_if_needed(inner.width, inner.height);
 
                 if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.instance_map.get(id) {
+                    if let Some(inst) = self.get_instance(id) {
                         Preview::render_with_cache(
                             frame,
                             inner,
@@ -494,7 +494,7 @@ impl HomeView {
 
                 if let Some(id) = selected_id {
                     // Determine which terminal to preview based on mode
-                    let terminal_mode = if let Some(inst) = self.instance_map.get(&id) {
+                    let terminal_mode = if let Some(inst) = self.get_instance(&id) {
                         if inst.is_sandboxed() {
                             self.get_terminal_mode(&id)
                         } else {
@@ -521,7 +521,7 @@ impl HomeView {
                     }
 
                     // Now borrow instance for rendering
-                    if let Some(inst) = self.instance_map.get(&id) {
+                    if let Some(inst) = self.get_instance(&id) {
                         let (terminal_running, preview_content) = match terminal_mode {
                             TerminalMode::Container => {
                                 let running = inst
@@ -600,7 +600,7 @@ impl HomeView {
         // Show c: container/host hint for sandboxed sessions in Terminal view
         if self.view_mode == ViewMode::Terminal {
             if let Some(id) = &self.selected_session {
-                if let Some(inst) = self.instance_map.get(id) {
+                if let Some(inst) = self.get_instance(id) {
                     if inst.is_sandboxed() {
                         spans.extend([
                             Span::styled("│", sep_style),


### PR DESCRIPTION
## Description

`HomeView` stores instances in two parallel collections (`instance_map` HashMap + `instances` Vec) that must stay in sync. Direct field mutations on one without updating the other caused subtle sync bugs -- e.g. container terminal launch was only writing to `instances`, leaving `instance_map` stale.

This PR introduces a small API layer over the dual storage:

- **`get_instance(id)`** -- single read entry point (O(1) via HashMap, replaces 23 raw `instance_map.get()` calls)
- **`mutate_instance(id, f)`** -- `FnOnce` closure applied once to the vec entry, then cloned into the map. Single-apply design prevents desync for non-idempotent closures.
- **`try_mutate_instance(id, f)`** -- same, for fallible `FnOnce` closures. Transactional: clones first, applies `f` to the clone, writes back to both collections only on success -- neither is modified on error.
- **`set_instance_status(id, status)`** / **`set_instance_error(id, error)`** -- dedicated single-field setters
- **`save()`** -- thin wrapper over `storage.save_with_groups()`

Every instance read and write in `input.rs`, `render.rs`, `operations.rs`, and `mod.rs` now goes through these helpers. No raw `instance_map` / `instances` field access remains outside of helper definitions and structural operations (push/retain/remove followed by `reload()`).

Also fixes a concrete bug: `start_container_terminal_for_instance_with_size` was only updating `self.instances`, not `instance_map`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via OpenCode)

**Any Additional AI Details you'd like to share:** Exhaustive audit of all 31 raw `instance_map`/`instances` accesses was done collaboratively to ensure zero missed sites.

- [ ] I am an AI Agent filling out this form (check box if true)