### PR TITLE
fix(docs): add web dashboard nav entry and build-time nav validation

### DIFF
--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -235,4 +235,21 @@ for (const page of PAGES) {
   console.log(`  ${page.source} -> ${page.dest}`);
 }
 
+// Verify every synced page appears in docsNav.ts
+const navPath = join(__dirname, "..", "src", "data", "docsNav.ts");
+const navSource = readFileSync(navPath, "utf8");
+const navHrefs = new Set([...navSource.matchAll(/href:\s*"([^"]+)"/g)].map((m) => m[1]));
+let missing = 0;
+for (const page of PAGES) {
+  const url = "/" + page.dest.replace(/\.md$/, "/").replace(/\/index\/$/, "/");
+  if (!navHrefs.has(url)) {
+    console.error(`  WARNING: ${url} (from ${page.source}) is not in docsNav.ts`);
+    missing++;
+  }
+}
+if (missing > 0) {
+  console.error(`\n${missing} page(s) missing from sidebar navigation (website/src/data/docsNav.ts)`);
+  process.exit(1);
+}
+
 console.log("Done.");

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -21,6 +21,7 @@ export const docsNav: NavSection[] = [
     title: "Guides",
     items: [
       { title: "Docker Sandbox", href: "/guides/sandbox/" },
+      { title: "Web Dashboard", href: "/guides/web-dashboard/" },
       { title: "Repo Config & Hooks", href: "/guides/repo-config/" },
       { title: "Git Worktrees", href: "/guides/worktrees/" },
       { title: "Diff View", href: "/guides/diff-view/" },


### PR DESCRIPTION
## Description

Follow-up to #635. Two fixes:

1. **Add Web Dashboard to sidebar nav** - the guide page existed at `/guides/web-dashboard/` but was never added to `docsNav.ts`, making it unreachable from the sidebar.

2. **Build-time nav validation** - the sync script now reads `docsNav.ts` after syncing and fails the build if any synced page is missing from the navigation. Prevents ghost pages going forward.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)