### PR TITLE
feat: add Shift+T shortcut to attach terminal from any view

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 36;
+const DIALOG_HEIGHT: u16 = 37;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -32,6 +32,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
             "Actions",
             vec![
                 ("Enter", "Attach to session"),
+                ("T", "Attach to terminal"),
                 ("n", "New session"),
                 ("N", "New from selection"),
                 ("x", "Stop session"),

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -478,6 +478,26 @@ impl HomeView {
                     ViewMode::Terminal => ViewMode::Agent,
                 };
             }
+            KeyCode::Char('T') => {
+                // Quick-attach to paired terminal from any view
+                if let Some(id) = &self.selected_session {
+                    if let Some(inst) = self.get_instance(id) {
+                        if inst.status == Status::Deleting {
+                            return None;
+                        }
+                    }
+                    let terminal_mode = if let Some(inst) = self.get_instance(id) {
+                        if inst.is_sandboxed() {
+                            self.get_terminal_mode(id)
+                        } else {
+                            TerminalMode::Host
+                        }
+                    } else {
+                        TerminalMode::Host
+                    };
+                    return Some(Action::AttachTerminal(id.clone(), terminal_mode));
+                }
+            }
             KeyCode::Char('c') => {
                 // Toggle container/host terminal mode (only in Terminal view for sandboxed sessions)
                 if self.view_mode == ViewMode::Terminal {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -819,6 +819,46 @@ fn test_enter_returns_attach_terminal_in_terminal_view() {
 
 #[test]
 #[serial]
+fn test_shift_t_attaches_terminal_from_agent_view() {
+    let env = create_test_env_with_sessions(1);
+    let mut view = env.view;
+
+    // Should be in Agent view by default
+    assert_eq!(view.view_mode, ViewMode::Agent);
+
+    // Shift+T should return AttachTerminal without switching view mode
+    let action = view.handle_key(key(KeyCode::Char('T')));
+    assert!(matches!(action, Some(Action::AttachTerminal(_, _))));
+    assert_eq!(view.view_mode, ViewMode::Agent);
+}
+
+#[test]
+#[serial]
+fn test_shift_t_attaches_terminal_from_terminal_view() {
+    let env = create_test_env_with_sessions(1);
+    let mut view = env.view;
+
+    // Switch to Terminal view
+    view.handle_key(key(KeyCode::Char('t')));
+    assert_eq!(view.view_mode, ViewMode::Terminal);
+
+    // Shift+T should also work from Terminal view
+    let action = view.handle_key(key(KeyCode::Char('T')));
+    assert!(matches!(action, Some(Action::AttachTerminal(_, _))));
+}
+
+#[test]
+#[serial]
+fn test_shift_t_noop_with_no_sessions() {
+    let env = create_test_env_empty();
+    let mut view = env.view;
+
+    let action = view.handle_key(key(KeyCode::Char('T')));
+    assert!(action.is_none());
+}
+
+#[test]
+#[serial]
 fn test_d_shows_info_dialog_in_terminal_view() {
     let env = create_test_env_with_sessions(1);
     let mut view = env.view;


### PR DESCRIPTION
## Description

Adds a `T` (Shift+t) keyboard shortcut that directly attaches to the paired terminal from any view mode. Previously, attaching to a terminal required switching to Terminal view with `t` and then pressing Enter. Now users can press `T` from the Agent view dashboard to jump straight into the terminal.

Fixes #506

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Changes

- **`src/tui/home/input.rs`** — Added `KeyCode::Char('T')` handler that returns `Action::AttachTerminal` from any view mode, respecting deleting-session guards and sandbox terminal mode
- **`src/tui/components/help.rs`** — Added `T → Attach to terminal` to the Actions section of the help overlay; bumped dialog height to fit
- **`src/tui/home/tests.rs`** — Added 3 tests: attach from agent view, attach from terminal view, no-op with no sessions

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)