### PR TITLE
fix: strip ANSI codes before status detection to fix false Running/Idle

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -7,12 +7,16 @@ use super::utils::strip_ansi;
 const SPINNER_CHARS: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
 pub fn detect_status_from_content(content: &str, tool: &str, _fg_pid: Option<u32>) -> Status {
+    // Strip ANSI escape codes before passing to detectors. capture-pane is
+    // called with -e (to preserve colors for the TUI preview), but color codes
+    // interspersed in text like "esc interrupt" break plain substring matches.
+    let clean = strip_ansi(content);
     let status = crate::agents::get_agent(tool)
-        .map(|a| (a.detect_status)(content))
+        .map(|a| (a.detect_status)(&clean))
         .unwrap_or(Status::Idle);
 
     if status == Status::Idle {
-        let last_lines: Vec<&str> = content.lines().rev().take(5).collect();
+        let last_lines: Vec<&str> = clean.lines().rev().take(5).collect();
         tracing::debug!(
             "status detection returned Idle for tool '{}', last 5 lines: {:?}",
             tool,
@@ -558,6 +562,28 @@ mod tests {
     fn test_detect_status_from_content_unknown_tool_returns_idle() {
         let status = detect_status_from_content("Processing ⠋", "unknown_tool", None);
         assert_eq!(status, Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_status_strips_ansi_before_matching() {
+        // capture-pane -e injects ANSI color codes between characters, which
+        // can split signal strings like "esc interrupt" so they no longer match
+        // as plain substrings. The dispatcher must strip ANSI before calling
+        // any agent detector.
+        let ansi_running =
+            "\x1b[38;2;39;62;94m⬝⬝⬝⬝⬝⬝⬝⬝\x1b[0m  \x1b[38;2;238;238;238mesc \x1b[38;2;128;128;128minterrupt\x1b[0m";
+        assert_eq!(
+            detect_status_from_content(ansi_running, "opencode", None),
+            Status::Running,
+            "ANSI codes around 'esc interrupt' should not prevent Running detection"
+        );
+
+        let ansi_spinner = "\x1b[38;2;255;255;255m⠋\x1b[0m generating";
+        assert_eq!(
+            detect_status_from_content(ansi_spinner, "opencode", None),
+            Status::Running,
+            "ANSI codes around spinner chars should not prevent Running detection"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`capture-pane` is called with `-e` to preserve ANSI color codes for the TUI preview. However, the same captured content is also fed directly into status detection, where plain substring matching is used (e.g. `"esc interrupt"`, `"esc to interrupt"`, braille spinner chars). ANSI color escape sequences injected between characters break these matches -- for example `"esc interrupt"` in the OpenCode status bar arrives as:

```
\x1b[38;2;238;238;238mesc \x1b[38;2;128;128;128minterrupt\x1b[0m
```

...which does not contain the substring `"esc interrupt"`, so the session is reported as Idle when it is actually Running.

The `-e` flag was added in commit `77e509e` (released in **0.17.1**) to fix ANSI color rendering in the preview pane. That is when this regression was introduced -- users on 0.16.x and earlier were unaffected.

The fix strips ANSI codes at the single entry point (`detect_status_from_content`) before dispatching to any agent detector, so all agents benefit without any per-detector changes. The individual `strip_ansi` calls that already exist inside some detectors remain harmless.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Sonnet 4.6 via OpenCode

**Any Additional AI Details you'd like to share:** Diagnosed and implemented with AI assistance through agent-of-empires itself.

- [x] I am an AI Agent filling out this form (check box if true)