### PR TITLE
fix(web): replace disconnect toast spam with persistent banner

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import { Dashboard } from "./components/Dashboard";
 import { LoginPage } from "./components/LoginPage";
 import { AboutModal } from "./components/AboutModal";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
+import { DisconnectBanner } from "./components/DisconnectBanner";
 
 export default function App() {
   const [loginRequired, setLoginRequired] = useState<boolean | null>(null);
@@ -372,6 +373,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         isOffline={!!error}
         onGoDashboard={handleGoDashboard}
       />
+
+      <DisconnectBanner />
 
       <div className="flex flex-1 min-h-0">
         <WorkspaceSidebar

--- a/web/src/components/DisconnectBanner.tsx
+++ b/web/src/components/DisconnectBanner.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import { onServerDownChange, isServerDown } from "../lib/connectionState";
+
+/**
+ * Full-width banner shown when the backend server is unreachable. Replaces the
+ * repeated "network error" toast spam with a single persistent notification
+ * that auto-dismisses when the connection recovers.
+ */
+export function DisconnectBanner() {
+  const [down, setDown] = useState(isServerDown);
+  const [reconnected, setReconnected] = useState(false);
+
+  useEffect(() => {
+    return onServerDownChange((isDown) => {
+      if (!isDown && down) {
+        // Server came back. Flash a "reconnected" message briefly.
+        setReconnected(true);
+        setDown(false);
+        const t = setTimeout(() => setReconnected(false), 3000);
+        return () => clearTimeout(t);
+      }
+      setDown(isDown);
+      if (isDown) setReconnected(false);
+    });
+  }, [down]);
+
+  if (reconnected) {
+    return (
+      <div
+        role="status"
+        className="bg-status-running/10 border-b border-status-running/30 px-4 py-2 flex items-center justify-center gap-2 text-xs font-mono text-status-running animate-fade-in"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+        Reconnected
+      </div>
+    );
+  }
+
+  if (!down) return null;
+
+  return (
+    <div
+      role="alert"
+      className="bg-status-error/10 border-b border-status-error/30 px-4 py-2 flex items-center justify-center gap-2 text-xs font-mono text-status-error animate-fade-in"
+    >
+      <span className="w-1.5 h-1.5 rounded-full bg-status-error animate-pulse shrink-0" />
+      Server unreachable. Reconnecting automatically...
+    </div>
+  );
+}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { SessionResponse } from "../lib/types";
 import { fetchSessions } from "../lib/api";
+import { setServerDown } from "../lib/connectionState";
 
 const POLL_INTERVAL = 3000;
 
@@ -14,8 +15,10 @@ export function useSessions() {
     if (data !== null) {
       setSessions(data);
       setError(false);
+      setServerDown(false);
     } else {
       setError(true);
+      setServerDown(true);
     }
   }, []);
 
@@ -25,8 +28,10 @@ export function useSessions() {
       if (data !== null) {
         setSessions(data);
         setError(false);
+        setServerDown(false);
       } else {
         setError(true);
+        setServerDown(true);
       }
     });
 
@@ -36,8 +41,10 @@ export function useSessions() {
         if (data !== null) {
           setSessions(data);
           setError(false);
+          setServerDown(false);
         } else {
           setError(true);
+          setServerDown(true);
         }
       });
     }, POLL_INTERVAL);

--- a/web/src/lib/connectionState.ts
+++ b/web/src/lib/connectionState.ts
@@ -1,0 +1,27 @@
+/**
+ * Tracks whether the backend server is reachable. When the connection is known
+ * to be down, the fetch interceptor suppresses per-request "network error"
+ * toasts so the user sees one clear disconnect banner instead of a toast flood.
+ *
+ * The session poller (`useSessions`) is the source of truth: it hits
+ * `/api/sessions` every 3s and calls `setServerDown(true/false)` based on
+ * whether that request succeeds.
+ */
+
+let serverDown = false;
+const listeners = new Set<(down: boolean) => void>();
+
+export function setServerDown(down: boolean): void {
+  if (serverDown === down) return;
+  serverDown = down;
+  for (const fn of listeners) fn(down);
+}
+
+export function isServerDown(): boolean {
+  return serverDown;
+}
+
+export function onServerDownChange(fn: (down: boolean) => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -1,3 +1,4 @@
+import { isServerDown } from "./connectionState";
 import { reportError } from "./toastBus";
 import { clearToken, getToken, saveToken } from "./token";
 
@@ -49,7 +50,7 @@ export function installFetchErrorToasts(): void {
       if (res.status === 401 && isApi && getToken()) {
         handleTokenRejected();
       }
-      if (isApi && res.status >= 500) {
+      if (isApi && res.status >= 500 && !isServerDown()) {
         reportError(`Server error ${res.status} from ${path}`);
       }
       return res;
@@ -61,7 +62,9 @@ export function installFetchErrorToasts(): void {
       ) {
         throw err;
       }
-      if (isApi) {
+      // When the server is known to be down, suppress per-request toasts.
+      // The DisconnectBanner handles the user-facing notification instead.
+      if (isApi && !isServerDown()) {
         reportError(
           `Network error contacting ${path}. Check your connection.`,
         );


### PR DESCRIPTION
## Description

When the server shuts down, the web dashboard spams repeated "network error" toast popups every 3 seconds (one per failed API poll). Toasts live 6 seconds each, so they stack 2-3 deep and keep appearing forever.

This replaces that behavior with a single persistent disconnect banner below the TopBar that auto-clears when the connection recovers.

**How it works:**
- New `connectionState` module tracks server reachability (simple boolean + listener pattern)
- The session poller (`useSessions`) is the source of truth, calling `setServerDown(true/false)` on each poll result
- The fetch interceptor checks `isServerDown()` before calling `reportError()`, suppressing toasts when the server is known to be down
- A `DisconnectBanner` component shows "Server unreachable. Reconnecting automatically..." while down, then flashes "Reconnected" for 3s when it recovers
- The first failed request (before the poller has flagged offline) may still show one toast, which is fine

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)