### PR TITLE
fix: resolve clawhub publish path with space in bun global directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,8 @@ jobs:
         run: |
           bun install -g clawhub
           # Workaround: clawhub CLI v0.7.0 doesn't send acceptLicenseTerms
-          PUBLISH_JS="$(bun pm ls -g 2>/dev/null | grep -o '/.*node_modules')/clawhub/dist/cli/commands/publish.js"
+          GLOBAL_DIR="$(bun pm ls -g 2>/dev/null | head -1 | sed 's/ .*//')"
+          PUBLISH_JS="${GLOBAL_DIR}/node_modules/clawhub/dist/cli/commands/publish.js"
           sed -i 's/slug,/slug, acceptLicenseTerms: true,/' "$PUBLISH_JS"
 
       - name: Publish skill


### PR DESCRIPTION
`bun pm ls -g` outputs lines like `/path/to/global node_modules` where "node_modules" is a display label separated by a space. The previous `grep -o '/.*node_modules'` captured the space, producing an invalid file path that caused `sed` to fail with "No such file or directory".

Extract just the directory prefix and construct the path explicitly.

## Description
<!-- Describe your changes and the problem they solve -->


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] I understand the code I am submitting
- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)
