### PR TITLE
fix: quote env var values in yolo mode to prevent shell expansion

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -457,7 +457,7 @@ impl Instance {
                                         cmd = format!("{} {}", cmd, flag);
                                     }
                                     crate::agents::YoloMode::EnvVar(key, value) => {
-                                        cmd = format!("{}={} {}", key, value, cmd);
+                                        cmd = format!("{}='{}' {}", key, value, cmd);
                                     }
                                     crate::agents::YoloMode::AlwaysYolo => {}
                                 }
@@ -477,7 +477,7 @@ impl Instance {
                                 cmd = format!("{} {}", cmd, flag);
                             }
                             crate::agents::YoloMode::EnvVar(key, value) => {
-                                cmd = format!("{}={} {}", key, value, cmd);
+                                cmd = format!("{}='{}' {}", key, value, cmd);
                             }
                             crate::agents::YoloMode::AlwaysYolo => {}
                         }
@@ -771,6 +771,17 @@ mod tests {
         inst.yolo_mode = true;
         assert!(inst.is_yolo_mode());
         assert!(!inst.is_sandboxed());
+    }
+
+    #[test]
+    fn test_yolo_envvar_command_is_quoted() {
+        // EnvVar values containing JSON must be single-quoted to prevent
+        // shell expansion of special characters ({, *, ").
+        let key = "OPENCODE_PERMISSION";
+        let value = r#"{"*":"allow"}"#;
+        let cmd = "opencode";
+        let result = format!("{}='{}' {}", key, value, cmd);
+        assert_eq!(result, r#"OPENCODE_PERMISSION='{"*":"allow"}' opencode"#);
     }
 
     // Additional tests for is_sandboxed

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -451,7 +451,7 @@ impl Instance {
                                         cmd = format!("{} {}", cmd, flag);
                                     }
                                     crate::agents::YoloMode::EnvVar(key, value) => {
-                                        cmd = format!("{}='{}' {}", key, value, cmd);
+                                        cmd = format_env_var_prefix(key, value, &cmd);
                                     }
                                     crate::agents::YoloMode::AlwaysYolo => {}
                                 }
@@ -471,7 +471,7 @@ impl Instance {
                                 cmd = format!("{} {}", cmd, flag);
                             }
                             crate::agents::YoloMode::EnvVar(key, value) => {
-                                cmd = format!("{}='{}' {}", key, value, cmd);
+                                cmd = format_env_var_prefix(key, value, &cmd);
                             }
                             crate::agents::YoloMode::AlwaysYolo => {}
                         }
@@ -695,6 +695,16 @@ fn generate_id() -> String {
     Uuid::new_v4().to_string().replace("-", "")[..16].to_string()
 }
 
+/// Format an environment variable assignment as a shell-safe command prefix.
+///
+/// Uses `shell_escape` (double-quote escaping) so the value is preserved
+/// verbatim when parsed by the inner `bash -c '...'` shell created by
+/// `wrap_command_ignore_suspend`.
+fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
+    let escaped = shell_escape(value);
+    format!("{}={} {}", key, escaped, cmd)
+}
+
 /// Wrap a command to disable Ctrl-Z (SIGTSTP) suspension.
 ///
 /// When running agents directly as tmux session commands (without a parent shell),
@@ -769,13 +779,26 @@ mod tests {
 
     #[test]
     fn test_yolo_envvar_command_is_quoted() {
-        // EnvVar values containing JSON must be single-quoted to prevent
-        // shell expansion of special characters ({, *, ").
-        let key = "OPENCODE_PERMISSION";
-        let value = r#"{"*":"allow"}"#;
-        let cmd = "opencode";
-        let result = format!("{}='{}' {}", key, value, cmd);
-        assert_eq!(result, r#"OPENCODE_PERMISSION='{"*":"allow"}' opencode"#);
+        // EnvVar values containing JSON must be shell-escaped to prevent
+        // the inner bash from expanding special characters ({, *, ").
+        let result = format_env_var_prefix("OPENCODE_PERMISSION", r#"{"*":"allow"}"#, "opencode");
+        assert_eq!(
+            result,
+            r#"OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode"#
+        );
+    }
+
+    #[test]
+    fn test_yolo_envvar_survives_suspend_wrapper() {
+        // The full chain: format_env_var_prefix -> wrap_command_ignore_suspend
+        // must preserve the JSON value through both quoting layers.
+        let cmd = format_env_var_prefix("OPENCODE_PERMISSION", r#"{"*":"allow"}"#, "opencode");
+        let wrapped = wrap_command_ignore_suspend(&cmd);
+        assert!(
+            wrapped.contains(r#"OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode"#),
+            "wrapped command should contain the escaped env var assignment: {}",
+            wrapped,
+        );
     }
 
     // Additional tests for is_sandboxed


### PR DESCRIPTION
## Description

`YoloMode::EnvVar` passes a JSON value as an inline shell variable (e.g. `OPENCODE_PERMISSION={"*":"allow"} opencode`). Without quoting, the shell expands `{`, `*`, and `"` as metacharacters, corrupting the value and crashing the agent on startup.

Wraps the value in single quotes so the shell preserves it verbatim: `OPENCODE_PERMISSION='{"*":"allow"}' opencode`.

Adds a regression test for the quoting format.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude claude-opus-4-6 via OpenCode

**Any Additional AI Details you'd like to share:** Root cause analysis and fix identified with AI assistance, manually verified by launching an OpenCode session in yolo mode.

- [ ] I am an AI Agent filling out this form (check box if true)