### PR TITLE
fix(server): prevent daemon from dying on SIGHUP/SIGTERM

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -340,6 +340,21 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
 
     cmd.stdin(Stdio::null());
 
+    // Create a new session so the daemon is not killed by SIGHUP when the
+    // parent terminal closes. setsid() is async-signal-safe.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: setsid() is async-signal-safe per POSIX, which is the
+        // only requirement for pre_exec closures.
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::other)?;
+                Ok(())
+            });
+        }
+    }
+
     // Redirect stdout/stderr to a log file so controllers like the TUI can
     // tail the daemon's output. Truncate on each start so stale content from
     // a prior run doesn't confuse the UI.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -372,10 +372,32 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         token_manager.spawn_rotation_task();
     }
 
-    // Graceful shutdown with tunnel cleanup
+    // Graceful shutdown: SIGINT (Ctrl-C), SIGTERM (`aoe serve --stop`),
+    // and SIGHUP (parent session died). Without these, the default handler
+    // kills the process immediately, skipping PID/URL file cleanup.
     let shutdown_signal = async {
-        let _ = tokio::signal::ctrl_c().await;
-        info!("Shutting down...");
+        #[cfg(unix)]
+        {
+            use tokio::signal::unix::{signal, SignalKind};
+            let mut sigterm = signal(SignalKind::terminate()).ok();
+            let mut sighup = signal(SignalKind::hangup()).ok();
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {
+                    info!("Received SIGINT, shutting down...");
+                }
+                _ = async { match sigterm { Some(ref mut s) => { s.recv().await; } None => std::future::pending().await } } => {
+                    info!("Received SIGTERM, shutting down...");
+                }
+                _ = async { match sighup { Some(ref mut s) => { s.recv().await; } None => std::future::pending().await } } => {
+                    info!("Received SIGHUP, shutting down...");
+                }
+            }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = tokio::signal::ctrl_c().await;
+            info!("Shutting down...");
+        }
     };
 
     axum::serve(


### PR DESCRIPTION
## Description

The server daemon started from the TUI would die unexpectedly because:

1. `start_daemon()` spawned the server without calling `setsid()`, so the child inherited the parent's session. When the parent terminal closed or was disrupted, the kernel sent SIGHUP to the daemon.
2. `start_server()` only handled SIGINT (Ctrl-C). SIGHUP and SIGTERM hit the default handler, which killed the process immediately with no log output and no PID/URL file cleanup.

**Fix:**
- Call `setsid()` via `pre_exec` in `start_daemon()` so the daemon creates its own session and is fully detached from the parent terminal.
- Handle SIGTERM and SIGHUP alongside SIGINT in the server's graceful shutdown signal, matching the TUI's existing pattern (`src/tui/app.rs:174`).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)