### PR TITLE
docs: web dashboard is no longer experimental

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@
 - `src/process/`: OS-specific process handling (`macos.rs`, `linux.rs`).
 - `src/docker/`: Docker sandboxing and container management.
 - `src/git/`: git worktree operations and template resolution.
-- `src/server/`: web dashboard backend (axum server, REST API, WebSocket PTY relay, auth), gated behind `serve` feature.
+- `src/server/`: web dashboard backend (axum server, REST API, WebSocket PTY relay, auth).
 - `src/update/`: version checking against GitHub releases.
 - `web/`: React + TypeScript frontend for the web dashboard (built with Vite + Tailwind CSS).
 - `src/migrations/`: versioned data migrations for breaking changes (see below).
@@ -29,15 +29,13 @@
 
 - `cargo build` / `cargo build --release`: TUI-only (release binary at `target/release/aoe`).
 - `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Use `--release` for CI.
-- `cargo build --features serve`: web dashboard support (needs Node.js + npm).
+- `cargo build --features serve`: includes the web dashboard (needs Node.js + npm).
 - `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.
 - Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
 - Running from source needs `tmux` installed.
 
-### Web Dashboard (experimental)
-
-Behind the `serve` feature flag; experimental, subject to change.
+### Web Dashboard
 
 - Stack: React 19, TypeScript, Vite, Tailwind v4, xterm.js v6. Installable as a PWA ("Install Agent of Empires" in Chrome; "Add to Home Screen" on iOS).
 - Build: `cargo build --features serve` (build.rs runs `npm install && npm run build` in `web/` when inputs change).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   </p>
 </p>
 
-A session manager for AI coding agents on Linux and macOS. Use it from the terminal (TUI) or from any browser ([web dashboard](docs/guides/web-dashboard.md), experimental).
+A session manager for AI coding agents on Linux and macOS. Use it from the terminal (TUI) or from any browser ([web dashboard](docs/guides/web-dashboard.md)).
 
 Run multiple AI agents in parallel across different branches of your codebase, each in its own isolated session with optional Docker sandboxing. Access your agents from your laptop, phone, or tablet.
 
@@ -33,7 +33,7 @@ Running one AI agent is easy. Running five of them across different branches, ke
 
 - **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi.dev, and Factory Droid
 - **TUI app**: visual interface to create, monitor, and manage sessions
-- **Web app**: create, monitor, and control your agents from any browser, installable as a PWA ([experimental](docs/guides/web-dashboard.md))
+- **Web app**: create, monitor, and control your agents from any browser, installable as a PWA ([guide](docs/guides/web-dashboard.md))
 - **CLI app**: create, monitor, and control agents from the command line (integrates with tools like OpenClaw)
 - **Remote access from your phone**: press `R` in the TUI to expose the web dashboard over a Cloudflare tunnel with QR + passphrase auth ([guide](docs/guides/remote-phone-access.md))
 - **Status detection**: see which agents are running, waiting for input, or idle
@@ -42,7 +42,7 @@ Running one AI agent is easy. Running five of them across different branches, ke
 - **Diff view**: review git changes and edit files without leaving the TUI
 - **Profiles**: separate workspaces for different projects or clients
 
-## Web Dashboard (Beta)
+## Web Dashboard
 
 Access your agents from any browser. The real agent terminal renders in the page; switch sessions, type into the terminal, and review diffs without leaving the tab. Press `R` in the TUI to start the server, or see the [web dashboard guide](docs/guides/web-dashboard.md) for details.
 
@@ -66,7 +66,7 @@ curl -fsSL \
   https://raw.githubusercontent.com/njbrake/agent-of-empires/main/scripts/install.sh \
   | bash
 
-# Homebrew (TUI only, web dashboard not yet included)
+# Homebrew
 brew install aoe
 
 # Nix

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -72,7 +72,7 @@ Run without arguments to launch the TUI dashboard.
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
 * `theme` — Manage color themes (list, export, customize)
-* `serve` — Start a web dashboard for remote session access [experimental]
+* `serve` — Start a web dashboard for remote session access
 * `uninstall` — Uninstall Agent of Empires
 * `completion` — Generate shell completions
 
@@ -628,7 +628,7 @@ Show the custom themes directory path
 
 ## `aoe serve`
 
