### PR TITLE
feat(tui): serve dialog picks local network or Cloudflare tunnel

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -109,6 +109,7 @@ pub fn daemon_pid() -> Option<u32> {
                 if let Ok(dir) = crate::session::get_app_dir() {
                     let _ = std::fs::remove_file(dir.join("serve.url"));
                     let _ = std::fs::remove_file(dir.join("serve.log"));
+                    let _ = std::fs::remove_file(dir.join("serve.mode"));
                 }
                 None
             }
@@ -245,6 +246,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     }
     if let Ok(dir) = crate::session::get_app_dir() {
         let _ = std::fs::remove_file(dir.join("serve.url"));
+        let _ = std::fs::remove_file(dir.join("serve.mode"));
     }
 
     result
@@ -362,6 +364,7 @@ fn stop_daemon() -> Result<()> {
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.log"));
+                let _ = std::fs::remove_file(dir.join("serve.mode"));
             }
             println!("Stopped aoe serve daemon (PID {})", pid);
         }
@@ -371,6 +374,7 @@ fn stop_daemon() -> Result<()> {
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.log"));
+                let _ = std::fs::remove_file(dir.join("serve.mode"));
             }
             println!("Daemon was not running (stale PID file cleaned up)");
         }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 use std::path::PathBuf;
+use std::sync::Mutex;
 
 #[derive(Args)]
 pub struct ServeArgs {
@@ -51,6 +52,47 @@ pub struct ServeArgs {
 pub fn pid_file_path() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?;
     Ok(dir.join("serve.pid"))
+}
+
+/// Cached read of `$APP_DIR/serve.mode`, keyed on the current daemon
+/// PID. The status bar calls this on every render frame; without
+/// caching, that's a syscall + file read per frame just to compute a
+/// one-word label. We re-read the mode file only when the PID changes
+/// (daemon restart, fresh spawn), which is exactly when the mode could
+/// have changed.
+///
+/// Returns `None` when no daemon is running OR when the mode file is
+/// missing/unparseable. Callers can treat both cases the same way:
+/// "show the generic Serving label, no mode tag."
+pub fn cached_serve_mode_label() -> Option<&'static str> {
+    static CACHE: Mutex<Option<(u32, Option<&'static str>)>> = Mutex::new(None);
+
+    let pid = daemon_pid()?;
+    if let Ok(mut guard) = CACHE.lock() {
+        if let Some((cached_pid, cached_label)) = *guard {
+            if cached_pid == pid {
+                return cached_label;
+            }
+        }
+        let label = read_serve_mode_label();
+        *guard = Some((pid, label));
+        label
+    } else {
+        // Lock poisoned (only happens if a previous holder panicked
+        // while reading the file); fall back to a fresh read so the
+        // status bar still works.
+        read_serve_mode_label()
+    }
+}
+
+fn read_serve_mode_label() -> Option<&'static str> {
+    let dir = crate::session::get_app_dir().ok()?;
+    let raw = std::fs::read_to_string(dir.join("serve.mode")).ok()?;
+    match raw.trim() {
+        "local" => Some("local"),
+        "tunnel" => Some("tunnel"),
+        _ => None,
+    }
 }
 
 /// Cross-platform check that `pid` belongs to an aoe / agent-of-empires

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -248,9 +248,14 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             tunnel::print_qr_code(&tunnel_url_with_token);
         }
 
-        // Write tunnel URL for daemon discovery
+        // Write tunnel URL for daemon discovery. Single-line content:
+        // backward-compatible with any consumer that does `head -1 serve.url`,
+        // and the TUI parses both single- and multi-URL formats.
         if let Ok(app_dir) = crate::session::get_app_dir() {
             write_secret_file(&app_dir.join("serve.url"), &tunnel_url_with_token);
+            // serve.mode lets the TUI reattach to a running daemon and
+            // know whether to render "Serving (tunnel)" vs "(local)".
+            let _ = std::fs::write(app_dir.join("serve.mode"), "tunnel\n");
         }
 
         // Start health monitor (uses CancellationToken internally)
@@ -258,7 +263,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
         Some(handle)
     } else {
-        // Local mode: print URLs as before
+        // Local mode: print URLs as before.
         let make_url = |h: &str| {
             if let Some(ref token) = auth_token {
                 format!("http://{}:{}/?token={}", h, port, token)
@@ -267,14 +272,23 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             }
         };
 
-        println!("aoe web dashboard running at:");
-        if host == "0.0.0.0" {
-            println!("  {}", make_url("localhost"));
-            for addr in discover_local_ips() {
-                println!("  {}", make_url(&addr));
-            }
+        // Collect labeled URLs in preference order (Tailscale > LAN > localhost).
+        // When bound to 0.0.0.0 we're reachable on all three; on a specific
+        // host we just surface that one.
+        let labeled_urls: Vec<(IpKind, String)> = if host == "0.0.0.0" {
+            let mut urls: Vec<(IpKind, String)> = discover_tagged_ips()
+                .into_iter()
+                .map(|(kind, ip)| (kind, make_url(&ip.to_string())))
+                .collect();
+            urls.push((IpKind::Loopback, make_url("localhost")));
+            urls
         } else {
-            println!("  {}", make_url(host));
+            vec![(IpKind::Loopback, make_url(host))]
+        };
+
+        println!("aoe web dashboard running at:");
+        for (_, u) in &labeled_urls {
+            println!("  {}", u);
         }
         if auth_token.is_some() {
             println!();
@@ -283,9 +297,24 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             );
         }
 
-        let url = make_url(if host == "0.0.0.0" { "localhost" } else { host });
+        // serve.url: primary URL on line 1 (unlabeled, backward-compatible
+        // with any `head -1 serve.url` consumer). Alternates below as
+        // `kind\turl` so the TUI can cycle them. Always owner-only perms
+        // since the URL embeds the auth token.
         if let Ok(app_dir) = crate::session::get_app_dir() {
-            write_secret_file(&app_dir.join("serve.url"), &url);
+            let mut contents = String::new();
+            if let Some((_, primary)) = labeled_urls.first() {
+                contents.push_str(primary);
+                contents.push('\n');
+            }
+            for (kind, url) in labeled_urls.iter().skip(1) {
+                contents.push_str(kind.label());
+                contents.push('\t');
+                contents.push_str(url);
+                contents.push('\n');
+            }
+            write_secret_file(&app_dir.join("serve.url"), &contents);
+            let _ = std::fs::write(app_dir.join("serve.mode"), "local\n");
         }
 
         None
@@ -452,25 +481,66 @@ fn serve_embedded_file(path: &str) -> axum::response::Response {
     }
 }
 
-/// Discover non-loopback IPv4 addresses on all network interfaces.
-fn discover_local_ips() -> Vec<String> {
-    let mut ips = Vec::new();
+/// Kind tag for a local IPv4 address. Ordering in this enum is also the
+/// preference order for picking the "primary" URL to show in a QR: when
+/// the user serves on a Tailnet, that's almost always the one they want
+/// a phone (on cellular) to scan, not the LAN IP behind their NAT.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum IpKind {
+    Tailscale,
+    Lan,
+    Loopback,
+}
+
+impl IpKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            IpKind::Tailscale => "tailscale",
+            IpKind::Lan => "lan",
+            IpKind::Loopback => "localhost",
+        }
+    }
+}
+
+/// Classify a v4 address into Tailscale (CGNAT 100.64.0.0/10, which is
+/// what Tailscale hands out), regular LAN (RFC1918), or loopback.
+/// Public non-RFC1918 / non-CGNAT addresses are rare on an `aoe serve`
+/// host (would mean serving directly on the open internet) and fall
+/// through to `Lan` so we still surface them.
+pub fn classify_ip(ip: std::net::Ipv4Addr) -> IpKind {
+    let octets = ip.octets();
+    if ip.is_loopback() {
+        return IpKind::Loopback;
+    }
+    // CGNAT 100.64.0.0/10 (RFC 6598). Second octet is 64..=127.
+    if octets[0] == 100 && (64..=127).contains(&octets[1]) {
+        return IpKind::Tailscale;
+    }
+    IpKind::Lan
+}
+
+/// Discover non-loopback IPv4 addresses on all network interfaces,
+/// tagged by kind and sorted so the preferred URL (Tailscale > LAN)
+/// is first. Caller decides whether to include loopback.
+pub fn discover_tagged_ips() -> Vec<(IpKind, std::net::Ipv4Addr)> {
+    let mut out: Vec<(IpKind, std::net::Ipv4Addr)> = Vec::new();
     if let Ok(addrs) = nix::ifaddrs::getifaddrs() {
         for ifaddr in addrs {
             if let Some(addr) = ifaddr.address {
                 if let Some(sockaddr) = addr.as_sockaddr_in() {
                     let ip = sockaddr.ip();
-                    if !ip.is_loopback() {
-                        let s = ip.to_string();
-                        if !ips.contains(&s) {
-                            ips.push(s);
-                        }
+                    if ip.is_loopback() {
+                        continue;
+                    }
+                    if !out.iter().any(|(_, existing)| *existing == ip) {
+                        out.push((classify_ip(ip), ip));
                     }
                 }
             }
         }
     }
-    ips
+    out.sort_by_key(|(k, _)| *k);
+    out
 }
 
 /// Write a file with owner-only permissions (0600) to protect secrets.
@@ -624,6 +694,52 @@ mod tests {
         assert!(!is_valid_token_format("short"));
         assert!(!is_valid_token_format(""));
         assert!(!is_valid_token_format("ZZZZ0000111122223333444455556666"));
+    }
+
+    #[test]
+    fn classify_ip_recognizes_tailscale_cgnat() {
+        use std::net::Ipv4Addr;
+        // CGNAT range 100.64.0.0/10 = second octet 64..=127.
+        assert_eq!(classify_ip(Ipv4Addr::new(100, 64, 0, 1)), IpKind::Tailscale);
+        assert_eq!(
+            classify_ip(Ipv4Addr::new(100, 100, 50, 50)),
+            IpKind::Tailscale
+        );
+        assert_eq!(
+            classify_ip(Ipv4Addr::new(100, 127, 255, 254)),
+            IpKind::Tailscale
+        );
+        // Boundary: 100.63.x.x is NOT CGNAT, it's just regular public
+        // space — classify as LAN so we still surface it (rare but
+        // possible on a weird home network).
+        assert_eq!(classify_ip(Ipv4Addr::new(100, 63, 0, 1)), IpKind::Lan);
+        // Boundary: 100.128.x.x is also not CGNAT.
+        assert_eq!(classify_ip(Ipv4Addr::new(100, 128, 0, 1)), IpKind::Lan);
+    }
+
+    #[test]
+    fn classify_ip_recognizes_rfc1918_lan() {
+        use std::net::Ipv4Addr;
+        assert_eq!(classify_ip(Ipv4Addr::new(192, 168, 1, 42)), IpKind::Lan);
+        assert_eq!(classify_ip(Ipv4Addr::new(10, 0, 0, 1)), IpKind::Lan);
+        assert_eq!(classify_ip(Ipv4Addr::new(172, 16, 5, 10)), IpKind::Lan);
+    }
+
+    #[test]
+    fn classify_ip_recognizes_loopback() {
+        use std::net::Ipv4Addr;
+        assert_eq!(classify_ip(Ipv4Addr::new(127, 0, 0, 1)), IpKind::Loopback);
+        assert_eq!(classify_ip(Ipv4Addr::new(127, 1, 2, 3)), IpKind::Loopback);
+    }
+
+    #[test]
+    fn ip_kind_ordering_prefers_tailscale() {
+        // This is the "Tailscale first in QR" contract. If the sort order
+        // ever flips, the user's phone would scan a LAN IP from cellular
+        // and hit a timeout — regression test locks it in.
+        let mut v = [IpKind::Loopback, IpKind::Lan, IpKind::Tailscale];
+        v.sort();
+        assert_eq!(v, [IpKind::Tailscale, IpKind::Lan, IpKind::Loopback]);
     }
 
     #[tokio::test]

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -60,7 +60,7 @@ fn shortcuts() -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
                 ("n/N", "Next/prev match"),
                 ("s", "Settings"),
                 ("P", "Profiles"),
-                ("R", "Remote access (phone)"),
+                ("R", "Serve (LAN / Tunnel)"),
                 ("?", "Toggle help"),
                 ("q", "Quit"),
             ],

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -10,10 +10,10 @@ mod hooks_install;
 mod info;
 mod new_session;
 mod profile_picker;
