### PR TITLE
fix(docs): resolve asset paths for guides in subdirectories

### DIFF
--- a/scripts/build-site.sh
+++ b/scripts/build-site.sh
@@ -22,10 +22,11 @@ cp "$ROOT_DIR/assets/logo.png" "$ROOT_DIR/website/public/assets/"
 cp "$ROOT_DIR/assets/social-preview.png" "$ROOT_DIR/website/public/assets/" 2>/dev/null || true
 cp "$ROOT_DIR/assets/social-preview.svg" "$ROOT_DIR/website/public/assets/" 2>/dev/null || true
 cp "$ROOT_DIR/theme/favicon.png" "$ROOT_DIR/website/public/assets/" 2>/dev/null || true
-if [ -f "$ROOT_DIR/docs/assets/demo.gif" ]; then
-  cp "$ROOT_DIR/docs/assets/demo.gif" "$ROOT_DIR/website/public/assets/"
-  echo "  - demo.gif copied ($(du -h "$ROOT_DIR/docs/assets/demo.gif" | cut -f1))"
-fi
+for f in "$ROOT_DIR/docs/assets/"*; do
+  [ -f "$f" ] || continue
+  cp "$f" "$ROOT_DIR/website/public/assets/"
+  echo "  - $(basename "$f") copied ($(du -h "$f" | cut -f1))"
+done
 
 # 2. Build Astro website
 echo "Building Astro website..."

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -198,7 +198,8 @@ function rewriteLinks(content, sourceDir) {
 
   // Rewrite relative image/asset paths to absolute (assets/ → /assets/)
   // The build copies docs/assets/* to website/public/assets/
-  content = content.replace(/\]\(assets\//g, "](/assets/");
+  // Handle both assets/ (from docs/) and ../assets/ (from docs/guides/)
+  content = content.replace(/\]\((?:\.\.\/)*assets\//g, "](/assets/");
 
   return content;
 }


### PR DESCRIPTION
## Description

Fixes the CI build failure on main introduced by #743.

Two issues:
1. `sync-docs.mjs` only rewrote `](assets/` image paths, but docs in subdirectories (like `docs/guides/agent-override.md`) use `](../assets/`. Updated the regex to handle any depth of `../` prefixes.
2. `build-site.sh` only copied `demo.gif` from `docs/assets/` to `website/public/assets/`. Updated to copy all files from `docs/assets/`, so `tui_session_settings.png` (and any future doc assets) are included in the website build.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)