### PR TITLE
fix: subscribe to ElicitationResult hook to unstick waiting status

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -94,6 +94,11 @@ const CLAUDE_CURSOR_HOOK_EVENTS: &[HookEvent] = &[
         matcher: Some("permission_prompt|elicitation_dialog"),
         status: Some("waiting"),
     },
+    HookEvent {
+        name: "ElicitationResult",
+        matcher: None,
+        status: Some("running"),
+    },
 ];
 
 pub const AGENTS: &[AgentDef] = &[

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -261,6 +261,7 @@ mod tests {
         assert!(hooks.contains_key("UserPromptSubmit"));
         assert!(hooks.contains_key("Stop"));
         assert!(hooks.contains_key("Notification"));
+        assert!(hooks.contains_key("ElicitationResult"));
     }
 
     #[test]
@@ -376,6 +377,19 @@ mod tests {
         assert!(
             cmd.contains("printf idle"),
             "Stop hook should write idle status: {}",
+            cmd
+        );
+    }
+
+    #[test]
+    fn test_elicitation_result_hook_writes_running() {
+        let hooks = build_aoe_hooks(claude_events());
+        let er = hooks["ElicitationResult"].as_array().unwrap();
+        assert_eq!(er.len(), 1);
+        let cmd = er[0]["hooks"][0]["command"].as_str().unwrap();
+        assert!(
+            cmd.contains("printf running"),
+            "ElicitationResult hook should write running status: {}",
             cmd
         );
     }


### PR DESCRIPTION
## Description

When a user answers Claude's elicitation dialog (question), the status sticks on "waiting" instead of transitioning to "running". This happens because `Notification(elicitation_dialog)` writes "waiting" to the hook status file, but no subsequent hook fires when the user responds -- `UserPromptSubmit` only fires for the main prompt, not elicitation responses.

The fix adds an `ElicitationResult` hook event to `CLAUDE_CURSOR_HOOK_EVENTS`. This event fires after a user responds to an MCP elicitation dialog, writing "running" to the status file.

**Flow before:**
1. `Notification(elicitation_dialog)` -> "waiting"
2. User answers -> (no hook fires) -> status stuck on "waiting"

**Flow after:**
1. `Notification(elicitation_dialog)` -> "waiting"
2. User answers -> `ElicitationResult` -> "running"

Fixes #521

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)