### PR TITLE
fix: use single-quote escaping for custom sandbox instructions

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -43,17 +43,18 @@ pub(crate) fn user_posix_shell() -> String {
 }
 
 /// Shell-escape a value for safe interpolation into a shell command string.
-/// Uses double-quote escaping so values can be nested inside a `shell -c '...'`
-/// wrapper (single quotes in the outer wrapper are literal, double quotes work inside).
+///
+/// Uses single-quote escaping: inside single quotes ALL characters are literal
+/// except `'` itself, which is escaped via the POSIX `'\''` technique. This is
+/// the most robust approach -- it prevents expansion of `$`, `` ` ``, `\`, `!`,
+/// and every other shell metacharacter in one shot.
+///
+/// Newlines and carriage returns are replaced with literal `\n` / `\r` text to
+/// keep the command on a single line (required for tmux session commands).
 pub(crate) fn shell_escape(val: &str) -> String {
-    let escaped = val
-        .replace('\\', "\\\\")
-        .replace('"', "\\\"")
-        .replace('$', "\\$")
-        .replace('`', "\\`")
-        .replace('\n', "\\n")
-        .replace('\r', "\\r");
-    format!("\"{}\"", escaped)
+    let val = val.replace('\n', "\\n").replace('\r', "\\r");
+    let escaped = val.replace('\'', "'\\''");
+    format!("'{}'", escaped)
 }
 
 /// Resolve an environment value. If the value starts with `$`, read the
