### PR TITLE
Dashboard hardening: WS backoff, CSP, cleanup-cache struct

### DIFF
--- a/src/server/api.rs
+++ b/src/server/api.rs
@@ -106,13 +106,13 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
     let instances = state.instances.read().await;
     let mut sessions: Vec<SessionResponse> = instances.iter().map(SessionResponse::from).collect();
 
-    // Resolve per-profile cleanup defaults with a 30s TTL cache on AppState
+    // Resolve per-profile cleanup defaults with a TTL cache on AppState
     let cache = {
         let guard = state.cleanup_defaults_cache.read().await;
-        if guard.0.elapsed() < std::time::Duration::from_secs(30) {
-            Some(guard.1.clone())
-        } else {
+        if guard.stale() {
             None
+        } else {
+            Some(guard.entries.clone())
         }
     };
 
@@ -136,7 +136,10 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
                     })
             });
         }
-        *state.cleanup_defaults_cache.write().await = (std::time::Instant::now(), fresh.clone());
+        *state.cleanup_defaults_cache.write().await = super::CleanupDefaultsCache {
+            refreshed_at: std::time::Instant::now(),
+            entries: fresh.clone(),
+        };
         fresh
     };
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -146,6 +146,21 @@ impl TokenManager {
 
 // ── AppState ────────────────────────────────────────────────────────────────
 
+/// Per-profile cleanup defaults with a refresh timestamp. Re-resolved from
+/// disk after `CLEANUP_DEFAULTS_TTL`.
+pub struct CleanupDefaultsCache {
+    pub refreshed_at: std::time::Instant,
+    pub entries: std::collections::HashMap<String, api::CleanupDefaults>,
+}
+
+pub const CLEANUP_DEFAULTS_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+
+impl CleanupDefaultsCache {
+    pub fn stale(&self) -> bool {
+        self.refreshed_at.elapsed() >= CLEANUP_DEFAULTS_TTL
+    }
+}
+
 /// Shared application state accessible by all request handlers.
 pub struct AppState {
     pub profile: String,
@@ -162,11 +177,9 @@ pub struct AppState {
     /// as many as the user has sessions.
     pub instance_locks: RwLock<std::collections::HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
     /// Cached per-profile cleanup defaults for the delete dialog, with a
-    /// timestamp so we re-resolve after config changes. TTL: 30 seconds.
-    pub cleanup_defaults_cache: RwLock<(
-        std::time::Instant,
-        std::collections::HashMap<String, api::CleanupDefaults>,
-    )>,
+    /// timestamp so we re-resolve after config changes (see
+    /// `CLEANUP_DEFAULTS_TTL`).
+    pub cleanup_defaults_cache: RwLock<CleanupDefaultsCache>,
     /// Cached remote owner per repo path. Remote owners don't change, so
     /// entries live for the lifetime of the process.
     pub remote_owner_cache: RwLock<std::collections::HashMap<String, Option<String>>>,
@@ -256,10 +269,12 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         devices: RwLock::new(Vec::new()),
         behind_tunnel: remote,
         instance_locks: RwLock::new(std::collections::HashMap::new()),
-        cleanup_defaults_cache: RwLock::new((
-            std::time::Instant::now() - std::time::Duration::from_secs(60),
-            std::collections::HashMap::new(),
-        )),
+        cleanup_defaults_cache: RwLock::new(CleanupDefaultsCache {
+            // Seed with an already-stale timestamp so the first request
+            // forces a fresh resolve instead of handing out an empty map.
+            refreshed_at: std::time::Instant::now() - CLEANUP_DEFAULTS_TTL,
+            entries: std::collections::HashMap::new(),
+        }),
         remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
     });
 
@@ -807,6 +822,26 @@ mod tests {
         let mut v = [IpKind::Loopback, IpKind::Lan, IpKind::Tailscale];
         v.sort();
         assert_eq!(v, [IpKind::Tailscale, IpKind::Lan, IpKind::Loopback]);
+    }
+
+    #[test]
+    fn cleanup_defaults_cache_stale_within_ttl_is_false() {
+        let cache = CleanupDefaultsCache {
+            refreshed_at: std::time::Instant::now(),
+            entries: std::collections::HashMap::new(),
+        };
+        assert!(!cache.stale());
+    }
+
+    #[test]
+    fn cleanup_defaults_cache_stale_past_ttl_is_true() {
+        let cache = CleanupDefaultsCache {
+            refreshed_at: std::time::Instant::now()
+                - CLEANUP_DEFAULTS_TTL
+                - std::time::Duration::from_millis(1),
+            entries: std::collections::HashMap::new(),
+        };
+        assert!(cache.stale());
     }
 
     #[tokio::test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -502,6 +502,34 @@ fn build_router(state: Arc<AppState>) -> Router {
         .with_state(state)
 }
 
