### PR TITLE
fix(web): persist TUI serve port so dashboard URL stays stable

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -345,9 +345,8 @@ pub async fn auth_middleware(
         // Bearer header. Setting the cookie on those responses "rehydrates" it
         // so the next browser navigation (HTML page load) works without
         // re-pasting the ?token= URL.
-        let should_refresh = source == TokenSource::QueryParam
-            || source == TokenSource::Bearer
-            || needs_upgrade;
+        let should_refresh =
+            source == TokenSource::QueryParam || source == TokenSource::Bearer || needs_upgrade;
 
         if should_refresh {
             attach_token_headers(&mut response, &state).await;

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -300,7 +300,10 @@ pub async fn auth_middleware(
 
                         // Set token cookie/header on the redirect so the browser
                         // has the current token when it follows the redirect.
-                        if source == TokenSource::QueryParam || needs_upgrade {
+                        if source == TokenSource::QueryParam
+                            || source == TokenSource::Bearer
+                            || needs_upgrade
+                        {
                             attach_token_headers(&mut response, &state).await;
                         }
 
@@ -312,8 +315,12 @@ pub async fn auth_middleware(
                 let session_id = session_id.expect("valid session implies session_id exists");
                 let mut response = next.run(request).await;
 
-                // Set token cookie/header if needed
-                if source == TokenSource::QueryParam || needs_upgrade {
+                // Set token cookie/header if needed (including Bearer to
+                // rehydrate cookie from localStorage)
+                if source == TokenSource::QueryParam
+                    || source == TokenSource::Bearer
+                    || needs_upgrade
+                {
                     attach_token_headers(&mut response, &state).await;
                 }
 
@@ -331,10 +338,16 @@ pub async fn auth_middleware(
 
         let mut response = next.run(request).await;
 
-        // Set cookie/X-Aoe-Token if authenticated via query param or if token
-        // needs upgrade. The X-Aoe-Token header lets the PWA update its
-        // localStorage-cached token without a full page reload.
-        let should_refresh = source == TokenSource::QueryParam || needs_upgrade;
+        // Refresh the auth cookie when the token was provided via query param,
+        // Bearer header, or when the token needs upgrade (grace period).
+        // Including Bearer here is important: when the cookie expires but the
+        // SPA still has the token in localStorage, API calls authenticate via
+        // Bearer header. Setting the cookie on those responses "rehydrates" it
+        // so the next browser navigation (HTML page load) works without
+        // re-pasting the ?token= URL.
+        let should_refresh = source == TokenSource::QueryParam
+            || source == TokenSource::Bearer
+            || needs_upgrade;
 
         if should_refresh {
             attach_token_headers(&mut response, &state).await;
@@ -343,9 +356,19 @@ pub async fn auth_middleware(
         return response;
     }
 
-    // Auth failed: record failure
+    // Auth failed. For API and WebSocket routes, return 401. For everything
+    // else (the SPA shell, static assets), serve the page anyway so the
+    // frontend can attempt auth via localStorage + Bearer header. Without
+    // this, an expired cookie means the SPA never loads and localStorage
+    // never gets a chance to re-authenticate.
+    let path = request.uri().path();
+    let is_api_or_ws = path.starts_with("/api/") || path.contains("/ws");
+
+    if !is_api_or_ws {
+        return next.run(request).await;
+    }
+
     let locked = state.rate_limiter.record_failure(client_ip).await;
-    let path = request.uri().path().to_string();
     tracing::warn!(
         ip = %client_ip,
         path = %path,

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -640,6 +640,16 @@ fn spawn_daemon(mode: ServeMode, passphrase: Option<&str>) -> Result<(), String>
         .map_err(|e| format!("Failed to launch `aoe serve --daemon`: {}", e))?;
 
     if !status.success() {
+        // If the daemon failed because the port was in use, clear the
+        // persisted port so the next attempt picks a fresh one instead
+        // of getting stuck on the same occupied port forever.
+        let tail = initial_log_tail().join("\n");
+        if tail.contains("EADDRINUSE") || tail.contains("Address already in use") {
+            if let Ok(dir) = crate::session::get_app_dir() {
+                let _ = std::fs::remove_file(dir.join("serve.last_port"));
+            }
+        }
+
         let hint = match mode {
             ServeMode::Tunnel => format!(
                 "Most likely `cloudflared` is not installed \
@@ -2009,5 +2019,62 @@ localhost\thttp://localhost:54321/?token=abc\n";
         assert_eq!(out.len(), 2);
         assert_eq!(out[1].label, None);
         assert_eq!(out[1].url, "http://no-label-here/");
+    }
+
+    // ── load_or_generate_port ────────────────────────────────────────────
+    //
+    // The real function reads from $APP_DIR/serve.last_port, which we can't
+    // control in unit tests. These tests exercise the same parse + validate
+    // + generate logic via a small shim that mirrors the function's core.
+
+    /// Mirrors load_or_generate_port's logic against an arbitrary directory
+    /// so we can test without touching the real app dir.
+    fn load_or_generate_port_from(dir: &std::path::Path) -> u16 {
+        let port_path = dir.join("serve.last_port");
+        if let Ok(raw) = std::fs::read_to_string(&port_path) {
+            if let Ok(port) = raw.trim().parse::<u16>() {
+                if port >= 49152 {
+                    return port;
+                }
+            }
+        }
+        let port: u16 = rand::rng().random_range(49152..65535);
+        let _ = std::fs::write(&port_path, port.to_string());
+        port
+    }
+
+    #[test]
+    fn load_or_generate_port_generates_and_persists() {
+        let tmp = tempfile::tempdir().unwrap();
+        let port = load_or_generate_port_from(tmp.path());
+        assert!(port >= 49152, "generated port should be in ephemeral range");
+        // File was written
+        let raw = std::fs::read_to_string(tmp.path().join("serve.last_port")).unwrap();
+        assert_eq!(raw, port.to_string());
+    }
+
+    #[test]
+    fn load_or_generate_port_reuses_persisted() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("serve.last_port"), "55555").unwrap();
+        let port = load_or_generate_port_from(tmp.path());
+        assert_eq!(port, 55555);
+    }
+
+    #[test]
+    fn load_or_generate_port_rejects_low_port() {
+        let tmp = tempfile::tempdir().unwrap();
+        // A port below the ephemeral range should be ignored and regenerated.
+        std::fs::write(tmp.path().join("serve.last_port"), "8080").unwrap();
+        let port = load_or_generate_port_from(tmp.path());
+        assert!(port >= 49152, "low port should be rejected: got {}", port);
+    }
+
+    #[test]
+    fn load_or_generate_port_handles_garbage_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("serve.last_port"), "not-a-number\n").unwrap();
+        let port = load_or_generate_port_from(tmp.path());
+        assert!(port >= 49152, "garbage content should be regenerated");
     }
 }

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -605,9 +605,12 @@ fn spawn_daemon(mode: ServeMode, passphrase: Option<&str>) -> Result<(), String>
         let _ = std::fs::remove_file(dir.join("serve.mode"));
     }
 
-    // Use a high ephemeral port so we don't collide with a user's own
-    // `aoe serve` on 8080.
-    let port: u16 = rand::rng().random_range(49152..65535);
+    // Reuse the port from the last TUI-launched daemon so the user can
+    // bookmark the URL and not have to re-paste it after every restart.
+    // Only generate a fresh random port on the very first launch (or if
+    // the persisted file is missing). This avoids colliding with a user's
+    // own `aoe serve` on the default 8080.
+    let port: u16 = load_or_generate_port();
 
     let mut cmd = Command::new(&exe);
     cmd.args(["serve", "--daemon", "--port", &port.to_string()]);
@@ -766,6 +769,28 @@ fn remember_last_mode(mode: ServeMode) {
     if let Ok(dir) = crate::session::get_app_dir() {
         let _ = std::fs::write(dir.join("serve.last_mode"), mode.file_token());
     }
+}
+
+/// Load a previously used port from `serve.last_port`, or generate a fresh
+/// random one in the ephemeral range and persist it. This keeps the URL
+/// stable across TUI daemon restarts so users can bookmark it.
+fn load_or_generate_port() -> u16 {
+    if let Ok(dir) = crate::session::get_app_dir() {
+        let port_path = dir.join("serve.last_port");
+        if let Ok(raw) = std::fs::read_to_string(&port_path) {
+            if let Ok(port) = raw.trim().parse::<u16>() {
+                if port >= 49152 {
+                    return port;
+                }
+            }
+        }
+        // No valid persisted port; generate and save one.
+        let port: u16 = rand::rng().random_range(49152..65535);
+        let _ = std::fs::write(&port_path, port.to_string());
+        return port;
+    }
+    // Can't access app dir; fall back to random (won't persist).
+    rand::rng().random_range(49152..65535)
 }
 
 fn log_file_path() -> Option<PathBuf> {

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -46,8 +46,12 @@ export function installFetchErrorToasts(): void {
         const rotated = res.headers.get("x-aoe-token");
         if (rotated) saveToken(rotated);
       }
-      if (res.status === 401 && isApi && getToken()) {
-        handleTokenRejected();
+      if (res.status === 401 && isApi) {
+        if (getToken()) {
+          handleTokenRejected();
+        } else {
+          handleNoToken();
+        }
       }
       if (isApi && res.status >= 500) {
         reportError(`Server error ${res.status} from ${path}`);
@@ -81,6 +85,17 @@ function handleTokenRejected(): void {
   tokenRejectedReported = true;
   reportError(
     "Session expired. Open the current dashboard URL from `aoe serve` to reconnect.",
+  );
+}
+
+// On 401 with no token at all (cookie expired AND localStorage cleared).
+// Show a one-time toast so the user isn't staring at an empty dashboard.
+let noTokenReported = false;
+function handleNoToken(): void {
+  if (noTokenReported) return;
+  noTokenReported = true;
+  reportError(
+    "Not authenticated. Paste the dashboard URL from `aoe serve` to connect.",
   );
 }
 


### PR DESCRIPTION
## Description

The TUI serve dialog picked a **random ephemeral port** (49152-65535) every time it spawned the daemon. This forced users to re-paste the full `?token=` URL after every server restart since nothing listened on the old port anymore.

Three changes:

1. **Port persistence** (`src/tui/dialogs/serve.rs`): New `load_or_generate_port()` saves the port to `serve.last_port` on first launch and reuses it on subsequent launches. The URL stays stable across restarts so users can bookmark it.

2. **SPA shell auth fallback** (`src/server/auth.rs`): Non-API/WS routes now serve the SPA shell even when the auth cookie has expired. This lets the frontend recover via its localStorage token + Bearer header, instead of showing raw JSON `{"error":"unauthorized"}`.

3. **Cookie rehydration from Bearer** (`src/server/auth.rs`): Bearer-authenticated API calls now refresh the `aoe_token` cookie. When the SPA recovers auth via localStorage, the cookie gets restored for future browser navigations.

4. **No-token toast** (`web/src/lib/fetchInterceptor.ts`): When both cookie and localStorage are empty, show a helpful "not authenticated" toast instead of a silent empty dashboard.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)