### PR TITLE
fix: limit cargo build parallelism to 4 jobs

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
+[build]
+jobs = 4
+
 [alias]
 xtask = "run -p xtask --"


### PR DESCRIPTION
## Summary
- Add `[build] jobs = 4` to `.cargo/config.toml` to cap Cargo's parallel compilation
- In Docker Desktop on macOS, Cargo detects all host CPUs and spawns that many parallel rustc processes, causing 17000%+ CPU usage
- 4 jobs keeps builds fast while staying within reasonable resource bounds for the Docker VM

## Related
- #597 (volume_ignores gap for parent repo mounts is a separate fix)

## Test plan
- [x] `cargo build` completes successfully with the job limit
- [ ] Verify CPU usage is reasonable on macOS Docker Desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)