### PR TITLE
fix: stop session restart loop for fish/nu/pwsh shell users

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -984,10 +984,15 @@ fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
 /// Single quotes in `cmd` are escaped with the `'\''` technique to prevent
 /// breaking out of the outer single-quoted wrapper.
 fn wrap_command_ignore_suspend(cmd: &str) -> String {
-    let shell = super::environment::user_posix_shell();
+    let user = super::environment::user_shell();
+    let posix = super::environment::user_posix_shell();
     let escaped = cmd.replace('\'', "'\\''");
     // Use login shell (-l) so version-manager PATHs (NVM, etc.) are available.
-    format!("{} -lc 'stty susp undef; exec env {}'", shell, escaped)
+    // Skip -l when falling back to bash for a non-POSIX user shell (fish, nu,
+    // pwsh): bash's login scripts won't contain the user's PATH setup and -l
+    // may reset the inherited PATH that already has the correct entries.
+    let flag = if user == posix { "-lc" } else { "-c" };
+    format!("{} {} 'stty susp undef; exec env {}'", posix, flag, escaped)
 }
 
 /// Check whether captured pane content indicates a living agent rather than
@@ -1112,6 +1117,65 @@ mod tests {
             "wrapped command should contain the escaped env var assignment: {}",
             wrapped,
         );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn test_wrap_command_posix_shell_uses_login() {
+        let original = std::env::var("SHELL").ok();
+        std::env::set_var("SHELL", "/bin/zsh");
+        let wrapped = wrap_command_ignore_suspend("claude");
+        // POSIX shell: should use -lc for version-manager PATHs
+        assert!(
+            wrapped.contains("-lc"),
+            "POSIX shell should use -lc: {}",
+            wrapped,
+        );
+        match original {
+            Some(v) => std::env::set_var("SHELL", v),
+            None => std::env::remove_var("SHELL"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn test_wrap_command_fish_skips_login() {
+        let original = std::env::var("SHELL").ok();
+        std::env::set_var("SHELL", "/usr/bin/fish");
+        let wrapped = wrap_command_ignore_suspend("claude");
+        // Fish: should use -c (no -l) because bash's login scripts
+        // won't have fish's PATH setup.
+        assert!(
+            wrapped.starts_with("bash -c "),
+            "fish shell should fall back to bash -c (no login): {}",
+            wrapped,
+        );
+        assert!(
+            !wrapped.contains("-lc"),
+            "fish shell should NOT use -lc: {}",
+            wrapped,
+        );
+        match original {
+            Some(v) => std::env::set_var("SHELL", v),
+            None => std::env::remove_var("SHELL"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn test_wrap_command_nu_skips_login() {
+        let original = std::env::var("SHELL").ok();
+        std::env::set_var("SHELL", "/usr/bin/nu");
+        let wrapped = wrap_command_ignore_suspend("claude");
+        assert!(
+            wrapped.starts_with("bash -c "),
+            "nu shell should fall back to bash -c (no login): {}",
+            wrapped,
+        );
+        match original {
+            Some(v) => std::env::set_var("SHELL", v),
+            None => std::env::remove_var("SHELL"),
+        }
     }
 
     // Additional tests for is_sandboxed


### PR DESCRIPTION
## Description

When `$SHELL` is a non-POSIX shell (fish, nu, pwsh), `wrap_command_ignore_suspend` falls back to `bash` via `user_posix_shell()`. It was using `bash -lc` which sources bash's login scripts. Fish users configure PATH in `~/.config/fish/config.fish`, not in `~/.bash_profile`, so bash's login environment doesn't have the agent binary on PATH. `exec env claude` fails silently, the pane dies immediately, and the TUI restarts the session on every re-attach attempt.

The fix: skip the `-l` (login) flag when falling back to bash for non-POSIX shell users. The correct PATH is already inherited from the `aoe` process which was launched from fish. POSIX shell users (bash, zsh) still get `-lc` so version-manager PATHs (NVM, etc.) continue to load from their login scripts.

Fixes #757

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

**Any Additional AI Details you'd like to share:** Root cause investigation and fix implementation.

- [x] I am an AI Agent filling out this form (check box if true)