### PR TITLE
fix(server): prevent daemon orphaning on failed re-spawn

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -282,13 +282,21 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     })
     .await;
 
-    // Clean up PID and URL files on exit
+    // Clean up PID and URL files on exit, but only if the PID file
+    // still belongs to this process. A newer daemon spawn may have
+    // overwritten it; removing their file would orphan them.
     if let Ok(path) = pid_file_path() {
-        let _ = std::fs::remove_file(path);
-    }
-    if let Ok(dir) = crate::session::get_app_dir() {
-        let _ = std::fs::remove_file(dir.join("serve.url"));
-        let _ = std::fs::remove_file(dir.join("serve.mode"));
+        let is_ours = std::fs::read_to_string(&path)
+            .ok()
+            .and_then(|s| s.trim().parse::<u32>().ok())
+            .is_some_and(|pid| pid == std::process::id());
+        if is_ours {
+            let _ = std::fs::remove_file(&path);
+            if let Ok(dir) = crate::session::get_app_dir() {
+                let _ = std::fs::remove_file(dir.join("serve.url"));
+                let _ = std::fs::remove_file(dir.join("serve.mode"));
+            }
+        }
     }
 
     result
@@ -304,6 +312,19 @@ pub fn daemon_log_path() -> Result<PathBuf> {
 
 fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     use std::process::{Command, Stdio};
+
+    // Refuse to spawn if another daemon is already running. The TUI
+    // dialog checks daemon_pid() before reaching here, but a CLI user
+    // could call `aoe serve --daemon` twice, and a race between the
+    // TUI check and this function could overwrite the PID file and
+    // orphan the existing daemon.
+    if let Some(existing) = daemon_pid() {
+        bail!(
+            "A serve daemon is already running (PID {}). \
+             Stop it first with `aoe serve --stop`.",
+            existing
+        );
+    }
 
     let exe = std::env::current_exe()?;
     let mut cmd = Command::new(exe);
@@ -417,7 +438,36 @@ fn stop_daemon() -> Result<()> {
         nix::sys::signal::Signal::SIGTERM,
     ) {
         Ok(()) => {
-            std::fs::remove_file(&path)?;
+            // Wait for the process to actually exit so the port is
+            // released before a new daemon can be spawned. Without
+            // this, closing the dialog and immediately reopening
+            // races with the dying daemon and can orphan it.
+            let deadline =
+                std::time::Instant::now() + std::time::Duration::from_secs(2);
+            loop {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+                match nix::sys::signal::kill(
+                    nix::unistd::Pid::from_raw(pid),
+                    None,
+                ) {
+                    Err(nix::errno::Errno::ESRCH) => break,
+                    _ if std::time::Instant::now() >= deadline => {
+                        // Still alive after timeout; escalate.
+                        let _ = nix::sys::signal::kill(
+                            nix::unistd::Pid::from_raw(pid),
+                            nix::sys::signal::Signal::SIGKILL,
+                        );
+                        std::thread::sleep(
+                            std::time::Duration::from_millis(50),
+                        );
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            // The daemon's own cleanup may have already removed some
+            // of these; that's fine.
+            let _ = std::fs::remove_file(&path);
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.log"));

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -594,6 +594,17 @@ impl ServeDialog {
 fn spawn_daemon(mode: ServeMode, passphrase: Option<&str>) -> Result<(), String> {
     use std::process::Command;
 
+    // Guard: refuse to spawn if a daemon is already running. The dialog
+    // constructor checks daemon_pid() and skips to Active, but there is
+    // a window between that check and reaching here (user navigating
+    // ModePicker). A spawn here would overwrite the PID file and orphan
+    // the existing daemon.
+    if crate::cli::serve::daemon_pid().is_some() {
+        return Err(
+            "A daemon is already running. Close this dialog and reopen to see it.".to_string(),
+        );
+    }
+
     let exe =
         std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
 


### PR DESCRIPTION
## Description

Fixes a bug where an `aoe serve` daemon can become orphaned (still running, still holding the port, but no PID file to track or stop it). This happens when:

1. `stop_daemon()` removes `serve.pid` immediately after sending SIGTERM, before the daemon actually exits
2. User reopens the serve dialog, sees no daemon running, spawns a new one
3. New daemon fails to bind (port still held by the dying daemon), and its exit cleanup removes `serve.pid`
4. Original daemon is now untracked with no way to stop it via `aoe serve --stop`

Three guards now prevent this:

- **PID-owned cleanup**: daemon exit only removes `serve.pid` if the PID in the file matches `std::process::id()`, preventing a failed daemon from deleting another daemon's tracking file
- **Pre-spawn guard**: `start_daemon()` and the TUI's `spawn_daemon()` check `daemon_pid()` before spawning, refusing to overwrite a live daemon's PID file
- **Wait-for-exit**: `stop_daemon()` polls `kill(pid, 0)` for up to 2s after SIGTERM (escalating to SIGKILL on timeout) before removing the PID file, closing the race window

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)