### PR TITLE
fix: replace time-based hook staleness with process-aware liveness checks

### DIFF
--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -4,14 +4,10 @@
 //! file path so AoE can detect agent status without parsing tmux pane content.
 
 use std::path::PathBuf;
-use std::time::Duration;
 
 use crate::session::Status;
 
 use super::HOOK_STATUS_BASE;
-
-/// Status files older than this are considered stale (safety net for crashed sessions).
-const STALENESS_THRESHOLD: Duration = Duration::from_secs(5 * 60);
 
 /// Return the directory for a given instance's hook status file.
 pub fn hook_status_dir(instance_id: &str) -> PathBuf {
@@ -20,22 +16,11 @@ pub fn hook_status_dir(instance_id: &str) -> PathBuf {
 
 /// Read the hook-written status file for the given instance.
 ///
-/// Returns `None` if the file doesn't exist or is older than the staleness
-/// threshold (indicating a crashed/abandoned session).
+/// Returns `None` if the file doesn't exist. Callers are responsible for
+/// detecting crashed/abandoned sessions via process liveness checks
+/// (e.g. `is_pane_dead()`, `is_pane_running_shell()`).
 pub fn read_hook_status(instance_id: &str) -> Option<Status> {
     let status_path = hook_status_dir(instance_id).join("status");
-
-    // Check file age first -- ignore stale files from crashed sessions
-    let metadata = std::fs::symlink_metadata(&status_path).ok()?;
-    let modified = metadata.modified().ok()?;
-    if modified.elapsed().ok()? > STALENESS_THRESHOLD {
-        tracing::debug!(
-            "Hook status file for {} is stale (>{:?}), ignoring",
-            instance_id,
-            STALENESS_THRESHOLD
-        );
-        return None;
-    }
 
     let content = std::fs::read_to_string(&status_path).ok()?;
     match content.trim() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -639,7 +639,8 @@ impl Instance {
         // Check hook-based status first (more reliable than tmux pane parsing)
         if let Some(hook_status) = crate::hooks::read_hook_status(&self.id) {
             tracing::trace!("hook status detection '{}': {:?}", self.title, hook_status);
-            self.status = if session.is_pane_dead() {
+            let crashed_to_shell = !self.expects_shell() && session.is_pane_running_shell();
+            self.status = if session.is_pane_dead() || crashed_to_shell {
                 Status::Error
             } else {
                 hook_status


### PR DESCRIPTION
## Description

The 5-minute `STALENESS_THRESHOLD` on hook status files caused sessions to incorrectly show as Idle during long-running MCP tool calls (>5 min). When the hook file's mtime exceeded the threshold, `read_hook_status()` returned `None`, falling through to the `detect_claude_status()` stub which always returns Idle.

This replaces the time-based staleness check with process-aware liveness checks that already exist in the codebase:

- **`is_pane_dead()`** -- detects exited processes (tmux `#{pane_dead}` flag)
- **`is_pane_running_shell()`** -- detects agents that crashed back to a shell prompt

**Changes:**
1. `src/hooks/status_file.rs` -- Removed `STALENESS_THRESHOLD` and the mtime check from `read_hook_status()`. It now reads and parses the file without time-based filtering.
2. `src/session/instance.rs` -- Added `is_pane_running_shell()` check to the hook status path in `update_status()`, matching the safety checks already present in the fallback path.

**Bonus fix:** The hook path previously only checked `is_pane_dead()`. If Claude crashed to a shell without the `Stop` hook firing, the stale "running" status would be trusted until the file expired after 5 minutes. Now it's caught immediately.

**How I tested:** `cargo test` (830 pass), `cargo clippy`, `cargo fmt`. Manual testing approach: backdate a hook status file with `touch -t` and verify the session status stays correct as long as the pane process is alive.

Fixes #423

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Implementation was pair-programmed with Claude Code. Design approach (process-aware vs time-based staleness) was discussed and chosen by the maintainer.

- [x] I am an AI Agent filling out this form (check box if true)