### PR TITLE
feat(web): iOS mobile terminal improvements (scroll, paste, keyboard, backspace)

### DIFF
--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -119,6 +119,30 @@ export function MobileTerminalToolbar({
         onClick={() => { send("\x03"); if (ctrlActive) onCtrlToggle(); }}>
         <span className="font-mono text-xs">^C</span>
       </button>
+      <button type="button" aria-label="Paste from clipboard" className={btnBase}
+        onClick={async () => {
+          try {
+            const text = await navigator.clipboard.readText();
+            if (text) send(text);
+          } catch {
+            // Clipboard access denied or unavailable
+          }
+        }}>
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+        >
+          <rect x="9" y="2" width="6" height="4" rx="1" />
+          <path d="M8 4H6a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-2" />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/web/src/components/MobileTerminalToolbar.tsx
+++ b/web/src/components/MobileTerminalToolbar.tsx
@@ -120,13 +120,18 @@ export function MobileTerminalToolbar({
         <span className="font-mono text-xs">^C</span>
       </button>
       <button type="button" aria-label="Paste from clipboard" className={btnBase}
-        onClick={async () => {
-          try {
-            const text = await navigator.clipboard.readText();
-            if (text) send(text);
-          } catch {
-            // Clipboard access denied or unavailable
+        onClick={() => {
+          haptic();
+          // Focus wterm's textarea and use execCommand('paste'). On
+          // Safari 13+, this shows a native "Paste" permission callout.
+          // When confirmed, wterm's handlePaste fires automatically.
+          // Works on non-HTTPS origins unlike navigator.clipboard.readText.
+          const ta = termRef.current?.element.querySelector("textarea");
+          if (ta) {
+            (ta as HTMLTextAreaElement).focus({ preventScroll: true });
+            document.execCommand("paste");
           }
+          refocusTerminal();
         }}>
         <svg
           width="14"

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -309,8 +309,6 @@ export function TerminalView({ session }: Props) {
               autoComplete="off"
               autoCorrect="off"
               autoCapitalize="none"
-              inputMode="none"
-              enterKeyHint="send"
               spellCheck={false}
               onInput={onProxyInput}
               onKeyDown={onProxyKeyDown}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { ClipboardEvent as ReactClipboardEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { useWebSettings } from "../hooks/useWebSettings";
@@ -24,7 +23,6 @@ export function TerminalView({ session }: Props) {
     useTerminal(ensureState === "ready" ? session.id : null);
   const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const { settings } = useWebSettings();
-  const proxyRef = useRef<HTMLInputElement>(null);
   const [proxyFocused, setProxyFocused] = useState(false);
   const [ctrlActive, setCtrlActive] = useState(false);
 
@@ -77,10 +75,23 @@ export function TerminalView({ session }: Props) {
     }
   });
   const showScrollHint = isMobile && state.connected && !hintDismissed;
-  // Treat the keyboard as "up" whenever the proxy input has focus, not only
-  // when visualViewport reports a shrunk viewport. On iOS PWA standalone
-  // mode and iPadOS floating keyboards, visualViewport can lag or never
-  // fire; proxy focus flips instantly.
+  // Track focus on wterm's textarea to detect keyboard state. On iOS PWA
+  // standalone mode and iPadOS floating keyboards, visualViewport can lag;
+  // focus state flips instantly.
+  useEffect(() => {
+    const el = termRef.current?.element;
+    if (!el) return;
+    const ta = el.querySelector("textarea");
+    if (!ta) return;
+    const onFocus = () => setProxyFocused(true);
+    const onBlur = () => setProxyFocused(false);
+    ta.addEventListener("focus", onFocus);
+    ta.addEventListener("blur", onBlur);
+    return () => {
+      ta.removeEventListener("focus", onFocus);
+      ta.removeEventListener("blur", onBlur);
+    };
+  }, [termRef, state.connected]);
   const keyboardVisible = keyboardOpen || proxyFocused;
 
   // Re-layout the terminal and scroll to the cursor when the keyboard settles.
@@ -112,99 +123,11 @@ export function TerminalView({ session }: Props) {
     const delays = [50, 200, 500];
     const timers = delays.map((ms) =>
       setTimeout(() => {
-        if (!proxyRef.current) return;
-        proxyRef.current.focus();
+        termRef.current?.focus();
       }, ms),
     );
     return () => timers.forEach(clearTimeout);
-  }, [isMobile, state.connected, session.id, settings.autoOpenKeyboard]);
-
-  // The proxy input is the keyboard bridge: soft keyboard types into it,
-  // we relay each input to the PTY and clear. Mobile browsers don't
-  // reliably expose the terminal's own helper textarea for the soft keyboard.
-  const onProxyInput = useCallback(
-    (e: FormEvent<HTMLInputElement>) => {
-      const value = e.currentTarget.value;
-      if (!value) return;
-      if (ctrlActive) {
-        // Transform each character to its Ctrl equivalent.
-        // Ctrl+A = \x01, Ctrl+Z = \x1a, etc.
-        for (const ch of value) {
-          const code = ch.toUpperCase().charCodeAt(0);
-          if (code >= 65 && code <= 90) {
-            sendData(String.fromCharCode(code - 64));
-          }
-        }
-        setCtrlActive(false);
-      } else {
-        sendData(value);
-      }
-      e.currentTarget.value = "";
-    },
-    [sendData, ctrlActive],
-  );
-
-  // Catch paste events on the proxy input and relay the text to the PTY.
-  // On iOS the proxy input is the only focused element, so paste events land
-  // here rather than on wterm's hidden textarea.
-  const onProxyPaste = useCallback(
-    (e: ReactClipboardEvent<HTMLInputElement>) => {
-      e.preventDefault();
-      const text = e.clipboardData.getData("text");
-      if (text) sendData(text);
-    },
-    [sendData],
-  );
-
-  // iOS soft keyboards don't fire 'input' for Enter/Backspace/Tab/Arrows — they
-  // only fire keydown. Without this handler, hitting Return on iOS silently
-  // dropped the keystroke (Enter never reached the PTY). Translate the common
-  // non-printing keys into the byte sequences the shell expects. Printable
-  // keys stay on the 'input' path so composition/autocorrect still works.
-  const onProxyKeyDown = useCallback(
-    (e: ReactKeyboardEvent<HTMLInputElement>) => {
-      // Single printable character with Ctrl armed: transform to control char.
-      if (ctrlActive && e.key.length === 1) {
-        const code = e.key.toUpperCase().charCodeAt(0);
-        if (code >= 65 && code <= 90) {
-          e.preventDefault();
-          sendData(String.fromCharCode(code - 64));
-          setCtrlActive(false);
-          if (proxyRef.current) proxyRef.current.value = "";
-          return;
-        }
-      }
-
-      const seq = (() => {
-        switch (e.key) {
-          case "Enter":
-            return "\r";
-          case "Backspace":
-            return "\x7f";
-          case "Tab":
-            return "\t";
-          case "Escape":
-            return "\x1b";
-          case "ArrowUp":
-            return "\x1b[A";
-          case "ArrowDown":
-            return "\x1b[B";
-          case "ArrowRight":
-            return "\x1b[C";
-          case "ArrowLeft":
-            return "\x1b[D";
-          default:
-            return null;
-        }
-      })();
-      if (seq === null) return;
-      e.preventDefault();
-      sendData(seq);
-      if (ctrlActive) setCtrlActive(false);
-      if (proxyRef.current) proxyRef.current.value = "";
-    },
-    [sendData, ctrlActive],
-  );
+  }, [isMobile, state.connected, session.id, settings.autoOpenKeyboard, termRef]);
 
   // Tap the terminal pane to reopen the keyboard. Skip when text is
   // selected (preserves native long-press-to-select behavior).
@@ -212,12 +135,12 @@ export function TerminalView({ session }: Props) {
     if (!isMobile) return;
     const selection = window.getSelection()?.toString() ?? "";
     if (selection.length > 0) return;
-    proxyRef.current?.focus();
-  }, [isMobile]);
+    termRef.current?.focus();
+  }, [isMobile, termRef]);
 
-  const focusProxy = useCallback(() => {
-    proxyRef.current?.focus();
-  }, []);
+  const focusTerminal = useCallback(() => {
+    termRef.current?.focus();
+  }, [termRef]);
 
   // Dismiss the one-time scroll hint on first touchmove or after a timeout.
   // Persisted to localStorage so it's shown only once per device.
@@ -303,29 +226,12 @@ export function TerminalView({ session }: Props) {
 
         {isMobile && state.connected && (
           <>
-            <input
-              ref={proxyRef}
-              type="text"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="none"
-              spellCheck={false}
-              onInput={onProxyInput}
-              onKeyDown={onProxyKeyDown}
-              onPaste={onProxyPaste}
-              onFocus={() => setProxyFocused(true)}
-              onBlur={() => setProxyFocused(false)}
-              aria-hidden="true"
-              tabIndex={-1}
-              className="absolute opacity-0 pointer-events-none w-px h-px -z-10"
-              style={{ left: 0, top: 0 }}
-            />
 
             {!keyboardVisible && (
               <button
                 type="button"
                 aria-label="Open keyboard"
-                onClick={focusProxy}
+                onClick={focusTerminal}
                 className="absolute right-3 bottom-3 w-9 h-9 rounded-full bg-surface-800 border border-surface-700/30 text-text-secondary flex items-center justify-center motion-safe:transition-opacity motion-safe:duration-150 hover:bg-surface-700 active:scale-95"
               >
                 <svg

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
-import type { FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
+import type { ClipboardEvent as ReactClipboardEvent, FormEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { useWebSettings } from "../hooks/useWebSettings";
@@ -83,20 +83,23 @@ export function TerminalView({ session }: Props) {
   // fire; proxy focus flips instantly.
   const keyboardVisible = keyboardOpen || proxyFocused;
 
-  // Re-layout the terminal and scroll to the cursor whenever keyboardHeight
-  // changes. useLayoutEffect runs synchronously after React has committed
-  // the new paddingBottom to the DOM, so wterm's ResizeObserver picks up
-  // the correct container size. A rAF then scrolls to bottom after reflow.
+  // Re-layout the terminal and scroll to the cursor when the keyboard settles.
+  // Debounce the resize dispatch so it fires once after the iOS keyboard
+  // animation (~300ms) instead of on every intermediate height change.
+  const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useLayoutEffect(() => {
-    window.dispatchEvent(new Event("resize"));
-    if (!keyboardOpen) return;
-    const id = requestAnimationFrame(() => {
-      if (termRef.current) {
+    if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+    resizeTimerRef.current = setTimeout(() => {
+      resizeTimerRef.current = null;
+      window.dispatchEvent(new Event("resize"));
+      if (keyboardOpen && termRef.current) {
         const el = termRef.current.element;
         el.scrollTop = el.scrollHeight;
       }
-    });
-    return () => cancelAnimationFrame(id);
+    }, 150);
+    return () => {
+      if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+    };
   }, [keyboardOpen, keyboardHeight, termRef]);
 
   // Auto-open soft keyboard when a session is selected, if the user wants it.
@@ -139,6 +142,18 @@ export function TerminalView({ session }: Props) {
       e.currentTarget.value = "";
     },
     [sendData, ctrlActive],
+  );
+
+  // Catch paste events on the proxy input and relay the text to the PTY.
+  // On iOS the proxy input is the only focused element, so paste events land
+  // here rather than on wterm's hidden textarea.
+  const onProxyPaste = useCallback(
+    (e: ReactClipboardEvent<HTMLInputElement>) => {
+      e.preventDefault();
+      const text = e.clipboardData.getData("text");
+      if (text) sendData(text);
+    },
+    [sendData],
   );
 
   // iOS soft keyboards don't fire 'input' for Enter/Backspace/Tab/Arrows — they
@@ -294,9 +309,12 @@ export function TerminalView({ session }: Props) {
               autoComplete="off"
               autoCorrect="off"
               autoCapitalize="none"
+              inputMode="none"
+              enterKeyHint="send"
               spellCheck={false}
               onInput={onProxyInput}
               onKeyDown={onProxyKeyDown}
+              onPaste={onProxyPaste}
               onFocus={() => setProxyFocused(true)}
               onBlur={() => setProxyFocused(false)}
               aria-hidden="true"
@@ -346,7 +364,7 @@ export function TerminalView({ session }: Props) {
                   <span aria-hidden="true" className="text-base leading-none">
                     {"\u21C5"}
                   </span>
-                  Two fingers to scroll
+                  Swipe to scroll
                 </span>
               </div>
             )}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -22,6 +22,7 @@ export function TerminalView({ session }: Props) {
     useTerminal(ensureState === "ready" ? session.id : null);
   const { isMobile, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
+  const [keyboardOpen, setKeyboardOpen] = useState(true);
 
   ctrlActiveRef.current = ctrlActive;
   clearCtrlRef.current = () => setCtrlActive(false);
@@ -81,6 +82,25 @@ export function TerminalView({ session }: Props) {
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
     };
   }, [keyboardHeight]);
+
+  // FAB controls keyboard: focus or blur wterm's textarea.
+  useEffect(() => {
+    if (!isMobile || !state.connected) return;
+    const term = termRef.current;
+    if (!term) return;
+    if (keyboardOpen) {
+      // Small delay to ensure wterm is fully mounted
+      const t = setTimeout(() => term.focus(), 50);
+      return () => clearTimeout(t);
+    } else {
+      const ta = term.element.querySelector("textarea");
+      ta?.blur();
+    }
+  }, [isMobile, state.connected, keyboardOpen, termRef]);
+
+  const toggleKeyboard = useCallback(() => {
+    setKeyboardOpen((v) => !v);
+  }, []);
 
   // Dismiss scroll hint on first touch or timeout.
   useEffect(() => {
@@ -171,6 +191,37 @@ export function TerminalView({ session }: Props) {
               Swipe to scroll
             </span>
           </div>
+        )}
+
+        {isMobile && state.connected && (
+          <button
+            type="button"
+            aria-label={keyboardOpen ? "Close keyboard" : "Open keyboard"}
+            onClick={toggleKeyboard}
+            className="absolute right-3 bottom-3 z-10 w-10 h-10 rounded-full bg-surface-800/90 border border-surface-700/30 text-text-secondary flex items-center justify-center shadow-lg backdrop-blur-sm active:scale-95"
+          >
+            {keyboardOpen ? (
+              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="1" y="1" width="22" height="16" rx="2" />
+                <line x1="5" y1="13" x2="19" y2="13" />
+                <line x1="8" y1="20" x2="16" y2="20" />
+                <line x1="12" y1="17" x2="12" y2="20" />
+              </svg>
+            ) : (
+              <svg width="18" height="14" viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                <rect x="1" y="1" width="22" height="16" rx="2" />
+                <line x1="5" y1="13" x2="19" y2="13" />
+                <line x1="5" y1="9" x2="5.01" y2="9" />
+                <line x1="9" y1="9" x2="9.01" y2="9" />
+                <line x1="13" y1="9" x2="13.01" y2="9" />
+                <line x1="17" y1="9" x2="17.01" y2="9" />
+                <line x1="5" y1="5" x2="5.01" y2="5" />
+                <line x1="9" y1="5" x2="9.01" y2="5" />
+                <line x1="13" y1="5" x2="13.01" y2="5" />
+                <line x1="17" y1="5" x2="17.01" y2="5" />
+              </svg>
+            )}
+          </button>
         )}
       </div>
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
-import { useWebSettings } from "../hooks/useWebSettings";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
 import { ensureSession } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
@@ -21,12 +20,9 @@ export function TerminalView({ session }: Props) {
   const [ensureError, setEnsureError] = useState<string | null>(null);
   const { containerRef, termRef, state, manualReconnect, sendData, ctrlActiveRef, clearCtrlRef } =
     useTerminal(ensureState === "ready" ? session.id : null);
-  const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
-  const { settings } = useWebSettings();
-  const [proxyFocused, setProxyFocused] = useState(false);
+  const { isMobile, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
 
-  // Keep the shared ref in sync so wterm's onData callback can read it.
   ctrlActiveRef.current = ctrlActive;
   clearCtrlRef.current = () => setCtrlActive(false);
 
@@ -43,14 +39,10 @@ export function TerminalView({ session }: Props) {
         setEnsureError(res.message ?? "Could not start session.");
       }
     });
-    // Abort the in-flight ensure when the selected session changes or the
-    // component unmounts. Without this, switching sessions mid-ensure would
-    // let the server restart the previous session after the user moved on.
     return () => controller.abort();
   }, [session.id]);
 
   const retryEnsure = useCallback(() => {
-    // Re-entrancy guard: ignore clicks while a retry is already in flight.
     setEnsureState((prev) => {
       if (prev === "pending") return prev;
       setEnsureError(null);
@@ -67,83 +59,30 @@ export function TerminalView({ session }: Props) {
       return "pending";
     });
   }, [session.id]);
+
   const [hintDismissed, setHintDismissed] = useState(() => {
     try {
       return localStorage.getItem(SCROLL_HINT_SEEN_KEY) === "1";
     } catch {
-      return true; // localStorage unavailable — treat as already seen
+      return true;
     }
   });
   const showScrollHint = isMobile && state.connected && !hintDismissed;
-  // Track focus on wterm's textarea to detect keyboard state. On iOS PWA
-  // standalone mode and iPadOS floating keyboards, visualViewport can lag;
-  // focus state flips instantly.
-  useEffect(() => {
-    const el = termRef.current?.element;
-    if (!el) return;
-    const ta = el.querySelector("textarea");
-    if (!ta) return;
-    const onFocus = () => setProxyFocused(true);
-    const onBlur = () => setProxyFocused(false);
-    ta.addEventListener("focus", onFocus);
-    ta.addEventListener("blur", onBlur);
-    return () => {
-      ta.removeEventListener("focus", onFocus);
-      ta.removeEventListener("blur", onBlur);
-    };
-  }, [termRef, state.connected]);
-  const keyboardVisible = keyboardOpen || proxyFocused;
 
-  // Re-layout the terminal and scroll to the cursor when the keyboard settles.
-  // Debounce the resize dispatch so it fires once after the iOS keyboard
-  // animation (~300ms) instead of on every intermediate height change.
+  // Debounce terminal resize when keyboard height changes.
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useLayoutEffect(() => {
     if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
     resizeTimerRef.current = setTimeout(() => {
       resizeTimerRef.current = null;
       window.dispatchEvent(new Event("resize"));
-      if (keyboardOpen && termRef.current) {
-        const el = termRef.current.element;
-        el.scrollTop = el.scrollHeight;
-      }
     }, 150);
     return () => {
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
     };
-  }, [keyboardOpen, keyboardHeight, termRef]);
+  }, [keyboardHeight]);
 
-  // Auto-open soft keyboard when a session is selected, if the user wants it.
-  // iOS can delay or skip showing the keyboard when focus() is called from a
-  // timeout (broken user-gesture chain). Retry a few times with increasing
-  // delay to cover the WS-connect + terminal-mount + keyboard-animation window.
-  useEffect(() => {
-    if (!isMobile || !state.connected) return;
-    if (!settings.autoOpenKeyboard) return;
-    const delays = [50, 200, 500];
-    const timers = delays.map((ms) =>
-      setTimeout(() => {
-        termRef.current?.focus();
-      }, ms),
-    );
-    return () => timers.forEach(clearTimeout);
-  }, [isMobile, state.connected, session.id, settings.autoOpenKeyboard, termRef]);
-
-  // Tap the terminal pane to reopen the keyboard. Skip when text is
-  // selected (preserves native long-press-to-select behavior).
-  const onContainerClick = useCallback(() => {
-    if (!isMobile) return;
-    const selection = window.getSelection()?.toString() ?? "";
-    if (selection.length > 0) return;
-    termRef.current?.focus();
-  }, [isMobile, termRef]);
-
-  const focusTerminal = useCallback(() => {
-    termRef.current?.focus();
-  }, [termRef]);
-
-  // Dismiss the one-time scroll hint on first touchmove or after a timeout.
-  // Persisted to localStorage so it's shown only once per device.
+  // Dismiss scroll hint on first touch or timeout.
   useEffect(() => {
     if (!showScrollHint) return;
     const markSeen = () => {
@@ -151,7 +90,7 @@ export function TerminalView({ session }: Props) {
       try {
         localStorage.setItem(SCROLL_HINT_SEEN_KEY, "1");
       } catch {
-        // ignore quota / disabled-storage errors
+        // ignore
       }
     };
     const t = setTimeout(markSeen, SCROLL_HINT_TIMEOUT_MS);
@@ -218,61 +157,20 @@ export function TerminalView({ session }: Props) {
       )}
 
       <div className="flex-1 overflow-hidden bg-surface-950 relative">
-        <div
-          ref={containerRef}
-          onClick={onContainerClick}
-          className="absolute inset-0"
-        />
+        <div ref={containerRef} className="absolute inset-0" />
 
-        {isMobile && state.connected && (
-          <>
-
-            {!keyboardVisible && (
-              <button
-                type="button"
-                aria-label="Open keyboard"
-                onClick={focusTerminal}
-                className="absolute right-3 bottom-3 w-9 h-9 rounded-full bg-surface-800 border border-surface-700/30 text-text-secondary flex items-center justify-center motion-safe:transition-opacity motion-safe:duration-150 hover:bg-surface-700 active:scale-95"
-              >
-                <svg
-                  width="18"
-                  height="14"
-                  viewBox="0 0 24 18"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  aria-hidden="true"
-                >
-                  <rect x="1" y="1" width="22" height="16" rx="2" />
-                  <line x1="5" y1="13" x2="19" y2="13" />
-                  <line x1="5" y1="9" x2="5.01" y2="9" />
-                  <line x1="9" y1="9" x2="9.01" y2="9" />
-                  <line x1="13" y1="9" x2="13.01" y2="9" />
-                  <line x1="17" y1="9" x2="17.01" y2="9" />
-                  <line x1="5" y1="5" x2="5.01" y2="5" />
-                  <line x1="9" y1="5" x2="9.01" y2="5" />
-                  <line x1="13" y1="5" x2="13.01" y2="5" />
-                  <line x1="17" y1="5" x2="17.01" y2="5" />
-                </svg>
-              </button>
-            )}
-
-            {showScrollHint && (
-              <div
-                aria-hidden="true"
-                className="absolute left-0 right-0 top-3 flex justify-center pointer-events-none motion-safe:animate-[fadeIn_300ms_ease-out]"
-              >
-                <span className="flex items-center gap-2 font-mono text-[13px] text-text-primary bg-surface-800/95 border border-surface-700 rounded-md px-3 py-2 shadow-lg backdrop-blur-sm">
-                  <span aria-hidden="true" className="text-base leading-none">
-                    {"\u21C5"}
-                  </span>
-                  Swipe to scroll
-                </span>
-              </div>
-            )}
-          </>
+        {showScrollHint && (
+          <div
+            aria-hidden="true"
+            className="absolute left-0 right-0 top-3 flex justify-center pointer-events-none motion-safe:animate-[fadeIn_300ms_ease-out]"
+          >
+            <span className="flex items-center gap-2 font-mono text-[13px] text-text-primary bg-surface-800/95 border border-surface-700 rounded-md px-3 py-2 shadow-lg backdrop-blur-sm">
+              <span aria-hidden="true" className="text-base leading-none">
+                {"\u21C5"}
+              </span>
+              Swipe to scroll
+            </span>
+          </div>
         )}
       </div>
 

--- a/web/src/hooks/useMobileKeyboard.ts
+++ b/web/src/hooks/useMobileKeyboard.ts
@@ -14,6 +14,7 @@ export function useMobileKeyboard() {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const rafRef = useRef(0);
   const stableCountRef = useRef(0);
+  const lastOcclusionRef = useRef(0);
   // Track the max viewport height ever seen (before keyboard opens) so we can
   // detect keyboard-open on devices where innerHeight shrinks with the keyboard.
   const fullHeightRef = useRef(0);
@@ -71,15 +72,25 @@ export function useMobileKeyboard() {
     };
 
     // iOS keyboard animation takes ~300ms but visualViewport events don't
-    // fire every frame during it. Poll via rAF to catch the transition as
-    // it happens, then stop once the value is stable for ~60 frames.
+    // fire every frame during it. Poll via rAF to catch the transition,
+    // stopping early when the measurement stabilizes (same value 3 frames
+    // in a row) or after 20 frames max to avoid burning CPU while typing.
+    const MAX_POLL_FRAMES = 20;
+    const STABLE_THRESHOLD = 3;
     const startPolling = () => {
       cancelAnimationFrame(rafRef.current);
       stableCountRef.current = 0;
+      let frameCount = 0;
       const poll = () => {
-        measure();
-        stableCountRef.current++;
-        if (stableCountRef.current < 60) {
+        frameCount++;
+        const occlusion = measure();
+        if (Math.abs(occlusion - lastOcclusionRef.current) < 1) {
+          stableCountRef.current++;
+        } else {
+          stableCountRef.current = 0;
+        }
+        lastOcclusionRef.current = occlusion;
+        if (stableCountRef.current < STABLE_THRESHOLD && frameCount < MAX_POLL_FRAMES) {
           rafRef.current = requestAnimationFrame(poll);
         }
       };

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -463,7 +463,7 @@ export function useTerminal(
       s.fontSize = "14px";
       s.fontFamily = "system-ui, sans-serif";
       s.backdropFilter = "blur(8px)";
-      (s as Record<string, string>)["webkitBackdropFilter"] = "blur(8px)";
+      s.setProperty("-webkit-backdrop-filter", "blur(8px)");
       s.boxShadow = "0 4px 16px rgba(0,0,0,0.4)";
       s.cursor = "pointer";
       s.touchAction = "manipulation";

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -137,12 +137,17 @@ export function useTerminal(
     // iOS can't show a paste popup on it. Use the toolbar Paste button.
     const BACKSPACE_SEED = "\u200B";
     let wtermTextarea: HTMLTextAreaElement | null = null;
+    // Hoisted so cleanup can remove the scroll listener.
+    const syncTextareaScroll = () => {
+      if (wtermTextarea) {
+        wtermTextarea.style.top = `${term.element.scrollTop}px`;
+      }
+    };
     const setupMobileTextarea = () => {
       if (!isMobileViewport()) return;
       wtermTextarea = termEl.querySelector("textarea");
       if (!wtermTextarea) return;
       wtermTextarea.style.left = "0";
-      wtermTextarea.style.top = "0";
       wtermTextarea.style.width = "100%";
       wtermTextarea.style.height = "100%";
       wtermTextarea.style.pointerEvents = "auto";
@@ -151,6 +156,15 @@ export function useTerminal(
       // non-zero value. The textarea already has color:transparent and
       // background:transparent so it stays invisible to the human eye.
       wtermTextarea.style.opacity = "0.01";
+      // Ensure textarea is above the terminal grid for touch events.
+      wtermTextarea.style.zIndex = "10";
+      // wterm's .wterm element is scrollable (overflow-y:auto) for
+      // scrollback. position:absolute + top:0 puts the textarea at the
+      // top of the scroll CONTENT, which scrolls off-screen as output
+      // grows. Sync the textarea's top with scrollTop so it always
+      // covers the visible area.
+      syncTextareaScroll();
+      term.element.addEventListener("scroll", syncTextareaScroll);
 
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {
@@ -722,6 +736,7 @@ export function useTerminal(
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheel);
+      viewport.removeEventListener("scroll", syncTextareaScroll);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
       wsRef.current?.close();

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -468,18 +468,18 @@ export function useTerminal(
       s.cursor = "pointer";
       s.touchAction = "manipulation";
       btn.addEventListener("pointerdown", (e) => e.stopPropagation());
-      btn.addEventListener("click", async (e) => {
+      btn.addEventListener("click", (e) => {
         e.stopPropagation();
-        try {
-          const text = await navigator.clipboard.readText();
-          if (text) {
-            const ws = wsRef.current;
-            if (ws?.readyState === WebSocket.OPEN) {
-              ws.send(new TextEncoder().encode(text));
-            }
-          }
-        } catch {
-          // Clipboard access denied
+        // Focus wterm's textarea and use execCommand('paste'). On
+        // Safari 13+, this shows a native "Paste" permission callout.
+        // When the user confirms, the paste event fires on the textarea
+        // and wterm's handlePaste processes it automatically.
+        // This works on non-HTTPS origins where the Clipboard API
+        // (navigator.clipboard.readText) is unavailable.
+        const ta = term.element.querySelector("textarea");
+        if (ta) {
+          ta.focus({ preventScroll: true });
+          document.execCommand("paste");
         }
         dismissPastePopup();
       });

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -133,13 +133,13 @@ export function useTerminal(
       if (!isMobileViewport()) return;
       wtermTextarea = termEl.querySelector("textarea");
       if (!wtermTextarea) return;
+      // Move the textarea into the viewport (from -9999px) so iOS shows
+      // the keyboard when it's focused. Keep it tiny and non-interactive
+      // so it doesn't block touches on the terminal content (text
+      // selection, long-press, etc.). Paste uses the toolbar button.
       const ts = wtermTextarea.style;
       ts.left = "0";
       ts.top = "0";
-      ts.width = "100%";
-      ts.height = "100%";
-      ts.pointerEvents = "auto";
-      ts.touchAction = "auto";
 
       // Seed the textarea so iOS has something to delete when backspace
       // is held. Without this, iOS never enters its key-repeat loop.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -123,12 +123,59 @@ export function useTerminal(
 
     termRef.current = term;
 
+    // On mobile, restyle wterm's hidden textarea so it covers the terminal
+    // area. This lets iOS show the paste popup on long-press and gives the
+    // soft keyboard a real element to attach to. The textarea is still
+    // visually hidden (opacity 0) but touchable.
+    const BACKSPACE_SEED = "\u200B";
+    let wtermTextarea: HTMLTextAreaElement | null = null;
+    const setupMobileTextarea = () => {
+      if (!isMobileViewport()) return;
+      wtermTextarea = termEl.querySelector("textarea");
+      if (!wtermTextarea) return;
+      const ts = wtermTextarea.style;
+      ts.left = "0";
+      ts.top = "0";
+      ts.width = "100%";
+      ts.height = "100%";
+      ts.pointerEvents = "auto";
+
+      // Seed the textarea so iOS has something to delete when backspace
+      // is held. Without this, iOS never enters its key-repeat loop.
+      const seedTextarea = () => {
+        if (wtermTextarea && !wtermTextarea.value) {
+          wtermTextarea.value = BACKSPACE_SEED;
+          wtermTextarea.setSelectionRange(1, 1);
+        }
+      };
+      wtermTextarea.addEventListener("focus", seedTextarea);
+
+      // Intercept Backspace before wterm's handler (which calls
+      // preventDefault and kills iOS repeat). We let the deletion happen
+      // natively, then re-seed in a microtask.
+      wtermTextarea.addEventListener("keydown", (e: KeyboardEvent) => {
+        if (e.key !== "Backspace") return;
+        e.stopImmediatePropagation(); // skip wterm's preventDefault
+        const ws = wsRef.current;
+        if (ws?.readyState === WebSocket.OPEN) {
+          ws.send(new TextEncoder().encode("\x7f"));
+        }
+        queueMicrotask(seedTextarea);
+      }, true);
+
+      // After wterm clears the textarea on regular input, re-seed.
+      wtermTextarea.addEventListener("input", () => {
+        queueMicrotask(seedTextarea);
+      });
+    };
+
     // Initialize the WASM bridge, then connect to the PTY.
     let connectOnReady = true;
     term
       .init()
       .then(() => {
         if (!connectOnReady) return;
+        setupMobileTextarea();
         connect();
       })
       .catch((err: unknown) => {
@@ -243,11 +290,13 @@ export function useTerminal(
 
       // Relay keystrokes as binary. When the virtual Ctrl button is armed,
       // intercept single printable characters and transform them to their
-      // Ctrl equivalents (Ctrl+A = 0x01, Ctrl+U = 0x15, etc.). This works
-      // regardless of whether the keystroke came from our mobile proxy input
-      // or from wterm's own hidden textarea.
+      // Ctrl equivalents (Ctrl+A = 0x01, Ctrl+U = 0x15, etc.).
       term.onData = (data: string) => {
         if (ws.readyState !== WebSocket.OPEN) return;
+        // Strip the backspace-seed ZWS so it never reaches the PTY.
+        const cleaned = data.replace(/\u200B/g, "");
+        if (!cleaned) return;
+        data = cleaned;
         if (ctrlActiveRef.current && data.length === 1) {
           const code = data.toUpperCase().charCodeAt(0);
           if (code >= 65 && code <= 90) {

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -137,34 +137,18 @@ export function useTerminal(
     // iOS can't show a paste popup on it. Use the toolbar Paste button.
     const BACKSPACE_SEED = "\u200B";
     let wtermTextarea: HTMLTextAreaElement | null = null;
-    // Hoisted so cleanup can remove the scroll listener.
-    const syncTextareaScroll = () => {
-      if (wtermTextarea) {
-        wtermTextarea.style.top = `${term.element.scrollTop}px`;
-      }
-    };
     const setupMobileTextarea = () => {
       if (!isMobileViewport()) return;
       wtermTextarea = termEl.querySelector("textarea");
       if (!wtermTextarea) return;
+
+      // Move wterm's textarea from -9999px into the viewport so iOS
+      // opens the soft keyboard when it receives focus.
       wtermTextarea.style.left = "0";
-      wtermTextarea.style.width = "100%";
-      wtermTextarea.style.height = "100%";
-      wtermTextarea.style.pointerEvents = "auto";
-      // wterm sets opacity:0 which makes iOS refuse to show the paste
-      // callout (it considers the element invisible). Override to a tiny
-      // non-zero value. The textarea already has color:transparent and
-      // background:transparent so it stays invisible to the human eye.
+      wtermTextarea.style.top = "0";
+      // wterm sets opacity:0; override so the textarea is technically
+      // "visible" to iOS (needed for future keyboard/paste improvements).
       wtermTextarea.style.opacity = "0.01";
-      // Ensure textarea is above the terminal grid for touch events.
-      wtermTextarea.style.zIndex = "10";
-      // wterm's .wterm element is scrollable (overflow-y:auto) for
-      // scrollback. position:absolute + top:0 puts the textarea at the
-      // top of the scroll CONTENT, which scrolls off-screen as output
-      // grows. Sync the textarea's top with scrollTop so it always
-      // covers the visible area.
-      syncTextareaScroll();
-      term.element.addEventListener("scroll", syncTextareaScroll);
 
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {
@@ -173,7 +157,6 @@ export function useTerminal(
         }
       };
       wtermTextarea.addEventListener("focus", seedTextarea);
-      // Seed immediately so the textarea has content even before first focus.
       seedTextarea();
 
       // Capture-phase: block wterm's preventDefault on Backspace so iOS
@@ -197,88 +180,6 @@ export function useTerminal(
         }
         queueMicrotask(seedTextarea);
       });
-
-      // DEBUG: comprehensive paste diagnosis
-      // 1. Dump textarea computed styles that affect iOS paste behavior
-      const dumpTaStyles = () => {
-        const cs = getComputedStyle(ta);
-        console.log("[paste-debug] textarea styles:", {
-          opacity: cs.opacity,
-          pointerEvents: cs.pointerEvents,
-          userSelect: cs.getPropertyValue("user-select") || cs.getPropertyValue("-webkit-user-select"),
-          touchCallout: cs.getPropertyValue("-webkit-touch-callout"),
-          position: cs.position,
-          left: cs.left,
-          top: cs.top,
-          width: cs.width,
-          height: cs.height,
-          visibility: cs.visibility,
-          display: cs.display,
-          zIndex: cs.zIndex,
-          caretColor: cs.caretColor,
-        });
-        console.log("[paste-debug] textarea rect:", ta.getBoundingClientRect());
-        console.log("[paste-debug] textarea contentEditable:", ta.contentEditable);
-        console.log("[paste-debug] textarea readOnly:", ta.readOnly);
-        console.log("[paste-debug] textarea disabled:", ta.disabled);
-        console.log("[paste-debug] textarea value:", JSON.stringify(ta.value));
-      };
-      setTimeout(dumpTaStyles, 500);
-
-      // 2. Trace touch events with timestamps to measure hold duration
-      let touchStartTime = 0;
-      ta.addEventListener("touchstart", (e: TouchEvent) => {
-        touchStartTime = performance.now();
-        console.log("[paste-debug] textarea touchstart", {
-          touches: e.touches.length,
-          defaultPrevented: e.defaultPrevented,
-          cancelable: e.cancelable,
-        });
-      });
-      ta.addEventListener("touchend", (e: TouchEvent) => {
-        const holdMs = performance.now() - touchStartTime;
-        console.log("[paste-debug] textarea touchend", {
-          holdMs: Math.round(holdMs),
-          defaultPrevented: e.defaultPrevented,
-        });
-      });
-      ta.addEventListener("touchmove", (e: TouchEvent) => {
-        console.log("[paste-debug] textarea touchmove", {
-          defaultPrevented: e.defaultPrevented,
-        });
-      });
-      ta.addEventListener("contextmenu", (e: Event) => {
-        console.log("[paste-debug] textarea contextmenu!", {
-          defaultPrevented: e.defaultPrevented,
-          cancelable: e.cancelable,
-        });
-      });
-      ta.addEventListener("focus", () => console.log("[paste-debug] textarea focus"));
-      ta.addEventListener("blur", () => console.log("[paste-debug] textarea blur"));
-      ta.addEventListener("select", () => {
-        console.log("[paste-debug] textarea select event, selectionStart:", ta.selectionStart, "selectionEnd:", ta.selectionEnd);
-      });
-
-      // 3. Listen on document (capture) for contextmenu anywhere
-      document.addEventListener("contextmenu", (e: Event) => {
-        console.log("[paste-debug] DOCUMENT contextmenu", {
-          target: (e.target as HTMLElement)?.tagName,
-          defaultPrevented: e.defaultPrevented,
-        });
-      }, true);
-
-      // 4. Monitor if our parent touch handlers are calling preventDefault
-      // by wrapping the original method briefly
-      const origPreventDefault = TouchEvent.prototype.preventDefault;
-      TouchEvent.prototype.preventDefault = function(this: TouchEvent) {
-        console.log("[paste-debug] preventDefault called on", this.type, {
-          target: (this.target as HTMLElement)?.tagName,
-          stack: new Error().stack?.split("\n").slice(1, 4).join(" | "),
-        });
-        return origPreventDefault.call(this);
-      };
-      // Restore after 60s to avoid perf impact
-      setTimeout(() => { TouchEvent.prototype.preventDefault = origPreventDefault; }, 60000);
     };
 
     // Initialize the WASM bridge, then connect to the PTY.
@@ -529,8 +430,78 @@ export function useTerminal(
       }
     };
 
+    // Long-press paste popup for mobile. iOS won't show native paste on
+    // wterm's invisible textarea, so we detect the long-press ourselves
+    // and show a floating "Paste" button that uses the Clipboard API.
+    let pastePopup: HTMLElement | null = null;
+    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
+    const PASTE_LONG_PRESS_MS = 500;
+
+    const dismissPastePopup = () => {
+      if (pastePopup) {
+        pastePopup.remove();
+        pastePopup = null;
+      }
+    };
+
+    const showPastePopup = (x: number, y: number) => {
+      dismissPastePopup();
+      const btn = document.createElement("button");
+      btn.textContent = "Paste";
+      btn.setAttribute("type", "button");
+      const s = btn.style;
+      s.position = "fixed";
+      s.left = `${x}px`;
+      s.top = `${y - 44}px`;
+      s.transform = "translateX(-50%)";
+      s.zIndex = "9999";
+      s.padding = "6px 16px";
+      s.borderRadius = "8px";
+      s.border = "1px solid rgba(255,255,255,0.15)";
+      s.background = "rgba(40,40,44,0.95)";
+      s.color = "#e4e4e7";
+      s.fontSize = "14px";
+      s.fontFamily = "system-ui, sans-serif";
+      s.backdropFilter = "blur(8px)";
+      s.WebkitBackdropFilter = "blur(8px)";
+      s.boxShadow = "0 4px 16px rgba(0,0,0,0.4)";
+      s.cursor = "pointer";
+      s.touchAction = "manipulation";
+      btn.addEventListener("pointerdown", (e) => e.stopPropagation());
+      btn.addEventListener("click", async (e) => {
+        e.stopPropagation();
+        try {
+          const text = await navigator.clipboard.readText();
+          if (text) {
+            const ws = wsRef.current;
+            if (ws?.readyState === WebSocket.OPEN) {
+              ws.send(new TextEncoder().encode(text));
+            }
+          }
+        } catch {
+          // Clipboard access denied
+        }
+        dismissPastePopup();
+      });
+      document.body.appendChild(btn);
+      pastePopup = btn;
+      // Auto-dismiss after 3s
+      setTimeout(() => {
+        if (pastePopup === btn) dismissPastePopup();
+      }, 3000);
+    };
+
+    const cancelLongPress = () => {
+      if (longPressTimer !== null) {
+        clearTimeout(longPressTimer);
+        longPressTimer = null;
+      }
+    };
+
     const onTouchStart = (e: TouchEvent) => {
       cancelMomentum();
+      cancelLongPress();
+      dismissPastePopup();
       suppressNextClick = false;
 
       if (e.touches.length === 1) {
@@ -542,10 +513,25 @@ export function useTerminal(
         singleLastTs = singleStartTs;
         velocity = 0;
         gestureMode = null;
+
+        // Start long-press timer for paste popup (mobile only)
+        if (isMobileViewport()) {
+          const px = t.clientX;
+          const py = t.clientY;
+          longPressTimer = setTimeout(() => {
+            longPressTimer = null;
+            // Only show if gesture hasn't been classified as scroll
+            if (gestureMode === null) {
+              showPastePopup(px, py);
+              navigator.vibrate?.(10);
+            }
+          }, PASTE_LONG_PRESS_MS);
+        }
         return;
       }
 
       if (e.touches.length === 2) {
+        cancelLongPress();
         gestureMode = null;
         touchMidY = midpointY(e);
         touchAccum = 0;
@@ -572,6 +558,7 @@ export function useTerminal(
           // Long-press then drag is text selection, not scroll.
           if (now - singleStartTs > LONG_PRESS_MS) return;
           gestureMode = "single-scroll";
+          cancelLongPress();
           singleY = y;
         }
 
@@ -638,6 +625,7 @@ export function useTerminal(
     };
 
     const onTouchEnd = (e: TouchEvent) => {
+      cancelLongPress();
       if (e.touches.length > 0) return;
       if (gestureMode === "pinch") {
         flushFontSize();
@@ -681,12 +669,9 @@ export function useTerminal(
       momentumRaf = requestAnimationFrame(decay);
     };
 
-    // Attach touch handlers to the .wterm element. wterm adds this class to
-    // the container automatically during construction.
-    // NOTE: we intentionally do NOT set touch-action: none. Our non-passive
-    // capture-phase handlers call preventDefault() when scrolling, which is
-    // sufficient. Leaving touch-action unset lets iOS show the paste popup
-    // on long-press of the terminal's textarea.
+    // Attach touch handlers to the .wterm element. We do NOT set
+    // touch-action: none; our non-passive capture-phase handlers call
+    // preventDefault() when scrolling, which is sufficient.
     const viewport = term.element;
     const touchOpts = { passive: false, capture: true } as const;
     viewport.addEventListener("touchstart", onTouchStart, touchOpts);
@@ -730,13 +715,14 @@ export function useTerminal(
     return () => {
       connectOnReady = false;
       cancelMomentum();
+      cancelLongPress();
+      dismissPastePopup();
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheel);
-      viewport.removeEventListener("scroll", syncTextareaScroll);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
       wsRef.current?.close();

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -284,11 +284,13 @@ export function useTerminal(
     let pinchStartSize = DEFAULT_FONT_SIZE;
     let pinchStartMidY = 0;
     let singleStartY = 0;
+    let singleStartTs = 0;
     let singleY = 0;
     let singleAccum = 0;
     let singleLastTs = 0;
     let suppressNextClick = false;
     const GESTURE_LOCK_PX = 12;
+    const LONG_PRESS_MS = 300;
     const LINES_PER_WHEEL = 2;
     const MAX_VELOCITY = 2.0;
     const MAX_WHEELS_PER_FRAME = 6;
@@ -373,9 +375,10 @@ export function useTerminal(
       if (e.touches.length === 1) {
         const t = e.touches[0]!;
         singleStartY = t.clientY;
+        singleStartTs = performance.now();
         singleY = t.clientY;
         singleAccum = 0;
-        singleLastTs = performance.now();
+        singleLastTs = singleStartTs;
         velocity = 0;
         gestureMode = null;
         return;
@@ -405,6 +408,8 @@ export function useTerminal(
             singleLastTs = now;
             return;
           }
+          // Long-press then drag is text selection, not scroll.
+          if (now - singleStartTs > LONG_PRESS_MS) return;
           gestureMode = "single-scroll";
           singleY = y;
         }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -146,9 +146,6 @@ export function useTerminal(
       wtermTextarea.style.width = "100%";
       wtermTextarea.style.height = "100%";
       wtermTextarea.style.pointerEvents = "auto";
-      // Let text selection pass through to terminal content underneath
-      wtermTextarea.style.userSelect = "none";
-      wtermTextarea.style.webkitUserSelect = "none";
 
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {
@@ -158,21 +155,16 @@ export function useTerminal(
       };
       wtermTextarea.addEventListener("focus", seedTextarea);
 
-      // Capture-phase: intercept Backspace before wterm's preventDefault.
-      // Send \x7f ourselves and let the native deletion happen (no
-      // preventDefault) so iOS enters its key-repeat loop.
+      // Capture-phase: block wterm's preventDefault on Backspace so iOS
+      // can enter its key-repeat loop. Don't send \x7f here; the native
+      // deletion fires a deleteContentBackward input event which handles it.
       wtermTextarea.addEventListener("keydown", (e: KeyboardEvent) => {
         if (e.key !== "Backspace") return;
         e.stopImmediatePropagation();
-        const ws = wsRef.current;
-        if (ws?.readyState === WebSocket.OPEN) {
-          ws.send(new TextEncoder().encode("\x7f"));
-        }
-        queueMicrotask(seedTextarea);
       }, true);
 
-      // iOS key-repeat fires "input" events with deleteContentBackward,
-      // not repeated keydown. Send \x7f for each one and re-seed.
+      // All backspace handling (first press + iOS repeat) comes through
+      // here as deleteContentBackward input events. Send \x7f and re-seed.
       const ta = wtermTextarea;
       ta.addEventListener("input", (e: Event) => {
         const ie = e as InputEvent;
@@ -184,6 +176,13 @@ export function useTerminal(
         }
         queueMicrotask(seedTextarea);
       });
+
+      // DEBUG: trace touch/focus events on the textarea to diagnose paste
+      ta.addEventListener("touchstart", () => console.log("[wterm-textarea] touchstart"));
+      ta.addEventListener("touchend", () => console.log("[wterm-textarea] touchend"));
+      ta.addEventListener("contextmenu", () => console.log("[wterm-textarea] contextmenu"));
+      ta.addEventListener("focus", () => console.log("[wterm-textarea] focus"));
+      ta.addEventListener("blur", () => console.log("[wterm-textarea] blur"));
     };
 
     // Initialize the WASM bridge, then connect to the PTY.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -146,6 +146,11 @@ export function useTerminal(
       wtermTextarea.style.width = "100%";
       wtermTextarea.style.height = "100%";
       wtermTextarea.style.pointerEvents = "auto";
+      // wterm sets opacity:0 which makes iOS refuse to show the paste
+      // callout (it considers the element invisible). Override to a tiny
+      // non-zero value. The textarea already has color:transparent and
+      // background:transparent so it stays invisible to the human eye.
+      wtermTextarea.style.opacity = "0.01";
 
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {
@@ -154,6 +159,8 @@ export function useTerminal(
         }
       };
       wtermTextarea.addEventListener("focus", seedTextarea);
+      // Seed immediately so the textarea has content even before first focus.
+      seedTextarea();
 
       // Capture-phase: block wterm's preventDefault on Backspace so iOS
       // can enter its key-repeat loop. Don't send \x7f here; the native

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -139,6 +139,7 @@ export function useTerminal(
       ts.width = "100%";
       ts.height = "100%";
       ts.pointerEvents = "auto";
+      ts.touchAction = "auto";
 
       // Seed the textarea so iOS has something to delete when backspace
       // is held. Without this, iOS never enters its key-repeat loop.
@@ -571,8 +572,11 @@ export function useTerminal(
 
     // Attach touch handlers to the .wterm element. wterm adds this class to
     // the container automatically during construction.
+    // NOTE: we intentionally do NOT set touch-action: none. Our non-passive
+    // capture-phase handlers call preventDefault() when scrolling, which is
+    // sufficient. Leaving touch-action unset lets iOS show the paste popup
+    // on long-press of the terminal's textarea.
     const viewport = term.element;
-    viewport.style.touchAction = "none";
     const touchOpts = { passive: false, capture: true } as const;
     viewport.addEventListener("touchstart", onTouchStart, touchOpts);
     viewport.addEventListener("touchmove", onTouchMove, touchOpts);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -598,15 +598,15 @@ export function useTerminal(
     viewport.addEventListener("touchend", onTouchEnd, touchOpts);
     viewport.addEventListener("touchcancel", onTouchEnd, touchOpts);
 
-    // After a scroll gesture, suppress the click that follows so it doesn't
-    // accidentally open the soft keyboard.
-    const onClickAfterScroll = (e: MouseEvent) => {
-      if (suppressNextClick) {
-        suppressNextClick = false;
-        e.stopPropagation();
-      }
+    // On mobile, suppress ALL click-to-focus so the keyboard is only
+    // controlled via the FAB button. On desktop, only suppress after a
+    // scroll gesture.
+    const onClickCapture = (e: MouseEvent) => {
+      const wasScroll = suppressNextClick;
+      suppressNextClick = false;
+      if (isMobileViewport() || wasScroll) e.stopPropagation();
     };
-    viewport.addEventListener("click", onClickAfterScroll, true);
+    viewport.addEventListener("click", onClickCapture, true);
 
     // Trackpad pinch fires wheel events with ctrlKey=true
     let wheelAccum = 0;
@@ -638,7 +638,7 @@ export function useTerminal(
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
-      viewport.removeEventListener("click", onClickAfterScroll, true);
+      viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheel);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -463,7 +463,7 @@ export function useTerminal(
       s.fontSize = "14px";
       s.fontFamily = "system-ui, sans-serif";
       s.backdropFilter = "blur(8px)";
-      s.WebkitBackdropFilter = "blur(8px)";
+      (s as Record<string, string>)["webkitBackdropFilter"] = "blur(8px)";
       s.boxShadow = "0 4px 16px rgba(0,0,0,0.4)";
       s.cursor = "pointer";
       s.touchAction = "manipulation";

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -177,12 +177,87 @@ export function useTerminal(
         queueMicrotask(seedTextarea);
       });
 
-      // DEBUG: trace touch/focus events on the textarea to diagnose paste
-      ta.addEventListener("touchstart", () => console.log("[wterm-textarea] touchstart"));
-      ta.addEventListener("touchend", () => console.log("[wterm-textarea] touchend"));
-      ta.addEventListener("contextmenu", () => console.log("[wterm-textarea] contextmenu"));
-      ta.addEventListener("focus", () => console.log("[wterm-textarea] focus"));
-      ta.addEventListener("blur", () => console.log("[wterm-textarea] blur"));
+      // DEBUG: comprehensive paste diagnosis
+      // 1. Dump textarea computed styles that affect iOS paste behavior
+      const dumpTaStyles = () => {
+        const cs = getComputedStyle(ta);
+        console.log("[paste-debug] textarea styles:", {
+          opacity: cs.opacity,
+          pointerEvents: cs.pointerEvents,
+          userSelect: cs.getPropertyValue("user-select") || cs.getPropertyValue("-webkit-user-select"),
+          touchCallout: cs.getPropertyValue("-webkit-touch-callout"),
+          position: cs.position,
+          left: cs.left,
+          top: cs.top,
+          width: cs.width,
+          height: cs.height,
+          visibility: cs.visibility,
+          display: cs.display,
+          zIndex: cs.zIndex,
+          caretColor: cs.caretColor,
+        });
+        console.log("[paste-debug] textarea rect:", ta.getBoundingClientRect());
+        console.log("[paste-debug] textarea contentEditable:", ta.contentEditable);
+        console.log("[paste-debug] textarea readOnly:", ta.readOnly);
+        console.log("[paste-debug] textarea disabled:", ta.disabled);
+        console.log("[paste-debug] textarea value:", JSON.stringify(ta.value));
+      };
+      setTimeout(dumpTaStyles, 500);
+
+      // 2. Trace touch events with timestamps to measure hold duration
+      let touchStartTime = 0;
+      ta.addEventListener("touchstart", (e: TouchEvent) => {
+        touchStartTime = performance.now();
+        console.log("[paste-debug] textarea touchstart", {
+          touches: e.touches.length,
+          defaultPrevented: e.defaultPrevented,
+          cancelable: e.cancelable,
+        });
+      });
+      ta.addEventListener("touchend", (e: TouchEvent) => {
+        const holdMs = performance.now() - touchStartTime;
+        console.log("[paste-debug] textarea touchend", {
+          holdMs: Math.round(holdMs),
+          defaultPrevented: e.defaultPrevented,
+        });
+      });
+      ta.addEventListener("touchmove", (e: TouchEvent) => {
+        console.log("[paste-debug] textarea touchmove", {
+          defaultPrevented: e.defaultPrevented,
+        });
+      });
+      ta.addEventListener("contextmenu", (e: Event) => {
+        console.log("[paste-debug] textarea contextmenu!", {
+          defaultPrevented: e.defaultPrevented,
+          cancelable: e.cancelable,
+        });
+      });
+      ta.addEventListener("focus", () => console.log("[paste-debug] textarea focus"));
+      ta.addEventListener("blur", () => console.log("[paste-debug] textarea blur"));
+      ta.addEventListener("select", () => {
+        console.log("[paste-debug] textarea select event, selectionStart:", ta.selectionStart, "selectionEnd:", ta.selectionEnd);
+      });
+
+      // 3. Listen on document (capture) for contextmenu anywhere
+      document.addEventListener("contextmenu", (e: Event) => {
+        console.log("[paste-debug] DOCUMENT contextmenu", {
+          target: (e.target as HTMLElement)?.tagName,
+          defaultPrevented: e.defaultPrevented,
+        });
+      }, true);
+
+      // 4. Monitor if our parent touch handlers are calling preventDefault
+      // by wrapping the original method briefly
+      const origPreventDefault = TouchEvent.prototype.preventDefault;
+      TouchEvent.prototype.preventDefault = function(this: TouchEvent) {
+        console.log("[paste-debug] preventDefault called on", this.type, {
+          target: (this.target as HTMLElement)?.tagName,
+          stack: new Error().stack?.split("\n").slice(1, 4).join(" | "),
+        });
+        return origPreventDefault.call(this);
+      };
+      // Restore after 60s to avoid perf impact
+      setTimeout(() => { TouchEvent.prototype.preventDefault = origPreventDefault; }, 60000);
     };
 
     // Initialize the WASM bridge, then connect to the PTY.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -143,6 +143,12 @@ export function useTerminal(
       if (!wtermTextarea) return;
       wtermTextarea.style.left = "0";
       wtermTextarea.style.top = "0";
+      wtermTextarea.style.width = "100%";
+      wtermTextarea.style.height = "100%";
+      wtermTextarea.style.pointerEvents = "auto";
+      // Let text selection pass through to terminal content underneath
+      wtermTextarea.style.userSelect = "none";
+      wtermTextarea.style.webkitUserSelect = "none";
 
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -123,26 +123,27 @@ export function useTerminal(
 
     termRef.current = term;
 
-    // On mobile, restyle wterm's hidden textarea so it covers the terminal
-    // area. This lets iOS show the paste popup on long-press and gives the
-    // soft keyboard a real element to attach to. The textarea is still
-    // visually hidden (opacity 0) but touchable.
+    // Two iOS patches for wterm's textarea:
+    // 1. Move from -9999px to 0,0 so iOS shows the soft keyboard on focus.
+    // 2. Fix backspace repeat: wterm calls preventDefault() on all keydown
+    //    events, which prevents iOS from entering its key-repeat loop.
+    //    We intercept Backspace in capture phase, skip wterm's handler,
+    //    and let the native deletion happen. iOS repeat fires "input"
+    //    events with inputType "deleteContentBackward" (not keydown),
+    //    so we detect those and send \x7f for each one.
+    //    A ZWS seed keeps the textarea non-empty so iOS always has
+    //    something to delete on each repeat tick.
+    // Paste: wterm's textarea has pointerEvents:none and is 1x1px, so
+    // iOS can't show a paste popup on it. Use the toolbar Paste button.
     const BACKSPACE_SEED = "\u200B";
     let wtermTextarea: HTMLTextAreaElement | null = null;
     const setupMobileTextarea = () => {
       if (!isMobileViewport()) return;
       wtermTextarea = termEl.querySelector("textarea");
       if (!wtermTextarea) return;
-      // Move the textarea into the viewport (from -9999px) so iOS shows
-      // the keyboard when it's focused. Keep it tiny and non-interactive
-      // so it doesn't block touches on the terminal content (text
-      // selection, long-press, etc.). Paste uses the toolbar button.
-      const ts = wtermTextarea.style;
-      ts.left = "0";
-      ts.top = "0";
+      wtermTextarea.style.left = "0";
+      wtermTextarea.style.top = "0";
 
-      // Seed the textarea so iOS has something to delete when backspace
-      // is held. Without this, iOS never enters its key-repeat loop.
       const seedTextarea = () => {
         if (wtermTextarea && !wtermTextarea.value) {
           wtermTextarea.value = BACKSPACE_SEED;
@@ -151,12 +152,12 @@ export function useTerminal(
       };
       wtermTextarea.addEventListener("focus", seedTextarea);
 
-      // Intercept Backspace before wterm's handler (which calls
-      // preventDefault and kills iOS repeat). We let the deletion happen
-      // natively, then re-seed in a microtask.
+      // Capture-phase: intercept Backspace before wterm's preventDefault.
+      // Send \x7f ourselves and let the native deletion happen (no
+      // preventDefault) so iOS enters its key-repeat loop.
       wtermTextarea.addEventListener("keydown", (e: KeyboardEvent) => {
         if (e.key !== "Backspace") return;
-        e.stopImmediatePropagation(); // skip wterm's preventDefault
+        e.stopImmediatePropagation();
         const ws = wsRef.current;
         if (ws?.readyState === WebSocket.OPEN) {
           ws.send(new TextEncoder().encode("\x7f"));
@@ -164,8 +165,17 @@ export function useTerminal(
         queueMicrotask(seedTextarea);
       }, true);
 
-      // After wterm clears the textarea on regular input, re-seed.
-      wtermTextarea.addEventListener("input", () => {
+      // iOS key-repeat fires "input" events with deleteContentBackward,
+      // not repeated keydown. Send \x7f for each one and re-seed.
+      const ta = wtermTextarea;
+      ta.addEventListener("input", (e: Event) => {
+        const ie = e as InputEvent;
+        if (ie.inputType === "deleteContentBackward") {
+          const ws = wsRef.current;
+          if (ws?.readyState === WebSocket.OPEN) {
+            ws.send(new TextEncoder().encode("\x7f"));
+          }
+        }
         queueMicrotask(seedTextarea);
       });
     };

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -261,7 +261,7 @@ export function useTerminal(
       };
     }
 
-    // Two-finger swipe emits SGR mouse-wheel escape sequences to the PTY,
+    // Touch swipe emits SGR mouse-wheel escape sequences to the PTY,
     // so tmux mouse-mode enters copy-mode and scrolls.
     const WHEEL_UP_SEQ = "\x1b[<64;1;1M";
     const WHEEL_DOWN_SEQ = "\x1b[<65;1;1M";
@@ -279,10 +279,15 @@ export function useTerminal(
     let lastMoveTs = 0;
     let velocity = 0;
     let momentumRaf: number | null = null;
-    let gestureMode: "pinch" | "scroll" | null = null;
+    let gestureMode: "single-scroll" | "pinch" | "scroll" | null = null;
     let pinchStartDist = 0;
     let pinchStartSize = DEFAULT_FONT_SIZE;
     let pinchStartMidY = 0;
+    let singleStartY = 0;
+    let singleY = 0;
+    let singleAccum = 0;
+    let singleLastTs = 0;
+    let suppressNextClick = false;
     const GESTURE_LOCK_PX = 12;
     const LINES_PER_WHEEL = 2;
     const MAX_VELOCITY = 2.0;
@@ -363,25 +368,73 @@ export function useTerminal(
 
     const onTouchStart = (e: TouchEvent) => {
       cancelMomentum();
-      if (e.touches.length !== 2) return;
-      touchMidY = midpointY(e);
-      touchAccum = 0;
-      velocity = 0;
-      lastMoveTs = performance.now();
-      gestureMode = null;
-      pinchStartDist = touchDistance(e);
-      pinchStartSize = currentFontSize();
-      pinchStartMidY = touchMidY;
+      suppressNextClick = false;
+
+      if (e.touches.length === 1) {
+        const t = e.touches[0]!;
+        singleStartY = t.clientY;
+        singleY = t.clientY;
+        singleAccum = 0;
+        singleLastTs = performance.now();
+        velocity = 0;
+        gestureMode = null;
+        return;
+      }
+
+      if (e.touches.length === 2) {
+        gestureMode = null;
+        touchMidY = midpointY(e);
+        touchAccum = 0;
+        velocity = 0;
+        lastMoveTs = performance.now();
+        pinchStartDist = touchDistance(e);
+        pinchStartSize = currentFontSize();
+        pinchStartMidY = touchMidY;
+      }
     };
 
     const onTouchMove = (e: TouchEvent) => {
+      // Single-finger scroll
+      if (e.touches.length === 1 && (gestureMode === null || gestureMode === "single-scroll")) {
+        const t = e.touches[0]!;
+        const y = t.clientY;
+        const now = performance.now();
+
+        if (gestureMode === null) {
+          if (Math.abs(y - singleStartY) < GESTURE_LOCK_PX) {
+            singleLastTs = now;
+            return;
+          }
+          gestureMode = "single-scroll";
+          singleY = y;
+        }
+
+        e.preventDefault();
+
+        const dy = singleY - y;
+        singleY = y;
+        singleAccum += dy;
+        const step = pxPerWheel();
+        const rawWheels = Math.trunc(singleAccum / step);
+        const wheels = Math.max(-MAX_WHEELS_PER_FRAME, Math.min(MAX_WHEELS_PER_FRAME, rawWheels));
+        if (wheels !== 0) {
+          sendWheel(wheels > 0 ? "up" : "down", Math.abs(wheels));
+          singleAccum -= wheels * step;
+          const dt = Math.max(1, now - singleLastTs);
+          velocity = clampV(dy / dt);
+        }
+        singleLastTs = now;
+        return;
+      }
+
+      // Two-finger gesture (scroll or pinch)
       if (e.touches.length !== 2) return;
       e.preventDefault();
       const y = midpointY(e);
       const now = performance.now();
       const dist = touchDistance(e);
 
-      if (gestureMode === null) {
+      if (gestureMode === null || gestureMode === "single-scroll") {
         const distDelta = Math.abs(dist - pinchStartDist);
         const panDelta = Math.abs(y - pinchStartMidY);
         if (Math.max(distDelta, panDelta) < GESTURE_LOCK_PX) {
@@ -427,7 +480,9 @@ export function useTerminal(
         velocity = 0;
         return;
       }
+      const wasScrolling = gestureMode === "single-scroll" || gestureMode === "scroll";
       gestureMode = null;
+      if (wasScrolling) suppressNextClick = true;
       if (prefersReducedMotion() || Math.abs(velocity) < 0.05) {
         velocity = 0;
         return;
@@ -470,6 +525,16 @@ export function useTerminal(
     viewport.addEventListener("touchend", onTouchEnd, touchOpts);
     viewport.addEventListener("touchcancel", onTouchEnd, touchOpts);
 
+    // After a scroll gesture, suppress the click that follows so it doesn't
+    // accidentally open the soft keyboard.
+    const onClickAfterScroll = (e: MouseEvent) => {
+      if (suppressNextClick) {
+        suppressNextClick = false;
+        e.stopPropagation();
+      }
+    };
+    viewport.addEventListener("click", onClickAfterScroll, true);
+
     // Trackpad pinch fires wheel events with ctrlKey=true
     let wheelAccum = 0;
     let wheelPersistTimer: ReturnType<typeof setTimeout> | null = null;
@@ -500,6 +565,7 @@ export function useTerminal(
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
+      viewport.removeEventListener("click", onClickAfterScroll, true);
       viewport.removeEventListener("wheel", onWheel);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -430,78 +430,8 @@ export function useTerminal(
       }
     };
 
-    // Long-press paste popup for mobile. iOS won't show native paste on
-    // wterm's invisible textarea, so we detect the long-press ourselves
-    // and show a floating "Paste" button that uses the Clipboard API.
-    let pastePopup: HTMLElement | null = null;
-    let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-    const PASTE_LONG_PRESS_MS = 500;
-
-    const dismissPastePopup = () => {
-      if (pastePopup) {
-        pastePopup.remove();
-        pastePopup = null;
-      }
-    };
-
-    const showPastePopup = (x: number, y: number) => {
-      dismissPastePopup();
-      const btn = document.createElement("button");
-      btn.textContent = "Paste";
-      btn.setAttribute("type", "button");
-      const s = btn.style;
-      s.position = "fixed";
-      s.left = `${x}px`;
-      s.top = `${y - 44}px`;
-      s.transform = "translateX(-50%)";
-      s.zIndex = "9999";
-      s.padding = "6px 16px";
-      s.borderRadius = "8px";
-      s.border = "1px solid rgba(255,255,255,0.15)";
-      s.background = "rgba(40,40,44,0.95)";
-      s.color = "#e4e4e7";
-      s.fontSize = "14px";
-      s.fontFamily = "system-ui, sans-serif";
-      s.backdropFilter = "blur(8px)";
-      s.setProperty("-webkit-backdrop-filter", "blur(8px)");
-      s.boxShadow = "0 4px 16px rgba(0,0,0,0.4)";
-      s.cursor = "pointer";
-      s.touchAction = "manipulation";
-      btn.addEventListener("pointerdown", (e) => e.stopPropagation());
-      btn.addEventListener("click", (e) => {
-        e.stopPropagation();
-        // Focus wterm's textarea and use execCommand('paste'). On
-        // Safari 13+, this shows a native "Paste" permission callout.
-        // When the user confirms, the paste event fires on the textarea
-        // and wterm's handlePaste processes it automatically.
-        // This works on non-HTTPS origins where the Clipboard API
-        // (navigator.clipboard.readText) is unavailable.
-        const ta = term.element.querySelector("textarea");
-        if (ta) {
-          ta.focus({ preventScroll: true });
-          document.execCommand("paste");
-        }
-        dismissPastePopup();
-      });
-      document.body.appendChild(btn);
-      pastePopup = btn;
-      // Auto-dismiss after 3s
-      setTimeout(() => {
-        if (pastePopup === btn) dismissPastePopup();
-      }, 3000);
-    };
-
-    const cancelLongPress = () => {
-      if (longPressTimer !== null) {
-        clearTimeout(longPressTimer);
-        longPressTimer = null;
-      }
-    };
-
     const onTouchStart = (e: TouchEvent) => {
       cancelMomentum();
-      cancelLongPress();
-      dismissPastePopup();
       suppressNextClick = false;
 
       if (e.touches.length === 1) {
@@ -513,25 +443,10 @@ export function useTerminal(
         singleLastTs = singleStartTs;
         velocity = 0;
         gestureMode = null;
-
-        // Start long-press timer for paste popup (mobile only)
-        if (isMobileViewport()) {
-          const px = t.clientX;
-          const py = t.clientY;
-          longPressTimer = setTimeout(() => {
-            longPressTimer = null;
-            // Only show if gesture hasn't been classified as scroll
-            if (gestureMode === null) {
-              showPastePopup(px, py);
-              navigator.vibrate?.(10);
-            }
-          }, PASTE_LONG_PRESS_MS);
-        }
         return;
       }
 
       if (e.touches.length === 2) {
-        cancelLongPress();
         gestureMode = null;
         touchMidY = midpointY(e);
         touchAccum = 0;
@@ -558,7 +473,6 @@ export function useTerminal(
           // Long-press then drag is text selection, not scroll.
           if (now - singleStartTs > LONG_PRESS_MS) return;
           gestureMode = "single-scroll";
-          cancelLongPress();
           singleY = y;
         }
 
@@ -625,7 +539,6 @@ export function useTerminal(
     };
 
     const onTouchEnd = (e: TouchEvent) => {
-      cancelLongPress();
       if (e.touches.length > 0) return;
       if (gestureMode === "pinch") {
         flushFontSize();
@@ -715,8 +628,6 @@ export function useTerminal(
     return () => {
       connectOnReady = false;
       cancelMomentum();
-      cancelLongPress();
-      dismissPastePopup();
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);


### PR DESCRIPTION
## Summary

Overhauls the mobile terminal experience after switching from xterm.js to wterm. Addresses multiple iOS Safari issues that stem from wterm having zero mobile/touch support.

### What changed

- **Single-finger scroll**: Touch gesture system with momentum, disambiguating scroll vs text selection via a 300ms long-press gate. Two-finger scroll also supported.
- **Paste**: Toolbar paste button using `document.execCommand('paste')`, which triggers Safari's native paste permission callout. Works on non-HTTPS origins (unlike `navigator.clipboard.readText()`). Native iOS paste popup is not possible on hidden textareas, confirmed by research (xterm.js has the same open issue #3727).
- **Backspace key repeat**: wterm calls `preventDefault()` on all keydown events, which kills iOS's key-repeat loop. Fixed with a capture-phase intercept that blocks wterm's handler for Backspace, letting iOS fire `deleteContentBackward` input events for each repeat tick. ZWS seed keeps the textarea non-empty so iOS always has something to delete.
- **Keyboard toggle**: FAB button is the sole way to open/close the soft keyboard. wterm's native click-to-focus is suppressed on mobile to prevent accidental keyboard toggling during scroll.
- **Pinch-to-zoom font size**: Two-finger pinch adjusts terminal font size with debounced persistence.
- **wterm textarea patches**: Moved from `-9999px` to `0,0` so iOS opens the keyboard on focus. Opacity overridden from `0` to `0.01` (iOS refuses paste callout on fully transparent elements).

### Removed (xterm.js era workarounds)

- Proxy input element (~120 lines)
- Auto-focus effects and redundant keyboard tracking
- `touch-action: none` (was blocking native long-press behaviors)

### wterm upstream issues identified

Two bugs worth reporting:
1. **Textarea at `-9999px` with `pointerEvents: none`**: Prevents iOS from opening the soft keyboard on focus. Terminal consumers must patch both to `left: 0` and `pointerEvents: auto`.
2. **`preventDefault()` on ALL keydown events**: Kills iOS key repeat for backspace/delete. Should only `preventDefault()` for keys wterm actually handles.

## Test plan

- [ ] Single-finger scroll works on iOS (swipe up/down)
- [ ] Two-finger scroll works on iOS
- [ ] Long-press enables text selection (not scroll)
- [ ] Pinch-to-zoom changes font size
- [ ] Toolbar paste button triggers Safari paste permission, pastes text
- [ ] Backspace hold-to-delete works (continuous deletion)
- [ ] FAB toggles keyboard open/closed
- [ ] Desktop terminal unaffected (scroll, zoom, keyboard all work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)