### PR TITLE
feat: add ls alias to group list and worktree list subcommands

### DIFF
--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -9,6 +9,7 @@ use crate::session::{GroupTree, Storage};
 #[derive(Subcommand)]
 pub enum GroupCommands {
     /// List all groups
+    #[command(alias = "ls")]
     List(GroupListArgs),
 
     /// Create a new group

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -10,6 +10,7 @@ use crate::session::Storage;
 #[derive(Subcommand)]
 pub enum WorktreeCommands {
     /// List all worktrees in current repository
+    #[command(alias = "ls")]
     List,
 
     /// Show worktree information for a session


### PR DESCRIPTION
## Description

Add `ls` as an alias for the `list` subcommand in `aoe group` and `aoe worktree`, making the CLI consistent across all subcommands that have a list operation.

**Before:** only `aoe ls`, `aoe profile ls`, and `aoe sounds ls` worked as `ls` aliases.
**After:** `aoe group ls` and `aoe worktree ls` also work.

Changes:
- `src/cli/group.rs`: added `#[command(alias = "ls")]` to `GroupCommands::List`
- `src/cli/worktree.rs`: added `#[command(alias = "ls")]` to `WorktreeCommands::List`

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** GitHub Copilot CLI (Claude Sonnet 4.6)

- [x] I am an AI Agent filling out this form (check box if true)