### PR TITLE
feat(tui): press R for remote access over Cloudflare Tunnel

### DIFF
--- a/docs/guides/remote-phone-access.md
+++ b/docs/guides/remote-phone-access.md
@@ -1,0 +1,59 @@
+# Remote Access from Your Phone
+
+> Experimental — part of the web dashboard, which is still evolving.
+
+You can start agents on your laptop, go about your day, and check on them from your phone by scanning a QR code from the TUI. This guide takes about 60 seconds to walk through.
+
+## Prerequisite
+
+Install [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/):
+
+```bash
+# macOS
+brew install cloudflared
+
+# Debian/Ubuntu
+sudo apt install cloudflared
+```
+
+No Cloudflare account needed — `aoe` uses a Cloudflare *quick tunnel*, which is anonymous and ephemeral.
+
+## Enable from the TUI
+
+1. Launch `aoe` and press `R`.
+2. Read the security confirmation and press `Y` to enable.
+3. Wait 5–15 seconds for the tunnel to come up.
+4. Scan the QR code with your phone camera.
+5. When the browser opens, enter the displayed passphrase.
+
+That's it. Your phone is now inside the web dashboard. Any agent sessions you had running on your laptop are visible and interactive.
+
+## While it's running
+
+- The tunnel runs as a background daemon (the same one as `aoe serve --daemon`). It **survives TUI quits** — you can close the TUI and the tunnel keeps going.
+- Press `R` in the TUI any time to reopen the dialog; it reattaches to the running daemon and shows the URL again.
+- Press `S` inside the dialog to stop the daemon (equivalent to `aoe serve --stop`).
+- `Esc` just closes the dialog without touching the daemon.
+- If the daemon has been open for 8+ hours, the dialog header highlights as a passive nudge — nothing is killed.
+- The dialog shows the last 200 lines of the daemon's log so you can see what's happening under the hood.
+
+## Enabling via CLI instead
+
+If you prefer the command line, the same behavior is available via `aoe serve --remote --passphrase <value>`. The TUI toggle is a friendlier wrapper that generates the passphrase and URL for you and shows the QR code in-place. See [Web Dashboard](web-dashboard.md) for the full `aoe serve` reference.
+
+## Security notes
+
+- The tunnel URL alone is useless — the web dashboard requires the passphrase to log in.
+- If the passphrase leaks, someone else can run commands as you on this machine. Don't paste it into screenshots, don't post it on social, and stop the tunnel when you're done.
+- The quick tunnel URL rotates every time you re-enable it. Phones paired with an old URL will need to re-scan the new QR.
+- Each tunnel session gets a freshly generated passphrase. Nothing is persisted to disk.
+
+## Troubleshooting
+
+**"Cloudflare tunnel did not announce a URL within 60s."** Usually means `cloudflared` isn't installed or isn't on `$PATH`. Open a fresh shell, run `cloudflared --version`, and retry. The dialog leaves the daemon running — use `aoe serve --stop` if you want to fully reset before retrying.
+
+**"`aoe serve --remote --daemon` exited before the tunnel came up."** The daemon crashed at startup, most often because the chosen port was taken or `cloudflared` is missing. The dialog shows the last few log lines so you can see why; reopen the dialog to get a new port.
+
+**QR code looks garbled.** Widen your terminal window — the QR uses text cells and needs room. You can also scan the plain URL shown beneath the QR.
+
+**I started `aoe serve` from the CLI — does `R` still work?** Yes. The dialog detects the existing daemon and jumps straight to Active, showing the URL. Since it doesn't know the passphrase you typed at the CLI, the passphrase field shows "(set when the daemon started)" instead of the value.

--- a/docs/guides/remote-phone-access.md
+++ b/docs/guides/remote-phone-access.md
@@ -1,59 +1,26 @@
 # Remote Access from Your Phone
 
-> Experimental — part of the web dashboard, which is still evolving.
+Start agents on your laptop. Check on them from your phone.
 
-You can start agents on your laptop, go about your day, and check on them from your phone by scanning a QR code from the TUI. This guide takes about 60 seconds to walk through.
+## Four steps
 
-## Prerequisite
+1. **Install `aoe`** — see [Installation](../installation.md). You'll also need [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) (`brew install cloudflared` on macOS, `sudo apt install cloudflared` on Debian/Ubuntu). No Cloudflare account required.
+2. **Launch the TUI**: `aoe`.
+3. **Press `R`**, confirm, and wait ~10 seconds for the Cloudflare tunnel to come up.
+4. **Scan the QR code** with your phone camera, then type the displayed four-word passphrase.
 
-Install [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/):
+You're in.
 
-```bash
-# macOS
-brew install cloudflared
+## How it's protected
 
-# Debian/Ubuntu
-sudo apt install cloudflared
-```
+- **HTTPS end-to-end** via Cloudflare.
+- **Two factors**: the auth token embedded in the QR URL, plus the passphrase typed on the login page. Either alone is useless.
+- Tunnel stays up as a background daemon after you close the TUI. Press `R` again anytime to reattach, press `S` to stop, or run `aoe serve --stop` from a shell.
 
-No Cloudflare account needed — `aoe` uses a Cloudflare *quick tunnel*, which is anonymous and ephemeral.
-
-## Enable from the TUI
-
-1. Launch `aoe` and press `R`.
-2. Read the security confirmation and press `Y` to enable.
-3. Wait 5–15 seconds for the tunnel to come up.
-4. Scan the QR code with your phone camera.
-5. When the browser opens, enter the displayed passphrase.
-
-That's it. Your phone is now inside the web dashboard. Any agent sessions you had running on your laptop are visible and interactive.
-
-## While it's running
-
-- The tunnel runs as a background daemon (the same one as `aoe serve --daemon`). It **survives TUI quits** — you can close the TUI and the tunnel keeps going.
-- Press `R` in the TUI any time to reopen the dialog; it reattaches to the running daemon and shows the URL again.
-- Press `S` inside the dialog to stop the daemon (equivalent to `aoe serve --stop`).
-- `Esc` just closes the dialog without touching the daemon.
-- If the daemon has been open for 8+ hours, the dialog header highlights as a passive nudge — nothing is killed.
-- The dialog shows the last 200 lines of the daemon's log so you can see what's happening under the hood.
-
-## Enabling via CLI instead
-
-If you prefer the command line, the same behavior is available via `aoe serve --remote --passphrase <value>`. The TUI toggle is a friendlier wrapper that generates the passphrase and URL for you and shows the QR code in-place. See [Web Dashboard](web-dashboard.md) for the full `aoe serve` reference.
-
-## Security notes
-
-- The tunnel URL alone is useless — the web dashboard requires the passphrase to log in.
-- If the passphrase leaks, someone else can run commands as you on this machine. Don't paste it into screenshots, don't post it on social, and stop the tunnel when you're done.
-- The quick tunnel URL rotates every time you re-enable it. Phones paired with an old URL will need to re-scan the new QR.
-- Each tunnel session gets a freshly generated passphrase. Nothing is persisted to disk.
+Don't screenshot the QR and passphrase together, and stop the tunnel when you're done.
 
 ## Troubleshooting
 
-**"Cloudflare tunnel did not announce a URL within 60s."** Usually means `cloudflared` isn't installed or isn't on `$PATH`. Open a fresh shell, run `cloudflared --version`, and retry. The dialog leaves the daemon running — use `aoe serve --stop` if you want to fully reset before retrying.
-
-**"`aoe serve --remote --daemon` exited before the tunnel came up."** The daemon crashed at startup, most often because the chosen port was taken or `cloudflared` is missing. The dialog shows the last few log lines so you can see why; reopen the dialog to get a new port.
-
-**QR code looks garbled.** Widen your terminal window — the QR uses text cells and needs room. You can also scan the plain URL shown beneath the QR.
-
-**I started `aoe serve` from the CLI — does `R` still work?** Yes. The dialog detects the existing daemon and jumps straight to Active, showing the URL. Since it doesn't know the passphrase you typed at the CLI, the passphrase field shows "(set when the daemon started)" instead of the value.
+- **401 or "missing auth token"** — scan the QR, not a screenshot of the URL without the `?token=...` query.
+- **QR never appears** — `cloudflared --version` should work from the same shell you launched `aoe` from.
+- **Started `aoe serve` from the CLI instead** — press `R` in the TUI; it attaches to the running daemon.

--- a/docs/guides/remote-phone-access.md
+++ b/docs/guides/remote-phone-access.md
@@ -4,12 +4,12 @@ Start agents on your laptop. Check on them from your phone.
 
 ## Four steps
 
-1. **Install `aoe`** — see [Installation](../installation.md). You'll also need [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/) (`brew install cloudflared` on macOS, `sudo apt install cloudflared` on Debian/Ubuntu). No Cloudflare account required.
+1. **Install `aoe`** (see [Installation](../installation.md)). You'll also need [`cloudflared`](https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/): `brew install cloudflared` on macOS, `sudo apt install cloudflared` on Debian/Ubuntu. No Cloudflare account required.
 2. **Launch the TUI**: `aoe`.
 3. **Press `R`**, confirm, and wait ~10 seconds for the Cloudflare tunnel to come up.
 4. **Scan the QR code** with your phone camera, then type the displayed four-word passphrase.
 
-You're in. Tap **Share → Add to Home Screen** (iOS) or **three-dot menu → Install** (Android Chrome) and the dashboard installs as a PWA — launches from your home screen, standalone window, no browser chrome.
+You're in. Tap **Share → Add to Home Screen** (iOS) or **three-dot menu → Install** (Android Chrome) and the dashboard installs as a PWA: launches from your home screen, standalone window, no browser chrome.
 
 ## How it's protected
 
@@ -21,6 +21,6 @@ Don't screenshot the QR and passphrase together, and stop the tunnel when you're
 
 ## Troubleshooting
 
-- **401 or "missing auth token"** — scan the QR, not a screenshot of the URL without the `?token=...` query.
-- **QR never appears** — `cloudflared --version` should work from the same shell you launched `aoe` from.
-- **Started `aoe serve` from the CLI instead** — press `R` in the TUI; it attaches to the running daemon.
+- **401 or "missing auth token"**: scan the QR, not a screenshot of the URL without the `?token=...` query.
+- **QR never appears**: `cloudflared --version` should work from the same shell you launched `aoe` from.
+- **Started `aoe serve` from the CLI instead**: press `R` in the TUI; it attaches to the running daemon.

