### PR TITLE
fix: update oven-sh/setup-bun SHA in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,7 +252,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: oven-sh/setup-bun@735343b667d3e6656e3338e15e2e8dae48a3b65e # v2
+      - uses: oven-sh/setup-bun@ecf28ddc73e819eb6fa29df6b34ef8921c743461 # v2
         if: env.CLAWHUB_TOKEN != ''
 
       - name: Install clawhub CLI


### PR DESCRIPTION
## Description

The `publish-clawhub` job in the release workflow fails during action download because the pinned SHA `735343b667d3e6656e3338e15e2e8dae48a3b65e` for `oven-sh/setup-bun` does not exist in that repository. Updated to the correct SHA (`ecf28ddc`) that corresponds to the `v2` tag.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)