### PR TITLE
refactor: write debug logs to file and improve logging resilience

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - `cargo test`: run unit + integration tests (some tests skip if `tmux` is unavailable).
 - `cargo fmt`: format with rustfmt (run before pushing).
 - `cargo clippy`: lint (fix warnings unless there’s a strong reason not to).
-- Debug logging: `RUST_LOG=agent_of_empires=debug cargo run` (or `AGENT_OF_EMPIRES_DEBUG=1 cargo run`).
+- Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes to `debug.log` in app data dir).
 
 ## Settings & Configuration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,9 +43,9 @@ cargo fmt                      # Format code
 cargo clippy                   # Lint
 ```
 
-For debug logging:
+For debug logging (writes to `debug.log` in app data dir):
 ```bash
-RUST_LOG=agent_of_empires=debug cargo run
+AGENT_OF_EMPIRES_DEBUG=1 cargo run
 ```
 
 ## Making Changes

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ cargo fmt            # Format
 cargo clippy         # Lint
 cargo build --release  # Release build
 
-# Debug logging
+# Debug logging (writes to debug.log in app data dir)
 AGENT_OF_EMPIRES_DEBUG=1 cargo run
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,8 +14,7 @@ The release binary is at `target/release/aoe`.
 
 ```bash
 cargo run --release            # Run from source
-AGENT_OF_EMPIRES_DEBUG=1 cargo run  # With debug logging
-RUST_LOG=agent_of_empires=debug cargo run  # With env_logger debug output
+AGENT_OF_EMPIRES_DEBUG=1 cargo run  # Debug logging (writes to debug.log in app data dir)
 ```
 
 Requires `tmux` to be installed.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -35,7 +35,7 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 | Variable | Description |
 |----------|-------------|
 | `AGENT_OF_EMPIRES_PROFILE` | Default profile to use |
-| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging (`1` to enable) |
+| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging to `debug.log` in app data dir (`1` to enable) |
 
 ## Theme
 

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -160,7 +160,7 @@ sudo pacman -S alsa-utils pulseaudio
 - Check that sound files exist in `~/.config/agent-of-empires/sounds/`
 - Verify sounds are enabled in Settings
 - Test audio with: `aplay ~/.config/agent-of-empires/sounds/start.wav` (Linux)
-- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe`
+- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe` (writes to `debug.log` in app data dir)
 
 **Want Age of Empires II sounds?**
 If you own AoE II, manually copy the taunt files to your sounds directory.

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use clap_complete::generate;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let mut debug_log_warning: Option<String> = None;
     if std::env::var("AGENT_OF_EMPIRES_DEBUG").is_ok() {
         // Log to file to avoid corrupting the TUI on stderr.
         let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
@@ -24,9 +25,9 @@ async fn main() -> Result<()> {
                 .init();
             tracing::info!("Debug logging to {}", log_path.unwrap().display());
         } else {
-            tracing_subscriber::fmt()
-                .with_env_filter("agent_of_empires=debug")
-                .init();
+            debug_log_warning = Some(
+                "AGENT_OF_EMPIRES_DEBUG is set but the debug log file could not be created. Debug logging is disabled.".to_string(),
+            );
         }
     }
 
@@ -67,7 +68,7 @@ async fn main() -> Result<()> {
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
         Some(Commands::Profile { command }) => cli::profile::run(command).await,
         Some(Commands::Worktree { command }) => cli::worktree::run(&profile, command).await,
-        None => tui::run(&profile).await,
+        None => tui::run(&profile, debug_log_warning).await,
         _ => unreachable!(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,24 @@ use clap_complete::generate;
 #[tokio::main]
 async fn main() -> Result<()> {
     if std::env::var("AGENT_OF_EMPIRES_DEBUG").is_ok() {
-        tracing_subscriber::fmt()
-            .with_env_filter("agent_of_empires=debug")
-            .init();
+        // Log to file to avoid corrupting the TUI on stderr.
+        let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
+        let log_file = log_path
+            .as_ref()
+            .ok()
+            .and_then(|p| std::fs::File::create(p).ok());
+        if let Some(file) = log_file {
+            tracing_subscriber::fmt()
+                .with_env_filter("agent_of_empires=debug")
+                .with_writer(std::sync::Mutex::new(file))
+                .with_ansi(false)
+                .init();
+            tracing::info!("Debug logging to {}", log_path.unwrap().display());
+        } else {
+            tracing_subscriber::fmt()
+                .with_env_filter("agent_of_empires=debug")
+                .init();
+        }
     }
 
     let cli = Cli::parse();

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -11,7 +11,7 @@ use chrono::Utc;
 use crate::containers::{self, ContainerRuntimeInterface};
 use crate::git::GitWorktree;
 
-use super::{civilizations, Instance, SandboxInfo, WorktreeInfo};
+use super::{civilizations, Config, Instance, SandboxInfo, WorktreeInfo};
 
 /// Parameters for creating a new session instance.
 #[derive(Debug, Clone)]
@@ -68,7 +68,10 @@ pub fn build_instance(
         }
     }
 
-    let config = super::profile_config::resolve_config(profile).unwrap_or_default();
+    let config = super::profile_config::resolve_config(profile).unwrap_or_else(|e| {
+        tracing::warn!("Failed to load config, using defaults: {}", e);
+        Config::default()
+    });
 
     let mut final_path = PathBuf::from(&params.path)
         .canonicalize()

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -118,6 +118,10 @@ impl App {
         })
     }
 
+    pub fn show_startup_warning(&mut self, message: &str) {
+        self.home.info_dialog = Some(crate::tui::dialogs::InfoDialog::new("Warning", message));
+    }
+
     pub fn set_theme(&mut self, name: &str) {
         self.theme = load_theme(name);
         self.needs_redraw = true;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -26,7 +26,7 @@ use crate::migrations;
 use crate::session::get_update_settings;
 use crate::update::check_for_update;
 
-pub async fn run(profile: &str) -> Result<()> {
+pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // Run pending migrations with a spinner so users see progress
     if migrations::has_pending_migrations() {
         const SPINNER_FRAMES: &[char] = &['◐', '◓', '◑', '◒'];
@@ -100,6 +100,9 @@ pub async fn run(profile: &str) -> Result<()> {
 
     // Create app and run
     let mut app = App::new(profile, available_tools)?;
+    if let Some(warning) = startup_warning {
+        app.show_startup_warning(&warning);
+    }
     let result = app.run(&mut terminal).await;
 
     // Restore terminal

--- a/website/src/pages/docs/development.md
+++ b/website/src/pages/docs/development.md
@@ -18,8 +18,7 @@ The release binary is at `target/release/aoe`.
 
 ```bash
 cargo run --release            # Run from source