-Start a web dashboard for remote session access [experimental]
+Start a web dashboard for remote session access
 
 **Usage:** `aoe serve [OPTIONS]`
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -1,14 +1,10 @@
-# Web Dashboard (experimental)
-
-> This feature is experimental and subject to major changes.
+# Web Dashboard
 
 The web dashboard lets you monitor and interact with agent sessions from any browser, including your phone, tablet, or another computer. It runs as an embedded web server inside the `aoe` binary.
 
 ## Availability
 
-The web dashboard is included in release binaries downloaded from [GitHub Releases](https://github.com/njbrake/agent-of-empires/releases) and the [quick install script](../installation.md#quick-install-recommended). No extra build steps needed, just run `aoe serve`.
-
-> **Homebrew:** The Homebrew formula (`brew install aoe`) does not yet include the web dashboard since the feature is still experimental. Use the install script or build from source to get `aoe serve`.
+The web dashboard is included in all release binaries: [GitHub Releases](https://github.com/njbrake/agent-of-empires/releases), the [quick install script](../installation.md#quick-install-recommended), and Homebrew (`brew install aoe`). No extra build steps needed, just run `aoe serve`.
 
 ## Building from source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -4,7 +4,7 @@
 
 - [tmux](https://github.com/tmux/tmux/wiki) (required)
 - [Docker](https://www.docker.com/) (optional, for sandboxing agents in containers)
-- [Node.js](https://nodejs.org/) (optional, only for building the web dashboard with `--features serve`)
+- [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features serve`)
 
 ## Install Agent of Empires
 
@@ -23,8 +23,6 @@ curl -fsSL \
 ```bash
 brew install aoe
 ```
-
-> **Note:** The Homebrew formula does not yet include the web dashboard (`aoe serve`) since the feature is still experimental. To use the web dashboard, install via the [quick install script](#quick-install-recommended) or [build from source](#build-from-source) with `--features serve`.
 
 ### Build from Source
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -83,9 +83,7 @@ In the TUI, select the tool from the dropdown in the new session dialog.
 | `q` | Quit |
 | `Ctrl+b d` | Detach from tmux session |
 
-## Use the Web Dashboard (experimental)
-
-> The web dashboard is included in release binaries and the install script but not yet in the Homebrew formula. If you installed via `brew install aoe`, see the [installation docs](installation.md#homebrew) for alternatives.
+## Use the Web Dashboard
 
 Prefer a browser? Run `aoe serve` to start the web dashboard:
 

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -107,7 +107,7 @@ pub enum Commands {
         command: ThemeCommands,
     },
 
-    /// Start a web dashboard for remote session access [experimental]
+    /// Start a web dashboard for remote session access
     #[cfg(feature = "serve")]
     Serve(ServeArgs),
 

--- a/website/src/pages/guides/index.astro
+++ b/website/src/pages/guides/index.astro
@@ -9,7 +9,7 @@ const guides = [
   { title: "Git Worktrees", href: "/guides/worktrees/", description: "Git worktree commands and configuration reference." },
   { title: "Diff View", href: "/guides/diff-view/", description: "Review git changes and edit files from the TUI." },
   { title: "tmux Status Bar", href: "/guides/tmux-status-bar/", description: "Display session info in your tmux status bar." },
-  { title: "Web Dashboard", href: "/guides/web-dashboard/", description: "Remote access to sessions from any browser (experimental)." },
+  { title: "Web Dashboard", href: "/guides/web-dashboard/", description: "Remote access to sessions from any browser." },
 ];
 ---
 


### PR DESCRIPTION
## Description

The web dashboard is now bundled in all production releases, including Homebrew. This PR updates docs across the repo to reflect that:

- Removes "experimental", "beta", and "[experimental]" labels from the web dashboard everywhere (README, AGENTS.md, quick-start, web-dashboard guide, CLI help text, website)
- Removes the Homebrew exclusion warnings that told users to use the install script instead
- Updates the availability section to list Homebrew alongside GitHub Releases and the install script
- Regenerates `docs/cli/reference.md` via `cargo xtask gen-docs`

The `serve` feature flag remains for building from source (Node.js stays optional for contributors doing TUI-only work).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)