### PR TITLE
fix: avoid blocking Docker call on main thread during sandbox creation

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -156,8 +156,6 @@ pub struct NewSessionDialog {
     pub(super) loading: bool,
     /// Spinner animation frame counter
     pub(super) spinner_frame: usize,
-    /// Whether a Docker image pull will be needed (image not present locally)
-    pub(super) needs_image_pull: bool,
     /// Whether hooks are being executed during loading
     pub(super) has_hooks: bool,
     /// The currently running hook command
@@ -391,7 +389,7 @@ impl NewSessionDialog {
             show_help: false,
             loading: false,
             spinner_frame: 0,
-            needs_image_pull: false,
+
             has_hooks: false,
             current_hook: None,
             hook_output: Vec::new(),
@@ -424,12 +422,6 @@ impl NewSessionDialog {
         self.loading = loading;
         if loading {
             self.error_message = None;
-            // Check if image pull will be needed (only relevant for sandbox sessions)
-            if self.sandbox_enabled {
-                let image = self.sandbox_image.value().trim();
-                self.needs_image_pull =
-                    !containers::get_container_runtime().image_exists_locally(image);
-            }
         }
     }
 
@@ -602,7 +594,7 @@ impl NewSessionDialog {
             show_help: false,
             loading: false,
             spinner_frame: 0,
-            needs_image_pull: false,
+
             has_hooks: false,
             current_hook: None,
             hook_output: Vec::new(),
@@ -655,7 +647,7 @@ impl NewSessionDialog {
             show_help: false,
             loading: false,
             spinner_frame: 0,
-            needs_image_pull: false,
+
             has_hooks: false,
             current_hook: None,
             hook_output: Vec::new(),

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -958,20 +958,19 @@ impl NewSessionDialog {
     }
 
     fn render_loading(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let needs_extra_line = self.sandbox_enabled && self.needs_image_pull;
         let show_hook_output = self.has_hooks;
         let max_output_lines: usize = 6;
 
         let dialog_width: u16 = if show_hook_output {
             70
-        } else if needs_extra_line {
+        } else if self.sandbox_enabled {
             55
         } else {
             50
         };
         let dialog_height: u16 = if show_hook_output {
             (6 + max_output_lines as u16).min(area.height)
-        } else if needs_extra_line {
+        } else if self.sandbox_enabled {
             9
         } else {
             7
@@ -1054,11 +1053,7 @@ impl NewSessionDialog {
             frame.render_widget(Paragraph::new(lines), inner);
         } else {
             let loading_text = if self.sandbox_enabled {
-                if self.needs_image_pull {
-                    "Pulling sandbox image..."
-                } else {
-                    "Setting up sandbox container..."
-                }
+                "Setting up sandbox..."
             } else {
                 "Creating session..."
             };
@@ -1074,7 +1069,7 @@ impl NewSessionDialog {
                 ]),
             ];
 
-            if needs_extra_line {
+            if self.sandbox_enabled {
                 lines.push(Line::from(Span::styled(
                     "    (first time may take a few minutes)",
                     Style::default().fg(theme.dimmed),


### PR DESCRIPTION
## Description

`NewSessionDialog::set_loading()` calls `image_exists_locally()` synchronously on the main TUI thread, which runs `docker image inspect` as a blocking subprocess. When Docker Desktop is slow or unresponsive (common on macOS during disk pressure, after sleep/wake, or when the daemon has wedged), this freezes the entire TUI indefinitely with no way to recover except killing the process.

The check was purely cosmetic -- it determined whether the loading spinner shows "Pulling sandbox image..." vs "Setting up sandbox container...". The actual image availability check already runs in the background creation thread via `ensure_image()`.

**Fix:** Replace the blocking call with `needs_image_pull = true` (safe default) and simplify the loading text to "Setting up sandbox..." for all sandbox sessions.

Fixes #449

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**

Diagnosed via `sample` stack traces showing the main thread blocked in `poll` inside `std::process::Command::output` called from `image_exists_locally`. Debug logging confirmed the freeze occurs immediately after pressing Enter on the New Session dialog with Sandbox enabled.

- [x] I am an AI Agent filling out this form (check box if true)