### PR TITLE
feat(web): working mobile terminal scroll via PTY wheel events

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,46 +27,36 @@
 
 ## Build, Test, and Development Commands
 
-- `cargo build` / `cargo build --release`: compile TUI-only (release binary at `target/release/aoe`).
-- `cargo build --profile dev-release`: faster optimized builds for local development. Skips LTO for quicker compile times while still producing an optimized binary. Use `--release` for final/CI builds.
-- `cargo build --features serve`: compile with web dashboard support (requires Node.js + npm).
-- `cargo run --release`: run from source; requires `tmux` installed.
-- `cargo check`: fast type-checking during development.
-- `cargo test`: run unit + integration tests (some tests skip if `tmux` is unavailable).
-- `cargo fmt`: format with rustfmt (run before pushing).
-- `cargo clippy`: lint (fix warnings unless there’s a strong reason not to).
-- Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes to `debug.log` in app data dir).
+- `cargo build` / `cargo build --release`: TUI-only (release binary at `target/release/aoe`).
+- `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Use `--release` for CI.
+- `cargo build --features serve`: web dashboard support (needs Node.js + npm).
+- `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
+- `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.
+- Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
+- Running from source needs `tmux` installed.
 
 ### Web Dashboard (experimental)
 
-The web dashboard (`aoe serve`) is behind the `serve` Cargo feature flag. It is experimental and subject to major changes.
+Behind the `serve` feature flag; experimental, subject to change.
 
-- **Build**: `cargo build --features serve` (build.rs auto-runs `npm install && npm run build` in `web/` if needed).
-- **Run**: `aoe serve --host 0.0.0.0` starts the embedded web server with token-based auth.
-- **Frontend dev**: `cd web && npm run dev` for Vite HMR during development. The Rust server must also be running for API/WebSocket requests.
-- **Stack**: React 19, TypeScript, Vite, Tailwind CSS v4, xterm.js v6 for terminal rendering.
-- **PWA**: The dashboard is installable as a Progressive Web App. In Chrome: three-dot menu > "Install Agent of Empires". On iOS: Share > "Add to Home Screen". This creates a standalone window with no browser chrome.
-- **No npm for TUI-only builds**: `cargo build` (without `--features serve`) requires zero JavaScript tooling.
+- Stack: React 19, TypeScript, Vite, Tailwind v4, xterm.js v6. Installable as a PWA ("Install Agent of Empires" in Chrome; "Add to Home Screen" on iOS).
+- Build: `cargo build --features serve` (build.rs runs `npm install && npm run build` in `web/` when inputs change).
+- Run: `aoe serve --host 0.0.0.0` (token-based auth by default).
+- Frontend dev: `cd web && npm run dev` for Vite HMR; the Rust server must also be running for API/WebSocket requests.
+- TUI-only `cargo build` (without `--features serve`) needs no JS tooling.
 
 ## Settings & Configuration
 
-- **Every configurable field must be editable in the settings TUI.** When adding a new config field to `SandboxConfig`, `WorktreeConfig`, etc., you must also:
-  1. Add a `FieldKey` variant in `src/tui/settings/fields.rs`
-  2. Add a `SettingField` entry in the corresponding `build_*_fields()` function
-  3. Wire up `apply_field_to_global()` and `apply_field_to_profile()`
-  4. Add a `clear_profile_override()` case in `src/tui/settings/input.rs`
-- Profile overrides (`*ConfigOverride` structs in `profile_config.rs`) must also include the new field with merge logic in `merge_configs()`.
+Every configurable field must be editable in the settings TUI. When adding one to `SandboxConfig`, `WorktreeConfig`, etc., also: add a `FieldKey` in `src/tui/settings/fields.rs`; add a `SettingField` entry in the matching `build_*_fields()`; wire `apply_field_to_global()` + `apply_field_to_profile()`; add a `clear_profile_override()` case in `src/tui/settings/input.rs`; include the field in the `*ConfigOverride` struct in `profile_config.rs` with merge logic in `merge_configs()`.
 
 ## Coding Style & Naming Conventions
 
-- Prefer "let the tools decide": keep code `cargo fmt`-clean and `cargo clippy`-clean.
-- **Never use emdashes (—) or double-dashes (--)** as separators in documentation or comments. Use commas, semicolons, or rephrase instead.
-- Rust naming: `snake_case` for modules/functions, `CamelCase` for types, `SCREAMING_SNAKE_CASE` for constants.
-- Keep OS-specific logic in `src/process/{macos,linux}.rs` rather than sprinkling `cfg` checks.
-- Do not be concerned about maintaining backwards compatibility. You should not assume that it needs to be backwards compatible, but you should mention when you make a change that breaks backwards compatibility.
-- Add comments where they aid understanding, but remove obvious ones before finishing:
-  - **Keep**: comments explaining non-obvious formulas, layout structure documentation, or "why" something is done
-  - **Remove**: section headers that just name what the next line does (e.g., `// Render buttons` before `render_buttons()`), or comments restating the code
+- Let `cargo fmt` + `cargo clippy` decide; fix warnings.
+- **No emdashes or `--`** as separators in docs/comments; use commas, semicolons, or rephrase.
+- Rust naming: `snake_case` modules/functions, `CamelCase` types, `SCREAMING_SNAKE_CASE` constants.
+- Keep OS-specific logic in `src/process/{macos,linux}.rs`, not sprinkled `cfg` checks.
+- Don't preserve backwards compatibility by default; call it out when a change is breaking.
+- Comments: explain non-obvious "why"; skip section headers and comments that restate the code.
 
 ## Testing Guidelines
 
@@ -77,28 +67,26 @@ The web dashboard (`aoe serve`) is behind the `serve` Cargo feature flag. It is 
 
 ### E2E Tests
 
-Full-binary end-to-end tests live in `tests/e2e/`. They exercise `aoe` through tmux (for TUI tests) and as a subprocess (for CLI tests). Run them with:
+Full-binary e2e tests live in `tests/e2e/`, exercising `aoe` through tmux (TUI) and as a subprocess (CLI). Run with `cargo test --test e2e` (add `-- --nocapture` for screen dumps on failure).
 
-```sh
-cargo test --test e2e              # all e2e tests
-cargo test --test e2e -- --nocapture  # with screen dumps on failure
-```
+The harness (`tests/e2e/harness.rs`) exposes `TuiTestHarness` with `spawn_tui()`/`spawn(args)`, `send_keys(keys)`/`type_text(text)`, `wait_for(text)` (10s timeout), `capture_screen()`/`assert_screen_contains(text)`, and `run_cli(args)`. TUI tests auto-skip without tmux; Docker tests use `#[ignore]`; all use `#[serial]` for tmux isolation.
 
