### PR TITLE
feat: responsive list panel width on small terminals

### DIFF
--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -114,10 +114,15 @@ impl DiffView {
 
     fn render_content(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         // Split into file list (left) and diff content (right)
+        // On small screens, cap file list width so the diff pane gets adequate space
+        let effective_file_list_width = self
+            .file_list_width
+            .min(area.width.saturating_sub(40))
+            .max(5);
         let layout = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([
-                Constraint::Length(self.file_list_width),
+                Constraint::Length(effective_file_list_width),
                 Constraint::Min(40),
             ])
             .split(area);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -59,9 +59,18 @@ impl HomeView {
             .split(area);
 
         // Layout: left panel (list) and right panel (preview)
+        // On small screens, cap list width so the preview pane gets adequate space
+        let available_width = main_chunks[0].width;
+        let effective_list_width = self
+            .list_width
+            .min(available_width.saturating_sub(40))
+            .max(10);
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
-            .constraints([Constraint::Length(self.list_width), Constraint::Min(40)])
+            .constraints([
+                Constraint::Length(effective_list_width),
+                Constraint::Min(40),
+            ])
             .split(main_chunks[0]);
 
         self.render_list(frame, chunks[0], theme);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2058,3 +2058,32 @@ fn test_shift_n_prefills_session_path_for_ungrouped() {
         "ungrouped session should not pre-fill group"
     );
 }
+
+#[test]
+fn effective_list_width_clamps_on_small_screens() {
+    // The formula: list_width.min(available.saturating_sub(40)).max(10)
+    let clamp = |list_width: u16, available: u16| -> u16 {
+        list_width.min(available.saturating_sub(40)).max(10)
+    };
+
+    // Normal screen (120 cols): list_width 35 fits fine
+    assert_eq!(clamp(35, 120), 35);
+
+    // Medium screen (80 cols): list_width 35 still fits (80-40=40 > 35)
+    assert_eq!(clamp(35, 80), 35);
+
+    // Small screen (60 cols): list capped to 20, leaving 40 for preview
+    assert_eq!(clamp(35, 60), 20);
+
+    // Very small screen (50 cols): list capped to 10 (minimum)
+    assert_eq!(clamp(35, 50), 10);
+
+    // Tiny screen (30 cols): list stays at minimum 10
+    assert_eq!(clamp(35, 30), 10);
+
+    // User-resized list to 50 on a 100-col screen: capped to 60, but 50 < 60
+    assert_eq!(clamp(50, 100), 50);
+
+    // User-resized list to 50 on a 70-col screen: capped to 30, but min 10
+    assert_eq!(clamp(50, 70), 30);
+}


### PR DESCRIPTION
## Description

On small terminals (e.g. mobile browsers, tiled setups), the fixed-width list panel (default 35 columns) consumed a disproportionate amount of horizontal space, leaving the preview/output pane too narrow to be useful. The existing `Min(40)` constraint on the preview pane was effectively ignored because `Length()` is satisfied first in ratatui.

Now the effective list width is dynamically clamped at render time to ensure the preview pane always gets at least 40 columns:
- **120-col terminal**: list = 35, preview = 85 (unchanged)
- **80-col terminal**: list = 35, preview = 45 (unchanged)
- **60-col terminal**: list = 20, preview = 40 (was: list = 35, preview = 25)
- **50-col terminal**: list = 10, preview = 40 (was: list = 35, preview = 15)

The persisted `list_width` value is unchanged, so resizing the terminal back to full size restores the original proportions. The same fix is applied to the diff view's file list panel.

Fixes #503

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Implemented minimal responsive clamping logic for both home and diff view list panels, with unit test coverage for the clamping formula.

- [x] I am an AI Agent filling out this form (check box if true)