### PR TITLE
feat: support user-defined custom agents in config

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -54,12 +54,44 @@ name = "empire"   # empire, phosphor, tokyo-night-storm, catppuccin-latte, dracu
 [session]
 default_tool = "claude"   # any supported agent name
 yolo_mode_default = false
+agent_status_hooks = true
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `default_tool` | (auto-detect) | Default agent for new sessions. Falls back to the first available tool if unset or unavailable. |
+| `default_tool` | (auto-detect) | Default agent for new sessions. Falls back to the first available tool if unset or unavailable. Can be set to a custom agent name. |
 | `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. |
+| `agent_status_hooks` | `true` | Install status-detection hooks into the agent's settings file. When disabled, status detection falls back to tmux pane content parsing. |
+| `agent_extra_args` | `{}` | Per-agent extra arguments appended after the binary (e.g., `{ opencode = "--port 8080" }`). |
+| `agent_command_override` | `{}` | Per-agent command override replacing the binary entirely (e.g., `{ claude = "my-claude-wrapper" }`). |
+| `custom_agents` | `{}` | User-defined agents: name to command mapping. Custom agent names appear in the TUI agent picker alongside built-in agents. |
+| `agent_detect_as` | `{}` | Status detection mapping: maps an agent name to a built-in agent whose status heuristics should be used. |
+
+### Custom Agents
+
+You can register additional agents (SSH wrappers to remote machines, custom workflows, etc.) that appear in the TUI agent picker alongside built-in agents like `claude`, `opencode`, and `codex`.
+
+```toml
+[session]
+custom_agents = { "lenovo-claude" = "ssh -t lenovo claude" }
+agent_detect_as = { "lenovo-claude" = "claude" }
+```
+
+- **`custom_agents`**: Maps a display name to the command to run. The name appears in the agent picker when creating a new session, and the command is auto-filled as the session's command override.
+- **`agent_detect_as`** (optional): Maps a custom agent to a built-in agent's status detection. Without this, custom agents default to `Idle` status. Setting `"lenovo-claude" = "claude"` reuses Claude's Running/Waiting/Idle detection heuristics for the remote session.
+
+Custom agents are always shown as available in the picker (no binary detection), since the command may target a remote host or a wrapper script.
+
+You can also set `default_tool` to a custom agent name:
+
+```toml
+[session]
+default_tool = "lenovo-claude"
+custom_agents = { "lenovo-claude" = "ssh -t lenovo claude" }
+agent_detect_as = { "lenovo-claude" = "claude" }
+```
+
+Both fields are editable from the TUI settings screen and support profile/repo-level overrides.
 
 ## Worktree
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -93,6 +93,8 @@ agent_detect_as = { "lenovo-claude" = "claude" }
 
 Both fields are editable from the TUI settings screen and support profile/repo-level overrides.
 
+> **Note:** Profile and repo-level overrides fully replace the global value rather than merging with it. A profile that defines `custom_agents` replaces the entire global set, so you must redeclare any global agents you want to keep in that profile.
+
 ## Worktree
 
 ```toml

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -222,8 +222,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         }
     } else {
         // Use default_tool from resolved config, then first available tool, then "claude".
-        // default_tool may be a custom agent name, so check custom_agents if resolve_tool_name
-        // doesn't match a built-in.
+        // Check custom_agents first (exact match) before resolve_tool_name (substring match),
+        // so names like "lenovo-claude" resolve as the custom agent, not built-in "claude".
         let available_tools = crate::tmux::AvailableTools::detect();
         let tools_list = available_tools.available_list();
         instance.tool = config
@@ -231,13 +231,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             .default_tool
             .as_deref()
             .and_then(|name| {
-                crate::agents::resolve_tool_name(name).or_else(|| {
-                    if config.session.custom_agents.contains_key(name) {
-                        Some(name)
-                    } else {
-                        None
-                    }
-                })
+                if config.session.custom_agents.contains_key(name) {
+                    Some(name)
+                } else {
+                    crate::agents::resolve_tool_name(name)
+                }
             })
             .or_else(|| tools_list.first().map(|s| s.as_str()))
             .unwrap_or("claude")

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -221,17 +221,36 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             instance.command = cmd.clone();
         }
     } else {
-        // Use default_tool from resolved config, then first available tool, then "claude"
+        // Use default_tool from resolved config, then first available tool, then "claude".
+        // default_tool may be a custom agent name, so check custom_agents if resolve_tool_name
+        // doesn't match a built-in.
         let available_tools = crate::tmux::AvailableTools::detect();
+        let tools_list = available_tools.available_list();
         instance.tool = config
             .session
             .default_tool
             .as_deref()
-            .and_then(crate::agents::resolve_tool_name)
-            .or_else(|| available_tools.available_list().first().copied())
+            .and_then(|name| {
+                crate::agents::resolve_tool_name(name).or_else(|| {
+                    if config.session.custom_agents.contains_key(name) {
+                        Some(name)
+                    } else {
+                        None
+                    }
+                })
+            })
+            .or_else(|| tools_list.first().map(|s| s.as_str()))
             .unwrap_or("claude")
             .to_string();
     }
