### PR TITLE
feat(web): group sidebar sessions by repository

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,6 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "clsx": "^2.1.1",
-        "geist": "^1.7.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "tailwindcss": "^4.2.2"
@@ -27,6 +26,7 @@
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "geist": "^1.7.0",
         "globals": "^17.4.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "8.58.0",
@@ -872,6 +872,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -886,6 +887,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -909,6 +911,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -932,6 +935,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -949,6 +953,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -966,6 +971,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -983,6 +989,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1000,6 +1007,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1017,6 +1025,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1034,6 +1043,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1051,6 +1061,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1068,6 +1079,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1085,6 +1097,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1102,6 +1115,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1125,6 +1139,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1148,6 +1163,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1171,6 +1187,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1194,6 +1211,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1217,6 +1235,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1240,6 +1259,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1263,6 +1283,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1286,6 +1307,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "peer": true,
@@ -1303,6 +1325,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "peer": true,
@@ -1317,6 +1340,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1337,6 +1361,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1357,6 +1382,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1377,6 +1403,7 @@
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
       "integrity": "sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -1387,6 +1414,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1404,6 +1432,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1421,6 +1450,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1438,6 +1468,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1455,6 +1486,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1472,6 +1504,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1489,6 +1522,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1506,6 +1540,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1518,7 +1553,7 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.59.1"
@@ -1549,7 +1584,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.59.1"
@@ -1568,7 +1603,7 @@
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -1858,6 +1893,7 @@
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
       "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -2939,6 +2975,7 @@
       "version": "2.10.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
       "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -2951,6 +2988,7 @@
       "version": "1.0.30001785",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
       "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3047,6 +3085,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -3563,6 +3602,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/geist/-/geist-1.7.0.tgz",
       "integrity": "sha512-ZaoiZwkSf0DwwB1ncdLKp+ggAldqxl5L1+SXaNIBGkPAqcu+xjVJLxlf3/S8vLt9UHx1xu5fz3lbzKCj5iOVdQ==",
