### PR TITLE
fix: bare repo misidentified when parent has a spurious .git/ directory

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -122,7 +122,7 @@ impl GitWorktree {
         let git_or_bare_dir = worktrees_dir.parent()?;
         let parent_dir = git_or_bare_dir.parent()?;
         if git_or_bare_dir.file_name() == Some(OsStr::new(".git"))
-            || parent_dir.join(".git").exists()
+            || parent_dir.join(".git").is_file()
         {
             return Some(parent_dir.to_path_buf());
         }
@@ -1298,6 +1298,29 @@ mod tests {
             result.unwrap().canonicalize().unwrap(),
             bare_path.canonicalize().unwrap(),
             "find_main_repo should return the bare repo root itself, not its parent"
+        );
+    }
+
+    #[test]
+    fn test_find_main_repo_from_worktree_with_spurious_parent_git_dir() {
+        let Some((_dir, bare_path)) = setup_bare_repo_whose_parent_has_spurious_git_dir() else {
+            return;
+        };
+
+        // find_main_repo from a linked worktree inside the bare repo should resolve
+        // back to the bare repo, not to the parent with the spurious .git/ dir.
+        let worktree_path = bare_path.join("main");
+        let result = GitWorktree::find_main_repo(&worktree_path);
+        assert!(
+            result.is_ok(),
+            "find_main_repo from worktree should succeed, got: {:?}",
+            result.err()
+        );
+        let resolved = result.unwrap().canonicalize().unwrap();
+        let expected = bare_path.canonicalize().unwrap();
+        assert_eq!(
+            resolved, expected,
+            "should resolve to bare repo, not parent"
         );
     }
 


### PR DESCRIPTION
Human-written preamble: At some point, a `.git` folder was added to my bare repo.  Because of this, when I tried to create a new session in AOE, I'd get a "Path is not in a git repository" error.  The '.git' folder contained some git hooks (wrong spot for a bare repo) and some opencode session data.

## Description

`find_main_repo` would return the wrong path for a direct bare repo when
its parent directory contained a spurious `.git/` directory created by an
external tool (e.g. opencode creates a `.git/` dir wherever it runs to
store session state). This caused `GitWorktree::new` to fail with
`"Path is not in a git repository"` when creating a new worktree.

**Root cause:** `find_main_repo` detects the linked-bare-repo layout
(`repo/.git` file pointing to `repo/.bare/`) by checking whether the bare
repo's parent has a `.git` entry using `.exists()`, which matches both
files and directories. A spurious `.git/` directory in the parent would
cause the parent to be returned as the main repo path, which is not itself
a git repo.

**Fix:** Change `.exists()` to `.is_file()`. In a genuine linked bare repo
layout, `.git` is always a file (a `gitdir:` pointer). A spurious `.git/`
created by tooling is a directory and is now correctly ignored.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** OpenCode (claude-sonnet-4-6)

**Any Additional AI Details you'd like to share:** Used to diagnose the
bug, write the regression tests, and implement the fix.

- [x] I am an AI Agent filling out this form (check box if true)