+
+    // Set detect_as for status detection (resolved once, avoids config load in poll loop)
+    instance.detect_as = config
+        .session
+        .agent_detect_as
+        .get(&instance.tool)
+        .cloned()
+        .unwrap_or_default();
 
     // Apply set_default_command for agents that need it (e.g., opencode, codex)
     if instance.command.is_empty() {
@@ -262,9 +281,10 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
     if let Some(ref cmd) = args.cmd_override {
         instance.command = cmd.clone();
-    } else if let Some(cmd_override) = config.session.agent_command_override.get(&instance.tool) {
-        if !cmd_override.is_empty() {
-            instance.command = cmd_override.clone();
+    } else {
+        let resolved = config.session.resolve_tool_command(&instance.tool);
+        if !resolved.is_empty() {
+            instance.command = resolved;
         }
     }
 

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -341,6 +341,12 @@ pub fn build_instance(
     let mut instance = Instance::new(&final_title, &final_path);
     instance.group_path = params.group;
     instance.tool = params.tool.clone();
+    instance.detect_as = config
+        .session
+        .agent_detect_as
+        .get(&params.tool)
+        .cloned()
+        .unwrap_or_default();
     instance.command = crate::agents::get_agent(&params.tool)
         .filter(|a| a.set_default_command)
         .map(|a| a.binary.to_string())
@@ -349,13 +355,14 @@ pub fn build_instance(
     instance.workspace_info = workspace_info;
     instance.yolo_mode = params.yolo_mode;
 
-    // Apply agent_command_override and agent_extra_args from resolved config.
-    // Per-session values from params take priority over config.
+    // Apply command overrides and custom agent commands from resolved config.
+    // Priority: per-session params > agent_command_override > custom_agents > AgentDef default.
     if !params.command_override.is_empty() {
         instance.command = params.command_override;
-    } else if let Some(cmd_override) = config.session.agent_command_override.get(&params.tool) {
-        if !cmd_override.is_empty() {
-            instance.command = cmd_override.clone();
+    } else {
+        let resolved = config.session.resolve_tool_command(&params.tool);
+        if !resolved.is_empty() {
+            instance.command = resolved;
         }
     }
     if !params.extra_args.is_empty() {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -532,7 +532,6 @@ impl Config {
 
         let content = fs::read_to_string(&path)?;
         let config: Config = toml::from_str(&content)?;
-        config.session.warn_custom_agent_issues();
         Ok(config)
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -161,6 +161,46 @@ impl SessionConfig {
             .cloned()
             .unwrap_or_default()
     }
+
+    /// Log warnings for misconfigured custom agent entries.
+    /// Called after config load to surface TOML editing mistakes.
+    pub fn warn_custom_agent_issues(&self) {
+        for (name, command) in &self.custom_agents {
+            if name.is_empty() {
+                tracing::warn!("custom_agents: entry with empty name will be ignored");
+            }
+            if command.is_empty() {
+                tracing::warn!(
+                    "custom_agents: '{}' has an empty command, session will launch with no command",
+                    name
+                );
+            }
+            if crate::agents::get_agent(name).is_some() {
+                tracing::warn!(
+                    "custom_agents: '{}' shadows a built-in agent; use agent_command_override instead",
+                    name
+                );
+            }
+        }
+        for (name, target) in &self.agent_detect_as {
+            if name.is_empty() {
+                tracing::warn!("agent_detect_as: entry with empty agent name will be ignored");
+            }
+            if target.is_empty() {
+                tracing::warn!(
+                    "agent_detect_as: '{}' maps to an empty target, status detection will default to Idle",
+                    name
+                );
+            } else if crate::agents::get_agent(target).is_none() {
+                tracing::warn!(
+                    "agent_detect_as: '{}' maps to unknown agent '{}', status detection will default to Idle. Known agents: {}",
+                    name,
+                    target,
+                    crate::agents::agent_names().join(", ")
+                );
+            }
+        }
+    }
 }
 
 /// Diff view configuration
@@ -492,6 +532,7 @@ impl Config {
 
         let content = fs::read_to_string(&path)?;
         let config: Config = toml::from_str(&content)?;
+        config.session.warn_custom_agent_issues();
         Ok(config)
     }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -136,6 +136,31 @@ pub struct SessionConfig {
     /// to tmux pane content parsing, which is less reliable.
     #[serde(default = "default_true")]
     pub agent_status_hooks: bool,
+
+    /// User-defined custom agents: name -> launch command
+    /// (e.g., "lenovo-claude" = "ssh -t lenovo claude").
+    /// Custom agent names appear in the TUI agent picker alongside built-in agents.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub custom_agents: HashMap<String, String>,
+
+    /// Status detection mapping: agent name -> built-in agent name
+    /// (e.g., "lenovo-claude" = "claude").
+    /// Maps a custom (or built-in) agent to another agent's status detection heuristics.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub agent_detect_as: HashMap<String, String>,
+}
+
+impl SessionConfig {
+    /// Resolve the command override for a tool, checking agent_command_override first,
+    /// then falling back to custom_agents. Returns empty string if no override found.
+    pub fn resolve_tool_command(&self, tool: &str) -> String {
+        self.agent_command_override
+            .get(tool)
+            .filter(|s| !s.is_empty())
+            .or_else(|| self.custom_agents.get(tool))
+            .cloned()
+            .unwrap_or_default()
+    }
 }
 
 /// Diff view configuration

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1015,4 +1015,70 @@ mod tests {
             "agent_extra_args should survive roundtrip"
         );
     }
+
+    #[test]
+    fn test_resolve_tool_command_prefers_command_override() {
+        let mut config = SessionConfig::default();
+        config
+            .agent_command_override
+            .insert("my-agent".to_string(), "override-cmd".to_string());
+        config
+            .custom_agents
+            .insert("my-agent".to_string(), "custom-cmd".to_string());
+        assert_eq!(config.resolve_tool_command("my-agent"), "override-cmd");
+    }
+
+    #[test]
+    fn test_resolve_tool_command_falls_back_to_custom_agents() {
+        let mut config = SessionConfig::default();
+        config
+            .custom_agents
+            .insert("my-agent".to_string(), "ssh -t host claude".to_string());
+        assert_eq!(
+            config.resolve_tool_command("my-agent"),
+            "ssh -t host claude"
+        );
+    }
+
+    #[test]
+    fn test_resolve_tool_command_skips_empty_override() {
+        let mut config = SessionConfig::default();
+        config
+            .agent_command_override
+            .insert("my-agent".to_string(), String::new());
+        config
+            .custom_agents
+            .insert("my-agent".to_string(), "custom-cmd".to_string());
+        assert_eq!(config.resolve_tool_command("my-agent"), "custom-cmd");
+    }
+
+    #[test]
+    fn test_resolve_tool_command_returns_empty_for_unknown() {
+        let config = SessionConfig::default();
+        assert_eq!(config.resolve_tool_command("nonexistent"), "");
+    }
+
+    #[test]
+    fn test_custom_agents_roundtrip() {
+        let mut config = Config::default();
+        config.session.custom_agents.insert(
+            "lenovo-claude".to_string(),
+            "ssh -t lenovo claude".to_string(),
+        );
+        config
+            .session
+            .agent_detect_as
+            .insert("lenovo-claude".to_string(), "claude".to_string());
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(
+            deserialized.session.custom_agents.get("lenovo-claude"),
+            Some(&"ssh -t lenovo claude".to_string()),
+        );
+        assert_eq!(
+            deserialized.session.agent_detect_as.get("lenovo-claude"),
+            Some(&"claude".to_string()),
+        );
+    }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -100,6 +100,10 @@ pub struct Instance {
     pub extra_args: String,
     #[serde(default)]
     pub tool: String,
+    /// Built-in agent name used for status detection, resolved at build time from
+    /// config's agent_detect_as map. Avoids loading config during the polling hot path.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub detect_as: String,
     #[serde(default)]
     pub yolo_mode: bool,
     #[serde(default)]
@@ -148,6 +152,7 @@ impl Instance {
             command: String::new(),
             extra_args: String::new(),
             tool: "claude".to_string(),
+            detect_as: String::new(),
             yolo_mode: false,
             status: Status::Idle,
             created_at: Utc::now(),
@@ -738,7 +743,12 @@ impl Instance {
         }
 
         let pane_content = session.capture_pane(50).unwrap_or_default();
-        let detected = tmux::detect_status_from_content(&pane_content, &self.tool);
+        let detection_tool = if self.detect_as.is_empty() {
+            &self.tool
+        } else {
+            &self.detect_as
+        };
+        let detected = tmux::detect_status_from_content(&pane_content, detection_tool);
         tracing::trace!(
             "status '{}': detected={:?}, cmd_override={}, custom_cmd={}",
             self.title,

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -178,6 +178,12 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub agent_status_hooks: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_agents: Option<HashMap<String, String>>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_detect_as: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -360,6 +366,12 @@ pub fn apply_session_overrides(
     }
     if let Some(agent_status_hooks) = source.agent_status_hooks {
         target.agent_status_hooks = agent_status_hooks;
+    }
+    if let Some(ref custom_agents) = source.custom_agents {
+        target.custom_agents = custom_agents.clone();
+    }
+    if let Some(ref detect_as) = source.agent_detect_as {
+        target.agent_detect_as = detect_as.clone();
     }
 }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -207,16 +207,27 @@ fn is_agent_available(agent: &crate::agents::AgentDef) -> bool {
 
 #[derive(Debug, Clone)]
 pub struct AvailableTools {
-    available: Vec<&'static str>,
+    available: Vec<String>,
 }
 
 impl AvailableTools {
     pub fn detect() -> Self {
-        let available = crate::agents::AGENTS
+        let mut available: Vec<String> = crate::agents::AGENTS
             .iter()
             .filter(|a| is_agent_available(a))
-            .map(|a| a.name)
+            .map(|a| a.name.to_string())
             .collect();
+
+        // Append user-defined custom agents (always considered available since the
+        // command may target a remote host or a wrapper script).
+        if let Ok(config) = crate::session::config::Config::load() {
+            for name in config.session.custom_agents.keys() {
+                if !name.is_empty() && !available.iter().any(|n| n == name) {
+                    available.push(name.clone());
+                }
+            }
+        }
+
         Self { available }
     }
 
@@ -224,14 +235,14 @@ impl AvailableTools {
         !self.available.is_empty()
     }
 
-    pub fn available_list(&self) -> Vec<&'static str> {
-        self.available.clone()
+    pub fn available_list(&self) -> &[String] {
+        &self.available
     }
 
     #[cfg(test)]
-    pub fn with_tools(tools: &[&'static str]) -> Self {
+    pub fn with_tools(tools: &[&str]) -> Self {
         Self {
-            available: tools.to_vec(),
+            available: tools.iter().map(|s| s.to_string()).collect(),
         }
     }
 }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -221,6 +221,7 @@ impl AvailableTools {
         // Append user-defined custom agents (always considered available since the
         // command may target a remote host or a wrapper script).
         if let Ok(config) = crate::session::config::Config::load() {
+            config.session.warn_custom_agent_issues();
             let mut custom: Vec<_> = config
                 .session
                 .custom_agents

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -221,11 +221,15 @@ impl AvailableTools {
         // Append user-defined custom agents (always considered available since the
         // command may target a remote host or a wrapper script).
         if let Ok(config) = crate::session::config::Config::load() {
-            for name in config.session.custom_agents.keys() {
-                if !name.is_empty() && !available.iter().any(|n| n == name) {
-                    available.push(name.clone());
-                }
-            }
+            let mut custom: Vec<_> = config
+                .session
+                .custom_agents
+                .keys()
+                .filter(|name| !name.is_empty() && !available.iter().any(|n| n == *name))
+                .cloned()
+                .collect();
+            custom.sort();
+            available.extend(custom);
         }
 
         Self { available }

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -109,7 +109,7 @@ pub struct NewSessionDialog {
     pub(super) group: Input,
     pub(super) tool_index: usize,
     pub(super) focused_field: usize,
-    pub(super) available_tools: Vec<&'static str>,
+    pub(super) available_tools: Vec<String>,
     pub(super) existing_titles: Vec<String>,
     pub(super) worktree_branch: Input,
     pub(super) create_new_branch: bool,
@@ -308,7 +308,7 @@ impl NewSessionDialog {
             .map(|p| p.to_string_lossy().to_string())
             .unwrap_or_default();
 
-        let available_tools = tools.available_list();
+        let available_tools: Vec<String> = tools.available_list().to_vec();
         let docker_available = containers::get_container_runtime().is_available();
 
         // Load resolved config (global + profile + repo overrides from cwd)
@@ -322,7 +322,7 @@ impl NewSessionDialog {
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
             available_tools
                 .iter()
-                .position(|&t| t == default_tool.as_str())
+                .position(|t| t == default_tool)
                 .unwrap_or(0)
         } else {
             0
@@ -331,7 +331,7 @@ impl NewSessionDialog {
         // Apply sandbox defaults from config (disabled for host-only agents like settl)
         let is_default_tool_host_only = available_tools
             .get(tool_index)
-            .and_then(|&t| crate::agents::get_agent(t))
+            .and_then(|t| crate::agents::get_agent(t))
             .is_some_and(|a| a.host_only);
         let sandbox_enabled =
             docker_available && config.sandbox.enabled_by_default && !is_default_tool_host_only;
@@ -341,7 +341,7 @@ impl NewSessionDialog {
         let selected_tool = available_tools
             .get(tool_index)
             .or_else(|| available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         let extra_args_value = config
             .session
@@ -349,12 +349,7 @@ impl NewSessionDialog {
             .get(selected_tool)
             .cloned()
             .unwrap_or_default();
-        let command_override_value = config
-            .session
-            .agent_command_override
-            .get(selected_tool)
-            .cloned()
-            .unwrap_or_default();
+        let command_override_value = config.session.resolve_tool_command(selected_tool);
 
         // Initialize env entries and inherited settings from config when sandbox is enabled
         let (extra_env, inherited_settings) = if sandbox_enabled {
@@ -513,7 +508,7 @@ impl NewSessionDialog {
 
     /// Whether the currently selected tool is always in YOLO mode (no opt-in needed).
     fn selected_tool_always_yolo(&self) -> bool {
-        let tool_name = self.available_tools[self.tool_index];
+        let tool_name = &self.available_tools[self.tool_index];
         crate::agents::get_agent(tool_name)
             .and_then(|a| a.yolo.as_ref())
             .is_some_and(|y| matches!(y, crate::agents::YoloMode::AlwaysYolo))
@@ -521,7 +516,7 @@ impl NewSessionDialog {
 
     /// Whether the currently selected tool can only run on the host (no sandbox/worktree).
     fn selected_tool_host_only(&self) -> bool {
-        let tool_name = self.available_tools[self.tool_index];
+        let tool_name = &self.available_tools[self.tool_index];
         crate::agents::get_agent(tool_name).is_some_and(|a| a.host_only)
     }
 
@@ -546,7 +541,7 @@ impl NewSessionDialog {
         self.tool_index = if let Some(ref default_tool) = config.session.default_tool {
             self.available_tools
                 .iter()
-                .position(|&t| t == default_tool.as_str())
+                .position(|t| t == default_tool)
                 .unwrap_or(0)
         } else {
             0
@@ -576,7 +571,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         self.extra_args = Input::new(
             config
@@ -586,14 +581,7 @@ impl NewSessionDialog {
                 .cloned()
                 .unwrap_or_default(),
         );
-        self.command_override = Input::new(
-            config
-                .session
-                .agent_command_override
-                .get(selected_tool)
-                .cloned()
-                .unwrap_or_default(),
-        );
+        self.command_override = Input::new(config.session.resolve_tool_command(selected_tool));
         self.tool_config_mode = false;
         self.tool_config_focused_field = 0;
 
@@ -605,12 +593,10 @@ impl NewSessionDialog {
     }
 
     #[cfg(test)]
-    pub(super) fn new_with_config(tools: Vec<&'static str>, path: String, config: Config) -> Self {
+    pub(super) fn new_with_config(tools: Vec<&str>, path: String, config: Config) -> Self {
+        let tools: Vec<String> = tools.iter().map(|s| s.to_string()).collect();
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
-            tools
-                .iter()
-                .position(|&t| t == default_tool.as_str())
-                .unwrap_or(0)
+            tools.iter().position(|t| t == default_tool).unwrap_or(0)
         } else {
             0
         };
@@ -674,7 +660,7 @@ impl NewSessionDialog {
     }
 
     #[cfg(test)]
-    pub(super) fn new_with_tools(tools: Vec<&'static str>, path: String) -> Self {
+    pub(super) fn new_with_tools(tools: Vec<&str>, path: String) -> Self {
         Self {
             profile: "default".to_string(),
             available_profiles: vec!["default".to_string()],
@@ -684,7 +670,7 @@ impl NewSessionDialog {
             group: Input::default(),
             tool_index: 0,
             focused_field: 0,
-            available_tools: tools,
+            available_tools: tools.iter().map(|s| s.to_string()).collect(),
             existing_titles: Vec::new(),
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
@@ -1363,7 +1349,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         self.extra_args = Input::new(
             config
@@ -1373,14 +1359,7 @@ impl NewSessionDialog {
                 .cloned()
                 .unwrap_or_default(),
         );
-        self.command_override = Input::new(
-            config
-                .session
-                .agent_command_override
-                .get(tool)
-                .cloned()
-                .unwrap_or_default(),
-        );
+        self.command_override = Input::new(config.session.resolve_tool_command(tool));
     }
 
     fn current_input_mut(&mut self) -> &mut Input {
@@ -1461,7 +1440,7 @@ impl NewSessionDialog {
             title: final_title,
             path: self.path.value().trim().to_string(),
             group: self.group.value().trim().to_string(),
-            tool: self.available_tools[self.tool_index].to_string(),
+            tool: self.available_tools[self.tool_index].clone(),
             worktree_branch,
             create_new_branch: self.create_new_branch,
             extra_repo_paths: if has_worktree_branch {

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -188,7 +188,7 @@ impl NewSessionDialog {
                     tool_spans.push(Span::raw("  "));
                 }
                 tool_spans.push(Span::styled(if is_selected { "● " } else { "○ " }, style));
-                tool_spans.push(Span::styled(*tool_name, style));
+                tool_spans.push(Span::styled(tool_name.as_str(), style));
             }
 
             // Show Ctrl+P hint and summary of tool config
@@ -217,7 +217,10 @@ impl NewSessionDialog {
             let mut tool_spans = vec![
                 Span::styled("Tool:", tool_style),
                 Span::raw(" "),
-                Span::styled(self.available_tools[0], Style::default().fg(theme.accent)),
+                Span::styled(
+                    self.available_tools[0].as_str(),
+                    Style::default().fg(theme.accent),
+                ),
             ];
 
             let has_config =
@@ -704,7 +707,7 @@ impl NewSessionDialog {
             .available_tools
             .get(self.tool_index)
             .or_else(|| self.available_tools.first())
-            .copied()
+            .map(|s| s.as_str())
             .unwrap_or("claude");
         let title = format!(" Tool Configuration: {} ", selected_tool);
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -75,6 +75,8 @@ pub enum FieldKey {
     AgentExtraArgs,
     AgentCommandOverride,
     AgentStatusHooks,
+    CustomAgents,
+    AgentDetectAs,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -869,6 +871,56 @@ fn build_session_fields(
         items
     };
 
+    // Custom agents: HashMap -> Vec<String> of "name=command" items
+    let (custom_agents_map, custom_agents_override) = resolve_value(
+        scope,
+        global.session.custom_agents.clone(),
+        session.and_then(|s| s.custom_agents.clone()),
+    );
+    let custom_agents_list: Vec<String> = {
+        let mut items: Vec<_> = custom_agents_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_custom_agents_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .custom_agents
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
+    // Agent detect_as: HashMap -> Vec<String> of "name=builtin" items
+    let (detect_as_map, detect_as_override) = resolve_value(
+        scope,
+        global.session.agent_detect_as.clone(),
+        session.and_then(|s| s.agent_detect_as.clone()),
+    );
+    let detect_as_list: Vec<String> = {
+        let mut items: Vec<_> = detect_as_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_detect_as_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .agent_detect_as
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
     vec![
         SettingField {
             key: FieldKey::DefaultTool,
@@ -923,6 +975,31 @@ fn build_session_fields(
             inherited_display: inherited_if(
                 cmd_override_override,
                 FieldValue::List(global_cmd_override_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::CustomAgents,
+            label: "Custom Agents",
+            description:
+                "User-defined agents: name=command (e.g. lenovo-claude=ssh -t lenovo claude)",
+            value: FieldValue::List(custom_agents_list),
+            category: SettingsCategory::Session,
+            has_override: custom_agents_override,
+            inherited_display: inherited_if(
+                custom_agents_override,
+                FieldValue::List(global_custom_agents_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentDetectAs,
+            label: "Agent Detect As",
+            description: "Status detection mapping: agent=builtin (e.g. lenovo-claude=claude)",
+            value: FieldValue::List(detect_as_list),
+            category: SettingsCategory::Session,
+            has_override: detect_as_override,
+            inherited_display: inherited_if(
+                detect_as_override,
+                FieldValue::List(global_detect_as_list),
             ),
         },
         SettingField {
@@ -1253,6 +1330,12 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::AgentCommandOverride, FieldValue::List(v)) => {
             config.session.agent_command_override = parse_key_value_list(v);
         }
+        (FieldKey::CustomAgents, FieldValue::List(v)) => {
+            config.session.custom_agents = parse_key_value_list(v);
+        }
+        (FieldKey::AgentDetectAs, FieldValue::List(v)) => {
+            config.session.agent_detect_as = parse_key_value_list(v);
+        }
         // Sound
         (FieldKey::SoundEnabled, FieldValue::Bool(v)) => config.sound.enabled = *v,
         (FieldKey::SoundMode, FieldValue::Select { selected, .. }) => {
@@ -1454,6 +1537,22 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 .session
                 .get_or_insert_with(SessionConfigOverride::default);
             s.agent_command_override = Some(map);
+        }
+        (FieldKey::CustomAgents, FieldValue::List(v)) => {
+            let map = parse_key_value_list(v);
+            use crate::session::SessionConfigOverride;
+            let s = config
+                .session
+                .get_or_insert_with(SessionConfigOverride::default);
+            s.custom_agents = Some(map);
+        }
+        (FieldKey::AgentDetectAs, FieldValue::List(v)) => {
+            let map = parse_key_value_list(v);
+            use crate::session::SessionConfigOverride;
+            let s = config
+                .session
+                .get_or_insert_with(SessionConfigOverride::default);
+            s.agent_detect_as = Some(map);
         }
         // Sound
         (FieldKey::SoundEnabled, FieldValue::Bool(v)) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -464,19 +464,22 @@ impl SettingsView {
                         let field_key = self.fields[self.selected_field].key;
 
                         // Validate key=value format for agent override fields
-                        if matches!(
-                            field_key,
-                            FieldKey::AgentExtraArgs | FieldKey::AgentCommandOverride
-                        ) {
-                            if let Err(msg) = validate_agent_key_value(&text) {
-                                self.error_message = Some(msg);
-                                // Re-open the editor so the user can fix the entry
-                                if let Some(ref mut s) = self.list_edit_state {
-                                    s.editing_item = Some(tui_input::Input::new(text));
-                                    s.adding_new = adding_new;
-                                }
-                                return SettingsAction::Continue;
+                        let validation_result = match field_key {
+                            FieldKey::AgentExtraArgs | FieldKey::AgentCommandOverride => {
+                                Some(validate_agent_key_value(&text))
                             }
+                            FieldKey::CustomAgents => Some(validate_custom_agent_entry(&text)),
+                            FieldKey::AgentDetectAs => Some(validate_detect_as_entry(&text)),
+                            _ => None,
+                        };
+                        if let Some(Err(msg)) = validation_result {
+                            self.error_message = Some(msg);
+                            // Re-open the editor so the user can fix the entry
+                            if let Some(ref mut s) = self.list_edit_state {
+                                s.editing_item = Some(tui_input::Input::new(text));
+                                s.adding_new = adding_new;
+                            }
+                            return SettingsAction::Continue;
                         }
 
                         // Validate env var references before accepting
@@ -628,6 +631,16 @@ impl SettingsView {
             FieldKey::AgentCommandOverride => {
                 if let Some(ref mut s) = config.session {
                     s.agent_command_override = None;
+                }
+            }
+            FieldKey::CustomAgents => {
+                if let Some(ref mut s) = config.session {
+                    s.custom_agents = None;
+                }
+            }
+            FieldKey::AgentDetectAs => {
+                if let Some(ref mut s) = config.session {
+                    s.agent_detect_as = None;
                 }
             }
             FieldKey::AgentStatusHooks => {
@@ -810,6 +823,49 @@ fn validate_agent_key_value(text: &str) -> Result<(), String> {
         ));
     }
 
+    Ok(())
+}
+
+/// Validate a custom agent entry: name=command. Name must not collide with built-in agents.
+fn validate_custom_agent_entry(text: &str) -> Result<(), String> {
+    let Some((key, value)) = text.split_once('=') else {
+        return Err(
+            "Must be in name=command format (e.g. lenovo-claude=ssh -t lenovo claude)".to_string(),
+        );
+    };
+    if key.is_empty() {
+        return Err("Agent name cannot be empty".to_string());
+    }
+    if value.is_empty() {
+        return Err("Command cannot be empty".to_string());
+    }
+    if crate::agents::get_agent(key).is_some() {
+        return Err(format!(
+            "'{}' is a built-in agent. Use Agent Command Override to override built-in agents.",
+            key
+        ));
+    }
+    Ok(())
+}
+
+/// Validate a detect_as entry: name=builtin_agent. Value must be a known built-in agent.
+fn validate_detect_as_entry(text: &str) -> Result<(), String> {
+    let Some((key, value)) = text.split_once('=') else {
+        return Err("Must be in name=builtin format (e.g. lenovo-claude=claude)".to_string());
+    };
+    if key.is_empty() {
+        return Err("Agent name cannot be empty".to_string());
+    }
+    if value.is_empty() {
+        return Err("Built-in agent name cannot be empty".to_string());
+    }
+    if crate::agents::get_agent(value).is_none() {
+        let names = crate::agents::agent_names().join(", ");
+        return Err(format!(
+            "'{}' is not a known built-in agent. Known agents: {}",
+            value, names
+        ));
+    }
     Ok(())
 }
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -902,4 +902,67 @@ mod tests {
         let err = validate_agent_key_value("nonexistent=cmd").unwrap_err();
         assert!(err.contains("not a known agent"));
     }
+
+    // Tests for validate_custom_agent_entry
+    #[test]
+    fn test_validate_custom_agent_entry_valid() {
+        assert!(validate_custom_agent_entry("lenovo-claude=ssh -t lenovo claude").is_ok());
+        assert!(validate_custom_agent_entry("my-wrapper=./run.sh").is_ok());
+    }
+
+    #[test]
+    fn test_validate_custom_agent_entry_missing_equals() {
+        let err = validate_custom_agent_entry("just-a-name").unwrap_err();
+        assert!(err.contains("name=command"));
+    }
+
+    #[test]
+    fn test_validate_custom_agent_entry_empty_name() {
+        let err = validate_custom_agent_entry("=ssh -t host claude").unwrap_err();
+        assert!(err.contains("name cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_custom_agent_entry_empty_command() {
+        let err = validate_custom_agent_entry("my-agent=").unwrap_err();
+        assert!(err.contains("Command cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_custom_agent_entry_rejects_builtin() {
+        let err = validate_custom_agent_entry("claude=my-wrapper").unwrap_err();
+        assert!(err.contains("built-in agent"));
+        assert!(err.contains("Agent Command Override"));
+    }
+
+    // Tests for validate_detect_as_entry
+    #[test]
+    fn test_validate_detect_as_entry_valid() {
+        assert!(validate_detect_as_entry("lenovo-claude=claude").is_ok());
+    }
+
+    #[test]
+    fn test_validate_detect_as_entry_missing_equals() {
+        let err = validate_detect_as_entry("just-a-name").unwrap_err();
+        assert!(err.contains("name=builtin"));
+    }
+
+    #[test]
+    fn test_validate_detect_as_entry_empty_name() {
+        let err = validate_detect_as_entry("=claude").unwrap_err();
+        assert!(err.contains("name cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_detect_as_entry_empty_value() {
+        let err = validate_detect_as_entry("my-agent=").unwrap_err();
+        assert!(err.contains("cannot be empty"));
+    }
+
+    #[test]
+    fn test_validate_detect_as_entry_unknown_builtin() {
+        let err = validate_detect_as_entry("my-agent=nonexistent").unwrap_err();
+        assert!(err.contains("not a known built-in agent"));
+        assert!(err.contains("Known agents:"));
+    }
 }


### PR DESCRIPTION
## Description

Adds support for user-defined custom agents that appear in the TUI agent picker alongside built-in agents like `claude`, `opencode`, and `codex`. This enables use cases like running Claude over SSH to a remote machine without needing to manually type the command every time.

This is a reimplementation of the feature proposed in #624 by @fluffyspace, using a different config format that integrates cleanly with the existing settings TUI.

### Config format

```toml
[session]
custom_agents = { "lenovo-claude" = "ssh -t lenovo claude" }
agent_detect_as = { "lenovo-claude" = "claude" }
```

- **`custom_agents`**: Maps a display name to the command to run. The name appears in the agent picker; the command is auto-filled as the session's command override.
- **`agent_detect_as`** (optional): Maps an agent to a built-in agent's status detection heuristics. Without this, custom agents default to Idle status.

Both fields support profile and repo-level overrides, and are fully editable from the settings TUI.

### Why a different approach from #624

@fluffyspace's PR used `[[session.custom_agents]]` with a `Vec<CustomAgentDef>` struct, which is ergonomic TOML but had a few issues:

1. **Settings TUI gap**: `Vec<struct>` doesn't fit the existing `FieldValue::List` editor, so the PR acknowledged it couldn't be edited in settings (violating CLAUDE.md's requirement).
2. **Hot-path config loading**: `Config::load()` was called inside `detect_status_from_content()`, which runs on every poll cycle (~10x/sec per session).
3. **Duplicated logic**: Command pre-fill appeared in 3 places in the new session dialog.

By using two `HashMap<String, String>` fields instead, we get the same feature with:
- Full settings TUI integration (same pattern as `agent_extra_args` and `agent_command_override`)
- `detect_as` resolved once at session creation and stored on the `Instance` struct, so polling never touches config
- A `resolve_tool_command()` helper on `SessionConfig` that eliminates the duplication

### How to use this (for @fluffyspace's SSH use case)

```toml
[session]
default_tool = "lenovo-claude"
custom_agents = { "lenovo-claude" = "ssh -t lenovo claude" }
agent_detect_as = { "lenovo-claude" = "claude" }
```

This makes "lenovo-claude" the default agent. It appears in the picker, auto-fills `ssh -t lenovo claude` as the command, and reuses Claude's Running/Waiting/Idle detection for status.

### Changes

- `src/session/config.rs`: Add `custom_agents` and `agent_detect_as` HashMap fields to `SessionConfig`, plus `resolve_tool_command()` helper
- `src/session/profile_config.rs`: Profile override support for both fields
- `src/session/instance.rs`: Add `detect_as` field, use it in status detection call
- `src/session/builder.rs`: Resolve `detect_as` and custom agent command at build time
- `src/cli/add.rs`: Support custom agent names as `default_tool`, use `resolve_tool_command()`
- `src/tmux/mod.rs`: `AvailableTools` changed to `Vec<String>`, appends custom agents from config
- `src/tui/dialogs/new_session/`: Type propagation for `Vec<String>`, use `resolve_tool_command()`
- `src/tui/settings/fields.rs`: Add `FieldKey::CustomAgents` and `FieldKey::AgentDetectAs` with full wiring
- `src/tui/settings/input.rs`: Validation functions for both fields
- `docs/guides/configuration.md`: Document the feature with examples

### Testing

- `cargo fmt --check`, `cargo clippy`, `cargo test` all pass
- No visual UI changes beyond the picker list growing by one entry per custom agent

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Implementation designed and written by Claude Code in discussion with @njbrake. Inspired by #624 from @fluffyspace.

- [x] I am an AI Agent filling out this form (check box if true)