### PR TITLE
feat(tui): allow force-removing sessions stuck in deleting state

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -273,6 +273,7 @@ impl HomeView {
                 DialogResult::Cancel => {
                     self.confirm_dialog = None;
                     self.pending_stop_session = None;
+                    self.pending_force_remove_session = None;
                 }
                 DialogResult::Submit(_) => {
                     let action = dialog.action().to_string();
@@ -284,6 +285,12 @@ impl HomeView {
                     } else if action == "stop_session" {
                         if let Some(session_id) = self.pending_stop_session.take() {
                             return Some(Action::StopSession(session_id));
+                        }
+                    } else if action == "force_remove_session" {
+                        if let Some(session_id) = self.pending_force_remove_session.take() {
+                            if let Err(e) = self.force_remove_session(&session_id) {
+                                tracing::error!("Failed to force remove session: {}", e);
+                            }
                         }
                     }
                 }
@@ -701,6 +708,17 @@ impl HomeView {
                 if let Some(session_id) = &self.selected_session {
                     if let Some(inst) = self.get_instance(session_id) {
                         if inst.status == Status::Deleting {
+                            let message = format!(
+                                "'{}' is stuck deleting. Force remove it from the session list? \
+                                 (worktrees, branches, and containers will not be cleaned up)",
+                                inst.title
+                            );
+                            self.pending_force_remove_session = Some(session_id.clone());
+                            self.confirm_dialog = Some(ConfirmDialog::new(
+                                "Force Remove",
+                                &message,
+                                "force_remove_session",
+                            ));
                             return None;
                         }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -137,6 +137,8 @@ pub struct HomeView {
     pub(super) pending_attach_after_warning: Option<String>,
     /// Session to stop after the confirmation dialog is accepted
     pub(super) pending_stop_session: Option<String>,
+    /// Session to force-remove after the confirmation dialog is accepted
+    pub(super) pending_force_remove_session: Option<String>,
     // Search
     pub(super) search_active: bool,
     pub(super) search_query: Input,
@@ -270,6 +272,7 @@ impl HomeView {
             pending_send_session: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,
+            pending_force_remove_session: None,
             search_active: false,
             search_query: Input::default(),
             search_matches: Vec::new(),

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -192,6 +192,17 @@ impl HomeView {
         Ok(())
     }
 
+    /// Force-remove a session from storage without any cleanup.
+    /// Used for sessions stuck in the Deleting state where the background
+    /// deletion thread never returned a result.
+    pub(super) fn force_remove_session(&mut self, session_id: &str) -> anyhow::Result<()> {
+        self.remove_instance(session_id);
+        self.rebuild_group_trees();
+        self.save()?;
+        self.reload()?;
+        Ok(())
+    }
+
     pub(super) fn group_has_managed_worktrees(&self, group_path: &str, prefix: &str) -> bool {
         self.instances().iter().any(|i| {
             (i.group_path == group_path || i.group_path.starts_with(prefix))


### PR DESCRIPTION
## Description

When a session gets stuck in the `Deleting` state (e.g. the background deletion thread crashes or never returns a result), users previously had no way to remove it from the TUI. Pressing `d` was a no-op.

Now, pressing `d` on a session in the `Deleting` state shows a confirmation dialog offering to force-remove the session from storage. This skips all cleanup (worktrees, branches, containers) since the original deletion already attempted it.

The CLI `aoe remove` command already handles this case since it operates directly on storage regardless of session status.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)