### PR TITLE
fix: delay Enter after send-keys for Codex paste-burst suppression

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -71,6 +71,12 @@ pub struct AgentDef {
     /// If true, this agent can only run on the host (no sandbox/worktree support).
     /// The new-session dialog hides sandbox and worktree options for these agents.
     pub host_only: bool,
+    /// Milliseconds to wait between sending literal text and the final Enter key.
+    /// Agents with paste-burst detection (e.g. Codex, 120ms window) swallow Enter
+    /// keys that arrive too quickly after a stream of characters, treating them as
+    /// newlines within a paste rather than as "submit". A delay longer than the
+    /// agent's burst window lets the suppression expire before Enter arrives.
+    pub send_keys_enter_delay_ms: u64,
 }
 
 /// Hook events shared by Claude Code and Cursor CLI.
@@ -118,6 +124,7 @@ pub const AGENTS: &[AgentDef] = &[
             events: CLAUDE_CURSOR_HOOK_EVENTS,
         }),
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "opencode",
@@ -131,6 +138,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: None,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "vibe",
@@ -144,6 +152,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: None,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "codex",
@@ -159,6 +168,10 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: None,
         host_only: false,
+        // Codex has paste-burst detection with a 120ms Enter-suppression window;
+        // Enter keys arriving within that window after a character stream are
+        // swallowed as newlines instead of triggering submit. 150ms > 120ms.
+        send_keys_enter_delay_ms: 150,
     },
     AgentDef {
         name: "gemini",
@@ -196,6 +209,7 @@ pub const AGENTS: &[AgentDef] = &[
             ],
         }),
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "cursor",
@@ -212,6 +226,7 @@ pub const AGENTS: &[AgentDef] = &[
             events: CLAUDE_CURSOR_HOOK_EVENTS,
         }),
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "copilot",
@@ -225,6 +240,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[("COPILOT_CONFIG_DIR", "/root/.copilot")],
         hook_config: None,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "pi",
@@ -239,6 +255,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[("PI_CODING_AGENT_DIR", "/root/.pi/agent")],
         hook_config: None,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "droid",
@@ -252,6 +269,7 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: None,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
     },
     AgentDef {
         name: "settl",
@@ -265,12 +283,21 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: None,
         host_only: true,
+        send_keys_enter_delay_ms: 0,
     },
 ];
 
 /// Look up an agent by canonical name.
 pub fn get_agent(name: &str) -> Option<&'static AgentDef> {
     AGENTS.iter().find(|a| a.name == name)
+}
+
+/// Returns the delay (in ms) to insert before the submit-Enter for this agent.
+/// Non-zero for agents with paste-burst detection that swallows fast Enters.
+pub fn send_keys_enter_delay(tool: &str) -> u64 {
+    get_agent(tool)
+        .map(|a| a.send_keys_enter_delay_ms)
+        .unwrap_or(0)
 }
 
 /// All canonical agent names in registry order.
@@ -406,5 +433,15 @@ mod tests {
                 agent.name
             );
         }
+    }
+
+    #[test]
+    fn test_send_keys_enter_delay() {
+        // Codex needs a delay to outlast its 120ms paste-burst suppression window
+        assert!(send_keys_enter_delay("codex") >= 150);
+        // Other agents should not delay
+        assert_eq!(send_keys_enter_delay("claude"), 0);
+        assert_eq!(send_keys_enter_delay("opencode"), 0);
+        assert_eq!(send_keys_enter_delay("unknown_agent"), 0);
     }
 }

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -32,7 +32,8 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         );
     }
 
-    tmux_session.send_keys(&args.message)?;
+    let delay = crate::agents::send_keys_enter_delay(&inst.tool);
+    tmux_session.send_keys_with_delay(&args.message, delay)?;
     println!("Sent message to '{}'", inst.title);
     Ok(())
 }

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -281,6 +281,15 @@ impl Session {
     /// terminals send for Shift+Enter) so the coding agent inserts a newline
     /// rather than submitting after each line.
     pub fn send_keys(&self, text: &str) -> Result<()> {
+        self.send_keys_with_delay(text, 0)
+    }
+
+    /// Like [`send_keys`](Self::send_keys), but waits `enter_delay_ms` between
+    /// the literal text and the final Enter. Agents with paste-burst detection
+    /// (e.g. Codex) swallow Enter keys that arrive within their burst window,
+    /// treating them as newlines instead of submit. The delay lets the
+    /// suppression window expire before Enter is sent.
+    pub fn send_keys_with_delay(&self, text: &str, enter_delay_ms: u64) -> Result<()> {
         if !self.exists() {
             bail!("Session does not exist: {}", self.name);
         }
@@ -294,6 +303,10 @@ impl Session {
                 // ESC + CR: what terminals send for Shift+Enter (inserts newline)
                 Self::tmux_send(&target, &["-H", "1b", "0d"])?;
             }
+        }
+
+        if enter_delay_ms > 0 {
+            std::thread::sleep(std::time::Duration::from_millis(enter_delay_ms));
         }
 
         // Enter to submit

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -452,7 +452,10 @@ impl HomeView {
                         if let Some(inst) = self.get_instance(&session_id) {
                             match crate::tmux::Session::new(&inst.id, &inst.title) {
                                 Ok(tmux_session) => {
-                                    if let Err(e) = tmux_session.send_keys(&message) {
+                                    let delay = crate::agents::send_keys_enter_delay(&inst.tool);
+                                    if let Err(e) =
+                                        tmux_session.send_keys_with_delay(&message, delay)
+                                    {
                                         self.info_dialog = Some(InfoDialog::new(
                                             "Send Failed",
                                             &format!("Failed to send message: {}", e),


### PR DESCRIPTION
## Description

Fixes the "m Msg" functionality not working with Codex sessions (#748). Messages would arrive in the Codex CLI input but never submit — users had to press Enter manually.

**Root cause:** Codex CLI has a [paste-burst detection system](https://github.com/openai/codex/blob/main/codex-rs/tui/src/bottom_pane/paste_burst.rs) with a 120ms Enter-suppression window (`PASTE_ENTER_SUPPRESS_WINDOW`). When `tmux send-keys -l` delivers characters rapidly, Codex classifies them as a paste burst. Any Enter key arriving within 120ms of the last burst character is treated as a newline within the paste (not as "submit"). Since AoE fires two back-to-back `tmux` subprocess calls, the Enter arrives well within that window and gets swallowed.

**Fix:** Add a per-agent `send_keys_enter_delay_ms` field to the agent registry (150ms for Codex, 0 for all others). A new `send_keys_with_delay` method sleeps between the literal text and the final Enter so the burst-suppression window expires before Enter arrives. Both the TUI message dialog and the `aoe send` CLI command use the delay-aware method.

**Why approval responses (1/2/3) still work:** Codex's approval prompts use a different input mode where single keypresses are acted on immediately, bypassing the chat composer's paste-burst logic.

Fixes #748

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Root cause was identified by reading the Codex CLI source code on GitHub (paste_burst.rs and chat_composer.rs) to understand the Enter-suppression mechanism.

- [x] I am an AI Agent filling out this form (check box if true)