### PR TITLE
fix(web): keep terminal cursor visible when mobile keyboard opens

### DIFF
--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -69,18 +69,44 @@ export function TerminalView({ session }: Props) {
   });
   const showScrollHint = isMobile && state.connected && !hintDismissed;
 
-  // Debounce terminal resize when keyboard height changes.
+  // When the keyboard opens (keyboardHeight goes from 0 → positive), the
+  // terminal container shrinks. wterm's ResizeObserver fires and checks
+  // _isScrolledToBottom() BEFORE the DOM has reflowed, sees the reduced
+  // clientHeight while scrollTop/scrollHeight are stale, and concludes "not
+  // at bottom." This makes it skip _scrollToBottom() after the resize,
+  // leaving the cursor off-screen.
+  //
+  // Fix: force a scroll-to-bottom via double-rAF (fires after wterm's own
+  // rAF render) on every keyboardHeight change, plus a debounced final
+  // scroll after the animation settles.
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollRafRef = useRef(0);
   useLayoutEffect(() => {
     if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+
+    // Immediate: double-rAF ensures we fire AFTER wterm's scheduled render
+    // (which also uses rAF). This keeps the cursor visible during the
+    // keyboard animation, not just after it settles.
+    cancelAnimationFrame(scrollRafRef.current);
+    scrollRafRef.current = requestAnimationFrame(() => {
+      scrollRafRef.current = requestAnimationFrame(() => {
+        const el = termRef.current?.element;
+        if (el) el.scrollTop = el.scrollHeight;
+      });
+    });
+
+    // Debounced: final correction after the keyboard animation fully settles.
     resizeTimerRef.current = setTimeout(() => {
       resizeTimerRef.current = null;
       window.dispatchEvent(new Event("resize"));
+      const el = termRef.current?.element;
+      if (el) el.scrollTop = el.scrollHeight;
     }, 150);
     return () => {
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
+      cancelAnimationFrame(scrollRafRef.current);
     };
-  }, [keyboardHeight]);
+  }, [keyboardHeight, termRef]);
 
   // On initial connect, auto-open the keyboard.
   useEffect(() => {


### PR DESCRIPTION
## Description

Fixes an intermittent bug where the terminal cursor (Claude's prompt line) would disappear behind the MobileTerminalToolbar when the soft keyboard opens on mobile.

**Root cause:** When the keyboard opens, `keyboardHeight` increases and `paddingBottom` is applied to the terminal container, shrinking it. wterm's `ResizeObserver` fires and calls `resize()`, which checks `_isScrolledToBottom()` at that moment. But `clientHeight` has already decreased while `scrollHeight` and `scrollTop` are stale, so the check returns `false` ("not at bottom"). After the resize rebuilds the grid and adds scrollback, `_scrollToBottom()` is skipped and the cursor stays off-screen.

**Fix:** Force a scroll-to-bottom via double-rAF (fires after wterm's own rAF render cycle) on every `keyboardHeight` change, plus a debounced final scroll after the animation settles. This keeps the cursor visible throughout the keyboard animation.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

**Any Additional AI Details you'd like to share:** Root cause investigation traced through wterm source code (`@wterm/dom` v0.1.8) to identify the `_isScrolledToBottom()` race condition during container resize.

- [x] I am an AI Agent filling out this form (check box if true)