### PR TITLE
feat: pre-filled New Session Dialog from selection (N key)

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 34;
+const DIALOG_HEIGHT: u16 = 35;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -33,6 +33,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
             vec![
                 ("Enter", "Attach to session"),
                 ("n", "New session"),
+                ("N", "New from selection"),
                 ("x", "Stop session"),
                 ("d", "Delete session/group"),
                 ("r", "Rename session"),

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -423,6 +423,31 @@ impl NewSessionDialog {
         }
     }
 
+    /// Pre-fill the path field (e.g. from a selected session).
+    pub fn set_path(&mut self, path: String) {
+        self.path = Input::new(path);
+    }
+
+    /// Pre-fill the group field (e.g. from a selected session or group).
+    pub fn set_group(&mut self, group: String) {
+        self.group = Input::new(group);
+    }
+
+    #[cfg(test)]
+    pub fn path_value(&self) -> &str {
+        self.path.value()
+    }
+
+    #[cfg(test)]
+    pub fn group_value(&self) -> &str {
+        self.group.value()
+    }
+
+    #[cfg(test)]
+    pub fn profile_value(&self) -> &str {
+        &self.profile
+    }
+
     /// Set whether hooks will be executed during session creation
     pub fn set_has_hooks(&mut self, has_hooks: bool) {
         self.has_hooks = has_hooks;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -500,6 +500,57 @@ impl HomeView {
                     };
                     self.cursor = self.search_matches[self.search_match_index];
                     self.update_selected();
+                } else {
+                    // Pre-filled new session from selection
+                    let prefill_path = self
+                        .selected_session
+                        .as_ref()
+                        .and_then(|id| self.get_instance(id))
+                        .map(|inst| {
+                            inst.worktree_info
+                                .as_ref()
+                                .map(|wt| wt.main_repo_path.clone())
+                                .unwrap_or_else(|| inst.project_path.clone())
+                        });
+                    let prefill_group = self
+                        .selected_session
+                        .as_ref()
+                        .and_then(|id| self.get_instance(id))
+                        .and_then(|inst| {
+                            if inst.group_path.is_empty() {
+                                None
+                            } else {
+                                Some(inst.group_path.clone())
+                            }
+                        })
+                        .or_else(|| self.selected_group.clone());
+
+                    if prefill_path.is_some() || prefill_group.is_some() {
+                        let existing_titles: Vec<String> =
+                            self.instances().iter().map(|i| i.title.clone()).collect();
+                        let existing_groups: Vec<String> =
+                            self.all_groups().iter().map(|g| g.path.clone()).collect();
+                        let current_profile = self
+                            .profile_for_cursor(self.cursor)
+                            .or_else(|| self.active_profile.clone())
+                            .unwrap_or_else(|| "default".to_string());
+                        let profiles =
+                            list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+                        let mut dialog = NewSessionDialog::new(
+                            self.available_tools.clone(),
+                            existing_titles,
+                            existing_groups,
+                            &current_profile,
+                            profiles,
+                        );
+                        if let Some(path) = prefill_path {
+                            dialog.set_path(path);
+                        }
+                        if let Some(group) = prefill_group {
+                            dialog.set_group(group);
+                        }
+                        self.new_dialog = Some(dialog);
+                    }
                 }
             }
             KeyCode::Char('s') => {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1947,3 +1947,114 @@ fn test_delete_group_scoped_to_owning_profile() {
         "beta's instance should still be in 'work'"
     );
 }
+
+#[test]
+#[serial]
+fn test_shift_n_opens_prefilled_dialog_from_session() {
+    let mut env = create_test_env_with_groups();
+    assert!(env.view.new_dialog.is_none());
+
+    // Move cursor to the "work-project" session (grouped under "work")
+    // flat_items: [Group("personal"), Session("personal-project"), Group("work"), Session("work-project"), Session("ungrouped")]
+    let work_session_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Session { id, .. } if env.view.get_instance(id).map(|i| i.title.as_str()) == Some("work-project")))
+        .expect("work-project session should exist in flat_items");
+    env.view.cursor = work_session_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('N')));
+    let dialog = env.view.new_dialog.as_ref().expect("N should open dialog");
+    assert_eq!(dialog.path_value(), "/tmp/work");
+    assert_eq!(dialog.group_value(), "work");
+}
+
+#[test]
+#[serial]
+fn test_shift_n_opens_prefilled_dialog_from_group() {
+    let mut env = create_test_env_with_groups();
+
+    // Move cursor to a group row
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { path, .. } if path == "work"))
+        .expect("work group should exist in flat_items");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('N')));
+    let dialog = env.view.new_dialog.as_ref().expect("N should open dialog");
+    assert_eq!(dialog.group_value(), "work");
+}
+
+#[test]
+#[serial]
+fn test_shift_n_does_nothing_with_no_selection() {
+    let mut env = create_test_env_empty();
+    env.view.handle_key(key(KeyCode::Char('N')));
+    assert!(
+        env.view.new_dialog.is_none(),
+        "N should not open dialog when nothing is selected"
+    );
+}
+
+#[test]
+#[serial]
+fn test_shift_n_prefills_main_repo_path_for_worktree_session() {
+    use crate::session::WorktreeInfo;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let mut inst = Instance::new("worktree-session", "/tmp/repo-worktrees/feature-branch");
+    inst.worktree_info = Some(WorktreeInfo {
+        branch: "feature-branch".to_string(),
+        main_repo_path: "/tmp/repo".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+    });
+    storage.save(&[inst]).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.cursor = 0;
+    view.update_selected();
+
+    view.handle_key(key(KeyCode::Char('N')));
+    let dialog = view.new_dialog.as_ref().expect("N should open dialog");
+    assert_eq!(
+        dialog.path_value(),
+        "/tmp/repo",
+        "Should pre-fill main_repo_path, not worktree path"
+    );
+}
+
+#[test]
+#[serial]
+fn test_shift_n_prefills_session_path_for_ungrouped() {
+    let mut env = create_test_env_with_groups();
+
+    // Move cursor to the ungrouped session
+    let ungrouped_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Session { id, .. } if env.view.get_instance(id).map(|i| i.title.as_str()) == Some("ungrouped")))
+        .expect("ungrouped session should exist");
+    env.view.cursor = ungrouped_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('N')));
+    let dialog = env.view.new_dialog.as_ref().expect("N should open dialog");
+    assert_eq!(dialog.path_value(), "/tmp/u");
+    assert_eq!(
+        dialog.group_value(),
+        "",
+        "ungrouped session should not pre-fill group"
+    );
+}


### PR DESCRIPTION
## Description

Adds a `Shift+N` shortcut that opens the New Session Dialog pre-filled with context from the current selection:

- **Session selected**: pre-fills path, group, and profile from that session. If the session is a worktree, pre-fills the main repo path instead of the worktree path.
- **Group selected**: pre-fills only the group (and profile). Path defaults to current directory.
- **Nothing selected**: does nothing.
- **Search mode active**: types `N` into the search query (existing behavior, unchanged).

The shortcut appears in the `?` help dialog under Actions but not in the status bar.

Fixes #410

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- `cargo test` -- all 878 tests pass (873 existing + 5 new)
- `cargo clippy` -- clean
- `cargo fmt` -- clean
- New unit tests cover:
  - `test_shift_n_opens_prefilled_dialog_from_session`
  - `test_shift_n_opens_prefilled_dialog_from_group`
  - `test_shift_n_does_nothing_with_no_selection`
  - `test_shift_n_prefills_main_repo_path_for_worktree_session`
  - `test_shift_n_prefills_session_path_for_ungrouped`

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)