### PR TITLE
fix(server): drop useless .into() in get_settings handler

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -1439,7 +1439,7 @@ pub async fn get_settings(
     let config_result = if let Some(ref profile_name) = query.profile {
         crate::session::resolve_config(profile_name)
     } else {
-        crate::session::Config::load().map_err(|e| e.into())
+        crate::session::Config::load()
     };
 
     match config_result {


### PR DESCRIPTION
## Description

One-line fix for \`clippy::useless_conversion\` at \`src/server/api.rs:1442\`. \`Config::load()\` already returns \`Result<Config, anyhow::Error>\`, so the trailing \`map_err(|e| e.into())\` was a no-op.

Before:
\`\`\`rust
crate::session::Config::load().map_err(|e| e.into())
\`\`\`
After:
\`\`\`rust
crate::session::Config::load()
\`\`\`

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo clippy --features serve\` now clean; \`cargo test --lib\` 1054 passed)
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: N/A

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details:** Spun off from a larger refactor PR (#737) to keep scope tight.

- [x] I am an AI Agent filling out this form (check box if true)