@@ -221,37 +222,52 @@ mod tests {
 
     #[test]
     fn test_shell_escape_simple() {
-        assert_eq!(shell_escape("hello"), "\"hello\"");
+        assert_eq!(shell_escape("hello"), "'hello'");
     }
 
     #[test]
-    fn test_shell_escape_quotes() {
-        assert_eq!(shell_escape("say \"hello\""), "\"say \\\"hello\\\"\"");
+    fn test_shell_escape_apostrophe() {
+        assert_eq!(shell_escape("Don't do that"), "'Don'\\''t do that'");
+    }
+
+    #[test]
+    fn test_shell_escape_double_quotes() {
+        // Double quotes are literal inside single quotes -- no escaping needed
+        assert_eq!(shell_escape("say \"hello\""), "'say \"hello\"'");
     }
 
     #[test]
     fn test_shell_escape_backslash() {
-        assert_eq!(shell_escape("path\\to\\file"), "\"path\\\\to\\\\file\"");
+        // Backslashes are literal inside single quotes -- no escaping needed
+        assert_eq!(shell_escape("path\\to\\file"), "'path\\to\\file'");
     }
 
     #[test]
     fn test_shell_escape_dollar() {
-        assert_eq!(shell_escape("$HOME/path"), "\"\\$HOME/path\"");
+        // $ is literal inside single quotes -- no expansion
+        assert_eq!(shell_escape("$HOME/path"), "'$HOME/path'");
     }
 
     #[test]
     fn test_shell_escape_backtick() {
-        assert_eq!(shell_escape("run `cmd`"), "\"run \\`cmd\\`\"");
+        // Backticks are literal inside single quotes -- no command substitution
+        assert_eq!(shell_escape("run `cmd`"), "'run `cmd`'");
+    }
+
+    #[test]
+    fn test_shell_escape_exclamation() {
+        // ! is literal inside single quotes -- no history expansion
+        assert_eq!(shell_escape("hello!"), "'hello!'");
     }
 
     #[test]
     fn test_shell_escape_newline() {
-        assert_eq!(shell_escape("line1\nline2"), "\"line1\\nline2\"");
+        assert_eq!(shell_escape("line1\nline2"), "'line1\\nline2'");
     }
 
     #[test]
     fn test_shell_escape_carriage_return() {
-        assert_eq!(shell_escape("line1\rline2"), "\"line1\\rline2\"");
+        assert_eq!(shell_escape("line1\rline2"), "'line1\\rline2'");
     }
 
     #[test]
@@ -260,22 +276,30 @@ mod tests {
         let escaped = shell_escape(instruction);
         assert_eq!(
             escaped,
-            "\"First instruction.\\nSecond instruction.\\nThird instruction.\""
+            "'First instruction.\\nSecond instruction.\\nThird instruction.'"
         );
         assert!(!escaped.contains('\n'));
     }
 
     #[test]
     fn test_shell_escape_crlf() {
-        assert_eq!(shell_escape("line1\r\nline2"), "\"line1\\r\\nline2\"");
+        assert_eq!(shell_escape("line1\r\nline2"), "'line1\\r\\nline2'");
     }
 
     #[test]
     fn test_shell_escape_combined() {
         let input = "Say \"hello\"\nRun `echo $HOME`";
         let escaped = shell_escape(input);
-        assert_eq!(escaped, "\"Say \\\"hello\\\"\\nRun \\`echo \\$HOME\\`\"");
+        assert_eq!(escaped, "'Say \"hello\"\\nRun `echo $HOME`'");
         assert!(!escaped.contains('\n'));
+    }
+
+    #[test]
+    fn test_shell_escape_mixed_quotes() {
+        // Both apostrophes and double quotes
+        let input = "He said \"don't\"";
+        let escaped = shell_escape(input);
+        assert_eq!(escaped, "'He said \"don'\\''t\"'");
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -738,7 +738,7 @@ fn generate_id() -> String {
 
 /// Format an environment variable assignment as a shell-safe command prefix.
 ///
-/// Uses `shell_escape` (double-quote escaping) so the value is preserved
+/// Uses `shell_escape` (single-quote escaping) so the value is preserved
 /// verbatim when parsed by the inner `bash -c '...'` shell created by
 /// `wrap_command_ignore_suspend`.
 fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
@@ -823,20 +823,20 @@ mod tests {
         // EnvVar values containing JSON must be shell-escaped to prevent
         // the inner bash from expanding special characters ({, *, ").
         let result = format_env_var_prefix("OPENCODE_PERMISSION", r#"{"*":"allow"}"#, "opencode");
-        assert_eq!(
-            result,
-            r#"OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode"#
-        );
+        assert_eq!(result, r#"OPENCODE_PERMISSION='{"*":"allow"}' opencode"#);
     }
 
     #[test]
     fn test_yolo_envvar_survives_suspend_wrapper() {
         // The full chain: format_env_var_prefix -> wrap_command_ignore_suspend
         // must preserve the JSON value through both quoting layers.
+        // Single quotes from shell_escape are escaped by wrap_command_ignore_suspend
+        // via the '\'' technique, which correctly round-trips through the shell.
         let cmd = format_env_var_prefix("OPENCODE_PERMISSION", r#"{"*":"allow"}"#, "opencode");
         let wrapped = wrap_command_ignore_suspend(&cmd);
+        // The inner single quotes from shell_escape become '\'' in the outer wrapper
         assert!(
-            wrapped.contains(r#"OPENCODE_PERMISSION="{\"*\":\"allow\"}" opencode"#),
+            wrapped.contains(r#"OPENCODE_PERMISSION='\''{"*":"allow"}'\'' opencode"#),
             "wrapped command should contain the escaped env var assignment: {}",
             wrapped,
         );


### PR DESCRIPTION
## Description

Fixes #274. Custom sandbox instructions didn't properly escape all characters (e.g., apostrophes).

Switched `shell_escape()` from double-quote escaping to single-quote escaping. Inside single quotes ALL characters are literal except `'` itself, which is escaped via the POSIX `'\''` technique. This is the most robust shell escaping approach -- it eliminates all metacharacter concerns (`$`, `` ` ``, `\`, `"`, `!`) in one shot, and explicitly handles apostrophes.

### Before
```rust
// Double-quote escaping -- had to manually escape \, ", $, `, \n, \r
// Did NOT handle ' (apostrophes) or ! (history expansion)
let escaped = val.replace('\\', "\\\\").replace('"', "\\\"")...;
format!("\"{}\"", escaped)
```

### After
```rust
// Single-quote escaping -- ALL chars literal except ' (escaped via '\'')
let escaped = val.replace('\'', "'\\''");
format!("'{}'", escaped)
```

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)