-The test harness (`tests/e2e/harness.rs`) provides `TuiTestHarness` with:
-- `spawn_tui()` / `spawn(args)`: launch `aoe` in a detached tmux session with isolated `$HOME`
-- `send_keys(keys)` / `type_text(text)`: send keystrokes or literal text
-- `wait_for(text)`: poll the screen until text appears (10s timeout, panics with screen dump)
-- `capture_screen()` / `assert_screen_contains(text)`: one-shot screen assertions
-- `run_cli(args)`: run `aoe` as a subprocess with the same env isolation
+Recording (for PR reviews): `RECORD_E2E=1 cargo test --test e2e -- --nocapture` locally (needs `asciinema` + `agg`, outputs to `target/e2e-recordings/`), or add the `needs-recording` label in CI.
 
-TUI tests auto-skip if tmux is not installed. Docker-dependent tests use `#[ignore]` and require a running daemon. All tests use `#[serial]` for tmux isolation.
+### Web Dashboard Playwright Tests
 
-#### Recording E2E Tests
+Baseline Playwright tests live in `web/tests/` (run with `cd web && npx playwright test`). For any change to touch events, xterm.js integration, mobile-viewport behavior, WebSocket message shape, or the soft keyboard, write a real-session e2e against a running `aoe serve` rather than relying on the user to verify on their phone.
 
-E2E tests can produce asciinema recordings (`.cast`) and GIF files automatically. This is useful for PR reviews and documenting TUI behavior.
+Recipe:
+1. Shim a fake tool on `$PATH` (a script named `claude` that execs `bash -i`) so `aoe add --cmd claude` creates a live tmux session.
+2. `cargo build --features serve`, then start `aoe serve --no-auth --port N` in the background with isolated `HOME=/tmp/aoehome`.
+3. In a Node script using `@playwright/test` (already a devDep), emulate mobile with `devices['iPhone 13']` so `pointer: coarse` matches.
+4. Spy on PTY bytes by patching `WebSocket.prototype.send` in an `addInitScript` and pushing into `window.__WS_SENT__`.
+5. Synthesize multi-touch via `page.evaluate` dispatching raw `new TouchEvent(...)` on `.xterm` — Playwright's `page.touchscreen` is single-finger only.
 
-- **Local**: `RECORD_E2E=1 cargo test --test e2e -- --nocapture` (requires `asciinema` and `agg` on `$PATH`). Outputs go to `target/e2e-recordings/`.
-- **CI**: Add the `needs-recording` label to a PR. The `E2E Recordings` workflow will run the tests with recording enabled and upload GIF artifacts.
+Keep the script ephemeral unless promoted to `web/tests/` with a mobile Playwright project (`hasTouch: true`, `isMobile: true`). Install browser deps with `npx playwright install-deps` if missing.
+
+**Gotcha:** synthetic touchmove events fire back-to-back with Δt≈1ms, which blows up any `Δpx / Δtime` velocity calculation. Cap velocity and per-frame emit counts, or a real device will look sane while the e2e produces runaway momentum (or vice-versa).
 
 ## Commit & Pull Request Guidelines
 
@@ -120,46 +108,15 @@ E2E tests can produce asciinema recordings (`.cast`) and GIF files automatically
 
 ## Data Migrations
 
-When making breaking changes to stored data (file locations, config schema, etc.), use the migration system in `src/migrations/` instead of adding fallback/compatibility logic to the main code.
+Breaking changes to stored data (file locations, config schema) go through `src/migrations/`, not inline fallback/compat shims. A `.schema_version` file tracks state; `migrations::run_migrations()` runs pending ones in order on startup and bumps the version.
 
-**Why**: Keeps the main codebase clean. Legacy transition logic is isolated and clearly marked as such.
+To add one:
+1. Create `src/migrations/vNNN_description.rs` with a `pub fn run() -> anyhow::Result<()>`.
+2. In `src/migrations/mod.rs`: add `mod vNNN_description;`, bump `CURRENT_VERSION`, append a `Migration { version: NNN, name: "description", run: vNNN_description::run }` entry.
 
-**How it works**:
-1. A `.schema_version` file in the app directory tracks the current version
-2. On startup, `migrations::run_migrations()` runs any pending migrations in order
-3. Each migration bumps the version after completion
+Migrations must be idempotent, use `tracing::info!`, gate platform-specific ones with `#[cfg(target_os = "...")]`, and be tested by hand-crafting the old state.
 
-**Adding a new migration**:
-
-1. Create `src/migrations/vNNN_description.rs`:
-   ```rust
-   use anyhow::Result;
-
-   pub fn run() -> Result<()> {
-       // Migration logic here
-       Ok(())
-   }
-   ```
-
-2. Update `src/migrations/mod.rs`:
-   ```rust
-   mod vNNN_description;
-
-   const CURRENT_VERSION: u32 = NNN;  // bump this
-
-   const MIGRATIONS: &[Migration] = &[
-       // ... existing migrations ...
-       Migration { version: NNN, name: "description", run: vNNN_description::run },
-   ];
-   ```
-
-**Guidelines**:
-- Migrations must be idempotent (safe to run multiple times)
-- Use `tracing::info!` to log what's happening
-- Platform-specific migrations should use `#[cfg(target_os = "...")]`
-- Test migrations by creating the old state manually and verifying the transition
-- Before finishing any feature request, make sure that you have run cargo fmt, clippy, and tests.
-- `docs/cli/reference.md` is auto-generated by `cargo xtask gen-docs`. Do not edit it by hand; update the clap help text in `src/cli/` instead and re-run the generator. CI checks that this file is in sync.
+`docs/cli/reference.md` is auto-generated by `cargo xtask gen-docs`; edit the clap help in `src/cli/` and re-run instead. CI enforces it.
 
 ## Website & Documentation
 
@@ -177,7 +134,5 @@ The public website (agent-of-empires.com) is an Astro static site in `website/`.
 The CI workflow (`.github/workflows/docs.yml`) triggers on changes to `docs/**`, `website/**`, and other relevant paths.
 
 ## Design System
-Always read `DESIGN.md` before making any visual or UI decisions.
-All font choices, colors, spacing, and aesthetic direction are defined there.
-Do not deviate without explicit user approval.
-In QA mode, flag any code that doesn't match DESIGN.md.
+
+Read `DESIGN.md` before any visual/UI change — fonts, colors, spacing, and aesthetic direction are defined there. Don't deviate without explicit approval; in QA mode, flag code that doesn't match.

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -6,8 +6,8 @@ use std::process::Command;
 use super::{
     refresh_session_cache, session_exists_from_cache,
     utils::{
-        append_pane_base_index_args, append_remain_on_exit_args, is_pane_dead,
-        is_pane_running_shell,
+        append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args,
+        is_pane_dead, is_pane_running_shell,
     },
     SESSION_PREFIX,
 };
