### PR TITLE
fix: enable bracketed paste for TUI text input dialogs

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1,7 +1,10 @@
 //! Main TUI application
 
 use anyhow::Result;
-use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers, MouseEvent};
+use crossterm::event::{
+    self, DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEvent, KeyModifiers,
+    MouseEvent,
+};
 use ratatui::prelude::*;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -29,6 +32,7 @@ where
         terminal.backend_mut(),
         crossterm::terminal::LeaveAlternateScreen,
         crossterm::event::DisableMouseCapture,
+        DisableBracketedPaste,
         crossterm::cursor::Show
     )?;
     std::io::Write::flush(terminal.backend_mut())?;
@@ -40,6 +44,7 @@ where
         terminal.backend_mut(),
         crossterm::terminal::EnterAlternateScreen,
         crossterm::event::EnableMouseCapture,
+        EnableBracketedPaste,
         crossterm::cursor::Hide
     )?;
     std::io::Write::flush(terminal.backend_mut())?;
@@ -210,6 +215,13 @@ impl App {
                         self.handle_mouse(mouse, terminal).await?;
 
                         // Draw immediately after input for responsiveness
+                        terminal.draw(|f| self.render(f))?;
+
+                        continue;
+                    }
+                    Event::Paste(text) => {
+                        self.home.handle_paste(&text);
+
                         terminal.draw(|f| self.render(f))?;
 
                         continue;

--- a/src/tui/dialogs/custom_instruction.rs
+++ b/src/tui/dialogs/custom_instruction.rs
@@ -80,6 +80,12 @@ impl CustomInstructionDialog {
         }
     }
 
+    pub fn handle_paste(&mut self, text: &str) {
+        if self.focused_zone == 0 {
+            self.text_area.insert_str(text);
+        }
+    }
+
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width = (area.width * 70 / 100).max(40).min(area.width);
         let dialog_height = (area.height * 60 / 100).max(10).min(area.height);

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1379,6 +1379,30 @@ impl NewSessionDialog {
         }
     }
 
+    pub fn handle_paste(&mut self, text: &str) {
+        let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+
+        // Route to the active sub-mode input if one is open
+        let target: &mut Input = if let Some(ref mut input) = self.env_editing_input {
+            input
+        } else if let Some(ref mut input) = self.workspace_repo_editing_input {
+            input
+        } else if self.tool_config_mode {
+            if self.tool_config_focused_field == 0 {
+                &mut self.command_override
+            } else {
+                &mut self.extra_args
+            }
+        } else if self.sandbox_config_mode && self.sandbox_focused_field == 0 {
+            &mut self.sandbox_image
+        } else {
+            self.current_input_mut()
+        };
+        for ch in sanitized.chars() {
+            target.handle(tui_input::InputRequest::InsertChar(ch));
+        }
+    }
+
     fn build_submit_result(&self) -> DialogResult<NewSessionData> {
         let title_value = self.title.value().trim();
         let final_title = if title_value.is_empty() {

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -303,6 +303,15 @@ impl RenameDialog {
         }
     }
 
+    pub fn handle_paste(&mut self, text: &str) {
+        if let Some(input) = self.focused_input() {
+            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            for ch in sanitized.chars() {
+                input.handle(tui_input::InputRequest::InsertChar(ch));
+            }
+        }
+    }
+
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         match self.mode {
             RenameMode::Session => self.render_session(frame, area, theme),

--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -57,6 +57,10 @@ impl SendMessageDialog {
         }
     }
 
+    pub fn handle_paste(&mut self, text: &str) {
+        self.text_area.insert_str(text);
+    }
+
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         // 2 for borders + 1 per content line, min 3 (single line), max 12
         let content_lines = self.text_area.lines().len() as u16;
@@ -169,5 +173,37 @@ mod tests {
         dialog.handle_key(key(KeyCode::Char('2')));
         let result = dialog.handle_key(key(KeyCode::Enter));
         assert!(matches!(result, DialogResult::Submit(ref s) if s == "l1\nl2"));
+    }
+
+    #[test]
+    fn test_paste_single_line() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_paste("hello world");
+        assert_eq!(dialog.get_text(), "hello world");
+    }
+
+    #[test]
+    fn test_paste_multiline() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_paste("line1\nline2\nline3");
+        assert_eq!(dialog.get_text(), "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn test_paste_then_submit() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_paste("pasted text");
+        let result = dialog.handle_key(key(KeyCode::Enter));
+        assert!(matches!(result, DialogResult::Submit(ref s) if s == "pasted text"));
+    }
+
+    #[test]
+    fn test_paste_appends_to_existing() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_key(key(KeyCode::Char('h')));
+        dialog.handle_key(key(KeyCode::Char('i')));
+        dialog.handle_key(key(KeyCode::Char(' ')));
+        dialog.handle_paste("world");
+        assert_eq!(dialog.get_text(), "hi world");
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -966,6 +966,25 @@ impl HomeView {
         }
     }
 
+    /// Route a bracketed paste event to the active text input dialog.
+    pub fn handle_paste(&mut self, text: &str) {
+        if let Some(ref mut settings) = self.settings_view {
+            settings.handle_paste(text);
+            return;
+        }
+        if let Some(ref mut dialog) = self.rename_dialog {
+            dialog.handle_paste(text);
+            return;
+        }
+        if let Some(ref mut dialog) = self.send_message_dialog {
+            dialog.handle_paste(text);
+            return;
+        }
+        if let Some(ref mut dialog) = self.new_dialog {
+            dialog.handle_paste(text);
+        }
+    }
+
     /// Re-score matches after a reload without moving the cursor.
     pub(super) fn refresh_search_matches(&mut self) {
         let query = self.search_query.value();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ pub use app::*;
 
 use anyhow::Result;
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
+    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -94,7 +94,12 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableMouseCapture,
+        EnableBracketedPaste
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -110,7 +115,8 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableMouseCapture
+        DisableMouseCapture,
+        DisableBracketedPaste
     )?;
     terminal.show_cursor()?;
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -764,6 +764,19 @@ impl SettingsView {
         self.rebuild_fields();
         Ok(())
     }
+
+    pub fn handle_paste(&mut self, text: &str) {
+        if let Some(ref mut dialog) = self.custom_instruction_dialog {
+            dialog.handle_paste(text);
+            return;
+        }
+        if let Some(ref mut input) = self.editing_input {
+            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            for ch in sanitized.chars() {
+                input.handle(tui_input::InputRequest::InsertChar(ch));
+            }
+        }
+    }
 }
 
 /// Validate that an entry for AgentExtraArgs or AgentCommandOverride is in `agent_name=value` format.


### PR DESCRIPTION
## Description

Pasting multiline text into the `m` send-message popup (and other text input dialogs) would immediately submit on the first newline, then spam random TUI commands from the remaining pasted characters. This happened because bracketed paste mode was not enabled, so pasted newlines arrived as plain Enter key events.

Enable crossterm's bracketed paste mode so pasted text arrives as a single `Event::Paste` instead of individual key events. Route paste events through the dialog dispatch chain to insert text directly into the active text area or input field.

Fixes #545

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)