-#[cfg(feature = "serve")]
-mod remote;
 mod rename;
 mod send_message;
+#[cfg(feature = "serve")]
+mod serve;
 mod welcome;
 
 pub use changelog::ChangelogDialog;
@@ -26,10 +26,10 @@ pub use hooks_install::HooksInstallDialog;
 pub use info::InfoDialog;
 pub use new_session::{NewSessionData, NewSessionDialog};
 pub use profile_picker::{ProfileEntry, ProfilePickerAction, ProfilePickerDialog};
-#[cfg(feature = "serve")]
-pub use remote::RemoteDialog;
 pub use rename::{RenameData, RenameDialog, RenameMode};
 pub use send_message::SendMessageDialog;
+#[cfg(feature = "serve")]
+pub use serve::ServeDialog;
 pub use welcome::WelcomeDialog;
 
 pub enum DialogResult<T> {

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -672,8 +672,8 @@ fn diagnose_daemon_exit(log: &str, mode: ServeMode) -> &'static str {
         };
     }
     if log.contains("EADDRINUSE") || log.contains("Address already in use") {
-        return "\n\nHint: the picked port is already in use. Try again; \
-                we pick a new random port each attempt.";
+        return "\n\nHint: the daemon couldn't bind the picked port. \
+                Reopen the dialog to try again with a fresh random port.";
     }
     if log.contains("Permission denied") {
         return "\n\nHint: permission denied on bind. Are you trying a \
@@ -1252,8 +1252,6 @@ fn render_active(
     let url_prefix = "URL: ";
     let full_url_len = url_prefix.chars().count() + full_url.chars().count();
     let (split_url, split_token) = split_url_and_token(full_url);
-    let split_url_line_len = url_prefix.chars().count() + split_url.chars().count();
-    let split_token_line_len = split_token.map(|t| 7 + t.chars().count()).unwrap_or(0);
 
     // Dialog wants to fit the full URL on one line. Floor at 80 for
     // breathing room; cap by terminal width.
@@ -1414,9 +1412,6 @@ fn render_active(
             idx += 1;
         }
     }
-    // Currently unused but kept for future layout tweaks that might
-    // want to size against the split lengths.
-    let _ = (split_url_line_len, split_token_line_len);
 
     if show_passphrase {
         let (pp_label, pp_style) = match passphrase {

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -1241,26 +1241,33 @@ fn render_active(
     let qr_height = qr_lines.len() as u16;
     let qr_width = qr_lines.first().map(|l| l.chars().count()).unwrap_or(0) as u16;
 
-    // Pull the token out of the URL so we can display URL and token on
-    // separate lines. Without this the combined string is ~115 chars and
-    // the token half gets clipped off the right edge of the dialog, which
-    // matters because the phone needs the token to reach the login page.
-    let (display_url, display_token) = split_url_and_token(url);
+    // Show the full URL (including `?token=...`) as a single, contiguous
+    // string. The user can triple-click it in their terminal and paste it
+    // straight into a browser — anything less (URL and token on separate
+    // rows) forces them to reconstruct the query string by hand, which
+    // is a real drag on cellular from a phone or a chat app. The QR is
+    // still the fastest path; this row is for copy-paste.
+    let full_url = url.as_str();
+    let url_prefix = "URL: ";
+    let full_url_len = url_prefix.chars().count() + full_url.chars().count();
 
-    // Dialog needs to fit the longer of URL / token; tokens are 64 hex
-    // chars plus the "Token: " label (71) so floor at 80 for breathing
-    // room around borders and margins.
-    let longest = display_url
-        .chars()
-        .count()
-        .max(display_token.map(|t| t.chars().count() + 7).unwrap_or(0))
-        + 10;
-    let want_width = (qr_width + 6).max(longest as u16).max(80);
+    // Dialog wants to fit the full URL on one line (URL + prefix + some
+    // padding). On narrow terminals we fall back to wrapping, computed
+    // below. Floor at 80 for breathing room.
+    let want_width = (qr_width + 6).max((full_url_len + 4) as u16).max(80);
     let log_height: u16 = 6;
-    let token_lines: u16 = if display_token.is_some() { 1 } else { 0 };
-    let want_height = qr_height + 4 + token_lines /* url/token/passphrase/elapsed */ + log_height + 3 /* borders */;
 
     let dialog_width = want_width.min(area.width);
+    // Inner width available for the URL row after the dialog border (1 col
+    // each side) and the layout margin (1 col each side) are subtracted.
+    let url_inner_width = dialog_width.saturating_sub(4).max(1) as usize;
+    let url_row_height: u16 = full_url_len.div_ceil(url_inner_width).clamp(1, 4) as u16;
+
+    let want_height = qr_height
+        + url_row_height
+        + 3 /* passphrase(opt) + elapsed + footer approx */
+        + log_height
+        + 3 /* borders + margins */;
     let dialog_height = want_height.min(area.height);
     let dialog = super::centered_rect(area, dialog_width, dialog_height);
     frame.render_widget(Clear, dialog);
@@ -1299,18 +1306,16 @@ fn render_active(
     let inner = block.inner(dialog);
     frame.render_widget(block, dialog);
 
-    // Layout: QR, optional kind label (Local mode w/ label), URL, optional
-    // token, optional passphrase (Tunnel only), elapsed, log tail, footer.
+    // Layout: QR, optional kind label (Local mode w/ label), full URL row
+    // (wraps on narrow terminals), optional passphrase (Tunnel only),
+    // elapsed, log tail, footer.
     let show_passphrase = matches!(mode, ServeMode::Tunnel);
     let show_kind_label = kind_label.is_some();
     let mut constraints = vec![Constraint::Length(qr_height)];
     if show_kind_label {
         constraints.push(Constraint::Length(1)); // kind label
     }
-    constraints.push(Constraint::Length(1)); // url
-    if display_token.is_some() {
-        constraints.push(Constraint::Length(1)); // token
-    }
+    constraints.push(Constraint::Length(url_row_height)); // full URL
     if show_passphrase {
         constraints.push(Constraint::Length(1)); // passphrase
     }
@@ -1346,27 +1351,21 @@ fn render_active(
         );
         idx += 1;
     }
+    // Full URL row: left-aligned so the string starts at a predictable
+    // column edge (a user triple-clicking in iTerm / gnome-terminal /
+    // Warp selects the whole URL on the first row, or row-by-row when
+    // wrapped on narrow terminals). Wrap is on as a fallback; we sized
+    // the dialog to fit the URL on one line when the terminal allows.
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled("URL: ", Style::default().fg(theme.dimmed)),
-            Span::styled(display_url.as_str(), Style::default().fg(theme.accent)),
+            Span::styled(url_prefix, Style::default().fg(theme.dimmed)),
+            Span::styled(full_url, Style::default().fg(theme.accent)),
         ]))
-        .alignment(Alignment::Center),
+        .alignment(Alignment::Left)
+        .wrap(Wrap { trim: false }),
         chunks[idx],
     );
     idx += 1;
