### PR TITLE
feat(web): primary-client model for multi-device terminal resize

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -211,6 +211,11 @@ pub struct AppState {
     /// Snapshot of the resolved WebConfig at startup. Consumed by the
     /// push consumer task to evaluate per-event-type defaults.
     pub web_config: crate::session::config::WebConfig,
+    /// Per-tmux-session primary WebSocket client. Maps tmux session name
+    /// to the client ID that most recently sent keyboard input. Only the
+    /// primary client's resize messages are applied to its PTY, preventing
+    /// multiple browser viewports from fighting over the tmux window size.
+    pub session_primaries: Arc<RwLock<std::collections::HashMap<String, String>>>,
 }
 
 impl AppState {
@@ -332,6 +337,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             entries: std::collections::HashMap::new(),
         }),
         remote_owner_cache: RwLock::new(std::collections::HashMap::new()),
+        session_primaries: Arc::new(RwLock::new(std::collections::HashMap::new())),
         status_tx: broadcast::channel(STATUS_CHANNEL_CAPACITY).0,
         push: push_state,
         push_enabled,

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -297,6 +297,19 @@ async fn handle_terminal_ws(
                             }
                             // Ignore zero-dimension resize (buggy client)
                             ControlMessage::Resize { .. } => {}
+                            ControlMessage::Activate => {
+                                let became_primary = claim_primary(
+                                    &primaries_for_recv,
+                                    &tmux_name_for_recv,
+                                    &client_id_for_recv,
+                                )
+                                .await;
+                                if became_primary {
+                                    if let Some((cols, rows)) = pending_size {
+                                        resize_pty(&master_for_resize, cols, rows).await;
+                                    }
+                                }
+                            }
                         }
                     } else if !read_only {
                         // Plain text input -> PTY stdin (blocked in read-only mode).
@@ -408,6 +421,11 @@ async fn resize_pty(
 enum ControlMessage {
     #[serde(rename = "resize")]
     Resize { cols: u16, rows: u16 },
+    /// Sent by the browser when the terminal tab/window gains focus.
+    /// Claims primary and applies the pending resize so the pane
+    /// snaps to this client's viewport without requiring a keystroke.
+    #[serde(rename = "activate")]
+    Activate,
 }
 
 #[cfg(test)]

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -280,7 +280,9 @@ async fn handle_terminal_ws(
                     // JSON control messages (resize) are always allowed
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
-                            ControlMessage::Resize { cols, rows } => {
+                            ControlMessage::Resize { cols, rows }
+                                if cols > 0 && rows > 0 =>
+                            {
                                 pending_size = Some((cols, rows));
 
                                 let dominated = is_primary_or_vacant(
@@ -293,6 +295,8 @@ async fn handle_terminal_ws(
                                     resize_pty(&master_for_resize, cols, rows).await;
                                 }
                             }
+                            // Ignore zero-dimension resize (buggy client)
+                            ControlMessage::Resize { .. } => {}
                         }
                     } else if !read_only {
                         // Plain text input -> PTY stdin (blocked in read-only mode).
@@ -404,4 +408,87 @@ async fn resize_pty(
 enum ControlMessage {
     #[serde(rename = "resize")]
     Resize { cols: u16, rows: u16 },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_primaries() -> SessionPrimaries {
+        Arc::new(RwLock::new(std::collections::HashMap::new()))
+    }
+
+    #[tokio::test]
+    async fn claim_primary_vacant_returns_true() {
+        let p = make_primaries();
+        assert!(claim_primary(&p, "session-1", "ws-0").await);
+        assert_eq!(p.read().await.get("session-1").unwrap(), "ws-0");
+    }
+
+    #[tokio::test]
+    async fn claim_primary_already_primary_returns_false() {
+        let p = make_primaries();
+        assert!(claim_primary(&p, "session-1", "ws-0").await);
+        assert!(!claim_primary(&p, "session-1", "ws-0").await);
+    }
+
+    #[tokio::test]
+    async fn claim_primary_steals_from_other_client() {
+        let p = make_primaries();
+        assert!(claim_primary(&p, "session-1", "ws-0").await);
+        assert!(claim_primary(&p, "session-1", "ws-1").await);
+        assert_eq!(p.read().await.get("session-1").unwrap(), "ws-1");
+    }
+
+    #[tokio::test]
+    async fn is_primary_or_vacant_when_vacant() {
+        let p = make_primaries();
+        assert!(is_primary_or_vacant(&p, "session-1", "ws-0").await);
+    }
+
+    #[tokio::test]
+    async fn is_primary_or_vacant_when_primary() {
+        let p = make_primaries();
+        claim_primary(&p, "session-1", "ws-0").await;
+        assert!(is_primary_or_vacant(&p, "session-1", "ws-0").await);
+    }
+
+    #[tokio::test]
+    async fn is_primary_or_vacant_when_not_primary() {
+        let p = make_primaries();
+        claim_primary(&p, "session-1", "ws-0").await;
+        assert!(!is_primary_or_vacant(&p, "session-1", "ws-1").await);
+    }
+
+    #[tokio::test]
+    async fn release_primary_clears_entry() {
+        let p = make_primaries();
+        claim_primary(&p, "session-1", "ws-0").await;
+        release_primary(&p, "session-1", "ws-0").await;
+        assert!(p.read().await.get("session-1").is_none());
+    }
+
+    #[tokio::test]
+    async fn release_primary_noop_for_different_client() {
+        let p = make_primaries();
+        claim_primary(&p, "session-1", "ws-0").await;
+        release_primary(&p, "session-1", "ws-1").await;
+        assert_eq!(p.read().await.get("session-1").unwrap(), "ws-0");
+    }
+
+    #[tokio::test]
+    async fn release_primary_noop_on_empty_map() {
+        let p = make_primaries();
+        release_primary(&p, "session-1", "ws-0").await;
+        assert!(p.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn independent_sessions_dont_interfere() {
+        let p = make_primaries();
+        claim_primary(&p, "session-1", "ws-0").await;
+        claim_primary(&p, "session-2", "ws-1").await;
+        assert_eq!(p.read().await.get("session-1").unwrap(), "ws-0");
+        assert_eq!(p.read().await.get("session-2").unwrap(), "ws-1");
+    }
 }

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -16,6 +16,7 @@ use axum::{
     response::IntoResponse,
 };
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
+use tokio::sync::RwLock;
 
 use super::AppState;
 
@@ -33,6 +34,7 @@ pub async fn paired_terminal_ws(
     drop(instances);
 
     let read_only = state.read_only;
+    let primaries = Arc::clone(&state.session_primaries);
 
     match session_info {
         // Accept the "aoe-auth" subprotocol so the browser's handshake
@@ -42,7 +44,9 @@ pub async fn paired_terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only))
+            .on_upgrade(move |socket| {
+                handle_terminal_ws(socket, tmux_name, read_only, primaries)
+            })
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
@@ -62,6 +66,7 @@ pub async fn container_terminal_ws(
     drop(instances);
 
     let read_only = state.read_only;
+    let primaries = Arc::clone(&state.session_primaries);
 
     match session_info {
         // Accept the "aoe-auth" subprotocol so the browser's handshake
@@ -71,7 +76,9 @@ pub async fn container_terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only))
+            .on_upgrade(move |socket| {
+                handle_terminal_ws(socket, tmux_name, read_only, primaries)
+            })
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
@@ -92,6 +99,7 @@ pub async fn terminal_ws(
     drop(instances);
 
     let read_only = state.read_only;
+    let primaries = Arc::clone(&state.session_primaries);
 
     match session_info {
         // Accept the "aoe-auth" subprotocol so the browser's handshake
@@ -101,14 +109,42 @@ pub async fn terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only))
+            .on_upgrade(move |socket| {
+                handle_terminal_ws(socket, tmux_name, read_only, primaries)
+            })
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
 }
 
-async fn handle_terminal_ws(socket: WebSocket, tmux_name: String, read_only: bool) {
+/// Unique client ID counter for primary-client tracking.
+static CLIENT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Per-tmux-session map tracking which WebSocket client "owns" resizing.
+///
+/// Only the primary client's resize messages are applied to its PTY. This
+/// prevents multiple browser viewports (phone, desktop, tablet) from
+/// fighting over the tmux window size. The primary is whichever client
+/// most recently sent keyboard input, since aoe is single-user: if
+/// you're typing on your phone you want phone-sized output.
+///
+/// When no client is primary (all have disconnected, or nobody has typed
+/// yet), any client's resize is applied so the initial connection still
+/// sets up the PTY dimensions from the default 80x24.
+type SessionPrimaries = Arc<RwLock<std::collections::HashMap<String, String>>>;
+
+async fn handle_terminal_ws(
+    socket: WebSocket,
+    tmux_name: String,
+    read_only: bool,
+    primaries: SessionPrimaries,
+) {
     use futures_util::{SinkExt, StreamExt};
+
+    let client_id = format!(
+        "ws-{}",
+        CLIENT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+    );
 
     // Spawn tmux attach inside a PTY
     let pty_system = NativePtySystem::default();
@@ -200,8 +236,15 @@ async fn handle_terminal_ws(socket: WebSocket, tmux_name: String, read_only: boo
     // Task 3: WebSocket receiver -> PTY stdin (and resize)
     let writer_for_input = writer.clone();
     let master_for_resize = master.clone();
+    let primaries_for_recv = primaries.clone();
+    let client_id_for_recv = client_id.clone();
+    let tmux_name_for_recv = tmux_name.clone();
 
     let recv_handle = tokio::spawn(async move {
+        // Track the last resize the browser requested so we can apply it
+        // when this client becomes primary.
+        let mut pending_size: Option<(u16, u16)> = None;
+
         while let Some(Ok(msg)) = ws_receiver.next().await {
             match msg {
                 Message::Binary(data) => {
@@ -209,6 +252,21 @@ async fn handle_terminal_ws(socket: WebSocket, tmux_name: String, read_only: boo
                     if read_only {
                         continue;
                     }
+
+                    // Claim primary on input. If we just became primary,
+                    // apply our pending resize so the PTY matches our viewport.
+                    let became_primary = claim_primary(
+                        &primaries_for_recv,
+                        &tmux_name_for_recv,
+                        &client_id_for_recv,
+                    )
+                    .await;
+                    if became_primary {
+                        if let Some((cols, rows)) = pending_size {
+                            resize_pty(&master_for_resize, cols, rows).await;
+                        }
+                    }
+
                     let writer = writer_for_input.clone();
                     let _ = tokio::task::spawn_blocking(move || {
                         if let Ok(mut w) = writer.lock() {
@@ -223,22 +281,34 @@ async fn handle_terminal_ws(socket: WebSocket, tmux_name: String, read_only: boo
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
                             ControlMessage::Resize { cols, rows } => {
-                                let master = master_for_resize.clone();
-                                let _ = tokio::task::spawn_blocking(move || {
-                                    if let Ok(m) = master.lock() {
-                                        let _ = m.resize(PtySize {
-                                            rows,
-                                            cols,
-                                            pixel_width: 0,
-                                            pixel_height: 0,
-                                        });
-                                    }
-                                })
+                                pending_size = Some((cols, rows));
+
+                                let dominated = is_primary_or_vacant(
+                                    &primaries_for_recv,
+                                    &tmux_name_for_recv,
+                                    &client_id_for_recv,
+                                )
                                 .await;
+                                if dominated {
+                                    resize_pty(&master_for_resize, cols, rows).await;
+                                }
                             }
                         }
                     } else if !read_only {
-                        // Plain text input -> PTY stdin (blocked in read-only mode)
+                        // Plain text input -> PTY stdin (blocked in read-only mode).
+                        // Also claims primary, same as binary input.
+                        let became_primary = claim_primary(
+                            &primaries_for_recv,
+                            &tmux_name_for_recv,
+                            &client_id_for_recv,
+                        )
+                        .await;
+                        if became_primary {
+                            if let Some((cols, rows)) = pending_size {
+                                resize_pty(&master_for_resize, cols, rows).await;
+                            }
+                        }
+
                         let writer = writer_for_input.clone();
                         let bytes: Vec<u8> = text.as_bytes().to_vec();
                         let _ = tokio::task::spawn_blocking(move || {
@@ -262,9 +332,71 @@ async fn handle_terminal_ws(socket: WebSocket, tmux_name: String, read_only: boo
         _ = recv_handle => {},
     }
 
+    // Release primary if this client held it, so the next client can take over.
+    release_primary(&primaries, &tmux_name, &client_id).await;
+
     // Clean up: kill the tmux attach process
     let _ = child.kill();
     let _ = child.wait();
+}
+
+/// Claim primary for this client. Returns `true` if the client was NOT
+/// already primary (i.e. it just became primary and should apply its
+/// pending resize).
+async fn claim_primary(
+    primaries: &SessionPrimaries,
+    session: &str,
+    client_id: &str,
+) -> bool {
+    let mut map = primaries.write().await;
+    let current = map.get(session);
+    if current.is_some_and(|id| id == client_id) {
+        return false; // already primary
+    }
+    map.insert(session.to_string(), client_id.to_string());
+    true
+}
+
+/// Check whether this client is primary, or no client is primary for
+/// this session (vacant). In either case the caller is allowed to resize.
+async fn is_primary_or_vacant(
+    primaries: &SessionPrimaries,
+    session: &str,
+    client_id: &str,
+) -> bool {
+    let map = primaries.read().await;
+    match map.get(session) {
+        None => true,
+        Some(id) => id == client_id,
+    }
+}
+
+/// Release primary if this client currently holds it.
+async fn release_primary(primaries: &SessionPrimaries, session: &str, client_id: &str) {
+    let mut map = primaries.write().await;
+    if map.get(session).is_some_and(|id| id == client_id) {
+        map.remove(session);
+    }
+}
+
+/// Resize the PTY master to the given dimensions.
+async fn resize_pty(
+    master: &Arc<std::sync::Mutex<Box<dyn portable_pty::MasterPty + Send>>>,
+    cols: u16,
+    rows: u16,
+) {
+    let master = master.clone();
+    let _ = tokio::task::spawn_blocking(move || {
+        if let Ok(m) = master.lock() {
+            let _ = m.resize(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            });
+        }
+    })
+    .await;
 }
 
 #[derive(serde::Deserialize)]

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -206,6 +206,8 @@ async fn handle_terminal_ws(
 
     // Use tokio channels to bridge sync PTY I/O with async WebSocket
     let (output_tx, mut output_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    // Control channel: server -> client JSON messages (primary status, etc.)
+    let (ctrl_tx, mut ctrl_rx) = tokio::sync::mpsc::channel::<String>(8);
 
     // Task 1: PTY stdout -> channel (blocking read in dedicated thread)
     tokio::task::spawn_blocking(move || {
@@ -223,11 +225,30 @@ async fn handle_terminal_ws(
         }
     });
 
-    // Task 2: channel -> WebSocket sender
+    // Task 2: PTY output + control messages -> WebSocket sender
     let send_handle = tokio::spawn(async move {
-        while let Some(data) = output_rx.recv().await {
-            if ws_sender.send(Message::Binary(data.into())).await.is_err() {
-                break; // WebSocket closed
+        loop {
+            tokio::select! {
+                data = output_rx.recv() => {
+                    match data {
+                        Some(data) => {
+                            if ws_sender.send(Message::Binary(data.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                msg = ctrl_rx.recv() => {
+                    match msg {
+                        Some(text) => {
+                            if ws_sender.send(Message::Text(text.into())).await.is_err() {
+                                break;
+                            }
+                        }
+                        None => break,
+                    }
+                }
             }
         }
         let _ = ws_sender.send(Message::Close(None)).await;
@@ -239,6 +260,7 @@ async fn handle_terminal_ws(
     let primaries_for_recv = primaries.clone();
     let client_id_for_recv = client_id.clone();
     let tmux_name_for_recv = tmux_name.clone();
+    let ctrl_tx_for_recv = ctrl_tx.clone();
 
     let recv_handle = tokio::spawn(async move {
         // Track the last resize the browser requested so we can apply it
@@ -265,6 +287,9 @@ async fn handle_terminal_ws(
                         if let Some((cols, rows)) = pending_size {
                             resize_pty(&master_for_resize, cols, rows).await;
                         }
+                        let _ = ctrl_tx_for_recv
+                            .send(r#"{"type":"primary_status","is_primary":true}"#.into())
+                            .await;
                     }
 
                     let writer = writer_for_input.clone();
@@ -277,7 +302,7 @@ async fn handle_terminal_ws(
                     .await;
                 }
                 Message::Text(text) => {
-                    // JSON control messages (resize) are always allowed
+                    // JSON control messages (resize, activate) are always allowed
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
                             ControlMessage::Resize { cols, rows }
@@ -293,11 +318,20 @@ async fn handle_terminal_ws(
                                 .await;
                                 if dominated {
                                     resize_pty(&master_for_resize, cols, rows).await;
+                                } else {
+                                    let _ = ctrl_tx_for_recv
+                                        .send(r#"{"type":"primary_status","is_primary":false}"#.into())
+                                        .await;
                                 }
                             }
                             // Ignore zero-dimension resize (buggy client)
                             ControlMessage::Resize { .. } => {}
                             ControlMessage::Activate => {
+                                // In read-only mode, don't claim primary. All
+                                // viewers get independent resize (vacant state).
+                                if read_only {
+                                    continue;
+                                }
                                 let became_primary = claim_primary(
                                     &primaries_for_recv,
                                     &tmux_name_for_recv,
@@ -308,6 +342,9 @@ async fn handle_terminal_ws(
                                     if let Some((cols, rows)) = pending_size {
                                         resize_pty(&master_for_resize, cols, rows).await;
                                     }
+                                    let _ = ctrl_tx_for_recv
+                                        .send(r#"{"type":"primary_status","is_primary":true}"#.into())
+                                        .await;
                                 }
                             }
                         }
@@ -324,6 +361,9 @@ async fn handle_terminal_ws(
                             if let Some((cols, rows)) = pending_size {
                                 resize_pty(&master_for_resize, cols, rows).await;
                             }
+                            let _ = ctrl_tx_for_recv
+                                .send(r#"{"type":"primary_status","is_primary":true}"#.into())
+                                .await;
                         }
 
                         let writer = writer_for_input.clone();

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -44,9 +44,7 @@ pub async fn paired_terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| {
-                handle_terminal_ws(socket, tmux_name, read_only, primaries)
-            })
+            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only, primaries))
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
@@ -76,9 +74,7 @@ pub async fn container_terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| {
-                handle_terminal_ws(socket, tmux_name, read_only, primaries)
-            })
+            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only, primaries))
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
@@ -109,9 +105,7 @@ pub async fn terminal_ws(
         // itself is not echoed, only the marker.
         Some(tmux_name) => ws
             .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| {
-                handle_terminal_ws(socket, tmux_name, read_only, primaries)
-            })
+            .on_upgrade(move |socket| handle_terminal_ws(socket, tmux_name, read_only, primaries))
             .into_response(),
         None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
     }
@@ -305,9 +299,7 @@ async fn handle_terminal_ws(
                     // JSON control messages (resize, activate) are always allowed
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
-                            ControlMessage::Resize { cols, rows }
-                                if cols > 0 && rows > 0 =>
-                            {
+                            ControlMessage::Resize { cols, rows } if cols > 0 && rows > 0 => {
                                 pending_size = Some((cols, rows));
 
                                 let dominated = is_primary_or_vacant(
@@ -320,7 +312,10 @@ async fn handle_terminal_ws(
                                     resize_pty(&master_for_resize, cols, rows).await;
                                 } else {
                                     let _ = ctrl_tx_for_recv
-                                        .send(r#"{"type":"primary_status","is_primary":false}"#.into())
+                                        .send(
+                                            r#"{"type":"primary_status","is_primary":false}"#
+                                                .into(),
+                                        )
                                         .await;
                                 }
                             }
@@ -343,7 +338,9 @@ async fn handle_terminal_ws(
                                         resize_pty(&master_for_resize, cols, rows).await;
                                     }
                                     let _ = ctrl_tx_for_recv
-                                        .send(r#"{"type":"primary_status","is_primary":true}"#.into())
+                                        .send(
+                                            r#"{"type":"primary_status","is_primary":true}"#.into(),
+                                        )
                                         .await;
                                 }
                             }
@@ -400,11 +397,7 @@ async fn handle_terminal_ws(
 /// Claim primary for this client. Returns `true` if the client was NOT
 /// already primary (i.e. it just became primary and should apply its
 /// pending resize).
-async fn claim_primary(
-    primaries: &SessionPrimaries,
-    session: &str,
-    client_id: &str,
-) -> bool {
+async fn claim_primary(primaries: &SessionPrimaries, session: &str, client_id: &str) -> bool {
     let mut map = primaries.write().await;
     let current = map.get(session);
     if current.is_some_and(|id| id == client_id) {

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -7,6 +7,7 @@ use super::{
     refresh_session_cache, session_exists_from_cache,
     utils::{
         append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args,
+        append_window_size_args,
         is_pane_dead, is_pane_running_shell,
     },
     SESSION_PREFIX,
@@ -68,6 +69,7 @@ impl Session {
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
+        append_window_size_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -7,8 +7,7 @@ use super::{
     refresh_session_cache, session_exists_from_cache,
     utils::{
         append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args,
-        append_window_size_args,
-        is_pane_dead, is_pane_running_shell,
+        append_window_size_args, is_pane_dead, is_pane_running_shell,
     },
     SESSION_PREFIX,
 };

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -4,7 +4,8 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::utils::{
-    append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args, is_pane_dead,
+    append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args,
+    append_window_size_args, is_pane_dead,
     sanitize_session_name,
 };
 use super::{
@@ -63,6 +64,7 @@ impl TerminalSession {
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
+        append_window_size_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -5,8 +5,7 @@ use std::process::Command;
 
 use super::utils::{
     append_mouse_on_args, append_pane_base_index_args, append_remain_on_exit_args,
-    append_window_size_args, is_pane_dead,
-    sanitize_session_name,
+    append_window_size_args, is_pane_dead, sanitize_session_name,
 };
 use super::{
     refresh_session_cache, session_exists_from_cache, CONTAINER_TERMINAL_PREFIX, TERMINAL_PREFIX,
@@ -225,6 +224,7 @@ impl ContainerTerminalSession {
         append_remain_on_exit_args(&mut args, &self.name);
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
+        append_window_size_args(&mut args, &self.name);
 
         let output = Command::new("tmux").args(&args).output()?;
 

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -86,6 +86,22 @@ pub fn append_mouse_on_args(args: &mut Vec<String>, target: &str) {
     ]);
 }
 
+/// Append `; set-option -t <target> window-size latest` so the tmux window
+/// follows the most recently active client. Required for the primary-client
+/// resize model: without this, a user's `~/.tmux.conf` could set
+/// `window-size smallest`, which would shrink the window to the smallest
+/// attached PTY regardless of which client is primary.
+pub fn append_window_size_args(args: &mut Vec<String>, target: &str) {
+    args.extend([
+        ";".to_string(),
+        "set-option".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        "window-size".to_string(),
+        "latest".to_string(),
+    ]);
+}
+
 pub fn is_pane_dead(session_name: &str) -> bool {
     // Use `^.0` to target the first window's first pane regardless of
     // base-index or which pane is active, so the check always hits the

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -107,7 +107,7 @@ export function TerminalView({ session }: Props) {
       if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
       cancelAnimationFrame(scrollRafRef.current);
     };
-  }, [keyboardHeight, termRef]);
+  }, [keyboardHeight, keyboardOpen, termRef]);
 
   // On initial connect, auto-open the keyboard.
   useEffect(() => {

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -18,7 +18,7 @@ export function TerminalView({ session }: Props) {
     "pending",
   );
   const [ensureError, setEnsureError] = useState<string | null>(null);
-  const { containerRef, termRef, state, manualReconnect, sendData, ctrlActiveRef, clearCtrlRef } =
+  const { containerRef, termRef, state, manualReconnect, sendData, activate, ctrlActiveRef, clearCtrlRef } =
     useTerminal(ensureState === "ready" ? session.id : null);
   const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
@@ -99,8 +99,10 @@ export function TerminalView({ session }: Props) {
   }, [isMobile, state.connected, termRef]);
 
   // Toggle keyboard: focus/blur synchronously in the click handler so iOS
-  // honors the user-gesture context.
+  // honors the user-gesture context. Also claims primary so the PTY
+  // resizes to this client's viewport.
   const toggleKeyboard = useCallback(() => {
+    activate();
     const term = termRef.current;
     if (!term) return;
     const ta = term.element.querySelector("textarea");
@@ -109,7 +111,7 @@ export function TerminalView({ session }: Props) {
     } else if (ta instanceof HTMLElement) {
       ta.focus();
     }
-  }, [termRef, keyboardOpen]);
+  }, [termRef, keyboardOpen, activate]);
 
   // Dismiss scroll hint on first touch or timeout.
   useEffect(() => {
@@ -185,7 +187,7 @@ export function TerminalView({ session }: Props) {
         </div>
       )}
 
-      <div className="flex-1 overflow-hidden bg-surface-950 relative">
+      <div className="flex-1 overflow-hidden bg-surface-950 relative" onPointerDown={activate}>
         <div ref={containerRef} className="absolute inset-0" />
 
         {showScrollHint && (

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -213,8 +213,8 @@ export function TerminalView({ session }: Props) {
         </div>
       )}
 
-      <div className="flex-1 overflow-hidden bg-surface-950 relative" onPointerDown={activate}>
-        <div ref={containerRef} className="absolute inset-0" />
+      <div className="flex-1 overflow-hidden bg-surface-950 relative">
+        <div ref={containerRef} className="absolute inset-0" onPointerDown={activate} />
 
         {showScrollHint && (
           <div

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -82,6 +82,7 @@ export function TerminalView({ session }: Props) {
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollRafRef = useRef(0);
   useLayoutEffect(() => {
+    console.debug("[aoe:keyboard] keyboardHeight changed", { keyboardHeight, keyboardOpen });
     if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
 
     // Immediate: double-rAF ensures we fire AFTER wterm's scheduled render
@@ -129,6 +130,7 @@ export function TerminalView({ session }: Props) {
   // focus() (even a synchronous ws.send) can break iOS keyboard display.
   // Claim primary after the focus so the PTY resizes to this viewport.
   const toggleKeyboard = useCallback(() => {
+    console.debug("[aoe:keyboard] toggleKeyboard", { keyboardOpen });
     const term = termRef.current;
     if (!term) return;
     const ta = term.element.querySelector("textarea");
@@ -187,6 +189,7 @@ export function TerminalView({ session }: Props) {
   const rootStyle = {
     paddingBottom: keyboardHeight > 0 ? keyboardHeight : undefined,
   } as const;
+  console.debug("[aoe:layout] rootStyle", rootStyle, { keyboardHeight, keyboardOpen });
 
   return (
     <div

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -217,6 +217,17 @@ export function TerminalView({ session }: Props) {
       <div className="flex-1 overflow-hidden bg-surface-950 relative">
         <div ref={containerRef} className="absolute inset-0" onPointerDown={activate} />
 
+        {state.connected && !state.isPrimary && (
+          <div
+            aria-hidden="true"
+            className="absolute left-0 right-0 top-3 flex justify-center pointer-events-none z-10"
+          >
+            <span className="font-mono text-[11px] text-text-dim bg-surface-800/80 border border-surface-700/50 rounded-md px-2.5 py-1 backdrop-blur-sm">
+              Viewing from another device. Tap to take over.
+            </span>
+          </div>
+        )}
+
         {showScrollHint && (
           <div
             aria-hidden="true"

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
@@ -18,8 +24,16 @@ export function TerminalView({ session }: Props) {
     "pending",
   );
   const [ensureError, setEnsureError] = useState<string | null>(null);
-  const { containerRef, termRef, state, manualReconnect, sendData, activate, ctrlActiveRef, clearCtrlRef } =
-    useTerminal(ensureState === "ready" ? session.id : null);
+  const {
+    containerRef,
+    termRef,
+    state,
+    manualReconnect,
+    sendData,
+    activate,
+    ctrlActiveRef,
+    clearCtrlRef,
+  } = useTerminal(ensureState === "ready" ? session.id : null);
   const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
 
@@ -201,9 +215,7 @@ export function TerminalView({ session }: Props) {
       )}
       {!state.connected && !state.reconnecting && state.retryCount >= 3 && (
         <div className="bg-status-error/10 border-b border-status-error/30 px-4 py-1.5 flex items-center gap-2 shrink-0">
-          <span className="text-xs text-status-error">
-            Connection lost
-          </span>
+          <span className="text-xs text-status-error">Connection lost</span>
           <button
             onClick={manualReconnect}
             className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer underline"
@@ -214,7 +226,11 @@ export function TerminalView({ session }: Props) {
       )}
 
       <div className="flex-1 overflow-hidden bg-surface-950 relative">
-        <div ref={containerRef} className="absolute inset-0" onPointerDown={activate} />
+        <div
+          ref={containerRef}
+          className="absolute inset-0"
+          onPointerDown={activate}
+        />
 
         {state.connected && !state.isPrimary && (
           <div
@@ -249,14 +265,34 @@ export function TerminalView({ session }: Props) {
             className="absolute right-3 bottom-3 z-10 w-10 h-10 rounded-full bg-surface-800/90 border border-surface-700/30 text-text-secondary flex items-center justify-center shadow-lg backdrop-blur-sm active:scale-95"
           >
             {keyboardOpen ? (
-              <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <svg
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
                 <rect x="1" y="1" width="22" height="16" rx="2" />
                 <line x1="5" y1="13" x2="19" y2="13" />
                 <line x1="8" y1="20" x2="16" y2="20" />
                 <line x1="12" y1="17" x2="12" y2="20" />
               </svg>
             ) : (
-              <svg width="18" height="14" viewBox="0 0 24 18" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <svg
+                width="18"
+                height="14"
+                viewBox="0 0 24 18"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
                 <rect x="1" y="1" width="22" height="16" rx="2" />
                 <line x1="5" y1="13" x2="19" y2="13" />
                 <line x1="5" y1="9" x2="5.01" y2="9" />

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -82,7 +82,6 @@ export function TerminalView({ session }: Props) {
   const resizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollRafRef = useRef(0);
   useLayoutEffect(() => {
-    console.debug("[aoe:keyboard] keyboardHeight changed", { keyboardHeight, keyboardOpen });
     if (resizeTimerRef.current) clearTimeout(resizeTimerRef.current);
 
     // Immediate: double-rAF ensures we fire AFTER wterm's scheduled render
@@ -130,7 +129,6 @@ export function TerminalView({ session }: Props) {
   // focus() (even a synchronous ws.send) can break iOS keyboard display.
   // Claim primary after the focus so the PTY resizes to this viewport.
   const toggleKeyboard = useCallback(() => {
-    console.debug("[aoe:keyboard] toggleKeyboard", { keyboardOpen });
     const term = termRef.current;
     if (!term) return;
     const ta = term.element.querySelector("textarea");
@@ -189,8 +187,6 @@ export function TerminalView({ session }: Props) {
   const rootStyle = {
     paddingBottom: keyboardHeight > 0 ? keyboardHeight : undefined,
   } as const;
-  console.debug("[aoe:layout] rootStyle", rootStyle, { keyboardHeight, keyboardOpen });
-
   return (
     <div
       className="flex-1 flex flex-col overflow-hidden relative"

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -124,11 +124,11 @@ export function TerminalView({ session }: Props) {
     return () => timers.forEach(clearTimeout);
   }, [isMobile, state.connected, termRef]);
 
-  // Toggle keyboard: focus/blur synchronously in the click handler so iOS
-  // honors the user-gesture context. Also claims primary so the PTY
-  // resizes to this client's viewport.
+  // Toggle keyboard: focus/blur MUST be the first thing in this handler
+  // so iOS considers it part of the user-gesture chain. Anything before
+  // focus() (even a synchronous ws.send) can break iOS keyboard display.
+  // Claim primary after the focus so the PTY resizes to this viewport.
   const toggleKeyboard = useCallback(() => {
-    activate();
     const term = termRef.current;
     if (!term) return;
     const ta = term.element.querySelector("textarea");
@@ -137,6 +137,7 @@ export function TerminalView({ session }: Props) {
     } else if (ta instanceof HTMLElement) {
       ta.focus();
     }
+    activate();
   }, [termRef, keyboardOpen, activate]);
 
   // Dismiss scroll hint on first touch or timeout.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { WTerm } from "@wterm/dom";
-import type { ActivateMessage, PrimaryStatusMessage, ResizeMessage } from "../lib/types";
+import type {
+  ActivateMessage,
+  PrimaryStatusMessage,
+  ResizeMessage,
+} from "../lib/types";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 
@@ -32,10 +36,7 @@ export interface TerminalState {
  * Manages a wterm terminal connected to a PTY-relayed WebSocket.
  * Returns a ref to attach to a container div, plus connection state.
  */
-export function useTerminal(
-  sessionId: string | null,
-  wsPath: string = "ws",
-) {
+export function useTerminal(sessionId: string | null, wsPath: string = "ws") {
   const { settings, update } = useWebSettings();
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<WTerm | null>(null);
@@ -178,10 +179,14 @@ export function useTerminal(
       // Capture-phase: block wterm's preventDefault on Backspace so iOS
       // can enter its key-repeat loop. Don't send \x7f here; the native
       // deletion fires a deleteContentBackward input event which handles it.
-      wtermTextarea.addEventListener("keydown", (e: KeyboardEvent) => {
-        if (e.key !== "Backspace") return;
-        e.stopImmediatePropagation();
-      }, true);
+      wtermTextarea.addEventListener(
+        "keydown",
+        (e: KeyboardEvent) => {
+          if (e.key !== "Backspace") return;
+          e.stopImmediatePropagation();
+        },
+        true,
+      );
 
       // All backspace handling (first press + iOS repeat) comes through
       // here as deleteContentBackward input events. Send \x7f and re-seed.
@@ -395,7 +400,9 @@ export function useTerminal(
       Math.max(-MAX_VELOCITY, Math.min(MAX_VELOCITY, v));
     const cellHeight = () => {
       const cs = getComputedStyle(term.element);
-      return parseFloat(cs.getPropertyValue("--term-font-size")) || DEFAULT_FONT_SIZE;
+      return (
+        parseFloat(cs.getPropertyValue("--term-font-size")) || DEFAULT_FONT_SIZE
+      );
     };
     const pxPerWheel = () => cellHeight() * LINES_PER_WHEEL;
     const prefersReducedMotion = () =>
@@ -423,7 +430,9 @@ export function useTerminal(
     let fontSizeRaf: number | null = null;
     const currentFontSize = (): number => {
       const cs = getComputedStyle(term.element);
-      return parseFloat(cs.getPropertyValue("--term-font-size")) || DEFAULT_FONT_SIZE;
+      return (
+        parseFloat(cs.getPropertyValue("--term-font-size")) || DEFAULT_FONT_SIZE
+      );
     };
     const applyFontSize = (size: number) => {
       const next = clampFont(Math.round(size));
@@ -455,8 +464,7 @@ export function useTerminal(
         pendingFontSize = null;
       }
     };
-    const currentPendingOrLiveSize = () =>
-      pendingFontSize ?? currentFontSize();
+    const currentPendingOrLiveSize = () => pendingFontSize ?? currentFontSize();
 
     const cancelMomentum = () => {
       if (momentumRaf !== null) {
@@ -495,7 +503,10 @@ export function useTerminal(
 
     const onTouchMove = (e: TouchEvent) => {
       // Single-finger scroll
-      if (e.touches.length === 1 && (gestureMode === null || gestureMode === "single-scroll")) {
+      if (
+        e.touches.length === 1 &&
+        (gestureMode === null || gestureMode === "single-scroll")
+      ) {
         const t = e.touches[0]!;
         const y = t.clientY;
         const now = performance.now();
@@ -518,7 +529,10 @@ export function useTerminal(
         singleAccum += dy;
         const step = pxPerWheel();
         const rawWheels = Math.trunc(singleAccum / step);
-        const wheels = Math.max(-MAX_WHEELS_PER_FRAME, Math.min(MAX_WHEELS_PER_FRAME, rawWheels));
+        const wheels = Math.max(
+          -MAX_WHEELS_PER_FRAME,
+          Math.min(MAX_WHEELS_PER_FRAME, rawWheels),
+        );
         if (wheels !== 0) {
           sendWheel(wheels > 0 ? "up" : "down", Math.abs(wheels));
           singleAccum -= wheels * step;
@@ -582,7 +596,8 @@ export function useTerminal(
         velocity = 0;
         return;
       }
-      const wasScrolling = gestureMode === "single-scroll" || gestureMode === "scroll";
+      const wasScrolling =
+        gestureMode === "single-scroll" || gestureMode === "scroll";
       gestureMode = null;
       if (wasScrolling) suppressNextClick = true;
       if (prefersReducedMotion() || Math.abs(velocity) < 0.05) {
@@ -736,9 +751,20 @@ export function useTerminal(
 
   const activate = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      wsRef.current.send(JSON.stringify({ type: "activate" } as ActivateMessage));
+      wsRef.current.send(
+        JSON.stringify({ type: "activate" } as ActivateMessage),
+      );
     }
   }, []);
 
-  return { containerRef, termRef, state, manualReconnect, sendData, activate, ctrlActiveRef, clearCtrlRef };
+  return {
+    containerRef,
+    termRef,
+    state,
+    manualReconnect,
+    sendData,
+    activate,
+    ctrlActiveRef,
+    clearCtrlRef,
+  };
 }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { WTerm } from "@wterm/dom";
-import type { ResizeMessage } from "../lib/types";
+import type { ActivateMessage, ResizeMessage } from "../lib/types";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 
@@ -632,9 +632,26 @@ export function useTerminal(
     };
     viewport.addEventListener("wheel", onWheel, { passive: false });
 
+    // When the user switches to this tab/window, tell the server so it
+    // can claim primary and resize the PTY to match this viewport.
+    const sendActivate = () => {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
+        const msg: ActivateMessage = { type: "activate" };
+        ws.send(JSON.stringify(msg));
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") sendActivate();
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    window.addEventListener("focus", sendActivate);
+
     return () => {
       connectOnReady = false;
       cancelMomentum();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      window.removeEventListener("focus", sendActivate);
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -223,6 +223,10 @@ export function useTerminal(
           retryCountdown: 0,
         });
         term.focus();
+        // Claim primary immediately so this client's resize is applied.
+        // Without this, the first resize lands in "vacant" state (which
+        // works) but a race with focus/visibility events could delay it.
+        ws.send(JSON.stringify({ type: "activate" } as ActivateMessage));
         // Send initial PTY dimensions from the already-autoresized terminal.
         if (
           term.cols > 0 &&
@@ -704,5 +708,11 @@ export function useTerminal(
     }
   }, []);
 
-  return { containerRef, termRef, state, manualReconnect, sendData, ctrlActiveRef, clearCtrlRef };
+  const activate = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: "activate" } as ActivateMessage));
+    }
+  }, []);
+
+  return { containerRef, termRef, state, manualReconnect, sendData, activate, ctrlActiveRef, clearCtrlRef };
 }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -125,12 +125,14 @@ export function useTerminal(
       autoResize: true,
       cursorBlink: true,
       onResize: (cols: number, rows: number) => {
+        console.debug("[aoe:resize] onResize fired", { cols, rows });
         if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
         resizeDebounceTimer = setTimeout(() => {
           resizeDebounceTimer = null;
           const ws = wsRef.current;
           if (ws?.readyState === WebSocket.OPEN) {
             const msg: ResizeMessage = { type: "resize", cols, rows };
+            console.debug("[aoe:resize] sending debounced resize", msg);
             ws.send(JSON.stringify(msg));
           }
         }, RESIZE_DEBOUNCE_MS);
@@ -277,6 +279,7 @@ export function useTerminal(
             const msg = JSON.parse(event.data) as { type?: string };
             if (msg.type === "primary_status") {
               const status = msg as PrimaryStatusMessage;
+              console.debug("[aoe:primary]", status);
               setState((prev) => ({ ...prev, isPrimary: status.is_primary }));
               return;
             }
@@ -736,6 +739,7 @@ export function useTerminal(
 
   const activate = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
+      console.debug("[aoe:activate] sending activate");
       wsRef.current.send(JSON.stringify({ type: "activate" } as ActivateMessage));
     }
   }, []);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { WTerm } from "@wterm/dom";
-import type { ActivateMessage, ResizeMessage } from "../lib/types";
+import type { ActivateMessage, PrimaryStatusMessage, ResizeMessage } from "../lib/types";
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 
@@ -18,12 +18,14 @@ const DEFAULT_FONT_SIZE = 14;
 const MOBILE_BREAKPOINT_PX = 768;
 const WHEEL_ZOOM_SENSITIVITY = 0.05;
 const WHEEL_PERSIST_DEBOUNCE_MS = 400;
+const RESIZE_DEBOUNCE_MS = 50;
 
 export interface TerminalState {
   connected: boolean;
   reconnecting: boolean;
   retryCount: number;
   retryCountdown: number;
+  isPrimary: boolean;
 }
 
 /**
@@ -53,6 +55,7 @@ export function useTerminal(
     reconnecting: false,
     retryCount: 0,
     retryCountdown: 0,
+    isPrimary: true,
   });
 
   useEffect(() => {
@@ -114,16 +117,23 @@ export function useTerminal(
     termEl.style.setProperty("--term-font-size", `${fontSize}px`);
 
     // wterm's autoResize uses ResizeObserver to fit the terminal element.
+    // Debounce resize messages to avoid SIGWINCH storms during keyboard
+    // animation (ResizeObserver fires multiple times with intermediate
+    // sizes). 50ms settles after the animation ends.
+    let resizeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
     const term = new WTerm(termEl, {
       autoResize: true,
       cursorBlink: true,
       onResize: (cols: number, rows: number) => {
-        // Relay resize to the PTY backend
-        const ws = wsRef.current;
-        if (ws?.readyState === WebSocket.OPEN) {
-          const msg: ResizeMessage = { type: "resize", cols, rows };
-          ws.send(JSON.stringify(msg));
-        }
+        if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
+        resizeDebounceTimer = setTimeout(() => {
+          resizeDebounceTimer = null;
+          const ws = wsRef.current;
+          if (ws?.readyState === WebSocket.OPEN) {
+            const msg: ResizeMessage = { type: "resize", cols, rows };
+            ws.send(JSON.stringify(msg));
+          }
+        }, RESIZE_DEBOUNCE_MS);
       },
     });
 
@@ -221,6 +231,7 @@ export function useTerminal(
           reconnecting: false,
           retryCount: 0,
           retryCountdown: 0,
+          isPrimary: true,
         });
         term.focus();
         // Claim primary immediately so this client's resize is applied.
@@ -260,8 +271,19 @@ export function useTerminal(
       ws.onmessage = (event: MessageEvent) => {
         if (event.data instanceof ArrayBuffer) {
           term.write(new Uint8Array(event.data));
-        } else {
-          term.write(event.data as string);
+        } else if (typeof event.data === "string") {
+          // Check for server control messages before writing to terminal
+          try {
+            const msg = JSON.parse(event.data) as { type?: string };
+            if (msg.type === "primary_status") {
+              const status = msg as PrimaryStatusMessage;
+              setState((prev) => ({ ...prev, isPrimary: status.is_primary }));
+              return;
+            }
+          } catch {
+            // Not JSON, treat as terminal text
+          }
+          term.write(event.data);
         }
       };
 
@@ -273,12 +295,13 @@ export function useTerminal(
           const delayMs = retryDelayMs(count);
           let countdown = Math.ceil(delayMs / 1000);
 
-          setState({
+          setState((prev) => ({
+            ...prev,
             connected: false,
             reconnecting: true,
             retryCount: count,
             retryCountdown: countdown,
-          });
+          }));
 
           term.write(
             `\r\n\x1b[33m[Disconnected, reconnecting in ${countdown}s... (${count}/${MAX_RETRIES})]\x1b[0m\r\n`,
@@ -299,12 +322,13 @@ export function useTerminal(
           term.write(
             "\r\n\x1b[31m[Connection lost. Click retry or press Enter to reconnect.]\x1b[0m\r\n",
           );
-          setState({
+          setState((prev) => ({
+            ...prev,
             connected: false,
             reconnecting: false,
             retryCount: retryCountRef.current,
             retryCountdown: 0,
-          });
+          }));
         }
       };
 
@@ -663,6 +687,7 @@ export function useTerminal(
       viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheel);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
+      if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
       wsRef.current?.close();
       term.destroy();
@@ -693,12 +718,13 @@ export function useTerminal(
 
   const manualReconnect = () => {
     retryCountRef.current = 0;
-    setState({
+    setState((prev) => ({
+      ...prev,
       connected: false,
       reconnecting: true,
       retryCount: 0,
       retryCountdown: 0,
-    });
+    }));
     wsRef.current?.close();
   };
 

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -125,14 +125,12 @@ export function useTerminal(
       autoResize: true,
       cursorBlink: true,
       onResize: (cols: number, rows: number) => {
-        console.debug("[aoe:resize] onResize fired", { cols, rows });
         if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
         resizeDebounceTimer = setTimeout(() => {
           resizeDebounceTimer = null;
           const ws = wsRef.current;
           if (ws?.readyState === WebSocket.OPEN) {
             const msg: ResizeMessage = { type: "resize", cols, rows };
-            console.debug("[aoe:resize] sending debounced resize", msg);
             ws.send(JSON.stringify(msg));
           }
         }, RESIZE_DEBOUNCE_MS);
@@ -279,7 +277,6 @@ export function useTerminal(
             const msg = JSON.parse(event.data) as { type?: string };
             if (msg.type === "primary_status") {
               const status = msg as PrimaryStatusMessage;
-              console.debug("[aoe:primary]", status);
               setState((prev) => ({ ...prev, isPrimary: status.is_primary }));
               return;
             }
@@ -739,7 +736,6 @@ export function useTerminal(
 
   const activate = useCallback(() => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {
-      console.debug("[aoe:activate] sending activate");
       wsRef.current.send(JSON.stringify({ type: "activate" } as ActivateMessage));
     }
   }, []);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -53,6 +53,12 @@ export interface ActivateMessage {
   type: "activate";
 }
 
+/** Server → client control message indicating primary status */
+export interface PrimaryStatusMessage {
+  type: "primary_status";
+  is_primary: boolean;
+}
+
 /** Rich diff file info with addition/deletion stats */
 export interface RichDiffFile {
   path: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -49,6 +49,10 @@ export interface ResizeMessage {
   rows: number;
 }
 
+export interface ActivateMessage {
+  type: "activate";
+}
+
 /** Rich diff file info with addition/deletion stats */
 export interface RichDiffFile {
   path: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -63,7 +63,14 @@ export interface PrimaryStatusMessage {
 export interface RichDiffFile {
   path: string;
   old_path: string | null;
-  status: "added" | "modified" | "deleted" | "renamed" | "copied" | "untracked" | "conflicted";
+  status:
+    | "added"
+    | "modified"
+    | "deleted"
+    | "renamed"
+    | "copied"
+    | "untracked"
+    | "conflicted";
   additions: number;
   deletions: number;
 }


### PR DESCRIPTION
## Description

When multiple browser clients (phone, desktop, different tabs) view the same tmux session via the web dashboard, every client's resize messages raced to change the PTY dimensions, causing the tmux window to constantly reflow. This broke status detection, TUI previews, and made running programs receive spurious SIGWINCH signals.

This PR introduces a "primary client" model: only one browser client at a time controls the PTY size. Whichever client the user is actively interacting with becomes primary.

### Server (Rust)
- Per-session primary tracking via `session_primaries` HashMap in AppState
- Only the primary client's resize messages resize the PTY; non-primary clients store pending size
- `Activate` control message for claiming primary without keyboard input
- Server-to-client `primary_status` feedback via a control channel
- Read-only mode guard: viewers can't steal primary
- `window-size latest` set on all tmux sessions at creation
- Zero-dimension resize guard
- 10 unit tests for the primary state machine

### Client (TypeScript)
- Sends `activate` on ws.onopen, tab focus, window focus, terminal tap, and keyboard FAB
- 50ms resize debounce to reduce SIGWINCH storms during keyboard animation
- "Viewing from another device" banner when not primary
- iOS gesture chain fix: focus/blur runs before activate in toggleKeyboard
- Scroll-to-bottom effect fires on `keyboardOpen` changes (fixes iOS PWA where keyboardHeight is always 0)

### What claims primary
| Action | Mechanism |
|--------|-----------|
| Open web app | `ws.onopen` sends activate |
| Tap terminal | `onPointerDown` on container |
| Type | Binary/text input in recv loop |
| Switch browser tab | `visibilitychange` listener |
| Open keyboard (mobile) | `toggleKeyboard` calls activate |
| Close tab | `release_primary` clears slot |

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)