--- a/docs/guides/remote-phone-access.md
+++ b/docs/guides/remote-phone-access.md
@@ -9,7 +9,7 @@ Start agents on your laptop. Check on them from your phone.
 3. **Press `R`**, confirm, and wait ~10 seconds for the Cloudflare tunnel to come up.
 4. **Scan the QR code** with your phone camera, then type the displayed four-word passphrase.
 
-You're in.
+You're in. Tap **Share → Add to Home Screen** (iOS) or **three-dot menu → Install** (Android Chrome) and the dashboard installs as a PWA — launches from your home screen, standalone window, no browser chrome.
 
 ## How it's protected
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -48,9 +48,29 @@ pub struct ServeArgs {
     pub passphrase: Option<String>,
 }
 
-fn pid_file_path() -> Result<PathBuf> {
+pub fn pid_file_path() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?;
     Ok(dir.join("serve.pid"))
+}
+
+/// Returns Some(pid) if the daemon's PID file exists AND the process is
+/// still alive (via kill(pid, 0)). Cleans up stale PID files it finds.
+/// The TUI uses this to decide whether to jump straight to the Active
+/// state when the Remote Access dialog is opened.
+pub fn daemon_pid() -> Option<u32> {
+    let path = pid_file_path().ok()?;
+    let pid_str = std::fs::read_to_string(&path).ok()?;
+    let pid: i32 = pid_str.trim().parse().ok()?;
+
+    match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
+        Ok(()) => Some(pid as u32),
+        Err(_) => {
+            // Stale PID file; the ESRCH case is handled the same as any
+            // other error — the process is not reachable.
+            let _ = std::fs::remove_file(&path);
+            None
+        }
+    }
 }
 
 pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
@@ -181,6 +201,14 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     result
 }
 
+/// Path to the daemon's combined stdout/stderr log.
+/// Kept alongside the PID file so the TUI can tail it while the
+/// server runs without attaching to the process directly.
+pub fn daemon_log_path() -> Result<PathBuf> {
+    let dir = crate::session::get_app_dir()?;
+    Ok(dir.join("serve.log"))
+}
+
 fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     use std::process::{Command, Stdio};
 
@@ -217,9 +245,25 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
         cmd.args(["--profile", profile]);
     }
 
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null());
+    cmd.stdin(Stdio::null());
+
+    // Redirect stdout/stderr to a log file so controllers like the TUI can
+    // tail the daemon's output. Truncate on each start so stale content from
+    // a prior run doesn't confuse the UI.
+    let log_path = daemon_log_path().ok();
+    match log_path
+        .as_ref()
+        .and_then(|p| std::fs::File::create(p).ok().map(|f| (p.clone(), f)))
+    {
+        Some((_, log_file)) => {
+            let stdout = log_file.try_clone()?;
+            let stderr = log_file;
+            cmd.stdout(Stdio::from(stdout)).stderr(Stdio::from(stderr));
+        }
+        None => {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+    }
 
     let child = cmd.spawn()?;
     let pid = child.id();
@@ -273,6 +317,7 @@ fn stop_daemon() -> Result<()> {
             std::fs::remove_file(&path)?;
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
+                let _ = std::fs::remove_file(dir.join("serve.log"));
             }
             println!("Stopped aoe serve daemon (PID {})", pid);
         }
@@ -281,6 +326,7 @@ fn stop_daemon() -> Result<()> {
             std::fs::remove_file(&path)?;
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
+                let _ = std::fs::remove_file(dir.join("serve.log"));
             }
             println!("Daemon was not running (stale PID file cleaned up)");
         }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -53,17 +53,66 @@ pub fn pid_file_path() -> Result<PathBuf> {
     Ok(dir.join("serve.pid"))
 }
 
+/// Cross-platform check that `pid` belongs to an aoe / agent-of-empires
+/// process. PIDs get recycled, so `kill(pid, 0) == Ok` is not enough on
+/// its own — we also want to know it's actually *our* daemon.
+///
+/// Returns `true` if the process looks like ours, `false` otherwise.
+/// If we can't determine either way (platform lacks the lookup, ps
+/// missing), we return `true` so behavior matches the legacy Linux path
+/// of trusting the PID file rather than falsely flagging a real daemon
+/// as foreign.
+fn verify_pid_is_aoe(pid: i32) -> bool {
+    // Linux fast path: read /proc directly, no subprocess.
+    let proc_path = format!("/proc/{}/cmdline", pid);
+    if std::path::Path::new(&proc_path).exists() {
+        if let Ok(cmdline) = std::fs::read_to_string(&proc_path) {
+            return cmdline.contains("aoe") || cmdline.contains("agent-of-empires");
+        }
+    }
+
+    // macOS / other: shell out to `ps`. `-o command=` prints the full
+    // command (path + args) with no header.
+    match std::process::Command::new("ps")
+        .args(["-o", "command=", "-p", &pid.to_string()])
+        .output()
+    {
+        Ok(out) if out.status.success() => {
+            let s = String::from_utf8_lossy(&out.stdout);
+            s.contains("aoe") || s.contains("agent-of-empires")
+        }
+        // ps failed or unavailable — we can't verify, so trust the PID
+        // file rather than ghosting a real daemon.
+        _ => true,
+    }
+}
+
 /// Returns Some(pid) if the daemon's PID file exists AND the process is