@@ -67,6 +67,7 @@ impl Session {
         let mut args = build_create_args(&self.name, working_dir, command, size);
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
+        append_mouse_on_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -4,7 +4,8 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::utils::{
-    append_pane_base_index_args, append_remain_on_exit_args, is_pane_dead, sanitize_session_name,
+    append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args, is_pane_dead,
+    sanitize_session_name,
 };
 use super::{
     refresh_session_cache, session_exists_from_cache, CONTAINER_TERMINAL_PREFIX, TERMINAL_PREFIX,
@@ -61,6 +62,7 @@ impl TerminalSession {
         let mut args = build_terminal_create_args(&self.name, working_dir, command, size);
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
+        append_mouse_on_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 
@@ -214,6 +216,7 @@ impl ContainerTerminalSession {
         let mut args = build_terminal_create_args(&self.name, working_dir, command, size);
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
+        append_mouse_on_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -71,6 +71,21 @@ pub fn append_pane_base_index_args(args: &mut Vec<String>, target: &str) {
     ]);
 }
 
+/// Append `; set-option -t <target> mouse on` to an in-flight tmux argument
+/// list so that mouse/wheel events are forwarded into tmux copy-mode.
+/// Required for the web dashboard's two-finger scroll on mobile, which
+/// emits SGR mouse-wheel escape sequences that tmux must interpret.
+pub fn append_mouse_on_args(args: &mut Vec<String>, target: &str) {
+    args.extend([
+        ";".to_string(),
+        "set-option".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        "mouse".to_string(),
+        "on".to_string(),
+    ]);
+}
+
 pub fn is_pane_dead(session_name: &str) -> bool {
     // Use `^.0` to target the first window's first pane regardless of
     // base-index or which pane is active, so the check always hits the

--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -9,6 +9,12 @@ const TERMINAL_SHORTCUTS = [
   { key: "Up/Down", desc: "Scroll terminal history" },
 ];
 
+const MOBILE_GESTURES = [
+  { key: "Two fingers", desc: "Swipe up/down to scroll the terminal (tmux copy-mode)" },
+  { key: "Tap pane", desc: "Open the soft keyboard" },
+  { key: "Long-press ↑↓", desc: "Drag horizontally to emit ← →" },
+];
+
 const IS_MAC =
   typeof navigator !== "undefined" &&
   /Mac|iPhone|iPad|iPod/.test(navigator.platform);
@@ -35,9 +41,7 @@ export function HelpOverlay({ onClose }: Props) {
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between px-5 py-4 border-b border-surface-700">
-          <h2 className="text-sm font-semibold text-text-bright">
-            Keyboard Shortcuts
-          </h2>
+          <h2 className="text-sm font-semibold text-text-bright">Help</h2>
           <button
             onClick={onClose}
             className="text-text-muted hover:text-text-secondary cursor-pointer"
@@ -65,7 +69,7 @@ export function HelpOverlay({ onClose }: Props) {
             </div>
           </div>
 
-          <div>
+          <div className="mb-5">
             <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-2">
               Terminal
             </h3>
@@ -78,6 +82,22 @@ export function HelpOverlay({ onClose }: Props) {
                   <span className="text-sm text-text-secondary">
                     {s.desc}
                   </span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-2">
+              Mobile gestures
+            </h3>
+            <div className="space-y-1">
+              {MOBILE_GESTURES.map((g) => (
+                <div key={g.key} className="flex items-center gap-3">
+                  <kbd className="font-mono text-xs bg-surface-900 border border-surface-700 rounded px-1.5 py-0.5 text-accent-600 text-center whitespace-nowrap">
+                    {g.key}
+                  </kbd>
+                  <span className="text-sm text-text-secondary">{g.desc}</span>
                 </div>
               ))}
             </div>

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -1,156 +1,122 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { Terminal } from "@xterm/xterm";
 import type { RefObject } from "react";
+import { useLongPressDrag, type DragAxis } from "../hooks/useLongPressDrag";
 
 interface Props {
   sendData: (data: string) => void;
   termRef: RefObject<Terminal | null>;
+  keyboardHeight: number;
 }
 
-interface KeyDef {
-  label: string;
-  ariaLabel: string;
-  data: string;
-  repeatable?: boolean;
-}
+const ARROW_UP = "\x1b[A";
+const ARROW_DOWN = "\x1b[B";
+const ARROW_LEFT = "\x1b[D";
+const ARROW_RIGHT = "\x1b[C";
 
-const KEYS: KeyDef[] = [
-  { label: "\u2190", ariaLabel: "Arrow left", data: "\x1b[D", repeatable: true },
-  { label: "\u2191", ariaLabel: "Arrow up", data: "\x1b[A", repeatable: true },
-  { label: "\u2193", ariaLabel: "Arrow down", data: "\x1b[B", repeatable: true },
-  { label: "\u2192", ariaLabel: "Arrow right", data: "\x1b[C", repeatable: true },
-  { label: "Tab", ariaLabel: "Tab", data: "\t" },
-  { label: "Esc", ariaLabel: "Escape", data: "\x1b" },
-];
-
-const LONG_PRESS_DELAY = 300;
-const LONG_PRESS_INTERVAL = 100;
-
-export function MobileTerminalToolbar({ sendData, termRef }: Props) {
+export function MobileTerminalToolbar({
+  sendData,
+  termRef,
+  keyboardHeight,
+}: Props) {
   const [ctrlActive, setCtrlActive] = useState(false);
-  const repeatTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const repeatInterval = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  // Clean up timers on unmount
-  useEffect(() => {
-    return () => {
-      if (repeatTimer.current) clearTimeout(repeatTimer.current);
-      if (repeatInterval.current) clearInterval(repeatInterval.current);
-    };
-  }, []);
-
-  // Listen for terminal data events to apply Ctrl modifier
-  useEffect(() => {
-    const term = termRef.current;
-    if (!term || !ctrlActive) return;
-
-    const disposable = term.onData(() => {
-      setCtrlActive(false);
-    });
-
-    return () => disposable.dispose();
-  }, [ctrlActive, termRef]);
+  const [upAxis, setUpAxis] = useState<DragAxis>("vertical");
+  const [downAxis, setDownAxis] = useState<DragAxis>("vertical");
 
   const haptic = useCallback(() => {
     navigator.vibrate?.(10);
   }, []);
 
-  const handleSend = useCallback(
+  // Reset ctrl flag once the terminal consumes a keystroke after it was armed.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term || !ctrlActive) return;
+    const disposable = term.onData(() => setCtrlActive(false));
+    return () => disposable.dispose();
+  }, [ctrlActive, termRef]);
+
+  const refocusTerminal = useCallback(() => {
+    termRef.current?.focus();
+  }, [termRef]);
+
+  const send = useCallback(
     (data: string) => {
       haptic();
       sendData(data);
-      // Refocus terminal to keep soft keyboard open
-      termRef.current?.focus();
+      refocusTerminal();
     },
-    [sendData, termRef, haptic],
+    [sendData, refocusTerminal, haptic],
   );
 
-  const handleKeyPress = useCallback(
-    (key: KeyDef) => {
-      handleSend(key.data);
-    },
-    [handleSend],
-  );
-
-  const handleCtrlToggle = useCallback(() => {
-    haptic();
-    setCtrlActive((prev) => !prev);
-    termRef.current?.focus();
-  }, [termRef, haptic]);
-
-  const handleCtrlC = useCallback(() => {
-    handleSend("\x03");
-    setCtrlActive(false);
-  }, [handleSend]);
-
-  const clearRepeat = useCallback(() => {
-    if (repeatTimer.current) {
-      clearTimeout(repeatTimer.current);
-      repeatTimer.current = null;
-    }
-    if (repeatInterval.current) {
-      clearInterval(repeatInterval.current);
-      repeatInterval.current = null;
-    }
-  }, []);
-
-  const handlePointerDown = useCallback(
-    (key: KeyDef) => {
-      if (!key.repeatable) return;
-      clearRepeat();
-      repeatTimer.current = setTimeout(() => {
-        repeatInterval.current = setInterval(() => {
-          handleSend(key.data);
-        }, LONG_PRESS_INTERVAL);
-      }, LONG_PRESS_DELAY);
-    },
-    [handleSend, clearRepeat],
-  );
-
-  const handlePointerUp = useCallback(() => {
-    clearRepeat();
-  }, [clearRepeat]);
+  const upHandlers = useLongPressDrag({
+    onRepeat: () => sendData(ARROW_UP),
+    onHorizontal: (dir) => sendData(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
+    onAxisChange: setUpAxis,
+  });
+  const downHandlers = useLongPressDrag({
+    onRepeat: () => sendData(ARROW_DOWN),
+    onHorizontal: (dir) => sendData(dir === "left" ? ARROW_LEFT : ARROW_RIGHT),
+    onAxisChange: setDownAxis,
+  });
 
   const btnBase =
-    "flex-1 flex items-center justify-center h-11 rounded-md transition-colors duration-75 text-text-secondary select-none touch-manipulation";
-  const btnDefault = `${btnBase} active:bg-surface-700/50 active:scale-95`;
-  const btnCtrl = ctrlActive
-    ? `${btnBase} bg-brand-600/20 text-brand-400`
-    : btnDefault;
+    "flex-1 flex items-center justify-center h-11 rounded-md transition-colors duration-75 text-text-secondary select-none touch-manipulation relative active:bg-surface-700/50 active:scale-95";
+
+  const strip =
+    "shrink-0 flex items-center gap-1 px-2 py-1.5 bg-surface-850 border-t border-surface-700/20 safe-area-bottom";
+
+  // Pin the strip above the soft keyboard when it's open; otherwise sit on
+  // the pane bottom. env(keyboard-inset-height) covers iPadOS floating
+  // keyboards where visualViewport doesn't shrink.
+  const translateY = keyboardHeight > 0 ? -keyboardHeight : 0;
+  const stripStyle = {
+    transform: `translateY(${translateY}px)`,
+    paddingBottom: keyboardHeight > 0 ? undefined : "env(keyboard-inset-height, 0px)",
+  };
+
+  const arrowHint = (axis: DragAxis) =>
+    axis !== "vertical" ? (
+      <span
+        aria-hidden="true"
+        className="absolute bottom-0.5 left-1/2 -translate-x-1/2 font-mono text-[9px] text-brand-400"
+      >
+        ←→
+      </span>
+    ) : null;
 
   return (
-    <div className="shrink-0 flex items-center gap-1 px-2 py-1.5 bg-surface-850 border-t border-surface-700/20 safe-area-bottom">
-      {KEYS.map((key) => (
-        <button
-          key={key.ariaLabel}
-          type="button"
-          aria-label={key.ariaLabel}
-          className={btnDefault}
-          onClick={() => handleKeyPress(key)}
-          onPointerDown={() => handlePointerDown(key)}
-          onPointerUp={handlePointerUp}
-          onPointerCancel={handlePointerUp}
-          onPointerLeave={handlePointerUp}
-        >
-          <span className="font-mono text-sm">{key.label}</span>
-        </button>
-      ))}
-
+    <div className={strip} style={stripStyle}>
+      <button type="button" aria-label="Arrow up" className={btnBase} {...upHandlers}>
+        <span className="font-mono text-sm">{"\u2191"}</span>
+        {arrowHint(upAxis)}
+      </button>
+      <button type="button" aria-label="Arrow down" className={btnBase} {...downHandlers}>
+        <span className="font-mono text-sm">{"\u2193"}</span>
+        {arrowHint(downAxis)}
+      </button>
+      <button type="button" aria-label="Tab" className={btnBase}
+        onClick={() => send("\t")}>
+        <span className="font-mono text-sm">Tab</span>
+      </button>
+      <button type="button" aria-label="Escape" className={btnBase}
+        onClick={() => send("\x1b")}>
+        <span className="font-mono text-sm">Esc</span>
+      </button>
       <button
         type="button"
         aria-label="Ctrl"
-        className={btnCtrl}
-        onClick={handleCtrlToggle}
+        aria-pressed={ctrlActive}
+        className={
+          ctrlActive
+            ? `${btnBase.replace("text-text-secondary", "text-brand-400")} bg-brand-600/20`
+            : btnBase
+        }
+        onClick={() => { haptic(); setCtrlActive((v) => !v); refocusTerminal(); }}
       >
         <span className="font-mono text-xs">Ctrl</span>
       </button>
-
-      <button
-        type="button"
-        aria-label="Ctrl+C interrupt"
-        className={btnDefault}
-        onClick={handleCtrlC}
-      >
+      <button type="button" aria-label="Ctrl+C interrupt" className={btnBase}
+        onClick={() => { send("\x03"); setCtrlActive(false); }}>
         <span className="font-mono text-xs">^C</span>
       </button>
     </div>

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -47,6 +47,28 @@ export function TerminalSettings() {
             Changing this will reconnect active sessions.
           </p>
         </div>
+
+        <div>
+          <label className="flex items-center justify-between gap-3 cursor-pointer">
+            <div>
+              <div className="text-[13px] text-text-secondary">
+                Auto-open keyboard on mobile
+              </div>
+              <p className="text-[11px] text-text-muted mt-1">
+                Open the soft keyboard when you select a session. Turn off for
+                monitoring-first workflows.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={settings.autoOpenKeyboard}
+              onChange={(e) =>
+                update({ autoOpenKeyboard: e.target.checked })
+              }
+              className="accent-brand-600 w-4 h-4 shrink-0"
+            />
+          </label>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { FormEvent } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
@@ -11,12 +11,29 @@ interface Props {
   session: SessionResponse;
 }
 
+const SCROLL_HINT_SEEN_KEY = "aoe-mobile-scroll-hint-seen";
+const SCROLL_HINT_TIMEOUT_MS = 8000;
+
 export function TerminalView({ session }: Props) {
   const { containerRef, termRef, state, manualReconnect, sendData } =
     useTerminal(session.id);
-  const { isMobile, keyboardHeight } = useMobileKeyboard();
+  const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const { settings } = useWebSettings();
   const proxyRef = useRef<HTMLInputElement>(null);
+  const [proxyFocused, setProxyFocused] = useState(false);
+  const [hintDismissed, setHintDismissed] = useState(() => {
+    try {
+      return localStorage.getItem(SCROLL_HINT_SEEN_KEY) === "1";
+    } catch {
+      return true; // localStorage unavailable — treat as already seen
+    }
+  });
+  const showScrollHint = isMobile && state.connected && !hintDismissed;
+  // Treat the keyboard as "up" whenever the proxy input has focus, not only
+  // when visualViewport reports a shrunk viewport. On iOS PWA standalone
+  // mode and iPadOS floating keyboards, visualViewport can lag or never
+  // fire; proxy focus flips instantly.
+  const keyboardVisible = keyboardOpen || proxyFocused;
 
   // Auto-open soft keyboard when a session is selected, if the user wants it.
   useEffect(() => {
@@ -46,6 +63,31 @@ export function TerminalView({ session }: Props) {
     if (selection.length > 0) return;
     proxyRef.current?.focus();
   }, [isMobile]);
+
+  const focusProxy = useCallback(() => {
+    proxyRef.current?.focus();
+  }, []);
+
+  // Dismiss the one-time scroll hint on first touchmove or after a timeout.
+  // Persisted to localStorage so it's shown only once per device.
+  useEffect(() => {
+    if (!showScrollHint) return;
+    const markSeen = () => {
+      setHintDismissed(true);
+      try {
+        localStorage.setItem(SCROLL_HINT_SEEN_KEY, "1");
+      } catch {
+        // ignore quota / disabled-storage errors
+      }
+    };
+    const t = setTimeout(markSeen, SCROLL_HINT_TIMEOUT_MS);
+    const c = containerRef.current;
+    c?.addEventListener("touchmove", markSeen, { once: true });
+    return () => {
+      clearTimeout(t);
+      c?.removeEventListener("touchmove", markSeen);
+    };
+  }, [showScrollHint, containerRef]);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden relative">
@@ -78,19 +120,69 @@ export function TerminalView({ session }: Props) {
         />
 
         {isMobile && state.connected && (
-          <input
-            ref={proxyRef}
-            type="text"
-            autoComplete="off"
-            autoCorrect="off"
-            autoCapitalize="none"
-            spellCheck={false}
-            onInput={onProxyInput}
-            aria-hidden="true"
-            tabIndex={-1}
-            className="absolute opacity-0 pointer-events-none w-px h-px -z-10"
-            style={{ left: 0, top: 0 }}
-          />
+          <>
+            <input
+              ref={proxyRef}
+              type="text"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="none"
+              spellCheck={false}
+              onInput={onProxyInput}
+              onFocus={() => setProxyFocused(true)}
+              onBlur={() => setProxyFocused(false)}
+              aria-hidden="true"
+              tabIndex={-1}
+              className="absolute opacity-0 pointer-events-none w-px h-px -z-10"
+              style={{ left: 0, top: 0 }}
+            />
+
+            {!keyboardVisible && (
+              <button
+                type="button"
+                aria-label="Open keyboard"
+                onClick={focusProxy}
+                className="absolute right-3 bottom-3 w-9 h-9 rounded-full bg-surface-800 border border-surface-700/30 text-text-secondary flex items-center justify-center motion-safe:transition-opacity motion-safe:duration-150 hover:bg-surface-700 active:scale-95"
+              >
+                <svg
+                  width="18"
+                  height="14"
+                  viewBox="0 0 24 18"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                >
+                  <rect x="1" y="1" width="22" height="16" rx="2" />
+                  <line x1="5" y1="13" x2="19" y2="13" />
+                  <line x1="5" y1="9" x2="5.01" y2="9" />
+                  <line x1="9" y1="9" x2="9.01" y2="9" />
+                  <line x1="13" y1="9" x2="13.01" y2="9" />
+                  <line x1="17" y1="9" x2="17.01" y2="9" />
+                  <line x1="5" y1="5" x2="5.01" y2="5" />
+                  <line x1="9" y1="5" x2="9.01" y2="5" />
+                  <line x1="13" y1="5" x2="13.01" y2="5" />
+                  <line x1="17" y1="5" x2="17.01" y2="5" />
+                </svg>
+              </button>
+            )}
+
+            {showScrollHint && (
+              <div
+                aria-hidden="true"
+                className="absolute left-0 right-0 top-3 flex justify-center pointer-events-none motion-safe:animate-[fadeIn_300ms_ease-out]"
+              >
+                <span className="flex items-center gap-2 font-mono text-[13px] text-text-primary bg-surface-800/95 border border-surface-700 rounded-md px-3 py-2 shadow-lg backdrop-blur-sm">
+                  <span aria-hidden="true" className="text-base leading-none">
+                    {"\u21C5"}
+                  </span>
+                  Two fingers to scroll
+                </span>
+              </div>
+            )}
+          </>
         )}
       </div>
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,5 +1,8 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { FormEvent } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
+import { useWebSettings } from "../hooks/useWebSettings";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import type { SessionResponse } from "../lib/types";
 import "@xterm/xterm/css/xterm.css";
@@ -11,7 +14,38 @@ interface Props {
 export function TerminalView({ session }: Props) {
   const { containerRef, termRef, state, manualReconnect, sendData } =
     useTerminal(session.id);
-  const { isMobile, keyboardOpen } = useMobileKeyboard();
+  const { isMobile, keyboardHeight } = useMobileKeyboard();
+  const { settings } = useWebSettings();
+  const proxyRef = useRef<HTMLInputElement>(null);
+
+  // Auto-open soft keyboard when a session is selected, if the user wants it.
+  useEffect(() => {
+    if (!isMobile || !state.connected) return;
+    if (!settings.autoOpenKeyboard) return;
+    const id = setTimeout(() => proxyRef.current?.focus(), 50);
+    return () => clearTimeout(id);
+  }, [isMobile, state.connected, session.id, settings.autoOpenKeyboard]);
+
+  // The proxy input is the keyboard bridge: soft keyboard types into it,
+  // we relay each input to the PTY and clear. Mobile browsers don't
+  // reliably expose xterm's own helper textarea for the soft keyboard.
+  const onProxyInput = useCallback(
+    (e: FormEvent<HTMLInputElement>) => {
+      const value = e.currentTarget.value;
+      if (value) sendData(value);
+      e.currentTarget.value = "";
+    },
+    [sendData],
+  );
+
+  // Tap the terminal pane to reopen the keyboard. Skip when text is
+  // selected (preserves native long-press-to-select behavior).
+  const onContainerClick = useCallback(() => {
+    if (!isMobile) return;
+    const selection = window.getSelection()?.toString() ?? "";
+    if (selection.length > 0) return;
+    proxyRef.current?.focus();
+  }, [isMobile]);
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden relative">
@@ -36,13 +70,36 @@ export function TerminalView({ session }: Props) {
         </div>
       )}
 
-      <div
-        ref={containerRef}
-        className="flex-1 overflow-hidden bg-surface-950"
-      />
+      <div className="flex-1 overflow-hidden bg-surface-950 relative">
+        <div
+          ref={containerRef}
+          onClick={onContainerClick}
+          className="absolute inset-0"
+        />
 
-      {isMobile && keyboardOpen && state.connected && (
-        <MobileTerminalToolbar sendData={sendData} termRef={termRef} />
+        {isMobile && state.connected && (
+          <input
+            ref={proxyRef}
+            type="text"
+            autoComplete="off"
+            autoCorrect="off"
+            autoCapitalize="none"
+            spellCheck={false}
+            onInput={onProxyInput}
+            aria-hidden="true"
+            tabIndex={-1}
+            className="absolute opacity-0 pointer-events-none w-px h-px -z-10"
+            style={{ left: 0, top: 0 }}
+          />
+        )}
+      </div>
+
+      {isMobile && state.connected && (
+        <MobileTerminalToolbar
+          sendData={sendData}
+          termRef={termRef}
+          keyboardHeight={keyboardHeight}
+        />
       )}
     </div>
   );

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -42,7 +42,7 @@ export function TopBar({
   const overflowItems = useMemo<OverflowItem[]>(() => {
     const items: OverflowItem[] = [
       { label: "Settings", onClick: onOpenSettings },
-      { label: "Keyboard shortcuts", onClick: onOpenHelp },
+      { label: "Help", onClick: onOpenHelp },
       { label: "About", onClick: onOpenAbout },
     ];
     if (loginRequired) items.push({ label: "Sign out", onClick: onLogout });

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -74,9 +74,9 @@ export function useCommandActions({
 
     actions.push({
       id: "action:help",
-      title: "Show keyboard shortcuts",
+      title: "Show help",
       group: "Actions",
-      keywords: ["help", "keys", "?"],
+      keywords: ["help", "keys", "shortcuts", "gestures", "?"],
       shortcut: "?",
       perform: onOpenHelp,
     });

--- a/web/src/hooks/useLongPressDrag.ts
+++ b/web/src/hooks/useLongPressDrag.ts
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { PointerEvent as ReactPointerEvent } from "react";
+
+const LONG_PRESS_DELAY = 300;
+const REPEAT_INTERVAL = 100;
+const HORIZONTAL_THRESHOLD = 16;
+
+export type DragAxis = "vertical" | "horizontal-left" | "horizontal-right";
+
+interface Handlers {
+  onPointerDown: (e: ReactPointerEvent) => void;
+  onPointerMove: (e: ReactPointerEvent) => void;
+  onPointerUp: (e: ReactPointerEvent) => void;
+  onPointerCancel: (e: ReactPointerEvent) => void;
+  onPointerLeave: (e: ReactPointerEvent) => void;
+}
+
+// Press to tap (fires once on release); press and hold to repeat the same
+// vertical arrow; drag horizontally mid-press to emit horizontal arrows
+// instead. Dominant axis wins on diagonal drags. Emits an "axis change"
+// callback so callers can show a visual hint.
+export function useLongPressDrag(opts: {
+  onRepeat: () => void;
+  onHorizontal: (direction: "left" | "right") => void;
+  onAxisChange?: (axis: DragAxis) => void;
+}): Handlers {
+  const { onRepeat, onHorizontal, onAxisChange } = opts;
+  const delayTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const intervalTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const axis = useRef<DragAxis>("vertical");
+  const pressed = useRef(false);
+  const emitted = useRef(false); // true once any emit fired this press
+
+  const clearTimers = useCallback(() => {
+    if (delayTimer.current) {
+      clearTimeout(delayTimer.current);
+      delayTimer.current = null;
+    }
+    if (intervalTimer.current) {
+      clearInterval(intervalTimer.current);
+      intervalTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearTimers, [clearTimers]);
+
+  const startInterval = useCallback(() => {
+    if (intervalTimer.current) return;
+    intervalTimer.current = setInterval(() => {
+      emitted.current = true;
+      if (axis.current === "vertical") {
+        onRepeat();
+      } else if (axis.current === "horizontal-left") {
+        onHorizontal("left");
+      } else {
+        onHorizontal("right");
+      }
+    }, REPEAT_INTERVAL);
+  }, [onRepeat, onHorizontal]);
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      pressed.current = true;
+      emitted.current = false;
+      startX.current = e.clientX;
+      startY.current = e.clientY;
+      axis.current = "vertical";
+      onAxisChange?.("vertical");
+      clearTimers();
+      delayTimer.current = setTimeout(() => {
+        if (pressed.current) startInterval();
+      }, LONG_PRESS_DELAY);
+    },
+    [clearTimers, startInterval, onAxisChange],
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent) => {
+      if (!pressed.current) return;
+      const dx = e.clientX - startX.current;
+      const dy = e.clientY - startY.current;
+      // Dominant axis wins on diagonal drags.
+      const horizontal = Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > HORIZONTAL_THRESHOLD;
+      const next: DragAxis = horizontal
+        ? dx > 0 ? "horizontal-right" : "horizontal-left"
+        : "vertical";
+      if (next !== axis.current) {
+        axis.current = next;
+        onAxisChange?.(next);
+      }
+    },
+    [onAxisChange],
+  );
+
+  // Short press + release with no horizontal drag and no interval emits
+  // fires a single "tap" — the same effect as one repeat. Long-press that
+  // triggered the interval suppresses the tap.
+  const onPointerUp = useCallback(() => {
+    if (pressed.current && !emitted.current && axis.current === "vertical") {
+      onRepeat();
+    }
+    pressed.current = false;
+    clearTimers();
+    axis.current = "vertical";
+    onAxisChange?.("vertical");
+  }, [clearTimers, onAxisChange, onRepeat]);
+
+  const cancel = useCallback(() => {
+    pressed.current = false;
+    clearTimers();
+    axis.current = "vertical";
+    onAxisChange?.("vertical");
+  }, [clearTimers, onAxisChange]);
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel: cancel,
+    onPointerLeave: cancel,
+  };
+}

--- a/web/src/hooks/useMobileKeyboard.ts
+++ b/web/src/hooks/useMobileKeyboard.ts
@@ -1,32 +1,25 @@
 import { useEffect, useState } from "react";
 
-/**
- * Detects mobile touch devices and manages keyboard lifecycle:
- * - Tracks whether the soft keyboard is open (via visualViewport height)
- * - Fires terminal refit when the soft keyboard opens/closes
- * - Provides focusTerminal() to programmatically open the keyboard
- */
+// Detects touch-primary devices and tracks soft-keyboard state via visualViewport.
+// isMobile is used to decide whether the mobile toolbar renders at all.
+// keyboardOpen and keyboardHeight are used for POSITIONING the toolbar above
+// the soft keyboard, not for gating whether it renders.
 export function useMobileKeyboard() {
   const [isMobile, setIsMobile] = useState(() =>
     typeof window !== "undefined" &&
-    window.innerWidth < 768 &&
-    navigator.maxTouchPoints > 0,
+    window.matchMedia?.("(pointer: coarse)").matches,
   );
   const [keyboardOpen, setKeyboardOpen] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
 
-  // Re-evaluate on resize (e.g., device rotation or resizing browser)
   useEffect(() => {
-    const check = () => {
-      setIsMobile(window.innerWidth < 768 && navigator.maxTouchPoints > 0);
-    };
-    window.addEventListener("resize", check);
-    return () => window.removeEventListener("resize", check);
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setIsMobile(mql.matches);
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
   }, []);
 
-  // Detect keyboard open/close via visualViewport and trigger terminal refit.
-  // When the keyboard opens, visualViewport.height shrinks well below
-  // window.innerHeight. A threshold of 150px avoids false positives from
-  // browser chrome changes.
   useEffect(() => {
     if (!isMobile) return;
     const vv = window.visualViewport;
@@ -34,12 +27,16 @@ export function useMobileKeyboard() {
 
     const handleResize = () => {
       const heightDiff = window.innerHeight - vv.height;
-      setKeyboardOpen(heightDiff > 150);
+      // Threshold avoids false positives from browser chrome changes.
+      const open = heightDiff > 150;
+      setKeyboardOpen(open);
+      setKeyboardHeight(open ? heightDiff : 0);
       window.dispatchEvent(new Event("resize"));
     };
+    handleResize();
     vv.addEventListener("resize", handleResize);
     return () => vv.removeEventListener("resize", handleResize);
   }, [isMobile]);
 
-  return { isMobile, keyboardOpen };
+  return { isMobile, keyboardOpen, keyboardHeight };
 }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -205,38 +205,147 @@ export function useTerminal(
     const handleResize = () => fitAddon.fit();
     window.addEventListener("resize", handleResize);
 
-    // Touch-to-scroll: xterm.js doesn't natively translate touch swipes into
-    // buffer scrolling. We track touchmove Y-delta and call scrollLines().
-    // preventDefault stops the browser from pulling-to-refresh.
-    let touchStartY = 0;
-    let touchAccum = 0;
-    const cellHeight = () => term.options.fontSize ?? 14;
-
-    const onTouchStart = (e: TouchEvent) => {
-      const t = e.touches[0];
-      if (!t) return;
-      touchStartY = t.clientY;
-      touchAccum = 0;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      const t = e.touches[0];
-      if (!t) return;
-      e.preventDefault();
-      const dy = touchStartY - t.clientY;
-      touchStartY = t.clientY;
-      touchAccum += dy;
-      const lines = Math.trunc(touchAccum / cellHeight());
-      if (lines !== 0) {
-        term.scrollLines(lines);
-        touchAccum -= lines * cellHeight();
+    // Two-finger swipe emits SGR mouse-wheel escape sequences to the PTY,
+    // so tmux mouse-mode enters copy-mode and scrolls (and apps that read
+    // wheel events handle their own scrolling). We intentionally do NOT
+    // call term.scrollLines() — under tmux/alt-screen the local xterm
+    // scrollback is empty, so scrollLines would no-op. One-finger touches
+    // are left to xterm's native handling (text selection, taps). Calling
+    // preventDefault on one-finger moves breaks selection — never do it.
+    //
+    // Why we attach to .xterm and not the outer container: xterm.js
+    // registers document-level touch handlers that dispatch custom gesture
+    // events. Our listener sits on xterm's root element with capture:true
+    // so we fire before xterm's internal handlers. touch-action:none
+    // prevents the browser's native pan from competing for the gesture.
+    const WHEEL_UP_SEQ = "\x1b[<64;1;1M";
+    const WHEEL_DOWN_SEQ = "\x1b[<65;1;1M";
+    const sendWheel = (dir: "up" | "down", count: number) => {
+      const seq = dir === "up" ? WHEEL_UP_SEQ : WHEEL_DOWN_SEQ;
+      const ws = wsRef.current;
+      if (ws?.readyState !== WebSocket.OPEN) return;
+      for (let i = 0; i < count; i++) {
+        ws.send(new TextEncoder().encode(seq));
       }
     };
-    container.addEventListener("touchstart", onTouchStart, { passive: true });
-    container.addEventListener("touchmove", onTouchMove, { passive: false });
+
+    let touchMidY = 0;
+    let touchAccum = 0;
+    let lastMoveTs = 0;
+    let velocity = 0; // pixels per ms
+    let momentumRaf: number | null = null;
+    const LINES_PER_WHEEL = 2; // swipe pixels-per-wheel-event = cellHeight * 2
+    const MAX_VELOCITY = 2.0; // px/ms — a genuinely fast finger is ~1–2 px/ms
+    const MAX_WHEELS_PER_FRAME = 6; // cap runaway bursts
+    const clampV = (v: number) =>
+      Math.max(-MAX_VELOCITY, Math.min(MAX_VELOCITY, v));
+    const cellHeight = () => term.options.fontSize ?? 14;
+    const pxPerWheel = () => cellHeight() * LINES_PER_WHEEL;
+    const prefersReducedMotion = () =>
+      window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+
+    const midpointY = (e: TouchEvent) => {
+      const a = e.touches[0];
+      const b = e.touches[1];
+      if (!a || !b) return 0;
+      return (a.clientY + b.clientY) / 2;
+    };
+
+    const cancelMomentum = () => {
+      if (momentumRaf !== null) {
+        cancelAnimationFrame(momentumRaf);
+        momentumRaf = null;
+      }
+    };
+
+    const onTouchStart = (e: TouchEvent) => {
+      cancelMomentum();
+      if (e.touches.length !== 2) return;
+      touchMidY = midpointY(e);
+      touchAccum = 0;
+      velocity = 0;
+      lastMoveTs = performance.now();
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 2) return; // Single-finger = xterm handles it.
+      e.preventDefault();
+      const y = midpointY(e);
+      const now = performance.now();
+      const dy = touchMidY - y;
+      touchMidY = y;
+      touchAccum += dy;
+      const step = pxPerWheel();
+      const rawWheels = Math.trunc(touchAccum / step);
+      const wheels = Math.max(
+        -MAX_WHEELS_PER_FRAME,
+        Math.min(MAX_WHEELS_PER_FRAME, rawWheels),
+      );
+      if (wheels !== 0) {
+        // Positive wheels means scrolled up (dy positive = finger moved up =
+        // content should scroll up to reveal lines above = wheel-up).
+        sendWheel(wheels > 0 ? "up" : "down", Math.abs(wheels));
+        touchAccum -= wheels * step;
+        const dt = Math.max(1, now - lastMoveTs);
+        velocity = clampV(dy / dt);
+      }
+      lastMoveTs = now;
+    };
+
+    const onTouchEnd = (e: TouchEvent) => {
+      // Fires whenever the touch count changes; only decay when all fingers lift.
+      if (e.touches.length > 0) return;
+      if (prefersReducedMotion() || Math.abs(velocity) < 0.05) {
+        velocity = 0;
+        return;
+      }
+      let v = velocity; // px/ms
+      let last = performance.now();
+      let carry = 0;
+      const decay = () => {
+        const now = performance.now();
+        const dt = now - last;
+        last = now;
+        v *= Math.pow(0.92, dt / 16); // ~400ms decay
+        carry += v * dt;
+        const step = pxPerWheel();
+        const rawW = Math.trunc(carry / step);
+        const w = Math.max(
+          -MAX_WHEELS_PER_FRAME,
+          Math.min(MAX_WHEELS_PER_FRAME, rawW),
+        );
+        if (w !== 0) {
+          sendWheel(w > 0 ? "up" : "down", Math.abs(w));
+          carry -= w * step;
+        }
+        if (Math.abs(v) > 0.05) {
+          momentumRaf = requestAnimationFrame(decay);
+        } else {
+          momentumRaf = null;
+        }
+      };
+      momentumRaf = requestAnimationFrame(decay);
+    };
+
+    // Attach to the root `.xterm` element created by term.open. It's the
+    // common parent of .xterm-viewport, .xterm-screen, and helpers, so
+    // touches on any xterm surface bubble here first. Capture phase
+    // guarantees we fire before xterm's document-level gesture handler.
+    const viewport =
+      container.querySelector<HTMLElement>(".xterm") ?? container;
+    viewport.style.touchAction = "none";
+    const touchOpts = { passive: false, capture: true } as const;
+    viewport.addEventListener("touchstart", onTouchStart, touchOpts);
+    viewport.addEventListener("touchmove", onTouchMove, touchOpts);
+    viewport.addEventListener("touchend", onTouchEnd, touchOpts);
+    viewport.addEventListener("touchcancel", onTouchEnd, touchOpts);
 
     return () => {
-      container.removeEventListener("touchstart", onTouchStart);
-      container.removeEventListener("touchmove", onTouchMove);
+      cancelMomentum();
+      viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
+      viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
+      viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
+      viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       window.removeEventListener("resize", handleResize);
       dataDisposable?.dispose();
       resizeDisposable?.dispose();

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -4,10 +4,12 @@ const STORAGE_KEY = "aoe-web-settings";
 
 export interface WebSettings {
   mobileFontSize: number;
+  autoOpenKeyboard: boolean;
 }
 
 const DEFAULTS: WebSettings = {
   mobileFontSize: 8,
+  autoOpenKeyboard: true,
 };
 
 function getSnapshot(): WebSettings {


### PR DESCRIPTION
## Description

The mobile terminal UX shipped in #644 wasn't actually functional in practice. The toolbar was gated on a visualViewport height-diff heuristic that fired unreliably, a focus-proxy input that was silently removed in the same PR's review fixes, and single-finger scroll that fought xterm's text selection. Even when the toolbar did render, its PgUp / PgDn / Home / End buttons called xterm's local \`scrollLines\` — which no-ops under any alt-screen TUI (tmux, Claude Code, vim, less), so they did nothing.

This branch rewrites the mobile path around what actually works: sending real PTY escape sequences so tmux's own mouse mode handles scroll.

### What changed

- **Detection:** \`matchMedia('(pointer: coarse)')\` replaces \`maxTouchPoints + innerWidth\`. iPads, landscape phones, and PWA standalone mode now render the toolbar.
- **Focus proxy:** a visually-hidden input bridges the soft keyboard to the PTY, restoring the keyboard-opening path. New \`autoOpenKeyboard\` setting (default on) in the Settings page; tap the terminal pane to reopen.
- **Toolbar:** 6 keys (↑ ↓ Tab Esc Ctrl ^C) instead of 8, so every key meets the 44px touch target at 375px. Horizontal arrows come from long-press-drag on ↑/↓ (Termius pattern) with a faint ←→ hint.
- **Scroll:** two-finger swipe emits SGR mouse-wheel escape sequences (\`\x1b[<64;1;1M\` / \`\x1b[<65;1;1M\`). tmux enters copy-mode and scrolls. Momentum + rAF decay included, with a 2 px/ms velocity cap and 6-wheel-per-frame burst cap to prevent runaway. One-finger touches fall through to xterm for native text selection.
- **tmux precondition:** \`set-option -t <session> mouse on\` is appended to every new-session invocation in \`Session::create_with_size\` and \`TerminalSession::create_with_size\`, so the precondition for wheel-event scrolling is guaranteed for sessions \`aoe\` creates.
- **AGENTS.md:** documents the Playwright real-session e2e recipe (fake-claude shim + isolated \$HOME + WebSocket send spy + synthetic multi-touch) and the velocity-cap gotcha that synthetic events expose. Trimmed the rest of the file for repeated instructions.

### Breaking

Sessions created **before this change** still need \`C-b :set mouse on\` (or a kill+recreate) to pick up the new scroll behavior. No config format changes.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo test --lib --features serve\`: 1120 passed; web \`tsc -b\`, \`eslint\`, \`vite build\` all clean)
- [x] Documentation was updated where necessary (AGENTS.md)
- [x] For UI changes: included screenshot or recording *(see Test plan — on-phone recording to be added by @njbrake before merge)*

## Test plan

- [x] Rust: \`cargo test --lib --features serve\` (1120 passed), \`cargo clippy --features serve\`, \`cargo fmt --check\` all clean
- [x] Web: \`npx tsc -b\`, \`npx eslint\`, \`npx vite build\` clean
- [x] Real-session Playwright e2e (script in PR discussion below) verified: toolbar renders under iPhone 13 emulation; two-finger swipe emits 33 SGR wheel-up sequences (bounded); reverse swipe emits wheel-down; arrow-up button tap sends exactly one \`\\x1b[A\`; desktop viewport renders no mobile toolbar
- [x] Direct check that \`tmux show-options -t <session> mouse\` returns \`mouse on\` after \`aoe add --launch\`
- [ ] **On-phone verification by @njbrake** — real iOS Safari + Android Chrome two-finger scroll inside a Claude Code session, plus a before/after screen recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (via Claude Code)

**Any Additional AI Details you'd like to share:**
Planned via \`/office-hours\` → \`/plan-design-review\` → \`/plan-eng-review\`. Design doc and test plan stored under \`~/.gstack/projects/agent-of-empires/\` (not in the repo). The eng review and a real-session Playwright e2e each caught a shipping-blocker the previous layer missed: focus-proxy removal (eng review), runaway momentum + missing tap-emit (e2e).

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)