-
-    if let Some(token) = display_token {
-        frame.render_widget(
-            Paragraph::new(Line::from(vec![
-                Span::styled("Token: ", Style::default().fg(theme.dimmed)),
-                Span::styled(token, Style::default().fg(theme.accent)),
-            ]))
-            .alignment(Alignment::Center),
-            chunks[idx],
-        );
-        idx += 1;
-    }
 
     if show_passphrase {
         let (pp_label, pp_style) = match passphrase {
@@ -1431,30 +1430,6 @@ fn render_active(
         .alignment(Alignment::Center),
         chunks[idx],
     );
-}
-
-/// Split a tunnel URL of the form `https://host/?token=XYZ` into a
-/// "clean" base URL and its token so the dialog can render them on
-/// separate lines. Falls back to returning the whole URL if the query
-/// param is missing or malformed.
-fn split_url_and_token(url: &str) -> (String, Option<&str>) {
-    // Look for the query prefix `?token=` — the server is the one
-    // writing this file, and it always emits the token as the first
-    // query param in `{url}/?token={token}`.
-    if let Some(q_start) = url.find("?token=") {
-        let base = url[..q_start].trim_end_matches('?').to_string();
-        let token_start = q_start + "?token=".len();
-        // Stop at the next `&` in case other query params ever appear.
-        let token_end = url[token_start..]
-            .find('&')
-            .map(|n| token_start + n)
-            .unwrap_or(url.len());
-        let token = &url[token_start..token_end];
-        if !token.is_empty() {
-            return (base, Some(token));
-        }
-    }
-    (url.to_string(), None)
 }
 
 fn render_error(frame: &mut Frame, area: Rect, theme: &Theme, msg: &str) {
@@ -1766,29 +1741,6 @@ mod tests {
 
         forget_passphrase();
         assert_eq!(recall_passphrase(), None);
-    }
-
-    #[test]
-    fn split_url_and_token_extracts_token() {
-        let (base, token) =
-            split_url_and_token("https://foo-bar.trycloudflare.com/?token=abc123def456");
-        assert_eq!(base, "https://foo-bar.trycloudflare.com/");
-        assert_eq!(token, Some("abc123def456"));
-    }
-
-    #[test]
-    fn split_url_and_token_preserves_url_without_token() {
-        let (base, token) = split_url_and_token("https://foo-bar.trycloudflare.com/");
-        assert_eq!(base, "https://foo-bar.trycloudflare.com/");
-        assert_eq!(token, None);
-    }
-
-    #[test]
-    fn split_url_and_token_handles_additional_query_params() {
-        let (base, token) =
-            split_url_and_token("https://foo.trycloudflare.com/?token=abc123&foo=bar");
-        assert_eq!(base, "https://foo.trycloudflare.com/");
-        assert_eq!(token, Some("abc123"));
     }
 
     #[test]

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -1241,27 +1241,42 @@ fn render_active(
     let qr_height = qr_lines.len() as u16;
     let qr_width = qr_lines.first().map(|l| l.chars().count()).unwrap_or(0) as u16;
 
-    // Show the full URL (including `?token=...`) as a single, contiguous
-    // string. The user can triple-click it in their terminal and paste it
-    // straight into a browser — anything less (URL and token on separate
-    // rows) forces them to reconstruct the query string by hand, which
-    // is a real drag on cellular from a phone or a chat app. The QR is
-    // still the fastest path; this row is for copy-paste.
+    // We want to show the full URL (including `?token=...`) on ONE line
+    // so the user can triple-click it and paste straight into a browser.
+    // That only works when the terminal is wide enough; on narrower
+    // terminals the combined string would clip off the right edge, which
+    // is worse than the split display because the token half disappears
+    // entirely. So: prefer the combined row, fall back to URL + Token on
+    // separate rows when we can't fit.
     let full_url = url.as_str();
     let url_prefix = "URL: ";
     let full_url_len = url_prefix.chars().count() + full_url.chars().count();
+    let (split_url, split_token) = split_url_and_token(full_url);
+    let split_url_line_len = url_prefix.chars().count() + split_url.chars().count();
+    let split_token_line_len = split_token.map(|t| 7 + t.chars().count()).unwrap_or(0);
 
-    // Dialog wants to fit the full URL on one line (URL + prefix + some
-    // padding). On narrow terminals we fall back to wrapping, computed
-    // below. Floor at 80 for breathing room.
+    // Dialog wants to fit the full URL on one line. Floor at 80 for
+    // breathing room; cap by terminal width.
     let want_width = (qr_width + 6).max((full_url_len + 4) as u16).max(80);
     let log_height: u16 = 6;
 
     let dialog_width = want_width.min(area.width);
-    // Inner width available for the URL row after the dialog border (1 col
-    // each side) and the layout margin (1 col each side) are subtracted.
+    // Inner width available for a content row after the dialog border
+    // (1 col each side) and the layout margin (1 col each side).
     let url_inner_width = dialog_width.saturating_sub(4).max(1) as usize;
-    let url_row_height: u16 = full_url_len.div_ceil(url_inner_width).clamp(1, 4) as u16;
+    // Combined URL fits on one line = copy-paste friendly rendering.
+    // Otherwise fall back to split so at least both halves are visible.
+    let url_fits_one_line = full_url_len <= url_inner_width;
+    let url_row_height: u16 = if url_fits_one_line {
+        1
+    } else {
+        // Fallback: base URL row + token row (if there is a token).
+        if split_token.is_some() {
+            2
+        } else {
+            1
+        }
+    };
 
     let want_height = qr_height
         + url_row_height
@@ -1306,16 +1321,20 @@ fn render_active(
     let inner = block.inner(dialog);
     frame.render_widget(block, dialog);
 
-    // Layout: QR, optional kind label (Local mode w/ label), full URL row
-    // (wraps on narrow terminals), optional passphrase (Tunnel only),
-    // elapsed, log tail, footer.
+    // Layout: QR, optional kind label, URL row(s) (either a single full
+    // URL for copy-paste, or split URL/Token fallback), optional
+    // passphrase (Tunnel only), elapsed, log tail, footer.
     let show_passphrase = matches!(mode, ServeMode::Tunnel);
     let show_kind_label = kind_label.is_some();
+    let show_split_token = !url_fits_one_line && split_token.is_some();
     let mut constraints = vec![Constraint::Length(qr_height)];
     if show_kind_label {
         constraints.push(Constraint::Length(1)); // kind label
     }
-    constraints.push(Constraint::Length(url_row_height)); // full URL
+    constraints.push(Constraint::Length(1)); // url (full or base)
+    if show_split_token {
+        constraints.push(Constraint::Length(1)); // token (split fallback)
+    }
     if show_passphrase {
         constraints.push(Constraint::Length(1)); // passphrase
     }
@@ -1351,21 +1370,53 @@ fn render_active(
         );
         idx += 1;
     }
-    // Full URL row: left-aligned so the string starts at a predictable
-    // column edge (a user triple-clicking in iTerm / gnome-terminal /
-    // Warp selects the whole URL on the first row, or row-by-row when
-    // wrapped on narrow terminals). Wrap is on as a fallback; we sized
-    // the dialog to fit the URL on one line when the terminal allows.
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled(url_prefix, Style::default().fg(theme.dimmed)),
-            Span::styled(full_url, Style::default().fg(theme.accent)),
-        ]))
-        .alignment(Alignment::Left)
-        .wrap(Wrap { trim: false }),
-        chunks[idx],
-    );
-    idx += 1;
+    if url_fits_one_line {
+        // Copy-paste path: full URL on one row, left-aligned so a triple-
+        // click in iTerm / gnome-terminal / Warp selects the whole URL.
+        // No wrap — the dialog width was sized to fit the URL exactly.
+        // The leading " URL: " label lives in the same Paragraph so a
+        // whole-line select catches both the label and the URL; most
+        // users will just triple-click-then-paste, pasting "URL: ..."
+        // and editing the label off, which is still faster than typing
+        // out a 64-char token by hand.
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(url_prefix, Style::default().fg(theme.dimmed)),
+                Span::styled(full_url, Style::default().fg(theme.accent)),
+            ]))
+            .alignment(Alignment::Left),
+            chunks[idx],
+        );
+        idx += 1;
+    } else {
+        // Fallback: split URL and Token onto separate centered rows so
+        // neither half clips. User has to copy twice, but that's a
+        // strict improvement over the combined string getting truncated
+        // and the token half disappearing entirely.
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(url_prefix, Style::default().fg(theme.dimmed)),
+                Span::styled(split_url.as_str(), Style::default().fg(theme.accent)),
+            ]))
+            .alignment(Alignment::Center),
+            chunks[idx],
+        );
+        idx += 1;
+        if let Some(token) = split_token {
+            frame.render_widget(
+                Paragraph::new(Line::from(vec![
+                    Span::styled("Token: ", Style::default().fg(theme.dimmed)),
+                    Span::styled(token, Style::default().fg(theme.accent)),
+                ]))
+                .alignment(Alignment::Center),
+                chunks[idx],
+            );
+            idx += 1;
+        }
+    }
+    // Currently unused but kept for future layout tweaks that might
+    // want to size against the split lengths.
+    let _ = (split_url_line_len, split_token_line_len);
 
     if show_passphrase {
         let (pp_label, pp_style) = match passphrase {
@@ -1430,6 +1481,30 @@ fn render_active(
         .alignment(Alignment::Center),
         chunks[idx],
     );
+}
+
+/// Split a URL of the form `https://host/?token=XYZ` into a "clean" base
+/// URL and its token so the dialog can fall back to rendering them on
+/// separate rows when the combined string would clip off the right edge
+/// of the dialog. Returns `(url, None)` when the query param is missing
+/// or empty.
+fn split_url_and_token(url: &str) -> (String, Option<&str>) {
+    // The server always emits the token as the first query param in
+    // `{url}/?token={token}`, so `?token=` is a safe anchor.
+    if let Some(q_start) = url.find("?token=") {
+        let base = url[..q_start].trim_end_matches('?').to_string();
+        let token_start = q_start + "?token=".len();
+        // Stop at the next `&` in case other query params ever appear.
+        let token_end = url[token_start..]
+            .find('&')
+            .map(|n| token_start + n)
+            .unwrap_or(url.len());
+        let token = &url[token_start..token_end];
+        if !token.is_empty() {
+            return (base, Some(token));
+        }
+    }
+    (url.to_string(), None)
 }
 
 fn render_error(frame: &mut Frame, area: Rect, theme: &Theme, msg: &str) {
@@ -1741,6 +1816,65 @@ mod tests {
 
         forget_passphrase();
         assert_eq!(recall_passphrase(), None);
+    }
+
+    #[test]
+    fn split_url_and_token_extracts_token() {
+        let (base, token) =
+            split_url_and_token("https://foo-bar.trycloudflare.com/?token=abc123def456");
+        assert_eq!(base, "https://foo-bar.trycloudflare.com/");
+        assert_eq!(token, Some("abc123def456"));
+    }
+
+    #[test]
+    fn split_url_and_token_preserves_url_without_token() {
+        let (base, token) = split_url_and_token("https://foo-bar.trycloudflare.com/");
+        assert_eq!(base, "https://foo-bar.trycloudflare.com/");
+        assert_eq!(token, None);
+    }
+
+    #[test]
+    fn split_url_and_token_handles_additional_query_params() {
+        let (base, token) =
+            split_url_and_token("https://foo.trycloudflare.com/?token=abc123&foo=bar");
+        assert_eq!(base, "https://foo.trycloudflare.com/");
+        assert_eq!(token, Some("abc123"));
+    }
+
+    /// Exercises the fit logic that the render path uses: full URL on
+    /// one line when it fits, split when it doesn't. Copies the arithmetic
+    /// from render_active (url_inner_width = dialog_width - 4).
+    fn url_fits_one_line(url: &str, dialog_width: u16) -> bool {
+        let url_prefix = "URL: ";
+        let full_url_len = url_prefix.chars().count() + url.chars().count();
+        let url_inner_width = dialog_width.saturating_sub(4).max(1) as usize;
+        full_url_len <= url_inner_width
+    }
+
+    #[test]
+    fn url_fits_one_line_on_wide_terminal() {
+        // Typical tunnel URL: ~115 chars including "URL: " prefix.
+        let url = "https://foo-bar.trycloudflare.com/?token=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+        assert!(
+            url_fits_one_line(url, 120),
+            "120-wide should fit ~115 chars"
+        );
+        assert!(
+            url_fits_one_line(url, 115),
+            "exact-fit boundary should pass"
+        );
+    }
+
+    #[test]
+    fn url_splits_on_narrow_terminal() {
+        // 80-col terminal can't fit the combined tunnel URL; force the
+        // split fallback so the token doesn't clip off the edge.
+        let url = "https://foo-bar.trycloudflare.com/?token=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+        assert!(!url_fits_one_line(url, 80));
+        // Local URL is shorter (~70 with token) — depends on IP/port.
+        let local = "http://192.168.1.42:54321/?token=a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
+        assert!(!url_fits_one_line(local, 80));
+        assert!(url_fits_one_line(local, 110));
     }
 
     #[test]

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -1,7 +1,8 @@
-//! Remote access dialog: drives the `aoe serve --remote --daemon` daemon
-//! lifecycle and shows a QR + URL + passphrase + log tail so a phone can
-//! connect. The TUI is a controller here, not a host: it spawns the daemon,
-//! reads `$APP_DIR/serve.{pid,url,log}` files, and runs `aoe serve --stop`
+//! Serve dialog: drives the `aoe serve --daemon` lifecycle (either Local
+//! network mode on 0.0.0.0, or Cloudflare Tunnel mode) and shows a QR +
+//! URL + (passphrase for Tunnel) + log tail so a phone can connect. The
+//! TUI is a controller here, not a host: it spawns the daemon, reads
+//! `$APP_DIR/serve.{pid,url,log,mode}` files, and runs `aoe serve --stop`
 //! to tear down. The daemon survives across TUI quits, just like tmux
 //! sessions or the CLI-invoked daemon path.
 //!
@@ -23,6 +24,43 @@ use ratatui::widgets::*;
 
 use super::DialogResult;
 use crate::tui::styles::Theme;
+
+/// Which transport the daemon is serving over. Persisted to
+/// `$APP_DIR/serve.mode` so a reattaching TUI can render the right label
+/// and the right set of controls (Tab to cycle is Local-only).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ServeMode {
+    Local,
+    Tunnel,
+}
+
+impl ServeMode {
+    fn file_token(self) -> &'static str {
+        match self {
+            ServeMode::Local => "local",
+            ServeMode::Tunnel => "tunnel",
+        }
+    }
+
+    fn from_file_token(s: &str) -> Option<Self> {
+        match s.trim() {
+            "local" => Some(ServeMode::Local),
+            "tunnel" => Some(ServeMode::Tunnel),
+            _ => None,
+        }
+    }
+}
+
+/// One URL we can show in the Active state. Tunnel mode has exactly one.
+/// Local mode may have multiple (Tailscale + LAN + localhost), and the
+/// user can Tab-cycle between them.
+#[derive(Debug, Clone)]
+pub struct ServeUrl {
+    /// Optional human-readable label ("tailscale", "lan", "localhost").
+    /// None for the single tunnel URL, which doesn't need one.
+    pub label: Option<String>,
+    pub url: String,
+}
 
 /// Passphrase cache for daemons this TUI process spawned, so reopening
 /// the Remote Access dialog after closing it can re-display the same
@@ -53,26 +91,43 @@ const TUNNEL_STARTUP_TIMEOUT_SECS: u64 = 60;
 /// How much of `serve.log` to keep in memory for the tail pane.
 const LOG_TAIL_LINES: usize = 200;
 
