### PR TITLE
fix(web): useWebSettings cache invalidation on localStorage failure

### DIFF
--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -57,8 +57,12 @@ export function useWebSettings() {
   const update = useCallback((patch: Partial<WebSettings>) => {
     const current = getSnapshot();
     const next = { ...current, ...patch };
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
-    cachedRaw = null; // invalidate cache
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch (err) {
+      console.warn("aoe-web-settings: failed to persist", err);
+    }
+    cachedRaw = null;
     emitChange();
   }, []);
 


### PR DESCRIPTION
## Description

Wraps `localStorage.setItem` in a try/catch in `useWebSettings.update()` so that if the write fails (quota exceeded, private browsing restrictions, disabled storage under corp policies), cache invalidation and subscriber notification still fire and the UI stays in sync.

Previously, a thrown exception from `setItem` would prevent `cachedRaw = null` and `emitChange()` from running, leaving subscribers stale with no error surfaced to the user.

Closes #689

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)