### PR TITLE
fix: support Shift+Enter for newlines in send message dialog

### DIFF
--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -223,7 +223,9 @@ impl Session {
     }
 
     /// Send literal text to the session's first window pane, followed by Enter.
-    /// Multi-line text is sent line by line, each followed by Enter.
+    /// For multi-line text, newlines are sent as ESC+CR (the same sequence
+    /// terminals send for Shift+Enter) so the coding agent inserts a newline
+    /// rather than submitting after each line.
     pub fn send_keys(&self, text: &str) -> Result<()> {
         if !self.exists() {
             bail!("Session does not exist: {}", self.name);
@@ -231,24 +233,31 @@ impl Session {
 
         let target = format!("{}:^.0", self.name);
 
-        for line in text.lines() {
-            let output = Command::new("tmux")
-                .args(["send-keys", "-t", &target, "-l", line])
-                .output()?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                bail!("Failed to send keys: {}", stderr);
+        let lines: Vec<&str> = text.lines().collect();
+        for (i, line) in lines.iter().enumerate() {
+            Self::tmux_send(&target, &["-l", line])?;
+            if i < lines.len() - 1 {
+                // ESC + CR: what terminals send for Shift+Enter (inserts newline)
+                Self::tmux_send(&target, &["-H", "1b", "0d"])?;
             }
+        }
 
-            let output = Command::new("tmux")
-                .args(["send-keys", "-t", &target, "Enter"])
-                .output()?;
+        // Enter to submit
+        Self::tmux_send(&target, &["Enter"])?;
 
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-                bail!("Failed to send Enter: {}", stderr);
-            }
+        Ok(())
+    }
+
+    fn tmux_send(target: &str, args: &[&str]) -> Result<()> {
+        let output = Command::new("tmux")
+            .arg("send-keys")
+            .args(["-t", target])
+            .args(args)
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to send keys: {}", stderr);
         }
 
         Ok(())

--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -31,8 +31,13 @@ impl SendMessageDialog {
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<String> {
         match key.code {
             KeyCode::Esc => DialogResult::Cancel,
-            // Shift+Enter inserts a newline
-            KeyCode::Enter if key.modifiers.contains(KeyModifiers::SHIFT) => {
+            // Shift+Enter inserts a newline.
+            // Most terminals send Shift+Enter as ESC + CR (\x1b\r), which crossterm
+            // decodes as Alt+Enter, so we accept both ALT and SHIFT modifiers.
+            KeyCode::Enter
+                if key.modifiers.contains(KeyModifiers::SHIFT)
+                    || key.modifiers.contains(KeyModifiers::ALT) =>
+            {
                 self.text_area.insert_newline();
                 DialogResult::Continue
             }
@@ -99,6 +104,10 @@ mod tests {
         KeyEvent::new(code, KeyModifiers::SHIFT)
     }
 
+    fn alt_key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::ALT)
+    }
+
     #[test]
     fn test_esc_cancels() {
         let mut dialog = SendMessageDialog::new("Test Session");
@@ -134,6 +143,16 @@ mod tests {
         let mut dialog = SendMessageDialog::new("Test Session");
         dialog.handle_key(key(KeyCode::Char('a')));
         let result = dialog.handle_key(shift_key(KeyCode::Enter));
+        assert!(matches!(result, DialogResult::Continue));
+        dialog.handle_key(key(KeyCode::Char('b')));
+        assert_eq!(dialog.get_text(), "a\nb");
+    }
+
+    #[test]
+    fn test_alt_enter_adds_newline() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_key(key(KeyCode::Char('a')));
+        let result = dialog.handle_key(alt_key(KeyCode::Enter));
         assert!(matches!(result, DialogResult::Continue));
         dialog.handle_key(key(KeyCode::Char('b')));
         assert_eq!(dialog.get_text(), "a\nb");


### PR DESCRIPTION
## Description

Two issues fixed with the send message dialog (`m` key):

1. **Shift+Enter didn't insert newlines.** Most terminals send Shift+Enter as ESC+CR (`\x1b\r`), which crossterm decodes as Alt+Enter, not Shift+Enter. The dialog now accepts both ALT and SHIFT modifiers with Enter.

2. **Multi-line messages were sent as separate commands.** Each line was submitted individually to the coding agent. Now newlines between lines are sent as ESC+CR (the Shift+Enter keystroke) so the agent inserts newlines, with only one final Enter to submit the complete message.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Code (Claude Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)