### PR TITLE
refactor: remove dead code and dedupe helpers across web + tui + server

### DIFF
--- a/src/tui/dialogs/new_session/path_input.rs
+++ b/src/tui/dialogs/new_session/path_input.rs
@@ -10,8 +10,6 @@ pub(in crate::tui::dialogs) struct PathGhostCompletion {
     pub(super) input_snapshot: String,
     pub(super) cursor_snapshot: usize,
     pub(super) ghost_text: String,
-    #[allow(dead_code)]
-    candidates: Vec<String>,
 }
 
 fn char_to_byte_idx(value: &str, char_idx: usize) -> usize {
@@ -136,7 +134,6 @@ pub(super) fn compute_path_ghost(input: &Input) -> Option<PathGhostCompletion> {
         input_snapshot: value,
         cursor_snapshot: cursor_char,
         ghost_text,
-        candidates: matches,
     })
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useCommandActions } from "./hooks/useCommandActions";
+import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
@@ -253,100 +254,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setSidebarOpen((o) => !o);
   }, []);
 
-  useEffect(() => {
-    if (sidebarOpen) return;
-    const EDGE_PX = 24;
-    const THRESHOLD_PX = 60;
-    let startX = 0;
-    let startY = 0;
-    let tracking = false;
-
-    const onTouchStart = (e: TouchEvent) => {
-      if (window.innerWidth >= 768 || e.touches.length !== 1) return;
-      const t = e.touches[0];
-      if (!t || t.clientX > EDGE_PX) return;
-      tracking = true;
-      startX = t.clientX;
-      startY = t.clientY;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      if (!tracking) return;
-      const t = e.touches[0];
-      if (!t) return;
-      const dx = t.clientX - startX;
-      const dy = t.clientY - startY;
-      if (dx > THRESHOLD_PX && Math.abs(dx) > Math.abs(dy)) {
-        tracking = false;
-        // Dismiss the soft keyboard before opening the sidebar
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur();
-        }
-        setSidebarOpen(true);
-      } else if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 16) {
-        tracking = false;
-      }
-    };
-    const onTouchEnd = () => {
-      tracking = false;
-    };
-
-    window.addEventListener("touchstart", onTouchStart, { passive: true });
-    window.addEventListener("touchmove", onTouchMove, { passive: true });
-    window.addEventListener("touchend", onTouchEnd, { passive: true });
-    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
-    return () => {
-      window.removeEventListener("touchstart", onTouchStart);
-      window.removeEventListener("touchmove", onTouchMove);
-      window.removeEventListener("touchend", onTouchEnd);
-      window.removeEventListener("touchcancel", onTouchEnd);
-    };
-  }, [sidebarOpen]);
-
-  // Right-edge swipe to open the diff/shell panel (mirrors left-edge sidebar swipe)
-  useEffect(() => {
-    if (!diffCollapsed || !activeSessionId) return;
-    const EDGE_PX = 24;
-    const THRESHOLD_PX = 60;
-    let startX = 0;
-    let startY = 0;
-    let tracking = false;
-
-    const onTouchStart = (e: TouchEvent) => {
-      if (window.innerWidth >= 768 || e.touches.length !== 1) return;
-      const t = e.touches[0];
-      if (!t || t.clientX < window.innerWidth - EDGE_PX) return;
-      tracking = true;
-      startX = t.clientX;
-      startY = t.clientY;
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      if (!tracking) return;
-      const t = e.touches[0];
-      if (!t) return;
-      const dx = startX - t.clientX;
-      const dy = t.clientY - startY;
-      if (dx > THRESHOLD_PX && Math.abs(dx) > Math.abs(dy)) {
-        tracking = false;
-        setDiffCollapsed(false);
-      } else if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > 16) {
-        tracking = false;
-      }
-    };
-    const onTouchEnd = () => {
-      tracking = false;
-    };
-
-    window.addEventListener("touchstart", onTouchStart, { passive: true });
-    window.addEventListener("touchmove", onTouchMove, { passive: true });
-    window.addEventListener("touchend", onTouchEnd, { passive: true });
-    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
-    return () => {
-      window.removeEventListener("touchstart", onTouchStart);
-      window.removeEventListener("touchmove", onTouchMove);
-      window.removeEventListener("touchend", onTouchEnd);
-      window.removeEventListener("touchcancel", onTouchEnd);
-    };
-  }, [diffCollapsed, activeSessionId]);
+  const openSidebar = useCallback(() => setSidebarOpen(true), []);
+  const openDiff = useCallback(() => setDiffCollapsed(false), []);
+  useEdgeSwipe({
+    edge: "left",
+    enabled: !sidebarOpen,
+    onSwipe: openSidebar,
+    blurOnSwipe: true,
+  });
+  useEdgeSwipe({
+    edge: "right",
+    enabled: diffCollapsed && !!activeSessionId,
+    onSwipe: openDiff,
+  });
 
   const handleNewSession = useCallback(() => {
     setWizardPrefill(undefined);
@@ -491,7 +411,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         <WorkspaceSidebar
           groups={groups}
           activeId={activeWorkspaceId}
-          creatingForProject={null}
           open={sidebarOpen}
           onToggle={() => setSidebarOpen(false)}
           onSelect={handleSelectWorkspace}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -14,7 +14,6 @@ const MAX_WIDTH = 480;
 interface Props {
   groups: RepoGroup[];
   activeId: string | null;
-  creatingForProject: string | null;
   open: boolean;
   onToggle: () => void;
   onSelect: (workspaceId: string) => void;
@@ -236,13 +235,11 @@ const SessionRow = memo(function SessionRow({
 const RepoGroupHeader = memo(function RepoGroupHeader({
   group,
   hasActiveChild,
-  creating,
   onClick,
   onNewSession,
 }: {
   group: RepoGroup;
   hasActiveChild: boolean;
-  creating: boolean;
   onClick: () => void;
   onNewSession: () => void;
 }) {
@@ -279,28 +276,16 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
           {group.displayName}
         </span>
       </button>
-      <Tooltip text={creating ? "Creating..." : "New session"}>
+      <Tooltip text="New session">
         <button
           onClick={onNewSession}
-          disabled={creating}
-          className={`w-8 h-8 flex items-center justify-center shrink-0 rounded-md transition-colors ${
-            creating
-              ? "text-text-dim cursor-not-allowed"
-              : "text-text-muted hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer"
-          }`}
+          className="w-8 h-8 flex items-center justify-center shrink-0 rounded-md transition-colors text-text-muted hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer"
           aria-label={`New session in ${group.displayName}`}
         >
-          {creating ? (
-            <svg className="animate-spin h-3.5 w-3.5" viewBox="0 0 24 24">
-              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" fill="none" />
-              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
-          ) : (
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-              <line x1="12" y1="5" x2="12" y2="19" />
-              <line x1="5" y1="12" x2="19" y2="12" />
-            </svg>
-          )}
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
         </button>
       </Tooltip>
     </div>
@@ -330,7 +315,6 @@ function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
 export function WorkspaceSidebar({
   groups,
   activeId,
-  creatingForProject,
   open,
   onToggle,
   onSelect,
@@ -520,7 +504,6 @@ export function WorkspaceSidebar({
                 <RepoGroupHeader
                   group={{ ...group, collapsed: !showExpanded }}
                   hasActiveChild={!showExpanded && hasActiveChild}
-                  creating={creatingForProject === group.repoPath}
                   onClick={() => !q && onToggleRepo(group.id)}
                   onNewSession={() => onCreateSession(group.repoPath)}
                 />

--- a/web/src/hooks/useEdgeSwipe.ts
+++ b/web/src/hooks/useEdgeSwipe.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+
+interface EdgeSwipeOptions {
+  edge: "left" | "right";
+  enabled: boolean;
+  onSwipe: () => void;
+  /** Before invoking onSwipe, blur the currently focused element. */
+  blurOnSwipe?: boolean;
+}
+
+const EDGE_PX = 24;
+const THRESHOLD_PX = 60;
+const VERTICAL_CANCEL_PX = 16;
+const MOBILE_BREAKPOINT = 768;
+
+/**
+ * Detect a one-finger swipe that starts at the left or right edge of the
+ * viewport and moves horizontally past a threshold. Used to open the sidebar
+ * (left edge) and the diff/right panel (right edge) on mobile.
+ */
+export function useEdgeSwipe({
+  edge,
+  enabled,
+  onSwipe,
+  blurOnSwipe = false,
+}: EdgeSwipeOptions) {
+  useEffect(() => {
+    if (!enabled) return;
+
+    let startX = 0;
+    let startY = 0;
+    let tracking = false;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (window.innerWidth >= MOBILE_BREAKPOINT || e.touches.length !== 1) return;
+      const t = e.touches[0];
+      if (!t) return;
+      const inEdge =
+        edge === "left"
+          ? t.clientX <= EDGE_PX
+          : t.clientX >= window.innerWidth - EDGE_PX;
+      if (!inEdge) return;
+      tracking = true;
+      startX = t.clientX;
+      startY = t.clientY;
+    };
+
+    const onTouchMove = (e: TouchEvent) => {
+      if (!tracking) return;
+      const t = e.touches[0];
+      if (!t) return;
+      const dx = edge === "left" ? t.clientX - startX : startX - t.clientX;
+      const dy = t.clientY - startY;
+      if (dx > THRESHOLD_PX && Math.abs(dx) > Math.abs(dy)) {
+        tracking = false;
+        if (blurOnSwipe && document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+        onSwipe();
+      } else if (Math.abs(dy) > Math.abs(dx) && Math.abs(dy) > VERTICAL_CANCEL_PX) {
+        tracking = false;
+      }
+    };
+
+    const onTouchEnd = () => {
+      tracking = false;
+    };
+
+    window.addEventListener("touchstart", onTouchStart, { passive: true });
+    window.addEventListener("touchmove", onTouchMove, { passive: true });
+    window.addEventListener("touchend", onTouchEnd, { passive: true });
+    window.addEventListener("touchcancel", onTouchEnd, { passive: true });
+    return () => {
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
+      window.removeEventListener("touchcancel", onTouchEnd);
+    };
+  }, [edge, enabled, onSwipe, blurOnSwipe]);
+}

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -17,8 +17,7 @@ export function useSessions() {
     });
   }, []);
 
-  const refresh = useCallback(async () => {
-    const data = await fetchSessions();
+  const applyResult = useCallback((data: SessionResponse[] | null) => {
     if (data !== null) {
       setSessions(data);
       setError(false);
@@ -29,37 +28,20 @@ export function useSessions() {
     }
   }, []);
 
+  const refresh = useCallback(async () => {
+    applyResult(await fetchSessions());
+  }, [applyResult]);
+
   useEffect(() => {
-    // Initial fetch
-    void fetchSessions().then((data) => {
-      if (data !== null) {
-        setSessions(data);
-        setError(false);
-        setServerDown(false);
-      } else {
-        setError(true);
-        setServerDown(true);
-      }
-    });
-
-    // Polling
-    intervalRef.current = setInterval(() => {
-      void fetchSessions().then((data) => {
-        if (data !== null) {
-          setSessions(data);
-          setError(false);
-          setServerDown(false);
-        } else {
-          setError(true);
-          setServerDown(true);
-        }
-      });
-    }, POLL_INTERVAL);
-
+    void fetchSessions().then(applyResult);
+    intervalRef.current = setInterval(
+      () => void fetchSessions().then(applyResult),
+      POLL_INTERVAL,
+    );
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);
     };
-  }, []);
+  }, [applyResult]);
 
   const setSessionStatus = useCallback((id: string, status: SessionResponse["status"]) => {
     setSessions((prev) => prev.map((s) => s.id === id ? { ...s, status } : s));

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,22 +5,26 @@ import type {
   AgentInfo,
   ProfileInfo,
   BrowseResponse,
-  BranchInfo,
   GroupInfo,
   DockerStatusResponse,
   CreateSessionRequest,
 } from "./types";
 
-// --- Sessions ---
-
-export async function fetchSessions(): Promise<SessionResponse[] | null> {
+// GET a JSON endpoint; returns null on non-2xx or network/parse errors.
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T | null> {
   try {
-    const res = await fetch("/api/sessions");
+    const res = await fetch(url, init);
     if (!res.ok) return null;
-    return await res.json();
+    return (await res.json()) as T;
   } catch {
     return null;
   }
+}
+
+// --- Sessions ---
+
+export function fetchSessions(): Promise<SessionResponse[] | null> {
+  return fetchJson<SessionResponse[]>("/api/sessions");
 }
 
 export interface EnsureSessionResult {
@@ -80,44 +84,26 @@ export async function ensureTerminal(
   }
 }
 
-export async function getSessionDiffFiles(
+export function getSessionDiffFiles(
   id: string,
 ): Promise<RichDiffFilesResponse | null> {
-  try {
-    const res = await fetch(`/api/sessions/${id}/diff/files`);
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+  return fetchJson<RichDiffFilesResponse>(`/api/sessions/${id}/diff/files`);
 }
 
-export async function getSessionFileDiff(
+export function getSessionFileDiff(
   id: string,
   filePath: string,
 ): Promise<RichFileDiffResponse | null> {
-  try {
-    const res = await fetch(
-      `/api/sessions/${id}/diff/file?path=${encodeURIComponent(filePath)}`,
-    );
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+  return fetchJson<RichFileDiffResponse>(
+    `/api/sessions/${id}/diff/file?path=${encodeURIComponent(filePath)}`,
+  );
 }
 
 // --- Settings ---
 
-export async function getSettings(profile?: string): Promise<Record<string, unknown> | null> {
-  try {
-    const params = profile ? `?profile=${encodeURIComponent(profile)}` : "";
-    const res = await fetch(`/api/settings${params}`);
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+export function getSettings(profile?: string): Promise<Record<string, unknown> | null> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : "";
+  return fetchJson<Record<string, unknown>>(`/api/settings${params}`);
 }
 
 export async function updateSettings(
@@ -146,14 +132,8 @@ export interface ServerAbout {
   profile: string;
 }
 
-export async function fetchAbout(): Promise<ServerAbout | null> {
-  try {
-    const res = await fetch("/api/about");
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
+export function fetchAbout(): Promise<ServerAbout | null> {
+  return fetchJson<ServerAbout>("/api/about");
 }
 
 // --- Devices ---
@@ -166,107 +146,47 @@ export interface DeviceInfo {
   request_count: number;
 }
 
-export async function fetchDevices(): Promise<DeviceInfo[] | null> {
-  try {
-    const res = await fetch("/api/devices");
-    if (!res.ok) return null;
-    return await res.json();
-  } catch {
-    return null;
-  }
-}
-
-// --- Themes ---
-
-export async function fetchThemes(): Promise<string[]> {
-  try {
-    const res = await fetch("/api/themes");
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
-    return [];
-  }
+export function fetchDevices(): Promise<DeviceInfo[] | null> {
+  return fetchJson<DeviceInfo[]>("/api/devices");
 }
 
 // --- Wizard APIs ---
 
 export async function fetchAgents(): Promise<AgentInfo[]> {
-  try {
-    const res = await fetch("/api/agents");
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
-    return [];
-  }
+  return (await fetchJson<AgentInfo[]>("/api/agents")) ?? [];
 }
 
 export async function fetchProfiles(): Promise<ProfileInfo[]> {
-  try {
-    const res = await fetch("/api/profiles");
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
-    return [];
-  }
+  return (await fetchJson<ProfileInfo[]>("/api/profiles")) ?? [];
 }
 
 export async function getHomePath(): Promise<string | null> {
-  try {
-    const res = await fetch("/api/filesystem/home");
-    if (!res.ok) return null;
-    const data = await res.json();
-    return data.path ?? null;
-  } catch {
-    return null;
-  }
+  const data = await fetchJson<{ path?: string }>("/api/filesystem/home");
+  return data?.path ?? null;
 }
 
 export async function browseFilesystem(
   path: string,
   limit?: number,
 ): Promise<BrowseResponse & { ok: boolean }> {
-  try {
-    const params = new URLSearchParams({ path });
-    if (limit != null) params.set("limit", String(limit));
-    const res = await fetch(`/api/filesystem/browse?${params}`);
-    if (!res.ok) return { entries: [], has_more: false, ok: false };
-    const data = await res.json();
-    return { ...data, ok: true };
-  } catch {
-    return { entries: [], has_more: false, ok: false };
-  }
-}
-
-export async function fetchBranches(path: string): Promise<BranchInfo[]> {
-  try {
-    const res = await fetch(
-      `/api/git/branches?path=${encodeURIComponent(path)}`,
-    );
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
-    return [];
-  }
+  const params = new URLSearchParams({ path });
+  if (limit != null) params.set("limit", String(limit));
+  const data = await fetchJson<BrowseResponse>(`/api/filesystem/browse?${params}`);
+  if (!data) return { entries: [], has_more: false, ok: false };
+  return { ...data, ok: true };
 }
 
 export async function fetchGroups(): Promise<GroupInfo[]> {
-  try {
-    const res = await fetch("/api/groups");
-    if (!res.ok) return [];
-    return await res.json();
-  } catch {
-    return [];
-  }
+  return (await fetchJson<GroupInfo[]>("/api/groups")) ?? [];
 }
 
 export async function fetchDockerStatus(): Promise<DockerStatusResponse> {
-  try {
-    const res = await fetch("/api/docker/status");
-    if (!res.ok) return { available: false, runtime: null };
-    return await res.json();
-  } catch {
-    return { available: false, runtime: null };
-  }
+  return (
+    (await fetchJson<DockerStatusResponse>("/api/docker/status")) ?? {
+      available: false,
+      runtime: null,
+    }
+  );
 }
 
 export async function createSession(
@@ -340,13 +260,11 @@ export async function loginStatus(): Promise<{
   required: boolean;
   authenticated: boolean;
 }> {
-  try {
-    const res = await fetch("/api/login/status");
-    if (!res.ok) return { required: false, authenticated: true };
-    return await res.json();
-  } catch {
-    return { required: false, authenticated: true };
-  }
+  return (
+    (await fetchJson<{ required: boolean; authenticated: boolean }>(
+      "/api/login/status",
+    )) ?? { required: false, authenticated: true }
+  );
 }
 
 export async function login(

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -140,12 +140,6 @@ export interface BrowseResponse {
   has_more: boolean;
 }
 
-/** Branch info returned by /api/git/branches */
-export interface BranchInfo {
-  name: string;
-  is_current: boolean;
-}
-
 /** Group info returned by /api/groups */
 export interface GroupInfo {
   path: string;


### PR DESCRIPTION
## Description

Cleanup pass across `web/`, `src/tui/`, and one stray clippy warning in `src/server/`. Two parallel analysis agents (Explore subagents) audited the web app and the TUI/CLI for dead code, duplication, and obvious refactor opportunities. Speculative or architectural recommendations were intentionally skipped per CLAUDE.md guidance; only clear, localized wins landed here.

### Web (`web/src/`)

- **Dead code removed**
  - `fetchThemes()` and `fetchBranches()` in `lib/api.ts` — no call sites anywhere.
  - `BranchInfo` interface in `lib/types.ts` — only used by the now-dead `fetchBranches`.
  - `creatingForProject` prop on `WorkspaceSidebar` — always passed `null` from `App.tsx`; the entire "Creating..." spinner branch in `RepoGroupHeader` was unreachable.
- **Dedupe**
  - New `useEdgeSwipe` hook replaces two nearly-identical ~45-line touch handlers in `App.tsx` (left-edge sidebar open, right-edge diff open).
  - New `fetchJson<T>` helper in `lib/api.ts` collapses the repeated try/res.ok/json/catch pattern across ~10 GET functions.
  - `useSessions` hook: initial-fetch and polling branches both applied the same 6-line result handler. Extracted into one \`applyResult\` callback.

### TUI (`src/tui/`)

- Dropped the unused \`candidates: Vec<String>\` field on \`PathGhostCompletion\` that was marked \`#[allow(dead_code)]\`.

### Server (`src/server/`)

- Removed a useless \`.into()\` conversion flagged by \`clippy::useless_conversion\`.

### Net

+156 / -283 across 8 files (1 new file: useEdgeSwipe.ts).

## PR Type

- [x] Refactor

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo test --lib\`: 1054 passed; \`npm run build\` + \`tsc -b\` clean; \`cargo clippy --features serve\` clean)
- [x] Documentation was updated where necessary (no docs affected)
- [x] For UI changes: no visual/UX changes — pure refactor preserving behavior

## How I verified

- \`cd web && npm run build\` — passes (tsc + vite).
- \`cd web && npx eslint .\` — same pre-existing 17 findings as main; zero new.
- \`cargo fmt && cargo clippy --features serve --lib --bins --no-deps\` — clean.
- \`cargo test --lib\` — 1054 passed / 0 failed.
- Web Playwright tests not run here (require a running \`aoe serve\`); reviewer should sanity-check the mobile swipe behavior on a device since that is the only observable behavior change.

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details:** Dead-code audit and design-flaw audit were each run as separate Explore subagents in parallel. Recommendations like extracting a Context to eliminate prop drilling, unifying TerminalView/PairedTerminal, adding focus-trap to modals, and rewriting api.ts with discriminated-union error types were intentionally rejected as out-of-scope speculative refactors.

- [x] I am an AI Agent filling out this form (check box if true)