### PR TITLE
feat(web): optimistic session creation, sidebar shortcuts, Mac-only Cmd+K

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { SettingsView } from "./components/SettingsView";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import type { WizardPrefill } from "./components/session-wizard/SessionWizard";
+import type { SessionResponse } from "./lib/types";
 import { Dashboard } from "./components/Dashboard";
 import { LoginPage } from "./components/LoginPage";
 import { AboutModal } from "./components/AboutModal";
@@ -54,7 +55,7 @@ export default function App() {
 }
 
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
-  const { sessions, error } = useSessions();
+  const { sessions, error, injectSession } = useSessions();
   const workspaces = useWorkspaces(sessions);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
 
@@ -274,6 +275,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onHelp: () => setShowHelp((h) => !h),
         onSettings: () => setShowSettings((s) => !s),
         onPalette: () => setShowPalette((p) => !p),
+        onToggleSidebar: () => setSidebarOpen((o) => !o),
+        onToggleRightPanel: () => setDiffCollapsed((c) => !c),
       }),
       [toggleDiff, showPalette],
     ),
@@ -397,7 +400,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       {showAddProject && (
         <SessionWizard
           onClose={() => { setShowAddProject(false); setWizardPrefill(undefined); }}
-          onCreated={() => { setShowAddProject(false); setWizardPrefill(undefined); }}
+          onCreated={(session?: SessionResponse) => { if (session) injectSession(session); setShowAddProject(false); setWizardPrefill(undefined); }}
           prefill={wizardPrefill}
         />
       )}

--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -23,8 +23,12 @@ const IS_MAC =
 export function HelpOverlay({ onClose }: Props) {
   const modKey = IS_MAC ? "⌘" : "Ctrl";
 
+  const optKey = IS_MAC ? "⌥" : "Alt";
+
   const shortcuts = [
     { key: `${modKey}K`, desc: "Open command palette" },
+    { key: `${modKey}B`, desc: "Toggle left sidebar" },
+    { key: `${modKey}${optKey}B`, desc: "Toggle right panel" },
     { key: "n", desc: "New session" },
     { key: "D", desc: "Toggle diff panel" },
     { key: "s", desc: "Toggle settings" },

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer } from "react";
-import type { AgentInfo, GroupInfo, ProfileInfo, CreateSessionRequest } from "../../lib/types";
+import type { AgentInfo, GroupInfo, ProfileInfo, CreateSessionRequest, SessionResponse } from "../../lib/types";
 import { fetchAgents, fetchGroups, fetchDockerStatus, fetchProfiles, getSettings, createSession } from "../../lib/api";
 import { StepIndicator } from "./StepIndicator";
 import type { StepDef, StepId } from "./StepIndicator";
@@ -120,7 +120,7 @@ export interface WizardPrefill {
 
 interface Props {
   onClose: () => void;
-  onCreated: () => void;
+  onCreated: (session?: SessionResponse) => void;
   prefill?: WizardPrefill;
 }
 
@@ -194,7 +194,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       profile: d.profile || undefined,
     };
     const result = await createSession(body);
-    if (result.ok) { dispatch({ type: "SUBMIT_SUCCESS" }); onCreated(); }
+    if (result.ok) { dispatch({ type: "SUBMIT_SUCCESS" }); onCreated(result.session); }
     else dispatch({ type: "SUBMIT_ERROR", error: result.error || "Unknown error" });
   };
 

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -1,4 +1,8 @@
 import { useMemo } from "react";
+
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
 import type { SessionResponse } from "../lib/types";
 import type { CommandAction } from "../components/command-palette/types";
 
@@ -69,7 +73,7 @@ export function useCommandActions({
       title: "Toggle sidebar",
       group: "Actions",
       keywords: ["hide", "show", "nav"],
-      shortcut: "⌘B",
+      shortcut: IS_MAC ? "⌘B" : "Ctrl+B",
       perform: onToggleSidebar,
     });
 

