### PR TITLE
feat(web): add passphrase login as second-factor auth for web dashboard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "1.1.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
+ "argon2",
  "axum",
  "cargo-husky",
  "cfg-if",
@@ -145,6 +146,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures 0.2.17",
+ "password-hash",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,6 +262,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +293,15 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "block-buffer"
@@ -681,6 +709,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1924,6 +1953,17 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,10 +105,11 @@ tower-http = { version = "0.6", features = ["fs"], optional = true }
 rust-embed = { version = "8", features = ["debug-embed"], optional = true }
 mime_guess = { version = "2.0", optional = true }
 qrcode = { version = "0.14", optional = true }
+argon2 = { version = "0.5", optional = true }
 
 [features]
 default = []
-serve = ["axum", "tower-http", "rust-embed", "mime_guess", "qrcode"]
+serve = ["axum", "tower-http", "rust-embed", "mime_guess", "qrcode", "argon2"]
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -647,6 +647,7 @@ Start a web dashboard for remote session access [experimental]
 * `--tunnel-url <TUNNEL_URL>` — Hostname for a named tunnel (e.g., aoe.example.com)
 * `--daemon` — Run as a background daemon (detach from terminal)
 * `--stop` — Stop a running daemon
+* `--passphrase <PASSPHRASE>` — Require a passphrase for login (second-factor auth). Can also be set via AOE_SERVE_PASSPHRASE environment variable
 
 
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -210,7 +210,8 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
         cmd.args(["--tunnel-url", url]);
     }
     if let Some(ref passphrase) = args.passphrase {
-        cmd.args(["--passphrase", passphrase]);
+        // Pass via env var to avoid exposing the passphrase in the process list
+        cmd.env("AOE_SERVE_PASSPHRASE", passphrase);
     }
     if !profile.is_empty() {
         cmd.args(["--profile", profile]);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -41,6 +41,11 @@ pub struct ServeArgs {
     /// Stop a running daemon
     #[arg(long)]
     pub stop: bool,
+
+    /// Require a passphrase for login (second-factor auth).
+    /// Can also be set via AOE_SERVE_PASSPHRASE environment variable.
+    #[arg(long, env = "AOE_SERVE_PASSPHRASE")]
+    pub passphrase: Option<String>,
 }
 
 fn pid_file_path() -> Result<PathBuf> {
@@ -125,6 +130,23 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
         eprintln!();
     }
 
+    // Passphrase strength check
+    if let Some(ref passphrase) = args.passphrase {
+        if let Some(warning) = crate::server::login::check_passphrase_strength(passphrase) {
+            eprintln!("{}", warning);
+            eprintln!();
+        }
+    }
+
+    // Block remote mode without passphrase
+    if args.remote && args.passphrase.is_none() {
+        bail!(
+            "Refusing to start in remote mode without a passphrase.\n\
+             --remote exposes terminal access to the internet.\n\
+             Add --passphrase <VALUE> or set AOE_SERVE_PASSPHRASE."
+        );
+    }
+
     if args.daemon {
         return start_daemon(profile, &args);
     }
@@ -144,6 +166,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
         tunnel_name: args.tunnel_name.as_deref(),
         tunnel_url: args.tunnel_url.as_deref(),
         is_daemon: false,
+        passphrase: args.passphrase.as_deref(),
     })
     .await;
 
