### PR TITLE
fix: update rand 0.10.0 → 0.10.1 (RUSTSEC-2026-0097)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ dependencies = [
  "p256",
  "portable-pty",
  "qrcode",
- "rand 0.10.0",
+ "rand 0.10.1",
  "ratatui",
  "ratatui-textarea",
  "rattles",
@@ -2511,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -3360,7 +3360,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",


### PR DESCRIPTION
## Description

Updates `rand` from 0.10.0 to 0.10.1 to resolve [RUSTSEC-2026-0097](https://rustsec.org/advisories/RUSTSEC-2026-0097), an unsoundness advisory when using `rand::rng()` with a custom logger.

This unblocks #733 (cargo-deny-action bump to 2.0.16), whose newer advisory database catches this issue.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)