+/// Content-Security-Policy for the dashboard.
+///
+/// - `default-src 'self'`: deny everything we don't explicitly allow.
+/// - `script-src 'self' 'wasm-unsafe-eval'`: wterm compiles WebAssembly;
+///   the `wasm-unsafe-eval` source is the CSP3 opt-in for WASM compilation.
+/// - `style-src 'self' 'unsafe-inline'`: React writes to element.style at
+///   runtime (terminal theme vars, font-size updates) and Tailwind v4 emits
+///   inline `<style>` blocks in dev. Blocking inline styles breaks wterm.
+/// - `img-src 'self' data: https://github.com https://avatars.githubusercontent.com`:
+///   repo-owner avatars are loaded from `github.com/{user}.png` which 302s
+///   to `avatars.githubusercontent.com`; CSP checks both URLs across the
+///   redirect, so both hosts must be allowed. `data:` covers inline icons.
+/// - `font-src 'self'`: Geist fonts are bundled under /fonts/.
+/// - `connect-src 'self' ws: wss:`: REST + PTY WebSocket to same origin.
+/// - `frame-ancestors 'none'`: CSP-native equivalent of X-Frame-Options.
+/// - `base-uri 'self'`, `form-action 'self'`, `object-src 'none'`: tighten
+///   the usual attack surfaces on injection bugs.
+const CSP: &str = "default-src 'self'; \
+    script-src 'self' 'wasm-unsafe-eval'; \
+    style-src 'self' 'unsafe-inline'; \
+    img-src 'self' data: https://github.com https://avatars.githubusercontent.com; \
+    font-src 'self'; \
+    connect-src 'self' ws: wss:; \
+    frame-ancestors 'none'; \
+    base-uri 'self'; \
+    form-action 'self'; \
+    object-src 'none'";
+
 /// Middleware that adds security headers to all responses.
 async fn security_headers(
     request: axum::extract::Request,
@@ -512,6 +540,7 @@ async fn security_headers(
     headers.insert("x-frame-options", "DENY".parse().unwrap());
     headers.insert("x-content-type-options", "nosniff".parse().unwrap());
     headers.insert("referrer-policy", "no-referrer".parse().unwrap());
+    headers.insert("content-security-policy", CSP.parse().unwrap());
     response
 }
 
@@ -822,6 +851,29 @@ mod tests {
         let mut v = [IpKind::Loopback, IpKind::Lan, IpKind::Tailscale];
         v.sort();
         assert_eq!(v, [IpKind::Tailscale, IpKind::Lan, IpKind::Loopback]);
+    }
+
+    #[test]
+    fn csp_parses_as_valid_header_value() {
+        // Catches typos that would make the header unparseable.
+        // security_headers() calls `.parse().unwrap()` at request time;
+        // this test surfaces any regression at `cargo test` time instead.
+        let parsed: axum::http::HeaderValue = CSP.parse().expect("CSP must parse");
+        let rendered = parsed.to_str().expect("CSP must be ASCII");
+        // Spot-check load-bearing directives so a future edit that
+        // accidentally drops one fails loudly.
+        for needle in [
+            "default-src 'self'",
+            "'wasm-unsafe-eval'",
+            "img-src 'self' data: https://github.com https://avatars.githubusercontent.com",
+            "connect-src 'self' ws: wss:",
+            "frame-ancestors 'none'",
+        ] {
+            assert!(
+                rendered.contains(needle),
+                "CSP is missing required directive fragment `{needle}`"
+            );
+        }
     }
 
     #[test]

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -4,8 +4,14 @@ import type { ResizeMessage } from "../lib/types";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 
-const MAX_RETRIES = 3;
-const RETRY_DELAY = 5000;
+// Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s (cap). Seven attempts
+// cover typical tunnel restarts and transient WiFi drops without flooding
+// the server or burning the user's battery on a truly dead backend.
+const MAX_RETRIES = 7;
+const RETRY_BASE_MS = 1000;
+const RETRY_CAP_MS = 30000;
+const retryDelayMs = (attempt: number) =>
+  Math.min(RETRY_CAP_MS, RETRY_BASE_MS * 2 ** (attempt - 1));
 const MIN_FONT_SIZE = 6;
 const MAX_FONT_SIZE = 28;
 const DEFAULT_FONT_SIZE = 14;
@@ -260,7 +266,8 @@ export function useTerminal(
         if (retryCountRef.current < MAX_RETRIES) {
           retryCountRef.current += 1;
           const count = retryCountRef.current;
-          let countdown = RETRY_DELAY / 1000;
+          const delayMs = retryDelayMs(count);
+          let countdown = Math.ceil(delayMs / 1000);
 
           setState({
             connected: false,
@@ -283,7 +290,7 @@ export function useTerminal(
           retryTimerRef.current = setTimeout(() => {
             if (countdownRef.current) clearInterval(countdownRef.current);
             connect();
-          }, RETRY_DELAY);
+          }, delayMs);
         } else {
           term.write(
             "\r\n\x1b[31m[Connection lost. Click retry or press Enter to reconnect.]\x1b[0m\r\n",

--- a/web/tests/ws-reconnect.spec.ts
+++ b/web/tests/ws-reconnect.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Verifies useTerminal.ts reconnects after a WS drop and that the first
+// retry fires within the expected ~1s exponential-backoff window (not the
+// old fixed 5s). Guards against regressions to the backoff constants.
+//
+// Note: we can't use installTerminalSpies here, because Playwright's
+// page.routeWebSocket installs its own WebSocket proxy AFTER addInitScript
+// runs, which overwrites any window.WebSocket patch. Instead we count
+// connection attempts in the route handler (Node side) and assert on that.
+
+async function mockApisExceptWs(page: Page, sessionTitle: string) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: [
+        {
+          id: sessionTitle,
+          title: sessionTitle,
+          project_path: `/tmp/${sessionTitle}`,
+          group_path: "/tmp",
+          tool: "claude",
+          status: "Running",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+        },
+      ],
+    });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) =>
+    r.fulfill({ json: { ok: true } }),
+  );
+  await page.route("**/api/sessions/*/terminal", (r) =>
+    r.fulfill({ status: 200, body: "" }),
+  );
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({ json: { files: [] } }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+async function openSession(page: Page, title: string) {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+  // The sidebar renders a repo-group header and a nested session row with
+  // the same text. Click the nested (last) one to open the session.
+  await page.locator("button").filter({ hasText: title }).last().click();
+  await page.locator(".wterm").first().waitFor({ state: "visible", timeout: 10_000 });
+}
+
+test.describe("Terminal WebSocket reconnection", () => {
+  test("reconnects after a dropped connection", async ({ page }) => {
+    const title = "reconnect-test";
+    await mockApisExceptWs(page, title);
+
+    // Side-channel WS (shell host terminal, container ws): keep them open
+    // and mute so they don't affect our main-terminal reconnect observations.
+    await page.routeWebSocket(
+      /\/sessions\/[^/]+\/(terminal\/ws|container-ws)$/,
+      (ws) => {
+        ws.onMessage(() => {});
+      },
+    );
+
+    let attempts = 0;
+    let firstClosedAt = 0;
+    let secondOpenedAt = 0;
+    await page.routeWebSocket(/\/sessions\/[^/]+\/ws$/, (ws) => {
+      attempts += 1;
+      const attemptNum = attempts;
+      ws.onMessage(() => {});
+      setTimeout(() => {
+        try {
+          ws.send(Buffer.from("$ "));
+        } catch {
+          /* may be closed */
+        }
+      }, 30);
+      if (attemptNum === 1) {
+        setTimeout(() => {
+          firstClosedAt = Date.now();
+          try {
+            ws.close();
+          } catch {
+            /* already closed */
+          }
+        }, 150);
+      } else if (attemptNum === 2) {
+        secondOpenedAt = Date.now();
+      }
+    });
+
+    await openSession(page, title);
+
+    // Wait for the reconnect to fire. First retry should be ~1s after the
+    // drop. 5s upper bound fails fast if we regressed to the old 5s delay.
+    await expect.poll(() => attempts, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
+
+    // Guard: both timestamps must have been set. Without this check, a 0
+    // firstClosedAt would make elapsed comically large and the < 3000
+    // assertion would dominate with a misleading message.
+    expect(firstClosedAt).toBeGreaterThan(0);
+    expect(secondOpenedAt).toBeGreaterThan(0);
+
+    // First retry is scheduled at 1s backoff. Allow 500-3000ms to absorb
+    // Playwright latency while still catching a regression to the old 5s.
+    const elapsed = secondOpenedAt - firstClosedAt;
+    expect(elapsed).toBeGreaterThan(500);
+    expect(elapsed).toBeLessThan(3_000);
+
+    // Second connection should be stable, no further reconnects.
+    await page.waitForTimeout(1_500);
+    expect(attempts).toBe(2);
+  });
+
+  test("retries more than the old max of 3", async ({ page }) => {
+    // The old hardcoded MAX_RETRIES was 3. The new value is 7 with
+    // exponential backoff (1s, 2s, 4s, …). We don't wait the full schedule;
+    // we just verify the counter climbs past the old limit to prove the new
+    // constant is in effect. Budget: ~1+2+4 = 7s for 4 total attempts.
+    const title = "retry-test";
+    await mockApisExceptWs(page, title);
+
+    await page.routeWebSocket(
+      /\/sessions\/[^/]+\/(terminal\/ws|container-ws)$/,
+      (ws) => {
+        ws.onMessage(() => {});
+      },
+    );
+
+    let attempts = 0;
+    await page.routeWebSocket(/\/sessions\/[^/]+\/ws$/, (ws) => {
+      attempts += 1;
+      ws.onMessage(() => {});
+      setTimeout(() => {
+        try {
+          ws.close();
+        } catch {
+          /* already closed */
+        }
+      }, 30);
+    });
+
+    await openSession(page, title);
+
+    await expect
+      .poll(() => attempts, { timeout: 15_000, intervals: [100, 250] })
+      .toBeGreaterThanOrEqual(4);
+  });
+});


### PR DESCRIPTION
## Description

Three small, independent hardening tweaks to the web dashboard stack, surfaced from an audit of `src/server/` + `web/`. Each commit stands alone.

**1. `fix(web): exponential backoff on WS reconnect`** — The PTY WebSocket retried at a fixed 5s × 3 (15s total). A transient tunnel restart or WiFi blip ate a 5s wait even though the server was back; a truly dead backend had the client giving up in 15s. Replaced with 7 attempts on an exponential curve (1s, 2s, 4s, 8s, 16s, 30s, 30s cap). Adds `web/tests/ws-reconnect.spec.ts` — one test drops the first WS and asserts the retry lands in a 0.5–3s window (fails fast on a regression to 5s); the other proves the attempt counter climbs past the old cap of 3.

**2. `feat(server): set Content-Security-Policy on dashboard responses`** — The `security_headers` middleware only set \`X-Frame-Options\` / \`X-Content-Type-Options\` / \`Referrer-Policy\`. A reflected-XSS bug in any handler would run with zero in-browser mitigation. Adds a scoped CSP with \`wasm-unsafe-eval\` for wterm, \`'unsafe-inline'\` style-src for React's runtime \`element.style\` writes, \`https://github.com\` in \`img-src\` for repo-owner avatars, and \`frame-ancestors 'none'\` + \`object-src 'none'\` for the usual defenses. Every directive is commented so future edits know what depends on it.

**3. `refactor(server): replace cleanup_defaults_cache tuple with named struct`** — The per-profile delete-dialog defaults cache was \`RwLock<(Instant, HashMap)>\`. Tuple-index access (\`.0\`, \`.1\`) is easy to misread, and the 30s TTL was an anonymous magic number at every call site. Promoted to \`CleanupDefaultsCache { refreshed_at, entries }\` + \`CLEANUP_DEFAULTS_TTL\` + \`stale()\` method. Pure readability; no behavior change.

## Context

Grew out of a broader audit of the web dashboard stack. Several issues the audit surfaced turned out to be false positives after reading the code (token-rotation handling already exists in \`fetchInterceptor.ts\`, \`create_session\` already checks read-only, \`Deleting\` sessions are already disabled in the sidebar, the PTY channel isn't silently dropping — \`blocking_send\` backpressures). This PR ships the verified-real ones.

## PR Type

- [ ] New Feature
- [x] Bug Fix (WS backoff)
- [x] Refactor (cleanup-cache struct)
- [x] Infrastructure / CI (CSP header, Playwright test)

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo test --features serve --lib server::\` 76/76; \`ws-reconnect.spec.ts\` 2/2)
- [x] Documentation was updated where necessary (every CSP directive is commented inline)
- [ ] For UI changes: included screenshot or recording — no visible UI change

## Testing

- \`cargo check --features serve\` + \`cargo clippy --features serve --lib\` — clean
- \`cargo test --features serve --lib server::\` — 76/76
- \`cargo fmt --check\` — clean
- \`npx eslint\` on changed files — clean
- \`npx playwright test ws-reconnect.spec.ts\` — 2/2

Pre-existing failures in \`dashboard.spec.ts\`, \`pinch-zoom*.spec.ts\`, and \`ensure-session-restart.spec.ts\` were confirmed broken on main before these changes (verified by stashing and re-running). Out of scope here.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Audit + implementation + tests all from one session. The initial audit overclaimed — five findings were discarded after verifying them against the source. The three commits here are the ones that survived verification.

- [x] I am an AI Agent filling out this form (check box if true)