### PR TITLE
fix: apply volume_ignores to parent repo mount in worktree sessions

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -775,6 +775,13 @@ pub(crate) fn build_container_config(
         compute_volume_paths(project_path, project_path_str)?
     };
 
+    // Save project volume container paths so volume_ignores can be applied to all
+    // project mounts (e.g., both the worktree and parent repo in worktree sessions).
+    let project_container_paths: Vec<String> = project_volumes
+        .iter()
+        .map(|v| v.container_path.clone())
+        .collect();
+
     let mut volumes = project_volumes;
 
     let sandbox_config = {
@@ -950,10 +957,14 @@ pub(crate) fn build_container_config(
     //   - Exact match: both point to same path
     //   - Anonymous volume is parent of extra_volume (would shadow the mount)
     //   - Anonymous volume is inside extra_volume (redundant/conflicting)
-    let anonymous_volumes: Vec<String> = sandbox_config
-        .volume_ignores
+    let anonymous_volumes: Vec<String> = project_container_paths
         .iter()
-        .map(|ignore| format!("{}/{}", workspace_path, ignore))
+        .flat_map(|base_path| {
+            sandbox_config
+                .volume_ignores
+                .iter()
+                .map(move |ignore| format!("{}/{}", base_path, ignore))
+        })
         .filter(|anon_path| {
             !extra_volume_container_paths.iter().any(|extra_path| {
                 anon_path == extra_path
@@ -2154,6 +2165,121 @@ extra_volumes = ["/host/data:/container/data:ro"]
             volume_pairs.contains(&("/host/data", "/container/data")),
             "extra_volumes should include /host/data:/container/data, got: {:?}",
             volume_pairs
+        );
+    }
+
+    /// Regression test for #597: volume_ignores must apply to the parent repo
+    /// mount as well as the worktree mount in sibling-worktree sessions.
+    #[test]
+    #[serial_test::serial]
+    fn test_volume_ignores_applied_to_parent_repo_mount() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let (_dir, repo_path) = setup_regular_repo();
+
+        // Create a sibling worktree (non-bare layout)
+        let worktree_path = repo_path.parent().unwrap().join("my-worktree");
+        let head = git2::Repository::open(&repo_path)
+            .unwrap()
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        let repo = git2::Repository::open(&repo_path).unwrap();
+        repo.branch("wt-branch", &repo.find_commit(head).unwrap(), false)
+            .unwrap();
+        drop(repo);
+
+        let output = std::process::Command::new("git")
+            .args([
+                "worktree",
+                "add",
+                worktree_path.to_str().unwrap(),
+                "wt-branch",
+            ])
+            .current_dir(&repo_path)
+            .output()
+            .unwrap();
+        if !output.status.success() {
+            return; // git not available, skip
+        }
+
+        // Write repo-level config with volume_ignores
+        let config_dir = worktree_path.join(".agent-of-empires");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            r#"
+[sandbox]
+volume_ignores = ["target", "node_modules"]
+"#,
+        )
+        .unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            created_at: None,
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let project_path_str = worktree_path.to_str().unwrap();
+        let config = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            "claude",
+            false,
+            "test-instance-id",
+            None,
+        )
+        .unwrap();
+
+        // Verify volume_ignores are applied to the worktree mount
+        assert!(
+            config
+                .anonymous_volumes
+                .iter()
+                .any(|v| v.ends_with("/my-worktree/target")),
+            "anonymous_volumes should contain worktree target, got: {:?}",
+            config.anonymous_volumes
+        );
+        assert!(
+            config
+                .anonymous_volumes
+                .iter()
+                .any(|v| v.ends_with("/my-worktree/node_modules")),
+            "anonymous_volumes should contain worktree node_modules, got: {:?}",
+            config.anonymous_volumes
+        );
+
+        // Verify volume_ignores are also applied to the parent repo mount (the fix for #597)
+        let repo_name = repo_path
+            .canonicalize()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let expected_repo_target = format!("/workspace/{}/target", repo_name);
+        let expected_repo_node = format!("/workspace/{}/node_modules", repo_name);
+        assert!(
+            config.anonymous_volumes.contains(&expected_repo_target),
+            "anonymous_volumes should contain parent repo target ({}), got: {:?}",
+            expected_repo_target,
+            config.anonymous_volumes
+        );
+        assert!(
+            config.anonymous_volumes.contains(&expected_repo_node),
+            "anonymous_volumes should contain parent repo node_modules ({}), got: {:?}",
+            expected_repo_node,
+            config.anonymous_volumes
         );
     }
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -775,12 +775,16 @@ pub(crate) fn build_container_config(
         compute_volume_paths(project_path, project_path_str)?
     };
 
-    // Save project volume container paths so volume_ignores can be applied to all
-    // project mounts (e.g., both the worktree and parent repo in worktree sessions).
-    let project_container_paths: Vec<String> = project_volumes
+    // Collect all paths that should receive volume_ignores: the workspace_path
+    // (where builds happen) plus every project mount root (which may differ in
+    // bare-repo layouts where workspace_path is a subdirectory of the mount).
+    let mut volume_ignore_bases: Vec<String> = project_volumes
         .iter()
         .map(|v| v.container_path.clone())
         .collect();
+    if !volume_ignore_bases.contains(&workspace_path) {
+        volume_ignore_bases.push(workspace_path.clone());
+    }
 
     let mut volumes = project_volumes;
 
@@ -957,7 +961,7 @@ pub(crate) fn build_container_config(
     //   - Exact match: both point to same path
     //   - Anonymous volume is parent of extra_volume (would shadow the mount)
     //   - Anonymous volume is inside extra_volume (redundant/conflicting)
-    let anonymous_volumes: Vec<String> = project_container_paths
+    let anonymous_volumes: Vec<String> = volume_ignore_bases
         .iter()
         .flat_map(|base_path| {
             sandbox_config
@@ -2279,6 +2283,74 @@ volume_ignores = ["target", "node_modules"]
             config.anonymous_volumes.contains(&expected_repo_node),
             "anonymous_volumes should contain parent repo node_modules ({}), got: {:?}",
             expected_repo_node,
+            config.anonymous_volumes
+        );
+    }
+
+    /// Regression test: volume_ignores must still apply to the workspace_path
+    /// in bare-repo layouts where workspace_path is a subdirectory of the mount.
+    #[test]
+    #[serial_test::serial]
+    fn test_volume_ignores_applied_to_bare_repo_worktree() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let (_dir, main_repo_path, worktree_path) = setup_bare_repo_with_worktree();
+
+        if !worktree_path.exists() {
+            return; // git worktree add failed, skip
+        }
+
+        // Write repo-level config with volume_ignores
+        let config_dir = worktree_path.join(".agent-of-empires");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            r#"
+[sandbox]
+volume_ignores = ["target"]
+"#,
+        )
+        .unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            created_at: None,
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let project_path_str = worktree_path.to_str().unwrap();
+        let config = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            "claude",
+            false,
+            "test-instance-id",
+            None,
+        )
+        .unwrap();
+
+        // In bare-repo layout, workspace_path is a subdirectory of the single mount.
+        // volume_ignores must apply to the workspace_path (where builds run), not
+        // just the mount root.
+        let main_name = main_repo_path
+            .canonicalize()
+            .unwrap()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        let expected_wt_target = format!("/workspace/{}/main/target", main_name);
+        assert!(
+            config.anonymous_volumes.contains(&expected_wt_target),
+            "anonymous_volumes should contain worktree target ({}), got: {:?}",
+            expected_wt_target,
             config.anonymous_volumes
         );
     }


### PR DESCRIPTION
## Description

When running a worktree session in a Docker sandbox, `volume_ignores` (which creates anonymous Docker volumes for directories like `target/`, `node_modules/`, `.venv/`) was only applied to the worktree mount, not the parent repo mount. This meant the parent repo's heavy directories were bind-mounted through VirtioFS on macOS, causing high CPU usage.

The fix saves all project volume container paths before they're merged with other volumes, then applies `volume_ignores` to every project mount instead of just the workspace path.

Fixes #597

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)