### PR TITLE
feat(web): show repo owner avatar next to project name

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -29,7 +29,7 @@ pub(crate) fn open_repo_at(path: &Path) -> std::result::Result<git2::Repository,
 /// - SSH shorthand: `git@github.com:owner/repo.git`
 /// - HTTPS: `https://github.com/owner/repo.git`
 /// - SSH URL: `ssh://git@github.com/owner/repo.git`
-pub fn parse_owner_from_remote_url(url: &str) -> Option<String> {
+pub(crate) fn parse_owner_from_remote_url(url: &str) -> Option<String> {
     // SSH shorthand: git@host:owner/repo.git
     // Detect by presence of '@' before ':' and no "://" scheme prefix.
     if !url.contains("://") {
@@ -44,7 +44,7 @@ pub fn parse_owner_from_remote_url(url: &str) -> Option<String> {
 
     // URL format: scheme://[user@]host/owner/repo.git
     let without_scheme = url.split("://").nth(1).unwrap_or(url);
-    let after_host = &without_scheme[without_scheme.find('/')?  + 1..];
+    let after_host = &without_scheme[without_scheme.find('/')? + 1..];
     let owner = after_host.split('/').next()?;
     (!owner.is_empty()).then(|| owner.to_string())
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -23,6 +23,42 @@ pub(crate) fn open_repo_at(path: &Path) -> std::result::Result<git2::Repository,
     )
 }
 
+/// Extract the owner (first path segment) from a git remote URL.
+///
+/// Handles common formats:
+/// - SSH shorthand: `git@github.com:owner/repo.git`
+/// - HTTPS: `https://github.com/owner/repo.git`
+/// - SSH URL: `ssh://git@github.com/owner/repo.git`
+pub fn parse_owner_from_remote_url(url: &str) -> Option<String> {
+    // SSH shorthand: git@host:owner/repo.git
+    // Detect by presence of '@' before ':' and no "://" scheme prefix.
+    if !url.contains("://") {
+        if let Some(colon_pos) = url.find(':') {
+            if url[..colon_pos].contains('@') {
+                let after = &url[colon_pos + 1..];
+                let owner = after.split('/').next()?;
+                return (!owner.is_empty()).then(|| owner.to_string());
+            }
+        }
+    }
+
+    // URL format: scheme://[user@]host/owner/repo.git
+    let without_scheme = url.split("://").nth(1).unwrap_or(url);
+    let after_host = &without_scheme[without_scheme.find('/')?  + 1..];
+    let owner = after_host.split('/').next()?;
+    (!owner.is_empty()).then(|| owner.to_string())
+}
+
+/// Look up the owner of a git repository by reading the `origin` remote URL.
+/// Returns `None` if the path is not a git repo, has no origin remote, or the
+/// URL cannot be parsed.
+pub fn get_remote_owner(path: &Path) -> Option<String> {
+    let repo = open_repo_at(path).ok()?;
+    let remote = repo.find_remote("origin").ok()?;
+    let url = remote.url()?;
+    parse_owner_from_remote_url(url)
+}
+
 pub struct WorktreeEntry {
     pub path: PathBuf,
     pub branch: Option<String>,
@@ -1359,5 +1395,50 @@ mod tests {
             wt_path.join(".git").is_file(),
             "Worktree should have a .git pointer file"
         );
+    }
+
+    #[test]
+    fn test_parse_owner_ssh_shorthand() {
+        assert_eq!(
+            parse_owner_from_remote_url("git@github.com:njbrake/agent-of-empires.git"),
+            Some("njbrake".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_parse_owner_https() {
+        assert_eq!(
+            parse_owner_from_remote_url("https://github.com/njbrake/agent-of-empires.git"),
+            Some("njbrake".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_parse_owner_ssh_url() {
+        assert_eq!(
+            parse_owner_from_remote_url("ssh://git@github.com/njbrake/agent-of-empires.git"),
+            Some("njbrake".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_parse_owner_http() {
+        assert_eq!(
+            parse_owner_from_remote_url("http://github.com/mozilla-ai/lumigator.git"),
+            Some("mozilla-ai".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_parse_owner_no_dotgit_suffix() {
+        assert_eq!(
+            parse_owner_from_remote_url("https://github.com/njbrake/agent-of-empires"),
+            Some("njbrake".to_string()),
+        );
+    }
+
+    #[test]
+    fn test_parse_owner_empty_url() {
+        assert_eq!(parse_owner_from_remote_url(""), None);
     }
 }

--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -57,6 +57,7 @@ pub struct SessionResponse {
     pub has_terminal: bool,
     pub profile: String,
     pub cleanup_defaults: CleanupDefaults,
+    pub remote_owner: Option<String>,
 }
 
 #[derive(Serialize, Clone)]
@@ -96,6 +97,7 @@ impl From<&Instance> for SessionResponse {
                 delete_branch: false,
                 delete_sandbox: true,
             },
+            remote_owner: None,
         }
     }
 }
@@ -138,9 +140,54 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
         fresh
     };
 
-    for session in &mut sessions {
-        if let Some(defaults) = defaults_map.get(&session.profile) {
-            session.cleanup_defaults = defaults.clone();
+    // Resolve remote owners with a permanent cache on AppState
+    {
+        let cache = state.remote_owner_cache.read().await;
+        for session in &mut sessions {
+            if let Some(defaults) = defaults_map.get(&session.profile) {
+                session.cleanup_defaults = defaults.clone();
+            }
+            let repo_path = session
+                .main_repo_path
+                .as_deref()
+                .unwrap_or(&session.project_path);
+            if let Some(owner) = cache.get(repo_path) {
+                session.remote_owner = owner.clone();
+            }
+        }
+    }
+
+    // Fill any uncached repo paths
+    let uncached: Vec<String> = sessions
+        .iter()
+        .filter(|s| s.remote_owner.is_none())
+        .map(|s| {
+            s.main_repo_path
+                .clone()
+                .unwrap_or_else(|| s.project_path.clone())
+        })
+        .collect::<std::collections::HashSet<_>>()
+        .into_iter()
+        .collect();
+
+    if !uncached.is_empty() {
+        let mut cache = state.remote_owner_cache.write().await;
+        for path in &uncached {
+            if !cache.contains_key(path.as_str()) {
+                let owner = crate::git::get_remote_owner(std::path::Path::new(path));
+                cache.insert(path.clone(), owner);
+            }
+        }
+        for session in &mut sessions {
+            let repo_path = session
+                .main_repo_path
+                .as_deref()
+                .unwrap_or(&session.project_path);
+            if session.remote_owner.is_none() {
+                if let Some(owner) = cache.get(repo_path) {
+                    session.remote_owner = owner.clone();
+                }
+            }
         }
     }
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -167,6 +167,9 @@ pub struct AppState {
         std::time::Instant,
         std::collections::HashMap<String, api::CleanupDefaults>,
     )>,
+    /// Cached remote owner per repo path. Remote owners don't change, so
+    /// entries live for the lifetime of the process.
+    pub remote_owner_cache: RwLock<std::collections::HashMap<String, Option<String>>>,
 }
 
 impl AppState {
@@ -257,6 +260,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             std::time::Instant::now() - std::time::Duration::from_secs(60),
             std::collections::HashMap::new(),
         )),
+        remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
     });
 
     let app = build_router(state.clone());

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import type { SessionResponse, SessionStatus } from "../lib/types";
 import { STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
 import { StatusGlyph } from "./StatusGlyph";
 import { renameSession } from "../lib/api";
+import { OwnerAvatar } from "./OwnerAvatar";
 
 interface Props {
   sessions: SessionResponse[];
@@ -14,6 +15,7 @@ interface Props {
 interface ProjectGroup {
   repoPath: string;
   displayName: string;
+  remoteOwner: string | null;
   sessions: SessionResponse[];
   hasActive: boolean;
   activeCount: number;
@@ -63,6 +65,7 @@ export function Dashboard({ sessions, onSelectSession, onNewSession, onCreateSes
         map.set(key, {
           repoPath: key,
           displayName: key.split("/").filter(Boolean).pop() || key,
+          remoteOwner: s.remote_owner,
           sessions: [s],
           hasActive: active,
           activeCount: active ? 1 : 0,
@@ -202,6 +205,7 @@ function ProjectCard({
     >
       {/* Card header */}
       <div className="px-3 py-2 border-b border-surface-800 flex items-center gap-2">
+        <OwnerAvatar owner={group.remoteOwner} size={18} />
         <span className="text-sm font-medium text-text-primary truncate flex-1" title={group.repoPath}>
           {group.displayName}
         </span>

--- a/web/src/components/OwnerAvatar.tsx
+++ b/web/src/components/OwnerAvatar.tsx
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+/** Renders the GitHub avatar for a repo owner. Hides itself on load error. */
+export function OwnerAvatar({
+  owner,
+  size = 16,
+}: {
+  owner: string | null;
+  size?: number;
+}) {
+  const [hidden, setHidden] = useState(false);
+
+  if (!owner || hidden) return null;
+
+  return (
+    <img
+      src={`https://github.com/${owner}.png?size=${size * 2}`}
+      alt={owner}
+      width={size}
+      height={size}
+      className="rounded-sm shrink-0"
+      onError={() => setHidden(true)}
+    />
+  );
+}

--- a/web/src/components/OwnerAvatar.tsx
+++ b/web/src/components/OwnerAvatar.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 /** Renders the GitHub avatar for a repo owner. Hides itself on load error. */
 export function OwnerAvatar({
@@ -9,6 +9,8 @@ export function OwnerAvatar({
   size?: number;
 }) {
   const [hidden, setHidden] = useState(false);
+
+  useEffect(() => setHidden(false), [owner]);
 
   if (!owner || hidden) return null;
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -4,6 +4,7 @@ import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
 import { STATUS_DOT_CLASS, STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
 import { renameSession } from "../lib/api";
 import { StatusGlyph } from "./StatusGlyph";
+import { OwnerAvatar } from "./OwnerAvatar";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const DEFAULT_WIDTH = 280;
@@ -273,6 +274,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
         >
           <path d="M2 3 L5 6.5 L8 3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
         </svg>
+        <OwnerAvatar owner={group.remoteOwner} size={16} />
         <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={group.repoPath}>
           {group.displayName}
         </span>

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -44,10 +44,14 @@ export function useRepoGroups(workspaces: Workspace[]): {
       const collapsed =
         collapsedMap[repoPath] ?? loadCollapsed(repoPath);
 
+      const remoteOwner =
+        sorted[0]?.sessions[0]?.remote_owner ?? null;
+
       repoGroups.push({
         id: repoPath,
         repoPath,
         displayName: repoPath.split("/").pop() ?? repoPath,
+        remoteOwner,
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
         collapsed,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -17,6 +17,7 @@ export interface SessionResponse {
   has_terminal: boolean;
   profile: string;
   cleanup_defaults: CleanupDefaults;
+  remote_owner: string | null;
 }
 
 export interface CleanupDefaults {
@@ -93,6 +94,7 @@ export interface RepoGroup {
   id: string;
   repoPath: string;
   displayName: string;
+  remoteOwner: string | null;
   workspaces: Workspace[];
   status: WorkspaceStatus;
   collapsed: boolean;


### PR DESCRIPTION
## Description

Renders the GitHub avatar for the repository owner to the left of the project name in the web dashboard. For instance, projects owned by `njbrake` display their GitHub profile picture in both the sidebar and the dashboard project cards.

**Backend:**
- Added `parse_owner_from_remote_url()` to extract the owner from SSH/HTTPS/SSH-URL git remote formats
- Added `get_remote_owner()` to look up the origin remote owner from a repo path via `git2`
- Extended `SessionResponse` with `remote_owner: Option<String>`, resolved per unique repo path with a permanent in-process cache on `AppState`

**Frontend:**
- New `OwnerAvatar` component fetches `https://github.com/{owner}.png` and hides on error (non-GitHub remotes, no network)
- Propagated `remoteOwner` through `RepoGroup` type and `useRepoGroups` hook
- Rendered avatar in `RepoGroupHeader` (sidebar) and `ProjectCard` (dashboard)

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

## Test plan
- [x] All 1054 Rust unit tests pass (including 6 new URL parser tests)
- [x] TypeScript compiles cleanly
- [x] Vite production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)