-AGENT_OF_EMPIRES_DEBUG=1 cargo run  # With debug logging
-RUST_LOG=agent_of_empires=debug cargo run  # With env_logger debug output
+AGENT_OF_EMPIRES_DEBUG=1 cargo run  # Debug logging (writes to debug.log in app data dir)
 ```
 
 Requires `tmux` to be installed.

--- a/website/src/pages/docs/guides/configuration.md
+++ b/website/src/pages/docs/guides/configuration.md
@@ -39,7 +39,7 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 | Variable | Description |
 |----------|-------------|
 | `AGENT_OF_EMPIRES_PROFILE` | Default profile to use |
-| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging (`1` to enable) |
+| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging to `debug.log` in app data dir (`1` to enable) |
 
 ## Session
 

--- a/website/src/pages/docs/sounds.md
+++ b/website/src/pages/docs/sounds.md
@@ -164,7 +164,7 @@ sudo pacman -S alsa-utils pulseaudio
 - Check that sound files exist in `~/.config/agent-of-empires/sounds/`
 - Verify sounds are enabled in Settings
 - Test audio with: `aplay ~/.config/agent-of-empires/sounds/start.wav` (Linux)
-- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe`
+- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe` (writes to `debug.log` in app data dir)
 
 **Want Age of Empires II sounds?**
 If you own AoE II, manually copy the taunt files to your sounds directory.


### PR DESCRIPTION
## Description

Extract logging improvements from #382 that are not directly related to its session management feature, reducing the review surface of that PR.

- Debug output now writes to `debug.log` in the app data dir instead of stderr, preventing TUI corruption
- Config resolution failure in the session builder logs a `tracing::warn` instead of silently falling back to defaults
- All documentation updated to reflect file-based debug logging

Changes are identical to the corresponding hunks in #382.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude claude-opus-4-6 via OpenCode

**Any Additional AI Details you'd like to share:** Automated extraction of logging-specific changes from #382 with byte-level diff verification against the source PR.

- [x] I am an AI Agent filling out this form (check box if true)