+      "dev": true,
       "license": "SIL OPEN FONT LICENSE",
       "peerDependencies": {
         "next": ">=13.2.0"
@@ -3924,6 +3964,7 @@
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/next/-/next-16.2.2.tgz",
       "integrity": "sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4063,6 +4104,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4119,7 +4161,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4132,6 +4174,7 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -4187,6 +4230,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
       "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -4215,6 +4259,7 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { useSessions } from "./hooks/useSessions";
 import { useWorkspaces } from "./hooks/useWorkspaces";
+import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { isSessionActive } from "./lib/session";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
@@ -14,6 +15,8 @@ import { HelpOverlay } from "./components/HelpOverlay";
 export default function App() {
   const { sessions, error } = useSessions();
   const workspaces = useWorkspaces(sessions);
+  const { groups, standalone, toggleRepoCollapsed } =
+    useRepoGroups(workspaces);
 
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
     null,
@@ -245,10 +248,12 @@ export default function App() {
       <div className="flex flex-1 min-h-0">
         {sidebarOpen && (
           <WorkspaceSidebar
-            workspaces={workspaces}
+            groups={groups}
+            standalone={standalone}
             activeId={activeWorkspaceId}
             onToggle={() => setSidebarOpen(false)}
             onSelect={handleSelectWorkspace}
+            onToggleRepo={toggleRepoCollapsed}
             onNew={() => setShowCreate(true)}
             onSettings={() => setShowSettings((s) => !s)}
           />

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -91,18 +91,10 @@ const SessionRow = memo(function SessionRow({
           {label}
         </span>
       </div>
-      <div className="ml-[18px] mt-0.5 flex items-center gap-1.5">
+      <div className="ml-[18px] mt-0.5">
         <span className="font-mono text-[11px] text-text-dim truncate">
           {workspace.primaryAgent}
         </span>
-        {workspace.branch && workspace.sessions[0]?.title !== workspace.branch && (
-          <>
-            <span className="text-text-dim/40 text-[11px]">&middot;</span>
-            <span className="font-mono text-[11px] text-text-dim truncate">
-              {workspace.sessions.length} session{workspace.sessions.length !== 1 ? "s" : ""}
-            </span>
-          </>
-        )}
       </div>
     </button>
   );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1,7 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import type { Workspace, SessionStatus } from "../lib/types";
-
-import { STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
+import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
+import { STATUS_DOT_CLASS, STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const DEFAULT_WIDTH = 280;
@@ -9,10 +8,12 @@ const MIN_WIDTH = 200;
 const MAX_WIDTH = 480;
 
 interface Props {
-  workspaces: Workspace[];
+  groups: RepoGroup[];
+  standalone: Workspace[];
   activeId: string | null;
   onToggle: () => void;
   onSelect: (workspaceId: string) => void;
+  onToggleRepo: (repoId: string) => void;
   onNew: () => void;
   onSettings: () => void;
 }
@@ -54,10 +55,12 @@ const SessionRow = memo(function SessionRow({
   workspace,
   isActive,
   onClick,
+  indented,
 }: {
   workspace: Workspace;
   isActive: boolean;
   onClick: () => void;
+  indented?: boolean;
 }) {
   const sessionStatus = bestSessionStatus(workspace);
   const textClass = STATUS_TEXT_CLASS[sessionStatus] ?? "text-status-idle";
@@ -68,7 +71,9 @@ const SessionRow = memo(function SessionRow({
   return (
     <button
       onClick={onClick}
-      className={`w-full text-left px-3 py-2 cursor-pointer transition-colors duration-75 ${
+      className={`w-full text-left py-2 cursor-pointer transition-colors duration-75 ${
+        indented ? "pl-6 pr-3" : "px-3"
+      } ${
         isActive
           ? "bg-surface-850 border-l-2 border-brand-600"
           : "border-l-2 border-transparent hover:bg-surface-800/50"
@@ -103,11 +108,65 @@ const SessionRow = memo(function SessionRow({
   );
 });
 
+const RepoGroupHeader = memo(function RepoGroupHeader({
+  group,
+  hasActiveChild,
+  onClick,
+}: {
+  group: RepoGroup;
+  hasActiveChild: boolean;
+  onClick: () => void;
+}) {
+  const dotClass =
+    STATUS_DOT_CLASS[
+      group.status === "active" ? "Running" : "Idle"
+    ] ?? "bg-status-idle";
+
+  return (
+    <button
+      onClick={onClick}
+      aria-expanded={!group.collapsed}
+      className={`w-full text-left flex items-center gap-2 px-3 py-2 cursor-pointer transition-colors duration-75 text-text-secondary hover:bg-surface-800/50 ${
+        hasActiveChild ? "border-l-2 border-brand-600" : ""
+      }`}
+    >
+      <svg
+        width="10"
+        height="10"
+        viewBox="0 0 10 10"
+        fill="currentColor"
+        className={`shrink-0 text-text-dim transition-transform duration-75 ${
+          group.collapsed ? "-rotate-90" : ""
+        }`}
+      >
+        <path d="M2 3 L5 6.5 L8 3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <span className="text-[13px] font-medium truncate flex-1" title={group.repoPath}>
+        {group.displayName}
+      </span>
+      <span
+        className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`}
+      />
+    </button>
+  );
+});
+
+function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
+  return (
+    ws.displayName.toLowerCase().includes(q) ||
+    ws.projectPath.toLowerCase().includes(q) ||
+    ws.agents.some((a) => a.toLowerCase().includes(q)) ||
+    ws.sessions.some((s) => s.title.toLowerCase().includes(q))
+  );
+}
+
 export function WorkspaceSidebar({
-  workspaces,
+  groups,
+  standalone,
   activeId,
   onToggle,
   onSelect,
+  onToggleRepo,
   onNew,
   onSettings,
 }: Props) {
@@ -117,17 +176,25 @@ export function WorkspaceSidebar({
   const filterRef = useRef<HTMLInputElement>(null);
   const dragging = useRef(false);
 
-  const filtered = filterQuery.trim()
-    ? workspaces.filter((ws) => {
-        const q = filterQuery.toLowerCase();
-        return (
-          ws.displayName.toLowerCase().includes(q) ||
-          ws.projectPath.toLowerCase().includes(q) ||
-          ws.agents.some((a) => a.toLowerCase().includes(q)) ||
-          ws.sessions.some((s) => s.title.toLowerCase().includes(q))
-        );
-      })
-    : workspaces;
+  const q = filterQuery.trim().toLowerCase();
+
+  const filteredGroups = q
+    ? groups
+        .map((g) => ({
+          ...g,
+          workspaces: g.workspaces.filter((ws) =>
+            workspaceMatchesFilter(ws, q) ||
+            g.displayName.toLowerCase().includes(q),
+          ),
+        }))
+        .filter((g) => g.workspaces.length > 0)
+    : groups;
+
+  const filteredStandalone = q
+    ? standalone.filter((ws) => workspaceMatchesFilter(ws, q))
+    : standalone;
+
+  const hasResults = filteredGroups.length > 0 || filteredStandalone.length > 0;
 
   const toggleFilter = () => {
     setFilterOpen((o) => {
@@ -254,7 +321,33 @@ export function WorkspaceSidebar({
         )}
 
         <div className="flex-1 overflow-y-auto">
-          {filtered.map((ws) => (
+          {filteredGroups.map((group) => {
+            const showExpanded = q ? true : !group.collapsed;
+            const hasActiveChild = group.workspaces.some(
+              (ws) => ws.id === activeId,
+            );
+            return (
+              <div key={group.id}>
+                <RepoGroupHeader
+                  group={{ ...group, collapsed: !showExpanded }}
+                  hasActiveChild={!showExpanded && hasActiveChild}
+                  onClick={() => !q && onToggleRepo(group.id)}
+                />
+                {showExpanded &&
+                  group.workspaces.map((ws) => (
+                    <SessionRow
+                      key={ws.id}
+                      workspace={ws}
+                      isActive={ws.id === activeId}
+                      onClick={() => onSelect(ws.id)}
+                      indented
+                    />
+                  ))}
+              </div>
+            );
+          })}
+
+          {filteredStandalone.map((ws) => (
             <SessionRow
               key={ws.id}
               workspace={ws}
@@ -263,10 +356,10 @@ export function WorkspaceSidebar({
             />
           ))}
 
-          {filtered.length === 0 && filterQuery && (
+          {!hasResults && filterQuery && (
             <div className="px-4 py-8 text-center">
               <p className="text-sm text-text-muted">
-                No matches for "{filterQuery}"
+                No matches for &ldquo;{filterQuery}&rdquo;
               </p>
             </div>
           )}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -90,9 +90,7 @@ const SessionRow = memo(function SessionRow({
         <span className={`text-[13px] truncate flex-1 ${isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
           {label}
         </span>
-      </div>
-      <div className="ml-[18px] mt-0.5">
-        <span className="font-mono text-[11px] text-text-dim truncate">
+        <span className="font-mono text-[11px] text-text-dim shrink-0">
           {workspace.primaryAgent}
         </span>
       </div>

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -1,0 +1,91 @@
+import { useCallback, useMemo, useState } from "react";
+import type { Workspace, RepoGroup } from "../lib/types";
+
+const COLLAPSED_KEY_PREFIX = "aoe-repo-collapsed-";
+
+function loadCollapsed(id: string): boolean {
+  try {
+    return localStorage.getItem(`${COLLAPSED_KEY_PREFIX}${id}`) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function useRepoGroups(workspaces: Workspace[]): {
+  groups: RepoGroup[];
+  standalone: Workspace[];
+  toggleRepoCollapsed: (repoId: string) => void;
+} {
+  const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
+
+  const { groups, standalone } = useMemo(() => {
+    const byRepo = new Map<string, Workspace[]>();
+
+    for (const ws of workspaces) {
+      const existing = byRepo.get(ws.projectPath);
+      if (existing) {
+        existing.push(ws);
+      } else {
+        byRepo.set(ws.projectPath, [ws]);
+      }
+    }
+
+    const repoGroups: RepoGroup[] = [];
+    const standaloneList: Workspace[] = [];
+
+    for (const [repoPath, repoWorkspaces] of byRepo) {
+      if (repoWorkspaces.length < 2) {
+        standaloneList.push(repoWorkspaces[0]!);
+        continue;
+      }
+
+      const sorted = [...repoWorkspaces].sort((a, b) => {
+        if (a.status === "active" && b.status !== "active") return -1;
+        if (a.status !== "active" && b.status === "active") return 1;
+        const aName = a.branch ?? "";
+        const bName = b.branch ?? "";
+        return aName.localeCompare(bName) || a.id.localeCompare(b.id);
+      });
+
+      const hasActive = sorted.some((ws) => ws.status === "active");
+      const collapsed =
+        collapsedMap[repoPath] ?? loadCollapsed(repoPath);
+
+      repoGroups.push({
+        id: repoPath,
+        repoPath,
+        displayName: repoPath.split("/").pop() ?? repoPath,
+        workspaces: sorted,
+        status: hasActive ? "active" : "idle",
+        collapsed,
+      });
+    }
+
+    repoGroups.sort((a, b) => {
+      if (a.status === "active" && b.status !== "active") return -1;
+      if (a.status !== "active" && b.status === "active") return 1;
+      return a.displayName.localeCompare(b.displayName) || a.repoPath.localeCompare(b.repoPath);
+    });
+
+    return { groups: repoGroups, standalone: standaloneList };
+  }, [workspaces, collapsedMap]);
+
+  const toggleRepoCollapsed = useCallback((repoId: string) => {
+    setCollapsedMap((prev) => {
+      const current = prev[repoId] ?? loadCollapsed(repoId);
+      const next = !current;
+      try {
+        if (next) {
+          localStorage.setItem(`${COLLAPSED_KEY_PREFIX}${repoId}`, "1");
+        } else {
+          localStorage.removeItem(`${COLLAPSED_KEY_PREFIX}${repoId}`);
+        }
+      } catch {
+        // ignore
+      }
+      return { ...prev, [repoId]: next };
+    });
+  }, []);
+
+  return { groups, standalone, toggleRepoCollapsed };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -47,6 +47,16 @@ export interface DiffFileInfo {
 /** Workspace status derived from session states */
 export type WorkspaceStatus = "active" | "idle";
 
+/** Repository group: workspaces sharing the same parent repo */
+export interface RepoGroup {
+  id: string;
+  repoPath: string;
+  displayName: string;
+  workspaces: Workspace[];
+  status: WorkspaceStatus;
+  collapsed: boolean;
+}
+
 /** Workspace: a group of sessions sharing the same project + branch */
 export interface Workspace {
   id: string;


### PR DESCRIPTION
## Description

Adds repo-level grouping to the web dashboard sidebar. When multiple worktrees of the same repository exist, their workspaces are automatically nested under a collapsible repo header instead of appearing as separate flat items.

**Before:** Flat list of workspaces, no visual relationship between worktrees of the same repo.

**After:** Two-level hierarchy with collapsible repo headers grouping related workspaces.

```
▼ agent-of-empires            ●
    main                  claude
    feature/auth          claude
    fix/nav               codex
    feature/api           gemini

▼ other-project               ●
    main                  claude

  standalone-session      opencode
```

### Key decisions
- Repos with 2+ workspaces get a collapsible header; single-workspace repos stay flat
- Frontend-only change: no backend API modifications (uses existing `main_repo_path` and `branch` fields)
- Additive architecture: new `useRepoGroups` hook layers on top of unchanged `useWorkspaces`
- Collapsed state persisted in localStorage (same pattern as sidebar width)
- Filter auto-expands groups when query matches; toggle suppressed during active filter
- Stable sort with tiebreakers to prevent sidebar jitter on poll cycles

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (1M context) via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)