### PR TITLE
fix: rename tmux session before mutating instance title

### DIFF
--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -264,22 +264,16 @@ impl HomeView {
             }
 
             // No profile change - update in place
-            // Read old title before mutation so we can detect renames
+            // Rename tmux session BEFORE mutating the instance, so we can
+            // look up the session by its current (old) name.
             let old_title = self.get_instance(&id).map(|i| i.title.clone());
-
-            self.mutate_instance(&id, |inst| {
-                inst.title = effective_title.clone();
-                inst.group_path = effective_group.clone();
-            });
-
-            // Handle tmux rename if title changed
-            if old_title.is_some_and(|t| t != effective_title) {
-                if let Some(inst) = self.get_instance(&id) {
-                    let tmux_session = inst.tmux_session()?;
-                    if tmux_session.exists() {
+            if let Some(ref old_t) = old_title {
+                if *old_t != effective_title {
+                    let old_tmux_session = crate::tmux::Session::new(&id, old_t)?;
+                    if old_tmux_session.exists() {
                         let new_tmux_name =
                             crate::tmux::Session::generate_name(&id, &effective_title);
-                        if let Err(e) = tmux_session.rename(&new_tmux_name) {
+                        if let Err(e) = old_tmux_session.rename(&new_tmux_name) {
                             tracing::warn!("Failed to rename tmux session: {}", e);
                         } else {
                             crate::tmux::refresh_session_cache();
@@ -287,6 +281,11 @@ impl HomeView {
                     }
                 }
             }
+
+            self.mutate_instance(&id, |inst| {
+                inst.title = effective_title.clone();
+                inst.group_path = effective_group.clone();
+            });
 
             // Rebuild group tree and create group if needed
             self.group_tree = GroupTree::new_with_groups(&self.instances, &self.groups);

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1,6 +1,7 @@
 use serial_test::serial;
+use std::process::Command;
 
-use crate::harness::TuiTestHarness;
+use crate::harness::{require_tmux, TuiTestHarness};
 
 /// Helper to read a session field from the sessions.json in the harness's isolated home.
 fn read_sessions_json(h: &TuiTestHarness) -> serde_json::Value {
@@ -410,4 +411,91 @@ fn test_cli_add_default_tool_no_config() {
         "tool should default to first available tool ('{}') when no default_tool config",
         expected
     );
+}
+
+/// Renaming a session via CLI should rename the tmux session, not kill it.
+/// Regression test for https://github.com/njbrake/agent-of-empires/issues/431
+#[test]
+#[serial]
+fn test_cli_rename_preserves_tmux_session() {
+    require_tmux!();
+
+    let h = TuiTestHarness::new("cli_rename_tmux");
+    let project = h.project_path();
+
+    // 1. Add a session
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "OldName"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    // 2. Read the session ID from storage
+    let sessions = read_sessions_json(&h);
+    let session_id = sessions[0]["id"].as_str().expect("session should have id");
+    let truncated_id = &session_id[..8.min(session_id.len())];
+
+    // 3. Compute the tmux session name that aoe would use
+    let old_tmux_name = format!("aoe_OldName_{}", truncated_id);
+
+    // Create a real tmux session with that name (simulates a running session)
+    let create = Command::new("tmux")
+        .args([
+            "new-session",
+            "-d",
+            "-s",
+            &old_tmux_name,
+            "-x",
+            "80",
+            "-y",
+            "24",
+            "sleep",
+            "60",
+        ])
+        .output()
+        .expect("tmux new-session");
+    assert!(
+        create.status.success(),
+        "failed to create tmux session: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+
+    // 4. Rename the session via CLI
+    let rename_output = h.run_cli(&["session", "rename", session_id, "-t", "NewName"]);
+    assert!(
+        rename_output.status.success(),
+        "aoe session rename failed: {}",
+        String::from_utf8_lossy(&rename_output.stderr)
+    );
+
+    // 5. The old tmux session name should be gone
+    let old_exists = Command::new("tmux")
+        .args(["has-session", "-t", &old_tmux_name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        !old_exists,
+        "Old tmux session '{}' should no longer exist after rename",
+        old_tmux_name
+    );
+
+    // 6. The new tmux session name should exist
+    let new_tmux_name = format!("aoe_NewName_{}", truncated_id);
+    let new_exists = Command::new("tmux")
+        .args(["has-session", "-t", &new_tmux_name])
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(
+        new_exists,
+        "New tmux session '{}' should exist after rename",
+        new_tmux_name
+    );
+
+    // Cleanup
+    let _ = Command::new("tmux")
+        .args(["kill-session", "-t", &new_tmux_name])
+        .output();
 }


### PR DESCRIPTION
## Description

Fixes #431 - Renaming a session was killing it because the TUI rename path mutated the session title (via `mutate_instance()`) BEFORE attempting to rename the tmux session. This caused `tmux_session()` to generate a name from the NEW title, failing to find the actual running tmux session (which still had the OLD name). The rename was silently skipped, and on the next status check the session appeared dead.

The fix reorders operations to rename the tmux session FIRST (using the old title to locate it), then mutate the instance data. This matches how the CLI rename path (`cli/session.rs`) already worked correctly.

Also adds an e2e regression test that creates a session with a tmux session, renames it via CLI, and verifies the tmux session survives with the new name.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)