### PR TITLE
feat(web): add virtual keyboard bar to right panel terminal

### DIFF
--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { DiffFileList } from "./diff/DiffFileList";
 import { useTerminal } from "../hooks/useTerminal";
+import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
+import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import { ensureTerminal } from "../lib/api";
 import type { RichDiffFile, SessionResponse } from "../lib/types";
 import "@wterm/dom/css";
@@ -46,10 +48,13 @@ function PairedTerminal({
   const [ready, setReady] = useState(false);
   const wsPath =
     mode === "container" ? "container-terminal/ws" : "terminal/ws";
-  const { containerRef, state, manualReconnect } = useTerminal(
-    ready ? sessionId : null,
-    wsPath,
-  );
+  const { containerRef, termRef, state, manualReconnect, sendData, ctrlActiveRef, clearCtrlRef } =
+    useTerminal(ready ? sessionId : null, wsPath);
+  const { isMobile, keyboardHeight } = useMobileKeyboard();
+  const [ctrlActive, setCtrlActive] = useState(false);
+
+  ctrlActiveRef.current = ctrlActive;
+  clearCtrlRef.current = () => setCtrlActive(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -94,6 +99,15 @@ function PairedTerminal({
         ref={containerRef}
         className="flex-1 overflow-hidden bg-surface-950"
       />
+      {isMobile && state.connected && (
+        <MobileTerminalToolbar
+          sendData={sendData}
+          termRef={termRef}
+          keyboardHeight={keyboardHeight}
+          ctrlActive={ctrlActive}
+          onCtrlToggle={() => setCtrlActive((v) => !v)}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Description

The `MobileTerminalToolbar` (arrow keys, Tab, Esc, Ctrl, ^C) was only rendered in the main `TerminalView` for agent sessions. The paired terminal in the right sidebar (`PairedTerminal` inside `RightPanel`) had no way to send special keys on mobile, making it impossible to send Ctrl+C etc. into terminal-view sessions.

This wires up the same toolbar in `PairedTerminal` using the existing `useMobileKeyboard` hook and `MobileTerminalToolbar` component, matching the pattern already established in `TerminalView`.

Fixes #722

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Single-file change following the existing pattern from TerminalView.tsx.

- [x] I am an AI Agent filling out this form (check box if true)