@@ -185,6 +208,9 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     }
     if let Some(ref url) = args.tunnel_url {
         cmd.args(["--tunnel-url", url]);
+    }
+    if let Some(ref passphrase) = args.passphrase {
+        cmd.args(["--passphrase", passphrase]);
     }
     if !profile.is_empty() {
         cmd.args(["--profile", profile]);

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -242,15 +242,11 @@ pub async fn auth_middleware(
                 || path.starts_with("/icon-");
 
             if !is_login_exempt {
-                let has_valid_session =
-                    if let Some(session_id) = super::login::extract_login_session(&request) {
-                        state
-                            .login_manager
-                            .validate_session(&session_id, client_ip)
-                            .await
-                    } else {
-                        false
-                    };
+                let session_id = super::login::extract_login_session(&request);
+                let has_valid_session = match session_id {
+                    Some(ref id) => state.login_manager.validate_session(id, client_ip).await,
+                    None => false,
+                };
 
                 if !has_valid_session {
                     // For API routes, return JSON 401. For HTML routes, redirect.
@@ -284,33 +280,31 @@ pub async fn auth_middleware(
                     }
                 }
 
-                // Sliding window: refresh the login session cookie
-                if let Some(session_id) = super::login::extract_login_session(&request) {
-                    let mut response = next.run(request).await;
+                // Session is valid. Refresh the sliding window cookie.
+                let session_id = session_id.expect("valid session implies session_id exists");
+                let mut response = next.run(request).await;
 
-                    // Set token cookie if needed
-                    let should_set_token = source == TokenSource::QueryParam || needs_upgrade;
-                    if should_set_token {
-                        if let Some(current) = state.token_manager.current_token().await {
-                            let max_age = state.token_manager.lifetime_secs().await;
-                            let cookie = build_cookie(&current, state.behind_tunnel, max_age);
-                            response.headers_mut().insert(
-                                header::SET_COOKIE,
-                                cookie.parse().expect("cookie format must be valid"),
-                            );
-                        }
+                // Set token cookie if needed
+                if source == TokenSource::QueryParam || needs_upgrade {
+                    if let Some(current) = state.token_manager.current_token().await {
+                        let max_age = state.token_manager.lifetime_secs().await;
+                        let cookie = build_cookie(&current, state.behind_tunnel, max_age);
+                        response.headers_mut().insert(
+                            header::SET_COOKIE,
+                            cookie.parse().expect("cookie format must be valid"),
+                        );
                     }
-
-                    // Refresh login session cookie (sliding window)
-                    let login_cookie =
-                        super::login::refresh_login_cookie(&session_id, state.behind_tunnel);
-                    response.headers_mut().append(
-                        header::SET_COOKIE,
-                        login_cookie.parse().expect("cookie format must be valid"),
-                    );
-
-                    return response;
                 }
+
+                // Refresh login session cookie (sliding window)
+                let login_cookie =
+                    super::login::build_login_cookie(&session_id, state.behind_tunnel);
+                response.headers_mut().append(
+                    header::SET_COOKIE,
+                    login_cookie.parse().expect("cookie format must be valid"),
+                );
+
+                return response;
             }
         }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -32,7 +32,10 @@ pub(crate) fn constant_time_eq(a: &str, b: &str) -> bool {
 
 /// Resolve the real client IP, trusting X-Forwarded-For only from loopback
 /// (i.e., only when the request came through the cloudflared proxy).
-fn resolve_client_ip(socket_addr: SocketAddr, headers: &axum::http::HeaderMap) -> IpAddr {
+pub(crate) fn resolve_client_ip(
+    socket_addr: SocketAddr,
+    headers: &axum::http::HeaderMap,
+) -> IpAddr {
     let socket_ip = socket_addr.ip();
     if socket_ip.is_loopback() {
         if let Some(cf_ip) = headers.get("cf-connecting-ip") {
@@ -101,17 +104,19 @@ async fn record_device(state: &AppState, ip: IpAddr, user_agent: &str) {
     }
 }
 
-/// Extract a token from the request cookie or query parameter.
-/// WebSocket protocols are handled separately since multiple protocols may be
-/// present and each must be tried against the token manager.
-fn extract_token(request: &Request) -> Option<(&str, TokenSource)> {
+/// Extract all token candidates from the request (cookie and query parameter).
+/// Returns them in priority order so callers can try each until one validates.
+/// A stale cookie must not prevent a valid query param from being tried.
+fn extract_tokens(request: &Request) -> Vec<(&str, TokenSource)> {
+    let mut tokens = Vec::new();
+
     // Check cookie
     if let Some(cookie_header) = request.headers().get(header::COOKIE) {
         if let Ok(cookie_str) = cookie_header.to_str() {
             for cookie in cookie_str.split(';') {
                 let cookie = cookie.trim();
                 if let Some(value) = cookie.strip_prefix("aoe_token=") {
-                    return Some((value, TokenSource::Cookie));
+                    tokens.push((value, TokenSource::Cookie));
                 }
             }
         }
@@ -121,12 +126,12 @@ fn extract_token(request: &Request) -> Option<(&str, TokenSource)> {
     if let Some(query) = request.uri().query() {
         for param in query.split('&') {
             if let Some(value) = param.strip_prefix("token=") {
-                return Some((value, TokenSource::QueryParam));
+                tokens.push((value, TokenSource::QueryParam));
             }
         }
     }
 
-    None
+    tokens
 }
 
 /// Extract all WebSocket sub-protocol values from the request.
@@ -183,15 +188,17 @@ pub async fn auth_middleware(
             .into_response();
     }
 
-    // Try cookie/query param first
+    // Try each token source in order: cookie, then query param.
+    // A stale cookie must not block a valid query param token.
     let mut matched_source = None;
     let mut needs_upgrade = false;
 
-    if let Some((token_value, source)) = extract_token(&request) {
+    for (token_value, source) in extract_tokens(&request) {
         let (valid, upgrade) = state.token_manager.validate(token_value).await;
         if valid {
             matched_source = Some(source);
             needs_upgrade = upgrade;
+            break;
         }
     }
 
@@ -219,6 +226,93 @@ pub async fn auth_middleware(
             .and_then(|v| v.to_str().ok())
             .unwrap_or("unknown");
         record_device(&state, client_ip, user_agent).await;
+
+        // Login session check (second factor)
+        if state.login_manager.is_enabled() {
+            let path = request.uri().path();
+
+            // Allow login-related paths and static assets through without a session
+            let is_login_exempt = path == "/login"
+                || path == "/api/login"
+                || path == "/api/login/status"
+                || path == "/api/logout"
+                || path.starts_with("/assets/")
+                || path == "/manifest.json"
+                || path == "/sw.js"
+                || path.starts_with("/icon-");
+
+            if !is_login_exempt {
+                let has_valid_session =
+                    if let Some(session_id) = super::login::extract_login_session(&request) {
+                        state
+                            .login_manager
+                            .validate_session(&session_id, client_ip)
+                            .await
+                    } else {
+                        false
+                    };
+
+                if !has_valid_session {
+                    // For API routes, return JSON 401. For HTML routes, redirect.
+                    if path.starts_with("/api/") || path.contains("/ws") {
+                        return (
+                            StatusCode::UNAUTHORIZED,
+                            axum::Json(serde_json::json!({
+                                "error": "login_required",
+                                "message": "Passphrase login required"
+                            })),
+                        )
+                            .into_response();
+                    } else {
+                        let mut response =
+                            axum::response::Redirect::temporary("/login").into_response();
+
+                        // Set token cookie on the redirect so the browser has it
+                        // when following the redirect to /login
+                        if source == TokenSource::QueryParam || needs_upgrade {
+                            if let Some(current) = state.token_manager.current_token().await {
+                                let max_age = state.token_manager.lifetime_secs().await;
+                                let cookie = build_cookie(&current, state.behind_tunnel, max_age);
+                                response.headers_mut().insert(
+                                    header::SET_COOKIE,
+                                    cookie.parse().expect("cookie format must be valid"),
+                                );
+                            }
+                        }
+
+                        return response;
+                    }
+                }
+
+                // Sliding window: refresh the login session cookie
+                if let Some(session_id) = super::login::extract_login_session(&request) {
+                    let mut response = next.run(request).await;
+
+                    // Set token cookie if needed
+                    let should_set_token = source == TokenSource::QueryParam || needs_upgrade;
+                    if should_set_token {
+                        if let Some(current) = state.token_manager.current_token().await {
+                            let max_age = state.token_manager.lifetime_secs().await;
+                            let cookie = build_cookie(&current, state.behind_tunnel, max_age);
+                            response.headers_mut().insert(
+                                header::SET_COOKIE,
+                                cookie.parse().expect("cookie format must be valid"),
+                            );
+                        }
+                    }
+
+                    // Refresh login session cookie (sliding window)
+                    let login_cookie =
+                        super::login::refresh_login_cookie(&session_id, state.behind_tunnel);
+                    response.headers_mut().append(
+                        header::SET_COOKIE,
+                        login_cookie.parse().expect("cookie format must be valid"),
+                    );
+
+                    return response;
+                }
+            }
+        }
 
         let mut response = next.run(request).await;
 

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -121,22 +121,23 @@ impl LoginManager {
             return false;
         }
 
+        // Read lock first to check validity without blocking other readers
+        {
+            let sessions = self.sessions.read().await;
+            let Some(session) = sessions.get(session_id) else {
+                return false;
+            };
+            if Instant::now() > session.expires_at || session.ip != client_ip {
+                // Expired sessions are cleaned up by the periodic task
+                return false;
+            }
+        }
+
+        // Only take write lock to extend the sliding window
         let mut sessions = self.sessions.write().await;
-        let Some(session) = sessions.get_mut(session_id) else {
-            return false;
-        };
-
-        if Instant::now() > session.expires_at {
-            sessions.remove(session_id);
-            return false;
+        if let Some(session) = sessions.get_mut(session_id) {
+            session.expires_at = Instant::now() + SESSION_LIFETIME;
         }
-
-        if session.ip != client_ip {
-            return false;
-        }
-
-        // Sliding window: extend expiry on each valid access
-        session.expires_at = Instant::now() + SESSION_LIFETIME;
         true
     }
 
@@ -190,9 +191,10 @@ pub struct LoginRequest {
 pub async fn login_handler(
     State(state): State<Arc<AppState>>,
     axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
-    request: axum::extract::Request,
+    headers: axum::http::HeaderMap,
+    login_body: Result<Json<LoginRequest>, axum::extract::rejection::JsonRejection>,
 ) -> axum::response::Response {
-    let client_ip = resolve_client_ip(addr, request.headers());
+    let client_ip = resolve_client_ip(addr, &headers);
 
     if !state.login_manager.is_enabled() {
         return (
@@ -218,23 +220,8 @@ pub async fn login_handler(
             .into_response();
     }
 
-    // Extract body
-    let body = match axum::body::to_bytes(request.into_body(), 1024).await {
-        Ok(b) => b,
-        Err(_) => {
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({
-                    "error": "bad_request",
-                    "message": "Invalid request body"
-                })),
-            )
-                .into_response();
-        }
-    };
-
-    let login_req: LoginRequest = match serde_json::from_slice(&body) {
-        Ok(r) => r,
+    let login_req = match login_body {
+        Ok(Json(req)) => req,
         Err(_) => {
             return (
                 StatusCode::BAD_REQUEST,
@@ -256,7 +243,7 @@ pub async fn login_handler(
     if state.login_manager.verify_passphrase(&login_req.passphrase) {
         state.rate_limiter.record_success(client_ip).await;
 
-        let user_agent = addr.to_string(); // simplified
+        let user_agent = addr.to_string();
         let session_id = state
             .login_manager
             .create_session(client_ip, &user_agent)
@@ -359,7 +346,7 @@ pub fn extract_login_session(request: &axum::extract::Request) -> Option<String>
 }
 
 /// Build a Set-Cookie header for the login session.
-fn build_login_cookie(session_id: &str, secure: bool) -> String {
+pub fn build_login_cookie(session_id: &str, secure: bool) -> String {
     let mut cookie = format!(
         "aoe_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=2592000",
         session_id
@@ -368,11 +355,6 @@ fn build_login_cookie(session_id: &str, secure: bool) -> String {
         cookie.push_str("; Secure");
     }
     cookie
-}
-
-/// Build a Set-Cookie header that refreshes the sliding window.
-pub fn refresh_login_cookie(session_id: &str, secure: bool) -> String {
-    build_login_cookie(session_id, secure)
 }
 
 #[cfg(test)]

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -121,23 +121,22 @@ impl LoginManager {
             return false;
         }
 
-        // Read lock first to check validity without blocking other readers
-        {
-            let sessions = self.sessions.read().await;
-            let Some(session) = sessions.get(session_id) else {
-                return false;
-            };
-            if Instant::now() > session.expires_at || session.ip != client_ip {
-                // Expired sessions are cleaned up by the periodic task
-                return false;
-            }
+        let mut sessions = self.sessions.write().await;
+        let Some(session) = sessions.get_mut(session_id) else {
+            return false;
+        };
+
+        if Instant::now() > session.expires_at {
+            sessions.remove(session_id);
+            return false;
         }
 
-        // Only take write lock to extend the sliding window
-        let mut sessions = self.sessions.write().await;
-        if let Some(session) = sessions.get_mut(session_id) {
-            session.expires_at = Instant::now() + SESSION_LIFETIME;
+        if session.ip != client_ip {
+            return false;
         }
+
+        // Sliding window: extend expiry on each valid access
+        session.expires_at = Instant::now() + SESSION_LIFETIME;
         true
     }
 

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -1,0 +1,566 @@
+//! Passphrase-based login as a second authentication factor.
+//!
+//! When a passphrase is configured, users must enter it after token auth
+//! to access the dashboard. Login sessions are tracked server-side with
+//! IP binding and a 30-day sliding expiry window.
+
+use std::collections::HashMap;
+use std::net::IpAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::http::{header, StatusCode};
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::Deserialize;
+use tokio::sync::RwLock;
+
+use super::auth::resolve_client_ip;
+use super::AppState;
+
+/// 30-day session lifetime (sliding window).
+const SESSION_LIFETIME: Duration = Duration::from_secs(30 * 24 * 60 * 60);
+
+/// Maximum concurrent login sessions before evicting the oldest.
+const MAX_SESSIONS: usize = 50;
+
+/// Minimum recommended passphrase length.
+const MIN_PASSPHRASE_LENGTH: usize = 8;
+
+struct LoginSession {
+    expires_at: Instant,
+    ip: IpAddr,
+    #[allow(dead_code)]
+    user_agent: String,
+}
+
+/// Manages passphrase verification and login session lifecycle.
+pub struct LoginManager {
+    passphrase_hash: Option<String>,
+    sessions: RwLock<HashMap<String, LoginSession>>,
+}
+
+impl LoginManager {
+    /// Create a new login manager. If `passphrase` is `Some`, hash it with argon2.
+    pub fn new(passphrase: Option<&str>) -> Self {
+        let passphrase_hash = passphrase.map(|p| {
+            use argon2::password_hash::SaltString;
+            use argon2::{Argon2, PasswordHasher};
+            use rand::RngExt;
+
+            let mut salt_bytes = [0u8; 16];
+            rand::rng().fill(&mut salt_bytes);
+            let salt = SaltString::encode_b64(&salt_bytes).expect("salt encoding must succeed");
+            Argon2::default()
+                .hash_password(p.as_bytes(), &salt)
+                .expect("argon2 hashing must not fail")
+                .to_string()
+        });
+
+        Self {
+            passphrase_hash,
+            sessions: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Whether passphrase login is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.passphrase_hash.is_some()
+    }
+
+    /// Verify a passphrase against the stored hash.
+    pub fn verify_passphrase(&self, input: &str) -> bool {
+        let Some(ref hash) = self.passphrase_hash else {
+            return false;
+        };
+
+        use argon2::password_hash::PasswordHash;
+        use argon2::{Argon2, PasswordVerifier};
+
+        let parsed = match PasswordHash::new(hash) {
+            Ok(h) => h,
+            Err(_) => return false,
+        };
+
+        Argon2::default()
+            .verify_password(input.as_bytes(), &parsed)
+            .is_ok()
+    }
+
+    /// Create a new login session. Returns the session ID (64-char hex).
+    pub async fn create_session(&self, ip: IpAddr, user_agent: &str) -> String {
+        let session_id = super::generate_token();
+        let session = LoginSession {
+            expires_at: Instant::now() + SESSION_LIFETIME,
+            ip,
+            user_agent: user_agent.to_string(),
+        };
+
+        let mut sessions = self.sessions.write().await;
+
+        // Evict oldest if at capacity
+        if sessions.len() >= MAX_SESSIONS {
+            if let Some(oldest_id) = sessions
+                .iter()
+                .min_by_key(|(_, s)| s.expires_at)
+                .map(|(id, _)| id.clone())
+            {
+                sessions.remove(&oldest_id);
+            }
+        }
+
+        sessions.insert(session_id.clone(), session);
+        session_id
+    }
+
+    /// Validate a session. Checks existence, expiry, and IP match.
+    /// On success, extends the sliding window.
+    pub async fn validate_session(&self, session_id: &str, client_ip: IpAddr) -> bool {
+        if session_id.is_empty() {
+            return false;
+        }
+
+        let mut sessions = self.sessions.write().await;
+        let Some(session) = sessions.get_mut(session_id) else {
+            return false;
+        };
+
+        if Instant::now() > session.expires_at {
+            sessions.remove(session_id);
+            return false;
+        }
+
+        if session.ip != client_ip {
+            return false;
+        }
+
+        // Sliding window: extend expiry on each valid access
+        session.expires_at = Instant::now() + SESSION_LIFETIME;
+        true
+    }
+
+    /// Invalidate a session (logout).
+    pub async fn invalidate_session(&self, session_id: &str) {
+        self.sessions.write().await.remove(session_id);
+    }
+
+    /// Remove expired sessions. Called periodically.
+    pub async fn cleanup_expired(&self) {
+        let mut sessions = self.sessions.write().await;
+        let now = Instant::now();
+        sessions.retain(|_, s| now < s.expires_at);
+    }
+
+    /// Spawn periodic cleanup (piggybacks on the rate limiter's interval).
+    pub fn spawn_cleanup_task(self: &Arc<Self>) {
+        let manager = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                manager.cleanup_expired().await;
+            }
+        });
+    }
+}
+
+/// Check if passphrase meets minimum length. Returns a warning message if not.
+pub fn check_passphrase_strength(passphrase: &str) -> Option<String> {
+    if passphrase.len() < MIN_PASSPHRASE_LENGTH {
+        Some(format!(
+            "WARNING: Passphrase is only {} characters. \
+             Consider using at least {} characters for better security.",
+            passphrase.len(),
+            MIN_PASSPHRASE_LENGTH
+        ))
+    } else {
+        None
+    }
+}
+
+// ── Handlers ───────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct LoginRequest {
+    passphrase: String,
+}
+
+/// POST /api/login
+pub async fn login_handler(
+    State(state): State<Arc<AppState>>,
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
+    request: axum::extract::Request,
+) -> axum::response::Response {
+    let client_ip = resolve_client_ip(addr, request.headers());
+
+    if !state.login_manager.is_enabled() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "not_found",
+                "message": "Login is not enabled"
+            })),
+        )
+            .into_response();
+    }
+
+    // Rate limit check
+    if let Some(remaining) = state.rate_limiter.check_locked(client_ip).await {
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            [("Retry-After", remaining.to_string())],
+            Json(serde_json::json!({
+                "error": "rate_limited",
+                "message": format!("Too many failed attempts. Try again in {} seconds.", remaining)
+            })),
+        )
+            .into_response();
+    }
+
+    // Extract body
+    let body = match axum::body::to_bytes(request.into_body(), 1024).await {
+        Ok(b) => b,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_request",
+                    "message": "Invalid request body"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let login_req: LoginRequest = match serde_json::from_slice(&body) {
+        Ok(r) => r,
+        Err(_) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_request",
+                    "message": "Missing or invalid passphrase field"
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    tracing::debug!(
+        ip = %client_ip,
+        passphrase_len = login_req.passphrase.len(),
+        "Login attempt"
+    );
+
+    if state.login_manager.verify_passphrase(&login_req.passphrase) {
+        state.rate_limiter.record_success(client_ip).await;
+
+        let user_agent = addr.to_string(); // simplified
+        let session_id = state
+            .login_manager
+            .create_session(client_ip, &user_agent)
+            .await;
+
+        tracing::info!(ip = %client_ip, "Login successful");
+
+        let cookie = build_login_cookie(&session_id, state.behind_tunnel);
+        let mut response = Json(serde_json::json!({
+            "ok": true
+        }))
+        .into_response();
+
+        response.headers_mut().insert(
+            header::SET_COOKIE,
+            cookie.parse().expect("cookie format must be valid"),
+        );
+
+        response
+    } else {
+        let locked = state.rate_limiter.record_failure(client_ip).await;
+        tracing::warn!(ip = %client_ip, locked = locked, "Login failed: incorrect passphrase");
+
+        (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({
+                "error": "unauthorized",
+                "message": "Incorrect passphrase"
+            })),
+        )
+            .into_response()
+    }
+}
+
+/// POST /api/logout
+pub async fn logout_handler(
+    State(state): State<Arc<AppState>>,
+    request: axum::extract::Request,
+) -> axum::response::Response {
+    // Extract session cookie
+    if let Some(session_id) = extract_login_session(&request) {
+        state.login_manager.invalidate_session(&session_id).await;
+    }
+
+    let clear_cookie = format!(
+        "aoe_session=; HttpOnly; SameSite=Strict; Path=/; Max-Age=0{}",
+        if state.behind_tunnel { "; Secure" } else { "" }
+    );
+
+    let mut response = Json(serde_json::json!({ "ok": true })).into_response();
+    response.headers_mut().insert(
+        header::SET_COOKIE,
+        clear_cookie.parse().expect("cookie format must be valid"),
+    );
+
+    response
+}
+
+/// GET /api/login/status
+pub async fn login_status_handler(
+    State(state): State<Arc<AppState>>,
+    axum::extract::ConnectInfo(addr): axum::extract::ConnectInfo<std::net::SocketAddr>,
+    request: axum::extract::Request,
+) -> Json<serde_json::Value> {
+    let required = state.login_manager.is_enabled();
+
+    let authenticated = if required {
+        if let Some(session_id) = extract_login_session(&request) {
+            let client_ip = resolve_client_ip(addr, request.headers());
+            state
+                .login_manager
+                .validate_session(&session_id, client_ip)
+                .await
+        } else {
+            false
+        }
+    } else {
+        true
+    };
+
+    Json(serde_json::json!({
+        "required": required,
+        "authenticated": authenticated
+    }))
+}
+
+/// Extract the `aoe_session` cookie value from a request.
+pub fn extract_login_session(request: &axum::extract::Request) -> Option<String> {
+    let cookie_header = request.headers().get(header::COOKIE)?;
+    let cookie_str = cookie_header.to_str().ok()?;
+    for cookie in cookie_str.split(';') {
+        let cookie = cookie.trim();
+        if let Some(value) = cookie.strip_prefix("aoe_session=") {
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Build a Set-Cookie header for the login session.
+fn build_login_cookie(session_id: &str, secure: bool) -> String {
+    let mut cookie = format!(
+        "aoe_session={}; HttpOnly; SameSite=Strict; Path=/; Max-Age=2592000",
+        session_id
+    );
+    if secure {
+        cookie.push_str("; Secure");
+    }
+    cookie
+}
+
+/// Build a Set-Cookie header that refreshes the sliding window.
+pub fn refresh_login_cookie(session_id: &str, secure: bool) -> String {
+    build_login_cookie(session_id, secure)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn login_manager_disabled_when_no_passphrase() {
+        let mgr = LoginManager::new(None);
+        assert!(!mgr.is_enabled());
+    }
+
+    #[test]
+    fn login_manager_enabled_when_passphrase_set() {
+        let mgr = LoginManager::new(Some("test123"));
+        assert!(mgr.is_enabled());
+    }
+
+    #[test]
+    fn verify_correct_passphrase() {
+        let mgr = LoginManager::new(Some("my_secret"));
+        assert!(mgr.verify_passphrase("my_secret"));
+    }
+
+    #[test]
+    fn verify_incorrect_passphrase() {
+        let mgr = LoginManager::new(Some("my_secret"));
+        assert!(!mgr.verify_passphrase("wrong"));
+    }
+
+    #[test]
+    fn verify_empty_passphrase() {
+        let mgr = LoginManager::new(Some("my_secret"));
+        assert!(!mgr.verify_passphrase(""));
+    }
+
+    #[test]
+    fn verify_fails_when_disabled() {
+        let mgr = LoginManager::new(None);
+        assert!(!mgr.verify_passphrase("anything"));
+    }
+
+    #[tokio::test]
+    async fn create_and_validate_session() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let session_id = mgr.create_session(ip, "test-agent").await;
+
+        assert!(mgr.validate_session(&session_id, ip).await);
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_wrong_ip() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let other_ip: IpAddr = "5.6.7.8".parse().unwrap();
+        let session_id = mgr.create_session(ip, "test-agent").await;
+
+        assert!(!mgr.validate_session(&session_id, other_ip).await);
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_unknown_session() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+
+        assert!(!mgr.validate_session("nonexistent", ip).await);
+    }
+
+    #[tokio::test]
+    async fn validate_rejects_empty_session_id() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+
+        assert!(!mgr.validate_session("", ip).await);
+    }
+
+    #[tokio::test]
+    async fn invalidate_session_removes_it() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let session_id = mgr.create_session(ip, "test-agent").await;
+
+        mgr.invalidate_session(&session_id).await;
+        assert!(!mgr.validate_session(&session_id, ip).await);
+    }
+
+    #[tokio::test]
+    async fn invalidate_unknown_session_is_noop() {
+        let mgr = LoginManager::new(Some("test"));
+        mgr.invalidate_session("nonexistent").await;
+        // No panic, no error
+    }
+
+    #[tokio::test]
+    async fn max_sessions_evicts_oldest() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+
+        let mut first_id = String::new();
+        for i in 0..MAX_SESSIONS {
+            let id = mgr.create_session(ip, &format!("agent-{}", i)).await;
+            if i == 0 {
+                first_id = id;
+            }
+        }
+
+        // First session should still be valid (at capacity, not over)
+        assert!(mgr.validate_session(&first_id, ip).await);
+
+        // Adding one more should evict the oldest (which is now the second one,
+        // since first_id just had its expiry refreshed by validate_session above)
+        let _new_id = mgr.create_session(ip, "agent-overflow").await;
+        let sessions = mgr.sessions.read().await;
+        assert_eq!(sessions.len(), MAX_SESSIONS);
+    }
+
+    #[tokio::test]
+    async fn cleanup_expired_removes_stale() {
+        let mgr = LoginManager::new(Some("test"));
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let session_id = mgr.create_session(ip, "test-agent").await;
+
+        // Manually expire the session
+        {
+            let mut sessions = mgr.sessions.write().await;
+            if let Some(s) = sessions.get_mut(&session_id) {
+                s.expires_at = Instant::now() - Duration::from_secs(1);
+            }
+        }
+
+        mgr.cleanup_expired().await;
+
+        assert!(!mgr.validate_session(&session_id, ip).await);
+    }
+
+    #[test]
+    fn passphrase_strength_short() {
+        assert!(check_passphrase_strength("short").is_some());
+    }
+
+    #[test]
+    fn passphrase_strength_adequate() {
+        assert!(check_passphrase_strength("longenough").is_none());
+    }
+
+    #[test]
+    fn build_cookie_without_secure() {
+        let cookie = build_login_cookie("abc123", false);
+        assert!(cookie.contains("aoe_session=abc123"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Strict"));
+        assert!(cookie.contains("Max-Age=2592000"));
+        assert!(!cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn build_cookie_with_secure() {
+        let cookie = build_login_cookie("abc123", true);
+        assert!(cookie.contains("Secure"));
+    }
+
+    #[test]
+    fn extract_session_from_cookie_header() {
+        let request = axum::http::Request::builder()
+            .header(header::COOKIE, "aoe_token=foo; aoe_session=bar123")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        assert_eq!(extract_login_session(&request), Some("bar123".to_string()));
+    }
+
+    #[test]
+    fn extract_session_missing_cookie() {
+        let request = axum::http::Request::builder()
+            .header(header::COOKIE, "aoe_token=foo")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        assert_eq!(extract_login_session(&request), None);
+    }
+
+    #[test]
+    fn extract_session_no_cookie_header() {
+        let request = axum::http::Request::builder()
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        assert_eq!(extract_login_session(&request), None);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod api;
 pub mod auth;
+pub mod login;
 pub mod rate_limit;
 pub mod tunnel;
 pub mod ws;
@@ -151,6 +152,7 @@ pub struct AppState {
     pub read_only: bool,
     pub instances: RwLock<Vec<Instance>>,
     pub token_manager: Arc<TokenManager>,
+    pub login_manager: Arc<login::LoginManager>,
     pub rate_limiter: Arc<RateLimiter>,
     pub devices: RwLock<Vec<DeviceInfo>>,
     pub behind_tunnel: bool,
@@ -168,6 +170,7 @@ pub struct ServerConfig<'a> {
     pub tunnel_name: Option<&'a str>,
     pub tunnel_url: Option<&'a str>,
     pub is_daemon: bool,
+    pub passphrase: Option<&'a str>,
 }
 
 pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
@@ -181,6 +184,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         tunnel_name,
         tunnel_url,
         is_daemon,
+        passphrase,
     } = config;
     let instances = load_all_instances()?;
 
@@ -202,13 +206,19 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     };
 
     let token_manager = Arc::new(TokenManager::new(auth_token.clone(), token_lifetime));
+    let login_manager = Arc::new(login::LoginManager::new(passphrase));
     let rate_limiter = Arc::new(RateLimiter::new());
+
+    if login_manager.is_enabled() {
+        info!("Passphrase login enabled (second-factor authentication)");
+    }
 
     let state = Arc::new(AppState {
         profile: profile.to_string(),
         read_only,
         instances: RwLock::new(instances),
         token_manager: Arc::clone(&token_manager),
+        login_manager: Arc::clone(&login_manager),
         rate_limiter: Arc::clone(&rate_limiter),
         devices: RwLock::new(Vec::new()),
         behind_tunnel: remote,
@@ -288,6 +298,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     });
 
     rate_limiter.spawn_cleanup_task();
+    login_manager.spawn_cleanup_task();
 
     if remote {
         token_manager.spawn_rotation_task();
@@ -344,6 +355,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_settings).patch(api::update_settings),
         )
         .route("/api/themes", get(api::list_themes))
+        // Login (second-factor auth)
+        .route("/api/login", post(login::login_handler))
+        .route("/api/logout", post(login::logout_handler))
+        .route("/api/login/status", get(login::login_status_handler))
         // Devices
         .route("/api/devices", get(api::list_devices))
         // Terminal WebSockets

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,10 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useSessions } from "./hooks/useSessions";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { isSessionActive } from "./lib/session";
-import { createSession } from "./lib/api";
+import { createSession, loginStatus, logout } from "./lib/api";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { WorkspaceHeader } from "./components/WorkspaceHeader";
 import { ContentSplit } from "./components/ContentSplit";
@@ -14,8 +14,42 @@ import { SettingsView } from "./components/SettingsView";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import { Dashboard } from "./components/Dashboard";
+import { LoginPage } from "./components/LoginPage";
 
 export default function App() {
+  const [loginRequired, setLoginRequired] = useState<boolean | null>(null);
+  const [loginAuthenticated, setLoginAuthenticated] = useState(true);
+
+  useEffect(() => {
+    loginStatus().then(({ required, authenticated }) => {
+      setLoginRequired(required);
+      setLoginAuthenticated(authenticated);
+    });
+  }, []);
+
+  const handleLoginSuccess = () => {
+    setLoginAuthenticated(true);
+  };
+
+  const handleLogout = async () => {
+    await logout();
+    setLoginAuthenticated(false);
+  };
+
+  // Show login page if required and not authenticated
+  if (loginRequired && !loginAuthenticated) {
+    return <LoginPage onSuccess={handleLoginSuccess} />;
+  }
+
+  // While checking login status, show nothing (brief flash)
+  if (loginRequired === null) {
+    return <div className="h-dvh bg-surface-900" />;
+  }
+
+  return <AppContent loginRequired={loginRequired} onLogout={handleLogout} />;
+}
+
+function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
   const { sessions, error } = useSessions();
   const workspaces = useWorkspaces(sessions);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
@@ -238,6 +272,16 @@ export default function App() {
                 <rect x="3" y="3" width="18" height="18" rx="2" />
                 <line x1="15" y1="3" x2="15" y2="21" />
               </svg>
+            </button>
+          )}
+          {loginRequired && (
+            <button
+              onClick={onLogout}
+              className="px-2 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors text-text-dim hover:text-text-secondary hover:bg-surface-700/50 font-mono text-xs"
+              title="Sign out"
+              aria-label="Sign out"
+            >
+              log out
             </button>
           )}
         </div>

--- a/web/src/components/LoginPage.tsx
+++ b/web/src/components/LoginPage.tsx
@@ -1,0 +1,115 @@
+import { useState, useRef, useEffect } from "react";
+import { login } from "../lib/api";
+
+interface Props {
+  onSuccess: () => void;
+}
+
+export function LoginPage({ onSuccess }: Props) {
+  const [passphrase, setPassphrase] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [showPassphrase, setShowPassphrase] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (loading || !passphrase.trim()) return;
+
+    setLoading(true);
+    setError(null);
+
+    const result = await login(passphrase);
+
+    if (result.ok) {
+      onSuccess();
+    } else {
+      setError(result.error ?? "Login failed");
+      setLoading(false);
+      inputRef.current?.focus();
+    }
+  };
+
+  return (
+    <div className="h-dvh flex items-center justify-center bg-surface-900 p-4">
+      <div className="w-full max-w-sm animate-slide-up">
+        <form onSubmit={handleSubmit} className="bg-surface-800 border border-surface-700/40 rounded-xl p-8">
+          {/* Logo */}
+          <div className="flex items-center justify-center gap-2 mb-8">
+            <img src="/icon-192.png" alt="" width="28" height="28" className="rounded-sm" />
+            <span className="font-mono text-lg text-text-primary tracking-tight">aoe</span>
+          </div>
+
+          {/* Passphrase input */}
+          <div className="mb-4">
+            <label htmlFor="passphrase" className="block text-xs text-text-muted mb-2 font-medium">
+              Passphrase
+            </label>
+            <div className="relative">
+              <input
+                ref={inputRef}
+                id="passphrase"
+                type={showPassphrase ? "text" : "password"}
+                value={passphrase}
+                onChange={(e) => setPassphrase(e.target.value)}
+                disabled={loading}
+                autoComplete="current-password"
+                className="w-full px-3 py-2.5 pr-10 bg-surface-900 border border-surface-700/60 rounded-lg text-text-primary text-sm placeholder:text-text-dim focus:outline-none focus:ring-2 focus:ring-brand-600 focus:border-transparent disabled:opacity-50 transition-colors"
+                placeholder="Enter passphrase"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassphrase((s) => !s)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 w-7 h-7 flex items-center justify-center text-text-dim hover:text-text-secondary transition-colors cursor-pointer rounded"
+                tabIndex={-1}
+                aria-label={showPassphrase ? "Hide passphrase" : "Show passphrase"}
+              >
+                {showPassphrase ? (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                    <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                    <line x1="1" y1="1" x2="23" y2="23" />
+                    <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+                  </svg>
+                ) : (
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                    <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                    <circle cx="12" cy="12" r="3" />
+                  </svg>
+                )}
+              </button>
+            </div>
+          </div>
+
+          {/* Error message */}
+          {error && (
+            <p className="text-status-error text-xs mb-4">{error}</p>
+          )}
+
+          {/* Submit button */}
+          <button
+            type="submit"
+            disabled={loading || !passphrase.trim()}
+            className="w-full py-2.5 bg-brand-600 hover:bg-brand-700 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer flex items-center justify-center gap-2"
+          >
+            {loading ? (
+              <>
+                <svg className="animate-spin h-4 w-4" viewBox="0 0 24 24" fill="none">
+                  <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                  <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z" />
+                </svg>
+                Signing in...
+              </>
+            ) : (
+              "Sign in"
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -208,6 +208,49 @@ export async function createSession(
   }
 }
 
+// --- Login ---
+
+export async function loginStatus(): Promise<{
+  required: boolean;
+  authenticated: boolean;
+}> {
+  try {
+    const res = await fetch("/api/login/status");
+    if (!res.ok) return { required: false, authenticated: true };
+    return await res.json();
+  } catch {
+    return { required: false, authenticated: true };
+  }
+}
+
+export async function login(
+  passphrase: string,
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch("/api/login", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ passphrase }),
+    });
+    if (res.ok) return { ok: true };
+    const data = await res.json().catch(() => null);
+    return {
+      ok: false,
+      error: data?.message ?? `Login failed (${res.status})`,
+    };
+  } catch {
+    return { ok: false, error: "Network error" };
+  }
+}
+
+export async function logout(): Promise<void> {
+  try {
+    await fetch("/api/logout", { method: "POST" });
+  } catch {
+    // Best effort
+  }
+}
+
 export async function renameSession(
   id: string,
   title: string,


### PR DESCRIPTION
## Description

  The web dashboard provides full terminal access to agent sessions. A leaked token URL previously meant immediate shell access. This adds an optional passphrase as a second authentication factor: even if the
  token leaks, an attacker still needs the passphrase.

  **Security model:** Cloudflare Tunnel (HTTPS) -> token auth -> passphrase login (NEW)

  ### Backend
  - LoginManager with argon2 passphrase hashing, IP-bound server-side sessions
  - 30-day sliding session window (refreshes on each use)
  - Login/logout/status API endpoints inside the token auth middleware
  - Rate limiting reuses existing RateLimiter (5 attempts / 15 min lockout)
  - --passphrase CLI flag and AOE_SERVE_PASSPHRASE env var
  - Passphrase required for --remote mode (hard error)
  - Passphrase strength warning for < 8 characters
  - 21 unit tests for LoginManager

  ### Frontend
  - Login page with passphrase input, show/hide eye toggle, error states
  - App checks /api/login/status on mount, conditionally renders login page
  - log out button in header when login is active

  ### Bug fix (pre-existing)
  A stale aoe_token cookie would block a valid token in the query parameter. extract_token now returns all candidates and tries each until one validates.

  ### Usage
  \`\`\`bash
  # With passphrase (second factor enabled)
  aoe serve --passphrase \"my-secret\"

  # Via env var
  AOE_SERVE_PASSPHRASE=\"my-secret\" aoe serve

  # Without passphrase (existing behavior, unchanged)
  aoe serve

  # Remote mode requires passphrase
  aoe serve --remote --passphrase \"my-secret\"
  \`\`\`

  ## PR Type

  - [x] New Feature
  - [x] Bug Fix

  ## Checklist

  - [x] I understand the code I am submitting
  - [x] New and existing tests pass
  - [x] Documentation was updated where necessary
  - [ ] For UI changes: included screenshot or recording

  ## AI Usage

  - [x] This is fully AI-generated

  **AI Model/Tool used:** Claude Opus 4.6 via Claude Code

  - [x] I am an AI Agent filling out this form (check box if true)"