### PR TITLE
fix(ci): apply cargo fmt to serve.rs

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -442,14 +442,10 @@ fn stop_daemon() -> Result<()> {
             // released before a new daemon can be spawned. Without
             // this, closing the dialog and immediately reopening
             // races with the dying daemon and can orphan it.
-            let deadline =
-                std::time::Instant::now() + std::time::Duration::from_secs(2);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
             loop {
                 std::thread::sleep(std::time::Duration::from_millis(50));
-                match nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(pid),
-                    None,
-                ) {
+                match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
                     Err(nix::errno::Errno::ESRCH) => break,
                     _ if std::time::Instant::now() >= deadline => {
                         // Still alive after timeout; escalate.
@@ -457,9 +453,7 @@ fn stop_daemon() -> Result<()> {
                             nix::unistd::Pid::from_raw(pid),
                             nix::sys::signal::Signal::SIGKILL,
                         );
-                        std::thread::sleep(
-                            std::time::Duration::from_millis(50),
-                        );
+                        std::thread::sleep(std::time::Duration::from_millis(50));
                         break;
                     }
                     _ => {}


### PR DESCRIPTION
## Description

Commit ddb05bc (#742) introduced three formatting violations in `src/cli/serve.rs` (`stop_daemon()`) that broke the CI format check on main. This PR applies `cargo fmt` to fix them:

1. Line-length wrapping on the `deadline` assignment
2. Multi-line `nix::sys::signal::kill()` call collapsed to single line
3. Multi-line `std::thread::sleep()` call collapsed to single line

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

**Any Additional AI Details you'd like to share:** Used to diagnose the CI failure and apply `cargo fmt`.

- [x] I am an AI Agent filling out this form (check box if true)