### PR TITLE
fix: restore dev-release Cargo profile for faster local builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@
 ## Build, Test, and Development Commands
 
 - `cargo build` / `cargo build --release`: compile TUI-only (release binary at `target/release/aoe`).
+- `cargo build --profile dev-release`: faster optimized builds for local development. Skips LTO for quicker compile times while still producing an optimized binary. Use `--release` for final/CI builds.
 - `cargo build --features serve`: compile with web dashboard support (requires Node.js + npm).
 - `cargo run --release`: run from source; requires `tmux` installed.
 - `cargo check`: fast type-checking during development.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ cargo run --release
 ```bash
 cargo build                    # Debug build
 cargo build --release          # Release build
+cargo build --profile dev-release  # Fast optimized build for local dev
 cargo check                    # Fast type-checking
 cargo test                     # Run tests
 cargo fmt                      # Format code

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,11 @@ lto = true
 codegen-units = 1
 strip = true
 
+[profile.dev-release]
+inherits = "release"
+lto = false
+codegen-units = 16
+
 [[bin]]
 name = "aoe"
 path = "src/main.rs"

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@
 ```bash
 cargo build                    # Debug build
 cargo build --release          # Release build (with LTO)
+cargo build --profile dev-release  # Optimized build without LTO (faster compile)
 ```
 
 The release binary is at `target/release/aoe`.

--- a/website/src/pages/docs/development.md
+++ b/website/src/pages/docs/development.md
@@ -9,6 +9,7 @@ description: Build, run, and test Agent of Empires from source.
 ```bash
 cargo build                    # Debug build
 cargo build --release          # Release build (with LTO)
+cargo build --profile dev-release  # Optimized build without LTO (faster compile)
 ```
 
 The release binary is at `target/release/aoe`.


### PR DESCRIPTION
## Description

Restores the `dev-release` Cargo profile that was removed in #582. The removal was motivated by simplifying build config, but in practice this profile provides significant compile time savings for local development by skipping LTO (`lto = false`) and parallelizing codegen (`codegen-units = 16`) while still producing optimized binaries.

Without it, developers must choose between unoptimized debug builds or full release builds with expensive LTO + single codegen unit, which is especially painful with native C deps like openssl, libgit2, and aws-lc.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)