### PR TITLE
fix: preserve tmux ANSI colors in preview capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 3
 name = "agent-of-empires"
 version = "0.17.0"
 dependencies = [
+ "ansi-to-tui",
  "anyhow",
  "cargo-husky",
  "cfg-if",
@@ -65,6 +66,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi-to-tui"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
+dependencies = [
+ "nom",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1291,6 +1305,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1324,6 +1344,16 @@ dependencies = [
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -2130,6 +2160,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "similar"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ clap_complete = "4.5"
 # TUI
 ratatui = { version = "0.29", features = ["crossterm"] }
 crossterm = "0.28"
+ansi-to-tui = "7.0"
 tui-textarea = "0.7"
 tui-input = "0.11"
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -187,6 +187,7 @@ impl Session {
                 "-t",
                 &target,
                 "-p",
+                "-e",
                 "-S",
                 &format!("-{}", lines),
             ])

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -143,6 +143,7 @@ impl TerminalSession {
                 "-t",
                 &target,
                 "-p",
+                "-e",
                 "-S",
                 &format!("-{}", lines),
             ])
@@ -292,6 +293,7 @@ impl ContainerTerminalSession {
                 "-t",
                 &target,
                 "-p",
+                "-e",
                 "-S",
                 &format!("-{}", lines),
             ])

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -1,5 +1,6 @@
 //! Preview panel component
 
+use ansi_to_tui::IntoText;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
 
@@ -91,12 +92,8 @@ impl Preview {
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
         } else {
-            let output_lines: Vec<Line> = cached_output
-                .lines()
-                .map(|line| Line::from(Span::raw(line)))
-                .collect();
-
-            let line_count = output_lines.len();
+            let output_text = parse_output_text(cached_output);
+            let line_count = output_text.lines.len();
             let visible_height = inner.height as usize;
 
             let scroll_offset = if line_count > visible_height {
@@ -105,7 +102,7 @@ impl Preview {
                 0
             };
 
-            let paragraph = Paragraph::new(output_lines)
+            let paragraph = Paragraph::new(output_text)
                 .style(Style::default().fg(theme.text))
                 .scroll((scroll_offset, 0));
 
@@ -245,12 +242,8 @@ impl Preview {
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
         } else {
-            let output_lines: Vec<Line> = cached_output
-                .lines()
-                .map(|line| Line::from(Span::raw(line)))
-                .collect();
-
-            let line_count = output_lines.len();
+            let output_text = parse_output_text(cached_output);
+            let line_count = output_text.lines.len();
             let visible_height = inner.height as usize;
 
             // Scroll to show the bottom of the content
@@ -260,13 +253,19 @@ impl Preview {
                 0
             };
 
-            let paragraph = Paragraph::new(output_lines)
+            let paragraph = Paragraph::new(output_text)
                 .style(Style::default().fg(theme.text))
                 .scroll((scroll_offset, 0));
 
             frame.render_widget(paragraph, inner);
         }
     }
+}
+
+fn parse_output_text(content: &str) -> Text<'static> {
+    content
+        .into_text()
+        .unwrap_or_else(|_| Text::from(content.to_string()))
 }
 
 fn shorten_path(path: &str) -> String {


### PR DESCRIPTION

Hello, human here: 
i like aoe, but looking at uncolored previews felt wrong. 
i asked an ai to implement this for me and wanted to share.
disclamer: i dont know rust, and have no idea if this was a good idea at all. code change is small. it compiles and tests pass.
anyway, back to the ai:


## Description
Fixes terminal/session preview output appearing as plain text without colors.

This change preserves ANSI escape sequences when capturing tmux pane output and renders those ANSI styles correctly in the TUI preview panel.

### What changed
- Add `-e` to tmux pane capture calls so style/color escapes are preserved:
  - `src/tmux/session.rs`
  - `src/tmux/terminal_session.rs`
- Parse ANSI output into ratatui `Text` in preview rendering:
  - `src/tui/components/preview.rs`
- Add ANSI parser dependency:
  - `ansi-to-tui = "7.0"` in `Cargo.toml` (compatible with current `ratatui = 0.29`)
  
### Why
`capture-pane` without `-e` drops styling info, and preview rendering previously treated captured output as raw lines. Together this caused minimal/plain output in preview even when underlying tmux content was colored.

### Screenshots
- Before: 
<img width="1793" height="1114" alt="Screenshot 2026-03-19 at 21 40 26" src="https://github.com/user-attachments/assets/2d4f8a39-2938-4da9-80ac-ade644694e80" />

- After: 
<img width="1796" height="1114" alt="Screenshot 2026-03-19 at 21 40 50" src="https://github.com/user-attachments/assets/f7a7deed-3b73-4875-9be5-fcdc690120a2" />

## PR Type
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
gpt-5.3-codex via OpenCode
**Any Additional AI Details you'd like to share:**
AI assistance was used to implement, validate, and explain the fix. Final PR content reviewed by author.

- [x] I am an AI Agent filling out this form (check box if true)