--- a/web/src/hooks/useCommandActions.ts
+++ b/web/src/hooks/useCommandActions.ts
@@ -69,6 +69,7 @@ export function useCommandActions({
       title: "Toggle sidebar",
       group: "Actions",
       keywords: ["hide", "show", "nav"],
+      shortcut: "⌘B",
       perform: onToggleSidebar,
     });
 

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,9 @@
 import { useEffect } from "react";
 
+const IS_MAC =
+  typeof navigator !== "undefined" &&
+  /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+
 interface ShortcutActions {
   onNew: () => void;
   onDiff: () => void;
@@ -7,12 +11,14 @@ interface ShortcutActions {
   onHelp: () => void;
   onSettings: () => void;
   onPalette: () => void;
+  onToggleSidebar: () => void;
+  onToggleRightPanel: () => void;
 }
 
 /**
  * Global keyboard shortcuts for the dashboard.
  * Single-key shortcuts fire only when no input/textarea/terminal is focused.
- * Cmd/Ctrl+K (palette) and Escape fire regardless of focus.
+ * Cmd+K (Mac) / Ctrl+K (other) and Escape fire regardless of focus.
  */
 export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
   useEffect(() => {
@@ -25,12 +31,32 @@ export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
           target.isContentEditable);
 
       const actions = getActions();
+      const mod = IS_MAC ? e.metaKey : e.metaKey || e.ctrlKey;
 
-      // Palette: Cmd+K / Ctrl+K, works everywhere.
-      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
+      // Palette: Cmd+K (Mac) / Ctrl+K (other), works everywhere.
+      if (mod && !e.shiftKey && !e.altKey && e.key.toLowerCase() === "k") {
         e.preventDefault();
         e.stopPropagation();
         actions.onPalette();
+        return;
+      }
+
+      // Use e.code for B shortcuts because Option+B on Mac produces "∫"
+      // instead of "b", causing e.key matching to fail.
+      // Toggle right panel: Cmd+Opt+B (Mac) / Ctrl+Alt+B (other)
+      // Check alt combo first so Cmd+B doesn't swallow Cmd+Opt+B.
+      if (mod && !e.shiftKey && e.altKey && e.code === "KeyB") {
+        e.preventDefault();
+        e.stopPropagation();
+        actions.onToggleRightPanel();
+        return;
+      }
+
+      // Toggle left sidebar: Cmd+B (Mac) / Ctrl+B (other)
+      if (mod && !e.shiftKey && !e.altKey && e.code === "KeyB") {
+        e.preventDefault();
+        e.stopPropagation();
+        actions.onToggleSidebar();
         return;
       }
 

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -9,6 +9,13 @@ export function useSessions() {
   const [error, setError] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  const injectSession = useCallback((session: SessionResponse) => {
+    setSessions((prev) => {
+      if (prev.some((s) => s.id === session.id)) return prev;
+      return [session, ...prev];
+    });
+  }, []);
+
   const refresh = useCallback(async () => {
     const data = await fetchSessions();
     if (data !== null) {
@@ -47,5 +54,5 @@ export function useSessions() {
     };
   }, []);
 
-  return { sessions, error, refresh };
+  return { sessions, error, refresh, injectSession };
 }


### PR DESCRIPTION
## Description

Three web dashboard UX improvements:

1. **Optimistic session in sidebar**: When creating a session via the wizard, it now appears immediately in the sidebar with its "Creating" state instead of waiting up to 3 seconds for the next poll cycle. The API response already includes the session data; we inject it into the sessions list optimistically (deduplicated by ID so the next poll replaces it cleanly).

2. **Sidebar toggle shortcuts**: Added `Cmd+B` (Mac) / `Ctrl+B` to toggle the left sidebar, and `Cmd+Opt+B` (Mac) / `Ctrl+Alt+B` to toggle the right panel. Uses `e.code` instead of `e.key` for the B shortcuts because `Option+B` on Mac produces "∫" instead of "b". The more specific combo (with Alt) is checked first so it isn't swallowed.

3. **Mac-only Cmd+K**: On Mac, only `Cmd+K` opens the command palette (not `Ctrl+K`), since `Ctrl` is used as the tmux/terminal prefix key inside terminal sessions. Non-Mac platforms still accept both `Ctrl+K` and `Meta+K`.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)