### PR TITLE
fix: target window 0 pane 0 in tmux health checks

### DIFF
--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -10,8 +10,11 @@ mod macos;
 
 /// Get the PID of the shell process running in a tmux pane
 pub fn get_pane_pid(session_name: &str) -> Option<u32> {
+    // Target window 0, pane 0 explicitly so we always query the agent's pane,
+    // not whichever window happens to be active.  See #435.
+    let target = format!("{session_name}:0.0");
     let output = Command::new("tmux")
-        .args(["display-message", "-t", session_name, "-p", "#{pane_pid}"])
+        .args(["display-message", "-t", &target, "-p", "#{pane_pid}"])
         .output()
         .ok()?;
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -179,11 +179,13 @@ impl Session {
             return Ok(String::new());
         }
 
+        // Target window 0, pane 0 explicitly.  See #435.
+        let target = format!("{}:0.0", self.name);
         let output = Command::new("tmux")
             .args([
                 "capture-pane",
                 "-t",
-                &self.name,
+                &target,
                 "-p",
                 "-S",
                 &format!("-{}", lines),
@@ -377,6 +379,70 @@ mod tests {
             .map(|s| s.trim() == "1")
             .unwrap_or(false);
         assert!(!pane_dead, "Pane should be alive while command is running");
+
+        // Clean up
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &session_name])
+            .output();
+    }
+
+    /// Regression test for #435: with multiple tmux windows, pane health
+    /// checks must target window 0 pane 0 explicitly so that a dead pane in
+    /// a second window does not cause the agent pane to be killed.
+    #[test]
+    #[serial_test::serial]
+    fn test_is_pane_dead_targets_window_zero_with_multiple_windows() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+
+        let session_name = format!("aoe_test_multiwin_{}", std::process::id());
+
+        // Create session with a long-running command in window 0
+        let output = Command::new("tmux")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &session_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep 30",
+                ";",
+                "set-option",
+                "-p",
+                "-t",
+                &session_name,
+                "remain-on-exit",
+                "on",
+            ])
+            .output()
+            .expect("tmux new-session");
+        assert!(output.status.success());
+
+        // Create a second window with a command that exits immediately
+        let output = Command::new("tmux")
+            .args([
+                "new-window",
+                "-t",
+                &session_name,
+                "true", // exits immediately
+            ])
+            .output()
+            .expect("tmux new-window");
+        assert!(output.status.success());
+
+        std::thread::sleep(std::time::Duration::from_millis(300));
+
+        // The agent pane (window 0) is still alive, so is_pane_dead should
+        // return false even though the second window's pane has exited.
+        assert!(
+            !is_pane_dead(&session_name),
+            "is_pane_dead should check window 0 pane 0, not the active window"
+        );
 
         // Clean up
         let _ = Command::new("tmux")

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -136,11 +136,12 @@ impl TerminalSession {
             return Ok(String::new());
         }
 
+        let target = format!("{}:0.0", self.name);
         let output = Command::new("tmux")
             .args([
                 "capture-pane",
                 "-t",
-                &self.name,
+                &target,
                 "-p",
                 "-S",
                 &format!("-{}", lines),
@@ -284,11 +285,12 @@ impl ContainerTerminalSession {
             return Ok(String::new());
         }
 
+        let target = format!("{}:0.0", self.name);
         let output = Command::new("tmux")
             .args([
                 "capture-pane",
                 "-t",
-                &self.name,
+                &target,
                 "-p",
                 "-S",
                 &format!("-{}", lines),

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -57,8 +57,12 @@ pub fn append_remain_on_exit_args(args: &mut Vec<String>, target: &str) {
 }
 
 pub fn is_pane_dead(session_name: &str) -> bool {
+    // Target window 0, pane 0 explicitly so the check always hits the agent's
+    // pane, even when the user has created additional tmux windows and the
+    // active window is not the first one.  See #435.
+    let target = format!("{session_name}:0.0");
     Command::new("tmux")
-        .args(["display-message", "-t", session_name, "-p", "#{pane_dead}"])
+        .args(["display-message", "-t", &target, "-p", "#{pane_dead}"])
         .output()
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
@@ -67,11 +71,12 @@ pub fn is_pane_dead(session_name: &str) -> bool {
 }
 
 fn pane_current_command(session_name: &str) -> Option<String> {
+    let target = format!("{session_name}:0.0");
     Command::new("tmux")
         .args([
             "display-message",
             "-t",
-            session_name,
+            &target,
             "-p",
             "#{pane_current_command}",
         ])


### PR DESCRIPTION
## Description

When users create additional tmux windows (`Ctrl+b c`) in an aoe session and detach from a non-first window, tmux `display-message -t <session>` resolves to the currently active window/pane rather than window 0 where the agent runs. This caused `is_pane_dead()` and `is_pane_running_shell()` to query the wrong pane, incorrectly concluding the agent was dead, and killing/restarting the session on reattach.

The fix pins all pane-querying tmux commands (`display-message`, `capture-pane`) to the explicit target `{session}:0.0` so they always check the agent's pane regardless of which window is active.

**Files changed:**
- `src/tmux/utils.rs` - `is_pane_dead()` and `pane_current_command()` now target `:0.0`
- `src/process/mod.rs` - `get_pane_pid()` now targets `:0.0`
- `src/tmux/session.rs` - `capture_pane_with_size()` targets `:0.0` + new regression test
- `src/tmux/terminal_session.rs` - Both `TerminalSession` and `ContainerTerminalSession` `capture_pane()` target `:0.0`

Fixes #435

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Root cause analysis from issue comments was used to guide the fix.

- [x] I am an AI Agent filling out this form (check box if true)