### PR TITLE
fix: respect default_tool and yolo_mode_default config in aoe add (#408)

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -184,12 +184,14 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             instance.command = cmd.clone();
         }
     } else {
-        // Use default_tool from resolved config, fall back to "claude"
+        // Use default_tool from resolved config, then first available tool, then "claude"
+        let available_tools = crate::tmux::AvailableTools::detect();
         instance.tool = config
             .session
             .default_tool
             .as_deref()
             .and_then(crate::agents::resolve_tool_name)
+            .or_else(|| available_tools.available_list().first().copied())
             .unwrap_or("claude")
             .to_string();
     }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use crate::containers::{self, ContainerRuntimeInterface};
 use crate::session::repo_config;
-use crate::session::{civilizations, Config, GroupTree, Instance, SandboxInfo, Storage};
+use crate::session::{civilizations, resolve_config, GroupTree, Instance, SandboxInfo, Storage};
 
 #[derive(Args)]
 pub struct AddArgs {
@@ -78,6 +78,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         bail!("Path is not a directory: {}", path.display());
     }
 
+    let config = resolve_config(profile).unwrap_or_default();
+
     let mut worktree_info_opt = None;
 
     if let Some(branch_raw) = &args.worktree_branch {
@@ -90,8 +92,6 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         if !GitWorktree::is_git_repo(&path) {
             bail!("Path is not in a git repository\nTip: Navigate to a git repository first");
         }
-
-        let config = Config::load()?;
 
         let main_repo_path = GitWorktree::find_main_repo(&path)?;
         let git_wt = GitWorktree::new(main_repo_path.clone())?;
@@ -183,15 +183,30 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         if cmd.trim().contains(' ') {
             instance.command = cmd.clone();
         }
+    } else {
+        // Use default_tool from resolved config, fall back to "claude"
+        instance.tool = config
+            .session
+            .default_tool
+            .as_deref()
+            .and_then(crate::agents::resolve_tool_name)
+            .unwrap_or("claude")
+            .to_string();
+    }
+
+    // Apply set_default_command for agents that need it (e.g., opencode, codex)
+    if instance.command.is_empty() {
+        instance.command = crate::agents::get_agent(&instance.tool)
+            .filter(|a| a.set_default_command)
+            .map(|a| a.binary.to_string())
+            .unwrap_or_default();
     }
 
     if let Some(worktree_info) = worktree_info_opt {
         instance.worktree_info = Some(worktree_info);
     }
 
-    instance.yolo_mode = args.yolo;
-
-    let config = Config::load()?;
+    instance.yolo_mode = args.yolo || config.session.yolo_mode_default;
 
     // Apply extra_args and command override: CLI flags take priority, then config defaults
     if let Some(ref extra) = args.extra_args {
@@ -238,9 +253,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 container_name,
                 created_at: None,
                 extra_env: None,
-                custom_instruction: Config::load()
-                    .ok()
-                    .and_then(|c| c.sandbox.custom_instruction),
+                custom_instruction: config.sandbox.custom_instruction.clone(),
             });
         }
     }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use crate::containers::{self, ContainerRuntimeInterface};
 use crate::git::GitWorktree;
 
-use super::{civilizations, Config, Instance, SandboxInfo, WorktreeInfo};
+use super::{civilizations, Instance, SandboxInfo, WorktreeInfo};
 
 /// Parameters for creating a new session instance.
 #[derive(Debug, Clone)]
