### PR TITLE
feat: add bun and pnpm to dev sandbox image

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,5 @@
 # aoe-dev-sandbox: Extended sandbox with development tools
-# Includes: Rust, uv (Python), nvm + Node.js, gh (GitHub CLI)
+# Includes: Rust, uv (Python), nvm + Node.js, pnpm, bun, gh (GitHub CLI)
 # Note: Claude Code, OpenCode, and Codex CLI are inherited from the base image
 
 ARG BASE_IMAGE=ghcr.io/njbrake/aoe-sandbox:latest
@@ -30,12 +30,19 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | b
     && . "$NVM_DIR/nvm.sh" \
     && nvm install --lts \
     && nvm alias default node \
+    && npm install -g pnpm \
     && ln -s "$(which node)" /root/.local/bin/node \
     && ln -s "$(which npm)" /root/.local/bin/npm \
-    && ln -s "$(which npx)" /root/.local/bin/npx
+    && ln -s "$(which npx)" /root/.local/bin/npx \
+    && ln -s "$(which pnpm)" /root/.local/bin/pnpm
+
+# Install Bun (requires unzip)
+RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/* \
+    && curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:${PATH}"
 
 # Add dev tool paths to profile.d so they're available in all shells (login and non-login)
-RUN echo 'export PATH="/root/.cargo/bin:/root/.local/bin:$PATH"' > /etc/profile.d/dev-tools.sh \
+RUN echo 'export PATH="/root/.bun/bin:/root/.cargo/bin:/root/.local/bin:$PATH"' > /etc/profile.d/dev-tools.sh \
     && echo 'export NVM_DIR="/root/.nvm"' >> /etc/profile.d/dev-tools.sh \
     && echo '[ -s "$NVM_DIR/nvm.sh" ] && . "$NVM_DIR/nvm.sh"' >> /etc/profile.d/dev-tools.sh \
     && chmod +x /etc/profile.d/dev-tools.sh


### PR DESCRIPTION
## Description

Adds bun and pnpm to the dev sandbox image (`Dockerfile.dev`). Both are widely used JS package managers/runtimes that projects may depend on but are currently missing from the sandbox.

I won't be offended if this PR gets rejected -- I can setup my own alt dev image and use that.  But I was genuinely bunmmed when bun wasn't available at the moment I needed to run a few scripts, and it knocked me out of my flow state :)

- **bun**: ~65MB, single binary, installed via official script to `/root/.bun/bin`
- **pnpm**: ~15MB, installed via `npm install -g`

Both are added to `PATH` via `ENV` and `/etc/profile.d/dev-tools.sh` so they're available in all shell contexts.

The base image (`Dockerfile`) is unchanged -- this only affects the dev sandbox.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Code (Opus 4.6)