### PR TITLE
fix(tui): cursor follows selected session after deletion

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -409,15 +409,13 @@ impl App {
                 self.should_quit = true;
                 return Ok(());
             }
-            (KeyCode::Char('q'), _) => {
-                if !self.home.has_dialog() {
-                    if self.home.is_creation_pending() {
-                        self.home.show_quit_during_creation_confirm();
-                        return Ok(());
-                    }
-                    self.should_quit = true;
+            (KeyCode::Char('q'), _) if !self.home.has_dialog() => {
+                if self.home.is_creation_pending() {
+                    self.home.show_quit_during_creation_confirm();
                     return Ok(());
                 }
+                self.should_quit = true;
+                return Ok(());
             }
             _ => {}
         }

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -153,15 +153,13 @@ impl DiffView {
                     self.select_branch(branch);
                 }
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if state.selected > 0 {
-                    state.selected -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if state.selected > 0 => {
+                state.selected -= 1;
             }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if state.selected < state.branches.len().saturating_sub(1) {
-                    state.selected += 1;
-                }
+            KeyCode::Down | KeyCode::Char('j')
+                if state.selected < state.branches.len().saturating_sub(1) =>
+            {
+                state.selected += 1;
             }
             _ => {}
         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -499,12 +499,10 @@ impl HomeView {
 
         // Normal mode keybindings
         match key.code {
-            KeyCode::Esc => {
-                if !self.search_matches.is_empty() {
-                    self.search_matches.clear();
-                    self.search_match_index = 0;
-                    self.search_query = Input::default();
-                }
+            KeyCode::Esc if !self.search_matches.is_empty() => {
+                self.search_matches.clear();
+                self.search_match_index = 0;
+                self.search_query = Input::default();
             }
             KeyCode::Char('q') => return Some(Action::Quit),
             KeyCode::Char('?') => {
@@ -558,20 +556,17 @@ impl HomeView {
                     return Some(Action::AttachTerminal(id.clone(), terminal_mode));
                 }
             }
-            KeyCode::Char('c') => {
-                // Toggle container/host terminal mode (only in Terminal view for sandboxed sessions)
-                if self.view_mode == ViewMode::Terminal {
-                    if let Some(id) = &self.selected_session {
-                        if let Some(inst) = self.get_instance(id) {
-                            if inst.is_sandboxed() {
-                                let id = id.clone();
-                                self.toggle_terminal_mode(&id);
-                            } else {
-                                self.info_dialog = Some(InfoDialog::new(
-                                    "Not Available",
-                                    "Only sandboxed sessions support container terminals. This session runs directly on the host.",
-                                ));
-                            }
+            KeyCode::Char('c') if self.view_mode == ViewMode::Terminal => {
+                if let Some(id) = &self.selected_session {
+                    if let Some(inst) = self.get_instance(id) {
+                        if inst.is_sandboxed() {
+                            let id = id.clone();
+                            self.toggle_terminal_mode(&id);
+                        } else {
+                            self.info_dialog = Some(InfoDialog::new(
+                                "Not Available",
+                                "Only sandboxed sessions support container terminals. This session runs directly on the host.",
+                            ));
                         }
                     }
                 }
@@ -920,11 +915,9 @@ impl HomeView {
             KeyCode::Char('g') => {
                 self.apply_group_by(self.group_by.cycle());
             }
-            KeyCode::End | KeyCode::Char('G') => {
-                if !self.flat_items.is_empty() {
-                    self.cursor = self.flat_items.len() - 1;
-                    self.update_selected();
-                }
+            KeyCode::End | KeyCode::Char('G') if !self.flat_items.is_empty() => {
+                self.cursor = self.flat_items.len() - 1;
+                self.update_selected();
             }
             KeyCode::Enter => {
                 if let Some(id) = &self.selected_session {
@@ -1142,7 +1135,7 @@ impl HomeView {
             }
         }
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|a| std::cmp::Reverse(a.1));
         self.search_matches = scored.into_iter().map(|(idx, _)| idx).collect();
         // Clamp match_index in case matches shrank
         if self.search_matches.is_empty() {
@@ -1196,7 +1189,7 @@ impl HomeView {
             }
         }
 
-        scored.sort_by(|a, b| b.1.cmp(&a.1));
+        scored.sort_by_key(|a| std::cmp::Reverse(a.1));
         self.search_matches = scored.into_iter().map(|(idx, _)| idx).collect();
 
         if let Some(&best) = self.search_matches.first() {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -442,9 +442,36 @@ impl HomeView {
             .iter()
             .map(|i| (i.id.clone(), i.clone()))
             .collect();
+        // Remember what the cursor was pointing at so we can follow it
+        let prev_selected_session = self.selected_session.clone();
+        let prev_selected_group = self.selected_group.clone();
+
         self.flat_items = self.build_flat_items();
 
-        if self.cursor >= self.flat_items.len() && !self.flat_items.is_empty() {
+        // Try to restore cursor to the same session/group after rebuild
+        let mut restored = false;
+        if let Some(ref sid) = prev_selected_session {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::Session { id, .. } = item {
+                    if id == sid {
+                        self.cursor = idx;
+                        restored = true;
+                        break;
+                    }
+                }
+            }
+        } else if let Some(ref gpath) = prev_selected_group {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::Group { path, .. } = item {
+                    if path == gpath {
+                        self.cursor = idx;
+                        restored = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !restored && self.cursor >= self.flat_items.len() && !self.flat_items.is_empty() {
             self.cursor = self.flat_items.len() - 1;
         }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2562,3 +2562,31 @@ fn test_project_group_name_handles_trailing_slash() {
     let inst = Instance::new("test", "/home/user/my-project/");
     assert_eq!(project_group_name(&inst), "my-project");
 }
+
+#[test]
+#[serial]
+fn test_cursor_follows_session_after_deletion() {
+    let mut env = create_test_env_with_sessions(4);
+
+    // Cursor starts at 0; move it to index 2 (session2)
+    env.view.cursor = 2;
+    env.view.update_selected();
+    let tracked_id = env.view.selected_session.clone().unwrap();
+
+    // Delete item at index 1 (a session above the cursor)
+    let victim_id = match &env.view.flat_items[1] {
+        Item::Session { id, .. } => id.clone(),
+        _ => panic!("expected session at index 1"),
+    };
+    env.view.remove_instance(&victim_id);
+    env.view.rebuild_group_trees();
+    let _ = env.view.save();
+    env.view.reload().unwrap();
+
+    // Cursor should have followed the tracked session to its new position
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(tracked_id.as_str())
+    );
+    assert_eq!(env.view.cursor, 1);
+}

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -390,10 +390,8 @@ impl SettingsView {
             KeyCode::Esc => {
                 self.list_edit_state = None;
             }
-            KeyCode::Up | KeyCode::Char('k') => {
-                if state.selected_index > 0 {
-                    state.selected_index -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if state.selected_index > 0 => {
+                state.selected_index -= 1;
             }
             KeyCode::Down | KeyCode::Char('j') => {
                 if let FieldValue::List(items) = &self.fields[self.selected_field].value {

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -326,15 +326,13 @@ impl SettingsView {
 
     pub(super) fn field_height(&self, field: &super::SettingField, index: usize) -> u16 {
         match &field.value {
-            FieldValue::List(items) => {
-                if self.list_edit_state.is_some() && index == self.selected_field {
-                    // label + description + header + items + add prompt
-                    1 + 1 + 1 + items.len() as u16 + 1
-                } else {
-                    1 + 1 + 1 // Label + description + summary
-                }
+            FieldValue::List(items)
+                if self.list_edit_state.is_some() && index == self.selected_field =>
+            {
+                // label + description + header + items + add prompt
+                1 + 1 + 1 + items.len() as u16 + 1
             }
-            _ => 1 + 1 + 1, // Label + description + value
+            _ => 1 + 1 + 1, // Label + description + value/summary
         }
     }
 


### PR DESCRIPTION
## Description

When a session above the cursor was deleted, the cursor index stayed the same, causing it to point to the wrong session. For example, if the cursor was on item 3 and item 2 was deleted, item 3 became item 2 but the cursor stayed at index 3 (now pointing to what was item 4).

The fix saves the selected session/group ID before rebuilding `flat_items` in `reload()`, then restores the cursor to its new position afterward. Falls back to existing out-of-bounds clamping if the tracked item was the one deleted.

Fixes #698

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)