### PR TITLE
feat(tui): smarter session display and group-by-project mode

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -185,7 +185,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         None
     };
 
-    // Generate title
+    // Generate title: use provided title, or branch name for worktree sessions, or random civ
     let final_title = if let Some(title) = &args.title {
         let trimmed_title = title.trim();
         if is_duplicate_session(&instances, trimmed_title, path.to_str().unwrap_or("")) {
@@ -196,6 +196,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             return Ok(());
         }
         trimmed_title.to_string()
+    } else if let Some(ref branch) = args.worktree_branch {
+        branch.trim().to_string()
     } else {
         let existing_titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
         civilizations::generate_random_title(&existing_titles)

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -197,7 +197,15 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         }
         trimmed_title.to_string()
     } else if let Some(ref branch) = args.worktree_branch {
-        branch.trim().to_string()
+        let branch_title = branch.trim().to_string();
+        if is_duplicate_session(&instances, &branch_title, path.to_str().unwrap_or("")) {
+            println!(
+                "Session already exists with same title and path: {}",
+                branch_title
+            );
+            return Ok(());
+        }
+        branch_title
     } else {
         let existing_titles: Vec<&str> = instances.iter().map(|i| i.title.as_str()).collect();
         civilizations::generate_random_title(&existing_titles)

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -245,8 +245,7 @@ pub async fn create_session(
             .filter(|s| !s.is_empty())
             .collect();
 
-        // When worktree_branch is empty string, generate a name from civilizations
-        // (matches TUI behavior where empty title gets auto-generated).
+        // When worktree_branch is empty string, generate a name from civilizations.
         // The generated name is used as both title and branch.
         let title = body.title.unwrap_or_default();
         let worktree_branch = match body.worktree_branch {

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -332,11 +332,7 @@ pub fn build_instance(
         bail!("Project path is not a directory: {}", final_path);
     }
 
-    let final_title = if params.title.is_empty() {
-        civilizations::generate_random_title(existing_titles)
-    } else {
-        params.title.clone()
-    };
+    let final_title = resolve_title(&params.title, &params.worktree_branch, existing_titles);
 
     let mut instance = Instance::new(&final_title, &final_path);
     instance.group_path = params.group;
@@ -440,4 +436,55 @@ pub fn cleanup_instance(
     }
 
     let _ = instance.kill();
+}
+
+/// Resolve the session title: use the provided title, or the worktree branch name,
+/// or fall back to a random civilization name.
+fn resolve_title(
+    title: &str,
+    worktree_branch: &Option<String>,
+    existing_titles: &[&str],
+) -> String {
+    if title.is_empty() {
+        if let Some(ref branch) = worktree_branch {
+            branch.clone()
+        } else {
+            civilizations::generate_random_title(existing_titles)
+        }
+    } else {
+        title.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_empty_title_with_worktree_uses_branch_name() {
+        let title = resolve_title("", &Some("feature-auth".to_string()), &[]);
+        assert_eq!(title, "feature-auth");
+    }
+
+    #[test]
+    fn test_empty_title_without_worktree_uses_civilization() {
+        let title = resolve_title("", &None, &[]);
+        assert!(
+            civilizations::CIVILIZATIONS.contains(&title.as_str()),
+            "Expected a civilization name, got: {}",
+            title
+        );
+    }
+
+    #[test]
+    fn test_provided_title_with_worktree_keeps_title() {
+        let title = resolve_title("My Session", &Some("feature-auth".to_string()), &[]);
+        assert_eq!(title, "My Session");
+    }
+
+    #[test]
+    fn test_provided_title_without_worktree_keeps_title() {
+        let title = resolve_title("Custom Name", &None, &[]);
+        assert_eq!(title, "Custom Name");
+    }
 }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -91,8 +91,8 @@ impl SortOrder {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GroupByMode {
-    Manual,
     #[default]
+    Manual,
     Project,
 }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -87,6 +87,31 @@ impl SortOrder {
     }
 }
 
+/// Session list grouping mode
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GroupByMode {
+    Manual,
+    #[default]
+    Project,
+}
+
+impl GroupByMode {
+    pub fn cycle(self) -> Self {
+        match self {
+            GroupByMode::Manual => GroupByMode::Project,
+            GroupByMode::Project => GroupByMode::Manual,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            GroupByMode::Manual => "Manual",
+            GroupByMode::Project => "Project",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AppStateConfig {
     #[serde(default)]
@@ -109,6 +134,9 @@ pub struct AppStateConfig {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub sort_order: Option<SortOrder>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub group_by: Option<GroupByMode>,
 }
 
 /// Session-related configuration defaults

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -15,8 +15,8 @@ mod storage;
 pub use crate::sound::{SoundConfig, SoundConfigOverride};
 pub use config::{
     get_claude_config_dir, get_update_settings, load_config, save_config, ClaudeConfig, Config,
-    ContainerRuntimeName, DefaultTerminalMode, SandboxConfig, SessionConfig, ThemeConfig,
-    TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig, WorktreeConfig,
+    ContainerRuntimeName, DefaultTerminalMode, GroupByMode, SandboxConfig, SessionConfig,
+    ThemeConfig, TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig, WorktreeConfig,
 };
 pub(crate) use environment::user_shell;
 pub use environment::validate_env_entry;

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 37;
+const DIALOG_HEIGHT: u16 = 38;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -24,7 +24,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("k/↑", "Move up"),
                 ("h/←", "Collapse group"),
                 ("l/→", "Expand group"),
-                ("g/G", "Go to top / bottom"),
+                ("Home/End", "Go to top / bottom"),
                 ("PgUp/Dn", "Move 10 items up / down"),
             ],
         ),
@@ -50,6 +50,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("H/L", "Resize list panel"),
                 ("o", "Cycle sort forward"),
                 ("Ctrl+o", "Cycle sort backward"),
+                ("g", "Toggle group by project"),
             ],
         ),
         (

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -117,12 +117,13 @@ impl Preview {
         cached_output: &str,
         theme: &Theme,
     ) {
-        // 3 base lines (profile+tool / path / status) + optional worktree block
+        // 3 base lines (profile+tool / path / status) + optional sandbox + optional worktree block
         let base = 3;
+        let sandbox_lines = if instance.is_sandboxed() { 1 } else { 0 };
         let info_height = if instance.worktree_info.is_some() {
-            base + 4 // blank + header + branch + main
+            base + sandbox_lines + 4 // blank + header + branch + main
         } else {
-            base
+            base + sandbox_lines
         };
 
         let chunks = Layout::default()
@@ -183,6 +184,16 @@ impl Preview {
                 ),
             ]),
         ]);
+
+        // Add sandbox information if present
+        if let Some(sandbox) = &instance.sandbox_info {
+            if sandbox.enabled {
+                info_lines.push(Line::from(vec![
+                    Span::styled("Sandbox: ", Style::default().fg(theme.dimmed)),
+                    Span::styled(&sandbox.container_name, Style::default().fg(theme.sandbox)),
+                ]));
+            }
+        }
 
         // Add worktree information if present
         if let Some(wt_info) = &instance.worktree_info {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -16,9 +16,9 @@ use super::DialogResult;
 use crate::containers::{self, ContainerRuntimeInterface};
 use crate::session::config::{DefaultTerminalMode, SandboxConfig};
 use crate::session::repo_config::HookProgress;
+use crate::session::resolve_config;
 #[cfg(test)]
 use crate::session::Config;
-use crate::session::{civilizations, resolve_config};
 use crate::tmux::AvailableTools;
 use crate::tui::components::{
     DirPicker, DirPickerResult, GroupGhostCompletion, ListPicker, ListPickerResult,
@@ -110,7 +110,6 @@ pub struct NewSessionDialog {
     pub(super) tool_index: usize,
     pub(super) focused_field: usize,
     pub(super) available_tools: Vec<String>,
-    pub(super) existing_titles: Vec<String>,
     pub(super) worktree_branch: Input,
     pub(super) create_new_branch: bool,
     pub(super) sandbox_enabled: bool,
@@ -299,7 +298,6 @@ fn build_inherited_settings(sandbox: &SandboxConfig) -> Vec<(String, String)> {
 impl NewSessionDialog {
     pub fn new(
         tools: AvailableTools,
-        existing_titles: Vec<String>,
         existing_groups: Vec<String>,
         profile: &str,
         available_profiles: Vec<String>,
@@ -374,7 +372,6 @@ impl NewSessionDialog {
             tool_index,
             focused_field: 0,
             available_tools,
-            existing_titles,
             existing_groups,
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
@@ -611,7 +608,6 @@ impl NewSessionDialog {
             tool_index,
             focused_field: 0,
             available_tools: tools,
-            existing_titles: Vec::new(),
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
@@ -671,7 +667,6 @@ impl NewSessionDialog {
             tool_index: 0,
             focused_field: 0,
             available_tools: tools.iter().map(|s| s.to_string()).collect(),
-            existing_titles: Vec::new(),
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
@@ -1422,12 +1417,7 @@ impl NewSessionDialog {
 
     fn build_submit_result(&self) -> DialogResult<NewSessionData> {
         let title_value = self.title.value().trim();
-        let final_title = if title_value.is_empty() {
-            let refs: Vec<&str> = self.existing_titles.iter().map(|s| s.as_str()).collect();
-            civilizations::generate_random_title(&refs)
-        } else {
-            title_value.to_string()
-        };
+        let final_title = title_value.to_string();
         let worktree_value = self.worktree_branch.value().trim();
         let has_worktree_branch = !worktree_value.is_empty();
         let worktree_branch = if has_worktree_branch {

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -49,18 +49,12 @@ fn test_esc_cancels() {
 }
 
 #[test]
-fn test_enter_submits_with_auto_title() {
-    use crate::session::civilizations;
-
+fn test_enter_submits_with_empty_title_for_builder() {
     let mut dialog = single_tool_dialog();
     let result = dialog.handle_key(key(KeyCode::Enter));
     match result {
         DialogResult::Submit(data) => {
-            assert!(
-                civilizations::CIVILIZATIONS.contains(&data.title.as_str()),
-                "Expected a civilization name, got: {}",
-                data.title
-            );
+            assert_eq!(data.title, "", "Empty title should pass through to builder");
             assert_eq!(data.path, TEST_PATH);
             assert_eq!(data.group, "");
             assert_eq!(data.tool, "claude");

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5,7 +5,7 @@ use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
 use super::{HomeView, TerminalMode, ViewMode};
-use crate::session::config::{load_config, save_config, SortOrder};
+use crate::session::config::{load_config, save_config, GroupByMode, SortOrder};
 use crate::session::{list_profiles, repo_config, resolve_config, Item, Status};
 use crate::tui::app::Action;
 use crate::tui::dialogs::{
@@ -560,8 +560,6 @@ impl HomeView {
                         "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
                     ));
                 } else {
-                    let existing_titles: Vec<String> =
-                        self.instances().iter().map(|i| i.title.clone()).collect();
                     let existing_groups: Vec<String> =
                         self.all_groups().iter().map(|g| g.path.clone()).collect();
                     let current_profile = self
@@ -572,7 +570,6 @@ impl HomeView {
                         list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
                     self.new_dialog = Some(NewSessionDialog::new(
                         self.available_tools.clone(),
-                        existing_titles,
                         existing_groups,
                         &current_profile,
                         profiles,
@@ -619,8 +616,6 @@ impl HomeView {
                         .or_else(|| self.selected_group.clone());
 
                     if prefill_path.is_some() || prefill_group.is_some() {
-                        let existing_titles: Vec<String> =
-                            self.instances().iter().map(|i| i.title.clone()).collect();
                         let existing_groups: Vec<String> =
                             self.all_groups().iter().map(|g| g.path.clone()).collect();
                         let current_profile = self
@@ -631,7 +626,6 @@ impl HomeView {
                             list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
                         let mut dialog = NewSessionDialog::new(
                             self.available_tools.clone(),
-                            existing_titles,
                             existing_groups,
                             &current_profile,
                             profiles,
@@ -873,9 +867,12 @@ impl HomeView {
             KeyCode::PageDown => {
                 self.move_cursor(10);
             }
-            KeyCode::Home | KeyCode::Char('g') if key.modifiers.contains(KeyModifiers::NONE) => {
+            KeyCode::Home => {
                 self.cursor = 0;
                 self.update_selected();
+            }
+            KeyCode::Char('g') => {
+                self.apply_group_by(self.group_by.cycle());
             }
             KeyCode::End | KeyCode::Char('G') => {
                 if !self.flat_items.is_empty() {
@@ -989,6 +986,19 @@ impl HomeView {
             config.app_state.sort_order = Some(self.sort_order);
             if let Err(e) = save_config(&config) {
                 tracing::warn!("Failed to save sort order: {}", e);
+            }
+        }
+    }
+
+    fn apply_group_by(&mut self, new_mode: GroupByMode) {
+        self.group_by = new_mode;
+        self.flat_items = self.build_flat_items();
+        self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
+        self.update_selected();
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.app_state.group_by = Some(self.group_by);
+            if let Err(e) = save_config(&config) {
+                tracing::warn!("Failed to save group_by mode: {}", e);
             }
         }
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -760,6 +760,13 @@ impl HomeView {
                         ));
                     }
                 } else if let Some(group_path) = &self.selected_group {
+                    if self.group_by == GroupByMode::Project {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Cannot Modify Project Groups",
+                            "Project groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
+                        ));
+                        return None;
+                    }
                     let prefix = format!("{}/", group_path);
                     let session_count = self
                         .instances
@@ -810,6 +817,13 @@ impl HomeView {
                         ));
                     }
                 } else if let Some(group_path) = &self.selected_group {
+                    if self.group_by == GroupByMode::Project {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Cannot Modify Project Groups",
+                            "Project groups are automatic. Press 'g' to switch to manual grouping to manage groups.",
+                        ));
+                        return None;
+                    }
                     let group_path = group_path.clone();
                     let current_profile = self
                         .selected_group_profile
@@ -995,15 +1009,31 @@ impl HomeView {
         self.flat_items = self.build_flat_items();
         self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
         self.update_selected();
-        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
-            config.app_state.group_by = Some(self.group_by);
-            if let Err(e) = save_config(&config) {
-                tracing::warn!("Failed to save group_by mode: {}", e);
+        match load_config().map(|c| c.unwrap_or_default()) {
+            Ok(mut config) => {
+                config.app_state.group_by = Some(self.group_by);
+                if let Err(e) = save_config(&config) {
+                    tracing::warn!("Failed to save group_by mode: {}", e);
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load config for group_by save: {}", e);
             }
         }
     }
 
     fn toggle_group_collapsed(&mut self, path: &str) {
+        if self.group_by == GroupByMode::Project {
+            let collapsed = self
+                .project_group_collapsed
+                .get(path)
+                .copied()
+                .unwrap_or(false);
+            self.project_group_collapsed
+                .insert(path.to_string(), !collapsed);
+            self.flat_items = self.build_flat_items();
+            return;
+        }
         // Route to the correct profile's GroupTree
         let profile = self.profile_for_cursor(self.cursor);
         if let Some(profile) = profile {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -40,10 +40,17 @@ fn project_group_name(inst: &Instance) -> String {
         .map(|wt| wt.main_repo_path.as_str())
         .unwrap_or(&inst.project_path);
 
-    std::path::Path::new(base_path)
-        .file_name()
+    let path = std::path::Path::new(base_path);
+    path.file_name()
         .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| base_path.to_string())
+        .unwrap_or_else(|| {
+            // For root paths like "/", use a readable fallback
+            if base_path == "/" || base_path.is_empty() {
+                "(root)".to_string()
+            } else {
+                base_path.to_string()
+            }
+        })
 }
 
 pub(super) struct GroupRenameContext {
@@ -134,6 +141,8 @@ pub struct HomeView {
     pub(super) view_mode: ViewMode,
     pub(super) sort_order: SortOrder,
     pub(super) group_by: GroupByMode,
+    /// Collapsed state for project-mode groups (persists across rebuilds)
+    pub(super) project_group_collapsed: HashMap<String, bool>,
 
     // Dialogs
     pub(super) show_help: bool,
@@ -286,6 +295,7 @@ impl HomeView {
             view_mode: ViewMode::default(),
             sort_order,
             group_by,
+            project_group_collapsed: HashMap::new(),
             show_help: false,
             new_dialog: None,
             confirm_dialog: None,
@@ -913,26 +923,65 @@ impl HomeView {
     }
 
     fn build_flat_items_by_project(&self) -> Vec<Item> {
-        let instances: Vec<Instance> = if let Some(profile) = &self.active_profile {
-            self.instances
+        let apply_project_groups = |instances: Vec<Instance>| -> Vec<Instance> {
+            instances
+                .into_iter()
+                .map(|mut inst| {
+                    inst.group_path = project_group_name(&inst);
+                    inst
+                })
+                .collect()
+        };
+
+        if let Some(profile) = &self.active_profile {
+            let filtered: Vec<Instance> = self
+                .instances
                 .iter()
                 .filter(|i| i.source_profile == *profile)
                 .cloned()
-                .collect()
+                .collect();
+            let grouped = apply_project_groups(filtered);
+            let mut tree = GroupTree::new_with_groups(&grouped, &[]);
+            for (path, &collapsed) in &self.project_group_collapsed {
+                if collapsed {
+                    tree.set_collapsed(path, true);
+                }
+            }
+            flatten_tree(&tree, &grouped, self.sort_order)
+        } else if self.storages.len() <= 1 {
+            let grouped = apply_project_groups(self.instances.clone());
+            let mut tree = GroupTree::new_with_groups(&grouped, &[]);
+            for (path, &collapsed) in &self.project_group_collapsed {
+                if collapsed {
+                    tree.set_collapsed(path, true);
+                }
+            }
+            flatten_tree(&tree, &grouped, self.sort_order)
         } else {
-            self.instances.clone()
-        };
-
-        let grouped: Vec<Instance> = instances
-            .into_iter()
-            .map(|mut inst| {
-                inst.group_path = project_group_name(&inst);
-                inst
-            })
-            .collect();
-
-        let tree = GroupTree::new_with_groups(&grouped, &[]);
-        flatten_tree(&tree, &grouped, self.sort_order)
+            // Multi-profile: build per-profile project trees, then flatten with profile headers
+            let mut per_profile_trees: HashMap<String, GroupTree> = HashMap::new();
+            let mut per_profile_instances: HashMap<String, Vec<Instance>> = HashMap::new();
+            for inst in &self.instances {
+                let mut grouped = inst.clone();
+                grouped.group_path = project_group_name(&grouped);
+                per_profile_instances
+                    .entry(inst.source_profile.clone())
+                    .or_default()
+                    .push(grouped);
+            }
+            for (profile, instances) in &per_profile_instances {
+                let mut tree = GroupTree::new_with_groups(instances, &[]);
+                for (path, &collapsed) in &self.project_group_collapsed {
+                    if collapsed {
+                        tree.set_collapsed(path, true);
+                    }
+                }
+                per_profile_trees.insert(profile.clone(), tree);
+            }
+            let all_grouped: Vec<Instance> =
+                per_profile_instances.into_values().flatten().collect();
+            flatten_tree_all_profiles(&all_grouped, &per_profile_trees, self.sort_order)
+        }
     }
 
     pub fn active_profile_display(&self) -> &str {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 use tui_input::Input;
 
 use crate::session::{
-    config::{load_config, save_config, SortOrder},
+    config::{load_config, save_config, GroupByMode, SortOrder},
     flatten_tree, flatten_tree_all_profiles, resolve_config, DefaultTerminalMode, Group, GroupTree,
     Instance, Item, Storage,
 };
@@ -29,6 +29,22 @@ use super::dialogs::{
 use super::diff::DiffView;
 use super::settings::SettingsView;
 use super::status_poller::StatusPoller;
+
+/// Extract a project group name from a session instance.
+/// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
+/// same repo group together), otherwise uses `project_path`. Returns the last path segment.
+fn project_group_name(inst: &Instance) -> String {
+    let base_path = inst
+        .worktree_info
+        .as_ref()
+        .map(|wt| wt.main_repo_path.as_str())
+        .unwrap_or(&inst.project_path);
+
+    std::path::Path::new(base_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| base_path.to_string())
+}
 
 pub(super) struct GroupRenameContext {
     pub(super) old_path: String,
@@ -117,6 +133,7 @@ pub struct HomeView {
     pub(super) selected_group_profile: Option<String>,
     pub(super) view_mode: ViewMode,
     pub(super) sort_order: SortOrder,
+    pub(super) group_by: GroupByMode,
 
     // Dialogs
     pub(super) show_help: bool,
@@ -250,6 +267,10 @@ impl HomeView {
             .as_ref()
             .and_then(|c| c.app_state.sort_order)
             .unwrap_or_default();
+        let group_by = user_config
+            .as_ref()
+            .and_then(|c| c.app_state.group_by)
+            .unwrap_or_default();
 
         let mut view = Self {
             storages,
@@ -264,6 +285,7 @@ impl HomeView {
             selected_group_profile: None,
             view_mode: ViewMode::default(),
             sort_order,
+            group_by,
             show_help: false,
             new_dialog: None,
             confirm_dialog: None,
@@ -490,10 +512,16 @@ impl HomeView {
     ) {
         // Build a stub instance to show in the list while creation runs
         let stub_title = if data.title.is_empty() {
-            std::path::Path::new(&data.path)
-                .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or_else(|| "New session".to_string())
+            data.worktree_branch
+                .as_deref()
+                .filter(|b| !b.is_empty())
+                .map(|b| b.to_string())
+                .unwrap_or_else(|| {
+                    std::path::Path::new(&data.path)
+                        .file_name()
+                        .map(|n| n.to_string_lossy().to_string())
+                        .unwrap_or_else(|| "New session".to_string())
+                })
         } else {
             data.title.clone()
         };
@@ -859,8 +887,11 @@ impl HomeView {
     }
 
     pub(super) fn build_flat_items(&self) -> Vec<Item> {
+        if self.group_by == GroupByMode::Project {
+            return self.build_flat_items_by_project();
+        }
+
         if let Some(profile) = &self.active_profile {
-            // Filtered to a single profile -- only include that profile's instances
             let filtered: Vec<Instance> = self
                 .instances
                 .iter()
@@ -872,7 +903,6 @@ impl HomeView {
                 None => Vec::new(),
             }
         } else if self.storages.len() <= 1 {
-            // All-profiles mode with only one profile -- skip the profile header
             match self.group_trees.values().next() {
                 Some(tree) => flatten_tree(tree, &self.instances, self.sort_order),
                 None => Vec::new(),
@@ -880,6 +910,29 @@ impl HomeView {
         } else {
             flatten_tree_all_profiles(&self.instances, &self.group_trees, self.sort_order)
         }
+    }
+
+    fn build_flat_items_by_project(&self) -> Vec<Item> {
+        let instances: Vec<Instance> = if let Some(profile) = &self.active_profile {
+            self.instances
+                .iter()
+                .filter(|i| i.source_profile == *profile)
+                .cloned()
+                .collect()
+        } else {
+            self.instances.clone()
+        };
+
+        let grouped: Vec<Instance> = instances
+            .into_iter()
+            .map(|mut inst| {
+                inst.group_path = project_group_name(&inst);
+                inst
+            })
+            .collect();
+
+        let tree = GroupTree::new_with_groups(&grouped, &[]);
+        flatten_tree(&tree, &grouped, self.sort_order)
     }
 
     pub fn active_profile_display(&self) -> &str {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -546,6 +546,20 @@ impl HomeView {
         stub.yolo_mode = data.yolo_mode;
         stub.source_profile = data.profile.clone();
 
+        // Set stub worktree_info so project-mode grouping works during creation.
+        // The real worktree_info (with resolved main_repo_path) replaces this
+        // once build_instance completes.
+        if let Some(ref branch) = data.worktree_branch {
+            if !branch.is_empty() {
+                stub.worktree_info = Some(crate::session::WorktreeInfo {
+                    branch: branch.clone(),
+                    main_repo_path: data.path.clone(),
+                    managed_by_aoe: false,
+                    created_at: chrono::Utc::now(),
+                });
+            }
+        }
+
         let stub_id = stub.id.clone();
         let target_profile = data.profile.clone();
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -276,10 +276,22 @@ impl HomeView {
             .as_ref()
             .and_then(|c| c.app_state.sort_order)
             .unwrap_or_default();
+        // New users (haven't dismissed the welcome screen) default to Project
+        // grouping so they see the same layout as the web dashboard. Existing
+        // users keep Manual (the existing behavior) unless they explicitly
+        // toggle to Project with `g`.
+        let is_new_user = user_config
+            .as_ref()
+            .is_none_or(|c| !c.app_state.has_seen_welcome);
+        let default_group_by = if is_new_user {
+            GroupByMode::Project
+        } else {
+            GroupByMode::Manual
+        };
         let group_by = user_config
             .as_ref()
             .and_then(|c| c.app_state.group_by)
-            .unwrap_or_default();
+            .unwrap_or(default_group_by);
 
         let mut view = Self {
             storages,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -923,65 +923,33 @@ impl HomeView {
     }
 
     fn build_flat_items_by_project(&self) -> Vec<Item> {
-        let apply_project_groups = |instances: Vec<Instance>| -> Vec<Instance> {
-            instances
-                .into_iter()
-                .map(|mut inst| {
-                    inst.group_path = project_group_name(&inst);
-                    inst
-                })
-                .collect()
-        };
-
-        if let Some(profile) = &self.active_profile {
-            let filtered: Vec<Instance> = self
-                .instances
+        // In project mode, always merge all sessions into one tree regardless of
+        // profile count. Project grouping unifies by repo across profiles.
+        let base_instances: Vec<Instance> = if let Some(profile) = &self.active_profile {
+            self.instances
                 .iter()
                 .filter(|i| i.source_profile == *profile)
                 .cloned()
-                .collect();
-            let grouped = apply_project_groups(filtered);
-            let mut tree = GroupTree::new_with_groups(&grouped, &[]);
-            for (path, &collapsed) in &self.project_group_collapsed {
-                if collapsed {
-                    tree.set_collapsed(path, true);
-                }
-            }
-            flatten_tree(&tree, &grouped, self.sort_order)
-        } else if self.storages.len() <= 1 {
-            let grouped = apply_project_groups(self.instances.clone());
-            let mut tree = GroupTree::new_with_groups(&grouped, &[]);
-            for (path, &collapsed) in &self.project_group_collapsed {
-                if collapsed {
-                    tree.set_collapsed(path, true);
-                }
-            }
-            flatten_tree(&tree, &grouped, self.sort_order)
+                .collect()
         } else {
-            // Multi-profile: build per-profile project trees, then flatten with profile headers
-            let mut per_profile_trees: HashMap<String, GroupTree> = HashMap::new();
-            let mut per_profile_instances: HashMap<String, Vec<Instance>> = HashMap::new();
-            for inst in &self.instances {
-                let mut grouped = inst.clone();
-                grouped.group_path = project_group_name(&grouped);
-                per_profile_instances
-                    .entry(inst.source_profile.clone())
-                    .or_default()
-                    .push(grouped);
+            self.instances.clone()
+        };
+
+        let grouped: Vec<Instance> = base_instances
+            .into_iter()
+            .map(|mut inst| {
+                inst.group_path = project_group_name(&inst);
+                inst
+            })
+            .collect();
+
+        let mut tree = GroupTree::new_with_groups(&grouped, &[]);
+        for (path, &collapsed) in &self.project_group_collapsed {
+            if collapsed {
+                tree.set_collapsed(path, true);
             }
-            for (profile, instances) in &per_profile_instances {
-                let mut tree = GroupTree::new_with_groups(instances, &[]);
-                for (path, &collapsed) in &self.project_group_collapsed {
-                    if collapsed {
-                        tree.set_collapsed(path, true);
-                    }
-                }
-                per_profile_trees.insert(profile.clone(), tree);
-            }
-            let all_grouped: Vec<Instance> =
-                per_profile_instances.into_values().flatten().collect();
-            flatten_tree_all_profiles(&all_grouped, &per_profile_trees, self.sort_order)
         }
+        flatten_tree(&tree, &grouped, self.sort_order)
     }
 
     pub fn active_profile_display(&self) -> &str {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -11,6 +11,7 @@ use super::{
     get_indent, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING, ICON_ERROR,
     ICON_EXPANDED, ICON_IDLE, ICON_STOPPED, ICON_UNKNOWN,
 };
+use crate::session::config::GroupByMode;
 use crate::session::{Item, Status};
 use crate::tui::components::{HelpOverlay, Preview};
 use crate::tui::styles::Theme;
@@ -165,9 +166,22 @@ impl HomeView {
     }
 
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let group_suffix = if self.group_by == GroupByMode::Project {
+            " (by project)"
+        } else {
+            ""
+        };
         let title = match self.view_mode {
-            ViewMode::Agent => format!(" Agent of Empires [{}] ", self.active_profile_display()),
-            ViewMode::Terminal => format!(" Terminals [{}] ", self.active_profile_display()),
+            ViewMode::Agent => format!(
+                " Agent of Empires [{}]{} ",
+                self.active_profile_display(),
+                group_suffix
+            ),
+            ViewMode::Terminal => format!(
+                " Terminals [{}]{} ",
+                self.active_profile_display(),
+                group_suffix
+            ),
         };
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Agent => (theme.border, theme.title),
@@ -410,28 +424,11 @@ impl HomeView {
                         Style::default().fg(theme.branch),
                     ));
                 } else if let Some(wt_info) = &inst.worktree_info {
-                    line_spans.push(Span::styled(
-                        format!("  {}", wt_info.branch),
-                        Style::default().fg(theme.branch),
-                    ));
-                }
-                if inst.is_sandboxed() {
-                    match self.view_mode {
-                        ViewMode::Agent => {
-                            line_spans.push(Span::styled(
-                                " [sandbox]",
-                                Style::default().fg(theme.sandbox),
-                            ));
-                        }
-                        ViewMode::Terminal => {
-                            let mode = self.get_terminal_mode(id);
-                            let mode_text = match mode {
-                                TerminalMode::Container => " [container]",
-                                TerminalMode::Host => " [host]",
-                            };
-                            line_spans
-                                .push(Span::styled(mode_text, Style::default().fg(theme.sandbox)));
-                        }
+                    if wt_info.branch != inst.title {
+                        line_spans.push(Span::styled(
+                            format!("  {}", wt_info.branch),
+                            Style::default().fg(theme.branch),
+                        ));
                     }
                 }
             }
@@ -800,6 +797,9 @@ impl HomeView {
             Span::styled("│", sep_style),
             Span::styled(" t", key_style),
             Span::styled(" View ", desc_style),
+            Span::styled("│", sep_style),
+            Span::styled(" g", key_style),
+            Span::styled(" Group ", desc_style),
         ]);
 
         // Show c: container/host hint for sandboxed sessions in Terminal view

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -27,15 +27,20 @@ struct TestEnv {
 }
 
 fn create_test_env_empty() -> TestEnv {
+    use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
     let _storage = Storage::new("test").unwrap(); // ensure profile dir exists
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     TestEnv { _temp: temp, view }
 }
 
 fn create_test_env_with_sessions(count: usize) -> TestEnv {
+    use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
     let storage = Storage::new("test").unwrap();
@@ -49,11 +54,15 @@ fn create_test_env_with_sessions(count: usize) -> TestEnv {
     storage.save(&instances).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     TestEnv { _temp: temp, view }
 }
 
 fn create_test_env_with_groups() -> TestEnv {
+    use crate::session::config::GroupByMode;
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
     let storage = Storage::new("test").unwrap();
@@ -73,7 +82,10 @@ fn create_test_env_with_groups() -> TestEnv {
     storage.save(&instances).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     TestEnv { _temp: temp, view }
 }
 
@@ -104,7 +116,10 @@ fn create_test_env_with_mixed_sessions() -> TestEnv {
     storage.save_with_groups(&instances, &group_tree).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     TestEnv { _temp: temp, view }
 }
 
@@ -183,7 +198,6 @@ fn test_has_dialog_returns_true_for_new_dialog() {
     let mut env = create_test_env_empty();
     env.view.new_dialog = Some(NewSessionDialog::new(
         AvailableTools::with_tools(&["claude"]),
-        Vec::new(),
         Vec::new(),
         "default",
         vec!["default".to_string()],
@@ -301,11 +315,15 @@ fn test_end_key() {
 
 #[test]
 #[serial]
-fn test_g_key_goes_to_start() {
-    let mut env = create_test_env_with_sessions(10);
-    env.view.cursor = 7;
+fn test_g_key_cycles_group_by() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_with_sessions(3);
+    env.view.group_by = GroupByMode::Manual;
     env.view.handle_key(key(KeyCode::Char('g')));
-    assert_eq!(env.view.cursor, 0);
+    assert_eq!(env.view.group_by, GroupByMode::Project);
+    env.view.handle_key(key(KeyCode::Char('g')));
+    assert_eq!(env.view.group_by, GroupByMode::Manual);
 }
 
 #[test]
@@ -767,6 +785,9 @@ fn test_uppercase_p_picker_switch_profile() {
     let _storage = Storage::new("first").unwrap();
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("first".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // Open picker
     view.handle_key(key(KeyCode::Char('P')));
@@ -952,7 +973,10 @@ fn create_test_env_with_group_sessions() -> TestEnv {
     storage.save_with_groups(&instances, &group_tree).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     TestEnv { _temp: temp, view }
 }
 
@@ -981,7 +1005,10 @@ fn test_group_has_managed_worktrees() {
     storage.save(&[inst1, inst2]).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     assert!(view.group_has_managed_worktrees("work", "work/"));
     assert!(!view.group_has_managed_worktrees("other", "other/"));
@@ -1014,7 +1041,10 @@ fn test_group_has_containers() {
     storage.save(&[inst1, inst2]).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     assert!(view.group_has_containers("work", "work/"));
     assert!(!view.group_has_containers("other", "other/"));
@@ -1152,6 +1182,9 @@ fn test_delete_group_with_sessions_respects_worktree_option() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // Select the work group
     view.cursor = 0;
@@ -1199,6 +1232,9 @@ fn test_delete_group_with_sessions_respects_container_option() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // Select the work group
     view.cursor = 0;
@@ -1675,7 +1711,10 @@ fn test_all_profiles_view_loads_from_multiple_profiles() {
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(None, tools).unwrap();
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     assert_eq!(view.instances().len(), 2);
     let profiles: Vec<&str> = view
@@ -1704,7 +1743,10 @@ fn test_filtered_view_loads_single_profile() {
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
+    let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     assert_eq!(view.instances().len(), 1);
     assert_eq!(view.instances()[0].title, "Alpha Session");
@@ -1724,7 +1766,10 @@ fn test_all_profiles_view_has_no_profile_headers() {
     storage_b.save(&[Instance::new("B1", "/tmp/b")]).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(None, tools).unwrap();
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // All items should be sessions (no profile headers)
     let session_count = view
@@ -1749,7 +1794,10 @@ fn test_all_profiles_view_shows_all_sessions_flat() {
     storage_b.save(&[Instance::new("B1", "/tmp/b")]).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(None, tools).unwrap();
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // All sessions from all profiles should be visible at depth 0
     for item in &view.flat_items {
@@ -1778,6 +1826,9 @@ fn test_create_session_in_all_mode_is_findable() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     let data = NewSessionData {
         profile: "alpha".to_string(),
@@ -1834,7 +1885,10 @@ fn test_save_preserves_per_profile_collapsed_state() {
 
     // Load unified view
     let tools = AvailableTools::with_tools(&["claude"]);
-    let view = HomeView::new(None, tools).unwrap();
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // Verify per-profile collapsed state is preserved
     let alpha_tree = view.group_trees.get("alpha").unwrap();
@@ -1927,6 +1981,9 @@ fn test_delete_group_scoped_to_owning_profile() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     // Both profiles should have a "work" group
     assert!(view.group_trees.get("alpha").unwrap().group_exists("work"));
@@ -2063,6 +2120,9 @@ fn test_shift_n_prefills_main_repo_path_for_worktree_session() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
     view.cursor = 0;
     view.update_selected();
 
@@ -2174,6 +2234,9 @@ fn test_rename_selected_group_with_children() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     view.group_rename_context = Some(super::GroupRenameContext {
         old_path: "work".to_string(),
@@ -2238,6 +2301,9 @@ fn test_rename_group_removes_old_path() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     view.group_rename_context = Some(super::GroupRenameContext {
         old_path: "work".to_string(),
@@ -2267,6 +2333,9 @@ fn test_rename_group_empty_group() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     view.group_rename_context = Some(super::GroupRenameContext {
         old_path: "empty-group".to_string(),
@@ -2306,6 +2375,9 @@ fn test_rename_group_duplicate_returns_error() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     view.group_rename_context = Some(super::GroupRenameContext {
         old_path: "work".to_string(),
@@ -2341,6 +2413,9 @@ fn test_rename_group_resort_az() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     view.group_rename_context = Some(super::GroupRenameContext {
         old_path: "zzz".to_string(),
@@ -2411,6 +2486,9 @@ fn test_apply_creation_results_returns_session_id() {
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("default".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
 
     let data = NewSessionData {
         profile: "default".to_string(),
@@ -2451,4 +2529,36 @@ fn test_apply_creation_results_returns_session_id() {
         view.get_instance(&session_id).is_some(),
         "created session should be findable after apply_creation_results"
     );
+}
+
+#[test]
+fn test_project_group_name_uses_last_path_segment() {
+    use super::project_group_name;
+
+    let mut inst = Instance::new("test", "/home/user/my-project");
+    assert_eq!(project_group_name(&inst), "my-project");
+}
+
+#[test]
+fn test_project_group_name_uses_main_repo_for_worktree() {
+    use super::project_group_name;
+    use crate::session::WorktreeInfo;
+    use chrono::Utc;
+
+    let mut inst = Instance::new("test", "/home/user/my-project/.worktrees/feature-abc");
+    inst.worktree_info = Some(WorktreeInfo {
+        branch: "feature-abc".to_string(),
+        main_repo_path: "/home/user/my-project".to_string(),
+        managed_by_aoe: true,
+        created_at: Utc::now(),
+    });
+    assert_eq!(project_group_name(&inst), "my-project");
+}
+
+#[test]
+fn test_project_group_name_handles_trailing_slash() {
+    use super::project_group_name;
+
+    let inst = Instance::new("test", "/home/user/my-project/");
+    assert_eq!(project_group_name(&inst), "my-project");
 }


### PR DESCRIPTION
## Description

Two UX improvements to the TUI session list:

**1. Default session name to branch name (#645)**
When creating a session with a worktree but no user-provided name, the branch name becomes the session title instead of a random civilization name. The branch is hidden from the session list when it matches the title (no redundancy). The `[sandbox]` indicator moves from the session list into the preview pane.

Before: `🔵 Koreans  trust [sandbox]`
After: `🔵 trust`

**2. Group sessions by project**
Press `g` to toggle between Manual grouping (user-defined) and Project grouping (automatic, by repository name). Project grouping mirrors the web dashboard's sidebar organization. Worktree sessions group by their main repo path. Project mode is the default for new users.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan
- [x] All Rust tests pass (1126 tests, 0 failures)
- [x] `cargo fmt` clean
- [x] `cargo clippy` clean
- [x] 8 new unit tests covering title resolution, project grouping, and keybinding

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)