-pub enum RemoteDialogState {
-    /// No daemon running; show the two-factor explanation and wait for the
-    /// user to confirm via Y/Enter/arrows. `confirm_selected` tracks which
-    /// button (Enable vs Cancel) is currently highlighted so Enter picks it.
-    /// Default is Cancel so a stray Enter doesn't expose the tunnel.
+pub enum ServeDialogState {
+    /// No daemon running; first screen the user sees. They pick Local
+    /// (bind 0.0.0.0, token auth only) or Tunnel (cloudflared + passphrase).
+    /// `cloudflared_available` gates the Tunnel card; `local_available`
+    /// is false when the host has no non-loopback interface (dockerized
+    /// dev env with only lo).
+    ModePicker {
+        selected: ServeMode,
+        cloudflared_available: bool,
+        local_available: bool,
+        /// Transient flash message shown for ~1s after a rejected keypress
+        /// (e.g., picking Tunnel when cloudflared isn't installed).
+        flash: Option<(String, Instant)>,
+    },
+    /// Tunnel-only: show the two-factor explanation and wait for the user
+    /// to confirm via Y/Enter/arrows. Local mode never enters Confirm —
+    /// it goes ModePicker → Starting directly.
     Confirm {
         confirm_selected: bool,
     },
-    /// We issued `aoe serve --remote --daemon`; now polling `serve.url`.
-    /// If `passphrase` is Some, the TUI spawned the daemon and knows it;
-    /// if None, a daemon was already running when the dialog opened.
+    /// We issued `aoe serve --daemon`; now polling `serve.url`.
+    /// `passphrase` is Some only for Tunnel spawns from this TUI.
     Starting {
+        mode: ServeMode,
         passphrase: Option<String>,
         started_at: Instant,
     },
     /// Daemon is live. No child field — the TUI does not own it.
     Active {
-        url: String,
+        mode: ServeMode,
+        urls: Vec<ServeUrl>,
+        /// Which `urls` entry is the primary QR target. Starts at 0.
+        /// Tab advances; cycles; no-op when urls.len() <= 1.
+        url_index: usize,
         /// Only known when this TUI started the daemon. For daemons
         /// started via the CLI we show a "set at startup" placeholder.
+        /// Always None for Local mode.
         passphrase: Option<String>,
         opened_at: Instant,
         log_tail: Vec<String>,
@@ -82,53 +137,82 @@ pub enum RemoteDialogState {
     Error(String),
 }
 
-pub struct RemoteDialog {
-    state: RemoteDialogState,
-    /// Passphrase we will use if the user confirms. Regenerated each time
-    /// the user opens the Confirm screen so leaked-to-stdout values rotate.
+pub struct ServeDialog {
+    state: ServeDialogState,
+    /// Passphrase we will use if the user picks Tunnel and confirms.
+    /// Regenerated each time the dialog opens so leaked-to-stdout values
+    /// rotate.
     pending_passphrase: String,
 }
 
-impl Default for RemoteDialog {
+impl Default for ServeDialog {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RemoteDialog {
+impl ServeDialog {
     /// Construct the dialog. If a daemon is already running (detected via
     /// `$APP_DIR/serve.pid`), jump straight to Active so the user can see
-    /// the URL and stop it; otherwise show Confirm.
+    /// the URL and stop it; otherwise show ModePicker.
     pub fn new() -> Self {
         if crate::cli::serve::daemon_pid().is_some() {
-            // There's already a daemon running. If this TUI process spawned
-            // it earlier, recall its passphrase so reopening the dialog
-            // shows it again. A daemon started outside this TUI (via CLI)
-            // leaves this None and renders the placeholder.
-            let remembered = recall_passphrase();
-            match read_serve_url() {
-                Some(url) => Self {
-                    state: RemoteDialogState::Active {
-                        url,
+            // There's already a daemon running. Read its mode from
+            // serve.mode (written by the server). If missing (older daemon
+            // from pre-mode-split version), assume Tunnel — that was the
+            // only mode the TUI could spawn before.
+            let mode = read_serve_mode().unwrap_or(ServeMode::Tunnel);
+            // Recall the passphrase only for Tunnel (Local has no passphrase).
+            let remembered = if matches!(mode, ServeMode::Tunnel) {
+                recall_passphrase()
+            } else {
+                None
+            };
+            let urls = read_serve_urls();
+            if urls.is_empty() {
+                Self {
+                    state: ServeDialogState::Starting {
+                        mode,
+                        passphrase: remembered,
+                        started_at: Instant::now(),
+                    },
+                    pending_passphrase: generate_passphrase(),
+                }
+            } else {
+                Self {
+                    state: ServeDialogState::Active {
+                        mode,
+                        urls,
+                        url_index: 0,
                         passphrase: remembered,
                         opened_at: Instant::now(),
                         log_tail: initial_log_tail(),
                         log_offset: log_file_size(),
                     },
                     pending_passphrase: generate_passphrase(),
-                },
-                None => Self {
-                    state: RemoteDialogState::Starting {
-                        passphrase: remembered,
-                        started_at: Instant::now(),
-                    },
-                    pending_passphrase: generate_passphrase(),
-                },
+                }
             }
         } else {
+            let cloudflared_available = crate::server::tunnel::check_cloudflared().is_ok();
+            let local_available = !crate::server::discover_tagged_ips().is_empty();
+            // Default highlight: the last mode the user successfully
+            // launched (read from serve.last_mode). Fall back to Local as
+            // safer first-time default. If Local isn't actually available,
+            // prefer Tunnel (and vice versa for cloudflared-missing).
+            let remembered_default = read_last_mode().unwrap_or(ServeMode::Local);
+            let selected = match remembered_default {
+                ServeMode::Local if local_available => ServeMode::Local,
+                ServeMode::Local if cloudflared_available => ServeMode::Tunnel,
+                ServeMode::Tunnel if cloudflared_available => ServeMode::Tunnel,
+                ServeMode::Tunnel if local_available => ServeMode::Local,
+                _ => ServeMode::Local, // no-op default when neither works; picker handles it
+            };
             Self {
-                state: RemoteDialogState::Confirm {
-                    confirm_selected: false,
+                state: ServeDialogState::ModePicker {
+                    selected,
+                    cloudflared_available,
+                    local_available,
+                    flash: None,
                 },
                 pending_passphrase: generate_passphrase(),
             }
@@ -137,18 +221,133 @@ impl RemoteDialog {
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
         match &mut self.state {
-            RemoteDialogState::Confirm { confirm_selected } => match key.code {
+            ServeDialogState::ModePicker {
+                selected,
+                cloudflared_available,
+                local_available,
+                flash,
+            } => {
+                // Helper: attempt to commit the current `selected` mode,
+                // transitioning to Confirm (Tunnel) or Starting (Local).
+                // Rejects with a flash message if the mode isn't available.
+                let commit = |dialog: &mut ServeDialog| -> DialogResult<()> {
+                    let ServeDialogState::ModePicker {
+                        selected,
+                        cloudflared_available,
+                        local_available,
+                        ..
+                    } = &dialog.state
+                    else {
+                        return DialogResult::Continue;
+                    };
+                    let mode = *selected;
+                    let cf = *cloudflared_available;
+                    let la = *local_available;
+                    match mode {
+                        ServeMode::Tunnel if !cf => {
+                            if let ServeDialogState::ModePicker { flash, .. } = &mut dialog.state {
+                                *flash = Some((
+                                    "Install cloudflared to enable Tunnel mode.".to_string(),
+                                    Instant::now(),
+                                ));
+                            }
+                            DialogResult::Continue
+                        }
+                        ServeMode::Local if !la => {
+                            if let ServeDialogState::ModePicker { flash, .. } = &mut dialog.state {
+                                *flash = Some((
+                                    "No non-loopback network interface available.".to_string(),
+                                    Instant::now(),
+                                ));
+                            }
+                            DialogResult::Continue
+                        }
+                        ServeMode::Tunnel => {
+                            dialog.state = ServeDialogState::Confirm {
+                                confirm_selected: false,
+                            };
+                            DialogResult::Continue
+                        }
+                        ServeMode::Local => {
+                            match spawn_daemon(ServeMode::Local, None) {
+                                Ok(()) => {
+                                    remember_last_mode(ServeMode::Local);
+                                    dialog.state = ServeDialogState::Starting {
+                                        mode: ServeMode::Local,
+                                        passphrase: None,
+                                        started_at: Instant::now(),
+                                    };
+                                }
+                                Err(e) => dialog.state = ServeDialogState::Error(e),
+                            }
+                            DialogResult::Continue
+                        }
+                    }
+                };
+
+                // Clear stale flash on any key press (helps the user feel
+                // they're making progress even if the next key is invalid).
+                if flash
+                    .as_ref()
+                    .map(|(_, t)| t.elapsed() > Duration::from_millis(1500))
+                    .unwrap_or(false)
+                {
+                    *flash = None;
+                }
+
+                match key.code {
+                    KeyCode::Left | KeyCode::Char('h') => {
+                        *selected = ServeMode::Local;
+                        DialogResult::Continue
+                    }
+                    KeyCode::Right | KeyCode::Char('l') => {
+                        // Only move to Tunnel if it's usable; otherwise
+                        // keep Local selected (don't let the user park
+                        // the cursor on a dimmed card).
+                        if *cloudflared_available {
+                            *selected = ServeMode::Tunnel;
+                        }
+                        DialogResult::Continue
+                    }
+                    KeyCode::Tab => {
+                        *selected = match *selected {
+                            ServeMode::Local if *cloudflared_available => ServeMode::Tunnel,
+                            ServeMode::Tunnel if *local_available => ServeMode::Local,
+                            other => other,
+                        };
+                        DialogResult::Continue
+                    }
+                    KeyCode::Char('t') | KeyCode::Char('T') => {
+                        *selected = ServeMode::Tunnel;
+                        commit(self)
+                    }
+                    KeyCode::Char('L') => {
+                        // Capital L as the explicit-Local shortcut. Keep
+                        // lowercase `l` as "→ move right" per the arrow-key
+                        // parallel above, which is the existing convention
+                        // in the rest of the TUI.
+                        *selected = ServeMode::Local;
+                        commit(self)
+                    }
+                    KeyCode::Enter => commit(self),
+                    KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
+                    _ => DialogResult::Continue,
+                }
+            }
+            ServeDialogState::Confirm { confirm_selected } => match key.code {
                 // Y always enables, regardless of which button is highlighted.
                 KeyCode::Char('y') | KeyCode::Char('Y') => {
-                    match spawn_daemon(&self.pending_passphrase) {
+                    match spawn_daemon(ServeMode::Tunnel, Some(&self.pending_passphrase)) {
                         Ok(()) => {
-                            self.state = RemoteDialogState::Starting {
+                            remember_last_mode(ServeMode::Tunnel);
+                            self.state = ServeDialogState::Starting {
+                                mode: ServeMode::Tunnel,
                                 passphrase: Some(self.pending_passphrase.clone()),
                                 started_at: Instant::now(),
                             };
                         }
                         Err(e) => {
-                            self.state = RemoteDialogState::Error(e);
+                            self.state = ServeDialogState::Error(e);
                         }
                     }
                     DialogResult::Continue
@@ -156,15 +355,17 @@ impl RemoteDialog {
                 // Enter picks whichever button is currently highlighted.
                 KeyCode::Enter => {
                     if *confirm_selected {
-                        match spawn_daemon(&self.pending_passphrase) {
+                        match spawn_daemon(ServeMode::Tunnel, Some(&self.pending_passphrase)) {
                             Ok(()) => {
-                                self.state = RemoteDialogState::Starting {
+                                remember_last_mode(ServeMode::Tunnel);
+                                self.state = ServeDialogState::Starting {
+                                    mode: ServeMode::Tunnel,
                                     passphrase: Some(self.pending_passphrase.clone()),
                                     started_at: Instant::now(),
                                 };
                             }
                             Err(e) => {
-                                self.state = RemoteDialogState::Error(e);
+                                self.state = ServeDialogState::Error(e);
                             }
                         }
                         DialogResult::Continue
@@ -189,7 +390,7 @@ impl RemoteDialog {
                 }
                 _ => DialogResult::Continue,
             },
-            RemoteDialogState::Starting { .. } => match key.code {
+            ServeDialogState::Starting { .. } => match key.code {
                 // Esc just closes the dialog; the daemon keeps coming up.
                 KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
                 KeyCode::Char('s') | KeyCode::Char('S') => {
@@ -199,23 +400,32 @@ impl RemoteDialog {
                 }
                 _ => DialogResult::Continue,
             },
-            RemoteDialogState::Active { .. } => match key.code {
+            ServeDialogState::Active {
+                urls, url_index, ..
+            } => match key.code {
                 KeyCode::Char('s') | KeyCode::Char('S') => match stop_daemon() {
                     Ok(()) => DialogResult::Cancel,
                     Err(e) => {
-                        self.state = RemoteDialogState::Error(format!(
+                        self.state = ServeDialogState::Error(format!(
                                 "Stop failed: {}. Daemon may still be running; retry or use `aoe serve --stop` from a shell.",
                                 e
                             ));
                         DialogResult::Continue
                     }
                 },
+                // Tab cycles URLs in Local mode (Tailscale ↔ LAN ↔ localhost).
+                // No-op when there's only one URL (Tunnel mode, or a Local
+                // host with just loopback).
+                KeyCode::Tab if urls.len() > 1 => {
+                    *url_index = (*url_index + 1) % urls.len();
+                    DialogResult::Continue
+                }
                 // Closing without stopping is explicitly allowed — TUI is a
                 // controller, the daemon keeps running.
                 KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
                 _ => DialogResult::Continue,
             },
-            RemoteDialogState::Error(_) => match key.code {
+            ServeDialogState::Error(_) => match key.code {
                 KeyCode::Char('s') | KeyCode::Char('S') => {
                     // Best-effort stop for a daemon that may still be
                     // lingering. Ignore the result — if there's no daemon
@@ -235,13 +445,29 @@ impl RemoteDialog {
     /// the visible state changed and a redraw is needed.
     pub fn tick(&mut self) -> bool {
         match &mut self.state {
-            RemoteDialogState::Starting {
+            ServeDialogState::ModePicker { flash, .. } => {
+                // Expire the flash message after 1.5s so it doesn't stick
+                // around forever without a follow-up key press.
+                if let Some((_, t)) = flash {
+                    if t.elapsed() > Duration::from_millis(1500) {
+                        *flash = None;
+                        return true;
+                    }
+                }
+                false
+            }
+            ServeDialogState::Starting {
+                mode,
                 passphrase,
                 started_at,
             } => {
-                if let Some(url) = read_serve_url() {
-                    self.state = RemoteDialogState::Active {
-                        url,
+                let mode = *mode;
+                let urls = read_serve_urls();
+                if !urls.is_empty() {
+                    self.state = ServeDialogState::Active {
+                        mode,
+                        urls,
+                        url_index: 0,
                         passphrase: passphrase.clone(),
                         opened_at: Instant::now(),
                         log_tail: initial_log_tail(),
@@ -251,27 +477,38 @@ impl RemoteDialog {
                 }
                 // If the daemon process dies before writing serve.url,
                 // fail fast with the last few log lines so the user can see
-                // why.
+                // why. Common Local mode causes: port in use, EADDRNOTAVAIL
+                // (Tailscale iface went away), permission denied.
                 if crate::cli::serve::daemon_pid().is_none() {
                     let tail = initial_log_tail();
-                    let detail = if tail.is_empty() {
+                    let joined = tail.join("\n");
+                    let hint = diagnose_daemon_exit(&joined, mode);
+                    let detail = if joined.is_empty() {
                         String::new()
                     } else {
-                        format!("\n\nLast log lines:\n{}", tail.join("\n"))
+                        format!("\n\nLast log lines:\n{}", joined)
                     };
-                    self.state = RemoteDialogState::Error(format!(
-                        "`aoe serve --remote --daemon` exited before the tunnel came up.{}",
-                        detail
-                    ));
+                    let prefix = match mode {
+                        ServeMode::Tunnel => {
+                            "`aoe serve --remote --daemon` exited before the tunnel came up."
+                        }
+                        ServeMode::Local => {
+                            "`aoe serve --daemon` exited before the server started."
+                        }
+                    };
+                    self.state = ServeDialogState::Error(format!("{}{}{}", prefix, hint, detail));
                     return true;
                 }
-                if started_at.elapsed() > Duration::from_secs(TUNNEL_STARTUP_TIMEOUT_SECS) {
+                // Local mode comes up ~instantly; no need for the 60s
+                // cloudflared-timeout path. Tunnel mode keeps it.
+                if matches!(mode, ServeMode::Tunnel)
+                    && started_at.elapsed() > Duration::from_secs(TUNNEL_STARTUP_TIMEOUT_SECS)
+                {
                     // Timeout: the daemon is alive but never produced a
                     // tunnel URL (cloudflared rate-limited, captive portal,
                     // etc.). Stop it now so we don't leave a zombie that
-                    // can never serve phones but keeps tripping "● Remote
-                    // on" in the status bar. Fall through to a log-tail
-                    // error view the user can act on.
+                    // can never serve phones but keeps tripping the status
+                    // bar indicator. Fall through to a log-tail error view.
                     let stop_note = match stop_daemon() {
                         Ok(()) => "Stuck daemon stopped.".to_string(),
                         Err(e) => format!(
@@ -286,7 +523,7 @@ impl RemoteDialog {
                     } else {
                         format!("\n\nLast log lines:\n{}", tail.join("\n"))
                     };
-                    self.state = RemoteDialogState::Error(format!(
+                    self.state = ServeDialogState::Error(format!(
                         "Cloudflare tunnel did not announce a URL within {}s. \
                          {}\n\n\
                          Most likely cause: `cloudflared` rate-limited, \
@@ -297,7 +534,7 @@ impl RemoteDialog {
                 }
                 false
             }
-            RemoteDialogState::Active {
+            ServeDialogState::Active {
                 log_tail,
                 log_offset,
                 ..
@@ -308,14 +545,30 @@ impl RemoteDialog {
 
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         match &self.state {
-            RemoteDialogState::Confirm { confirm_selected } => {
+            ServeDialogState::ModePicker {
+                selected,
+                cloudflared_available,
+                local_available,
+                flash,
+            } => render_mode_picker(
+                frame,
+                area,
+                theme,
+                *selected,
+                *cloudflared_available,
+                *local_available,
+                flash.as_ref().map(|(m, _)| m.as_str()),
+            ),
+            ServeDialogState::Confirm { confirm_selected } => {
                 render_confirm(frame, area, theme, *confirm_selected)
             }
-            RemoteDialogState::Starting { started_at, .. } => {
-                render_starting(frame, area, theme, started_at.elapsed())
-            }
-            RemoteDialogState::Active {
-                url,
+            ServeDialogState::Starting {
+                mode, started_at, ..
+            } => render_starting(frame, area, theme, *mode, started_at.elapsed()),
+            ServeDialogState::Active {
+                mode,
+                urls,
+                url_index,
                 passphrase,
                 opened_at,
                 log_tail,
@@ -324,63 +577,109 @@ impl RemoteDialog {
                 frame,
                 area,
                 theme,
-                url,
+                *mode,
+                urls,
+                *url_index,
                 passphrase.as_deref(),
                 opened_at.elapsed(),
                 log_tail,
             ),
-            RemoteDialogState::Error(msg) => render_error(frame, area, theme, msg),
+            ServeDialogState::Error(msg) => render_error(frame, area, theme, msg),
         }
     }
 }
 
-fn spawn_daemon(passphrase: &str) -> Result<(), String> {
+/// Spawn the aoe serve daemon in the requested mode. Tunnel requires a
+/// passphrase (it's public-internet exposure); Local ignores it.
+fn spawn_daemon(mode: ServeMode, passphrase: Option<&str>) -> Result<(), String> {
     use std::process::Command;
 
     let exe =
         std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
 
-    // Delete any stale serve.url from a previous hard-killed daemon
-    // before launching. Without this, Starting-state polling could latch
-    // onto the old URL before the new daemon writes the new one.
+    // Delete stale serve.url / serve.mode from a previous hard-killed
+    // daemon before launching. Without this, Starting-state polling could
+    // latch onto the old URL before the new daemon writes the new one.
     if let Ok(dir) = crate::session::get_app_dir() {
         let _ = std::fs::remove_file(dir.join("serve.url"));
+        let _ = std::fs::remove_file(dir.join("serve.mode"));
     }
 
     // Use a high ephemeral port so we don't collide with a user's own
     // `aoe serve` on 8080.
     let port: u16 = rand::rng().random_range(49152..65535);
 
-    let status = Command::new(&exe)
-        .args([
-            "serve",
-            "--remote",
-            "--daemon",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            &port.to_string(),
-        ])
-        .env("AOE_SERVE_PASSPHRASE", passphrase)
-        .stdin(std::process::Stdio::null())
+    let mut cmd = Command::new(&exe);
+    cmd.args(["serve", "--daemon", "--port", &port.to_string()]);
+    match mode {
+        ServeMode::Tunnel => {
+            cmd.args(["--remote", "--host", "127.0.0.1"]);
+            if let Some(pp) = passphrase {
+                cmd.env("AOE_SERVE_PASSPHRASE", pp);
+            }
+        }
+        ServeMode::Local => {
+            // 0.0.0.0 makes the server reachable on every local
+            // interface (Tailscale, LAN, loopback). The server-side
+            // serve.url writer picks Tailscale > LAN > localhost as the
+            // primary URL in the QR.
+            cmd.args(["--host", "0.0.0.0"]);
+        }
+    }
+    cmd.stdin(std::process::Stdio::null())
         // The daemon path forks and logs to serve.log; we only need its
         // exit status here (it's synchronous since it just double-forks).
         .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    let status = cmd
         .status()
-        .map_err(|e| format!("Failed to launch `aoe serve --remote --daemon`: {}", e))?;
+        .map_err(|e| format!("Failed to launch `aoe serve --daemon`: {}", e))?;
 
     if !status.success() {
+        let hint = match mode {
+            ServeMode::Tunnel => format!(
+                "Most likely `cloudflared` is not installed \
+                 (brew install cloudflared) or port {} is in use.",
+                port
+            ),
+            ServeMode::Local => format!("Most likely port {} is in use.", port),
+        };
         return Err(format!(
-            "`aoe serve --remote --daemon` exited with {:?}. \
-             Most likely `cloudflared` is not installed \
-             (brew install cloudflared) or port {} is in use.",
+            "`aoe serve --daemon` exited with {:?}. {}",
             status.code(),
-            port
+            hint
         ));
     }
-    remember_passphrase(passphrase);
+    if let Some(pp) = passphrase {
+        remember_passphrase(pp);
+    }
     Ok(())
+}
+
+/// Map a common Linux/BSD errno string found in the daemon log tail to a
+/// one-line user hint. Returns either `""` (no recognized error) or a
+/// hint prefixed with a blank line, suitable for string concat into an
+/// error message.
+fn diagnose_daemon_exit(log: &str, mode: ServeMode) -> &'static str {
+    if log.contains("EADDRNOTAVAIL") || log.contains("Cannot assign requested address") {
+        return match mode {
+            ServeMode::Local => {
+                "\n\nHint: the interface we tried to bind on went away. \
+                 Is Tailscale still up?"
+            }
+            ServeMode::Tunnel => "",
+        };
+    }
+    if log.contains("EADDRINUSE") || log.contains("Address already in use") {
+        return "\n\nHint: the picked port is already in use. Try again; \
+                we pick a new random port each attempt.";
+    }
+    if log.contains("Permission denied") {
+        return "\n\nHint: permission denied on bind. Are you trying a \
+                privileged port (<1024)? We normally pick a high port.";
+    }
+    ""
 }
 
 fn stop_daemon() -> Result<(), String> {
@@ -402,14 +701,70 @@ fn stop_daemon() -> Result<(), String> {
     Ok(())
 }
 
-fn read_serve_url() -> Option<String> {
+/// Read serve.url as a list of labeled URLs. File format:
+///
+/// ```text
+/// <primary-url>           ← line 1, unlabeled (backward-compatible)
+/// <label>\t<alt-url>      ← line 2+, tab-separated label/url
+/// ```
+///
+/// Returns `[]` when the file is missing or empty. The primary URL gets
+/// `label: None` for rendering. Alternates carry their label.
+fn read_serve_urls() -> Vec<ServeUrl> {
+    let Some(dir) = crate::session::get_app_dir().ok() else {
+        return Vec::new();
+    };
+    let Ok(raw) = std::fs::read_to_string(dir.join("serve.url")) else {
+        return Vec::new();
+    };
+    let mut out: Vec<ServeUrl> = Vec::new();
+    for (i, line) in raw.lines().enumerate() {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            continue;
+        }
+        if i == 0 {
+            // Primary line is the bare URL.
+            out.push(ServeUrl {
+                label: None,
+                url: line.to_string(),
+            });
+        } else if let Some((label, url)) = line.split_once('\t') {
+            out.push(ServeUrl {
+                label: Some(label.to_string()),
+                url: url.to_string(),
+            });
+        } else {
+            // Defensive: unlabeled extra line. Show as a nameless extra.
+            out.push(ServeUrl {
+                label: None,
+                url: line.to_string(),
+            });
+        }
+    }
+    out
+}
+
+/// Read the current daemon's mode marker (`serve.mode`). Returns None
+/// when the file is absent (pre-mode-split daemon) or unparseable.
+fn read_serve_mode() -> Option<ServeMode> {
     let dir = crate::session::get_app_dir().ok()?;
-    let raw = std::fs::read_to_string(dir.join("serve.url")).ok()?;
-    let trimmed = raw.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
+    let raw = std::fs::read_to_string(dir.join("serve.mode")).ok()?;
+    ServeMode::from_file_token(&raw)
+}
+
+/// Read the last mode the user picked (across TUI restarts). Used to
+/// default the ModePicker highlight on subsequent opens. Stored in a
+/// separate file from `serve.mode` so it survives `aoe serve --stop`.
+fn read_last_mode() -> Option<ServeMode> {
+    let dir = crate::session::get_app_dir().ok()?;
+    let raw = std::fs::read_to_string(dir.join("serve.last_mode")).ok()?;
+    ServeMode::from_file_token(&raw)
+}
+
+fn remember_last_mode(mode: ServeMode) {
+    if let Ok(dir) = crate::session::get_app_dir() {
+        let _ = std::fs::write(dir.join("serve.last_mode"), mode.file_token());
     }
 }
 
@@ -492,6 +847,192 @@ fn append_new_log_lines_from(
     changed
 }
 
+fn render_mode_picker(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    selected: ServeMode,
+    cloudflared_available: bool,
+    local_available: bool,
+    flash: Option<&str>,
+) {
+    let dialog = super::centered_rect(area, 72, 16);
+    frame.render_widget(Clear, dialog);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(theme.accent))
+        .title(Line::styled(
+            " Serve ",
+            Style::default().fg(theme.accent).bold(),
+        ));
+    let inner = block.inner(dialog);
+    frame.render_widget(block, dialog);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .margin(1)
+        .constraints([
+            Constraint::Length(1), // question
+            Constraint::Length(1), // spacer
+            Constraint::Min(7),    // cards
+            Constraint::Length(1), // flash
+            Constraint::Length(1), // keybinds
+        ])
+        .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "How should this be reachable?",
+            Style::default().fg(theme.title).bold(),
+        )))
+        .alignment(Alignment::Center),
+        rows[0],
+    );
+
+    let cards = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(50),
+            Constraint::Length(1),
+            Constraint::Percentage(50),
+        ])
+        .split(rows[2]);
+
+    // ── Local card ────────────────────────────────────────────────────────
+    let local_primary = crate::server::discover_tagged_ips()
+        .into_iter()
+        .next()
+        .map(|(kind, ip)| match kind {
+            crate::server::IpKind::Tailscale => format!("{} (Tailscale)", ip),
+            crate::server::IpKind::Lan => format!("{} (LAN)", ip),
+            crate::server::IpKind::Loopback => format!("{} (loopback)", ip),
+        })
+        .unwrap_or_else(|| "only localhost available".to_string());
+    let (local_border, local_title_style, local_body_style) =
+        if selected == ServeMode::Local && local_available {
+            (theme.accent, theme.accent, theme.text)
+        } else if !local_available {
+            (theme.dimmed, theme.dimmed, theme.dimmed)
+        } else {
+            (theme.border, theme.title, theme.text)
+        };
+    let local_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(local_border))
+        .padding(Padding::horizontal(1))
+        .title(Line::styled(
+            " Local network ",
+            Style::default().fg(local_title_style).bold(),
+        ));
+    let local_inner = local_block.inner(cards[0]);
+    frame.render_widget(local_block, cards[0]);
+    let local_body = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            local_primary,
+            Style::default().fg(if local_available {
+                theme.accent
+            } else {
+                theme.dimmed
+            }),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Token auth, no passphrase.",
+            Style::default().fg(local_body_style),
+        )),
+        Line::from(Span::styled(
+            "LAN + Tailscale. Instant.",
+            Style::default().fg(local_body_style),
+        )),
+        if !local_available {
+            Line::from(Span::styled(
+                "  (no non-loopback interface)",
+                Style::default().fg(theme.dimmed),
+            ))
+        } else {
+            Line::from("")
+        },
+    ];
+    frame.render_widget(Paragraph::new(local_body), local_inner);
+
+    // ── Tunnel card ───────────────────────────────────────────────────────
+    let (tunnel_border, tunnel_title_style, tunnel_body_style) =
+        if selected == ServeMode::Tunnel && cloudflared_available {
+            (theme.accent, theme.accent, theme.text)
+        } else if !cloudflared_available {
+            (theme.dimmed, theme.dimmed, theme.dimmed)
+        } else {
+            (theme.border, theme.title, theme.text)
+        };
+    let tunnel_block = Block::default()
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .border_style(Style::default().fg(tunnel_border))
+        .padding(Padding::horizontal(1))
+        .title(Line::styled(
+            " Cloudflare tunnel ",
+            Style::default().fg(tunnel_title_style).bold(),
+        ));
+    let tunnel_inner = tunnel_block.inner(cards[2]);
+    frame.render_widget(tunnel_block, cards[2]);
+    let tunnel_body = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            if cloudflared_available {
+                "public HTTPS URL"
+            } else {
+                "cloudflared not installed"
+            },
+            Style::default().fg(if cloudflared_available {
+                theme.accent
+            } else {
+                theme.dimmed
+            }),
+        )),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Token + passphrase (2FA).",
+            Style::default().fg(tunnel_body_style),
+        )),
+        Line::from(Span::styled(
+            "Reachable from anywhere.",
+            Style::default().fg(tunnel_body_style),
+        )),
+        if !cloudflared_available {
+            Line::from(Span::styled(
+                "  (brew install cloudflared)",
+                Style::default().fg(theme.dimmed),
+            ))
+        } else {
+            Line::from("")
+        },
+    ];
+    frame.render_widget(Paragraph::new(tunnel_body), tunnel_inner);
+
+    // ── Flash line ────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            flash.unwrap_or(""),
+            Style::default().fg(theme.error).bold(),
+        )))
+        .alignment(Alignment::Center),
+        rows[3],
+    );
+
+    // ── Keybinds ──────────────────────────────────────────────────────────
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "[←/→] choose    [L] Local    [T] Tunnel    [Enter] confirm    [Esc] cancel",
+            Style::default().fg(theme.dimmed),
+        )))
+        .alignment(Alignment::Center),
+        rows[4],
+    );
+}
+
 fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme, enable_selected: bool) {
     let dialog = super::centered_rect(area, 70, 22);
     frame.render_widget(Clear, dialog);
@@ -500,7 +1041,7 @@ fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme, enable_selected:
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.accent))
         .title(Line::styled(
-            " Enable remote access? ",
+            " Enable Cloudflare tunnel? ",
             Style::default().fg(theme.accent).bold(),
         ));
     let inner = block.inner(dialog);
@@ -613,30 +1154,39 @@ fn render_confirm(frame: &mut Frame, area: Rect, theme: &Theme, enable_selected:
     );
 }
 
-fn render_starting(frame: &mut Frame, area: Rect, theme: &Theme, elapsed: Duration) {
+fn render_starting(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    mode: ServeMode,
+    elapsed: Duration,
+) {
     let dialog = super::centered_rect(area, 60, 9);
     frame.render_widget(Clear, dialog);
+    let (title, wait_line1, wait_line2) = match mode {
+        ServeMode::Tunnel => (
+            " Starting Cloudflare tunnel... ",
+            "Waiting for the daemon to bring the tunnel up",
+            "(usually 5\u{2013}15 seconds).",
+        ),
+        ServeMode::Local => (
+            " Starting local server... ",
+            "Binding on 0.0.0.0 and discovering interfaces",
+            "(usually under a second).",
+        ),
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.border))
-        .title(Line::styled(
-            " Starting remote access... ",
-            Style::default().fg(theme.title).bold(),
-        ));
+        .title(Line::styled(title, Style::default().fg(theme.title).bold()));
     let inner = block.inner(dialog);
     frame.render_widget(block, dialog);
 
     let body = vec![
         Line::from(""),
-        Line::from(Span::styled(
-            "Waiting for the daemon to bring the tunnel up",
-            Style::default().fg(theme.text),
-        )),
-        Line::from(Span::styled(
-            "(usually 5\u{2013}15 seconds).",
-            Style::default().fg(theme.text),
-        )),
+        Line::from(Span::styled(wait_line1, Style::default().fg(theme.text))),
+        Line::from(Span::styled(wait_line2, Style::default().fg(theme.text))),
         Line::from(""),
         Line::from(Span::styled(
             format!("Elapsed: {}s    [Esc close]  [S stop]", elapsed.as_secs()),
@@ -646,15 +1196,28 @@ fn render_starting(frame: &mut Frame, area: Rect, theme: &Theme, elapsed: Durati
     frame.render_widget(Paragraph::new(body).alignment(Alignment::Center), inner);
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_active(
     frame: &mut Frame,
     area: Rect,
     theme: &Theme,
-    url: &str,
+    mode: ServeMode,
+    urls: &[ServeUrl],
+    url_index: usize,
     passphrase: Option<&str>,
     elapsed: Duration,
     log_tail: &[String],
 ) {
+    // Defensive: callers should never hand us an empty urls slice (the
+    // Starting → Active transition gates on non-empty serve.url). But if
+    // we somehow get here, fall through to an obvious-empty render.
+    let Some(active_url) = urls.get(url_index).or_else(|| urls.first()) else {
+        let msg = "Daemon started but no URL available yet.";
+        render_error(frame, area, theme, msg);
+        return;
+    };
+    let url = &active_url.url;
+    let kind_label = active_url.label.as_deref();
     // Encode the full URL including `?token=...` — the server's auth
     // middleware rejects requests on `/` with "invalid or missing auth
     // token" when the query param isn't present, so the phone would hit
@@ -703,13 +1266,21 @@ fn render_active(
     frame.render_widget(Clear, dialog);
 
     let eight_hours = Duration::from_secs(8 * 3600);
+    let base_title = match mode {
+        ServeMode::Local => " Serving (local) ",
+        ServeMode::Tunnel => " Serving (tunnel) ",
+    };
     let reminder = if elapsed >= eight_hours {
         format!(
-            " Remote access (open {}h) \u{2014} still need it? ",
+            " Serving ({}) open {}h \u{2014} still need it? ",
+            match mode {
+                ServeMode::Local => "local",
+                ServeMode::Tunnel => "tunnel",
+            },
             elapsed.as_secs() / 3600
         )
     } else {
-        " Remote access ".to_string()
+        base_title.to_string()
     };
     let title_color = if elapsed >= eight_hours {
         theme.waiting
@@ -728,15 +1299,22 @@ fn render_active(
     let inner = block.inner(dialog);
     frame.render_widget(block, dialog);
 
-    let mut constraints = vec![
-        Constraint::Length(qr_height),
-        Constraint::Length(1), // url
-    ];
+    // Layout: QR, optional kind label (Local mode w/ label), URL, optional
+    // token, optional passphrase (Tunnel only), elapsed, log tail, footer.
+    let show_passphrase = matches!(mode, ServeMode::Tunnel);
+    let show_kind_label = kind_label.is_some();
+    let mut constraints = vec![Constraint::Length(qr_height)];
+    if show_kind_label {
+        constraints.push(Constraint::Length(1)); // kind label
+    }
+    constraints.push(Constraint::Length(1)); // url
     if display_token.is_some() {
         constraints.push(Constraint::Length(1)); // token
     }
+    if show_passphrase {
+        constraints.push(Constraint::Length(1)); // passphrase
+    }
     constraints.extend_from_slice(&[
-        Constraint::Length(1), // passphrase
         Constraint::Length(1), // elapsed
         Constraint::Min(1),    // log tail
         Constraint::Length(1), // footer
@@ -757,6 +1335,17 @@ fn render_active(
     );
 
     let mut idx = 1;
+    if let Some(label) = kind_label {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!("via {}", label),
+                Style::default().fg(theme.dimmed).italic(),
+            )))
+            .alignment(Alignment::Center),
+            chunks[idx],
+        );
+        idx += 1;
+    }
     frame.render_widget(
         Paragraph::new(Line::from(vec![
             Span::styled("URL: ", Style::default().fg(theme.dimmed)),
@@ -779,23 +1368,25 @@ fn render_active(
         idx += 1;
     }
 
-    let (pp_label, pp_style) = match passphrase {
-        Some(pp) => (pp.to_string(), Style::default().fg(theme.accent).bold()),
-        None => (
-            "(set when the daemon started \u{2014} check the shell that ran `aoe serve`)"
-                .to_string(),
-            Style::default().fg(theme.dimmed),
-        ),
-    };
-    frame.render_widget(
-        Paragraph::new(Line::from(vec![
-            Span::styled("Passphrase: ", Style::default().fg(theme.dimmed)),
-            Span::styled(pp_label, pp_style),
-        ]))
-        .alignment(Alignment::Center),
-        chunks[idx],
-    );
-    idx += 1;
+    if show_passphrase {
+        let (pp_label, pp_style) = match passphrase {
+            Some(pp) => (pp.to_string(), Style::default().fg(theme.accent).bold()),
+            None => (
+                "(set when the daemon started \u{2014} check the shell that ran `aoe serve`)"
+                    .to_string(),
+                Style::default().fg(theme.dimmed),
+            ),
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled("Passphrase: ", Style::default().fg(theme.dimmed)),
+                Span::styled(pp_label, pp_style),
+            ]))
+            .alignment(Alignment::Center),
+            chunks[idx],
+        );
+        idx += 1;
+    }
 
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
@@ -827,9 +1418,14 @@ fn render_active(
     frame.render_widget(Paragraph::new(log_lines), log_inner);
     idx += 1;
 
+    let footer = if urls.len() > 1 {
+        "[Tab] switch URL   [S] Stop   [Esc] Close (daemon keeps running)"
+    } else {
+        "[S] Stop daemon    [Esc] Close (daemon keeps running)"
+    };
     frame.render_widget(
         Paragraph::new(Line::from(Span::styled(
-            "[S] Stop daemon    [Esc] Close (daemon keeps running)",
+            footer,
             Style::default().fg(theme.dimmed),
         )))
         .alignment(Alignment::Center),
@@ -869,7 +1465,7 @@ fn render_error(frame: &mut Frame, area: Rect, theme: &Theme, msg: &str) {
         .border_type(BorderType::Rounded)
         .border_style(Style::default().fg(theme.error))
         .title(Line::styled(
-            " Remote access failed ",
+            " Serve failed ",
             Style::default().fg(theme.error).bold(),
         ));
     let inner = block.inner(dialog);
@@ -1193,5 +1789,119 @@ mod tests {
             split_url_and_token("https://foo.trycloudflare.com/?token=abc123&foo=bar");
         assert_eq!(base, "https://foo.trycloudflare.com/");
         assert_eq!(token, Some("abc123"));
+    }
+
+    #[test]
+    fn serve_mode_file_token_roundtrip() {
+        assert_eq!(ServeMode::from_file_token("local"), Some(ServeMode::Local));
+        assert_eq!(
+            ServeMode::from_file_token("tunnel"),
+            Some(ServeMode::Tunnel)
+        );
+        // Trailing newline (the way the server writes it) still parses.
+        assert_eq!(
+            ServeMode::from_file_token("local\n"),
+            Some(ServeMode::Local)
+        );
+        assert_eq!(ServeMode::from_file_token("garbage"), None);
+        assert_eq!(ServeMode::from_file_token(""), None);
+    }
+
+    #[test]
+    fn diagnose_daemon_exit_recognizes_common_errnos() {
+        // Tailscale drop on Local: EADDRNOTAVAIL
+        let hint = diagnose_daemon_exit(
+            "ERROR: bind: Cannot assign requested address",
+            ServeMode::Local,
+        );
+        assert!(hint.contains("interface"));
+        // Same errno in Tunnel is not actionable in the same way, so we
+        // don't surface a hint.
+        assert_eq!(
+            diagnose_daemon_exit(
+                "ERROR: bind: Cannot assign requested address",
+                ServeMode::Tunnel,
+            ),
+            ""
+        );
+        // Port-in-use
+        assert!(diagnose_daemon_exit("Address already in use", ServeMode::Local).contains("port"));
+        // Permission denied on privileged port
+        assert!(diagnose_daemon_exit("Permission denied", ServeMode::Tunnel).contains("permission"));
+        // No match
+        assert_eq!(
+            diagnose_daemon_exit("some unrelated line", ServeMode::Local),
+            ""
+        );
+    }
+
+    // ── read_serve_urls ───────────────────────────────────────────────────
+    //
+    // The helper reads from $APP_DIR/serve.url, which is outside our
+    // control in unit tests. These tests exercise the parsing logic via a
+    // small shim that mirrors read_serve_urls' line-by-line behavior; the
+    // integration with the real file lives in e2e.
+    fn parse_serve_url_contents(raw: &str) -> Vec<ServeUrl> {
+        let mut out: Vec<ServeUrl> = Vec::new();
+        for (i, line) in raw.lines().enumerate() {
+            let line = line.trim_end_matches('\r');
+            if line.is_empty() {
+                continue;
+            }
+            if i == 0 {
+                out.push(ServeUrl {
+                    label: None,
+                    url: line.to_string(),
+                });
+            } else if let Some((label, url)) = line.split_once('\t') {
+                out.push(ServeUrl {
+                    label: Some(label.to_string()),
+                    url: url.to_string(),
+                });
+            } else {
+                out.push(ServeUrl {
+                    label: None,
+                    url: line.to_string(),
+                });
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn serve_url_parses_single_line_backward_compat() {
+        // Tunnel mode writes a single URL on line 1.
+        let out = parse_serve_url_contents("https://foo.trycloudflare.com/?token=abc\n");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].label, None);
+        assert_eq!(out[0].url, "https://foo.trycloudflare.com/?token=abc");
+    }
+
+    #[test]
+    fn serve_url_parses_multi_line_with_labels() {
+        // Local mode writes primary on line 1, `kind\turl` on alternates.
+        let raw = "\
+http://100.64.0.5:54321/?token=abc\n\
+lan\thttp://192.168.1.20:54321/?token=abc\n\
+localhost\thttp://localhost:54321/?token=abc\n";
+        let out = parse_serve_url_contents(raw);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].label, None);
+        assert_eq!(out[0].url, "http://100.64.0.5:54321/?token=abc");
+        assert_eq!(out[1].label.as_deref(), Some("lan"));
+        assert_eq!(out[1].url, "http://192.168.1.20:54321/?token=abc");
+        assert_eq!(out[2].label.as_deref(), Some("localhost"));
+    }
+
+    #[test]
+    fn serve_url_tolerates_empty_and_unlabeled_extras() {
+        // Defensive: if someone hand-edits serve.url and an extra line
+        // has no tab, we treat it as an unlabeled alt rather than
+        // dropping it.
+        let raw = "http://primary/\n\nhttp://no-label-here/\n";
+        let out = parse_serve_url_contents(raw);
+        assert_eq!(out.len(), 2);
+        assert_eq!(out[1].label, None);
+        assert_eq!(out[1].url, "http://no-label-here/");
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -427,12 +427,12 @@ impl HomeView {
 
         // Remote-access dialog (serve feature only)
         #[cfg(feature = "serve")]
-        if let Some(dialog) = &mut self.remote_dialog {
+        if let Some(dialog) = &mut self.serve_dialog {
             match dialog.handle_key(key) {
                 DialogResult::Continue => {}
                 DialogResult::Cancel | DialogResult::Submit(_) => {
                     // Dropping the dialog kills the subprocess via kill_on_drop.
-                    self.remote_dialog = None;
+                    self.serve_dialog = None;
                 }
             }
             return None;
@@ -515,7 +515,7 @@ impl HomeView {
             }
             #[cfg(feature = "serve")]
             KeyCode::Char('R') => {
-                self.remote_dialog = Some(crate::tui::dialogs::RemoteDialog::new());
+                self.serve_dialog = Some(crate::tui::dialogs::ServeDialog::new());
             }
             #[cfg(not(feature = "serve"))]
             KeyCode::Char('R') => {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -425,7 +425,7 @@ impl HomeView {
             return None;
         }
 
-        // Remote-access dialog (serve feature only)
+        // Serve dialog (serve feature only)
         #[cfg(feature = "serve")]
         if let Some(dialog) = &mut self.serve_dialog {
             match dialog.handle_key(key) {
@@ -520,16 +520,16 @@ impl HomeView {
             #[cfg(not(feature = "serve"))]
             KeyCode::Char('R') => {
                 self.info_dialog = Some(InfoDialog::new(
-                    "Remote access unavailable",
+                    "Serve unavailable",
                     "This `aoe` binary was built without the `serve` feature, \
-                     so the web dashboard and Cloudflare Tunnel integration \
-                     are not included.\n\n\
-                     To use remote access from your phone:\n\
+                     so the web dashboard, local network serving, and \
+                     Cloudflare Tunnel integration are not included.\n\n\
+                     To serve to your phone (LAN / Tailscale / tunnel):\n\
                        \u{2022} Install a release build from GitHub Releases, or\n\
                        \u{2022} Build from source with:\n\
                          cargo build --release --features serve\n\n\
                      Once you have a `serve`-enabled binary, press R again to \
-                     open the remote access dialog.",
+                     open the serve dialog.",
                 ));
             }
             KeyCode::Char('t') => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -22,7 +22,7 @@ use crate::tmux::AvailableTools;
 use super::creation_poller::{CreationPoller, CreationRequest};
 use super::deletion_poller::DeletionPoller;
 #[cfg(feature = "serve")]
-use super::dialogs::RemoteDialog;
+use super::dialogs::ServeDialog;
 use super::dialogs::{
     ChangelogDialog, ConfirmDialog, GroupDeleteOptionsDialog, HookTrustDialog, HooksInstallDialog,
     InfoDialog, NewSessionData, NewSessionDialog, ProfilePickerDialog, RenameDialog,
@@ -165,7 +165,7 @@ pub struct HomeView {
     pub(super) info_dialog: Option<InfoDialog>,
     pub(super) profile_picker_dialog: Option<ProfilePickerDialog>,
     #[cfg(feature = "serve")]
-    pub(super) remote_dialog: Option<RemoteDialog>,
+    pub(super) serve_dialog: Option<ServeDialog>,
     pub(super) send_message_dialog: Option<super::dialogs::SendMessageDialog>,
     /// Session to receive the message from the send dialog
     pub(super) pending_send_session: Option<String>,
@@ -328,7 +328,7 @@ impl HomeView {
             info_dialog: None,
             profile_picker_dialog: None,
             #[cfg(feature = "serve")]
-            remote_dialog: None,
+            serve_dialog: None,
             send_message_dialog: None,
             pending_send_session: None,
             pending_attach_after_warning: None,
@@ -839,7 +839,7 @@ impl HomeView {
 
         // Poll remote-access dialog for subprocess startup events.
         #[cfg(feature = "serve")]
-        if let Some(dialog) = &mut self.remote_dialog {
+        if let Some(dialog) = &mut self.serve_dialog {
             if dialog.tick() {
                 changed = true;
             }
@@ -874,9 +874,9 @@ impl HomeView {
 
     pub fn has_dialog(&self) -> bool {
         #[cfg(feature = "serve")]
-        let remote_open = self.remote_dialog.is_some();
+        let serve_open = self.serve_dialog.is_some();
         #[cfg(not(feature = "serve"))]
-        let remote_open = false;
+        let serve_open = false;
 
         self.show_help
             || self.search_active
@@ -892,7 +892,7 @@ impl HomeView {
             || self.info_dialog.is_some()
             || self.profile_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
-            || remote_open
+            || serve_open
             || self.settings_view.is_some()
             || self.diff_view.is_some()
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -837,7 +837,7 @@ impl HomeView {
             }
         }
 
-        // Poll remote-access dialog for subprocess startup events.
+        // Poll serve dialog for subprocess startup events.
         #[cfg(feature = "serve")]
         if let Some(dialog) = &mut self.serve_dialog {
             if dialog.tick() {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -774,36 +774,26 @@ impl HomeView {
 
         // Serve indicator: shown only when the `aoe serve` daemon is live.
         // The TUI does not own the daemon, so we probe the PID file each
-        // render. Mode is read from serve.mode (written by the daemon) so
-        // the status bar can distinguish Local vs Tunnel. Feature-gated
-        // alongside the rest of the serve-specific code.
+        // render. Mode comes from a PID-keyed cache so we don't read the
+        // serve.mode file from disk on every frame; the cache invalidates
+        // whenever the daemon PID changes (restart / fresh spawn).
         #[cfg(feature = "serve")]
-        if crate::cli::serve::daemon_pid().is_some() {
-            let mode_label = match std::fs::read_to_string(
-                crate::session::get_app_dir()
-                    .map(|d| d.join("serve.mode"))
-                    .unwrap_or_default(),
-            )
-            .ok()
-            .as_deref()
-            .map(str::trim)
-            {
-                Some("local") => Some("local"),
-                Some("tunnel") => Some("tunnel"),
-                _ => None,
-            };
-            // Drop the parenthetical under ~40 cols worth of status-bar
-            // budget. We don't know the width here, so rely on the full
-            // label and let the right-edge truncate do its thing — the
-            // important part (● Serving) lands first.
-            let label = match mode_label {
-                Some(m) => format!(" \u{25CF} Serving ({}) ", m),
-                None => " \u{25CF} Serving ".to_string(),
-            };
-            spans.extend([
-                Span::styled(label, Style::default().fg(theme.running).bold()),
-                Span::styled("│", sep_style),
-            ]);
+        {
+            let mode_label = crate::cli::serve::cached_serve_mode_label();
+            // cached_serve_mode_label() returns None both for "no daemon"
+            // and "daemon but mode unknown", so check the daemon PID to
+            // distinguish — only render the indicator when there's a
+            // daemon, with the mode tag if we have it.
+            if crate::cli::serve::daemon_pid().is_some() {
+                let label = match mode_label {
+                    Some(m) => format!(" \u{25CF} Serving ({}) ", m),
+                    None => " \u{25CF} Serving ".to_string(),
+                };
+                spans.extend([
+                    Span::styled(label, Style::default().fg(theme.running).bold()),
+                    Span::styled("│", sep_style),
+                ]);
+            }
         }
 
         spans.extend([

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -165,7 +165,7 @@ impl HomeView {
         }
 
         #[cfg(feature = "serve")]
-        if let Some(dialog) = &self.remote_dialog {
+        if let Some(dialog) = &self.serve_dialog {
             dialog.render(frame, area, theme);
         }
     }
@@ -772,17 +772,36 @@ impl HomeView {
 
         let mut spans: Vec<Span> = Vec::new();
 
-        // Remote-access indicator: shown only when the `aoe serve --remote`
-        // daemon is live. The TUI does not own the daemon, so we probe the
-        // PID file each render. Feature-gated alongside the rest of the
-        // serve-specific code.
+        // Serve indicator: shown only when the `aoe serve` daemon is live.
+        // The TUI does not own the daemon, so we probe the PID file each
+        // render. Mode is read from serve.mode (written by the daemon) so
+        // the status bar can distinguish Local vs Tunnel. Feature-gated
+        // alongside the rest of the serve-specific code.
         #[cfg(feature = "serve")]
         if crate::cli::serve::daemon_pid().is_some() {
+            let mode_label = match std::fs::read_to_string(
+                crate::session::get_app_dir()
+                    .map(|d| d.join("serve.mode"))
+                    .unwrap_or_default(),
+            )
+            .ok()
+            .as_deref()
+            .map(str::trim)
+            {
+                Some("local") => Some("local"),
+                Some("tunnel") => Some("tunnel"),
+                _ => None,
+            };
+            // Drop the parenthetical under ~40 cols worth of status-bar
+            // budget. We don't know the width here, so rely on the full
+            // label and let the right-edge truncate do its thing — the
+            // important part (● Serving) lands first.
+            let label = match mode_label {
+                Some(m) => format!(" \u{25CF} Serving ({}) ", m),
+                None => " \u{25CF} Serving ".to_string(),
+            };
             spans.extend([
-                Span::styled(
-                    " \u{25CF} Remote on ",
-                    Style::default().fg(theme.running).bold(),
-                ),
+                Span::styled(label, Style::default().fg(theme.running).bold()),
                 Span::styled("│", sep_style),
             ]);
         }


### PR DESCRIPTION
## Description

Adds a ModePicker as the first screen of the TUI serve dialog so users on Tailscale or a LAN can skip the Cloudflare tunnel entirely. Tunnel flow is unchanged (Confirm → passphrase → QR). Local flow is ModePicker → Starting → Active, with a Tailscale-first QR and Tab to cycle to LAN.

The motivation: I sometimes use Tailscale and don't want the Cloudflare hop. The TUI is the nicest way to manage the daemon, so rather than drop to `aoe serve --host 0.0.0.0`, picking Local from the dialog should be a one-key operation and still produce a scannable QR on my phone.

### Screens

```
╭──────────────── Serve ─────────────────╮
│   How should this be reachable?        │
│                                        │
│   ┌─ Local network ─┐  ┌─ Cloudflare ─┐│
│   │  100.64.0.5     │  │  tunnel      ││
│   │  (Tailscale)    │  │  public URL  ││
│   └─────────────────┘  └──────────────┘│
│                                        │
│   ←/→ choose   Enter confirm   Esc     │
╰────────────────────────────────────────╯
```

- `L` / `←` / `h` → Local, goes straight to Starting (no passphrase screen)
- `T` / `→` / `l` → Tunnel, existing Confirm → passphrase → QR flow
- Tunnel card dims with "(brew install cloudflared)" when cloudflared is missing
- Local card dims with "(no non-loopback interface)" in containerized dev envs
- In Active, Tab cycles between Tailscale / LAN / localhost URLs when more than one exists

### Mutual exclusion

The existing `serve.pid` lifecycle already prevents two daemons at once. Mode is persisted to a new `serve.mode` sidecar file so the TUI can reattach to a running daemon and render the right label. Last-used mode is remembered in `serve.last_mode` so reopening the dialog pre-highlights your choice.

### `serve.url` format

Tunnel still writes a single URL on line 1. Local now writes the primary URL on line 1 (Tailscale > LAN > localhost) and labeled alternates below (`kind\turl`). `head -1 serve.url` still returns the primary URL, so any scripts or docs that relied on that keep working.

### IP classifier

`classify_ip()` recognizes Tailscale CGNAT (`100.64.0.0/10`, RFC 6598) vs RFC1918 LAN vs loopback. The primary URL in the QR is Tailscale when available — the address your phone can actually reach from cellular.

### Error handling

The Starting state parses the daemon log tail for common errnos:
- `EADDRNOTAVAIL` / `Cannot assign requested address` in Local mode → "the interface we tried to bind on went away. Is Tailscale still up?"
- `EADDRINUSE` / `Address already in use` → retry hint (we pick a new random port each attempt)
- `Permission denied` → privileged-port hint

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib` → 1129 passing, +9 new)
- [ ] Documentation was updated where necessary (no user-facing docs currently cover the serve dialog keybinds; status bar and menu copy updated inline)
- [ ] For UI changes: included screenshot or recording (TUI — reviewers can `cargo run --features serve` and press `R`; mockup above)

## Test plan

- `cargo check` (no-serve) — passes
- `cargo check --features serve` — passes
- `cargo test --features serve --lib` — 1129 passing (+9 new: 4 IP classify, 1 mode-token roundtrip, 1 diagnose-matrix, 3 multi-URL parse)
- `cargo fmt` + `cargo clippy --features serve --lib` — clean
- Manual: open TUI, press `R`, pick Local, confirm QR renders with Tailscale IP; scan from phone on cellular

## Scope notes

What's NOT in scope, intentionally deferred:
- mDNS hostnames (`aoe.local`) — some routers block
- Tailscale MagicDNS hostnames — requires `tailscale status` parsing
- IPv6 link-local — QR scanners are flaky with these
- Per-interface bind (bind only to Tailscale, not 0.0.0.0) — security improvement, separate PR
- Surfacing `default_serve_mode` in the settings TUI — the `serve.last_mode` memory dotfile covers the "TUI remembers" case without the 5-place `FieldKey` plumbing. If more serve knobs accumulate, promote to a full config field then.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6, 1M context)

**Any Additional AI Details you'd like to share:**
Plan-design-review and plan-eng-review ran before implementation — the full plan is in ~/.gstack/projects/njbrake-agent-of-empires/. Three decision points were surfaced interactively: (1) Tailscale-first QR with Tab-cycle to LAN, (2) cloudflared-missing dims the card vs fails late, (3) Local mode stays token-only auth, no optional passphrase. One eng-review decision: rename `RemoteDialog` → `ServeDialog` in this PR rather than defer.

- [ ] I am an AI Agent filling out this form