### PR TITLE
fix(ci): skip nix npm hash commit when hash is unchanged

### DIFF
--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -57,14 +57,25 @@ jobs:
             | tr -d '[:space:]') || true
 
           if [ -z "$REAL" ]; then
-            echo "Could not extract hash from build output — hash may already be correct."
-            # Restore original hash from git
+            echo "Could not extract hash from build output; hash may already be correct."
             git checkout -- flake.nix
             echo "changed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          echo "New hash: $REAL"
+          # Compare against the hash already in the committed flake.nix
+          CURRENT=$(git show HEAD:flake.nix \
+            | grep 'npmDepsHash' \
+            | sed 's/.*npmDepsHash = "\(sha256-[^"]*\)".*/\1/')
+
+          if [ "$REAL" = "$CURRENT" ]; then
+            echo "Computed hash matches current flake.nix; nothing to update."
+            git checkout -- flake.nix
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "New hash: $REAL (was: $CURRENT)"
           echo "hash=$REAL" >> "$GITHUB_OUTPUT"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Description

The "Update Nix npm Hash" workflow fails when `web/package-lock.json` changes but the `npmDepsHash` in `flake.nix` stays the same.

**Root cause:** The workflow substitutes a fake hash into `flake.nix`, builds to get the real hash from the mismatch error, and sets `changed=true` if the real hash is non-empty. But when the real hash equals the one already in `flake.nix`, patching produces no diff, and `git commit` exits 1.

**Fix:** Compare the computed hash against the committed one before declaring a change. If they match, restore `flake.nix` and exit cleanly with `changed=false`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)