### PR TITLE
feat: widen send message popup to 80% of terminal width

### DIFF
--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -61,7 +61,8 @@ impl SendMessageDialog {
         // 2 for borders + 1 per content line, min 3 (single line), max 12
         let content_lines = self.text_area.lines().len() as u16;
         let height = (content_lines + 2).clamp(3, 12);
-        let dialog_area = super::centered_rect(area, 60, height);
+        let dialog_width = (area.width * 80 / 100).max(60).min(area.width);
+        let dialog_area = super::centered_rect(area, dialog_width, height);
 
         frame.render_widget(Clear, dialog_area);
 


### PR DESCRIPTION
## Description

The 'm' send message popup used a fixed 60-column width, which caused long messages to scroll horizontally instead of being visible. This changes the width to 80% of the terminal width (minimum 60 columns), matching the percentage-based pattern used by other dialogs like `custom_instruction.rs`.

This is a conservative first step toward #528. A follow-up could add text wrapping and vertical expansion.

Fixes #528

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**
Directed by the user to make a conservative fix (just widen the box).

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)