### PR TITLE
fix: trust hook status over shell detection for wrapper scripts

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -679,8 +679,11 @@ impl Instance {
         // Check hook-based status first (more reliable than tmux pane parsing)
         if let Some(hook_status) = crate::hooks::read_hook_status(&self.id) {
             tracing::trace!("hook status detection '{}': {:?}", self.title, hook_status);
-            let crashed_to_shell = !self.expects_shell() && session.is_pane_running_shell();
-            self.status = if session.is_pane_dead() || crashed_to_shell {
+            // Trust hook status over shell detection. Wrapper scripts (e.g.
+            // Devbox, version managers) run agents via a shell process, so
+            // `is_pane_running_shell()` returns true even though the agent is
+            // healthy. Only check if the pane is actually dead.
+            self.status = if session.is_pane_dead() {
                 Status::Error
             } else {
                 hook_status


### PR DESCRIPTION
## Description

When agents are launched via wrapper scripts (e.g. Claude installed with Devbox, version managers), tmux reports `pane_current_command` as `bash` because the outer process is a shell script. The `crashed_to_shell` check in `update_status()` was incorrectly overriding hook-based status with `Error` even when hooks reported a healthy status (`idle`/`running`/`waiting`).

This removes the shell check from the hook-status code path. If hooks are present and reporting a healthy status, we trust them. Only fall back to `Error` when the pane is actually dead.

Fixes #479

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)