### PR TITLE
feat: support user-defined custom agents in config.toml

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -223,12 +223,13 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     } else {
         // Use default_tool from resolved config, then first available tool, then "claude"
         let available_tools = crate::tmux::AvailableTools::detect();
+        let tools_list = available_tools.available_list();
         instance.tool = config
             .session
             .default_tool
             .as_deref()
             .and_then(crate::agents::resolve_tool_name)
-            .or_else(|| available_tools.available_list().first().copied())
+            .or_else(|| tools_list.first().map(|s| s.as_str()))
             .unwrap_or("claude")
             .to_string();
     }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -351,12 +351,20 @@ pub fn build_instance(
 
     // Apply agent_command_override and agent_extra_args from resolved config.
     // Per-session values from params take priority over config.
+    // For custom agents, fall back to the custom agent's command definition.
     if !params.command_override.is_empty() {
         instance.command = params.command_override;
     } else if let Some(cmd_override) = config.session.agent_command_override.get(&params.tool) {
         if !cmd_override.is_empty() {
             instance.command = cmd_override.clone();
         }
+    } else if let Some(custom) = config
+        .session
+        .custom_agents
+        .iter()
+        .find(|c| c.name == params.tool)
+    {
+        instance.command = custom.command.clone();
     }
     if !params.extra_args.is_empty() {
         instance.extra_args = params.extra_args;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -111,6 +111,18 @@ pub struct AppStateConfig {
     pub sort_order: Option<SortOrder>,
 }
 
+/// A user-defined custom agent that appears in the TUI agent picker.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CustomAgentDef {
+    /// Display name shown in the agent picker (e.g. "lenovo-claude")
+    pub name: String,
+    /// Command to run (e.g. "ssh -t lenovo claude")
+    pub command: String,
+    /// Optional: use a built-in agent's status detection (e.g. "claude")
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub detect_as: Option<String>,
+}
+
 /// Session-related configuration defaults
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct SessionConfig {
@@ -136,6 +148,10 @@ pub struct SessionConfig {
     /// to tmux pane content parsing, which is less reliable.
     #[serde(default = "default_true")]
     pub agent_status_hooks: bool,
+
+    /// User-defined custom agents that appear alongside built-in agents in the TUI picker
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_agents: Vec<CustomAgentDef>,
 }
 
 /// Diff view configuration

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -178,6 +178,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_status_hooks: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_agents: Option<Vec<super::config::CustomAgentDef>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -360,6 +363,9 @@ pub fn apply_session_overrides(
     }
     if let Some(agent_status_hooks) = source.agent_status_hooks {
         target.agent_status_hooks = agent_status_hooks;
+    }
+    if let Some(ref custom_agents) = source.custom_agents {
+        target.custom_agents = custom_agents.clone();
     }
 }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -207,16 +207,26 @@ fn is_agent_available(agent: &crate::agents::AgentDef) -> bool {
 
 #[derive(Debug, Clone)]
 pub struct AvailableTools {
-    available: Vec<&'static str>,
+    available: Vec<String>,
 }
 
 impl AvailableTools {
     pub fn detect() -> Self {
-        let available = crate::agents::AGENTS
+        let mut available: Vec<String> = crate::agents::AGENTS
             .iter()
             .filter(|a| is_agent_available(a))
-            .map(|a| a.name)
+            .map(|a| a.name.to_string())
             .collect();
+
+        // Append user-defined custom agents (always considered available)
+        if let Ok(config) = crate::session::config::Config::load() {
+            for custom in &config.session.custom_agents {
+                if !custom.name.is_empty() && !available.iter().any(|n| n == &custom.name) {
+                    available.push(custom.name.clone());
+                }
+            }
+        }
+
         Self { available }
     }
 
@@ -224,14 +234,14 @@ impl AvailableTools {
         !self.available.is_empty()
     }
 
-    pub fn available_list(&self) -> Vec<&'static str> {
+    pub fn available_list(&self) -> Vec<String> {
         self.available.clone()
     }
 
     #[cfg(test)]
-    pub fn with_tools(tools: &[&'static str]) -> Self {
+    pub fn with_tools(tools: &[&str]) -> Self {
         Self {
-            available: tools.to_vec(),
+            available: tools.iter().map(|s| s.to_string()).collect(),
         }
     }
 }

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -11,7 +11,24 @@ pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
     // called with -e (to preserve colors for the TUI preview), but color codes
     // interspersed in text like "esc interrupt" break plain substring matches.
     let clean = strip_ansi(content);
-    let status = crate::agents::get_agent(tool)
+    // Try built-in agent first; for custom agents, check detect_as mapping
+    let effective_tool = crate::agents::get_agent(tool).map(|_| tool).or_else(|| {
+        crate::session::config::Config::load()
+            .ok()
+            .and_then(|config| {
+                config
+                    .session
+                    .custom_agents
+                    .iter()
+                    .find(|c| c.name == tool)
+                    .and_then(|c| c.detect_as.clone())
+            })
+            .as_deref()
+            .and_then(crate::agents::get_agent)
+            .map(|a| a.name)
+    });
+    let status = effective_tool
+        .and_then(crate::agents::get_agent)
         .map(|a| (a.detect_status)(&clean))
         .unwrap_or(Status::Idle);
 

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -109,7 +109,7 @@ pub struct NewSessionDialog {
     pub(super) group: Input,
     pub(super) tool_index: usize,
     pub(super) focused_field: usize,
-    pub(super) available_tools: Vec<&'static str>,
+    pub(super) available_tools: Vec<String>,
     pub(super) existing_titles: Vec<String>,
     pub(super) worktree_branch: Input,
     pub(super) create_new_branch: bool,
@@ -322,7 +322,7 @@ impl NewSessionDialog {
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
             available_tools
                 .iter()
-                .position(|&t| t == default_tool.as_str())
+                .position(|t| t == default_tool)
                 .unwrap_or(0)
         } else {
             0
@@ -331,7 +331,7 @@ impl NewSessionDialog {
         // Apply sandbox defaults from config (disabled for host-only agents like settl)
         let is_default_tool_host_only = available_tools
             .get(tool_index)
-            .and_then(|&t| crate::agents::get_agent(t))
+            .and_then(|t| crate::agents::get_agent(t))
             .is_some_and(|a| a.host_only);
         let sandbox_enabled =
             docker_available && config.sandbox.enabled_by_default && !is_default_tool_host_only;
@@ -341,7 +341,7 @@ impl NewSessionDialog {
         let selected_tool = available_tools
             .get(tool_index)
             .or_else(|| available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         let extra_args_value = config
             .session
@@ -349,12 +349,23 @@ impl NewSessionDialog {
             .get(selected_tool)
             .cloned()
             .unwrap_or_default();
-        let command_override_value = config
+        let mut command_override_value = config
             .session
             .agent_command_override
             .get(selected_tool)
             .cloned()
             .unwrap_or_default();
+        // For custom agents, pre-fill command override from the custom agent definition
+        if command_override_value.is_empty() {
+            if let Some(custom) = config
+                .session
+                .custom_agents
+                .iter()
+                .find(|c| c.name == selected_tool)
+            {
+                command_override_value = custom.command.clone();
+            }
+        }
 
         // Initialize env entries and inherited settings from config when sandbox is enabled
         let (extra_env, inherited_settings) = if sandbox_enabled {
@@ -513,7 +524,7 @@ impl NewSessionDialog {
 
     /// Whether the currently selected tool is always in YOLO mode (no opt-in needed).
     fn selected_tool_always_yolo(&self) -> bool {
-        let tool_name = self.available_tools[self.tool_index];
+        let tool_name = &self.available_tools[self.tool_index];
         crate::agents::get_agent(tool_name)
             .and_then(|a| a.yolo.as_ref())
             .is_some_and(|y| matches!(y, crate::agents::YoloMode::AlwaysYolo))
@@ -521,7 +532,7 @@ impl NewSessionDialog {
 
     /// Whether the currently selected tool can only run on the host (no sandbox/worktree).
     fn selected_tool_host_only(&self) -> bool {
-        let tool_name = self.available_tools[self.tool_index];
+        let tool_name = &self.available_tools[self.tool_index];
         crate::agents::get_agent(tool_name).is_some_and(|a| a.host_only)
     }
 
@@ -546,7 +557,7 @@ impl NewSessionDialog {
         self.tool_index = if let Some(ref default_tool) = config.session.default_tool {
             self.available_tools
                 .iter()
-                .position(|&t| t == default_tool.as_str())
+                .position(|t| t == default_tool)
                 .unwrap_or(0)
         } else {
             0
@@ -576,7 +587,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         self.extra_args = Input::new(
             config
@@ -586,14 +597,23 @@ impl NewSessionDialog {
                 .cloned()
                 .unwrap_or_default(),
         );
-        self.command_override = Input::new(
-            config
+        let mut cmd_override = config
+            .session
+            .agent_command_override
+            .get(selected_tool)
+            .cloned()
+            .unwrap_or_default();
+        if cmd_override.is_empty() {
+            if let Some(custom) = config
                 .session
-                .agent_command_override
-                .get(selected_tool)
-                .cloned()
-                .unwrap_or_default(),
-        );
+                .custom_agents
+                .iter()
+                .find(|c| c.name == selected_tool)
+            {
+                cmd_override = custom.command.clone();
+            }
+        }
+        self.command_override = Input::new(cmd_override);
         self.tool_config_mode = false;
         self.tool_config_focused_field = 0;
 
@@ -605,12 +625,10 @@ impl NewSessionDialog {
     }
 
     #[cfg(test)]
-    pub(super) fn new_with_config(tools: Vec<&'static str>, path: String, config: Config) -> Self {
+    pub(super) fn new_with_config(tools: Vec<&str>, path: String, config: Config) -> Self {
+        let tools: Vec<String> = tools.iter().map(|s| s.to_string()).collect();
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
-            tools
-                .iter()
-                .position(|&t| t == default_tool.as_str())
-                .unwrap_or(0)
+            tools.iter().position(|t| t == default_tool).unwrap_or(0)
         } else {
             0
         };
@@ -674,7 +692,7 @@ impl NewSessionDialog {
     }
 
     #[cfg(test)]
-    pub(super) fn new_with_tools(tools: Vec<&'static str>, path: String) -> Self {
+    pub(super) fn new_with_tools(tools: Vec<&str>, path: String) -> Self {
         Self {
             profile: "default".to_string(),
             available_profiles: vec!["default".to_string()],
@@ -684,7 +702,7 @@ impl NewSessionDialog {
             group: Input::default(),
             tool_index: 0,
             focused_field: 0,
-            available_tools: tools,
+            available_tools: tools.iter().map(|s| s.to_string()).collect(),
             existing_titles: Vec::new(),
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
@@ -1363,7 +1381,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         self.extra_args = Input::new(
             config
@@ -1373,14 +1391,19 @@ impl NewSessionDialog {
                 .cloned()
                 .unwrap_or_default(),
         );
-        self.command_override = Input::new(
-            config
-                .session
-                .agent_command_override
-                .get(tool)
-                .cloned()
-                .unwrap_or_default(),
-        );
+        let mut cmd_override = config
+            .session
+            .agent_command_override
+            .get(tool)
+            .cloned()
+            .unwrap_or_default();
+        // For custom agents, pre-fill command override from the custom agent definition
+        if cmd_override.is_empty() {
+            if let Some(custom) = config.session.custom_agents.iter().find(|c| c.name == tool) {
+                cmd_override = custom.command.clone();
+            }
+        }
+        self.command_override = Input::new(cmd_override);
     }
 
     fn current_input_mut(&mut self) -> &mut Input {
@@ -1461,7 +1484,7 @@ impl NewSessionDialog {
             title: final_title,
             path: self.path.value().trim().to_string(),
             group: self.group.value().trim().to_string(),
-            tool: self.available_tools[self.tool_index].to_string(),
+            tool: self.available_tools[self.tool_index].clone(),
             worktree_branch,
             create_new_branch: self.create_new_branch,
             extra_repo_paths: if has_worktree_branch {

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -188,7 +188,7 @@ impl NewSessionDialog {
                     tool_spans.push(Span::raw("  "));
                 }
                 tool_spans.push(Span::styled(if is_selected { "● " } else { "○ " }, style));
-                tool_spans.push(Span::styled(*tool_name, style));
+                tool_spans.push(Span::styled(tool_name.as_str(), style));
             }
 
             // Show Ctrl+P hint and summary of tool config
@@ -217,7 +217,10 @@ impl NewSessionDialog {
             let mut tool_spans = vec![
                 Span::styled("Tool:", tool_style),
                 Span::raw(" "),
-                Span::styled(self.available_tools[0], Style::default().fg(theme.accent)),
+                Span::styled(
+                    self.available_tools[0].as_str(),
+                    Style::default().fg(theme.accent),
+                ),
             ];
 
             let has_config =
@@ -704,7 +707,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         let title = format!(" Tool Configuration: {} ", selected_tool);
 


### PR DESCRIPTION
## Description

Adds a `[[session.custom_agents]]` config section so users can register additional agents (SSH wrappers to remote machines, custom workflows, etc.) that appear in the TUI agent picker alongside built-in agents like `claude`, `opencode`, etc.

### Motivation

Today, the agent picker in the new-session dialog only offers agents from the static `AGENTS` registry. To run Claude Code on a remote machine via SSH, the user has to press Ctrl+P and type `ssh -t lenovo claude` every single time a new session is created. This PR lets the user declare that wrapper once in config and then select it as a first-class agent.

### Example config

```toml
[[session.custom_agents]]
name = "lenovo-claude"
command = "ssh -t lenovo claude"
detect_as = "claude"
```

- `name` — display name in the agent picker
- `command` — command to run (auto-filled into the session's command override)
- `detect_as` (optional) — map a custom agent to a built-in agent's status detection so running Claude over SSH still surfaces Running/Waiting/Idle correctly

### Changes

- Add `CustomAgentDef` struct and `custom_agents: Vec<CustomAgentDef>` field on `SessionConfig`, with profile override support in `SessionConfigOverride` and `apply_session_overrides`.
- Change `AvailableTools` from `Vec<&'static str>` to `Vec<String>` so it can hold dynamic custom-agent names alongside the static builtin names. `detect()` reads custom agents from config and appends them.
- Propagate the type change through `tui/dialogs/new_session/{mod,render}.rs` and `cli/add.rs`.
- `session/builder.rs` falls back to the custom agent's command when no explicit command override is set.
- `tmux/status_detection.rs` honours `detect_as` for custom agents so remote Claude/etc. still get proper status heuristics.

### Known limitation (intentionally scoped out)

Per `CLAUDE.md`, every config field must be editable in the settings TUI. This PR does **not** add settings-TUI editing for `custom_agents` because it's a `Vec<struct>` (unlike the existing `HashMap<String, String>` list fields) and would need a new `FieldValue` variant and a richer per-row editor. Happy to fold that into this PR or ship as a follow-up — whichever you prefer.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test`, `cargo clippy`, `cargo fmt --check` all clean)
- [ ] Documentation was updated where necessary — docs/guides/configuration still needs a short section; happy to add once direction is confirmed.
- [ ] For UI changes: included screenshot or recording — no visual changes, only the picker list length grows by one per custom agent

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude (Anthropic) via Claude Code

**Any Additional AI Details you'd like to share:** The human author inspected and tested the diff against their own AoE installation (local Claude + custom `lenovo-claude` over SSH). Verified build, test, clippy, and fmt all pass locally before pushing.

- [x] I am an AI Agent filling out this form (check box if true)