### PR TITLE
fix(tui): check creation results after event handling to prevent starvation

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -221,7 +221,14 @@ impl App {
                                 self.attach_session(&session_id, terminal)?;
                             }
 
-                            terminal.draw(|f| self.render(f))?;
+                            // Skip the draw when returning from tmux attach
+                            // (handle_key sync path or creation result above).
+                            // needs_redraw triggers a clear + stale event drain
+                            // on the next iteration; drawing before that drain
+                            // wastes a frame and can flicker.
+                            if !self.needs_redraw {
+                                terminal.draw(|f| self.render(f))?;
+                            }
 
                             if self.should_quit {
                                 break;
@@ -235,7 +242,9 @@ impl App {
                                 self.attach_session(&session_id, terminal)?;
                             }
 
-                            terminal.draw(|f| self.render(f))?;
+                            if !self.needs_redraw {
+                                terminal.draw(|f| self.render(f))?;
+                            }
 
                             continue;
                         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -213,6 +213,14 @@ impl App {
                         Some(Ok(Event::Key(key))) => {
                             self.handle_key(key, terminal).await?;
 
+                            // Check for creation results after key handling so
+                            // the async CreationPoller path isn't starved by
+                            // continuous input events (mouse moves, etc.)
+                            // that `continue` past the periodic refresh section.
+                            if let Some(session_id) = self.home.apply_creation_results() {
+                                self.attach_session(&session_id, terminal)?;
+                            }
+
                             terminal.draw(|f| self.render(f))?;
 
                             if self.should_quit {
@@ -222,6 +230,10 @@ impl App {
                         }
                         Some(Ok(Event::Mouse(mouse))) => {
                             self.handle_mouse(mouse, terminal).await?;
+
+                            if let Some(session_id) = self.home.apply_creation_results() {
+                                self.attach_session(&session_id, terminal)?;
+                            }
 
                             terminal.draw(|f| self.render(f))?;
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2393,3 +2393,62 @@ fn test_has_dialog_true_when_search_active() {
     view.handle_key(key(KeyCode::Char('/')));
     assert!(view.has_dialog());
 }
+
+/// Verify that the async CreationPoller path returns a session ID from
+/// `apply_creation_results` once the background thread finishes. This is
+/// the code path that was previously starved by continuous input events
+/// in the tokio::select! event loop (see #633).
+#[test]
+#[serial]
+fn test_apply_creation_results_returns_session_id() {
+    use crate::tui::dialogs::NewSessionData;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let project_dir = temp.path().join("project");
+    std::fs::create_dir_all(&project_dir).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("default".to_string()), tools).unwrap();
+
+    let data = NewSessionData {
+        profile: "default".to_string(),
+        title: "Async Test".to_string(),
+        path: project_dir.to_str().unwrap().to_string(),
+        group: String::new(),
+        tool: "claude".to_string(),
+        worktree_branch: None,
+        create_new_branch: false,
+        extra_repo_paths: Vec::new(),
+        sandbox: false,
+        sandbox_image: String::new(),
+        yolo_mode: false,
+        extra_env: Vec::new(),
+        extra_args: String::new(),
+        command_override: String::new(),
+    };
+
+    // Use the async CreationPoller path (pass None hooks, non-sandbox,
+    // but call request_creation directly to force the async path)
+    view.request_creation(data, None);
+    assert!(view.is_creation_pending());
+
+    // Wait for the background thread to finish (should be near-instant
+    // for non-sandbox, non-hook creation)
+    let start = std::time::Instant::now();
+    let mut session_id = None;
+    while start.elapsed() < std::time::Duration::from_secs(5) {
+        if let Some(id) = view.apply_creation_results() {
+            session_id = Some(id);
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    let session_id = session_id.expect("apply_creation_results should return Some(session_id)");
+    assert!(
+        view.get_instance(&session_id).is_some(),
+        "created session should be findable after apply_creation_results"
+    );
+}


### PR DESCRIPTION
## Description

The `tokio::select!` event loop (introduced in e5cf622) processes Key/Mouse/Paste events with `continue`, skipping the periodic refresh section where `apply_creation_results()` is called. Since `select!` biases toward the first branch (event_stream), continuous mouse events from `EnableMouseCapture` can starve the `refresh_interval.tick()` branch, preventing async `CreationPoller` results from being picked up. This caused newly created sessions to appear on the dashboard without auto-attaching, requiring a manual Enter press.

The fix adds `apply_creation_results()` checks inline after Key and Mouse event handling, so creation results are picked up immediately regardless of input event traffic.

Fixes #633

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Root cause analysis and fix implemented with AI assistance. The race condition was identified by tracing the event loop flow and understanding the `tokio::select!` bias semantics.

- [x] I am an AI Agent filling out this form (check box if true)