### PR TITLE
feat(web): right-edge swipe to open diff panel on mobile

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -298,6 +298,52 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
   }, [sidebarOpen]);
 
+  // Right-edge swipe to open the diff/shell panel (mirrors left-edge sidebar swipe)
+  useEffect(() => {
+    if (!diffCollapsed || !activeSessionId) return;
+    const EDGE_PX = 24;
+    const THRESHOLD_PX = 60;
+    let startX = 0;
+    let startY = 0;
+    let tracking = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (window.innerWidth >= 768 || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      if (!t || t.clientX < window.innerWidth - EDGE_PX) return;
+      tracking = true;
+      startX = t.clientX;
+      startY = t.clientY;
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (!tracking) return;
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = startX - t.clientX;
+      const dy = t.clientY - startY;
+      if (dx > THRESHOLD_PX && Math.abs(dx) > Math.abs(dy)) {
+        tracking = false;
+        setDiffCollapsed(false);
+      } else if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 16) {
+        tracking = false;
+      }
+    };
+    const onTouchEnd = () => {
+      tracking = false;
+    };
+
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    window.addEventListener("touchend", onTouchEnd, { passive: true });
+    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
+      window.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [diffCollapsed, activeSessionId]);
+
   const handleNewSession = useCallback(() => {
     setWizardPrefill(undefined);
     setShowAddProject(true);


### PR DESCRIPTION
## Description

On mobile, swiping left from the right edge of the screen now opens the diff/shell panel, mirroring the existing left-edge swipe that opens the workspace sidebar. Uses the same 24px edge zone, 60px threshold, angle detection, and passive listener pattern.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)