### PR TITLE
fix: hook exits cleanly for non-AoE Claude instances

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -23,7 +23,7 @@ const AOE_HOOK_MARKER: &str = "aoe-hooks";
 /// Build the shell command for a hook that writes a status value.
 fn hook_command(status: &str) -> String {
     format!(
-        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] && mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID && printf {} > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status'",
+        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID && printf {} > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status'",
         status
     )
 }
@@ -336,6 +336,28 @@ mod tests {
         assert!(cmd.contains("aoe-hooks"));
         assert!(cmd.contains("AOE_INSTANCE_ID"));
         assert!(cmd.contains("running"));
+    }
+
+    #[test]
+    fn test_hook_command_exits_cleanly_without_aoe_instance_id() {
+        let cmd = hook_command("idle");
+        // Run the hook command without AOE_INSTANCE_ID set; it should exit 0
+        let output = std::process::Command::new("sh")
+            .arg("-c")
+            .arg(
+                cmd.strip_prefix("sh -c '")
+                    .unwrap()
+                    .strip_suffix('\'')
+                    .unwrap(),
+            )
+            .env_remove("AOE_INSTANCE_ID")
+            .output()
+            .unwrap();
+        assert!(
+            output.status.success(),
+            "Hook should exit 0 when AOE_INSTANCE_ID is unset, got: {:?}",
+            output.status
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

AoE's installed Claude hooks use `[ -n "$AOE_INSTANCE_ID" ] && ...` as a guard clause. When `AOE_INSTANCE_ID` is not set (non-AoE-managed Claude instances), this returns exit code 1, causing Claude Code to report hook errors on every hook event:

```
Stop hook error: Failed with non-blocking status code: No stderr output
```

Changed the guard to `[ -n "$AOE_INSTANCE_ID" ] || exit 0; ...` so the hook exits cleanly (code 0) when not in an AoE session, while still surfacing real errors from the actual hook commands.

Fixes #412

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)