### PR TITLE
fix: remove stale version field from OpenClaw SKILL.md frontmatter

### DIFF
--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: aoe
 description: Manage AI coding agent sessions via Agent of Empires (aoe)
-version: 0.15.1
 metadata:
   openclaw:
     requires:

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -70,14 +70,14 @@ fn check_skill() {
     // The skill's published version is managed by clawhub via _meta.json and
     // the release workflow's `--version` flag. A static `version:` in the
     // frontmatter goes stale on every release, so disallow it.
-    if let Some(frontmatter) = content
+    if let Some((frontmatter, _)) = content
         .strip_prefix("---\n")
         .and_then(|s| s.split_once("\n---"))
     {
-        for line in frontmatter.0.lines() {
-            if line.trim_start().starts_with("version:") {
+        for line in frontmatter.lines() {
+            if line.starts_with("version:") {
                 eprintln!(
-                    "ERROR: SKILL.md frontmatter must not contain a `version:` field; \
+                    "ERROR: SKILL.md frontmatter must not contain a top-level `version:` field; \
                      clawhub's _meta.json is the source of truth"
                 );
                 has_error = true;

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -65,6 +65,27 @@ fn check_skill() {
 
     let content = fs::read_to_string(skill_path).expect("Failed to read SKILL.md");
 
+    let mut has_error = false;
+
+    // The skill's published version is managed by clawhub via _meta.json and
+    // the release workflow's `--version` flag. A static `version:` in the
+    // frontmatter goes stale on every release, so disallow it.
+    if let Some(frontmatter) = content
+        .strip_prefix("---\n")
+        .and_then(|s| s.split_once("\n---"))
+    {
+        for line in frontmatter.0.lines() {
+            if line.trim_start().starts_with("version:") {
+                eprintln!(
+                    "ERROR: SKILL.md frontmatter must not contain a `version:` field; \
+                     clawhub's _meta.json is the source of truth"
+                );
+                has_error = true;
+                break;
+            }
+        }
+    }
+
     // Build the clap command tree
     let cli_cmd = agent_of_empires::cli::Cli::command();
     let mut cli_commands: BTreeSet<String> = BTreeSet::new();
@@ -109,8 +130,6 @@ fn check_skill() {
             skill_commands.insert(best);
         }
     }
-
-    let mut has_error = false;
 
     // Check for skill references to commands that don't exist
     for skill_cmd in &skill_commands {


### PR DESCRIPTION
## Description

The `version:` field in `contrib/openclaw-skill/SKILL.md` frontmatter was never updated by the release workflow, leaving it stuck at `0.15.1` while clawhub's `_meta.json` advanced with each release (currently `1.3.0`). Agents reading the frontmatter saw a stale version number, causing confusion when debugging or auditing installed skills.

This PR removes the `version:` field entirely since `_meta.json` (populated by `clawhub publish --version "$VERSION_NUM"` in `.github/workflows/release.yml`) is the authoritative source. The field isn't required by the Claude skill spec, which matches the other SKILL.md in the repo (`.claude/skills/docs-review/SKILL.md`).

A guard is also added in `cargo xtask check-skill` so the field can't be reintroduced.

Fixes #654

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Verified:
- `cargo fmt --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo run -p xtask -- check-skill` passes on the cleaned file, and exits 1 with a clear error message when a `version:` field is reintroduced.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)