### PR TITLE
feat(web): pinch-to-zoom for terminal font size

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,2 +1,4 @@
 node_modules/
 dist/
+test-results/
+playwright-report/

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -49,6 +49,42 @@ export function TerminalSettings() {
         </div>
 
         <div>
+          <label className="block text-[13px] text-text-secondary mb-2">
+            Desktop font size
+          </label>
+          <div className="flex items-center gap-3">
+            <input
+              type="range"
+              min={6}
+              max={28}
+              step={1}
+              value={settings.desktopFontSize}
+              onChange={(e) =>
+                update({ desktopFontSize: Number(e.target.value) })
+              }
+              className="flex-1 accent-brand-600 h-1.5"
+            />
+            <select
+              value={settings.desktopFontSize}
+              onChange={(e) =>
+                update({ desktopFontSize: Number(e.target.value) })
+              }
+              className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
+            >
+              {FONT_SIZES.map((s) => (
+                <option key={s} value={s}>
+                  {s}px
+                </option>
+              ))}
+            </select>
+          </div>
+          <p className="text-[11px] text-text-muted mt-1">
+            Font size for the terminal on desktop. Hold Ctrl and scroll over the
+            terminal (or pinch on a trackpad) to zoom; the new size is saved here.
+          </p>
+        </div>
+
+        <div>
           <label className="flex items-center justify-between gap-3 cursor-pointer">
             <div>
               <div className="text-[13px] text-text-secondary">

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -1,6 +1,6 @@
 import { useWebSettings } from "../hooks/useWebSettings";
 
-const FONT_SIZES = [6, 7, 8, 9, 10, 11, 12, 13, 14];
+const FONT_SIZES = Array.from({ length: 23 }, (_, i) => i + 6); // 6..28
 
 export function TerminalSettings() {
   const { settings, update } = useWebSettings();
@@ -20,7 +20,7 @@ export function TerminalSettings() {
             <input
               type="range"
               min={6}
-              max={14}
+              max={28}
               step={1}
               value={settings.mobileFontSize}
               onChange={(e) =>
@@ -43,8 +43,8 @@ export function TerminalSettings() {
             </select>
           </div>
           <p className="text-[11px] text-text-muted mt-1">
-            Font size for the terminal on mobile devices. Desktop uses 14px.
-            Changing this will reconnect active sessions.
+            Font size for the terminal on mobile devices. Pinch the terminal
+            with two fingers to zoom; the new size is saved here.
           </p>
         </div>
 

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -8,6 +8,10 @@ const MAX_RETRIES = 3;
 const RETRY_DELAY = 5000;
 const MIN_FONT_SIZE = 6;
 const MAX_FONT_SIZE = 28;
+const DEFAULT_FONT_SIZE = 14;
+const MOBILE_BREAKPOINT_PX = 768;
+const WHEEL_ZOOM_SENSITIVITY = 0.05;
+const WHEEL_PERSIST_DEBOUNCE_MS = 400;
 
 export interface TerminalState {
   connected: boolean;
@@ -52,7 +56,7 @@ export function useTerminal(
     const container = containerRef.current;
     container.innerHTML = "";
 
-    const isMobileViewport = () => window.innerWidth < 768;
+    const isMobileViewport = () => window.innerWidth < MOBILE_BREAKPOINT_PX;
     const readFontSize = () =>
       isMobileViewport() ? settings.mobileFontSize : settings.desktopFontSize;
     const persistFontSize = (size: number) => {
@@ -247,7 +251,7 @@ export function useTerminal(
     // lock into either 'pinch' (zoom) or 'scroll' for the rest of the gesture.
     let gestureMode: "pinch" | "scroll" | null = null;
     let pinchStartDist = 0;
-    let pinchStartSize = 14;
+    let pinchStartSize = DEFAULT_FONT_SIZE;
     let pinchStartMidY = 0;
     const GESTURE_LOCK_PX = 12;
     const LINES_PER_WHEEL = 2; // swipe pixels-per-wheel-event = cellHeight * 2
@@ -255,7 +259,7 @@ export function useTerminal(
     const MAX_WHEELS_PER_FRAME = 6; // cap runaway bursts
     const clampV = (v: number) =>
       Math.max(-MAX_VELOCITY, Math.min(MAX_VELOCITY, v));
-    const cellHeight = () => term.options.fontSize ?? 14;
+    const cellHeight = () => term.options.fontSize ?? DEFAULT_FONT_SIZE;
     const pxPerWheel = () => cellHeight() * LINES_PER_WHEEL;
     const prefersReducedMotion = () =>
       window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
@@ -277,6 +281,11 @@ export function useTerminal(
     const clampFont = (n: number) =>
       Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, n));
 
+    // Pinch/wheel events fire faster than the frame rate; coalesce font-size
+    // updates to at most one fitAddon.fit() per animation frame to avoid
+    // layout thrash and spamming PTY resize messages over the WebSocket.
+    let pendingFontSize: number | null = null;
+    let fontSizeRaf: number | null = null;
     const applyFontSize = (size: number) => {
       const next = clampFont(Math.round(size));
       if (next !== term.options.fontSize) {
@@ -285,6 +294,29 @@ export function useTerminal(
       }
       return next;
     };
+    const scheduleFontSize = (size: number) => {
+      pendingFontSize = clampFont(Math.round(size));
+      if (fontSizeRaf !== null) return;
+      fontSizeRaf = requestAnimationFrame(() => {
+        fontSizeRaf = null;
+        if (pendingFontSize !== null) {
+          applyFontSize(pendingFontSize);
+          pendingFontSize = null;
+        }
+      });
+    };
+    const flushFontSize = () => {
+      if (fontSizeRaf !== null) {
+        cancelAnimationFrame(fontSizeRaf);
+        fontSizeRaf = null;
+      }
+      if (pendingFontSize !== null) {
+        applyFontSize(pendingFontSize);
+        pendingFontSize = null;
+      }
+    };
+    const currentPendingOrLiveSize = () =>
+      pendingFontSize ?? term.options.fontSize ?? DEFAULT_FONT_SIZE;
 
     const cancelMomentum = () => {
       if (momentumRaf !== null) {
@@ -302,7 +334,7 @@ export function useTerminal(
       lastMoveTs = performance.now();
       gestureMode = null;
       pinchStartDist = touchDistance(e);
-      pinchStartSize = term.options.fontSize ?? 14;
+      pinchStartSize = term.options.fontSize ?? DEFAULT_FONT_SIZE;
       pinchStartMidY = touchMidY;
     };
 
@@ -327,7 +359,7 @@ export function useTerminal(
 
       if (gestureMode === "pinch") {
         if (pinchStartDist > 0) {
-          applyFontSize(pinchStartSize * (dist / pinchStartDist));
+          scheduleFontSize(pinchStartSize * (dist / pinchStartDist));
         }
         lastMoveTs = now;
         return;
@@ -357,7 +389,8 @@ export function useTerminal(
       // Fires whenever the touch count changes; only decay when all fingers lift.
       if (e.touches.length > 0) return;
       if (gestureMode === "pinch") {
-        persistFontSize(term.options.fontSize ?? 14);
+        flushFontSize();
+        persistFontSize(term.options.fontSize ?? DEFAULT_FONT_SIZE);
         gestureMode = null;
         velocity = 0;
         return;
@@ -416,19 +449,20 @@ export function useTerminal(
     const onWheel = (e: WheelEvent) => {
       if (!e.ctrlKey) return;
       e.preventDefault();
-      wheelAccum -= e.deltaY * 0.05;
+      wheelAccum -= e.deltaY * WHEEL_ZOOM_SENSITIVITY;
       if (Math.abs(wheelAccum) < 1) return;
       const delta = Math.trunc(wheelAccum);
       wheelAccum -= delta;
-      const current = term.options.fontSize ?? 14;
-      const next = applyFontSize(current + delta);
-      if (next !== current) {
-        if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
-        wheelPersistTimer = setTimeout(() => {
-          persistFontSize(next);
-          wheelPersistTimer = null;
-        }, 400);
-      }
+      const base = currentPendingOrLiveSize();
+      const next = clampFont(Math.round(base + delta));
+      if (next === base) return;
+      scheduleFontSize(next);
+      if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
+      wheelPersistTimer = setTimeout(() => {
+        flushFontSize();
+        persistFontSize(term.options.fontSize ?? DEFAULT_FONT_SIZE);
+        wheelPersistTimer = null;
+      }, WHEEL_PERSIST_DEBOUNCE_MS);
     };
     viewport.addEventListener("wheel", onWheel, { passive: false });
 
@@ -440,6 +474,7 @@ export function useTerminal(
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("wheel", onWheel);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
+      if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
       window.removeEventListener("resize", handleResize);
       dataDisposable?.dispose();
       resizeDisposable?.dispose();
@@ -465,7 +500,7 @@ export function useTerminal(
     const fit = fitRef.current;
     if (!term) return;
     const size =
-      window.innerWidth < 768
+      window.innerWidth < MOBILE_BREAKPOINT_PX
         ? settings.mobileFontSize
         : settings.desktopFontSize;
     if (term.options.fontSize !== size) {

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -6,6 +6,8 @@ import { useWebSettings } from "./useWebSettings";
 
 const MAX_RETRIES = 3;
 const RETRY_DELAY = 5000;
+const MIN_FONT_SIZE = 6;
+const MAX_FONT_SIZE = 28;
 
 export interface TerminalState {
   connected: boolean;
@@ -22,7 +24,7 @@ export function useTerminal(
   sessionId: string | null,
   wsPath: string = "ws",
 ) {
-  const { settings } = useWebSettings();
+  const { settings, update } = useWebSettings();
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
@@ -50,7 +52,14 @@ export function useTerminal(
     const container = containerRef.current;
     container.innerHTML = "";
 
-    const fontSize = window.innerWidth < 768 ? settings.mobileFontSize : 14;
+    const isMobileViewport = () => window.innerWidth < 768;
+    const readFontSize = () =>
+      isMobileViewport() ? settings.mobileFontSize : settings.desktopFontSize;
+    const persistFontSize = (size: number) => {
+      if (isMobileViewport()) update({ mobileFontSize: size });
+      else update({ desktopFontSize: size });
+    };
+    const fontSize = readFontSize();
 
     const term = new Terminal({
       cursorBlink: true,
@@ -234,6 +243,13 @@ export function useTerminal(
     let lastMoveTs = 0;
     let velocity = 0; // pixels per ms
     let momentumRaf: number | null = null;
+    // Pinch state: once a two-finger gesture exceeds a small deadzone, we
+    // lock into either 'pinch' (zoom) or 'scroll' for the rest of the gesture.
+    let gestureMode: "pinch" | "scroll" | null = null;
+    let pinchStartDist = 0;
+    let pinchStartSize = 14;
+    let pinchStartMidY = 0;
+    const GESTURE_LOCK_PX = 12;
     const LINES_PER_WHEEL = 2; // swipe pixels-per-wheel-event = cellHeight * 2
     const MAX_VELOCITY = 2.0; // px/ms — a genuinely fast finger is ~1–2 px/ms
     const MAX_WHEELS_PER_FRAME = 6; // cap runaway bursts
@@ -251,6 +267,25 @@ export function useTerminal(
       return (a.clientY + b.clientY) / 2;
     };
 
+    const touchDistance = (e: TouchEvent) => {
+      const a = e.touches[0];
+      const b = e.touches[1];
+      if (!a || !b) return 0;
+      return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+    };
+
+    const clampFont = (n: number) =>
+      Math.max(MIN_FONT_SIZE, Math.min(MAX_FONT_SIZE, n));
+
+    const applyFontSize = (size: number) => {
+      const next = clampFont(Math.round(size));
+      if (next !== term.options.fontSize) {
+        term.options.fontSize = next;
+        fitAddon.fit();
+      }
+      return next;
+    };
+
     const cancelMomentum = () => {
       if (momentumRaf !== null) {
         cancelAnimationFrame(momentumRaf);
@@ -265,6 +300,10 @@ export function useTerminal(
       touchAccum = 0;
       velocity = 0;
       lastMoveTs = performance.now();
+      gestureMode = null;
+      pinchStartDist = touchDistance(e);
+      pinchStartSize = term.options.fontSize ?? 14;
+      pinchStartMidY = touchMidY;
     };
 
     const onTouchMove = (e: TouchEvent) => {
@@ -272,6 +311,28 @@ export function useTerminal(
       e.preventDefault();
       const y = midpointY(e);
       const now = performance.now();
+      const dist = touchDistance(e);
+
+      if (gestureMode === null) {
+        const distDelta = Math.abs(dist - pinchStartDist);
+        const panDelta = Math.abs(y - pinchStartMidY);
+        if (Math.max(distDelta, panDelta) < GESTURE_LOCK_PX) {
+          lastMoveTs = now;
+          return;
+        }
+        gestureMode = distDelta > panDelta ? "pinch" : "scroll";
+        // Reset scroll baseline so we don't replay the deadzone travel.
+        touchMidY = y;
+      }
+
+      if (gestureMode === "pinch") {
+        if (pinchStartDist > 0) {
+          applyFontSize(pinchStartSize * (dist / pinchStartDist));
+        }
+        lastMoveTs = now;
+        return;
+      }
+
       const dy = touchMidY - y;
       touchMidY = y;
       touchAccum += dy;
@@ -295,6 +356,13 @@ export function useTerminal(
     const onTouchEnd = (e: TouchEvent) => {
       // Fires whenever the touch count changes; only decay when all fingers lift.
       if (e.touches.length > 0) return;
+      if (gestureMode === "pinch") {
+        persistFontSize(term.options.fontSize ?? 14);
+        gestureMode = null;
+        velocity = 0;
+        return;
+      }
+      gestureMode = null;
       if (prefersReducedMotion() || Math.abs(velocity) < 0.05) {
         velocity = 0;
         return;
@@ -340,12 +408,38 @@ export function useTerminal(
     viewport.addEventListener("touchend", onTouchEnd, touchOpts);
     viewport.addEventListener("touchcancel", onTouchEnd, touchOpts);
 
+    // Trackpad pinch fires wheel events with ctrlKey=true (and Ctrl+wheel
+    // mouse zoom matches the same convention). Debounce persistence so we
+    // don't hammer localStorage on every frame of a pinch.
+    let wheelAccum = 0;
+    let wheelPersistTimer: ReturnType<typeof setTimeout> | null = null;
+    const onWheel = (e: WheelEvent) => {
+      if (!e.ctrlKey) return;
+      e.preventDefault();
+      wheelAccum -= e.deltaY * 0.05;
+      if (Math.abs(wheelAccum) < 1) return;
+      const delta = Math.trunc(wheelAccum);
+      wheelAccum -= delta;
+      const current = term.options.fontSize ?? 14;
+      const next = applyFontSize(current + delta);
+      if (next !== current) {
+        if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
+        wheelPersistTimer = setTimeout(() => {
+          persistFontSize(next);
+          wheelPersistTimer = null;
+        }, 400);
+      }
+    };
+    viewport.addEventListener("wheel", onWheel, { passive: false });
+
     return () => {
       cancelMomentum();
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
+      viewport.removeEventListener("wheel", onWheel);
+      if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       window.removeEventListener("resize", handleResize);
       dataDisposable?.dispose();
       resizeDisposable?.dispose();
@@ -357,7 +451,28 @@ export function useTerminal(
       wsRef.current = null;
       fitRef.current = null;
     };
-  }, [sessionId, wsPath, settings.mobileFontSize]);
+    // We intentionally do NOT depend on settings.{mobile,desktop}FontSize —
+    // that would tear down and reconnect the PTY every time the font
+    // changed (via slider or pinch). The sync effect below mutates
+    // term.options.fontSize in-place instead.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId, wsPath]);
+
+  // Apply font size changes (from settings UI or pinch persistence) to the
+  // live terminal without recreating it.
+  useEffect(() => {
+    const term = termRef.current;
+    const fit = fitRef.current;
+    if (!term) return;
+    const size =
+      window.innerWidth < 768
+        ? settings.mobileFontSize
+        : settings.desktopFontSize;
+    if (term.options.fontSize !== size) {
+      term.options.fontSize = size;
+      fit?.fit();
+    }
+  }, [settings.mobileFontSize, settings.desktopFontSize]);
 
   const manualReconnect = () => {
     retryCountRef.current = 0;

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -4,11 +4,13 @@ const STORAGE_KEY = "aoe-web-settings";
 
 export interface WebSettings {
   mobileFontSize: number;
+  desktopFontSize: number;
   autoOpenKeyboard: boolean;
 }
 
 const DEFAULTS: WebSettings = {
   mobileFontSize: 8,
+  desktopFontSize: 14,
   autoOpenKeyboard: true,
 };
 

--- a/web/test-results/.last-run.json
+++ b/web/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -1,0 +1,166 @@
+import type { Page } from "@playwright/test";
+
+// Shared mocks so a running `aoe serve` + tmux aren't required. We stub the
+// REST API and route the PTY WebSocket so the xterm terminal mounts and the
+// gesture handlers in useTerminal.ts are exercised against the real frontend.
+
+export async function mockTerminalApis(page: Page) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: [
+        {
+          id: "pinch-test",
+          title: "pinch-test",
+          project_path: "/tmp/pinch-test",
+          group_path: "/tmp",
+          tool: "claude",
+          status: "Running",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+        },
+      ],
+    });
+  });
+  await page.route("**/api/sessions/*/terminal", (r) =>
+    r.fulfill({ status: 200, body: "" }),
+  );
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({ json: { files: [] } }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+  await page.routeWebSocket(/\/sessions\/.*\/(ws|container-ws)$/, (ws) => {
+    ws.onMessage(() => {
+      /* absorb keystrokes / resize JSON */
+    });
+    setTimeout(() => {
+      try {
+        ws.send(Buffer.from("$ "));
+      } catch {
+        // ws may have been closed while the test ended — safe to ignore
+      }
+    }, 50);
+  });
+}
+
+// Install a WebSocket constructor spy and a localStorage.setItem spy on
+// window. Both run before any frontend script, so the React app sees the
+// patched globals. The counts let tests prove that a setting change does
+// NOT reopen the PTY, and that a gesture that should be a no-op did not
+// write to localStorage.
+export async function installTerminalSpies(page: Page) {
+  await page.addInitScript(() => {
+    const Orig = window.WebSocket;
+    (window as unknown as { __WS_COUNT__: number }).__WS_COUNT__ = 0;
+    // Preserve name + prototype by extending
+    window.WebSocket = class extends Orig {
+      constructor(url: string | URL, protocols?: string | string[]) {
+        super(url, protocols);
+        (window as unknown as { __WS_COUNT__: number }).__WS_COUNT__ += 1;
+      }
+    } as typeof WebSocket;
+
+    (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__ = [];
+    const origSetItem = Storage.prototype.setItem;
+    Storage.prototype.setItem = function (key: string, value: string) {
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__.push(
+        `${key}=${value}`,
+      );
+      return origSetItem.call(this, key, value);
+    };
+  });
+}
+
+export function readFontSize(page: Page, which: "mobile" | "desktop") {
+  return page.evaluate((which) => {
+    const raw = localStorage.getItem("aoe-web-settings");
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return which === "mobile" ? parsed.mobileFontSize : parsed.desktopFontSize;
+  }, which);
+}
+
+export async function seedSettings(
+  page: Page,
+  settings: { mobileFontSize?: number; desktopFontSize?: number },
+) {
+  await page.evaluate((settings) => {
+    localStorage.setItem(
+      "aoe-web-settings",
+      JSON.stringify({
+        mobileFontSize: 8,
+        desktopFontSize: 14,
+        autoOpenKeyboard: true,
+        ...settings,
+      }),
+    );
+  }, settings);
+}
+
+// Synthesize a multi-touch TouchEvent on the .xterm element.
+// Playwright's page.touchscreen is single-finger only; building raw Touch
+// objects is the only cross-browser way to dispatch two-finger gestures.
+export async function fireTouches(
+  page: Page,
+  type: "touchstart" | "touchmove" | "touchend" | "touchcancel",
+  points: { x: number; y: number }[],
+) {
+  await page.evaluate(
+    ({ type, points }) => {
+      const target = document.querySelector<HTMLElement>(".xterm");
+      if (!target) throw new Error(".xterm not mounted");
+      const rect = target.getBoundingClientRect();
+      const touches = points.map((p, i) => {
+        const clientX = rect.left + p.x;
+        const clientY = rect.top + p.y;
+        return new Touch({
+          identifier: i,
+          target,
+          clientX,
+          clientY,
+          pageX: clientX,
+          pageY: clientY,
+          screenX: clientX,
+          screenY: clientY,
+          radiusX: 2,
+          radiusY: 2,
+          rotationAngle: 0,
+          force: 1,
+        });
+      });
+      const lifted = type === "touchend" || type === "touchcancel";
+      const ev = new TouchEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        touches: lifted ? [] : touches,
+        targetTouches: lifted ? [] : touches,
+        changedTouches: touches,
+      });
+      target.dispatchEvent(ev);
+    },
+    { type, points },
+  );
+}

--- a/web/tests/pinch-zoom-desktop.spec.ts
+++ b/web/tests/pinch-zoom-desktop.spec.ts
@@ -1,0 +1,162 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockTerminalApis,
+  installTerminalSpies,
+  readFontSize,
+  seedSettings,
+} from "./helpers/terminal-mocks";
+
+// Desktop viewport: covers the Ctrl+wheel / trackpad pinch code path that
+// only runs when window.innerWidth >= MOBILE_BREAKPOINT_PX. Also proves the
+// settings-change → live-font-sync useEffect doesn't reopen the PTY.
+
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
+  async function openSession(page: Page) {
+    await page
+      .getByRole("button", { name: /pinch-test claude/ })
+      .first()
+      .click();
+    await page
+      .locator(".xterm")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+  }
+
+  async function wsCount(page: Page) {
+    return page.evaluate(
+      () => (window as unknown as { __WS_COUNT__: number }).__WS_COUNT__,
+    );
+  }
+
+  // Dispatch wheel events on .xterm with configurable ctrlKey/deltaY.
+  async function fireWheel(
+    page: Page,
+    opts: { deltaY: number; ctrlKey: boolean; times?: number },
+  ) {
+    await page.evaluate(
+      ({ deltaY, ctrlKey, times }) => {
+        const target = document.querySelector<HTMLElement>(".xterm");
+        if (!target) throw new Error(".xterm not mounted");
+        for (let i = 0; i < (times ?? 1); i++) {
+          target.dispatchEvent(
+            new WheelEvent("wheel", {
+              bubbles: true,
+              cancelable: true,
+              deltaY,
+              ctrlKey,
+            }),
+          );
+        }
+      },
+      opts,
+    );
+  }
+
+  test("Ctrl+wheel up increases desktopFontSize after debounce", async ({
+    page,
+  }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+
+    expect(await readFontSize(page, "desktop")).toBe(14);
+    const wsBefore = await wsCount(page);
+
+    // Each event contributes -(-60)*0.05 = +3 to the accumulator, so one
+    // event with deltaY=-60 should bump size by 3. Fire twice to leave no
+    // doubt.
+    await fireWheel(page, { deltaY: -60, ctrlKey: true, times: 2 });
+
+    await expect
+      .poll(() => readFontSize(page, "desktop"), { timeout: 2_000 })
+      .toBeGreaterThan(14);
+    expect(await wsCount(page)).toBe(wsBefore);
+  });
+
+  test("Ctrl+wheel down decreases desktopFontSize", async ({ page }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+
+    await fireWheel(page, { deltaY: 60, ctrlKey: true, times: 2 });
+
+    await expect
+      .poll(() => readFontSize(page, "desktop"), { timeout: 2_000 })
+      .toBeLessThan(14);
+  });
+
+  test("wheel without ctrlKey is ignored (native scroll path)", async ({
+    page,
+  }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+
+    // Clear any writes from seeding.
+    await page.evaluate(() => {
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__ = [];
+    });
+
+    await fireWheel(page, { deltaY: -120, ctrlKey: false, times: 5 });
+
+    // 500ms is longer than the 400ms debounce — if the handler leaked
+    // writes through without ctrlKey, they would have landed by now.
+    await page.waitForTimeout(500);
+    const writes = await page.evaluate(() =>
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__.filter(
+        (w) => w.includes("desktopFontSize"),
+      ),
+    );
+    expect(writes).toEqual([]);
+    expect(await readFontSize(page, "desktop")).toBe(14);
+  });
+
+  test("Ctrl+wheel zoom does NOT re-mount the xterm (live-sync regression guard)", async ({
+    page,
+  }) => {
+    // Regression guard for the load-bearing change in this PR: the main
+    // terminal useEffect no longer depends on the font-size setting, so
+    // persisting a new font size (via pinch/wheel → update()) must NOT
+    // tear down and rebuild the xterm. We can't drive this via the
+    // settings UI because SettingsView fully replaces the app view (and
+    // unmounts TerminalView). Instead, we tag the live .xterm before a
+    // Ctrl+wheel zoom and assert the same element survives the persist.
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+
+    const tag = `xterm-${Date.now()}`;
+    await page.evaluate((id) => {
+      const el = document.querySelector(".xterm");
+      if (!el) throw new Error("no .xterm to tag");
+      el.setAttribute("data-test-id", id);
+    }, tag);
+
+    await fireWheel(page, { deltaY: -60, ctrlKey: true, times: 2 });
+
+    await expect
+      .poll(() => readFontSize(page, "desktop"), { timeout: 2_000 })
+      .toBeGreaterThan(14);
+    // If the main effect had re-run on settings change, the tagged
+    // element would have been wiped by `container.innerHTML = ""`.
+    const stillThere = await page.evaluate(
+      (id) => !!document.querySelector(`[data-test-id="${id}"]`),
+      tag,
+    );
+    expect(stillThere).toBe(true);
+  });
+});

--- a/web/tests/pinch-zoom.spec.ts
+++ b/web/tests/pinch-zoom.spec.ts
@@ -1,166 +1,59 @@
 import { test, expect, devices, type Page } from "@playwright/test";
-
-// Mobile pinch-to-zoom for the terminal font size.
-//
-// Doesn't need a real `aoe serve`: we stub the REST API and route the PTY
-// WebSocket via `page.routeWebSocket`, so the xterm.js terminal mounts and
-// the pinch gesture handlers in useTerminal.ts are exercised against the
-// real frontend bundle. We then synthesize two-finger `TouchEvent`s on the
-// `.xterm` element (Playwright's `page.touchscreen` is single-finger) and
-// assert that the font size setting in localStorage updated.
+import {
+  mockTerminalApis,
+  installTerminalSpies,
+  readFontSize,
+  seedSettings,
+  fireTouches,
+} from "./helpers/terminal-mocks";
 
 test.use({ ...devices["iPhone 13"] });
 
-test.describe("Terminal pinch zoom", () => {
-  async function mockApis(page: Page) {
-    await page.route("**/api/login/status", (r) =>
-      r.fulfill({ json: { required: false, authenticated: true } }),
-    );
-    await page.route("**/api/sessions", (r) => {
-      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
-      return r.fulfill({
-        json: [
-          {
-            id: "pinch-test",
-            title: "pinch-test",
-            project_path: "/tmp/pinch-test",
-            group_path: "/tmp",
-            tool: "claude",
-            status: "Running",
-            yolo_mode: false,
-            created_at: new Date().toISOString(),
-            last_accessed_at: null,
-            last_error: null,
-            branch: null,
-            main_repo_path: null,
-            is_sandboxed: false,
-            has_terminal: true,
-            profile: "default",
-          },
-        ],
-      });
-    });
-    await page.route("**/api/sessions/*/terminal", (r) =>
-      r.fulfill({ status: 200, body: "" }),
-    );
-    await page.route("**/api/sessions/*/diff/files", (r) =>
-      r.fulfill({ json: { files: [] } }),
-    );
-    for (const path of [
-      "settings",
-      "themes",
-      "agents",
-      "profiles",
-      "groups",
-      "devices",
-      "docker/status",
-      "about",
-    ]) {
-      await page.route(`**/api/${path}`, (r) =>
-        r.fulfill({ json: path === "docker/status" ? {} : [] }),
-      );
-    }
-    // PTY WebSocket: keep open, acknowledge resize messages, ignore data.
-    await page.routeWebSocket(/\/sessions\/.*\/(ws|container-ws)$/, (ws) => {
-      ws.onMessage(() => {
-        /* absorb keystrokes / resize JSON */
-      });
-      // Minimal prompt so xterm shows something (helps visual debugging too).
-      setTimeout(() => ws.send(Buffer.from("$ ")), 50);
-    });
-  }
-
-  // Dispatches a TouchEvent with two touches relative to `.xterm`. The
-  // page.touchscreen API is single-finger only, so we build Touch objects
-  // and fire the event directly.
-  async function fireTouches(
-    page: Page,
-    type: "touchstart" | "touchmove" | "touchend",
-    points: { x: number; y: number }[],
-  ) {
-    await page.evaluate(
-      ({ type, points }) => {
-        const target = document.querySelector<HTMLElement>(".xterm");
-        if (!target) throw new Error(".xterm not mounted");
-        const rect = target.getBoundingClientRect();
-        const touches = points.map((p, i) => {
-          const clientX = rect.left + p.x;
-          const clientY = rect.top + p.y;
-          return new Touch({
-            identifier: i,
-            target,
-            clientX,
-            clientY,
-            pageX: clientX,
-            pageY: clientY,
-            screenX: clientX,
-            screenY: clientY,
-            radiusX: 2,
-            radiusY: 2,
-            rotationAngle: 0,
-            force: 1,
-          });
-        });
-        const ev = new TouchEvent(type, {
-          bubbles: true,
-          cancelable: true,
-          touches: type === "touchend" ? [] : touches,
-          targetTouches: type === "touchend" ? [] : touches,
-          changedTouches: touches,
-        });
-        target.dispatchEvent(ev);
-      },
-      { type, points },
-    );
-  }
-
-  function readFontSize(page: Page) {
-    return page.evaluate(() => {
-      const raw = localStorage.getItem("aoe-web-settings");
-      return raw ? JSON.parse(raw).mobileFontSize : null;
-    });
-  }
-
-  async function setFontSize(page: Page, size: number) {
-    await page.evaluate((size) => {
-      localStorage.setItem(
-        "aoe-web-settings",
-        JSON.stringify({ mobileFontSize: size, desktopFontSize: 14 }),
-      );
-    }, size);
-  }
-
-  test("two-finger spread increases saved mobile font size", async ({
-    page,
-  }) => {
-    await mockApis(page);
-    await page.goto("/");
-    // Seed a known starting size so the assertion is unambiguous.
-    await setFontSize(page, 10);
-    await page.reload();
-
-    // Tap the session row (uses its title).
+test.describe("Terminal pinch zoom (mobile)", () => {
+  async function openSession(page: Page) {
     await page
       .getByRole("button", { name: /pinch-test claude/ })
       .first()
       .click();
     await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+  }
 
-    const before = await readFontSize(page);
-    expect(before).toBe(10);
+  async function wsCount(page: Page) {
+    return page.evaluate(
+      () => (window as unknown as { __WS_COUNT__: number }).__WS_COUNT__,
+    );
+  }
 
-    // Pinch-out: start with fingers 80px apart, spread to ~240px. That's a
-    // 3x scale factor — ratio is clamped to MAX_FONT_SIZE = 28.
+  async function fontSizeWrites(page: Page) {
+    return page.evaluate(() =>
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__.filter(
+        (w) => w.includes("mobileFontSize") || w.includes("desktopFontSize"),
+      ),
+    );
+  }
+
+  test("two-finger spread zooms in and clamps at MAX_FONT_SIZE", async ({
+    page,
+  }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { mobileFontSize: 10 });
+    await page.reload();
+    await openSession(page);
+
+    expect(await readFontSize(page, "mobile")).toBe(10);
+    const wsBefore = await wsCount(page);
+
+    // Start 80px apart, spread to 464px: 5.8x ratio. 10 * 5.8 = 58 → clamped to 28.
     const cx = 160;
     const cy = 200;
     await fireTouches(page, "touchstart", [
       { x: cx - 40, y: cy },
       { x: cx + 40, y: cy },
     ]);
-    // Walk the fingers outward over several frames to cross the 12px lock
-    // deadzone and then climb steadily.
     for (let step = 1; step <= 16; step++) {
-      const spread = 40 + step * 12; // 52, 64, ... 232
+      const spread = 40 + step * 12;
       await fireTouches(page, "touchmove", [
         { x: cx - spread, y: cy },
         { x: cx + spread, y: cy },
@@ -168,29 +61,25 @@ test.describe("Terminal pinch zoom", () => {
     }
     await fireTouches(page, "touchend", []);
 
-    // Persist happens on touchend; give React a beat to flush.
     await expect
-      .poll(() => readFontSize(page), { timeout: 2_000 })
-      .toBeGreaterThan(10);
+      .poll(() => readFontSize(page, "mobile"), { timeout: 2_000 })
+      .toBe(28);
+    // Same session, no reconnect.
+    expect(await wsCount(page)).toBe(wsBefore);
   });
 
-  test("two-finger pinch-in decreases saved mobile font size", async ({
-    page,
-  }) => {
-    await mockApis(page);
+  test("two-finger pinch-in clamps at MIN_FONT_SIZE", async ({ page }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
     await page.goto("/");
-    await setFontSize(page, 14);
+    await seedSettings(page, { mobileFontSize: 14 });
     await page.reload();
+    await openSession(page);
 
-    await page
-      .getByRole("button", { name: /pinch-test claude/ })
-      .first()
-      .click();
-    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    expect(await readFontSize(page, "mobile")).toBe(14);
+    const wsBefore = await wsCount(page);
 
-    const before = await readFontSize(page);
-    expect(before).toBe(14);
-
+    // Start 240px apart, pinch to 48px: 0.2x ratio. 14 * 0.2 = 2.8 → clamped to 6.
     const cx = 160;
     const cy = 200;
     await fireTouches(page, "touchstart", [
@@ -198,7 +87,7 @@ test.describe("Terminal pinch zoom", () => {
       { x: cx + 120, y: cy },
     ]);
     for (let step = 1; step <= 16; step++) {
-      const spread = 120 - step * 6; // 114 ... 24
+      const spread = 120 - step * 6;
       await fireTouches(page, "touchmove", [
         { x: cx - spread, y: cy },
         { x: cx + spread, y: cy },
@@ -207,26 +96,26 @@ test.describe("Terminal pinch zoom", () => {
     await fireTouches(page, "touchend", []);
 
     await expect
-      .poll(() => readFontSize(page), { timeout: 2_000 })
-      .toBeLessThan(14);
+      .poll(() => readFontSize(page, "mobile"), { timeout: 2_000 })
+      .toBe(6);
+    expect(await wsCount(page)).toBe(wsBefore);
   });
 
-  test("two-finger vertical pan does NOT change font size (scroll mode)", async ({
+  test("two-finger vertical pan does NOT write to localStorage (scroll lock)", async ({
     page,
   }) => {
-    await mockApis(page);
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
     await page.goto("/");
-    await setFontSize(page, 10);
+    await seedSettings(page, { mobileFontSize: 10 });
     await page.reload();
+    await openSession(page);
 
-    await page
-      .getByRole("button", { name: /pinch-test claude/ })
-      .first()
-      .click();
-    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+    // Clear the write log from the seed/initial settings.
+    await page.evaluate(() => {
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__ = [];
+    });
 
-    // Pan: both fingers move down together, distance constant — should
-    // lock into scroll mode and leave the size untouched.
     const cx = 160;
     let cy = 100;
     await fireTouches(page, "touchstart", [
@@ -242,8 +131,39 @@ test.describe("Terminal pinch zoom", () => {
     }
     await fireTouches(page, "touchend", []);
 
-    // Give any async write a chance; size should still be exactly 10.
-    await page.waitForTimeout(300);
-    expect(await readFontSize(page)).toBe(10);
+    // No font-size write should have been issued (scroll mode, not pinch).
+    expect(await fontSizeWrites(page)).toEqual([]);
+    expect(await readFontSize(page, "mobile")).toBe(10);
+  });
+
+  test("touchcancel mid-pinch still persists the latest size", async ({
+    page,
+  }) => {
+    await installTerminalSpies(page);
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { mobileFontSize: 10 });
+    await page.reload();
+    await openSession(page);
+
+    const cx = 160;
+    const cy = 200;
+    await fireTouches(page, "touchstart", [
+      { x: cx - 40, y: cy },
+      { x: cx + 40, y: cy },
+    ]);
+    for (let step = 1; step <= 8; step++) {
+      const spread = 40 + step * 10;
+      await fireTouches(page, "touchmove", [
+        { x: cx - spread, y: cy },
+        { x: cx + spread, y: cy },
+      ]);
+    }
+    // A system gesture / incoming call cancels the touch instead of lifting it.
+    await fireTouches(page, "touchcancel", []);
+
+    await expect
+      .poll(() => readFontSize(page, "mobile"), { timeout: 2_000 })
+      .toBeGreaterThan(10);
   });
 });

--- a/web/tests/pinch-zoom.spec.ts
+++ b/web/tests/pinch-zoom.spec.ts
@@ -1,0 +1,249 @@
+import { test, expect, devices, type Page } from "@playwright/test";
+
+// Mobile pinch-to-zoom for the terminal font size.
+//
+// Doesn't need a real `aoe serve`: we stub the REST API and route the PTY
+// WebSocket via `page.routeWebSocket`, so the xterm.js terminal mounts and
+// the pinch gesture handlers in useTerminal.ts are exercised against the
+// real frontend bundle. We then synthesize two-finger `TouchEvent`s on the
+// `.xterm` element (Playwright's `page.touchscreen` is single-finger) and
+// assert that the font size setting in localStorage updated.
+
+test.use({ ...devices["iPhone 13"] });
+
+test.describe("Terminal pinch zoom", () => {
+  async function mockApis(page: Page) {
+    await page.route("**/api/login/status", (r) =>
+      r.fulfill({ json: { required: false, authenticated: true } }),
+    );
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+      return r.fulfill({
+        json: [
+          {
+            id: "pinch-test",
+            title: "pinch-test",
+            project_path: "/tmp/pinch-test",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+          },
+        ],
+      });
+    });
+    await page.route("**/api/sessions/*/terminal", (r) =>
+      r.fulfill({ status: 200, body: "" }),
+    );
+    await page.route("**/api/sessions/*/diff/files", (r) =>
+      r.fulfill({ json: { files: [] } }),
+    );
+    for (const path of [
+      "settings",
+      "themes",
+      "agents",
+      "profiles",
+      "groups",
+      "devices",
+      "docker/status",
+      "about",
+    ]) {
+      await page.route(`**/api/${path}`, (r) =>
+        r.fulfill({ json: path === "docker/status" ? {} : [] }),
+      );
+    }
+    // PTY WebSocket: keep open, acknowledge resize messages, ignore data.
+    await page.routeWebSocket(/\/sessions\/.*\/(ws|container-ws)$/, (ws) => {
+      ws.onMessage(() => {
+        /* absorb keystrokes / resize JSON */
+      });
+      // Minimal prompt so xterm shows something (helps visual debugging too).
+      setTimeout(() => ws.send(Buffer.from("$ ")), 50);
+    });
+  }
+
+  // Dispatches a TouchEvent with two touches relative to `.xterm`. The
+  // page.touchscreen API is single-finger only, so we build Touch objects
+  // and fire the event directly.
+  async function fireTouches(
+    page: Page,
+    type: "touchstart" | "touchmove" | "touchend",
+    points: { x: number; y: number }[],
+  ) {
+    await page.evaluate(
+      ({ type, points }) => {
+        const target = document.querySelector<HTMLElement>(".xterm");
+        if (!target) throw new Error(".xterm not mounted");
+        const rect = target.getBoundingClientRect();
+        const touches = points.map((p, i) => {
+          const clientX = rect.left + p.x;
+          const clientY = rect.top + p.y;
+          return new Touch({
+            identifier: i,
+            target,
+            clientX,
+            clientY,
+            pageX: clientX,
+            pageY: clientY,
+            screenX: clientX,
+            screenY: clientY,
+            radiusX: 2,
+            radiusY: 2,
+            rotationAngle: 0,
+            force: 1,
+          });
+        });
+        const ev = new TouchEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          touches: type === "touchend" ? [] : touches,
+          targetTouches: type === "touchend" ? [] : touches,
+          changedTouches: touches,
+        });
+        target.dispatchEvent(ev);
+      },
+      { type, points },
+    );
+  }
+
+  function readFontSize(page: Page) {
+    return page.evaluate(() => {
+      const raw = localStorage.getItem("aoe-web-settings");
+      return raw ? JSON.parse(raw).mobileFontSize : null;
+    });
+  }
+
+  async function setFontSize(page: Page, size: number) {
+    await page.evaluate((size) => {
+      localStorage.setItem(
+        "aoe-web-settings",
+        JSON.stringify({ mobileFontSize: size, desktopFontSize: 14 }),
+      );
+    }, size);
+  }
+
+  test("two-finger spread increases saved mobile font size", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.goto("/");
+    // Seed a known starting size so the assertion is unambiguous.
+    await setFontSize(page, 10);
+    await page.reload();
+
+    // Tap the session row (uses its title).
+    await page
+      .getByRole("button", { name: /pinch-test claude/ })
+      .first()
+      .click();
+    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+
+    const before = await readFontSize(page);
+    expect(before).toBe(10);
+
+    // Pinch-out: start with fingers 80px apart, spread to ~240px. That's a
+    // 3x scale factor — ratio is clamped to MAX_FONT_SIZE = 28.
+    const cx = 160;
+    const cy = 200;
+    await fireTouches(page, "touchstart", [
+      { x: cx - 40, y: cy },
+      { x: cx + 40, y: cy },
+    ]);
+    // Walk the fingers outward over several frames to cross the 12px lock
+    // deadzone and then climb steadily.
+    for (let step = 1; step <= 16; step++) {
+      const spread = 40 + step * 12; // 52, 64, ... 232
+      await fireTouches(page, "touchmove", [
+        { x: cx - spread, y: cy },
+        { x: cx + spread, y: cy },
+      ]);
+    }
+    await fireTouches(page, "touchend", []);
+
+    // Persist happens on touchend; give React a beat to flush.
+    await expect
+      .poll(() => readFontSize(page), { timeout: 2_000 })
+      .toBeGreaterThan(10);
+  });
+
+  test("two-finger pinch-in decreases saved mobile font size", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.goto("/");
+    await setFontSize(page, 14);
+    await page.reload();
+
+    await page
+      .getByRole("button", { name: /pinch-test claude/ })
+      .first()
+      .click();
+    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+
+    const before = await readFontSize(page);
+    expect(before).toBe(14);
+
+    const cx = 160;
+    const cy = 200;
+    await fireTouches(page, "touchstart", [
+      { x: cx - 120, y: cy },
+      { x: cx + 120, y: cy },
+    ]);
+    for (let step = 1; step <= 16; step++) {
+      const spread = 120 - step * 6; // 114 ... 24
+      await fireTouches(page, "touchmove", [
+        { x: cx - spread, y: cy },
+        { x: cx + spread, y: cy },
+      ]);
+    }
+    await fireTouches(page, "touchend", []);
+
+    await expect
+      .poll(() => readFontSize(page), { timeout: 2_000 })
+      .toBeLessThan(14);
+  });
+
+  test("two-finger vertical pan does NOT change font size (scroll mode)", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.goto("/");
+    await setFontSize(page, 10);
+    await page.reload();
+
+    await page
+      .getByRole("button", { name: /pinch-test claude/ })
+      .first()
+      .click();
+    await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
+
+    // Pan: both fingers move down together, distance constant — should
+    // lock into scroll mode and leave the size untouched.
+    const cx = 160;
+    let cy = 100;
+    await fireTouches(page, "touchstart", [
+      { x: cx - 50, y: cy },
+      { x: cx + 50, y: cy },
+    ]);
+    for (let step = 1; step <= 12; step++) {
+      cy = 100 + step * 16;
+      await fireTouches(page, "touchmove", [
+        { x: cx - 50, y: cy },
+        { x: cx + 50, y: cy },
+      ]);
+    }
+    await fireTouches(page, "touchend", []);
+
+    // Give any async write a chance; size should still be exactly 10.
+    await page.waitForTimeout(300);
+    expect(await readFontSize(page)).toBe(10);
+  });
+});


### PR DESCRIPTION
## Description

Adds pinch-to-zoom for the web terminal font size so mobile users no longer have to open Settings to resize. Two-finger pinch on mobile and trackpad pinch (wheel + ctrlKey) on desktop resize the xterm.js font live; the new size is persisted to web settings (new \`desktopFontSize\` alongside the existing \`mobileFontSize\`).

Implementation notes:
- Pinch vs. two-finger pan use a 12px deadzone then lock to either \`pinch\` or \`scroll\` mode for the rest of the gesture (approach matches Firefox's axis-locking design for pinch gestures).
- Kept TouchEvents rather than migrating to PointerEvents because xterm.js dispatches its own document-level touch handlers and we need capture-phase interop. \`touch-action: none\` on \`.xterm\` was already in place.
- Decoupled the main terminal effect from the font-size setting: live font changes now mutate \`term.options.fontSize\` + refit instead of tearing down and reconnecting the PTY. Removes the old "Changing this will reconnect active sessions" behavior.
- Clamp range is 6–28px. Settings slider UI extended to match.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- \`web/tests/pinch-zoom.spec.ts\` — three Playwright tests on an iPhone 13 emulation that mock the REST API and PTY WebSocket (via \`page.routeWebSocket\`) and synthesize multi-touch \`TouchEvent\`s on \`.xterm\`:
  - pinch-out increases saved font size
  - pinch-in decreases saved font size
  - two-finger vertical pan does NOT change size (scroll-mode lock)
- Full Playwright suite (31 tests) passes locally.
- \`tsc --noEmit\` clean.
- Not yet tested on a physical device — the Playwright harness exercises the real handler against the real frontend bundle, but hands-on verification on iOS Safari is still recommended before release.

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**
Research pass on 2025/2026 pinch-zoom best practice (MDN Pointer Events pinch-zoom, WebKit GestureEvent, Dan Burzo's DOM gestures survey, Firefox bug 1180865 on axis locking, Chromium trackpad pinch PSA) confirmed the TouchEvents + deadzone + mode-lock + \`touch-action: none\` + \`wheel\`/\`ctrlKey\` approach is aligned with current guidance. WCAG 2.5.1 (non-multipoint alternative) is satisfied by the existing settings slider.

- [x] I am an AI Agent filling out this form (check box if true)