### PR TITLE
feat(session): extract infrastructure modules from #382

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -24,6 +24,26 @@ pub enum YoloMode {
     AlwaysYolo,
 }
 
+/// How an agent resumes an existing session from the CLI.
+pub enum ResumeStrategy {
+    /// Append a flag (e.g. `--session <id>`). For agents where new and existing
+    /// sessions use the same flag.
+    Flag(&'static str),
+    /// Two different flags depending on whether conversation data already exists.
+    /// `existing` is used when there is prior conversation data (e.g. `--resume`),
+    /// `new_session` when creating/attaching unconditionally (e.g. `--session-id`).
+    FlagPair {
+        existing: &'static str,
+        new_session: &'static str,
+    },
+    /// Resume is a subcommand rather than a flag (e.g. `codex resume <id>`).
+    /// The subcommand + id are inserted right after the binary name so that
+    /// other flags land after it.
+    Subcommand(&'static str),
+    /// Agent does not support session resume.
+    Unsupported,
+}
+
 /// A single hook event that AoE registers in an agent's settings file.
 pub struct HookEvent {
     /// Event name as the agent expects it (e.g. `"PreToolUse"` for Claude Code).
@@ -39,7 +59,7 @@ pub struct AgentHookConfig {
     /// Path relative to the home dir where the agent's settings live
     /// (e.g. `.claude/settings.json`).
     pub settings_rel_path: &'static str,
-    /// Hook events to register (status transitions).
+    /// Hook events to register (status transitions and session lifecycle).
     pub events: &'static [HookEvent],
 }
 
@@ -70,6 +90,8 @@ pub struct AgentDef {
     /// hooks into the agent's settings file so status is written to a file instead
     /// of being parsed from tmux pane content.
     pub hook_config: Option<AgentHookConfig>,
+    /// How this agent resumes a prior session.
+    pub resume_strategy: ResumeStrategy,
 }
 
 /// Hook events shared by Claude Code and Cursor CLI.
@@ -94,6 +116,16 @@ const CLAUDE_CURSOR_HOOK_EVENTS: &[HookEvent] = &[
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some("waiting"),
     },
+    HookEvent {
+        name: "SessionStart",
+        matcher: None,
+        status: None,
+    },
+    HookEvent {
+        name: "SessionEnd",
+        matcher: None,
+        status: None,
+    },
 ];
 
 pub const AGENTS: &[AgentDef] = &[
@@ -112,6 +144,10 @@ pub const AGENTS: &[AgentDef] = &[
             settings_rel_path: ".claude/settings.json",
             events: CLAUDE_CURSOR_HOOK_EVENTS,
         }),
+        resume_strategy: ResumeStrategy::FlagPair {
+            existing: "--resume",
+            new_session: "--session-id",
+        },
     },
     AgentDef {
         name: "opencode",
@@ -125,6 +161,7 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_opencode_status,
         container_env: &[],
         hook_config: None,
+        resume_strategy: ResumeStrategy::Flag("--session"),
     },
     AgentDef {
         name: "vibe",
@@ -138,6 +175,7 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_vibe_status,
         container_env: &[],
         hook_config: None,
+        resume_strategy: ResumeStrategy::Flag("--resume"),
     },
     AgentDef {
         name: "codex",
@@ -153,6 +191,7 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_codex_status,
         container_env: &[],
         hook_config: None,
+        resume_strategy: ResumeStrategy::Subcommand("resume"),
     },
     AgentDef {
         name: "gemini",
@@ -188,8 +227,19 @@ pub const AGENTS: &[AgentDef] = &[
                     matcher: Some("ToolPermission"),
                     status: Some("waiting"),
                 },
+                HookEvent {
+                    name: "SessionStart",
+                    matcher: None,
+                    status: None,
+                },
+                HookEvent {
+                    name: "SessionEnd",
+                    matcher: None,
+                    status: None,
+                },
             ],
         }),
+        resume_strategy: ResumeStrategy::Flag("--resume"),
     },
     AgentDef {
         name: "cursor",
@@ -206,6 +256,7 @@ pub const AGENTS: &[AgentDef] = &[
             settings_rel_path: ".cursor/settings.json",
             events: CLAUDE_CURSOR_HOOK_EVENTS,
         }),
+        resume_strategy: ResumeStrategy::Unsupported,
     },
     AgentDef {
         name: "copilot",
@@ -219,6 +270,7 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_copilot_status,
         container_env: &[("COPILOT_CONFIG_DIR", "/root/.copilot")],
         hook_config: None,
+        resume_strategy: ResumeStrategy::Unsupported,
     },
     AgentDef {
         name: "pi",
@@ -233,6 +285,7 @@ pub const AGENTS: &[AgentDef] = &[
         detect_status: status_detection::detect_pi_status,
         container_env: &[("PI_CODING_AGENT_DIR", "/root/.pi/agent")],
         hook_config: None,
+        resume_strategy: ResumeStrategy::Unsupported,
     },
 ];
 

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -51,6 +51,8 @@ pub struct HookEvent {
     /// Optional matcher pattern (e.g. `"permission_prompt|elicitation_dialog"`).
     pub matcher: Option<&'static str>,
     /// AoE status to write when this event fires (`"running"`, `"idle"`, `"waiting"`).
+    /// `None` for lifecycle-only events (e.g. `SessionStart`/`SessionEnd`) that
+    /// are declared for future use but skipped by shell one-liner hooks.
     pub status: Option<&'static str>,
 }
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -261,6 +261,9 @@ mod tests {
         assert!(hooks.contains_key("UserPromptSubmit"));
         assert!(hooks.contains_key("Stop"));
         assert!(hooks.contains_key("Notification"));
+        // SessionStart/SessionEnd have status: None, so they are skipped by shell one-liners
+        assert!(!hooks.contains_key("SessionStart"));
+        assert!(!hooks.contains_key("SessionEnd"));
     }
 
     #[test]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -7,6 +7,7 @@ mod container_config;
 mod environment;
 mod groups;
 mod instance;
