### PR TITLE
feat: add aoe-with-web Nix package target with embedded web UI

### DIFF
--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -1,7 +1,8 @@
 name: Push to Cachix
 
-# Builds aoe-with-web (--features serve, web UI embedded) and pushes the
-# result to the Cachix binary cache so users can install without compiling.
+# Builds aoe-with-web (--features serve, web UI embedded) for Linux and macOS
+# and pushes the results to the Cachix binary cache so users can install
+# without compiling. Runs a matrix so both systems build in parallel.
 #
 # Requires two repository secrets set in the fork's Settings > Secrets:
 #   CACHIX_AUTH_TOKEN  - from cachix.org (Settings > Auth Tokens)
@@ -25,8 +26,12 @@ on:
 
 jobs:
   cachix:
-    name: Build and push to Cachix
-    runs-on: ubuntu-latest
+    name: Build and push (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -4,16 +4,13 @@ name: Push to Cachix
 # and pushes the results to the Cachix binary cache so users can install
 # without compiling. Runs a matrix so both systems build in parallel.
 #
-# Requires two repository secrets set in the fork's Settings > Secrets:
+# Requires two repository secrets:
 #   CACHIX_AUTH_TOKEN  - from cachix.org (Settings > Auth Tokens)
-#   CACHIX_CACHE_NAME  - your cache name (e.g. "gdw2vs")
-#
-# NOTE: feature/nix-web-build is listed until that PR merges into main.
-# Remove it once aoe-with-web lands in main.
+#   CACHIX_CACHE_NAME  - your cache name (e.g. "agent-of-empires")
 
 on:
   push:
-    branches: [main, feature/nix-web-build]
+    branches: [main]
     paths:
       - 'flake.nix'
       - 'flake.lock'

--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -1,0 +1,46 @@
+name: Push to Cachix
+
+# Builds aoe-with-web (--features serve, web UI embedded) and pushes the
+# result to the Cachix binary cache so users can install without compiling.
+#
+# Requires two repository secrets set in the fork's Settings > Secrets:
+#   CACHIX_AUTH_TOKEN  - from cachix.org (Settings > Auth Tokens)
+#   CACHIX_CACHE_NAME  - your cache name (e.g. "gdw2vs")
+#
+# NOTE: feature/nix-web-build is listed until that PR merges into main.
+# Remove it once aoe-with-web lands in main.
+
+on:
+  push:
+    branches: [main, feature/nix-web-build]
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'src/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'web/**'
+      - 'build.rs'
+  workflow_dispatch:
+
+jobs:
+  cachix:
+    name: Build and push to Cachix
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+
+      - name: Set up Cachix
+        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        with:
+          name: ${{ secrets.CACHIX_CACHE_NAME }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build aoe-with-web
+        run: nix build .#aoe-with-web
+
+      - name: Push to Cachix
+        run: cachix push ${{ secrets.CACHIX_CACHE_NAME }} ./result

--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
 
       - name: Set up Cachix
-        uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc # v15
+        uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c # v17
         with:
           name: ${{ secrets.CACHIX_CACHE_NAME }}
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,15 +102,17 @@ jobs:
           for system in $SYSTEMS; do
             echo ""
             echo "--- $system ---"
-            printf "  default: "
-            if output=$(nix eval ".#packages.$system.default.drvPath" --raw 2>&1); then
-              echo "✓"
-            else
-              echo "✗"
-              echo "::error::Evaluation failed for packages.$system.default"
-              echo "$output"
-              exit 1
-            fi
+            for pkg in default aoe-with-web; do
+              printf "  %s: " "$pkg"
+              if output=$(nix eval ".#packages.$system.$pkg.drvPath" --raw 2>&1); then
+                echo "✓"
+              else
+                echo "✗"
+                echo "::error::Evaluation failed for packages.$system.$pkg"
+                echo "$output"
+                exit 1
+              fi
+            done
           done
 
           echo ""

--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -1,0 +1,86 @@
+name: Update Nix npm Hash
+
+# Runs whenever web/package-lock.json changes on main, recomputes the
+# npmDepsHash in flake.nix and commits it if it changed.
+#
+# This keeps flake.nix in sync automatically so `nix build .#aoe-with-web`
+# never fails with a hash mismatch after a dependency update.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - web/package-lock.json
+
+# Only one instance runs at a time. If a second lockfile push lands while
+# this is running, cancel the in-progress run and start fresh with the
+# latest commit — so we never push a stale hash or hit a non-fast-forward.
+concurrency:
+  group: nix-npm-hash
+  cancel-in-progress: true
+
+jobs:
+  update-hash:
+    name: Recompute npmDepsHash
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Use GITHUB_TOKEN intentionally: the bot commit that updates the hash
+          # is mechanical and does not need to trigger CI. GITHUB_TOKEN pushes
+          # are deliberately excluded from workflow triggers by GitHub, which is
+          # the behavior we want here.
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34
+
+      - name: Compute new npmDepsHash
+        id: hash
+        run: |
+          set -euo pipefail
+
+          # Set a fake hash, build the npm deps derivation, capture the real
+          # hash from the mismatch error. This is the standard nixpkgs pattern.
+          FAKE="sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
+          # Patch flake.nix with the fake hash so Nix re-fetches
+          sed -i "s|npmDepsHash = \"sha256-[^\"]*\"|npmDepsHash = \"$FAKE\"|" flake.nix
+
+          # Build the npm deps derivation; it will fail with the real hash
+          REAL=$(nix build --no-link --impure \
+            .#packages.x86_64-linux.aoe-with-web 2>&1 \
+            | grep "got:" \
+            | sed 's/.*got:[[:space:]]*//' \
+            | tr -d '[:space:]') || true
+
+          if [ -z "$REAL" ]; then
+            echo "Could not extract hash from build output — hash may already be correct."
+            # Restore original hash from git
+            git checkout -- flake.nix
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "New hash: $REAL"
+          echo "hash=$REAL" >> "$GITHUB_OUTPUT"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Patch flake.nix with real hash
+        if: steps.hash.outputs.changed == 'true'
+        run: |
+          REAL="${{ steps.hash.outputs.hash }}"
+          sed -i "s|npmDepsHash = \"sha256-[^\"]*\"|npmDepsHash = \"$REAL\"|" flake.nix
+          echo "Updated flake.nix:"
+          grep "npmDepsHash" flake.nix
+
+      - name: Commit updated hash
+        if: steps.hash.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add flake.nix
+          git commit -m "chore: update Nix npmDepsHash for web dependencies"
+          git push

--- a/build.rs
+++ b/build.rs
@@ -66,6 +66,7 @@ fn check_stale_build_cache() {
 
 #[cfg(feature = "serve")]
 fn build_frontend() {
+    use std::path::Path;
     use std::process::Command;
 
     println!("cargo:rerun-if-changed=web/src");
@@ -74,6 +75,22 @@ fn build_frontend() {
     println!("cargo:rerun-if-changed=web/package-lock.json");
     println!("cargo:rerun-if-changed=web/vite.config.ts");
     println!("cargo:rerun-if-changed=web/tsconfig.json");
+
+    // AOE_WEB_DIST allows Nix (and other reproducible build systems) to supply
+    // a pre-built frontend directory, bypassing the npm build entirely. When
+    // set, the directory is copied to web/dist/ and npm is not invoked.
+    if let Ok(dist_src) = std::env::var("AOE_WEB_DIST") {
+        println!("cargo:rerun-if-env-changed=AOE_WEB_DIST");
+        eprintln!("Using pre-built web frontend from AOE_WEB_DIST={dist_src}");
+        let src = Path::new(&dist_src);
+        let dst = Path::new("web/dist");
+        if dst.exists() {
+            std::fs::remove_dir_all(dst).expect("Failed to remove existing web/dist");
+        }
+        // Recursively copy src -> web/dist
+        copy_dir(src, dst);
+        return;
+    }
 
     // Always rebuild: the rerun-if-changed directives above ensure this
     // function only runs when web source files actually changed.
@@ -157,6 +174,20 @@ fn maybe_install_web_deps() {
             "`npm {install_cmd}` failed in web/. \
              Run `cd web && npm {install_cmd}` to see the full error."
         );
+    }
+}
+
+#[cfg(feature = "serve")]
+fn copy_dir(src: &std::path::Path, dst: &std::path::Path) {
+    std::fs::create_dir_all(dst).expect("Failed to create directory");
+    for entry in std::fs::read_dir(src).expect("Failed to read directory") {
+        let entry = entry.expect("Failed to read entry");
+        let dst_path = dst.join(entry.file_name());
+        if entry.file_type().expect("Failed to get file type").is_dir() {
+            copy_dir(&entry.path(), &dst_path);
+        } else {
+            std::fs::copy(entry.path(), dst_path).expect("Failed to copy file");
+        }
     }
 }
 

--- a/build.rs
+++ b/build.rs
@@ -79,8 +79,11 @@ fn build_frontend() {
     // AOE_WEB_DIST allows Nix (and other reproducible build systems) to supply
     // a pre-built frontend directory, bypassing the npm build entirely. When
     // set, the directory is copied to web/dist/ and npm is not invoked.
+    //
+    // Registered unconditionally so Cargo re-runs build.rs when the var is
+    // added or removed, not only when it is already set.
+    println!("cargo:rerun-if-env-changed=AOE_WEB_DIST");
     if let Ok(dist_src) = std::env::var("AOE_WEB_DIST") {
-        println!("cargo:rerun-if-env-changed=AOE_WEB_DIST");
         eprintln!("Using pre-built web frontend from AOE_WEB_DIST={dist_src}");
         let src = Path::new(&dist_src);
         let dst = Path::new("web/dist");

--- a/flake.nix
+++ b/flake.nix
@@ -64,13 +64,61 @@
               mainProgram = "aoe";
             };
           });
+
+          # Build the React frontend as a standalone derivation (Forgejo/ntfy-sh pattern).
+          # This separates the npm build from the Rust build cleanly.
+          #
+          # Update npmDepsHash whenever web/package-lock.json changes:
+          #   nix-update aoe-with-web
+          # or manually: set npmDepsHash to lib.fakeHash, build, copy the got: hash.
+          webFrontend = pkgs.buildNpmPackage {
+            pname = "agent-of-empires-web";
+            version = "0";
+            src = ./web;
+            npmDepsHash = "sha256-6pxpDpc8tdx3K3RHvFex/c5qSdxFHbixcojsQxIV4Qk=";
+            # tsc -b && vite build; output goes to web/dist
+            installPhase = ''
+              mkdir $out
+              cp -r dist $out/
+            '';
+          };
+
+          # Base args for the web-enabled build. No npm tooling needed here since
+          # build.rs respects AOE_WEB_DIST to use the pre-built frontend.
+          # buildDepsOnly uses a dummy crate source so AOE_WEB_DIST is irrelevant there.
+          commonArgsWithWeb = commonArgs // {
+            cargoExtraArgs = "--package agent-of-empires --features serve";
+          };
+
+          # Rust dep cache compiled with --features serve (no npm involved).
+          cargoArtifactsWithWeb = craneLib.buildDepsOnly commonArgsWithWeb;
+
+          aoeWithWeb = craneLib.buildPackage (commonArgsWithWeb // {
+            cargoArtifacts = cargoArtifactsWithWeb;
+            doCheck = false;
+            # Point build.rs at the pre-built frontend; it will copy dist/ into
+            # place and skip running npm entirely (see build.rs AOE_WEB_DIST handling).
+            AOE_WEB_DIST = "${webFrontend}/dist";
+            postInstall = ''
+              installShellCompletion --cmd aoe \
+                --bash <($out/bin/aoe completion bash) \
+                --fish <($out/bin/aoe completion fish) \
+                --zsh <($out/bin/aoe completion zsh)
+            '';
+            meta = aoe.meta;
+            # Expose npmDeps so `nix-update` can automatically recompute the
+            # npmDepsHash in webFrontend when web/package-lock.json changes.
+            passthru.npmDeps = webFrontend.npmDeps;
+          });
         in
         {
           packages.default = aoe;
+          packages.aoe-with-web = aoeWithWeb;
 
           checks = {
-            # Build the package as a check too
+            # Build the packages as checks too
             inherit aoe;
+            inherit aoeWithWeb;
 
             aoe-clippy = craneLib.cargoClippy (commonArgs // {
               inherit cargoArtifacts;
@@ -94,6 +142,7 @@
             packages = with pkgs; [
               rust-analyzer
               tmux
+              nodejs # for web frontend development (--features serve)
             ];
           };
         };

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -29,6 +29,7 @@
         "eslint-plugin-react-refresh": "^0.5.2",
         "geist": "^1.7.0",
         "globals": "^17.4.0",
+        "tslib": "^2.8.1",
         "typescript": "~6.0.2",
         "typescript-eslint": "8.58.0",
         "vite": "8.0.3"
@@ -523,15 +524,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@emnapi/core": {
-      "optional": true
-    },
-    "node_modules/@emnapi/runtime": {
-      "optional": true
-    },
-    "node_modules/@emnapi/wasi-threads": {
-      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
@@ -1397,9 +1389,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@napi-rs/wasm-runtime": {
-      "optional": true
-    },
     "node_modules/@next/env": {
       "version": "16.2.2",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.2.tgz",
@@ -1554,6 +1543,8 @@
     },
     "node_modules/@playwright/test": {
       "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2676,6 +2667,64 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
+    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.2.tgz",
@@ -2753,9 +2802,6 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tybys/wasm-util": {
-      "optional": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -3545,6 +3591,8 @@
     },
     "node_modules/clsx": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4813,6 +4861,9 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
       "license": "0BSD"
     },
     "node_modules/typescript": {

--- a/web/package.json
+++ b/web/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-refresh": "^0.5.2",
     "geist": "^1.7.0",
     "globals": "^17.4.0",
+    "tslib": "^2.8.1",
     "typescript": "~6.0.2",
     "typescript-eslint": "8.58.0",
     "vite": "8.0.3"


### PR DESCRIPTION
## Description

Adds `packages.aoe-with-web` to `flake.nix`, which builds the binary with `--features serve` so the web dashboard is embedded and made available to nix users. Also adds `nodejs` to the default devShell and an `aoeWithWeb` check in CI.

The default `nix build` (TUI-only) is unchanged.

### Architecture

The React frontend is built as a standalone `buildNpmPackage` derivation (same pattern as Forgejo/ntfy-sh), then injected into the Rust build via a new `AOE_WEB_DIST` env var in `build.rs`. This avoids running npm inside the sandboxed Rust build where network access is unavailable.

### `build.rs` changes

- Adds `AOE_WEB_DIST` support: when set, copies the pre-built `dist/` into place and skips npm entirely. For normal `cargo build --features serve`, nothing changes.
- Merges upstream's refactor of the npm install logic into `maybe_install_web_deps()` + `is_newer_than()` helpers (conflict resolution from pull).
- Adds a `copy_dir()` helper (no equivalent in `std::fs`).

### `web/package-lock.json`

`tslib` and `clsx` are added as explicit deps even though they are transitive dependencies pulled in automatically. This is required because `prefetch-npm-deps` (used by `buildNpmPackage` internally) only fetches packages that have a `resolved` URL in `package-lock.json`. npm omits `resolved`/`integrity` fields for hoisted transitive deps, making them invisible to the fetcher and causing the Nix build to fail with `ENOTCACHED`.

### Hash maintenance

A new workflow (`.github/workflows/nix-npm-hash.yml`) automatically recomputes and commits the `npmDepsHash` in `flake.nix` whenever `web/package-lock.json` changes on `main`. Uses a concurrency group to prevent races if two lockfile changes land in quick succession.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** OpenCode (claude-sonnet-4-6)

**Any Additional AI Details you'd like to share:** This PR was generated with OpenCode. The Nix packaging approach, build.rs design, lockfile quirk, and workflow were all reasoned through interactively.

- [x] I am an AI Agent filling out this form (check box if true)