### PR TITLE
fix(server): serve embedded static files from SPA fallback

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -239,7 +239,8 @@ pub async fn auth_middleware(
                 || path.starts_with("/assets/")
                 || path == "/manifest.json"
                 || path == "/sw.js"
-                || path.starts_with("/icon-");
+                || path.starts_with("/icon-")
+                || path.starts_with("/fonts/");
 
             if !is_login_exempt {
                 let session_id = super::login::extract_login_session(&request);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -398,7 +398,21 @@ async fn security_headers(
     response
 }
 
-async fn serve_index() -> impl axum::response::IntoResponse {
+async fn serve_index(uri: axum::http::Uri) -> impl axum::response::IntoResponse {
+    use axum::response::IntoResponse;
+
+    let path = uri.path().trim_start_matches('/');
+    if !path.is_empty() && path != "index.html" {
+        if let Some(file) = StaticAssets::get(path) {
+            let mime = mime_guess::from_path(path).first_or_octet_stream();
+            return (
+                axum::http::StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, mime.as_ref().to_string())],
+                file.data.to_vec(),
+            )
+                .into_response();
+        }
+    }
     serve_embedded_file("index.html")
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -402,7 +402,7 @@ async fn serve_index(uri: axum::http::Uri) -> impl axum::response::IntoResponse 
     use axum::response::IntoResponse;
 
     let path = uri.path().trim_start_matches('/');
-    if !path.is_empty() && path != "index.html" {
+    if !path.is_empty() && path != "index.html" && path.contains('.') {
         if let Some(file) = StaticAssets::get(path) {
             let mime = mime_guess::from_path(path).first_or_octet_stream();
             return (


### PR DESCRIPTION
## Description

The SPA fallback handler (`serve_index`) always returned `index.html` for unmatched paths, which broke font loading introduced by #617. Requests to `/fonts/Geist-Regular.woff2` received `index.html` with `content-type: text/html`, causing the browser to fall back to system fonts.

This PR makes the fallback smarter: it tries `StaticAssets::get()` first and only serves `index.html` for paths that don't match an embedded file. This fixes fonts and prevents the same class of bug for any future static files added to `web/public/`.

Also adds `/fonts/` to the auth exemption list so fonts load on the login page (same as `/assets/` and icons).

Closes #618

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)