### PR TITLE
fix: correct terminal preview info_height off-by-one

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -19,9 +19,9 @@ impl Preview {
         theme: &Theme,
     ) {
         let info_height = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
-            5
+            4 // title + path + status + sandbox
         } else {
-            4
+            3 // title + path + status
         };
         let chunks = Layout::default()
             .direction(Direction::Vertical)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -368,14 +368,16 @@ impl HomeView {
     fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250; // Refresh preview 4x/second max
 
-        let needs_refresh = match &self.selected_session {
-            Some(id) => {
-                self.preview_cache.session_id.as_ref() != Some(id)
-                    || self.preview_cache.dimensions != (width, height)
-                    || self.preview_cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS
-            }
+        let session_changed = match &self.selected_session {
+            Some(id) => self.preview_cache.session_id.as_ref() != Some(id),
             None => false,
         };
+        let dims_changed = self.preview_cache.dimensions != (width, height);
+        let timer_expired =
+            self.preview_cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS;
+
+        let needs_refresh =
+            self.selected_session.is_some() && (session_changed || dims_changed || timer_expired);
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {


### PR DESCRIPTION
## Description

The terminal preview's `info_height` was 1 too large (5/4 instead of 4/3), stealing a line from the output area and causing misaligned content in the dashboard preview pane.

- `preview.rs`: Fix info_height calculation -- 3 lines (title + path + status) without sandbox, 4 with sandbox
- `render.rs`: Refactor preview cache refresh condition into named variables for readability

Closes #485

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)