+pub mod poller;
 pub mod profile_config;
 pub mod repo_config;
 mod storage;

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -1,0 +1,877 @@
+//! Adaptive polling interval and command channel for session monitoring
+
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::mpsc;
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+/// Global count of active poller threads for budget enforcement
+static ACTIVE_POLLER_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Maximum number of concurrent poller threads allowed
+const MAX_POLLER_THREADS: u32 = 20;
+
+/// RAII guard that decrements `ACTIVE_POLLER_COUNT` on drop.
+///
+/// Ensures the counter is always decremented even if the poller thread panics,
+/// preventing permanent budget exhaustion.
+struct PollerCountGuard;
+
+impl PollerCountGuard {
+    /// Atomically check the budget and increment. Returns `None` if at capacity.
+    fn try_acquire() -> Option<Self> {
+        let mut current = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
+        loop {
+            if current >= MAX_POLLER_THREADS {
+                return None;
+            }
+            match ACTIVE_POLLER_COUNT.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return Some(Self),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+}
+
+impl Drop for PollerCountGuard {
+    fn drop(&mut self) {
+        ACTIVE_POLLER_COUNT.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
+const POLL_INITIAL_INTERVAL: Duration = Duration::from_secs(2);
+const POLL_MAX_INTERVAL: Duration = Duration::from_secs(60);
+const POLL_BACKOFF_FACTOR: f64 = 1.5;
+const POLL_STABLE_THRESHOLD: u32 = 3;
+
+/// Timeout for deferred capture completion, with margin for retry delays.
+const CAPTURE_GATE_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Synchronization gate between deferred capture and polling threads.
+///
+/// Ensures capture completes before polling starts, avoiding concurrent storage writes.
+/// The capture thread calls [`CaptureGate::complete`]; the poller calls [`CaptureGate::wait`].
+pub struct CaptureGate {
+    inner: Mutex<CaptureGateState>,
+    cond: Condvar,
+}
+
+struct CaptureGateState {
+    done: bool,
+    captured_id: Option<String>,
+}
+
+impl CaptureGate {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(CaptureGateState {
+                done: false,
+                captured_id: None,
+            }),
+            cond: Condvar::new(),
+        }
+    }
+
+    /// Signal that the deferred capture is complete.
+    ///
+    /// `captured_id` is `Some(id)` on success, `None` if all attempts were exhausted.
+    pub fn complete(&self, captured_id: Option<String>) {
+        // Graceful degradation: if the mutex is poisoned, a thread panicked while holding
+        // the lock. Recovering via into_inner() could expose corrupted state. Losing one
+        // capture ID is safer than propagating potentially invalid data. The poller will
+        // timeout (CAPTURE_GATE_TIMEOUT) and proceed without the ID.
+        let Ok(mut state) = self.inner.lock() else {
+            tracing::warn!("CaptureGate lock poisoned in complete(), captured ID lost");
+            return;
+        };
+        state.done = true;
+        state.captured_id = captured_id;
+        self.cond.notify_all();
+    }
+
+    /// Block until the deferred capture completes, then return the captured ID (if any).
+    ///
+    /// Uses a timeout so the poller thread is never stuck indefinitely if the capture
+    /// thread panics or is cancelled.
+    pub fn wait(&self, timeout: Duration) -> Option<String> {
+        let Ok(state) = self.inner.lock() else {
+            tracing::warn!("CaptureGate lock poisoned in wait(), returning None");
+            return None;
+        };
+        let Ok(result) = self.cond.wait_timeout_while(state, timeout, |s| !s.done) else {
+            tracing::warn!("CaptureGate lock poisoned during wait(), returning None");
+            return None;
+        };
+        result.0.captured_id.clone()
+    }
+
+    /// Non-blocking check: if complete, take and return the captured ID (once only).
+    /// Subsequent calls return `None`.
+    pub fn try_take(&self) -> Option<String> {
+        let Ok(mut state) = self.inner.lock() else {
+            return None;
+        };
+        if state.done {
+            state.captured_id.take()
+        } else {
+            None
+        }
+    }
+}
+
+impl Default for CaptureGate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for CaptureGate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let state = self.inner.lock().ok();
+        f.debug_struct("CaptureGate")
+            .field("done", &state.as_ref().map(|s| s.done))
+            .finish()
+    }
+}
+
+/// Manages adaptive polling intervals that back off when no changes are detected
+#[derive(Debug)]
+pub struct AdaptiveInterval {
+    initial: Duration,
+    current: Duration,
+    max: Duration,
+    backoff_factor: f64,
+    stable_threshold: u32,
+    stable_count: u32,
+}
+
+impl AdaptiveInterval {
+    /// Create a new adaptive interval with custom parameters
+    pub fn new(
+        initial: Duration,
+        max: Duration,
+        backoff_factor: f64,
+        stable_threshold: u32,
+    ) -> Self {
+        Self {
+            initial,
+            current: initial,
+            max,
+            backoff_factor,
+            stable_threshold,
+            stable_count: 0,
+        }
+    }
+
+    pub fn current(&self) -> Duration {
+        self.current
+    }
+
+    /// Record that no changes were detected; increases backoff if threshold is reached.
+    ///
+    /// Uses `Duration::from_secs_f64` for sub-second precision in the backoff calculation
+    /// (e.g., 2.0s * 1.5 = 3.0s, 3.0s * 1.5 = 4.5s).
+    pub fn record_no_change(&mut self) {
+        self.stable_count += 1;
+        if self.stable_count >= self.stable_threshold {
+            let next_secs = self.current.as_secs_f64() * self.backoff_factor;
+            let next_duration = Duration::from_secs_f64(next_secs);
+            self.current = next_duration.min(self.max);
+            self.stable_count = 0;
+        }
+    }
+
+    /// Record that a change was detected; reset to initial interval
+    pub fn record_change(&mut self) {
+        self.current = self.initial;
+        self.stable_count = 0;
+    }
+
+    pub fn reset(&mut self) {
+        self.record_change();
+    }
+}
+
+/// Command sent to the session poller thread
+#[derive(Debug, Clone, Copy)]
+pub enum PollCommand {
+    /// Request an immediate poll
+    PollNow,
+    /// Stop the poller thread
+    Stop,
+}
+
+/// Manages polling thread lifecycle and inter-thread communication via mpsc channels.
+///
+/// # Cleanup
+///
+/// Cleanup is performed explicitly via `stop()` rather than `Drop` because
+/// the poller thread holds a clone of the command sender. Dropping the
+/// `SessionPoller` without `stop()` causes the thread to exit on the next
+/// `recv_timeout` when it detects channel disconnection, which may take up
+/// to `max_interval` seconds. Callers (Instance::kill, Instance::restart)
+/// call `stop()` explicitly for immediate shutdown.
+pub struct SessionPoller {
+    session_name: String,
+    cmd_tx: mpsc::Sender<PollCommand>,
+    cmd_rx: Option<mpsc::Receiver<PollCommand>>,
+    result_tx: mpsc::Sender<(String, String)>,
+    result_rx: Option<mpsc::Receiver<(String, String)>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl std::fmt::Debug for SessionPoller {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SessionPoller")
+            .field("session_name", &self.session_name)
+            .field("running", &self.handle.is_some())
+            .finish()
+    }
+}
+
+impl SessionPoller {
+    /// Create a new poller (does not start the thread)
+    pub fn new(session_name: String) -> Self {
+        let (cmd_tx, cmd_rx) = mpsc::channel();
+        let (result_tx, result_rx) = mpsc::channel();
+        Self {
+            session_name,
+            cmd_tx,
+            cmd_rx: Some(cmd_rx),
+            result_tx,
+            result_rx: Some(result_rx),
+            handle: None,
+        }
+    }
+
+    /// Start the polling thread with the given callbacks.
+    ///
+    /// When `capture_gate` is `Some`, the thread blocks until the deferred capture
+    /// completes, then uses the captured ID as its initial known value. This
+    /// prevents concurrent storage writes between the capture and poller threads.
+    ///
+    /// Returns `true` if the thread was successfully spawned, `false` if the
+    /// poller was already started, the thread budget was exhausted, or spawning failed.
+    pub fn start(
+        &mut self,
+        instance_id: String,
+        poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static>,
+        on_change: Box<dyn Fn(&str) + Send + 'static>,
+        initial_known: Option<String>,
+        capture_gate: Option<Arc<CaptureGate>>,
+    ) -> bool {
+        let cmd_rx = match self.cmd_rx.take() {
+            Some(rx) => rx,
+            None => {
+                tracing::warn!(
+                    "Poller for {} already started, ignoring duplicate start",
+                    instance_id
+                );
+                return false;
+            }
+        };
+
+        let _guard = match PollerCountGuard::try_acquire() {
+            Some(g) => g,
+            None => {
+                tracing::warn!(
+                    "Poller thread budget exhausted ({}/{}), skipping poller for {}",
+                    ACTIVE_POLLER_COUNT.load(Ordering::Relaxed),
+                    MAX_POLLER_THREADS,
+                    instance_id
+                );
+                self.cmd_rx = Some(cmd_rx);
+                return false;
+            }
+        };
+
+        let session_name = self.session_name.clone();
+        let thread_label = format!("aoe-poller/{}", instance_id);
+        let result_tx = self.result_tx.clone();
+
+        let handle = std::thread::Builder::new()
+            .name(thread_label.clone())
+            .stack_size(128 * 1024)
+            .spawn(move || {
+                // Move the guard into the thread so it decrements on exit (including panic)
+                let _guard = _guard;
+
+                let mut last_known = initial_known;
+                let had_gate = capture_gate.is_some();
+
+                if let Some(gate) = capture_gate {
+                    tracing::debug!("Poller for {} waiting on capture gate", instance_id);
+                    let captured = gate.wait(CAPTURE_GATE_TIMEOUT);
+                    if let Some(ref id) = captured {
+                        tracing::debug!("Poller for {} received captured ID: {}", instance_id, id);
+                    }
+                    last_known = last_known.or(captured);
+                }
+
+                let mut interval = AdaptiveInterval::new(
+                    POLL_INITIAL_INTERVAL,
+                    POLL_MAX_INTERVAL,
+                    POLL_BACKOFF_FACTOR,
+                    POLL_STABLE_THRESHOLD,
+                );
+
+                // Immediate first poll for sessions without a capture gate
+                // (e.g. pre-existing sessions loaded from disk)
+                if !had_gate {
+                    if let Some(new_id) = poll_fn() {
+                        if last_known.as_deref() != Some(&new_id) {
+                            on_change(&new_id);
+                            let _ = result_tx.send((instance_id.clone(), new_id.clone()));
+                            last_known = Some(new_id);
+                            interval.record_change();
+                        }
+                    }
+                }
+
+                loop {
+                    match cmd_rx.recv_timeout(interval.current()) {
+                        Ok(PollCommand::Stop) => break,
+                        Ok(PollCommand::PollNow) => {}
+                        Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+
+                    if crate::tmux::utils::is_pane_dead(&session_name) {
+                        tracing::info!("Pane dead for {}, stopping poller", session_name);
+                        break;
+                    }
+
+                    if let Some(new_id) = poll_fn() {
+                        let changed = last_known.as_deref() != Some(&new_id);
+                        if changed {
+                            on_change(&new_id);
+                            let _ = result_tx.send((instance_id.clone(), new_id.clone()));
+                            last_known = Some(new_id);
+                            interval.record_change();
+                        } else {
+                            interval.record_no_change();
+                        }
+                    } else {
+                        interval.record_no_change();
+                    }
+                }
+            });
+
+        match handle {
+            Ok(h) => {
+                self.handle = Some(h);
+                true
+            }
+            Err(e) => {
+                tracing::warn!("Failed to spawn poller thread {}: {}", thread_label, e);
+                // Restore channels to allow retrying spawn
+                let (cmd_tx, cmd_rx) = mpsc::channel();
+                self.cmd_tx = cmd_tx;
+                self.cmd_rx = Some(cmd_rx);
+                let (result_tx, result_rx) = mpsc::channel();
+                self.result_tx = result_tx;
+                self.result_rx = Some(result_rx);
+                false
+            }
+        }
+    }
+
+    /// Drain a pending session ID update, if any. Returns `(instance_id, session_id)`.
+    pub fn try_recv_session_update(&self) -> Option<(String, String)> {
+        self.result_rx.as_ref()?.try_recv().ok()
+    }
+
+    /// Send a poll command
+    pub fn poll_now(&self) {
+        let _ = self.cmd_tx.send(PollCommand::PollNow);
+    }
+
+    /// Stop the poller thread and wait for it to finish
+    pub fn stop(&mut self) {
+        let _ = self.cmd_tx.send(PollCommand::Stop);
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.join();
+        }
+    }
+
+    /// Check if the poller thread is running
+    pub fn is_running(&self) -> bool {
+        match &self.handle {
+            Some(handle) => !handle.is_finished(),
+            None => false,
+        }
+    }
+}
+
+impl Default for SessionPoller {
+    fn default() -> Self {
+        Self::new("default".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn test_adaptive_interval_initial() {
+        let interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        assert_eq!(interval.current(), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn test_adaptive_interval_record_no_change_increments_count() {
+        let mut interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        assert_eq!(interval.stable_count, 0);
+        interval.record_no_change();
+        assert_eq!(interval.stable_count, 1);
+        interval.record_no_change();
+        assert_eq!(interval.stable_count, 2);
+    }
+
+    #[test]
+    fn test_adaptive_interval_backoff_at_threshold() {
+        let mut interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        interval.record_no_change();
+        interval.record_no_change();
+        interval.record_no_change();
+        // After 3 calls: 2 * 1.5 = 3 seconds
+        assert_eq!(interval.current(), Duration::from_secs(3));
+        assert_eq!(interval.stable_count, 0);
+    }
+
+    #[test]
+    fn test_adaptive_interval_multiple_backoffs() {
+        let mut interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        // First backoff: 2 -> 3
+        for _ in 0..3 {
+            interval.record_no_change();
+        }
+        assert_eq!(interval.current(), Duration::from_secs(3));
+
+        // Second backoff: 3 -> 4.5 (with sub-second precision)
+        for _ in 0..3 {
+            interval.record_no_change();
+        }
+        let expected_secs = 3.0 * 1.5;
+        assert_eq!(interval.current(), Duration::from_secs_f64(expected_secs));
+    }
+
+    #[test]
+    fn test_adaptive_interval_respects_max() {
+        let mut interval = AdaptiveInterval::new(
+            Duration::from_secs(2),
+            Duration::from_secs(60),
+            1.5,
+            1, // threshold of 1 for faster test
+        );
+        interval.record_no_change(); // 2 * 1.5 = 3.0
+        interval.record_no_change(); // 3.0 * 1.5 = 4.5
+        interval.record_no_change(); // 4.5 * 1.5 = 6.75
+        interval.record_no_change(); // 6.75 * 1.5 = 10.125
+        interval.record_no_change(); // 10.125 * 1.5 = 15.1875
+        interval.record_no_change(); // 15.1875 * 1.5 = 22.78125
+        interval.record_no_change(); // 22.78125 * 1.5 = 34.171875
+        interval.record_no_change(); // 34.171875 * 1.5 = 51.2578125
+        interval.record_no_change(); // 51.2578125 * 1.5 = 76.88671875 > 60, capped at 60
+        assert!(interval.current() <= Duration::from_secs(60));
+    }
+
+    #[test]
+    fn test_adaptive_interval_record_change_resets() {
+        let mut interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        for _ in 0..3 {
+            interval.record_no_change();
+        }
+        assert_eq!(interval.current(), Duration::from_secs(3));
+
+        interval.record_change();
+        assert_eq!(interval.current(), Duration::from_secs(2));
+        assert_eq!(interval.stable_count, 0);
+    }
+
+    #[test]
+    fn test_adaptive_interval_reset_is_alias() {
+        let mut interval =
+            AdaptiveInterval::new(Duration::from_secs(2), Duration::from_secs(60), 1.5, 3);
+        for _ in 0..3 {
+            interval.record_no_change();
+        }
+        assert_eq!(interval.current(), Duration::from_secs(3));
+
+        interval.reset();
+        assert_eq!(interval.current(), Duration::from_secs(2));
+        assert_eq!(interval.stable_count, 0);
+    }
+
+    #[test]
+    fn test_session_poller_new() {
+        let poller = SessionPoller::new("test-session".to_string());
+        assert!(!poller.is_running());
+    }
+
+    #[test]
+    fn test_session_poller_stop_when_no_thread() {
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.stop(); // Should not panic
+        assert!(!poller.is_running());
+    }
+
+    #[test]
+    fn test_session_poller_double_stop_safe() {
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.stop();
+        poller.stop(); // Should not panic
+        assert!(!poller.is_running());
+    }
+
+    #[test]
+    fn test_session_poller_drop_is_clean() {
+        let poller = SessionPoller::new("test-session".to_string());
+        drop(poller); // Should not panic
+    }
+
+    #[test]
+    fn test_adaptive_interval_with_constants() {
+        let mut interval = AdaptiveInterval::new(
+            POLL_INITIAL_INTERVAL,
+            POLL_MAX_INTERVAL,
+            POLL_BACKOFF_FACTOR,
+            POLL_STABLE_THRESHOLD,
+        );
+        assert_eq!(interval.current(), Duration::from_secs(2));
+        for _ in 0..POLL_STABLE_THRESHOLD {
+            interval.record_no_change();
+        }
+        assert_eq!(interval.current(), Duration::from_secs(3));
+    }
+
+    #[test]
+    fn test_poller_detects_change() {
+        use std::sync::{Arc, Mutex};
+
+        let call_count = Arc::new(Mutex::new(0u32));
+        let call_count_clone = call_count.clone();
+
+        let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = Box::new(move || {
+            let mut count = call_count_clone.lock().unwrap();
+            *count += 1;
+            if *count <= 3 {
+                Some("id-1".to_string())
+            } else {
+                Some("id-2".to_string())
+            }
+        });
+
+        let changed_ids: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let changed_ids_clone = changed_ids.clone();
+
+        let on_change: Box<dyn Fn(&str) + Send + 'static> = Box::new(move |id: &str| {
+            changed_ids_clone.lock().unwrap().push(id.to_string());
+        });
+
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start(
+            "test-change".to_string(),
+            poll_fn,
+            on_change,
+            Some("id-1".to_string()),
+            None,
+        );
+
+        // Force polls via PollNow (the default interval is 2s, too slow for tests)
+        for _ in 0..5 {
+            poller.poll_now();
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        poller.stop();
+
+        let ids = changed_ids.lock().unwrap();
+        assert!(
+            ids.contains(&"id-2".to_string()),
+            "on_change should have been called with id-2, got: {:?}",
+            *ids
+        );
+        assert!(
+            !ids.contains(&"id-1".to_string()),
+            "on_change should NOT have been called with id-1 (initial known)"
+        );
+    }
+
+    #[test]
+    fn test_poll_now_triggers_poll() {
+        use std::sync::{Arc, Mutex};
+
+        let poll_count = Arc::new(Mutex::new(0u32));
+        let poll_count_clone = poll_count.clone();
+
+        let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = Box::new(move || {
+            let mut count = poll_count_clone.lock().unwrap();
+            *count += 1;
+            Some("stable-id".to_string())
+        });
+
+        let on_change: Box<dyn Fn(&str) + Send + 'static> = Box::new(|_| {});
+
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start("test-pollnow".to_string(), poll_fn, on_change, None, None);
+
+        std::thread::sleep(Duration::from_millis(50));
+        poller.poll_now();
+        poller.poll_now();
+        std::thread::sleep(Duration::from_millis(200));
+
+        let count = *poll_count.lock().unwrap();
+        assert!(
+            count >= 2,
+            "poll_fn should have been called at least twice via PollNow, got: {}",
+            count
+        );
+
+        poller.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn test_thread_budget_cap() {
+        let original = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
+        ACTIVE_POLLER_COUNT.store(MAX_POLLER_THREADS, Ordering::SeqCst);
+
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start(
+            "test-budget".to_string(),
+            Box::new(|| Some("id".to_string())),
+            Box::new(|_| {}),
+            None,
+            None,
+        );
+
+        assert!(
+            !poller.is_running(),
+            "poller should not have spawned when budget exhausted"
+        );
+        assert!(
+            poller.cmd_rx.is_some(),
+            "cmd_rx should be returned when budget exhausted"
+        );
+
+        ACTIVE_POLLER_COUNT.store(original, Ordering::SeqCst);
+    }
+
+    #[test]
+    #[serial]
+    fn test_poller_is_running_after_start() {
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start(
+            "test-running".to_string(),
+            Box::new(|| {
+                std::thread::sleep(Duration::from_millis(10));
+                Some("id".to_string())
+            }),
+            Box::new(|_| {}),
+            None,
+            None,
+        );
+
+        assert!(poller.is_running(), "poller should be running after start");
+        poller.stop();
+    }
+
+    #[test]
+    #[serial]
+    fn test_poller_cleanup_decrements_counter() {
+        use std::sync::{Arc, Mutex};
+
+        let entered = Arc::new(Mutex::new(false));
+        let entered_clone = entered.clone();
+
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start(
+            "test-cleanup".to_string(),
+            Box::new(move || {
+                *entered_clone.lock().unwrap() = true;
+                Some("id".to_string())
+            }),
+            Box::new(|_| {}),
+            None,
+            None,
+        );
+
+        poller.poll_now();
+        std::thread::sleep(Duration::from_millis(50));
+
+        let count_before_stop = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
+        poller.stop();
+        let count_after_stop = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
+
+        assert!(
+            count_after_stop < count_before_stop,
+            "counter should decrement after stop (before_stop={}, after_stop={})",
+            count_before_stop,
+            count_after_stop
+        );
+        assert!(*entered.lock().unwrap(), "poll_fn should have been called");
+    }
+
+    #[test]
+    fn test_interval_exact_at_threshold() {
+        let mut interval = AdaptiveInterval::new(
+            Duration::from_secs(2),
+            Duration::from_secs(60),
+            1.5,
+            POLL_STABLE_THRESHOLD,
+        );
+
+        for _ in 0..POLL_STABLE_THRESHOLD {
+            interval.record_no_change();
+        }
+        // 2 * 1.5 = 3
+        assert_eq!(interval.current(), Duration::from_secs(3));
+        assert_eq!(interval.stable_count, 0);
+
+        interval.record_no_change();
+        assert_eq!(interval.current(), Duration::from_secs(3));
+        assert_eq!(interval.stable_count, 1);
+    }
+
+    #[test]
+    fn test_interval_max_clamping_precision() {
+        let mut interval = AdaptiveInterval::new(
+            Duration::from_secs(2),
+            POLL_MAX_INTERVAL,
+            POLL_BACKOFF_FACTOR,
+            POLL_STABLE_THRESHOLD,
+        );
+
+        for _ in 0..1000 {
+            interval.record_no_change();
+            assert!(
+                interval.current() <= POLL_MAX_INTERVAL,
+                "interval {} exceeded max {}",
+                interval.current().as_secs(),
+                POLL_MAX_INTERVAL.as_secs()
+            );
+        }
+        assert_eq!(interval.current(), POLL_MAX_INTERVAL);
+    }
+
+    #[test]
+    fn test_interval_change_mid_backoff() {
+        let mut interval = AdaptiveInterval::new(
+            Duration::from_secs(2),
+            Duration::from_secs(60),
+            1.5,
+            POLL_STABLE_THRESHOLD,
+        );
+
+        interval.record_no_change();
+        interval.record_no_change();
+        assert_eq!(interval.stable_count, 2);
+        assert_eq!(interval.current(), Duration::from_secs(2));
+
+        interval.record_change();
+        assert_eq!(interval.current(), Duration::from_secs(2));
+        assert_eq!(interval.stable_count, 0);
+    }
+
+    #[test]
+    fn test_capture_gate_blocks_until_complete() {
+        let gate = Arc::new(CaptureGate::new());
+        let gate_clone = Arc::clone(&gate);
+
+        let waiter = std::thread::spawn(move || gate_clone.wait(Duration::from_secs(5)));
+
+        std::thread::sleep(Duration::from_millis(50));
+        gate.complete(Some("ses_123".to_string()));
+
+        let result = waiter.join().unwrap();
+        assert_eq!(result, Some("ses_123".to_string()));
+    }
+
+    #[test]
+    fn test_capture_gate_returns_none_on_exhausted() {
+        let gate = Arc::new(CaptureGate::new());
+        let gate_clone = Arc::clone(&gate);
+
+        let waiter = std::thread::spawn(move || gate_clone.wait(Duration::from_secs(5)));
+
+        std::thread::sleep(Duration::from_millis(50));
+        gate.complete(None);
+
+        let result = waiter.join().unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_capture_gate_timeout() {
+        let gate = Arc::new(CaptureGate::new());
+        let result = gate.wait(Duration::from_millis(50));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_capture_gate_already_complete_returns_immediately() {
+        let gate = CaptureGate::new();
+        gate.complete(Some("ses_fast".to_string()));
+        let result = gate.wait(Duration::from_millis(10));
+        assert_eq!(result, Some("ses_fast".to_string()));
+    }
+
+    #[test]
+    fn test_poller_with_capture_gate() {
+        let gate = Arc::new(CaptureGate::new());
+        let gate_clone = Arc::clone(&gate);
+
+        let poll_count = Arc::new(Mutex::new(0u32));
+        let poll_count_clone = poll_count.clone();
+
+        let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = Box::new(move || {
+            let mut count = poll_count_clone.lock().unwrap();
+            *count += 1;
+            Some("ses_polled".to_string())
+        });
+
+        let on_change: Box<dyn Fn(&str) + Send + 'static> = Box::new(|_| {});
+
+        let mut poller = SessionPoller::new("test-session".to_string());
+        poller.start(
+            "test-gate".to_string(),
+            poll_fn,
+            on_change,
+            None,
+            Some(gate_clone),
+        );
+
+        std::thread::sleep(Duration::from_millis(100));
+        let count_before = *poll_count.lock().unwrap();
+
+        gate.complete(Some("ses_captured".to_string()));
+
+        std::thread::sleep(Duration::from_millis(300));
+        poller.poll_now();
+        std::thread::sleep(Duration::from_millis(100));
+
+        let count_after = *poll_count.lock().unwrap();
+        assert!(
+            count_after > count_before,
+            "poller should have started polling after gate opened (before={}, after={})",
+            count_before,
+            count_after
+        );
+
+        poller.stop();
+    }
+}

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -213,11 +213,16 @@ pub enum PollCommand {
 /// # Cleanup
 ///
 /// Cleanup is performed explicitly via `stop()` rather than `Drop` because
-/// the poller thread holds a clone of the command sender. Dropping the
-/// `SessionPoller` without `stop()` causes the thread to exit on the next
-/// `recv_timeout` when it detects channel disconnection, which may take up
-/// to `max_interval` seconds. Callers (Instance::kill, Instance::restart)
-/// call `stop()` explicitly for immediate shutdown.
+/// `Drop` alone cannot guarantee prompt shutdown. The poller thread holds
+/// the `cmd_rx` receiver; when `SessionPoller` drops, the corresponding
+/// `cmd_tx` sender is dropped too and `recv_timeout` returns `Disconnected`
+/// immediately -- so in the common case the thread exits promptly.
+///
+/// However, if the thread is blocked on `CaptureGate::wait` (up to
+/// `CAPTURE_GATE_TIMEOUT`), the channel disconnection is not checked until
+/// that wait completes. `stop()` sends an explicit `PollCommand::Stop` and
+/// joins the thread, providing a deterministic shutdown path for callers
+/// like `Instance::kill` and `Instance::restart`.
 pub struct SessionPoller {
     session_name: String,
     cmd_tx: mpsc::Sender<PollCommand>,

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -1,0 +1,452 @@
+//! Hidden environment variable helpers for tmux sessions
+//!
+//! This module provides utilities to get and set hidden environment variables
+//! in tmux sessions using the `-h` flag. Hidden variables are not inherited by
+//! child processes, making them ideal for storing session metadata.
+
+use anyhow::bail;
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::RwLock;
+use std::time::{Duration, Instant};
+
+pub const AOE_INSTANCE_ID_KEY: &str = "AOE_INSTANCE_ID";
+pub const AOE_CAPTURED_SESSION_ID_KEY: &str = "AOE_CAPTURED_SESSION_ID";
+
+const ENV_CACHE_TTL: Duration = Duration::from_secs(30);
+
+struct EnvCacheEntry {
+    value: String,
+    fetched_at: Instant,
+}
+
+struct EnvCache {
+    entries: Option<HashMap<(String, String), EnvCacheEntry>>,
+}
+
+static ENV_CACHE: RwLock<EnvCache> = RwLock::new(EnvCache { entries: None });
+
+/// Set a hidden environment variable in a tmux session
+///
+/// Hidden variables (set with `-h`) are not inherited by child processes.
+pub fn set_hidden_env(session_name: &str, key: &str, value: &str) -> anyhow::Result<()> {
+    let output = Command::new("tmux")
+        .args(["set-environment", "-h", "-t", session_name, key, value])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to set hidden env var: {}", stderr);
+    }
+
+    invalidate_cache_entry(session_name, key);
+    Ok(())
+}
+
+/// Get a hidden environment variable from a tmux session
+///
+/// Cached for [`ENV_CACHE_TTL`] to reduce subprocess spawns. Positive hits
+/// cached; misses always go through tmux for freshness.
+pub fn get_hidden_env(session_name: &str, key: &str) -> Option<String> {
+    let cache_key = (session_name.to_string(), key.to_string());
+
+    if let Ok(cache) = ENV_CACHE.read() {
+        if let Some(entries) = &cache.entries {
+            if let Some(entry) = entries.get(&cache_key) {
+                if entry.fetched_at.elapsed() < ENV_CACHE_TTL {
+                    return Some(entry.value.clone());
+                }
+            }
+        }
+    }
+
+    let value = fetch_hidden_env(session_name, key)?;
+
+    if let Ok(mut cache) = ENV_CACHE.write() {
+        let entries = cache.entries.get_or_insert_with(HashMap::new);
+        entries.insert(
+            cache_key,
+            EnvCacheEntry {
+                value: value.clone(),
+                fetched_at: Instant::now(),
+            },
+        );
+    }
+
+    Some(value)
+}
+
+fn fetch_hidden_env(session_name: &str, key: &str) -> Option<String> {
+    let output = Command::new("tmux")
+        .args(["show-environment", "-h", "-t", session_name, key])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.trim();
+
+    // tmux outputs "-KEY" when the variable is unset
+    if line.starts_with('-') {
+        return None;
+    }
+
+    if let Some((_, value)) = line.split_once('=') {
+        Some(value.to_string())
+    } else {
+        None
+    }
+}
+
+/// Remove a hidden environment variable from a tmux session
+pub fn remove_hidden_env(session_name: &str, key: &str) -> anyhow::Result<()> {
+    let output = Command::new("tmux")
+        .args(["set-environment", "-h", "-u", "-t", session_name, key])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("Failed to remove hidden env var: {}", stderr);
+    }
+
+    invalidate_cache_entry(session_name, key);
+    Ok(())
+}
+
+/// Set hidden environment variables in multiple sessions with a single tmux command.
+///
+/// Each tuple is `(session_name, key, value)`. Falls back to individual
+/// `set_hidden_env` calls if the batch command fails (same pattern as
+/// `get_hidden_env_batch`).
+pub fn set_hidden_env_batch(entries: &[(&str, &str, &str)]) -> anyhow::Result<()> {
+    if entries.is_empty() {
+        return Ok(());
+    }
+
+    let mut args: Vec<String> = Vec::new();
+    for (i, (session_name, key, value)) in entries.iter().enumerate() {
+        if i > 0 {
+            args.push(";".to_string());
+        }
+        args.push("set-environment".to_string());
+        args.push("-h".to_string());
+        args.push("-t".to_string());
+        args.push(session_name.to_string());
+        args.push(key.to_string());
+        args.push(value.to_string());
+    }
+
+    let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let output = Command::new("tmux").args(&str_args).output();
+
+    match output {
+        Ok(out) if out.status.success() => {
+            for (session_name, key, _) in entries {
+                invalidate_cache_entry(session_name, key);
+            }
+            Ok(())
+        }
+        Ok(out) => {
+            tracing::debug!(
+                "Batch tmux set-environment failed (exit {}), falling back to sequential writes",
+                out.status
+            );
+            for (session_name, key, value) in entries {
+                set_hidden_env(session_name, key, value)?;
+            }
+            Ok(())
+        }
+        Err(e) => {
+            tracing::debug!(
+                "Batch tmux set-environment error: {}, falling back to sequential writes",
+                e
+            );
+            for (session_name, key, value) in entries {
+                set_hidden_env(session_name, key, value)?;
+            }
+            Ok(())
+        }
+    }
+}
+
+fn invalidate_cache_entry(session_name: &str, key: &str) {
+    if let Ok(mut cache) = ENV_CACHE.write() {
+        if let Some(entries) = &mut cache.entries {
+            entries.remove(&(session_name.to_string(), key.to_string()));
+        }
+    }
+}
+
+/// Get hidden environment variables from multiple sessions in a single tmux command
+///
+/// Attempts to batch-read from all sessions with a single command. Falls back to
+/// sequential reads if the batch command fails.
+///
+/// Returns a vector of (session_name, value) tuples in the same order as input.
+pub fn get_hidden_env_batch(session_names: &[&str], key: &str) -> Vec<(String, Option<String>)> {
+    if session_names.is_empty() {
+        return Vec::new();
+    }
+
+    // Build a batch tmux command: each segment needs the full
+    // `show-environment -h` prefix since `;` is a command separator.
+    let mut args: Vec<String> = Vec::new();
+    for (i, session_name) in session_names.iter().enumerate() {
+        if i > 0 {
+            args.push(";".to_string());
+        }
+        args.push("show-environment".to_string());
+        args.push("-h".to_string());
+        args.push("-t".to_string());
+        args.push(session_name.to_string());
+        args.push(key.to_string());
+    }
+
+    let str_args: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+    let output = Command::new("tmux").args(&str_args).output();
+
+    let fallback = || {
+        session_names
+            .iter()
+            .map(|name| (name.to_string(), get_hidden_env(name, key)))
+            .collect()
+    };
+
+    let results = match output {
+        Ok(out) if out.status.success() => {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            parse_batch_output(&stdout, session_names).unwrap_or_else(|| {
+                tracing::debug!(
+                    "Batch env parse failed (line count mismatch for {} sessions), falling back to sequential reads",
+                    session_names.len()
+                );
+                fallback()
+            })
+        }
+        Ok(out) => {
+            tracing::debug!(
+                "Batch tmux show-environment failed (exit {}), falling back to sequential reads",
+                out.status
+            );
+            fallback()
+        }
+        Err(ref e) => {
+            tracing::debug!(
+                "Batch tmux show-environment error: {}, falling back to sequential reads",
+                e
+            );
+            fallback()
+        }
+    };
+
+    if let Ok(mut cache) = ENV_CACHE.write() {
+        let entries = cache.entries.get_or_insert_with(HashMap::new);
+        let now = Instant::now();
+        for (session_name, value) in &results {
+            if let Some(v) = value {
+                entries.insert(
+                    (session_name.clone(), key.to_string()),
+                    EnvCacheEntry {
+                        value: v.clone(),
+                        fetched_at: now,
+                    },
+                );
+            }
+        }
+    }
+
+    results
+}
+
+/// Parse output from batch show-environment command.
+///
+/// Each session's output is on a separate line in the format "KEY=VALUE" or "-KEY".
+/// If the number of output lines does not match the number of sessions (e.g. due to
+/// tmux error lines), returns `None` so the caller can fall back to sequential reads.
+fn parse_batch_output(
+    output: &str,
+    session_names: &[&str],
+) -> Option<Vec<(String, Option<String>)>> {
+    let lines: Vec<&str> = output.lines().collect();
+    if lines.len() != session_names.len() {
+        return None;
+    }
+    let mut results = Vec::new();
+
+    for (i, session_name) in session_names.iter().enumerate() {
+        let line = lines[i].trim();
+        let value = if line.starts_with('-') {
+            None
+        } else if let Some((_, val)) = line.split_once('=') {
+            Some(val.to_string())
+        } else {
+            None
+        };
+        results.push((session_name.to_string(), value));
+    }
+
+    Some(results)
+}
+
+#[cfg(test)]
+fn clear_env_cache() {
+    if let Ok(mut cache) = ENV_CACHE.write() {
+        cache.entries = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_cache_populate_and_lookup() {
+        clear_env_cache();
+        let key = ("cache_test_sess".to_string(), "MY_KEY".to_string());
+
+        if let Ok(mut cache) = ENV_CACHE.write() {
+            let entries = cache.entries.get_or_insert_with(HashMap::new);
+            entries.insert(
+                key.clone(),
+                EnvCacheEntry {
+                    value: "cached_val".to_string(),
+                    fetched_at: Instant::now(),
+                },
+            );
+        }
+
+        let hit = ENV_CACHE.read().ok().and_then(|c| {
+            c.entries
+                .as_ref()?
+                .get(&key)
+                .filter(|e| e.fetched_at.elapsed() < ENV_CACHE_TTL)
+                .map(|e| e.value.clone())
+        });
+        assert_eq!(hit, Some("cached_val".to_string()));
+        clear_env_cache();
+    }
+
+    #[test]
+    #[serial]
+    fn test_cache_stale_entry_not_returned() {
+        clear_env_cache();
+        let key = ("stale_sess".to_string(), "MY_KEY".to_string());
+
+        if let Ok(mut cache) = ENV_CACHE.write() {
+            let entries = cache.entries.get_or_insert_with(HashMap::new);
+            entries.insert(
+                key.clone(),
+                EnvCacheEntry {
+                    value: "old_val".to_string(),
+                    fetched_at: Instant::now() - Duration::from_secs(60),
+                },
+            );
+        }
+
+        let hit = ENV_CACHE.read().ok().and_then(|c| {
+            c.entries
+                .as_ref()?
+                .get(&key)
+                .filter(|e| e.fetched_at.elapsed() < ENV_CACHE_TTL)
+                .map(|e| e.value.clone())
+        });
+        assert_eq!(hit, None);
+        clear_env_cache();
+    }
+
+    #[test]
+    #[serial]
+    fn test_invalidate_cache_entry_removes_key() {
+        clear_env_cache();
+        let session = "inv_test_sess";
+        let key = "MY_KEY";
+
+        if let Ok(mut cache) = ENV_CACHE.write() {
+            let entries = cache.entries.get_or_insert_with(HashMap::new);
+            entries.insert(
+                (session.to_string(), key.to_string()),
+                EnvCacheEntry {
+                    value: "val".to_string(),
+                    fetched_at: Instant::now(),
+                },
+            );
+        }
+
+        invalidate_cache_entry(session, key);
+
+        let exists = ENV_CACHE
+            .read()
+            .ok()
+            .and_then(|c| {
+                c.entries
+                    .as_ref()
+                    .map(|e| e.contains_key(&(session.to_string(), key.to_string())))
+            })
+            .unwrap_or(false);
+        assert!(!exists);
+        clear_env_cache();
+    }
+
+    #[test]
+    fn test_parse_key_value() {
+        let output = "AOE_INSTANCE_ID=abc123";
+        let result = parse_batch_output(output, &["test_session"]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "test_session");
+        assert_eq!(result[0].1, Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_parse_unset_key() {
+        let output = "-AOE_INSTANCE_ID";
+        let result = parse_batch_output(output, &["test_session"]).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "test_session");
+        assert_eq!(result[0].1, None);
+    }
+
+    #[test]
+    fn test_parse_multiple_sessions() {
+        let output = "AOE_INSTANCE_ID=abc123\n-AOE_INSTANCE_ID\nAOE_INSTANCE_ID=xyz789";
+        let result = parse_batch_output(output, &["session1", "session2", "session3"]).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].1, Some("abc123".to_string()));
+        assert_eq!(result[1].1, None);
+        assert_eq!(result[2].1, Some("xyz789".to_string()));
+    }
+
+    #[test]
+    fn test_parse_value_with_equals() {
+        let output = "KEY=value=with=equals";
+        let result = parse_batch_output(output, &["test_session"]).unwrap();
+        assert_eq!(result[0].1, Some("value=with=equals".to_string()));
+    }
+
+    #[test]
+    fn test_parse_line_count_mismatch_returns_none() {
+        let output = "";
+        assert!(parse_batch_output(output, &["session1", "session2"]).is_none());
+
+        let output = "VAL1\nVAL2\nVAL3";
+        assert!(parse_batch_output(output, &["session1"]).is_none());
+    }
+
+    #[test]
+    fn test_parse_whitespace_handling() {
+        let output = "  AOE_INSTANCE_ID=value123  \n  -AOE_INSTANCE_ID  ";
+        let result = parse_batch_output(output, &["session1", "session2"]).unwrap();
+        assert_eq!(result[0].1, Some("value123".to_string()));
+        assert_eq!(result[1].1, None);
+    }
+
+    #[test]
+    fn test_get_hidden_env_batch_empty_input() {
+        let result = get_hidden_env_batch(&[], "KEY");
+        assert_eq!(result.len(), 0);
+    }
+}

--- a/src/tmux/env.rs
+++ b/src/tmux/env.rs
@@ -60,6 +60,12 @@ pub fn get_hidden_env(session_name: &str, key: &str) -> Option<String> {
         }
     }
 
+    if let Ok(mut cache) = ENV_CACHE.write() {
+        if let Some(entries) = &mut cache.entries {
+            entries.remove(&cache_key);
+        }
+    }
+
     let value = fetch_hidden_env(session_name, key)?;
 
     if let Ok(mut cache) = ENV_CACHE.write() {

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -1,5 +1,6 @@
 //! tmux integration module
 
+pub mod env;
 mod session;
 pub mod status_bar;
 pub(crate) mod status_detection;


### PR DESCRIPTION
## Description

Extracts the self-contained infrastructure layer from #382 (session persistence) as the first step of the [agreed-upon split](https://github.com/njbrake/agent-of-empires/pull/382#issuecomment-4085221093) (PR A: Infrastructure).

### What's included

| Module | Description |
|--------|-------------|
| `src/tmux/env.rs` (new) | Hidden env variable helpers for tmux sessions with 30s TTL cache and batch read/write operations |
| `src/session/poller.rs` (new) | `AdaptiveInterval` (2s->60s backoff), `CaptureGate` (condvar sync), `SessionPoller` (thread lifecycle), `PollerCountGuard` (RAII budget cap at 20 threads) |
| `src/agents.rs` | `ResumeStrategy` enum + `resume_strategy` field on every `AgentDef` |
| `src/agents.rs` | `SessionStart`/`SessionEnd` lifecycle hook events (status: None, skipped by shell one-liners) |
| `src/tmux/mod.rs` | Wire `pub mod env` |
| `src/session/mod.rs` | Wire `pub mod poller` |
| `src/hooks/mod.rs` | Test coverage for SessionStart/SessionEnd skipping |

### Why it stands alone

These are purely additive library modules with their own unit tests. `ResumeStrategy` is added to agent definitions but nothing reads it yet. Zero behavioral change -- subsequent PRs (capture engine, resume integration, config) will wire these modules into the launch path.

Code is extracted identically from the `feat/session-management` branch to minimize conflicts with #382.

## PR Type

- [x] New Feature
- [x] Refactor

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- [x] `cargo fmt -- --check` -- clean
- [x] `cargo clippy -- -D warnings` -- clean
- [x] `cargo test` -- 906 unit tests pass, 0 failures
- Unit tests cover env cache populate/stale/invalidate, batch output parsing, adaptive interval backoff/reset/clamping, poller lifecycle (start/stop/change detection/budget cap/capture gate sync)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via OpenCode)

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)