### PR TITLE
fix(ci): chain cachix build after npm hash update

### DIFF
--- a/.github/workflows/cachix-push.yml
+++ b/.github/workflows/cachix-push.yml
@@ -17,13 +17,25 @@ on:
       - 'src/**'
       - 'Cargo.toml'
       - 'Cargo.lock'
-      - 'web/**'
       - 'build.rs'
+      # web/** is intentionally excluded: web/package-lock.json changes
+      # trigger the "Update Nix npm Hash" workflow, which updates the
+      # npmDepsHash in flake.nix. Building here before that hash is
+      # committed races and fails with ENOTCACHED. The workflow_run
+      # trigger below chains the cachix build after the hash update.
+  workflow_run:
+    workflows: ["Update Nix npm Hash"]
+    branches: [main]
+    types: [completed]
   workflow_dispatch:
 
 jobs:
   cachix:
     name: Build and push (${{ matrix.os }})
+    # Skip when triggered by a failed hash-update run.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

The `cachix-push` workflow was racing with `nix-npm-hash` when `web/package-lock.json` changed on `main`. Both workflows triggered simultaneously, and cachix-push tried to build with the stale `npmDepsHash` before the hash-update workflow could commit the correction. This caused `ENOTCACHED` failures (e.g., for `zod-validation-error`).

Fix: remove `web/**` from cachix-push's push path triggers and add a `workflow_run` trigger that chains the cachix build after the hash-update workflow completes successfully. This ensures the build always uses the correct `npmDepsHash`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)