### PR TITLE
feat(web): ability to delete sessions

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -10,10 +10,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::session::{Instance, Storage};
-
-#[cfg(test)]
-use crate::session::Status;
+use crate::session::{Instance, Status, Storage};
 
 use super::AppState;
 
@@ -56,6 +53,7 @@ pub struct SessionResponse {
     pub branch: Option<String>,
     pub main_repo_path: Option<String>,
     pub is_sandboxed: bool,
+    pub has_managed_worktree: bool,
     pub has_terminal: bool,
     pub profile: String,
 }
@@ -79,6 +77,10 @@ impl From<&Instance> for SessionResponse {
                 .as_ref()
                 .map(|w| w.main_repo_path.clone()),
             is_sandboxed: inst.is_sandboxed(),
+            has_managed_worktree: inst
+                .worktree_info
+                .as_ref()
+                .is_some_and(|w| w.managed_by_aoe),
             has_terminal: inst.terminal_info.is_some(),
             profile: inst.source_profile.clone(),
         }
@@ -133,15 +135,144 @@ pub async fn rename_session(
     }
 
     let response = SessionResponse::from(&*inst);
+    let profile = inst.source_profile.clone();
 
-    let profile = state.profile.clone();
     if let Ok(storage) = Storage::new(&profile) {
-        if let Err(e) = storage.save(&instances) {
+        let profile_instances: Vec<_> = instances
+            .iter()
+            .filter(|i| i.source_profile == profile)
+            .cloned()
+            .collect();
+        if let Err(e) = storage.save(&profile_instances) {
             tracing::error!("Failed to save after rename: {e}");
         }
     }
 
     (StatusCode::OK, Json(serde_json::json!(response)))
+}
+
+// --- Delete session ---
+
+#[derive(Default, Deserialize)]
+pub struct DeleteSessionBody {
+    #[serde(default)]
+    pub delete_worktree: bool,
+    #[serde(default)]
+    pub delete_branch: bool,
+    #[serde(default)]
+    pub delete_sandbox: bool,
+    #[serde(default)]
+    pub force_delete: bool,
+}
+
+pub async fn delete_session(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Option<Json<DeleteSessionBody>>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        );
+    }
+
+    let body = body.map(|Json(b)| b).unwrap_or_default();
+
+    // Acquire per-instance lock to serialize concurrent mutations
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    // Find and clone the instance (need the full Instance for deletion)
+    let instance = {
+        let instances = state.instances.read().await;
+        instances.iter().find(|i| i.id == id).cloned()
+    };
+
+    let Some(instance) = instance else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "message": "Session not found" })),
+        );
+    };
+
+    let profile = instance.source_profile.clone();
+
+    // Mark as Deleting so polling clients see the status change
+    {
+        let mut instances = state.instances.write().await;
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            inst.status = Status::Deleting;
+        }
+    }
+
+    // Run deletion on a blocking thread (may do git/docker/tmux operations)
+    let deletion_id = id.clone();
+    let deletion_result = tokio::task::spawn_blocking(move || {
+        crate::session::deletion::perform_deletion(&crate::session::deletion::DeletionRequest {
+            session_id: deletion_id,
+            instance,
+            delete_worktree: body.delete_worktree,
+            delete_branch: body.delete_branch,
+            delete_sandbox: body.delete_sandbox,
+            force_delete: body.force_delete,
+        })
+    })
+    .await;
+
+    match deletion_result {
+        Ok(result) if result.success => {
+            // Remove from in-memory state and persist
+            let mut instances = state.instances.write().await;
+            instances.retain(|i| i.id != id);
+
+            if let Ok(storage) = Storage::new(&profile) {
+                let profile_instances: Vec<_> = instances
+                    .iter()
+                    .filter(|i| i.source_profile == profile)
+                    .cloned()
+                    .collect();
+                if let Err(e) = storage.save(&profile_instances) {
+                    tracing::error!("Failed to save after deletion: {e}");
+                }
+            }
+
+            // Clean up per-instance lock entry
+            state.instance_locks.write().await.remove(&id);
+
+            (
+                StatusCode::OK,
+                Json(serde_json::json!({ "status": "deleted" })),
+            )
+        }
+        Ok(result) => {
+            // Deletion had errors; set status to Error
+            let error_msg = result.error.unwrap_or_else(|| "Unknown error".to_string());
+            {
+                let mut instances = state.instances.write().await;
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                    inst.status = Status::Error;
+                    inst.last_error = Some(error_msg.clone());
+                }
+            }
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": "deletion_failed",
+                    "message": error_msg,
+                })),
+            )
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": "internal",
+                "message": format!("Deletion task failed: {e}"),
+            })),
+        ),
+    }
 }
 
 // --- Create session ---

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -101,17 +101,26 @@ impl From<&Instance> for SessionResponse {
 }
 
 pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionResponse>> {
-    use std::collections::HashMap;
-
     let instances = state.instances.read().await;
     let mut sessions: Vec<SessionResponse> = instances.iter().map(SessionResponse::from).collect();
 
-    // Resolve per-profile cleanup defaults (cached per profile to avoid redundant I/O)
-    let mut config_cache: HashMap<String, CleanupDefaults> = HashMap::new();
-    for session in &mut sessions {
-        let defaults = config_cache
-            .entry(session.profile.clone())
-            .or_insert_with(|| {
+    // Resolve per-profile cleanup defaults with a 30s TTL cache on AppState
+    let cache = {
+        let guard = state.cleanup_defaults_cache.read().await;
+        if guard.0.elapsed() < std::time::Duration::from_secs(30) {
+            Some(guard.1.clone())
+        } else {
+            None
+        }
+    };
+
+    let defaults_map = if let Some(cached) = cache {
+        cached
+    } else {
+        use std::collections::HashMap;
+        let mut fresh: HashMap<String, CleanupDefaults> = HashMap::new();
+        for session in &sessions {
+            fresh.entry(session.profile.clone()).or_insert_with(|| {
                 crate::session::resolve_config(&session.profile)
                     .map(|cfg| CleanupDefaults {
                         delete_worktree: cfg.worktree.auto_cleanup,
@@ -124,7 +133,15 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
                         delete_sandbox: true,
                     })
             });
-        session.cleanup_defaults = defaults.clone();
+        }
+        *state.cleanup_defaults_cache.write().await = (std::time::Instant::now(), fresh.clone());
+        fresh
+    };
+
+    for session in &mut sessions {
+        if let Some(defaults) = defaults_map.get(&session.profile) {
+            session.cleanup_defaults = defaults.clone();
+        }
     }
 
     Json(sessions)

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -56,6 +56,14 @@ pub struct SessionResponse {
     pub has_managed_worktree: bool,
     pub has_terminal: bool,
     pub profile: String,
+    pub cleanup_defaults: CleanupDefaults,
+}
+
+#[derive(Serialize, Clone)]
+pub struct CleanupDefaults {
+    pub delete_worktree: bool,
+    pub delete_branch: bool,
+    pub delete_sandbox: bool,
 }
 
 impl From<&Instance> for SessionResponse {
@@ -83,13 +91,42 @@ impl From<&Instance> for SessionResponse {
                 .is_some_and(|w| w.managed_by_aoe),
             has_terminal: inst.terminal_info.is_some(),
             profile: inst.source_profile.clone(),
+            cleanup_defaults: CleanupDefaults {
+                delete_worktree: true,
+                delete_branch: false,
+                delete_sandbox: true,
+            },
         }
     }
 }
 
 pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionResponse>> {
+    use std::collections::HashMap;
+
     let instances = state.instances.read().await;
-    let sessions: Vec<SessionResponse> = instances.iter().map(SessionResponse::from).collect();
+    let mut sessions: Vec<SessionResponse> = instances.iter().map(SessionResponse::from).collect();
+
+    // Resolve per-profile cleanup defaults (cached per profile to avoid redundant I/O)
+    let mut config_cache: HashMap<String, CleanupDefaults> = HashMap::new();
+    for session in &mut sessions {
+        let defaults = config_cache
+            .entry(session.profile.clone())
+            .or_insert_with(|| {
+                crate::session::resolve_config(&session.profile)
+                    .map(|cfg| CleanupDefaults {
+                        delete_worktree: cfg.worktree.auto_cleanup,
+                        delete_branch: cfg.worktree.delete_branch_on_cleanup,
+                        delete_sandbox: cfg.sandbox.auto_cleanup,
+                    })
+                    .unwrap_or(CleanupDefaults {
+                        delete_worktree: true,
+                        delete_branch: false,
+                        delete_sandbox: true,
+                    })
+            });
+        session.cleanup_defaults = defaults.clone();
+    }
+
     Json(sessions)
 }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -388,7 +388,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/sessions",
             get(api::list_sessions).post(api::create_session),
         )
-        .route("/api/sessions/{id}", patch(api::rename_session))
+        .route(
+            "/api/sessions/{id}",
+            patch(api::rename_session).delete(api::delete_session),
+        )
         .route(
             "/api/sessions/{id}/diff/files",
             get(api::session_diff_files),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -161,6 +161,12 @@ pub struct AppState {
     /// first use and live for the lifetime of the process — there are only
     /// as many as the user has sessions.
     pub instance_locks: RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+    /// Cached per-profile cleanup defaults for the delete dialog, with a
+    /// timestamp so we re-resolve after config changes. TTL: 30 seconds.
+    pub cleanup_defaults_cache: RwLock<(
+        std::time::Instant,
+        std::collections::HashMap<String, api::CleanupDefaults>,
+    )>,
 }
 
 impl AppState {
@@ -247,6 +253,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         devices: RwLock::new(Vec::new()),
         behind_tunnel: remote,
         instance_locks: RwLock::new(std::collections::HashMap::new()),
+        cleanup_defaults_cache: RwLock::new((
+            std::time::Instant::now() - std::time::Duration::from_secs(60),
+            std::collections::HashMap::new(),
+        )),
     });
 
     let app = build_router(state.clone());

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -1,0 +1,315 @@
+//! Shared session deletion logic used by both TUI and web server.
+
+use std::path::{Path, PathBuf};
+
+use crate::containers::DockerContainer;
+use crate::git::cleanup::remove_managed_worktree;
+use crate::git::GitWorktree;
+use crate::session::repo_config;
+use crate::session::Instance;
+
+pub struct DeletionRequest {
+    pub session_id: String,
+    pub instance: Instance,
+    pub delete_worktree: bool,
+    pub delete_branch: bool,
+    pub delete_sandbox: bool,
+    pub force_delete: bool,
+}
+
+#[derive(Debug)]
+pub struct DeletionResult {
+    pub session_id: String,
+    pub success: bool,
+    pub error: Option<String>,
+}
+
+pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
+    let mut errors = Vec::new();
+
+    // Execute on_destroy hooks before any cleanup so resources (containers,
+    // worktrees) are still available for teardown commands.
+    run_on_destroy_hooks(&request.instance);
+
+    // Track branch info for potential deletion after worktree removal
+    let branch_to_delete = if request.delete_branch {
+        request
+            .instance
+            .worktree_info
+            .as_ref()
+            .filter(|wt| wt.managed_by_aoe)
+            .map(|wt| (wt.branch.clone(), PathBuf::from(&wt.main_repo_path)))
+    } else {
+        None
+    };
+
+    // Worktree cleanup (if user opted to delete it)
+    // Must happen before branch deletion since the worktree is using the branch
+    if request.delete_worktree {
+        if let Some(wt_info) = &request.instance.worktree_info {
+            if wt_info.managed_by_aoe {
+                let worktree_path = PathBuf::from(&request.instance.project_path);
+                let main_repo = PathBuf::from(&wt_info.main_repo_path);
+
+                match GitWorktree::new(main_repo.clone()) {
+                    Ok(git_wt) => {
+                        if let Err(errs) = remove_managed_worktree(
+                            &git_wt,
+                            &worktree_path,
+                            &main_repo,
+                            &request.instance,
+                            request.force_delete,
+                        ) {
+                            errors.extend(errs);
+                        }
+                    }
+                    Err(e) => {
+                        errors.push(format!("Worktree: {}", e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Workspace cleanup (if user opted to delete worktrees and instance has workspace_info)
+    if request.delete_worktree {
+        if let Some(ws_info) = &request.instance.workspace_info {
+            if ws_info.cleanup_on_delete {
+                for repo in &ws_info.repos {
+                    if repo.managed_by_aoe {
+                        let worktree_path = PathBuf::from(&repo.worktree_path);
+                        let main_repo = PathBuf::from(&repo.main_repo_path);
+
+                        match GitWorktree::new(main_repo.clone()) {
+                            Ok(git_wt) => {
+                                if let Err(errs) = remove_managed_worktree(
+                                    &git_wt,
+                                    &worktree_path,
+                                    &main_repo,
+                                    &request.instance,
+                                    request.force_delete,
+                                ) {
+                                    errors.extend(
+                                        errs.into_iter()
+                                            .map(|e| format!("Workspace ({}): {}", repo.name, e)),
+                                    );
+                                }
+                            }
+                            Err(e) => {
+                                errors.push(format!("Workspace ({}): {}", repo.name, e));
+                            }
+                        }
+                    }
+                }
+                // Remove workspace parent directory
+                let ws_path = PathBuf::from(&ws_info.workspace_dir);
+                if ws_path.exists() {
+                    if let Err(e) = std::fs::remove_dir_all(&ws_path) {
+                        errors.push(format!("Workspace dir: {}", e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Branch cleanup (if user opted to delete it and worktree was successfully removed)
+    if let Some((branch, main_repo)) = branch_to_delete {
+        let worktree_ok =
+            !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Worktree:"));
+        if worktree_ok {
+            match GitWorktree::new(main_repo) {
+                Ok(git_wt) => {
+                    if let Err(e) = git_wt.delete_branch(&branch) {
+                        errors.push(format!("Branch: {}", e));
+                    }
+                }
+                Err(e) => {
+                    errors.push(format!("Branch: {}", e));
+                }
+            }
+        }
+    }
+
+    // Branch cleanup for workspace repos
+    if request.delete_branch {
+        if let Some(ws_info) = &request.instance.workspace_info {
+            let worktree_ok =
+                !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Workspace ("));
+            if worktree_ok {
+                for repo in &ws_info.repos {
+                    if repo.managed_by_aoe {
+                        let main_repo = PathBuf::from(&repo.main_repo_path);
+                        if let Ok(git_wt) = GitWorktree::new(main_repo) {
+                            if let Err(e) = git_wt.delete_branch(&repo.branch) {
+                                errors.push(format!("Branch ({}): {}", repo.name, e));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Container cleanup (if user opted to delete it)
+    if request.delete_sandbox {
+        if let Some(sandbox) = &request.instance.sandbox_info {
+            if sandbox.enabled {
+                let container = DockerContainer::from_session_id(&request.instance.id);
+                if container.exists().unwrap_or(false) {
+                    if let Err(e) = container.remove(true) {
+                        errors.push(format!("Container: {}", e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Tmux kill - non-fatal if session already gone
+    let _ = request.instance.kill();
+
+    // Kill paired terminal session if it exists
+    let _ = request.instance.kill_terminal();
+
+    // Clean up hook status files
+    crate::hooks::cleanup_hook_status_dir(&request.instance.id);
+
+    DeletionResult {
+        session_id: request.session_id.clone(),
+        success: errors.is_empty(),
+        error: if errors.is_empty() {
+            None
+        } else {
+            Some(errors.join("; "))
+        },
+    }
+}
+
+/// Run on_destroy hooks for an instance. Uses best-effort execution so all
+/// hooks are attempted even if some fail. Failures are logged as warnings
+/// and never prevent deletion.
+///
+/// Global/profile hooks are implicitly trusted. Repo-level hooks go through
+/// the same trust verification as on_launch: if the hooks hash has changed
+/// since the user last approved, repo hooks are silently skipped.
+fn run_on_destroy_hooks(instance: &Instance) {
+    let profile = if instance.source_profile.is_empty() {
+        "default"
+    } else {
+        &instance.source_profile
+    };
+
+    let project_path = Path::new(&instance.project_path);
+
+    // Start with global+profile on_destroy hooks (implicitly trusted).
+    let mut resolved_on_destroy = crate::session::profile_config::resolve_config(profile)
+        .map(|c| c.hooks.on_destroy)
+        .unwrap_or_default();
+
+    // Check if repo has trusted hooks that override.
+    match repo_config::check_hook_trust(project_path) {
+        Ok(repo_config::HookTrustStatus::Trusted(hooks)) if !hooks.on_destroy.is_empty() => {
+            resolved_on_destroy = hooks.on_destroy.clone();
+        }
+        Ok(repo_config::HookTrustStatus::NeedsTrust { .. }) => {
+            tracing::warn!(
+                "Repo hooks changed since last trust approval; skipping repo on_destroy hooks"
+            );
+        }
+        _ => {}
+    }
+
+    if resolved_on_destroy.is_empty() {
+        return;
+    }
+
+    tracing::info!("Running on_destroy hooks for session {}", instance.id);
+
+    let is_sandboxed = instance.sandbox_info.as_ref().is_some_and(|s| s.enabled);
+
+    let errors = if is_sandboxed {
+        if let Some(ref sandbox) = instance.sandbox_info {
+            let workdir = instance.container_workdir();
+            repo_config::execute_hooks_in_container_best_effort(
+                &resolved_on_destroy,
+                &sandbox.container_name,
+                &workdir,
+            )
+        } else {
+            vec![]
+        }
+    } else {
+        repo_config::execute_hooks_best_effort(&resolved_on_destroy, project_path)
+    };
+
+    if !errors.is_empty() {
+        tracing::warn!(
+            "on_destroy hooks had {} failure(s) for session {}",
+            errors.len(),
+            instance.id
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_test_instance() -> Instance {
+        Instance::new("Test Session", "/tmp/test-project")
+    }
+
+    #[test]
+    fn test_deletion_result_success_when_no_worktree_or_sandbox() {
+        let instance = create_test_instance();
+        let request = DeletionRequest {
+            session_id: instance.id.clone(),
+            instance,
+            delete_worktree: false,
+            delete_branch: false,
+            delete_sandbox: false,
+            force_delete: false,
+        };
+
+        let result = perform_deletion(&request);
+
+        assert!(result.success);
+        assert!(result.error.is_none());
+        assert_eq!(result.session_id, request.session_id);
+    }
+
+    #[test]
+    fn test_deletion_result_success_even_with_delete_worktree_flag_when_no_worktree() {
+        let instance = create_test_instance();
+        let request = DeletionRequest {
+            session_id: instance.id.clone(),
+            instance,
+            delete_worktree: true,
+            delete_branch: false,
+            delete_sandbox: false,
+            force_delete: false,
+        };
+
+        let result = perform_deletion(&request);
+
+        assert!(result.success);
+        assert!(result.error.is_none());
+    }
+
+    #[test]
+    fn test_deletion_request_preserves_session_id() {
+        let instance = create_test_instance();
+        let custom_id = "custom-session-id-123".to_string();
+
+        let request = DeletionRequest {
+            session_id: custom_id.clone(),
+            instance,
+            delete_worktree: false,
+            delete_branch: false,
+            delete_sandbox: false,
+            force_delete: false,
+        };
+
+        let result = perform_deletion(&request);
+        assert_eq!(result.session_id, custom_id);
+    }
+}

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -4,6 +4,7 @@ pub mod builder;
 pub mod civilizations;
 pub mod config;
 pub(crate) mod container_config;
+pub mod deletion;
 pub(crate) mod environment;
 mod groups;
 mod instance;

--- a/src/tui/deletion_poller.rs
+++ b/src/tui/deletion_poller.rs
@@ -1,30 +1,10 @@
 //! Background deletion handler for TUI responsiveness
 
-use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::thread;
 
-use crate::containers::DockerContainer;
-use crate::git::cleanup::remove_managed_worktree;
-use crate::git::GitWorktree;
-use crate::session::repo_config;
-use crate::session::Instance;
-
-pub struct DeletionRequest {
-    pub session_id: String,
-    pub instance: Instance,
-    pub delete_worktree: bool,
-    pub delete_branch: bool,
-    pub delete_sandbox: bool,
-    pub force_delete: bool,
-}
-
-#[derive(Debug)]
-pub struct DeletionResult {
-    pub session_id: String,
-    pub success: bool,
-    pub error: Option<String>,
-}
+use crate::session::deletion::perform_deletion;
+pub use crate::session::deletion::{DeletionRequest, DeletionResult};
 
 pub struct DeletionPoller {
     request_tx: mpsc::Sender<DeletionRequest>,
@@ -53,237 +33,10 @@ impl DeletionPoller {
         result_tx: mpsc::Sender<DeletionResult>,
     ) {
         while let Ok(request) = request_rx.recv() {
-            let result = Self::perform_deletion(&request);
+            let result = perform_deletion(&request);
             if result_tx.send(result).is_err() {
                 break;
             }
-        }
-    }
-
-    fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
-        let mut errors = Vec::new();
-
-        // Execute on_destroy hooks before any cleanup so resources (containers,
-        // worktrees) are still available for teardown commands.
-        Self::run_on_destroy_hooks(&request.instance);
-
-        // Track branch info for potential deletion after worktree removal
-        let branch_to_delete = if request.delete_branch {
-            request
-                .instance
-                .worktree_info
-                .as_ref()
-                .filter(|wt| wt.managed_by_aoe)
-                .map(|wt| (wt.branch.clone(), PathBuf::from(&wt.main_repo_path)))
-        } else {
-            None
-        };
-
-        // Worktree cleanup (if user opted to delete it)
-        // Must happen before branch deletion since the worktree is using the branch
-        if request.delete_worktree {
-            if let Some(wt_info) = &request.instance.worktree_info {
-                if wt_info.managed_by_aoe {
-                    let worktree_path = PathBuf::from(&request.instance.project_path);
-                    let main_repo = PathBuf::from(&wt_info.main_repo_path);
-
-                    match GitWorktree::new(main_repo.clone()) {
-                        Ok(git_wt) => {
-                            if let Err(errs) = remove_managed_worktree(
-                                &git_wt,
-                                &worktree_path,
-                                &main_repo,
-                                &request.instance,
-                                request.force_delete,
-                            ) {
-                                errors.extend(errs);
-                            }
-                        }
-                        Err(e) => {
-                            errors.push(format!("Worktree: {}", e));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Workspace cleanup (if user opted to delete worktrees and instance has workspace_info)
-        if request.delete_worktree {
-            if let Some(ws_info) = &request.instance.workspace_info {
-                if ws_info.cleanup_on_delete {
-                    for repo in &ws_info.repos {
-                        if repo.managed_by_aoe {
-                            let worktree_path = PathBuf::from(&repo.worktree_path);
-                            let main_repo = PathBuf::from(&repo.main_repo_path);
-
-                            match GitWorktree::new(main_repo.clone()) {
-                                Ok(git_wt) => {
-                                    if let Err(errs) = remove_managed_worktree(
-                                        &git_wt,
-                                        &worktree_path,
-                                        &main_repo,
-                                        &request.instance,
-                                        request.force_delete,
-                                    ) {
-                                        errors.extend(
-                                            errs.into_iter().map(|e| {
-                                                format!("Workspace ({}): {}", repo.name, e)
-                                            }),
-                                        );
-                                    }
-                                }
-                                Err(e) => {
-                                    errors.push(format!("Workspace ({}): {}", repo.name, e));
-                                }
-                            }
-                        }
-                    }
-                    // Remove workspace parent directory
-                    let ws_path = PathBuf::from(&ws_info.workspace_dir);
-                    if ws_path.exists() {
-                        if let Err(e) = std::fs::remove_dir_all(&ws_path) {
-                            errors.push(format!("Workspace dir: {}", e));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Branch cleanup (if user opted to delete it and worktree was successfully removed)
-        if let Some((branch, main_repo)) = branch_to_delete {
-            let worktree_ok =
-                !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Worktree:"));
-            if worktree_ok {
-                match GitWorktree::new(main_repo) {
-                    Ok(git_wt) => {
-                        if let Err(e) = git_wt.delete_branch(&branch) {
-                            errors.push(format!("Branch: {}", e));
-                        }
-                    }
-                    Err(e) => {
-                        errors.push(format!("Branch: {}", e));
-                    }
-                }
-            }
-        }
-
-        // Branch cleanup for workspace repos
-        if request.delete_branch {
-            if let Some(ws_info) = &request.instance.workspace_info {
-                let worktree_ok = !request.delete_worktree
-                    || !errors.iter().any(|e| e.starts_with("Workspace ("));
-                if worktree_ok {
-                    for repo in &ws_info.repos {
-                        if repo.managed_by_aoe {
-                            let main_repo = PathBuf::from(&repo.main_repo_path);
-                            if let Ok(git_wt) = GitWorktree::new(main_repo) {
-                                if let Err(e) = git_wt.delete_branch(&repo.branch) {
-                                    errors.push(format!("Branch ({}): {}", repo.name, e));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Container cleanup (if user opted to delete it)
-        if request.delete_sandbox {
-            if let Some(sandbox) = &request.instance.sandbox_info {
-                if sandbox.enabled {
-                    let container = DockerContainer::from_session_id(&request.instance.id);
-                    if container.exists().unwrap_or(false) {
-                        if let Err(e) = container.remove(true) {
-                            errors.push(format!("Container: {}", e));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Tmux kill - non-fatal if session already gone
-        let _ = request.instance.kill();
-
-        // Kill paired terminal session if it exists
-        let _ = request.instance.kill_terminal();
-
-        // Clean up hook status files
-        crate::hooks::cleanup_hook_status_dir(&request.instance.id);
-
-        DeletionResult {
-            session_id: request.session_id.clone(),
-            success: errors.is_empty(),
-            error: if errors.is_empty() {
-                None
-            } else {
-                Some(errors.join("; "))
-            },
-        }
-    }
-
-    /// Run on_destroy hooks for an instance. Uses best-effort execution so all
-    /// hooks are attempted even if some fail. Failures are logged as warnings
-    /// and never prevent deletion.
-    ///
-    /// Global/profile hooks are implicitly trusted. Repo-level hooks go through
-    /// the same trust verification as on_launch: if the hooks hash has changed
-    /// since the user last approved, repo hooks are silently skipped.
-    fn run_on_destroy_hooks(instance: &Instance) {
-        let profile = if instance.source_profile.is_empty() {
-            "default"
-        } else {
-            &instance.source_profile
-        };
-
-        let project_path = Path::new(&instance.project_path);
-
-        // Start with global+profile on_destroy hooks (implicitly trusted).
-        let mut resolved_on_destroy = crate::session::profile_config::resolve_config(profile)
-            .map(|c| c.hooks.on_destroy)
-            .unwrap_or_default();
-
-        // Check if repo has trusted hooks that override.
-        match repo_config::check_hook_trust(project_path) {
-            Ok(repo_config::HookTrustStatus::Trusted(hooks)) if !hooks.on_destroy.is_empty() => {
-                resolved_on_destroy = hooks.on_destroy.clone();
-            }
-            Ok(repo_config::HookTrustStatus::NeedsTrust { .. }) => {
-                tracing::warn!(
-                    "Repo hooks changed since last trust approval; skipping repo on_destroy hooks"
-                );
-            }
-            _ => {}
-        }
-
-        if resolved_on_destroy.is_empty() {
-            return;
-        }
-
-        tracing::info!("Running on_destroy hooks for session {}", instance.id);
-
-        let is_sandboxed = instance.sandbox_info.as_ref().is_some_and(|s| s.enabled);
-
-        let errors = if is_sandboxed {
-            if let Some(ref sandbox) = instance.sandbox_info {
-                let workdir = instance.container_workdir();
-                repo_config::execute_hooks_in_container_best_effort(
-                    &resolved_on_destroy,
-                    &sandbox.container_name,
-                    &workdir,
-                )
-            } else {
-                vec![]
-            }
-        } else {
-            repo_config::execute_hooks_best_effort(&resolved_on_destroy, project_path)
-        };
-
-        if !errors.is_empty() {
-            tracing::warn!(
-                "on_destroy hooks had {} failure(s) for session {}",
-                errors.len(),
-                instance.id
-            );
         }
     }
 
@@ -305,47 +58,11 @@ impl Default for DeletionPoller {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::Instance;
     use std::time::Duration;
 
     fn create_test_instance() -> Instance {
         Instance::new("Test Session", "/tmp/test-project")
-    }
-
-    #[test]
-    fn test_deletion_result_success_when_no_worktree_or_sandbox() {
-        let instance = create_test_instance();
-        let request = DeletionRequest {
-            session_id: instance.id.clone(),
-            instance,
-            delete_worktree: false,
-            delete_branch: false,
-            delete_sandbox: false,
-            force_delete: false,
-        };
-
-        let result = DeletionPoller::perform_deletion(&request);
-
-        assert!(result.success);
-        assert!(result.error.is_none());
-        assert_eq!(result.session_id, request.session_id);
-    }
-
-    #[test]
-    fn test_deletion_result_success_even_with_delete_worktree_flag_when_no_worktree() {
-        let instance = create_test_instance();
-        let request = DeletionRequest {
-            session_id: instance.id.clone(),
-            instance,
-            delete_worktree: true,
-            delete_branch: false,
-            delete_sandbox: false,
-            force_delete: false,
-        };
-
-        let result = DeletionPoller::perform_deletion(&request);
-
-        assert!(result.success);
-        assert!(result.error.is_none());
     }
 
     #[test]
@@ -382,23 +99,5 @@ mod tests {
     fn test_deletion_poller_try_recv_returns_none_when_empty() {
         let poller = DeletionPoller::new();
         assert!(poller.try_recv_result().is_none());
-    }
-
-    #[test]
-    fn test_deletion_request_preserves_session_id() {
-        let instance = create_test_instance();
-        let custom_id = "custom-session-id-123".to_string();
-
-        let request = DeletionRequest {
-            session_id: custom_id.clone(),
-            instance,
-            delete_worktree: false,
-            delete_branch: false,
-            delete_sandbox: false,
-            force_delete: false,
-        };
-
-        let result = DeletionPoller::perform_deletion(&request);
-        assert_eq!(result.session_id, custom_id);
     }
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,8 +6,10 @@ import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useCommandActions } from "./hooks/useCommandActions";
-import { loginStatus, logout } from "./lib/api";
+import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
+import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
+import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
 import { ContentSplit } from "./components/ContentSplit";
 import { TerminalView } from "./components/TerminalView";
@@ -132,6 +134,46 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   };
 
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
+  const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
+  const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
+
+  useEffect(() => {
+    fetchAbout().then((about) => {
+      if (about) setServerAbout(about);
+    });
+  }, []);
+
+  const deletingWorkspace = deletingWorkspaceId
+    ? workspaces.find((w) => w.id === deletingWorkspaceId)
+    : null;
+  const deletingSession = deletingWorkspace?.sessions[0] ?? null;
+
+  const handleDeleteSession = useCallback((workspaceId: string) => {
+    setDeletingWorkspaceId(workspaceId);
+  }, []);
+
+  const handleConfirmDelete = useCallback(async (options: DeleteSessionOptions) => {
+    if (!deletingSession) return;
+    const sessionId = deletingSession.id;
+    const wasActive = sessionId === activeSessionId;
+
+    const result = await deleteSession(sessionId, options);
+    if (!result.ok) {
+      const { toastBus } = await import("./lib/toastBus");
+      toastBus.handler?.error(result.error || "Failed to delete session");
+      throw new Error(result.error);
+    }
+
+    setDeletingWorkspaceId(null);
+
+    if (wasActive) {
+      setActiveWorkspaceId(null);
+      setActiveSessionId(null);
+    }
+
+    const { toastBus } = await import("./lib/toastBus");
+    toastBus.handler?.info("Session deleted");
+  }, [deletingSession, activeSessionId]);
 
   const handleCreateSession = useCallback((repoPath: string) => {
     const projectSessions = sessions
@@ -261,6 +303,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onNew: () => setShowAddProject(true),
         onDiff: () => toggleDiff(),
         onEscape: () => {
+          if (deletingWorkspaceId) {
+            setDeletingWorkspaceId(null);
+            return;
+          }
           if (showPalette) {
             setShowPalette(false);
             return;
@@ -275,7 +321,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onSettings: () => setShowSettings((s) => !s),
         onPalette: () => setShowPalette((p) => !p),
       }),
-      [toggleDiff, showPalette],
+      [toggleDiff, showPalette, deletingWorkspaceId],
     ),
   );
 
@@ -387,6 +433,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           onSettings={() => { setShowSettings((s) => !s); if (window.innerWidth < 768) setSidebarOpen(false); }}
           onRepeatLast={handleRepeatLast}
           hasLastSession={!!lastSession}
+          onDeleteSession={handleDeleteSession}
+          readOnly={serverAbout?.read_only}
         />
 
         <div className="flex-1 flex flex-col min-h-0 min-w-0">
@@ -405,6 +453,18 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       {showHelp && <HelpOverlay onClose={() => setShowHelp(false)} />}
 
       {showAbout && <AboutModal onClose={() => setShowAbout(false)} />}
+
+      {deletingSession && (
+        <DeleteSessionDialog
+          sessionTitle={deletingSession.title}
+          sessionId={deletingSession.id}
+          branchName={deletingSession.branch}
+          hasManagedWorktree={deletingSession.has_managed_worktree}
+          isSandboxed={deletingSession.is_sandboxed}
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setDeletingWorkspaceId(null)}
+        />
+      )}
 
       <CommandPalette
         open={showPalette}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -57,7 +57,7 @@ export default function App() {
 }
 
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
-  const { sessions, error } = useSessions();
+  const { sessions, error, setSessionStatus } = useSessions();
   const workspaces = useWorkspaces(sessions);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
 
@@ -158,21 +158,25 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     const sessionId = deletingSession.id;
     const wasActive = sessionId === activeSessionId;
 
-    const result = await deleteSession(sessionId, options);
-    if (!result.ok) {
-      toastBus.handler?.error(result.error || "Failed to delete session");
-      throw new Error(result.error);
-    }
-
+    // Close dialog and show "Deleting" status immediately
     setDeletingWorkspaceId(null);
+    setSessionStatus(sessionId, "Deleting");
 
     if (wasActive) {
       setActiveWorkspaceId(null);
       setActiveSessionId(null);
     }
 
+    const result = await deleteSession(sessionId, options);
+    if (!result.ok) {
+      // Revert status on failure
+      setSessionStatus(sessionId, "Error");
+      toastBus.handler?.error(result.error || "Failed to delete session");
+      return;
+    }
+
     toastBus.handler?.info("Session deleted");
-  }, [deletingSession, activeSessionId]);
+  }, [deletingSession, activeSessionId, setSessionStatus]);
 
   const handleCreateSession = useCallback((repoPath: string) => {
     const projectSessions = sessions

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -459,6 +459,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           branchName={deletingSession.branch}
           hasManagedWorktree={deletingSession.has_managed_worktree}
           isSandboxed={deletingSession.is_sandboxed}
+          cleanupDefaults={deletingSession.cleanup_defaults}
           onConfirm={handleConfirmDelete}
           onCancel={() => setDeletingWorkspaceId(null)}
         />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
+import { toastBus } from "./lib/toastBus";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -159,7 +160,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
     const result = await deleteSession(sessionId, options);
     if (!result.ok) {
-      const { toastBus } = await import("./lib/toastBus");
       toastBus.handler?.error(result.error || "Failed to delete session");
       throw new Error(result.error);
     }
@@ -171,7 +171,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       setActiveSessionId(null);
     }
 
-    const { toastBus } = await import("./lib/toastBus");
     toastBus.handler?.info("Session deleted");
   }, [deletingSession, activeSessionId]);
 
@@ -457,7 +456,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       {deletingSession && (
         <DeleteSessionDialog
           sessionTitle={deletingSession.title}
-          sessionId={deletingSession.id}
           branchName={deletingSession.branch}
           hasManagedWorktree={deletingSession.has_managed_worktree}
           isSandboxed={deletingSession.is_sandboxed}

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -3,7 +3,6 @@ import type { DeleteSessionOptions } from "../lib/api";
 
 interface Props {
   sessionTitle: string;
-  sessionId: string;
   branchName: string | null;
   hasManagedWorktree: boolean;
   isSandboxed: boolean;

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { DeleteSessionOptions } from "../lib/api";
+import type { CleanupDefaults } from "../lib/types";
 
 interface Props {
   sessionTitle: string;
   branchName: string | null;
   hasManagedWorktree: boolean;
   isSandboxed: boolean;
+  cleanupDefaults: CleanupDefaults;
   onConfirm: (options: DeleteSessionOptions) => Promise<void>;
   onCancel: () => void;
 }
@@ -15,13 +17,14 @@ export function DeleteSessionDialog({
   branchName,
   hasManagedWorktree,
   isSandboxed,
+  cleanupDefaults,
   onConfirm,
   onCancel,
 }: Props) {
-  const [deleteWorktree, setDeleteWorktree] = useState(hasManagedWorktree);
+  const [deleteWorktree, setDeleteWorktree] = useState(hasManagedWorktree && cleanupDefaults.delete_worktree);
   const [forceDelete, setForceDelete] = useState(false);
-  const [deleteBranch, setDeleteBranch] = useState(false);
-  const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed);
+  const [deleteBranch, setDeleteBranch] = useState(hasManagedWorktree && cleanupDefaults.delete_branch);
+  const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed && cleanupDefaults.delete_sandbox);
   const [deleting, setDeleting] = useState(false);
   const dialogRef = useRef<HTMLDivElement>(null);
 

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -1,0 +1,184 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { DeleteSessionOptions } from "../lib/api";
+
+interface Props {
+  sessionTitle: string;
+  sessionId: string;
+  branchName: string | null;
+  hasManagedWorktree: boolean;
+  isSandboxed: boolean;
+  onConfirm: (options: DeleteSessionOptions) => Promise<void>;
+  onCancel: () => void;
+}
+
+export function DeleteSessionDialog({
+  sessionTitle,
+  branchName,
+  hasManagedWorktree,
+  isSandboxed,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [deleteWorktree, setDeleteWorktree] = useState(hasManagedWorktree);
+  const [forceDelete, setForceDelete] = useState(false);
+  const [deleteBranch, setDeleteBranch] = useState(false);
+  const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed);
+  const [deleting, setDeleting] = useState(false);
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  const hasOptions = hasManagedWorktree || isSandboxed;
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+
+  const handleConfirm = useCallback(async () => {
+    setDeleting(true);
+    try {
+      await onConfirm({
+        delete_worktree: deleteWorktree,
+        delete_branch: deleteBranch,
+        delete_sandbox: deleteSandbox,
+        force_delete: forceDelete,
+      });
+    } catch {
+      setDeleting(false);
+    }
+  }, [onConfirm, deleteWorktree, deleteBranch, deleteSandbox, forceDelete]);
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
+      onClick={onCancel}
+    >
+      <div
+        ref={dialogRef}
+        className="bg-surface-800 border border-surface-700/50 rounded-lg w-[420px] max-w-[90vw] shadow-2xl animate-slide-up"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="px-5 py-4 border-b border-surface-700">
+          <h2 className="text-sm font-semibold text-status-error">
+            Delete Session
+          </h2>
+        </div>
+
+        {/* Body */}
+        <div className="px-5 py-4 space-y-3">
+          <p className="text-[13px] text-text-secondary">
+            Delete{" "}
+            <span className="font-mono text-text-primary">{sessionTitle}</span>?
+          </p>
+
+          {hasOptions && (
+            <div className="space-y-2 pt-1">
+              {hasManagedWorktree && (
+                <>
+                  <Checkbox
+                    checked={deleteWorktree}
+                    onChange={setDeleteWorktree}
+                    label="Delete worktree"
+                    detail={branchName ? `Removes worktree for branch "${branchName}"` : undefined}
+                  />
+                  {deleteWorktree && (
+                    <div className="pl-6">
+                      <Checkbox
+                        checked={forceDelete}
+                        onChange={setForceDelete}
+                        label="Force delete"
+                        detail="Delete even if worktree has uncommitted changes"
+                      />
+                    </div>
+                  )}
+                  <Checkbox
+                    checked={deleteBranch}
+                    onChange={setDeleteBranch}
+                    label="Delete branch"
+                    detail={branchName ? `Removes branch "${branchName}"` : undefined}
+                  />
+                </>
+              )}
+              {isSandboxed && (
+                <Checkbox
+                  checked={deleteSandbox}
+                  onChange={setDeleteSandbox}
+                  label="Delete container"
+                  detail="Removes the Docker sandbox container"
+                />
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-5 py-3 border-t border-surface-700">
+          <button
+            onClick={onCancel}
+            disabled={deleting}
+            className="px-3 py-1.5 text-sm text-text-secondary hover:text-text-primary rounded-md hover:bg-surface-700/50 cursor-pointer transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={deleting}
+            className="px-3 py-1.5 text-sm text-white bg-status-error/90 hover:bg-status-error rounded-md cursor-pointer transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {deleting && (
+              <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+            )}
+            {deleting ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Checkbox({
+  checked,
+  onChange,
+  label,
+  detail,
+}: {
+  checked: boolean;
+  onChange: (val: boolean) => void;
+  label: string;
+  detail?: string;
+}) {
+  return (
+    <label className="flex items-start gap-2.5 cursor-pointer group">
+      <span
+        onClick={() => onChange(!checked)}
+        className={`mt-0.5 w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${
+          checked
+            ? "bg-status-error border-status-error"
+            : "border-surface-600 group-hover:border-surface-500"
+        }`}
+      >
+        {checked && (
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="none">
+            <path d="M2 5L4 7L8 3" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+          </svg>
+        )}
+      </span>
+      <span className="flex flex-col min-w-0">
+        <span className="text-[13px] text-text-secondary group-hover:text-text-primary transition-colors">
+          {label}
+        </span>
+        {detail && (
+          <span className="text-[12px] text-text-dim">{detail}</span>
+        )}
+      </span>
+    </label>
+  );
+}

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type { DeleteSessionOptions } from "../lib/api";
 import type { CleanupDefaults } from "../lib/types";
 
@@ -26,7 +26,6 @@ export function DeleteSessionDialog({
   const [deleteBranch, setDeleteBranch] = useState(hasManagedWorktree && cleanupDefaults.delete_branch);
   const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed && cleanupDefaults.delete_sandbox);
   const [deleting, setDeleting] = useState(false);
-  const dialogRef = useRef<HTMLDivElement>(null);
 
   const hasOptions = hasManagedWorktree || isSandboxed;
 
@@ -60,7 +59,6 @@ export function DeleteSessionDialog({
       onClick={onCancel}
     >
       <div
-        ref={dialogRef}
         className="bg-surface-800 border border-surface-700/50 rounded-lg w-[420px] max-w-[90vw] shadow-2xl animate-slide-up"
         onClick={(e) => e.stopPropagation()}
       >

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -495,7 +495,7 @@ export function WorkspaceSidebar({
           </div>
         )}
 
-        <div className="flex-1 overflow-y-auto">
+        <div className="flex-1 overflow-y-auto overflow-x-hidden">
           {hasLastSession && onRepeatLast && !filterQuery && (
             <button
               onClick={onRepeatLast}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -90,9 +90,13 @@ const SessionRow = memo(function SessionRow({
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
-    document.addEventListener("click", close);
-    document.addEventListener("contextmenu", close);
+    // Defer so the event that opened the menu finishes bubbling first
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("click", close);
+      document.addEventListener("contextmenu", close);
+    });
     return () => {
+      cancelAnimationFrame(id);
       document.removeEventListener("click", close);
       document.removeEventListener("contextmenu", close);
     };
@@ -184,8 +188,8 @@ const SessionRow = memo(function SessionRow({
         } ${
           isActive
             ? "bg-surface-850 border-l-2 border-brand-600"
-            : "border-l-2 border-transparent hover:bg-surface-800/50"
-        } ${isDeleting ? "opacity-50" : ""}`}
+            : "border-l-2 border-transparent hover:bg-surface-700/40"
+        } ${isDeleting ? "opacity-50 pointer-events-none" : ""}`}
       >
         <div className="flex items-center gap-2">
           <span

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -22,6 +22,8 @@ interface Props {
   onSettings: () => void;
   onRepeatLast?: () => void;
   hasLastSession?: boolean;
+  onDeleteSession?: (workspaceId: string) => void;
+  readOnly?: boolean;
 }
 
 function bestSession(ws: Workspace): { status: SessionStatus; createdAt: string | null } {
@@ -50,11 +52,15 @@ const SessionRow = memo(function SessionRow({
   workspace,
   isActive,
   onClick,
+  onDelete,
+  readOnly,
   indented,
 }: {
   workspace: Workspace;
   isActive: boolean;
   onClick: () => void;
+  onDelete?: (workspaceId: string) => void;
+  readOnly?: boolean;
   indented?: boolean;
 }) {
   const { status: sessionStatus, createdAt } = bestSession(workspace);
@@ -62,13 +68,15 @@ const SessionRow = memo(function SessionRow({
   const label =
     workspace.branch ?? workspace.sessions[0]?.title ?? "default";
   const sessionId = workspace.sessions[0]?.id;
+  const isDeleting = sessionStatus === "Deleting";
 
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; fromButton?: boolean } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(label);
   const renameRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressFired = useRef(false);
+  const moreRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     return () => {
@@ -92,8 +100,18 @@ const SessionRow = memo(function SessionRow({
   }, [contextMenu]);
 
   const handleContextMenu = (e: React.MouseEvent) => {
+    if (isDeleting) return;
     e.preventDefault();
     setContextMenu({ x: e.clientX, y: e.clientY });
+  };
+
+  const handleMoreClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (isDeleting) return;
+    const rect = moreRef.current?.getBoundingClientRect();
+    if (rect) {
+      setContextMenu({ x: rect.right, y: rect.bottom + 4, fromButton: true });
+    }
   };
 
   const clearLongPress = () => {
@@ -103,13 +121,17 @@ const SessionRow = memo(function SessionRow({
     }
   };
 
-  const handleTouchStart = () => {
+  const handleTouchStart = (e: React.TouchEvent) => {
     clearLongPress();
     longPressFired.current = false;
-    if (!sessionId) return;
+    if (!sessionId || isDeleting) return;
+    const touch = e.touches[0];
+    if (!touch) return;
+    const tx = touch.clientX;
+    const ty = touch.clientY;
     longPressTimer.current = setTimeout(() => {
       longPressFired.current = true;
-      startRename();
+      setContextMenu({ x: tx, y: ty });
     }, 500);
   };
 
@@ -134,6 +156,11 @@ const SessionRow = memo(function SessionRow({
     await renameSession(sessionId, trimmed);
   };
 
+  const handleDelete = () => {
+    setContextMenu(null);
+    onDelete?.(workspace.id);
+  };
+
   if (renaming) {
     return (
       <div className={`py-1 ${indented ? "pl-6 pr-3" : "px-3"}`}>
@@ -155,43 +182,75 @@ const SessionRow = memo(function SessionRow({
 
   return (
     <>
-      <button
-        onClick={() => { if (!longPressFired.current) onClick(); }}
+      <div
         onContextMenu={handleContextMenu}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
-        onTouchMove={clearLongPress}
-        onTouchCancel={clearLongPress}
-        className={`w-full text-left py-2 cursor-pointer transition-colors duration-75 ${
-          indented ? "pl-6 pr-3" : "px-3"
+        className={`group/row flex items-center transition-colors duration-75 ${
+          indented ? "pl-6 pr-1" : "pl-3 pr-1"
         } ${
           isActive
             ? "bg-surface-850 border-l-2 border-brand-600"
             : "border-l-2 border-transparent hover:bg-surface-800/50"
-        }`}
+        } ${isDeleting ? "opacity-50" : ""}`}
       >
-        <div className="flex items-center gap-2">
-          <span
-            className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
+        <button
+          onClick={() => { if (!longPressFired.current) onClick(); }}
+          onTouchStart={handleTouchStart}
+          onTouchEnd={handleTouchEnd}
+          onTouchMove={clearLongPress}
+          onTouchCancel={clearLongPress}
+          className="flex-1 min-w-0 text-left py-2 cursor-pointer"
+        >
+          <div className="flex items-center gap-2">
+            <span
+              className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
+            >
+              <StatusGlyph status={sessionStatus} createdAt={createdAt} />
+            </span>
+            <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive(sessionStatus) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+              {label}
+            </span>
+          </div>
+        </button>
+        {!isDeleting && (
+          <button
+            ref={moreRef}
+            onClick={handleMoreClick}
+            className="w-6 h-6 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            aria-label="Session actions"
           >
-            <StatusGlyph status={sessionStatus} createdAt={createdAt} />
-          </span>
-          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive(sessionStatus) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
-            {label}
-          </span>
-        </div>
-      </button>
+            <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
+              <circle cx="2" cy="6" r="1.2" />
+              <circle cx="6" cy="6" r="1.2" />
+              <circle cx="10" cy="6" r="1.2" />
+            </svg>
+          </button>
+        )}
+      </div>
       {contextMenu && (
         <div
           className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[140px]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          style={contextMenu.fromButton
+            ? { right: window.innerWidth - contextMenu.x, top: contextMenu.y }
+            : { left: contextMenu.x, top: contextMenu.y }
+          }
         >
           <button
             onClick={startRename}
-            className="w-full text-left px-3 py-2 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
           >
             Rename
           </button>
+          {!readOnly && (
+            <>
+              <div className="border-t border-surface-700/20 my-1" />
+              <button
+                onClick={handleDelete}
+                className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-status-error hover:bg-status-error/10 cursor-pointer transition-colors"
+              >
+                Delete
+              </button>
+            </>
+          )}
         </div>
       )}
     </>
@@ -304,6 +363,8 @@ export function WorkspaceSidebar({
   onSettings,
   onRepeatLast,
   hasLastSession,
+  onDeleteSession,
+  readOnly,
 }: Props) {
   const [width, setWidth] = useState(loadSavedWidth);
   const [filterOpen, setFilterOpen] = useState(false);
@@ -493,6 +554,8 @@ export function WorkspaceSidebar({
                       workspace={ws}
                       isActive={ws.id === activeId}
                       onClick={() => onSelect(ws.id)}
+                      onDelete={onDeleteSession}
+                      readOnly={readOnly}
                       indented
                     />
                   ))}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -107,10 +107,14 @@ const SessionRow = memo(function SessionRow({
 
   const handleMoreClick = (e: React.MouseEvent) => {
     e.stopPropagation();
+    e.preventDefault();
     if (isDeleting) return;
     const rect = moreRef.current?.getBoundingClientRect();
     if (rect) {
-      setContextMenu({ x: rect.right, y: rect.bottom + 4, fromButton: true });
+      const x = rect.right;
+      const y = rect.bottom + 4;
+      // Defer so the document click listener (which closes menus) fires first
+      setTimeout(() => setContextMenu({ x, y, fromButton: true }), 0);
     }
   };
 
@@ -185,7 +189,7 @@ const SessionRow = memo(function SessionRow({
       <div
         onContextMenu={handleContextMenu}
         className={`group/row flex items-center transition-colors duration-75 ${
-          indented ? "pl-6 pr-1" : "pl-3 pr-1"
+          indented ? "pl-6 pr-1 md:pr-3" : "pl-3 pr-1 md:pr-3"
         } ${
           isActive
             ? "bg-surface-850 border-l-2 border-brand-600"
@@ -215,7 +219,7 @@ const SessionRow = memo(function SessionRow({
           <button
             ref={moreRef}
             onClick={handleMoreClick}
-            className="w-6 h-6 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            className="w-6 h-6 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors md:hidden"
             aria-label="Session actions"
           >
             <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1,4 +1,5 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
 import { STATUS_DOT_CLASS, STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
 import { renameSession } from "../lib/api";
@@ -202,7 +203,7 @@ const SessionRow = memo(function SessionRow({
           </span>
         </div>
       </button>
-      {contextMenu && (
+      {contextMenu && createPortal(
         <div
           className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[140px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
@@ -224,7 +225,8 @@ const SessionRow = memo(function SessionRow({
               </button>
             </>
           )}
-        </div>
+        </div>,
+        document.body,
       )}
     </>
   );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -70,13 +70,12 @@ const SessionRow = memo(function SessionRow({
   const sessionId = workspace.sessions[0]?.id;
   const isDeleting = sessionStatus === "Deleting";
 
-  const [contextMenu, setContextMenu] = useState<{ x: number; y: number; fromButton?: boolean } | null>(null);
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(label);
   const renameRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressFired = useRef(false);
-  const moreRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     return () => {
@@ -103,19 +102,6 @@ const SessionRow = memo(function SessionRow({
     if (isDeleting) return;
     e.preventDefault();
     setContextMenu({ x: e.clientX, y: e.clientY });
-  };
-
-  const handleMoreClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    e.preventDefault();
-    if (isDeleting) return;
-    const rect = moreRef.current?.getBoundingClientRect();
-    if (rect) {
-      const x = rect.right;
-      const y = rect.bottom + 4;
-      // Defer so the document click listener (which closes menus) fires first
-      setTimeout(() => setContextMenu({ x, y, fromButton: true }), 0);
-    }
   };
 
   const clearLongPress = () => {
@@ -186,57 +172,36 @@ const SessionRow = memo(function SessionRow({
 
   return (
     <>
-      <div
+      <button
+        onClick={() => { if (!longPressFired.current) onClick(); }}
         onContextMenu={handleContextMenu}
-        className={`group/row flex items-center transition-colors duration-75 ${
-          indented ? "pl-6 pr-1 md:pr-3" : "pl-3 pr-1 md:pr-3"
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
+        onTouchMove={clearLongPress}
+        onTouchCancel={clearLongPress}
+        className={`w-full text-left py-2 cursor-pointer transition-colors duration-75 ${
+          indented ? "pl-6 pr-3" : "px-3"
         } ${
           isActive
             ? "bg-surface-850 border-l-2 border-brand-600"
             : "border-l-2 border-transparent hover:bg-surface-800/50"
         } ${isDeleting ? "opacity-50" : ""}`}
       >
-        <button
-          onClick={() => { if (!longPressFired.current) onClick(); }}
-          onTouchStart={handleTouchStart}
-          onTouchEnd={handleTouchEnd}
-          onTouchMove={clearLongPress}
-          onTouchCancel={clearLongPress}
-          className="flex-1 min-w-0 text-left py-2 cursor-pointer"
-        >
-          <div className="flex items-center gap-2">
-            <span
-              className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
-            >
-              <StatusGlyph status={sessionStatus} createdAt={createdAt} />
-            </span>
-            <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive(sessionStatus) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
-              {label}
-            </span>
-          </div>
-        </button>
-        {!isDeleting && (
-          <button
-            ref={moreRef}
-            onClick={handleMoreClick}
-            className="w-6 h-6 flex items-center justify-center shrink-0 rounded text-text-dim hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors md:hidden"
-            aria-label="Session actions"
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
           >
-            <svg width="12" height="12" viewBox="0 0 12 12" fill="currentColor">
-              <circle cx="2" cy="6" r="1.2" />
-              <circle cx="6" cy="6" r="1.2" />
-              <circle cx="10" cy="6" r="1.2" />
-            </svg>
-          </button>
-        )}
-      </div>
+            <StatusGlyph status={sessionStatus} createdAt={createdAt} />
+          </span>
+          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive(sessionStatus) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+            {label}
+          </span>
+        </div>
+      </button>
       {contextMenu && (
         <div
           className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[140px]"
-          style={contextMenu.fromButton
-            ? { right: window.innerWidth - contextMenu.x, top: contextMenu.y }
-            : { left: contextMenu.x, top: contextMenu.y }
-          }
+          style={{ left: contextMenu.x, top: contextMenu.y }}
         >
           <button
             onClick={startRename}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -184,7 +184,7 @@ const SessionRow = memo(function SessionRow({
         onTouchEnd={handleTouchEnd}
         onTouchMove={clearLongPress}
         onTouchCancel={clearLongPress}
-        className={`w-full text-left py-2 cursor-pointer transition-colors duration-75 ${
+        className={`w-full text-left py-2 cursor-pointer select-none transition-colors duration-75 ${
           indented ? "pl-6 pr-3" : "px-3"
         } ${
           isActive

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -47,5 +47,9 @@ export function useSessions() {
     };
   }, []);
 
-  return { sessions, error, refresh };
+  const setSessionStatus = useCallback((id: string, status: SessionResponse["status"]) => {
+    setSessions((prev) => prev.map((s) => s.id === id ? { ...s, status } : s));
+  }, []);
+
+  return { sessions, error, refresh, setSessionStatus };
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -361,3 +361,41 @@ export async function renameSession(
     return false;
   }
 }
+
+export interface DeleteSessionOptions {
+  delete_worktree?: boolean;
+  delete_branch?: boolean;
+  delete_sandbox?: boolean;
+  force_delete?: boolean;
+}
+
+export interface DeleteSessionResult {
+  ok: boolean;
+  error?: string;
+}
+
+export async function deleteSession(
+  id: string,
+  options: DeleteSessionOptions = {},
+): Promise<DeleteSessionResult> {
+  try {
+    const res = await fetch(`/api/sessions/${id}`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(options),
+    });
+    if (!res.ok) {
+      const data = await res.json().catch(() => ({}));
+      return {
+        ok: false,
+        error: data.message || `Server error (${res.status})`,
+      };
+    }
+    return { ok: true };
+  } catch (e) {
+    return {
+      ok: false,
+      error: `Network error: ${e instanceof Error ? e.message : "connection failed"}`,
+    };
+  }
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -13,6 +13,7 @@ export interface SessionResponse {
   branch: string | null;
   main_repo_path: string | null;
   is_sandboxed: boolean;
+  has_managed_worktree: boolean;
   has_terminal: boolean;
   profile: string;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -16,6 +16,13 @@ export interface SessionResponse {
   has_managed_worktree: boolean;
   has_terminal: boolean;
   profile: string;
+  cleanup_defaults: CleanupDefaults;
+}
+
+export interface CleanupDefaults {
+  delete_worktree: boolean;
+  delete_branch: boolean;
+  delete_sandbox: boolean;
 }
 
 export type SessionStatus =


### PR DESCRIPTION
## Description

Closes #704. Adds session deletion to the web dashboard with full feature parity to the TUI delete dialog.

**Backend:**
- Extract shared deletion logic to `src/session/deletion.rs` (reused by both TUI `DeletionPoller` and the new web endpoint)
- Add `DELETE /api/sessions/{id}` with optional JSON body for cleanup options (worktree, branch, sandbox, force)
- Add `has_managed_worktree` field to `SessionResponse` so the frontend knows when to show worktree/branch checkboxes
- Fix profile-save bug in `rename_session` (was writing all profiles into one storage file instead of filtering by `source_profile`)

**Frontend:**
- `DeleteSessionDialog` with contextual checkboxes only shown when relevant (managed worktree, branch, sandbox)
- Always-visible "..." overflow button on each session row opening a context menu with Rename + Delete
- Delete hidden in read-only mode, dimmed "Deleting" rows with actions disabled
- Mobile: long-press opens context menu, 44px touch targets
- Escape key cascade, optimistic "Deleting" status, toast notifications

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)