### PR TITLE
fix(web): prevent mobile context menu from closing on finger lift

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -116,6 +116,8 @@ const SessionRow = memo(function SessionRow({
   const renameRef = useRef<HTMLInputElement>(null);
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressFired = useRef(false);
+  const touchOpenedAt = useRef(0);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     return () => {
@@ -130,18 +132,27 @@ const SessionRow = memo(function SessionRow({
   useEffect(() => {
     if (!contextMenu) return;
     const close = () => setContextMenu(null);
+    const onDocClick = (e: MouseEvent) => {
+      // Clicks inside the menu should be handled by item onClick
+      // handlers, not by this dismiss listener.
+      if (menuRef.current?.contains(e.target as Node)) return;
+      // On mobile, lifting the finger after a long-press dispatches a
+      // synthetic click even when touchend called preventDefault().
+      // Ignore clicks that arrive shortly after a touch-triggered open.
+      if (Date.now() - touchOpenedAt.current < 500) return;
+      close();
+    };
     // Defer so the event that opened the menu finishes bubbling first
     const id = requestAnimationFrame(() => {
-      document.addEventListener("click", close);
+      document.addEventListener("click", onDocClick);
       document.addEventListener("contextmenu", close);
     });
     // Listen for the "close" broadcast from any sibling SessionRow
-    // that is opening its own menu. This is what fixes the long-press
-    // bug: touchstart doesn't propagate as "click" to document.
+    // that is opening its own menu.
     menuBus.addEventListener("close", close);
     return () => {
       cancelAnimationFrame(id);
-      document.removeEventListener("click", close);
+      document.removeEventListener("click", onDocClick);
       document.removeEventListener("contextmenu", close);
       menuBus.removeEventListener("close", close);
     };
@@ -171,6 +182,7 @@ const SessionRow = memo(function SessionRow({
     const ty = touch.clientY;
     longPressTimer.current = setTimeout(() => {
       longPressFired.current = true;
+      touchOpenedAt.current = Date.now();
       closeOtherContextMenus();
       setContextMenu({ x: tx, y: ty });
     }, 500);
@@ -251,6 +263,7 @@ const SessionRow = memo(function SessionRow({
       </button>
       {contextMenu && createPortal(
         <div
+          ref={menuRef}
           className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
         >


### PR DESCRIPTION
## Description

On mobile, long-pressing a session in the sidebar opens the context menu dropdown, but it
immediately disappears when you lift your finger, making it impossible to select any option.

**Root cause:** The menu lifecycle effect attaches a `document.addEventListener("click", close)`
via `requestAnimationFrame`. When the user lifts their finger, the browser synthesizes a click
event after `touchend`. While `handleTouchEnd` calls `e.preventDefault()`, this doesn't
reliably suppress the synthetic click across all mobile browsers (notably iOS Safari). The
synthetic click reaches the document listener and closes the menu.

**Fix (two parts):**
1. Track when the menu was opened via touch (`touchOpenedAt` ref). The document click handler
   ignores clicks within a 500ms grace window after a touch-triggered open.
2. Add a ref to the menu portal div (`menuRef`). Clicks inside the menu are ignored by the
   dismiss listener, letting item `onClick` handlers close it explicitly. This is cleaner
   than the previous approach where both the item handler and the document listener raced to
   close the menu.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)