-/// still alive (via kill(pid, 0)). Cleans up stale PID files it finds.
-/// The TUI uses this to decide whether to jump straight to the Active
-/// state when the Remote Access dialog is opened.
+/// still alive AND it looks like one of our aoe processes. Cleans up
+/// stale PID files it finds. The TUI uses this both to jump straight to
+/// the Active state when the Remote Access dialog opens and to render
+/// the "● Remote on" status-bar indicator.
 pub fn daemon_pid() -> Option<u32> {
     let path = pid_file_path().ok()?;
     let pid_str = std::fs::read_to_string(&path).ok()?;
     let pid: i32 = pid_str.trim().parse().ok()?;
 
     match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
-        Ok(()) => Some(pid as u32),
+        Ok(()) => {
+            if verify_pid_is_aoe(pid) {
+                Some(pid as u32)
+            } else {
+                // PID was recycled by an unrelated process — our daemon
+                // is dead. Clean up the stale file so subsequent callers
+                // don't keep false-positive-ing.
+                let _ = std::fs::remove_file(&path);
+                if let Ok(dir) = crate::session::get_app_dir() {
+                    let _ = std::fs::remove_file(dir.join("serve.url"));
+                    let _ = std::fs::remove_file(dir.join("serve.log"));
+                }
+                None
+            }
+        }
         Err(_) => {
             // Stale PID file; the ESRCH case is handled the same as any
             // other error — the process is not reachable.
@@ -294,18 +343,13 @@ fn stop_daemon() -> Result<()> {
         .parse()
         .map_err(|_| anyhow::anyhow!("Invalid PID in {}: {}", path.display(), pid_str.trim()))?;
 
-    // Verify PID belongs to an aoe process
-    let proc_path = format!("/proc/{}/cmdline", pid);
-    if std::path::Path::new(&proc_path).exists() {
-        if let Ok(cmdline) = std::fs::read_to_string(&proc_path) {
-            if !cmdline.contains("aoe") && !cmdline.contains("agent-of-empires") {
-                std::fs::remove_file(&path)?;
-                bail!(
-                    "PID {} belongs to a different process (stale PID file). Cleaned up.",
-                    pid
-                );
-            }
-        }
+    // Verify PID belongs to an aoe process on all platforms
+    if !verify_pid_is_aoe(pid) {
+        std::fs::remove_file(&path)?;
+        bail!(
+            "PID {} belongs to a different process (stale PID file). Cleaned up.",
+            pid
+        );
     }
 
     // Send SIGTERM

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 38;
+const DIALOG_HEIGHT: u16 = 39;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -60,6 +60,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("n/N", "Next/prev match"),
                 ("s", "Settings"),
                 ("P", "Profiles"),
+                ("R", "Remote access (phone)"),
                 ("?", "Toggle help"),
                 ("q", "Quit"),
             ],

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -10,6 +10,8 @@ mod hooks_install;
 mod info;
 mod new_session;
 mod profile_picker;
+#[cfg(feature = "serve")]
+mod remote;
 mod rename;
 mod send_message;
 mod welcome;
@@ -24,6 +26,8 @@ pub use hooks_install::HooksInstallDialog;
 pub use info::InfoDialog;
 pub use new_session::{NewSessionData, NewSessionDialog};
 pub use profile_picker::{ProfileEntry, ProfilePickerAction, ProfilePickerDialog};
+#[cfg(feature = "serve")]
+pub use remote::RemoteDialog;
 pub use rename::{RenameData, RenameDialog, RenameMode};
 pub use send_message::SendMessageDialog;
 pub use welcome::WelcomeDialog;

--- a/src/tui/dialogs/remote.rs
+++ b/src/tui/dialogs/remote.rs
@@ -1,0 +1,795 @@
+//! Remote access dialog: drives the `aoe serve --remote --daemon` daemon
+//! lifecycle and shows a QR + URL + passphrase + log tail so a phone can
+//! connect. The TUI is a controller here, not a host: it spawns the daemon,
+//! reads `$APP_DIR/serve.{pid,url,log}` files, and runs `aoe serve --stop`
+//! to tear down. The daemon survives across TUI quits, just like tmux
+//! sessions or the CLI-invoked daemon path.
+//!
+//! Only compiled with the `serve` feature, since the tunnel integration
+//! (and the qrcode crate it needs) lives there.
+#![cfg(feature = "serve")]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent};
+use qrcode::QrCode;
+use rand::distr::{Alphanumeric, SampleString};
+use rand::RngExt;
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use super::DialogResult;
+use crate::tui::styles::Theme;
+
+/// How long we wait for `serve.url` to appear after spawning the daemon.
+const TUNNEL_STARTUP_TIMEOUT_SECS: u64 = 60;
+/// How much of `serve.log` to keep in memory for the tail pane.
+const LOG_TAIL_LINES: usize = 200;
+
+pub enum RemoteDialogState {
+    /// No daemon running; show the scary warning and wait for Y/N.
+    Confirm,
+    /// We issued `aoe serve --remote --daemon`; now polling `serve.url`.
+    /// If `passphrase` is Some, the TUI spawned the daemon and knows it;
+    /// if None, a daemon was already running when the dialog opened.
+    Starting {
+        passphrase: Option<String>,
+        started_at: Instant,
+    },
+    /// Daemon is live. No child field — the TUI does not own it.
+    Active {
+        url: String,
+        /// Only known when this TUI started the daemon. For daemons
+        /// started via the CLI we show a "set at startup" placeholder.
+        passphrase: Option<String>,
+        opened_at: Instant,
+        log_tail: Vec<String>,
+        /// Last-seen log-file length so we only read appended bytes.
+        log_offset: u64,
+    },
+    Error(String),
+}
+
+pub struct RemoteDialog {
+    state: RemoteDialogState,
+    /// Passphrase we will use if the user confirms. Regenerated each time
+    /// the user opens the Confirm screen so leaked-to-stdout values rotate.
+    pending_passphrase: String,
+}
+
+impl Default for RemoteDialog {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RemoteDialog {
+    /// Construct the dialog. If a daemon is already running (detected via
+    /// `$APP_DIR/serve.pid`), jump straight to Active so the user can see
+    /// the URL and stop it; otherwise show Confirm.
+    pub fn new() -> Self {
+        if crate::cli::serve::daemon_pid().is_some() {
+            // There's already a daemon running. We don't know its passphrase
+            // (it may have been started from the CLI). Try to read serve.url
+            // immediately; if it's there, go Active. If not, wait.
+            match read_serve_url() {
+                Some(url) => Self {
+                    state: RemoteDialogState::Active {
+                        url,
+                        passphrase: None,
+                        opened_at: Instant::now(),
+                        log_tail: initial_log_tail(),
+                        log_offset: log_file_size(),
+                    },
+                    pending_passphrase: generate_passphrase(),
+                },
+                None => Self {
+                    state: RemoteDialogState::Starting {
+                        passphrase: None,
+                        started_at: Instant::now(),
+                    },
+                    pending_passphrase: generate_passphrase(),
+                },
+            }
+        } else {
+            Self {
+                state: RemoteDialogState::Confirm,
+                pending_passphrase: generate_passphrase(),
+            }
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        match &self.state {
+            RemoteDialogState::Confirm => match key.code {
+                KeyCode::Char('y') | KeyCode::Char('Y') => {
+                    match spawn_daemon(&self.pending_passphrase) {
+                        Ok(()) => {
+                            self.state = RemoteDialogState::Starting {
+                                passphrase: Some(self.pending_passphrase.clone()),
+                                started_at: Instant::now(),
+                            };
+                        }
+                        Err(e) => {
+                            self.state = RemoteDialogState::Error(e);
+                        }
+                    }
+                    DialogResult::Continue
+                }
+                KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Char('q') => {
+                    DialogResult::Cancel
+                }
+                _ => DialogResult::Continue,
+            },
+            RemoteDialogState::Starting { .. } => match key.code {
+                // Esc just closes the dialog; the daemon keeps coming up.
+                KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
+                KeyCode::Char('s') | KeyCode::Char('S') => {
+                    // Aborting startup: stop the (half-started) daemon.
+                    let _ = stop_daemon();
+                    DialogResult::Cancel
+                }
+                _ => DialogResult::Continue,
+            },
+            RemoteDialogState::Active { .. } => match key.code {
+                KeyCode::Char('s') | KeyCode::Char('S') => match stop_daemon() {
+                    Ok(()) => DialogResult::Cancel,
+                    Err(e) => {
+                        self.state = RemoteDialogState::Error(format!(
+                                "Stop failed: {}. Daemon may still be running; retry or use `aoe serve --stop` from a shell.",
+                                e
+                            ));
+                        DialogResult::Continue
+                    }
+                },
+                // Closing without stopping is explicitly allowed — TUI is a
+                // controller, the daemon keeps running.
+                KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
+                _ => DialogResult::Continue,
+            },
+            RemoteDialogState::Error(_) => match key.code {
+                KeyCode::Esc | KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('q') => {
+                    DialogResult::Cancel
+                }
+                _ => DialogResult::Continue,
+            },
+        }
+    }
+
+    /// Poll files on disk and drive state transitions. Returns true when
+    /// the visible state changed and a redraw is needed.
+    pub fn tick(&mut self) -> bool {
+        match &mut self.state {
+            RemoteDialogState::Starting {
+                passphrase,
+                started_at,
+            } => {
+                if let Some(url) = read_serve_url() {
+                    self.state = RemoteDialogState::Active {
+                        url,
+                        passphrase: passphrase.clone(),
+                        opened_at: Instant::now(),
+                        log_tail: initial_log_tail(),
+                        log_offset: log_file_size(),
+                    };
+                    return true;
+                }
+                // If the daemon process dies before writing serve.url,
+                // fail fast with the last few log lines so the user can see
+                // why.
+                if crate::cli::serve::daemon_pid().is_none() {
+                    let tail = initial_log_tail();
+                    let detail = if tail.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n\nLast log lines:\n{}", tail.join("\n"))
+                    };
+                    self.state = RemoteDialogState::Error(format!(
+                        "`aoe serve --remote --daemon` exited before the tunnel came up.{}",
+                        detail
+                    ));
+                    return true;
+                }
+                if started_at.elapsed() > Duration::from_secs(TUNNEL_STARTUP_TIMEOUT_SECS) {
+                    // Timeout: let the daemon keep running (user can use CLI),
+                    // but stop waiting on it in the dialog.
+                    self.state = RemoteDialogState::Error(format!(
+                        "Cloudflare tunnel did not announce a URL within {}s. \
+                         The daemon may still come up; check with `aoe serve --stop` or wait and reopen.",
+                        TUNNEL_STARTUP_TIMEOUT_SECS
+                    ));
+                    return true;
+                }
+                false
+            }
+            RemoteDialogState::Active {
+                log_tail,
+                log_offset,
+                ..
+            } => append_new_log_lines(log_tail, log_offset),
+            _ => false,
+        }
+    }
+
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        match &self.state {
+            RemoteDialogState::Confirm => render_confirm(frame, area, theme),
+            RemoteDialogState::Starting { started_at, .. } => {
+                render_starting(frame, area, theme, started_at.elapsed())
+            }
+            RemoteDialogState::Active {
+                url,
+                passphrase,
+                opened_at,
+                log_tail,
+                ..
+            } => render_active(
+                frame,
+                area,
+                theme,
+                url,
+                passphrase.as_deref(),
+                opened_at.elapsed(),
+                log_tail,
+            ),
+            RemoteDialogState::Error(msg) => render_error(frame, area, theme, msg),
+        }
+    }
+}
+
+fn spawn_daemon(passphrase: &str) -> Result<(), String> {
+    use std::process::Command;
+
+    let exe =
+        std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
+
+    // Use a high ephemeral port so we don't collide with a user's own
+    // `aoe serve` on 8080.
+    let port: u16 = rand::rng().random_range(49152..65535);
+
+    let status = Command::new(&exe)
+        .args([
+            "serve",
+            "--remote",
+            "--daemon",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port.to_string(),
+        ])
+        .env("AOE_SERVE_PASSPHRASE", passphrase)
+        .stdin(std::process::Stdio::null())
+        // The daemon path forks and logs to serve.log; we only need its
+        // exit status here (it's synchronous since it just double-forks).
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map_err(|e| format!("Failed to launch `aoe serve --remote --daemon`: {}", e))?;
+
+    if !status.success() {
+        return Err(format!(
+            "`aoe serve --remote --daemon` exited with {:?}. \
+             Most likely `cloudflared` is not installed \
+             (brew install cloudflared) or port {} is in use.",
+            status.code(),
+            port
+        ));
+    }
+    Ok(())
+}
+
+fn stop_daemon() -> Result<(), String> {
+    use std::process::Command;
+
+    let exe =
+        std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
+
+    let output = Command::new(&exe)
+        .args(["serve", "--stop"])
+        .output()
+        .map_err(|e| format!("Failed to invoke `aoe serve --stop`: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(stderr.trim().to_string());
+    }
+    Ok(())
+}
+
+fn read_serve_url() -> Option<String> {
+    let dir = crate::session::get_app_dir().ok()?;
+    let raw = std::fs::read_to_string(dir.join("serve.url")).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn log_file_path() -> Option<PathBuf> {
+    crate::cli::serve::daemon_log_path().ok()
+}
+
+fn log_file_size() -> u64 {
+    log_file_path()
+        .and_then(|p| std::fs::metadata(&p).ok())
+        .map(|m| m.len())
+        .unwrap_or(0)
+}
+
+fn initial_log_tail() -> Vec<String> {
+    let Some(path) = log_file_path() else {
+        return Vec::new();
+    };
+    let Ok(contents) = std::fs::read_to_string(&path) else {
+        return Vec::new();
+    };
+    let all: Vec<&str> = contents.lines().collect();
+    let start = all.len().saturating_sub(LOG_TAIL_LINES);
+    all[start..].iter().map(|s| s.to_string()).collect()
+}
+
+/// Read any new bytes appended to the log file since `offset` and push the
+/// resulting lines into `tail`, clamped to LOG_TAIL_LINES. Returns true if
+/// new content arrived.
+fn append_new_log_lines(tail: &mut Vec<String>, offset: &mut u64) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Some(path) = log_file_path() else {
+        return false;
+    };
+    let Ok(mut file) = std::fs::File::open(&path) else {
+        return false;
+    };
+    let Ok(size) = file.metadata().map(|m| m.len()) else {
+        return false;
+    };
+    if size <= *offset {
+        if size < *offset {
+            // File was truncated (daemon restart). Reset.
+            *offset = 0;
+            tail.clear();
+        } else {
+            return false;
+        }
+    }
+
+    if file.seek(SeekFrom::Start(*offset)).is_err() {
+        return false;
+    }
+    let mut buf = String::new();
+    if file.read_to_string(&mut buf).is_err() {
+        return false;
+    }
+    *offset = size;
+
+    let mut changed = false;
+    for line in buf.lines() {
+        tail.push(line.to_string());
+        changed = true;
+    }
+    if tail.len() > LOG_TAIL_LINES {
+        let drop = tail.len() - LOG_TAIL_LINES;
+        tail.drain(..drop);
+    }
+    changed
+}
+
+fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme) {
+    let dialog = super::centered_rect(area, 70, 22);
+    frame.render_widget(Clear, dialog);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.accent))
+        .title(Line::styled(
+            " Enable remote access? ",
+            Style::default().fg(theme.accent).bold(),
+        ));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Min(1), Constraint::Length(2)])
+        .split(inner);
+
+    let body = vec![
+        Line::from(Span::styled(
+            "This lets you reach your agent sessions from your phone",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(Span::styled(
+            "(or any browser) via a public Cloudflare URL.",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "How it's protected:",
+            Style::default().fg(theme.title).bold(),
+        )),
+        Line::from(vec![
+            Span::styled("  \u{2022} ", Style::default().fg(theme.running)),
+            Span::styled(
+                "HTTPS end-to-end via Cloudflare (traffic is encrypted).",
+                Style::default().fg(theme.text),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("  \u{2022} ", Style::default().fg(theme.running)),
+            Span::styled(
+                "Two factors required to log in: a token (in the URL /",
+                Style::default().fg(theme.text),
+            ),
+        ]),
+        Line::from(Span::styled(
+            "    QR code) AND a passphrase typed on a login page.",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(vec![
+            Span::styled("  \u{2022} ", Style::default().fg(theme.running)),
+            Span::styled(
+                "Knowing just the URL, or just the passphrase, is useless.",
+                Style::default().fg(theme.text),
+            ),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "What to watch out for:",
+            Style::default().fg(theme.title).bold(),
+        )),
+        Line::from(Span::styled(
+            "  If someone gets BOTH the token and the passphrase, they",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(Span::styled(
+            "  can run commands as you. Don't post screenshots of the",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(Span::styled(
+            "  QR + passphrase together, and stop the tunnel when done.",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Runs as a background daemon. Survives TUI exit.",
+            Style::default().fg(theme.dimmed),
+        )),
+        Line::from(Span::styled(
+            "Requires `cloudflared` (brew install cloudflared).",
+            Style::default().fg(theme.dimmed),
+        )),
+        Line::from(Span::styled(
+            "Stop anytime with [S] here or `aoe serve --stop`.",
+            Style::default().fg(theme.dimmed),
+        )),
+    ];
+    frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: true }), chunks[0]);
+
+    let buttons = Line::from(vec![
+        Span::styled("[Y] Enable", Style::default().fg(theme.running).bold()),
+        Span::raw("        "),
+        Span::styled("[N] Cancel", Style::default().fg(theme.dimmed).bold()),
+    ]);
+    frame.render_widget(
+        Paragraph::new(buttons).alignment(Alignment::Center),
+        chunks[1],
+    );
+}
+
+fn render_starting(frame: &mut Frame, area: Rect, theme: &Theme, elapsed: Duration) {
+    let dialog = super::centered_rect(area, 60, 9);
+    frame.render_widget(Clear, dialog);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.border))
+        .title(Line::styled(
+            " Starting remote access... ",
+            Style::default().fg(theme.title).bold(),
+        ));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+
+    let body = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "Waiting for the daemon to bring the tunnel up",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(Span::styled(
+            "(usually 5\u{2013}15 seconds).",
+            Style::default().fg(theme.text),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            format!("Elapsed: {}s    [Esc close]  [S stop]", elapsed.as_secs()),
+            Style::default().fg(theme.dimmed),
+        )),
+    ];
+    frame.render_widget(Paragraph::new(body).alignment(Alignment::Center), inner);
+}
+
+fn render_active(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    url: &str,
+    passphrase: Option<&str>,
+    elapsed: Duration,
+    log_tail: &[String],
+) {
+    // Keep the URL a QR encodes small: strip the `?token=` query so the QR
+    // stays dense and legible on terminals below ~90 cols. The phone still
+    // lands on the login page (passphrase required) so first-factor isn't
+    // lost.
+    let qr_target = strip_query(url);
+    let qr_text = match QrCode::new(qr_target.as_bytes()) {
+        Ok(code) => code
+            .render::<char>()
+            .quiet_zone(true)
+            .module_dimensions(2, 1)
+            .build(),
+        Err(_) => String::from("(QR unavailable \u{2014} use the URL below)"),
+    };
+
+    let qr_lines: Vec<&str> = qr_text.lines().collect();
+    let qr_height = qr_lines.len() as u16;
+    let qr_width = qr_lines.first().map(|l| l.chars().count()).unwrap_or(0) as u16;
+
+    let want_width = (qr_width + 6).max(60);
+    let log_height: u16 = 6;
+    let want_height = qr_height + 4 /* url/passphrase/elapsed */ + log_height + 3 /* borders */;
+
+    let dialog_width = want_width.min(area.width);
+    let dialog_height = want_height.min(area.height);
+    let dialog = super::centered_rect(area, dialog_width, dialog_height);
+    frame.render_widget(Clear, dialog);
+
+    let eight_hours = Duration::from_secs(8 * 3600);
+    let reminder = if elapsed >= eight_hours {
+        format!(
+            " Remote access (open {}h) \u{2014} still need it? ",
+            elapsed.as_secs() / 3600
+        )
+    } else {
+        " Remote access ".to_string()
+    };
+    let title_color = if elapsed >= eight_hours {
+        theme.waiting
+    } else {
+        theme.title
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.border))
+        .title(Line::styled(
+            reminder,
+            Style::default().fg(title_color).bold(),
+        ));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(qr_height),
+            Constraint::Length(1), // url
+            Constraint::Length(1), // passphrase
+            Constraint::Length(1), // elapsed
+            Constraint::Min(1),    // log tail
+            Constraint::Length(1), // footer
+        ])
+        .split(inner);
+
+    let qr_widget: Vec<Line> = qr_lines
+        .iter()
+        .map(|l| Line::from(Span::styled(*l, Style::default().fg(theme.text))))
+        .collect();
+    frame.render_widget(
+        Paragraph::new(qr_widget).alignment(Alignment::Center),
+        chunks[0],
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("URL: ", Style::default().fg(theme.dimmed)),
+            Span::styled(url, Style::default().fg(theme.accent)),
+        ]))
+        .alignment(Alignment::Center),
+        chunks[1],
+    );
+
+    let (pp_label, pp_style) = match passphrase {
+        Some(pp) => (pp.to_string(), Style::default().fg(theme.accent).bold()),
+        None => (
+            "(set when the daemon started \u{2014} check the shell that ran `aoe serve`)"
+                .to_string(),
+            Style::default().fg(theme.dimmed),
+        ),
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("Passphrase: ", Style::default().fg(theme.dimmed)),
+            Span::styled(pp_label, pp_style),
+        ]))
+        .alignment(Alignment::Center),
+        chunks[2],
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            format!(
+                "Open for {}  (daemon keeps running if you close this dialog)",
+                format_elapsed(elapsed)
+            ),
+            Style::default().fg(theme.dimmed),
+        )))
+        .alignment(Alignment::Center),
+        chunks[3],
+    );
+
+    let log_lines: Vec<Line> = log_tail
+        .iter()
+        .rev()
+        .take(chunks[4].height.max(1) as usize)
+        .rev()
+        .map(|l| Line::from(Span::styled(l.as_str(), Style::default().fg(theme.dimmed))))
+        .collect();
+    let log_block = Block::default()
+        .borders(Borders::TOP)
+        .border_style(Style::default().fg(theme.border))
+        .title(Line::styled(" Log ", Style::default().fg(theme.dimmed)));
+    let log_inner = log_block.inner(chunks[4]);
+    frame.render_widget(log_block, chunks[4]);
+    frame.render_widget(Paragraph::new(log_lines), log_inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "[S] Stop daemon    [Esc] Close (daemon keeps running)",
+            Style::default().fg(theme.dimmed),
+        )))
+        .alignment(Alignment::Center),
+        chunks[5],
+    );
+}
+
+fn render_error(frame: &mut Frame, area: Rect, theme: &Theme, msg: &str) {
+    let dialog = super::centered_rect(area, 70, 15);
+    frame.render_widget(Clear, dialog);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.error))
+        .title(Line::styled(
+            " Remote access failed ",
+            Style::default().fg(theme.error).bold(),
+        ));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(msg)
+            .wrap(Wrap { trim: true })
+            .style(Style::default().fg(theme.text)),
+        chunks[0],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "[Enter] Close",
+            Style::default().fg(theme.dimmed),
+        )))
+        .alignment(Alignment::Center),
+        chunks[1],
+    );
+}
+
+fn format_elapsed(d: Duration) -> String {
+    let total = d.as_secs();
+    let h = total / 3600;
+    let m = (total % 3600) / 60;
+    let s = total % 60;
+    if h > 0 {
+        format!("{}h {:02}m", h, m)
+    } else if m > 0 {
+        format!("{}m {:02}s", m, s)
+    } else {
+        format!("{}s", s)
+    }
+}
+
+fn generate_passphrase() -> String {
+    // 12 alphanumerics gives ~72 bits of entropy; legible over a phone screen.
+    Alphanumeric.sample_string(&mut rand::rng(), 12)
+}
+
+fn strip_query(url: &str) -> String {
+    match url.split_once('?') {
+        Some((before, _)) => before.trim_end_matches('/').to_string(),
+        None => url.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passphrase_has_expected_length_and_charset() {
+        let pw = generate_passphrase();
+        assert_eq!(pw.len(), 12);
+        assert!(pw.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn format_elapsed_shows_units() {
+        assert_eq!(format_elapsed(Duration::from_secs(5)), "5s");
+        assert_eq!(format_elapsed(Duration::from_secs(65)), "1m 05s");
+        assert_eq!(format_elapsed(Duration::from_secs(3600 + 120)), "1h 02m");
+    }
+
+    #[test]
+    fn strip_query_removes_token() {
+        assert_eq!(
+            strip_query("https://foo.trycloudflare.com/?token=abc"),
+            "https://foo.trycloudflare.com"
+        );
+        assert_eq!(
+            strip_query("https://foo.trycloudflare.com"),
+            "https://foo.trycloudflare.com"
+        );
+    }
+
+    #[test]
+    fn append_new_log_lines_detects_growth() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Shim: write into a controlled path and verify our helper shape
+        // by reading a simulated log file.
+        let path = tmp.path().join("fake.log");
+        std::fs::write(&path, "first line\nsecond line\n").unwrap();
+
+        // The real helper reads from $APP_DIR/serve.log; we test the
+        // parsing branch directly by calling with a known file.
+        let mut tail: Vec<String> = Vec::new();
+        let mut offset: u64 = 0;
+        // Emulate the helper body against a custom path.
+        use std::io::{Read, Seek, SeekFrom};
+        let mut f = std::fs::File::open(&path).unwrap();
+        let size = f.metadata().unwrap().len();
+        assert!(size > offset);
+        f.seek(SeekFrom::Start(offset)).unwrap();
+        let mut buf = String::new();
+        f.read_to_string(&mut buf).unwrap();
+        offset = size;
+        for l in buf.lines() {
+            tail.push(l.to_string());
+        }
+        assert_eq!(tail, vec!["first line", "second line"]);
+
+        // Second append.
+        std::fs::write(&path, "first line\nsecond line\nthird\n").unwrap();
+        let size = std::fs::metadata(&path).unwrap().len();
+        let mut f = std::fs::File::open(&path).unwrap();
+        f.seek(SeekFrom::Start(offset)).unwrap();
+        let mut buf = String::new();
+        f.read_to_string(&mut buf).unwrap();
+        let prior = tail.len();
+        for l in buf.lines() {
+            tail.push(l.to_string());
+        }
+        assert_eq!(tail.len(), prior + 1);
+        assert!(size >= offset);
+    }
+}

--- a/src/tui/dialogs/remote.rs
+++ b/src/tui/dialogs/remote.rs
@@ -625,12 +625,13 @@ fn render_active(
     elapsed: Duration,
     log_tail: &[String],
 ) {
-    // Keep the URL a QR encodes small: strip the `?token=` query so the QR
-    // stays dense and legible on terminals below ~90 cols. The phone still
-    // lands on the login page (passphrase required) so first-factor isn't
-    // lost.
-    let qr_target = strip_query(url);
-    let qr_text = match QrCode::new(qr_target.as_bytes()) {
+    // Encode the full URL including `?token=...` — the server's auth
+    // middleware rejects requests on `/` with "invalid or missing auth
+    // token" when the query param isn't present, so the phone would hit
+    // 401 before ever seeing the passphrase login. The QR is a little
+    // larger as a result; users with narrow terminals can always type
+    // the plain URL shown beneath it.
+    let qr_text = match QrCode::new(url.as_bytes()) {
         Ok(code) => code
             .render::<char>()
             .quiet_zone(true)
@@ -928,13 +929,6 @@ const PASSPHRASE_WORDS: &[&str] = &[
     "mule", "muse", "music", "mute", "myth",
 ];
 
-fn strip_query(url: &str) -> String {
-    match url.split_once('?') {
-        Some((before, _)) => before.trim_end_matches('/').to_string(),
-        None => url.to_string(),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -989,18 +983,6 @@ mod tests {
         assert_eq!(format_elapsed(Duration::from_secs(5)), "5s");
         assert_eq!(format_elapsed(Duration::from_secs(65)), "1m 05s");
         assert_eq!(format_elapsed(Duration::from_secs(3600 + 120)), "1h 02m");
-    }
-
-    #[test]
-    fn strip_query_removes_token() {
-        assert_eq!(
-            strip_query("https://foo.trycloudflare.com/?token=abc"),
-            "https://foo.trycloudflare.com"
-        );
-        assert_eq!(
-            strip_query("https://foo.trycloudflare.com"),
-            "https://foo.trycloudflare.com"
-        );
     }
 
     #[test]

--- a/src/tui/dialogs/remote.rs
+++ b/src/tui/dialogs/remote.rs
@@ -13,6 +13,7 @@ use std::path::PathBuf;
 use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent};
+use qrcode::render::unicode::Dense1x2;
 use qrcode::QrCode;
 use rand::prelude::IndexedRandom;
 use rand::RngExt;
@@ -628,14 +629,18 @@ fn render_active(
     // Encode the full URL including `?token=...` — the server's auth
     // middleware rejects requests on `/` with "invalid or missing auth
     // token" when the query param isn't present, so the phone would hit
-    // 401 before ever seeing the passphrase login. The QR is a little
-    // larger as a result; users with narrow terminals can always type
-    // the plain URL shown beneath it.
+    // 401 before ever seeing the passphrase login.
+    //
+    // Use half-block Unicode rendering (Dense1x2): each terminal row
+    // carries two QR module rows via `\u{2580}` / `\u{2584}` / space /
+    // full-block. That's roughly 4× smaller than the previous 2\u{00D7}1 char
+    // rendering while staying scannable on any phone camera.
     let qr_text = match QrCode::new(url.as_bytes()) {
         Ok(code) => code
-            .render::<char>()
+            .render::<Dense1x2>()
             .quiet_zone(true)
-            .module_dimensions(2, 1)
+            .dark_color(Dense1x2::Dark)
+            .light_color(Dense1x2::Light)
             .build(),
         Err(_) => String::from("(QR unavailable \u{2014} use the URL below)"),
     };

--- a/src/tui/dialogs/remote.rs
+++ b/src/tui/dialogs/remote.rs
@@ -188,6 +188,13 @@ impl RemoteDialog {
                 _ => DialogResult::Continue,
             },
             RemoteDialogState::Error(_) => match key.code {
+                KeyCode::Char('s') | KeyCode::Char('S') => {
+                    // Best-effort stop for a daemon that may still be
+                    // lingering. Ignore the result — if there's no daemon
+                    // to stop, that's the desired state anyway.
+                    let _ = stop_daemon();
+                    DialogResult::Cancel
+                }
                 KeyCode::Esc | KeyCode::Enter | KeyCode::Char(' ') | KeyCode::Char('q') => {
                     DialogResult::Cancel
                 }
@@ -231,12 +238,32 @@ impl RemoteDialog {
                     return true;
                 }
                 if started_at.elapsed() > Duration::from_secs(TUNNEL_STARTUP_TIMEOUT_SECS) {
-                    // Timeout: let the daemon keep running (user can use CLI),
-                    // but stop waiting on it in the dialog.
+                    // Timeout: the daemon is alive but never produced a
+                    // tunnel URL (cloudflared rate-limited, captive portal,
+                    // etc.). Stop it now so we don't leave a zombie that
+                    // can never serve phones but keeps tripping "● Remote
+                    // on" in the status bar. Fall through to a log-tail
+                    // error view the user can act on.
+                    let stop_note = match stop_daemon() {
+                        Ok(()) => "Stuck daemon stopped.".to_string(),
+                        Err(e) => format!(
+                            "Daemon may still be running \
+                             (tried to stop: {}). Stop manually with `aoe serve --stop`.",
+                            e
+                        ),
+                    };
+                    let tail = initial_log_tail();
+                    let tail_detail = if tail.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n\nLast log lines:\n{}", tail.join("\n"))
+                    };
                     self.state = RemoteDialogState::Error(format!(
                         "Cloudflare tunnel did not announce a URL within {}s. \
-                         The daemon may still come up; check with `aoe serve --stop` or wait and reopen.",
-                        TUNNEL_STARTUP_TIMEOUT_SECS
+                         {}\n\n\
+                         Most likely cause: `cloudflared` rate-limited, \
+                         captive portal, or no internet.{}",
+                        TUNNEL_STARTUP_TIMEOUT_SECS, stop_note, tail_detail
                     ));
                     return true;
                 }
@@ -284,6 +311,13 @@ fn spawn_daemon(passphrase: &str) -> Result<(), String> {
 
     let exe =
         std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
+
+    // Delete any stale serve.url from a previous hard-killed daemon
+    // before launching. Without this, Starting-state polling could latch
+    // onto the old URL before the new daemon writes the new one.
+    if let Ok(dir) = crate::session::get_app_dir() {
+        let _ = std::fs::remove_file(dir.join("serve.url"));
+    }
 
     // Use a high ephemeral port so we don't collide with a user's own
     // `aoe serve` on 8080.
@@ -376,12 +410,22 @@ fn initial_log_tail() -> Vec<String> {
 /// resulting lines into `tail`, clamped to LOG_TAIL_LINES. Returns true if
 /// new content arrived.
 fn append_new_log_lines(tail: &mut Vec<String>, offset: &mut u64) -> bool {
-    use std::io::{Read, Seek, SeekFrom};
-
     let Some(path) = log_file_path() else {
         return false;
     };
-    let Ok(mut file) = std::fs::File::open(&path) else {
+    append_new_log_lines_from(&path, tail, offset)
+}
+
+/// Path-explicit inner helper so tests can exercise the real logic
+/// against a tempfile.
+fn append_new_log_lines_from(
+    path: &std::path::Path,
+    tail: &mut Vec<String>,
+    offset: &mut u64,
+) -> bool {
+    use std::io::{Read, Seek, SeekFrom};
+
+    let Ok(mut file) = std::fs::File::open(path) else {
         return false;
     };
     let Ok(size) = file.metadata().map(|m| m.len()) else {
@@ -520,10 +564,18 @@ fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme, enable_selected:
     } else {
         Style::default().fg(theme.dimmed)
     };
+    // Enter activates whichever button is highlighted, so only show the
+    // hint on that one to avoid the "[Enter] Enable" lie when Cancel is
+    // selected.
+    let (enable_label, cancel_label) = if enable_selected {
+        ("[Enter/Y] Enable", "[Esc/N] Cancel")
+    } else {
+        ("[Y] Enable", "[Enter/Esc] Cancel")
+    };
     let buttons = Line::from(vec![
-        Span::styled("[Y/Enter] Enable", enable_style),
+        Span::styled(enable_label, enable_style),
         Span::raw("    "),
-        Span::styled("[N/Esc] Cancel", cancel_style),
+        Span::styled(cancel_label, cancel_style),
     ]);
     frame.render_widget(
         Paragraph::new(buttons).alignment(Alignment::Center),
@@ -739,7 +791,7 @@ fn render_error(frame: &mut Frame, area: Rect, theme: &Theme, msg: &str) {
     );
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "[Enter] Close",
+            "[S] Force-stop daemon    [Enter] Close",
             Style::default().fg(theme.dimmed),
         )))
         .alignment(Alignment::Center),
@@ -952,43 +1004,68 @@ mod tests {
     }
 
     #[test]
-    fn append_new_log_lines_detects_growth() {
+    fn append_new_log_lines_initial_read() {
         let tmp = tempfile::tempdir().unwrap();
-        // Shim: write into a controlled path and verify our helper shape
-        // by reading a simulated log file.
-        let path = tmp.path().join("fake.log");
+        let path = tmp.path().join("serve.log");
         std::fs::write(&path, "first line\nsecond line\n").unwrap();
 
-        // The real helper reads from $APP_DIR/serve.log; we test the
-        // parsing branch directly by calling with a known file.
         let mut tail: Vec<String> = Vec::new();
         let mut offset: u64 = 0;
-        // Emulate the helper body against a custom path.
-        use std::io::{Read, Seek, SeekFrom};
-        let mut f = std::fs::File::open(&path).unwrap();
-        let size = f.metadata().unwrap().len();
-        assert!(size > offset);
-        f.seek(SeekFrom::Start(offset)).unwrap();
-        let mut buf = String::new();
-        f.read_to_string(&mut buf).unwrap();
-        offset = size;
-        for l in buf.lines() {
-            tail.push(l.to_string());
-        }
+        let grew = append_new_log_lines_from(&path, &mut tail, &mut offset);
+        assert!(grew);
         assert_eq!(tail, vec!["first line", "second line"]);
+        assert_eq!(offset, std::fs::metadata(&path).unwrap().len());
+    }
 
-        // Second append.
-        std::fs::write(&path, "first line\nsecond line\nthird\n").unwrap();
-        let size = std::fs::metadata(&path).unwrap().len();
-        let mut f = std::fs::File::open(&path).unwrap();
-        f.seek(SeekFrom::Start(offset)).unwrap();
-        let mut buf = String::new();
-        f.read_to_string(&mut buf).unwrap();
-        let prior = tail.len();
-        for l in buf.lines() {
-            tail.push(l.to_string());
+    #[test]
+    fn append_new_log_lines_detects_growth_and_truncation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("serve.log");
+
+        // Seed.
+        std::fs::write(&path, "one\ntwo\n").unwrap();
+        let mut tail: Vec<String> = Vec::new();
+        let mut offset: u64 = 0;
+        assert!(append_new_log_lines_from(&path, &mut tail, &mut offset));
+        assert_eq!(tail, vec!["one", "two"]);
+        let after_seed_offset = offset;
+
+        // Append only.
+        std::fs::write(&path, "one\ntwo\nthree\n").unwrap();
+        assert!(append_new_log_lines_from(&path, &mut tail, &mut offset));
+        assert_eq!(tail, vec!["one", "two", "three"]);
+        assert!(offset > after_seed_offset);
+
+        // No growth → no change.
+        let before = offset;
+        assert!(!append_new_log_lines_from(&path, &mut tail, &mut offset));
+        assert_eq!(offset, before);
+
+        // Truncation (daemon restart): file shrank, tail resets.
+        std::fs::write(&path, "fresh\n").unwrap();
+        assert!(append_new_log_lines_from(&path, &mut tail, &mut offset));
+        assert_eq!(tail, vec!["fresh"]);
+    }
+
+    #[test]
+    fn append_new_log_lines_clamps_to_max_lines() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("serve.log");
+
+        // Write well over LOG_TAIL_LINES.
+        let mut big = String::new();
+        for i in 0..(LOG_TAIL_LINES + 50) {
+            big.push_str(&format!("line {}\n", i));
         }
-        assert_eq!(tail.len(), prior + 1);
-        assert!(size >= offset);
+        std::fs::write(&path, big).unwrap();
+
+        let mut tail: Vec<String> = Vec::new();
+        let mut offset: u64 = 0;
+        assert!(append_new_log_lines_from(&path, &mut tail, &mut offset));
+        assert_eq!(tail.len(), LOG_TAIL_LINES);
+        assert_eq!(
+            tail.last().unwrap(),
+            &format!("line {}", LOG_TAIL_LINES + 49)
+        );
     }
 }

--- a/src/tui/dialogs/remote.rs
+++ b/src/tui/dialogs/remote.rs
@@ -14,7 +14,7 @@ use std::time::{Duration, Instant};
 
 use crossterm::event::{KeyCode, KeyEvent};
 use qrcode::QrCode;
-use rand::distr::{Alphanumeric, SampleString};
+use rand::prelude::IndexedRandom;
 use rand::RngExt;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -28,8 +28,13 @@ const TUNNEL_STARTUP_TIMEOUT_SECS: u64 = 60;
 const LOG_TAIL_LINES: usize = 200;
 
 pub enum RemoteDialogState {
-    /// No daemon running; show the scary warning and wait for Y/N.
-    Confirm,
+    /// No daemon running; show the two-factor explanation and wait for the
+    /// user to confirm via Y/Enter/arrows. `confirm_selected` tracks which
+    /// button (Enable vs Cancel) is currently highlighted so Enter picks it.
+    /// Default is Cancel so a stray Enter doesn't expose the tunnel.
+    Confirm {
+        confirm_selected: bool,
+    },
     /// We issued `aoe serve --remote --daemon`; now polling `serve.url`.
     /// If `passphrase` is Some, the TUI spawned the daemon and knows it;
     /// if None, a daemon was already running when the dialog opened.
@@ -94,15 +99,18 @@ impl RemoteDialog {
             }
         } else {
             Self {
-                state: RemoteDialogState::Confirm,
+                state: RemoteDialogState::Confirm {
+                    confirm_selected: false,
+                },
                 pending_passphrase: generate_passphrase(),
             }
         }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
-        match &self.state {
-            RemoteDialogState::Confirm => match key.code {
+        match &mut self.state {
+            RemoteDialogState::Confirm { confirm_selected } => match key.code {
+                // Y always enables, regardless of which button is highlighted.
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
                     match spawn_daemon(&self.pending_passphrase) {
                         Ok(()) => {
@@ -115,6 +123,37 @@ impl RemoteDialog {
                             self.state = RemoteDialogState::Error(e);
                         }
                     }
+                    DialogResult::Continue
+                }
+                // Enter picks whichever button is currently highlighted.
+                KeyCode::Enter => {
+                    if *confirm_selected {
+                        match spawn_daemon(&self.pending_passphrase) {
+                            Ok(()) => {
+                                self.state = RemoteDialogState::Starting {
+                                    passphrase: Some(self.pending_passphrase.clone()),
+                                    started_at: Instant::now(),
+                                };
+                            }
+                            Err(e) => {
+                                self.state = RemoteDialogState::Error(e);
+                            }
+                        }
+                        DialogResult::Continue
+                    } else {
+                        DialogResult::Cancel
+                    }
+                }
+                KeyCode::Left | KeyCode::Char('h') => {
+                    *confirm_selected = true;
+                    DialogResult::Continue
+                }
+                KeyCode::Right | KeyCode::Char('l') => {
+                    *confirm_selected = false;
+                    DialogResult::Continue
+                }
+                KeyCode::Tab => {
+                    *confirm_selected = !*confirm_selected;
                     DialogResult::Continue
                 }
                 KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Char('q') => {
@@ -214,7 +253,9 @@ impl RemoteDialog {
 
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         match &self.state {
-            RemoteDialogState::Confirm => render_confirm(frame, area, theme),
+            RemoteDialogState::Confirm { confirm_selected } => {
+                render_confirm(frame, area, theme, *confirm_selected)
+            }
             RemoteDialogState::Starting { started_at, .. } => {
                 render_starting(frame, area, theme, started_at.elapsed())
             }
@@ -377,7 +418,7 @@ fn append_new_log_lines(tail: &mut Vec<String>, offset: &mut u64) -> bool {
     changed
 }
 
-fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme) {
+fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme, enable_selected: bool) {
     let dialog = super::centered_rect(area, 70, 22);
     frame.render_widget(Clear, dialog);
     let block = Block::default()
@@ -469,10 +510,20 @@ fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme) {
     ];
     frame.render_widget(Paragraph::new(body).wrap(Wrap { trim: true }), chunks[0]);
 
+    let enable_style = if enable_selected {
+        Style::default().fg(theme.running).bold()
+    } else {
+        Style::default().fg(theme.dimmed)
+    };
+    let cancel_style = if !enable_selected {
+        Style::default().fg(theme.accent).bold()
+    } else {
+        Style::default().fg(theme.dimmed)
+    };
     let buttons = Line::from(vec![
-        Span::styled("[Y] Enable", Style::default().fg(theme.running).bold()),
-        Span::raw("        "),
-        Span::styled("[N] Cancel", Style::default().fg(theme.dimmed).bold()),
+        Span::styled("[Y/Enter] Enable", enable_style),
+        Span::raw("    "),
+        Span::styled("[N/Esc] Cancel", cancel_style),
     ]);
     frame.render_widget(
         Paragraph::new(buttons).alignment(Alignment::Center),
@@ -710,10 +761,120 @@ fn format_elapsed(d: Duration) -> String {
     }
 }
 
+/// Generate a four-word lowercase passphrase (1Password / diceware style).
+/// Four words from a ~500-word list gives ~35 bits of entropy, which as a
+/// *second* factor on top of the URL token is plenty; far easier to type
+/// on a phone keyboard than a random alphanumeric soup.
 fn generate_passphrase() -> String {
-    // 12 alphanumerics gives ~72 bits of entropy; legible over a phone screen.
-    Alphanumeric.sample_string(&mut rand::rng(), 12)
+    let mut rng = rand::rng();
+    let words: Vec<&'static str> = (0..4)
+        .map(|_| {
+            *PASSPHRASE_WORDS
+                .choose(&mut rng)
+                .expect("wordlist nonempty")
+        })
+        .collect();
+    words.join(" ")
 }
+
+/// Curated list of short, unambiguous lowercase English words chosen for
+/// phone-typability. No words shorter than 3 letters or longer than 6.
+/// No near-homophones (e.g., "their"/"there") or visually confusable pairs.
+#[rustfmt::skip]
+const PASSPHRASE_WORDS: &[&str] = &[
+    "able", "acid", "aged", "acorn", "agent", "alarm", "album", "alert",
+    "algae", "alien", "alive", "alley", "alloy", "alpha", "amber", "amigo",
+    "amino", "amuse", "angel", "anger", "angle", "angry", "ankle", "anvil",
+    "apple", "apron", "arbor", "arena", "argon", "armor", "arrow", "ashen",
+    "aside", "aspen", "asset", "atlas", "atom", "audio", "audit", "aunt",
+    "avoid", "awake", "award", "aware", "awful", "axis", "bacon", "badge",
+    "bagel", "baker", "balmy", "banjo", "baron", "basil", "basin", "basis",
+    "batch", "baton", "beach", "beads", "beard", "beast", "beaver", "bench",
+    "berry", "bingo", "birch", "bison", "black", "blade", "blaze", "blend",
+    "bliss", "block", "bloom", "blues", "blunt", "blush", "board", "boast",
+    "bold", "bolt", "bonus", "boost", "booth", "boots", "bored", "boss",
+    "botany", "bowl", "brave", "bread", "break", "brick", "bride", "brief",
+    "bring", "brisk", "brook", "brown", "brush", "bucket", "bugle", "built",
+    "bulk", "bunny", "burly", "butter", "buzz", "cabin", "cable", "cactus",
+    "caddy", "camel", "camp", "candle", "candy", "canoe", "canon", "canyon",
+    "cape", "caper", "card", "care", "cargo", "carry", "cart", "carve",
+    "cash", "cast", "catch", "cedar", "chair", "chalk", "charm", "chart",
+    "chase", "cheek", "cheer", "chef", "chess", "chief", "child", "chill",
+    "chimp", "chip", "chirp", "choir", "chose", "chunk", "cider", "cinema",
+    "civic", "claim", "clamp", "clean", "clerk", "click", "cliff", "climb",
+    "cling", "clock", "clone", "cloth", "cloud", "clove", "clown", "club",
+    "clue", "coach", "coast", "cobra", "cocoa", "code", "coin", "colon",
+    "color", "comet", "coral", "cord", "corn", "cost", "couch", "cover",
+    "cozy", "craft", "crane", "crash", "crate", "cream", "crest", "crew",
+    "cross", "crowd", "crown", "crumb", "crush", "crust", "cube", "curl",
+    "cycle", "daisy", "dance", "dare", "dash", "data", "deal", "deck",
+    "delta", "dense", "depth", "derby", "desk", "diary", "dice", "diner",
+    "disco", "diver", "dock", "dodo", "dog", "doll", "dolly", "donkey",
+    "dough", "dove", "downy", "draft", "dragon", "drape", "dream", "drift",
+    "drill", "drive", "drop", "drum", "duck", "dusk", "dusty", "eager",
+    "eagle", "early", "earth", "ebony", "echo", "edge", "eject", "elbow",
+    "elder", "elf", "elite", "elk", "elm", "email", "empty", "enact",
+    "energy", "engine", "enjoy", "enter", "entry", "envoy", "epic", "equal",
+    "era", "error", "essay", "ether", "event", "every", "exact", "exile",
+    "exit", "extra", "eye", "fable", "face", "fact", "fade", "fair",
+    "fairy", "faith", "fall", "false", "fame", "family", "fancy", "farm",
+    "fast", "fat", "fate", "fault", "fawn", "fear", "feast", "feed",
+    "fern", "ferry", "fever", "few", "fiber", "field", "fifth", "fig",
+    "film", "find", "fine", "finer", "finish", "fire", "firm", "first",
+    "fish", "five", "fix", "flag", "flame", "flash", "flat", "flax",
+    "flex", "flint", "float", "flock", "flood", "floor", "flora", "flour",
+    "flow", "flower", "fluff", "fluid", "fluke", "flute", "fly", "foam",
+    "fog", "foil", "fold", "folk", "fond", "food", "foot", "force",
+    "ford", "forge", "fork", "form", "fort", "forum", "fossil", "fox",
+    "frame", "free", "fresh", "friar", "fries", "frog", "from", "front",
+    "frost", "froth", "fruit", "fry", "fuel", "full", "fun", "fund",
+    "funny", "fur", "fury", "fuse", "gable", "gadget", "gain", "gala",
+    "gamma", "gap", "garden", "gargle", "garlic", "gate", "gauge", "gear",
+    "gecko", "gem", "gentle", "gift", "ginger", "girl", "glad", "glide",
+    "glitch", "globe", "gloom", "gloss", "glove", "glow", "glue", "gnat",
+    "goat", "gold", "golf", "gone", "good", "goose", "gospel", "grab",
+    "grace", "grade", "grain", "grape", "graph", "grasp", "grass", "grate",
+    "gravy", "great", "grid", "grief", "grim", "grin", "grip", "grit",
+    "groan", "groom", "gross", "group", "grout", "grove", "grow", "grub",
+    "guess", "guide", "guild", "guilt", "guitar", "gulf", "gum", "guru",
+    "habit", "haiku", "hair", "half", "hall", "halt", "ham", "hand",
+    "hang", "happy", "harbor", "hard", "hare", "harm", "harp", "hash",
+    "haste", "hat", "hatch", "have", "haven", "hawk", "hay", "hazel",
+    "head", "heal", "heap", "heart", "heat", "heavy", "hedge", "heel",
+    "help", "hemp", "hen", "herb", "hero", "hex", "hide", "high",
+    "hike", "hill", "hip", "hive", "hobby", "hog", "hold", "hole",
+    "hollow", "holy", "home", "honey", "honor", "hood", "hoof", "hook",
+    "hoop", "hope", "horn", "horse", "host", "hot", "hound", "hour",
+    "house", "hub", "hug", "human", "humble", "humor", "hump", "hunch",
+    "hunt", "hurry", "husk", "hut", "hyena", "hymn", "ice", "icon",
+    "idea", "igloo", "imp", "index", "indigo", "infant", "inlet", "ink",
+    "inlay", "inner", "input", "iris", "iron", "ivory", "ivy", "jade",
+    "jam", "jar", "java", "jaw", "jazz", "jeans", "jelly", "jest",
+    "jet", "jewel", "jiffy", "jig", "job", "join", "joke", "jolly",
+    "joy", "judge", "juice", "jump", "jungle", "junior", "junk", "jury",
+    "kayak", "keep", "kept", "kettle", "key", "kick", "kid", "kilt",
+    "kind", "king", "kite", "kitten", "knack", "knee", "knife", "knock",
+    "koala", "label", "lace", "ladder", "lake", "lamb", "lamp", "lance",
+    "land", "lane", "laser", "later", "latte", "laugh", "lava", "lawn",
+    "layer", "lazy", "leaf", "lean", "leap", "learn", "lease", "led",
+    "ledge", "left", "legal", "lemon", "lend", "lens", "level", "lever",
+    "lick", "lid", "life", "lift", "light", "lilac", "lime", "line",
+    "link", "lint", "lion", "lip", "list", "live", "load", "loaf",
+    "loan", "lobby", "lobe", "local", "lock", "loft", "log", "logic",
+    "long", "look", "loop", "loose", "lotus", "loud", "lounge", "love",
+    "low", "loyal", "luck", "lunar", "lunch", "lung", "lure", "lush",
+    "lute", "lynx", "lyric", "mace", "madam", "made", "magic", "main",
+    "make", "mallet", "malt", "mango", "manor", "mantle", "maple", "march",
+    "mare", "mark", "mars", "marsh", "mask", "mast", "match", "mate",
+    "math", "maze", "meadow", "meal", "meat", "medal", "meet", "mellow",
+    "melody", "melt", "memo", "menu", "mercy", "merge", "merit", "merry",
+    "mesh", "metal", "meter", "mew", "mice", "midst", "might", "mild",
+    "mile", "milk", "mill", "mimic", "mind", "mine", "mint", "minus",
+    "mirror", "mist", "moat", "mocha", "modal", "model", "modem", "moist",
+    "mole", "money", "month", "moon", "moose", "moral", "more", "moth",
+    "motor", "mount", "mouse", "move", "movie", "much", "muffin", "mulch",
+    "mule", "muse", "music", "mute", "myth",
+];
 
 fn strip_query(url: &str) -> String {
     match url.split_once('?') {
@@ -727,10 +888,48 @@ mod tests {
     use super::*;
 
     #[test]
-    fn passphrase_has_expected_length_and_charset() {
+    fn passphrase_is_four_lowercase_words() {
         let pw = generate_passphrase();
-        assert_eq!(pw.len(), 12);
-        assert!(pw.chars().all(|c| c.is_ascii_alphanumeric()));
+        let words: Vec<&str> = pw.split(' ').collect();
+        assert_eq!(words.len(), 4, "passphrase should be 4 words: {:?}", pw);
+        for w in &words {
+            assert!(!w.is_empty(), "empty word in passphrase: {:?}", pw);
+            assert!(
+                w.chars().all(|c| c.is_ascii_lowercase()),
+                "non-lowercase-letter in word {:?} of {:?}",
+                w,
+                pw
+            );
+        }
+    }
+
+    #[test]
+    fn passphrase_words_are_from_the_wordlist() {
+        let pw = generate_passphrase();
+        for w in pw.split(' ') {
+            assert!(
+                PASSPHRASE_WORDS.contains(&w),
+                "word {:?} not in the embedded wordlist",
+                w
+            );
+        }
+    }
+
+    #[test]
+    fn wordlist_is_well_formed() {
+        assert!(
+            PASSPHRASE_WORDS.len() >= 256,
+            "wordlist too small for reasonable entropy: {}",
+            PASSPHRASE_WORDS.len()
+        );
+        for w in PASSPHRASE_WORDS {
+            assert!(!w.is_empty(), "empty word in list");
+            assert!(
+                w.chars().all(|c| c.is_ascii_lowercase()),
+                "non-lowercase word in list: {:?}",
+                w
+            );
+        }
     }
 
     #[test]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -425,6 +425,19 @@ impl HomeView {
             return None;
         }
 
+        // Remote-access dialog (serve feature only)
+        #[cfg(feature = "serve")]
+        if let Some(dialog) = &mut self.remote_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel | DialogResult::Submit(_) => {
+                    // Dropping the dialog kills the subprocess via kill_on_drop.
+                    self.remote_dialog = None;
+                }
+            }
+            return None;
+        }
+
         // Send message dialog
         if let Some(dialog) = &mut self.send_message_dialog {
             match dialog.handle_key(key) {
@@ -499,6 +512,25 @@ impl HomeView {
             }
             KeyCode::Char('P') => {
                 self.show_profile_picker();
+            }
+            #[cfg(feature = "serve")]
+            KeyCode::Char('R') => {
+                self.remote_dialog = Some(crate::tui::dialogs::RemoteDialog::new());
+            }
+            #[cfg(not(feature = "serve"))]
+            KeyCode::Char('R') => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Remote access unavailable",
+                    "This `aoe` binary was built without the `serve` feature, \
+                     so the web dashboard and Cloudflare Tunnel integration \
+                     are not included.\n\n\
+                     To use remote access from your phone:\n\
+                       \u{2022} Install a release build from GitHub Releases, or\n\
+                       \u{2022} Build from source with:\n\
+                         cargo build --release --features serve\n\n\
+                     Once you have a `serve`-enabled binary, press R again to \
+                     open the remote access dialog.",
+                ));
             }
             KeyCode::Char('t') => {
                 self.view_mode = match self.view_mode {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -21,6 +21,8 @@ use crate::tmux::AvailableTools;
 
 use super::creation_poller::{CreationPoller, CreationRequest};
 use super::deletion_poller::DeletionPoller;
+#[cfg(feature = "serve")]
+use super::dialogs::RemoteDialog;
 use super::dialogs::{
     ChangelogDialog, ConfirmDialog, GroupDeleteOptionsDialog, HookTrustDialog, HooksInstallDialog,
     InfoDialog, NewSessionData, NewSessionDialog, ProfilePickerDialog, RenameDialog,
@@ -162,6 +164,8 @@ pub struct HomeView {
     pub(super) changelog_dialog: Option<ChangelogDialog>,
     pub(super) info_dialog: Option<InfoDialog>,
     pub(super) profile_picker_dialog: Option<ProfilePickerDialog>,
+    #[cfg(feature = "serve")]
+    pub(super) remote_dialog: Option<RemoteDialog>,
     pub(super) send_message_dialog: Option<super::dialogs::SendMessageDialog>,
     /// Session to receive the message from the send dialog
     pub(super) pending_send_session: Option<String>,
@@ -323,6 +327,8 @@ impl HomeView {
             changelog_dialog: None,
             info_dialog: None,
             profile_picker_dialog: None,
+            #[cfg(feature = "serve")]
+            remote_dialog: None,
             send_message_dialog: None,
             pending_send_session: None,
             pending_attach_after_warning: None,
@@ -831,6 +837,14 @@ impl HomeView {
             }
         }
 
+        // Poll remote-access dialog for subprocess startup events.
+        #[cfg(feature = "serve")]
+        if let Some(dialog) = &mut self.remote_dialog {
+            if dialog.tick() {
+                changed = true;
+            }
+        }
+
         // Drain hook progress into the creating buffer when no dialog is open
         if self.new_dialog.is_none() {
             if let Some(ref stub_id) = self.creating_stub_id {
@@ -859,6 +873,11 @@ impl HomeView {
     }
 
     pub fn has_dialog(&self) -> bool {
+        #[cfg(feature = "serve")]
+        let remote_open = self.remote_dialog.is_some();
+        #[cfg(not(feature = "serve"))]
+        let remote_open = false;
+
         self.show_help
             || self.search_active
             || self.new_dialog.is_some()
@@ -873,6 +892,7 @@ impl HomeView {
             || self.info_dialog.is_some()
             || self.profile_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
+            || remote_open
             || self.settings_view.is_some()
             || self.diff_view.is_some()
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -770,18 +770,27 @@ impl HomeView {
         let desc_style = Style::default().fg(theme.dimmed);
         let sep_style = Style::default().fg(theme.border);
 
-        let (mode_indicator, mode_color) = match self.view_mode {
-            ViewMode::Agent => ("[Agent]", theme.waiting),
-            ViewMode::Terminal => ("[Term]", theme.terminal_border),
-        };
-        let mode_style = Style::default().fg(mode_color).bold();
+        let mut spans: Vec<Span> = Vec::new();
 
-        let mut spans = vec![
-            Span::styled(format!(" {} ", mode_indicator), mode_style),
-            Span::styled("│", sep_style),
+        // Remote-access indicator: shown only when the `aoe serve --remote`
+        // daemon is live. The TUI does not own the daemon, so we probe the
+        // PID file each render. Feature-gated alongside the rest of the
+        // serve-specific code.
+        #[cfg(feature = "serve")]
+        if crate::cli::serve::daemon_pid().is_some() {
+            spans.extend([
+                Span::styled(
+                    " \u{25CF} Remote on ",
+                    Style::default().fg(theme.running).bold(),
+                ),
+                Span::styled("│", sep_style),
+            ]);
+        }
+
+        spans.extend([
             Span::styled(" j/k", key_style),
             Span::styled(" Nav ", desc_style),
-        ];
+        ]);
         if let Some(enter_action_text) = match self.flat_items.get(self.cursor) {
             Some(Item::Group {
                 collapsed: true, ..

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -163,6 +163,11 @@ impl HomeView {
         if let Some(dialog) = &self.send_message_dialog {
             dialog.render(frame, area, theme);
         }
+
+        #[cfg(feature = "serve")]
+        if let Some(dialog) = &self.remote_dialog {
+            dialog.render(frame, area, theme);
+        }
     }
 
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -55,6 +55,13 @@ const PAGES = [
       "Remote access to AI coding agent sessions from any browser with Agent of Empires.",
   },
   {
+    source: "docs/guides/remote-phone-access.md",
+    dest: "guides/remote-phone-access.md",
+    title: "Remote Access from Your Phone",
+    description:
+      "Access your Agent of Empires sessions from your phone via a one-keystroke Cloudflare Tunnel with QR pairing.",
+  },
+  {
     source: "docs/guides/worktrees.md",
     dest: "guides/worktrees.md",
     title: "Worktrees Reference",
@@ -129,6 +136,7 @@ const URL_MAP = {
   "docs/guides/sandbox.md": "/guides/sandbox/",
   "docs/guides/tmux-status-bar.md": "/guides/tmux-status-bar/",
   "docs/guides/web-dashboard.md": "/guides/web-dashboard/",
+  "docs/guides/remote-phone-access.md": "/guides/remote-phone-access/",
   "docs/guides/worktrees.md": "/guides/worktrees/",
 };
 

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -22,6 +22,7 @@ export const docsNav: NavSection[] = [
     items: [
       { title: "Docker Sandbox", href: "/guides/sandbox/" },
       { title: "Web Dashboard", href: "/guides/web-dashboard/" },
+      { title: "Remote Phone Access", href: "/guides/remote-phone-access/" },
       { title: "Repo Config & Hooks", href: "/guides/repo-config/" },
       { title: "Git Worktrees", href: "/guides/worktrees/" },
       { title: "Diff View", href: "/guides/diff-view/" },


### PR DESCRIPTION
## Description

Surfaces the already-built `aoe serve --remote` + Cloudflare Tunnel path from inside the TUI. Press `R`, confirm the two-factor security model, scan the QR with your phone camera, type the passphrase, and you're inside the web dashboard from your phone. The daemon keeps running after you quit the TUI (same lifetime semantics as tmux sessions).

### Why

The `aoe serve --remote` + `cloudflared` stack landed in #641 / `a5c09a9`, but power users of the TUI can't discover it without knowing CLI flags exist. This PR connects the two — zero new server code, just TUI surfacing + lifecycle wiring.

Context and reasoning behind the staged approach (remote-access MVP first, DMG Mac app gated on signal): `~/.gstack/projects/njbrake-agent-of-empires/root-decision-design-20260415-114352.md`.

### What's in the PR

**TUI side**
- New dialog `src/tui/dialogs/remote.rs`: four-state (Confirm → Starting → Active → Error). No `Child` ownership — the dialog is a controller, not a host.
- On open: probes `$APP_DIR/serve.pid` with `kill(pid, 0)`. Live daemon → jump to Active. Otherwise → Confirm.
- Spawn path invokes `aoe serve --remote --daemon --host 127.0.0.1 --port <random-ephemeral> --passphrase <generated>`, then polls `serve.url`.
- Stop path shells out to `aoe serve --stop`.
- Active view renders a QR of the URL (token stripped so the QR stays dense), plain URL, passphrase, elapsed time, passive 8h "still need it?" title nudge, and a tail of the last 200 lines of `serve.log`.
- Confirm screen is benefit-first: explains HTTPS end-to-end and the two-factor (URL-token + passphrase login) model, then calls out the "don't screenshot QR + passphrase together" risk.
- Help overlay (`?`) shows the `R` shortcut unconditionally. Dialog height bumped to 39 rows so the row fits.

**Server + CLI side**
- `src/cli/serve.rs`: daemon stdout/stderr teed into `$APP_DIR/serve.log` (truncated on start) so the TUI can tail without attaching to the process. `pid_file_path()` + `daemon_log_path()` made `pub`; new `daemon_pid()` helper probes the PID file and auto-cleans stale entries. `serve.log` cleaned up on `--stop`.
- No changes to `src/server/mod.rs` — it was already writing `serve.url` for daemon discovery.

**TUI-only builds (no `serve` feature)**
- `R` still advertised in help. Pressing it opens an `InfoDialog` explaining the binary lacks `serve` and how to get a build that has it.
- Everything else (`RemoteDialog`, the `remote_dialog` field, its render/tick/has_dialog hooks) is `#[cfg(feature = "serve")]` so the dead code is literally absent from TUI-only binaries.

**Docs**
- New `docs/guides/remote-phone-access.md` — 60-second setup guide, troubleshooting, security notes, "started via CLI, attach via TUI" flow.
- Wired into the website: `PAGES`, `URL_MAP`, and `docsNav.ts` updated.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

> Screenshots not attached — this sandbox can't launch the TUI. Will attach before merge. The new dialog render paths are unit-testable but the actual visual layout (QR density, log-tail scrolling, 8h reminder title) should be eyeballed on a real terminal.

## Test plan

- [x] `cargo check` (default + `--features serve`)
- [x] `cargo clippy --lib` clean on both feature sets
- [x] `cargo test --features serve --lib`: 1102 passed (+4 new tests: passphrase entropy, elapsed formatting, QR token stripping, log-tail append)
- [x] `cargo test --lib`: 1036 passed (TUI-only build path)
- [x] `cargo fmt --check` clean
- [ ] **Manual verification needed before merge:**
  - [ ] In a `--features serve` build: press `R`, confirm `Y`, wait for QR, scan from phone, type passphrase, reach dashboard
  - [ ] Press `Esc` in Active state — dialog closes, `ps aux | grep "aoe serve"` still shows the daemon
  - [ ] Start daemon from CLI (`aoe serve --remote --daemon --passphrase testpass`), then open TUI and press `R` — should land in Active with the URL and a "(set when the daemon started)" passphrase placeholder
  - [ ] Press `S` from Active — daemon stops, `aoe serve --stop` exits cleanly, no orphan `cloudflared`
  - [ ] `cargo build --release` (no serve): press `R` — info dialog explains how to get a serve-enabled binary
  - [ ] On real iPhone + Android: confirm QR scan from camera app lands correctly on the login page, passphrase accepts

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.6, 1M context)

**Any Additional AI Details you'd like to share:**
Design doc, architecture decision (stage the bet on remote access, defer the full macOS DMG until demand evidence lands), implementation, tests, and docs were all produced in a single pair-programming session. The TUI-as-control-plane refactor (dropping `kill_on_drop` subprocess ownership in favor of `serve.pid`/`serve.url`/`serve.log` file-based coordination) was the operator's call, not the assistant's first draft — that exchange lives in the session transcript.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)