@@ -53,7 +53,11 @@ pub struct CreatedWorktree {
 /// This does NOT start the instance or create Docker containers - that happens
 /// separately via `instance.start()`. This separation allows for proper cleanup
 /// if starting fails.
-pub fn build_instance(params: InstanceParams, existing_titles: &[&str]) -> Result<BuildResult> {
+pub fn build_instance(
+    params: InstanceParams,
+    existing_titles: &[&str],
+    profile: &str,
+) -> Result<BuildResult> {
     if params.sandbox {
         let runtime = containers::get_container_runtime();
         if !runtime.is_available() {
@@ -64,7 +68,7 @@ pub fn build_instance(params: InstanceParams, existing_titles: &[&str]) -> Resul
         }
     }
 
-    let config = Config::load().unwrap_or_default();
+    let config = super::profile_config::resolve_config(profile).unwrap_or_default();
 
     let mut final_path = PathBuf::from(&params.path)
         .canonicalize()

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -92,6 +92,7 @@ impl CreationPoller {
     ) -> CreationResult {
         let data = request.data;
         let hooks = request.hooks;
+        let profile = data.profile.clone();
 
         let existing_titles: Vec<&str> = request
             .existing_instances
@@ -114,7 +115,7 @@ impl CreationPoller {
             command_override: data.command_override,
         };
 
-        let build_result = match builder::build_instance(params, &existing_titles) {
+        let build_result = match builder::build_instance(params, &existing_titles, &profile) {
             Ok(r) => r,
             Err(e) => return CreationResult::Error(format!("{:#}", e)),
         };

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -319,7 +319,11 @@ impl NewSessionDialog {
         let yolo_mode = config.session.yolo_mode_default;
 
         // Load extra args and command override for the default tool
-        let selected_tool = available_tools.get(tool_index).copied().unwrap_or("claude");
+        let selected_tool = available_tools
+            .get(tool_index)
+            .or_else(|| available_tools.first())
+            .copied()
+            .unwrap_or("claude");
         let extra_args_value = config
             .session
             .agent_extra_args
@@ -507,6 +511,7 @@ impl NewSessionDialog {
         let selected_tool = self
             .available_tools
             .get(self.tool_index)
+            .or_else(|| self.available_tools.first())
             .copied()
             .unwrap_or("claude");
         self.extra_args = Input::new(
@@ -1059,6 +1064,7 @@ impl NewSessionDialog {
         let tool = self
             .available_tools
             .get(self.tool_index)
+            .or_else(|| self.available_tools.first())
             .copied()
             .unwrap_or("claude");
         self.extra_args = Input::new(

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -659,6 +659,7 @@ impl NewSessionDialog {
         let selected_tool = self
             .available_tools
             .get(self.tool_index)
+            .or_else(|| self.available_tools.first())
             .copied()
             .unwrap_or("claude");
         let title = format!(" Tool Configuration: {} ", selected_tool);

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -39,7 +39,7 @@ impl HomeView {
             command_override: data.command_override,
         };
 
-        let build_result = builder::build_instance(params, &existing_titles)?;
+        let build_result = builder::build_instance(params, &existing_titles, &target_profile)?;
         let instance = build_result.instance;
         let session_id = instance.id.clone();
 

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -16,6 +16,15 @@ fn read_sessions_json(h: &TuiTestHarness) -> serde_json::Value {
     serde_json::from_str(&content).expect("invalid sessions JSON")
 }
 
+/// Return the first available tool on this system, or "claude" as final fallback.
+fn first_available_tool() -> &'static str {
+    agent_of_empires::tmux::AvailableTools::detect()
+        .available_list()
+        .first()
+        .copied()
+        .unwrap_or("claude")
+}
+
 #[test]
 #[serial]
 fn test_cli_add_and_list() {
@@ -92,6 +101,7 @@ has_seen_welcome = true
 last_seen_version = "{}"
 
 [session]
+default_tool = "claude"
 agent_extra_args = {{ claude = "--verbose --debug" }}
 "#,
         env!("CARGO_PKG_VERSION")
@@ -135,6 +145,7 @@ has_seen_welcome = true
 last_seen_version = "{}"
 
 [session]
+default_tool = "claude"
 agent_command_override = {{ claude = "my-custom-claude" }}
 "#,
         env!("CARGO_PKG_VERSION")
@@ -178,6 +189,7 @@ has_seen_welcome = true
 last_seen_version = "{}"
 
 [session]
+default_tool = "claude"
 agent_extra_args = {{ claude = "--from-config" }}
 agent_command_override = {{ claude = "config-claude" }}
 "#,
@@ -391,9 +403,11 @@ fn test_cli_add_default_tool_no_config() {
 
     let sessions = read_sessions_json(&h);
     let session = &sessions[0];
+    let expected = first_available_tool();
     assert_eq!(
         session["tool"].as_str().unwrap_or(""),
-        "claude",
-        "tool should default to 'claude' when no default_tool config"
+        expected,
+        "tool should default to first available tool ('{}') when no default_tool config",
+        expected
     );
 }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -215,3 +215,185 @@ agent_command_override = {{ claude = "config-claude" }}
         "CLI --cmd-override should override config"
     );
 }
+
+#[test]
+#[serial]
+fn test_cli_add_respects_default_tool() {
+    let h = TuiTestHarness::new("cli_add_default_tool");
+    let project = h.project_path();
+
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+default_tool = "opencode"
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "DefaultTool"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["tool"].as_str().unwrap_or(""),
+        "opencode",
+        "tool should be 'opencode' from default_tool config"
+    );
+    assert_eq!(
+        session["command"].as_str().unwrap_or(""),
+        "opencode",
+        "command should be 'opencode' via set_default_command"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_cmd_overrides_default_tool() {
+    let h = TuiTestHarness::new("cli_add_cmd_overrides");
+    let project = h.project_path();
+
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+default_tool = "opencode"
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-t",
+        "CmdOverride",
+        "--cmd",
+        "claude",
+    ]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["tool"].as_str().unwrap_or(""),
+        "claude",
+        "explicit --cmd should override default_tool config"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_respects_yolo_mode_default() {
+    let h = TuiTestHarness::new("cli_add_yolo_default");
+    let project = h.project_path();
+
+    let config_dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config/agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    let config_content = format!(
+        r#"[updates]
+check_enabled = false
+
+[app_state]
+has_seen_welcome = true
+last_seen_version = "{}"
+
+[session]
+yolo_mode_default = true
+"#,
+        env!("CARGO_PKG_VERSION")
+    );
+    std::fs::write(config_dir.join("config.toml"), config_content).expect("write config.toml");
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "YoloDefault"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["yolo_mode"].as_bool(),
+        Some(true),
+        "yolo_mode should be true from yolo_mode_default config"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_yolo_flag_without_config() {
+    let h = TuiTestHarness::new("cli_add_yolo_flag");
+    let project = h.project_path();
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "YoloFlag", "--yolo"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["yolo_mode"].as_bool(),
+        Some(true),
+        "--yolo flag should set yolo_mode to true"
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_default_tool_no_config() {
+    let h = TuiTestHarness::new("cli_add_no_config");
+    let project = h.project_path();
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "NoConfig"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let sessions = read_sessions_json(&h);
+    let session = &sessions[0];
+    assert_eq!(
+        session["tool"].as_str().unwrap_or(""),
+        "claude",
+        "tool should default to 'claude' when no default_tool config"
+    );
+}


### PR DESCRIPTION
## Description

Fixes #408. `aoe add` ignored `default_tool`, `yolo_mode_default`, and profile overrides because it used `Config::load()` instead of `resolve_config(profile)`. The TUI path worked correctly; the CLI and builder did not.

**What changed:**

1. **CLI `add.rs`**: consolidate three `Config::load()` into one `resolve_config(profile)`. Apply `default_tool`, `yolo_mode_default`, and `set_default_command` when no `--cmd` flag is given. Tool fallback chain: `config.default_tool -> first available tool -> "claude"` (matching TUI behavior).

2. **TUI fallbacks** (`new_session/mod.rs`, `render.rs`): replace four bare `.unwrap_or("claude")` with `.or_else(|| available_tools.first()).unwrap_or("claude")` so the first installed tool is preferred over a hardcoded "claude".

3. **Builder** (`builder.rs`): `build_instance()` now takes a `profile` parameter and uses `resolve_config(profile)` instead of `Config::load()`. This makes `agent_command_override`, `agent_extra_args`, worktree templates, and `sandbox.custom_instruction` profile-aware in the TUI path.

4. **E2E tests** (`tests/e2e/cli.rs`): 5 new tests covering `default_tool`, `--cmd` override, `yolo_mode_default`, yolo flag without config, and no-config fallback.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

```
cargo test          # 835 lib tests + 10 e2e cli_add tests -- all pass
cargo clippy        # 0 warnings
cargo fmt --check   # clean
```

E2E scenarios verified:
- `aoe add` with `default_tool = "opencode"` -> `tool = "opencode"`, `command = "opencode"`
- `aoe add --cmd claude` with `default_tool = "opencode"` -> flag wins -> `tool = "claude"`
- `aoe add` with `yolo_mode_default = true` (no `--yolo`) -> `yolo_mode = true`
- `aoe add` with no config -> falls back to first available tool, then "claude"

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (claude-opus-4-6) via OpenCode

- [x] I am an AI Agent filling out this form (check box if true)