### PR TITLE
fix: delegate input to branch picker in worktree config mode

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1152,6 +1152,13 @@ impl NewSessionDialog {
         const WT_EXTRA_REPOS: usize = 1;
         const WT_MAX: usize = 2;
 
+        if self.branch_picker.is_active() {
+            if let ListPickerResult::Selected(value) = self.branch_picker.handle_key(key) {
+                self.worktree_branch = Input::new(value);
+            }
+            return DialogResult::Continue;
+        }
+
         // Handle workspace repos list editing when expanded
         if self.workspace_repos_expanded && self.worktree_config_focused_field == WT_EXTRA_REPOS {
             return self.handle_workspace_repos_list_key(key);


### PR DESCRIPTION
## Description

When pressing Ctrl+P on the "new_branch" field in the worktree config overlay to open the branch picker, the modal appeared visually but input focus remained on the underlying worktree config form. Keys typed were processed by the worktree config handler instead of being forwarded to the branch picker.

The root cause was that `handle_worktree_config_key()` did not check `branch_picker.is_active()` before processing keys. The main `handle_key()` correctly delegates to the picker (line 790), but when `worktree_config_mode` is true, input is routed to the worktree config handler first (line 774), bypassing that check entirely.

The fix adds the same `branch_picker.is_active()` delegation at the top of `handle_worktree_config_key()`, matching the pattern used for the branch picker, group picker, and dir picker in the main handler.

Fixes #594

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Identified root cause by tracing the key event dispatch flow from `handle_key()` through `handle_worktree_config_key()` and comparing with correct delegation patterns elsewhere in the same file.

- [x] I am an AI Agent filling out this form (check box if true)