### PR TITLE
feat(tui): last-activity column + LastActivity sort

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -56,6 +56,7 @@ pub struct Config {
 pub enum SortOrder {
     #[default]
     Newest,
+    LastActivity,
     Oldest,
     AZ,
     ZA,
@@ -64,7 +65,8 @@ pub enum SortOrder {
 impl SortOrder {
     pub fn cycle(self) -> Self {
         match self {
-            SortOrder::Newest => SortOrder::Oldest,
+            SortOrder::Newest => SortOrder::LastActivity,
+            SortOrder::LastActivity => SortOrder::Oldest,
             SortOrder::Oldest => SortOrder::AZ,
             SortOrder::AZ => SortOrder::ZA,
             SortOrder::ZA => SortOrder::Newest,
@@ -74,7 +76,8 @@ impl SortOrder {
     pub fn cycle_reverse(self) -> Self {
         match self {
             SortOrder::Newest => SortOrder::ZA,
-            SortOrder::Oldest => SortOrder::Newest,
+            SortOrder::LastActivity => SortOrder::Newest,
+            SortOrder::Oldest => SortOrder::LastActivity,
             SortOrder::AZ => SortOrder::Oldest,
             SortOrder::ZA => SortOrder::AZ,
         }
@@ -83,6 +86,7 @@ impl SortOrder {
     pub fn label(self) -> &'static str {
         match self {
             SortOrder::Newest => "Newest",
+            SortOrder::LastActivity => "Recent",
             SortOrder::Oldest => "Oldest",
             SortOrder::AZ => "A-Z",
             SortOrder::ZA => "Z-A",

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -281,7 +281,7 @@ where
     match sort_order {
         SortOrder::AZ => items.sort_by_key(|a| key(a).to_lowercase()),
         SortOrder::ZA => items.sort_by_key(|b| std::cmp::Reverse(key(b).to_lowercase())),
-        _ => {}
+        SortOrder::Newest | SortOrder::Oldest | SortOrder::LastActivity => {}
     }
 }
 
@@ -309,6 +309,41 @@ fn min_created_at_in_group(path: &str, instances: &[Instance]) -> DateTime<Utc> 
         .unwrap_or(DateTime::<Utc>::MAX_UTC)
 }
 
+/// Get the most recent last_accessed_at among all sessions (direct and nested) in a group.
+/// Groups with no sessions (or whose sessions have never reported activity) sort to the bottom
+/// for descending order.
+fn max_last_accessed_in_group(path: &str, instances: &[Instance]) -> Option<DateTime<Utc>> {
+    let prefix = format!("{}/", path);
+    instances
+        .iter()
+        .filter(|i| i.group_path == path || i.group_path.starts_with(&prefix))
+        .filter_map(|i| i.last_accessed_at)
+        .max()
+}
+
+/// Key used to sort sessions by LastActivity in descending order, pushing
+/// sessions with no recorded activity to the bottom.
+///
+/// Rust's default ordering on `Option` places `None` BEFORE `Some(..)`; we
+/// invert by wrapping in `Reverse` AND bucketing `None` into the "has no
+/// activity" tier via the leading bool.
+fn last_activity_session_key(inst: &Instance) -> (bool, Reverse<Option<DateTime<Utc>>>) {
+    (
+        inst.last_accessed_at.is_none(),
+        Reverse(inst.last_accessed_at),
+    )
+}
+
+/// Key used to sort groups by LastActivity in descending order. Groups with no
+/// activity sort to the bottom.
+fn last_activity_group_key(
+    path: &str,
+    instances: &[Instance],
+) -> (bool, Reverse<Option<DateTime<Utc>>>) {
+    let ts = max_last_accessed_in_group(path, instances);
+    (ts.is_none(), Reverse(ts))
+}
+
 /// Flatten instances from multiple profiles into a single flat list.
 /// Merges all profiles' sessions and groups at depth 0 (no profile headers).
 /// Uses per-profile GroupTrees so collapsed state is isolated per profile.
@@ -328,7 +363,8 @@ pub fn flatten_tree_all_profiles(
     match sort_order {
         SortOrder::Oldest => ungrouped.sort_by_key(|i| i.created_at),
         SortOrder::Newest => ungrouped.sort_by_key(|i| Reverse(i.created_at)),
-        _ => sort_by_name(&mut ungrouped, sort_order, |i| &i.title),
+        SortOrder::LastActivity => ungrouped.sort_by_key(|i| last_activity_session_key(i)),
+        SortOrder::AZ | SortOrder::ZA => sort_by_name(&mut ungrouped, sort_order, |i| &i.title),
     }
 
     for inst in ungrouped {
@@ -358,7 +394,10 @@ pub fn flatten_tree_all_profiles(
         SortOrder::Newest => {
             all_roots.sort_by_key(|(_, g, insts)| Reverse(max_created_at_in_group(&g.path, insts)));
         }
-        _ => all_roots.sort_by_key(|(_, g, _)| g.name.to_lowercase()),
+        SortOrder::LastActivity => {
+            all_roots.sort_by_key(|(_, g, insts)| last_activity_group_key(&g.path, insts));
+        }
+        SortOrder::AZ | SortOrder::ZA => all_roots.sort_by_key(|(_, g, _)| g.name.to_lowercase()),
     }
     if matches!(sort_order, SortOrder::ZA) {
         all_roots.reverse();
@@ -394,7 +433,8 @@ pub fn flatten_tree(
     match sort_order {
         SortOrder::Oldest => ungrouped.sort_by_key(|i| i.created_at),
         SortOrder::Newest => ungrouped.sort_by_key(|i| Reverse(i.created_at)),
-        _ => sort_by_name(&mut ungrouped, sort_order, |i| &i.title),
+        SortOrder::LastActivity => ungrouped.sort_by_key(|i| last_activity_session_key(i)),
+        SortOrder::AZ | SortOrder::ZA => sort_by_name(&mut ungrouped, sort_order, |i| &i.title),
     }
 
     for inst in ungrouped {
@@ -414,7 +454,12 @@ pub fn flatten_tree(
         SortOrder::Newest => {
             roots_to_iterate.sort_by_key(|g| Reverse(max_created_at_in_group(&g.path, instances)));
         }
-        _ => sort_by_name(&mut roots_to_iterate, sort_order, |g| &g.name),
+        SortOrder::LastActivity => {
+            roots_to_iterate.sort_by_key(|g| last_activity_group_key(&g.path, instances));
+        }
+        SortOrder::AZ | SortOrder::ZA => {
+            sort_by_name(&mut roots_to_iterate, sort_order, |g| &g.name)
+        }
     }
 
     for root in roots_to_iterate {
@@ -456,7 +501,10 @@ fn flatten_group(
     match sort_order {
         SortOrder::Oldest => group_sessions.sort_by_key(|i| i.created_at),
         SortOrder::Newest => group_sessions.sort_by_key(|i| Reverse(i.created_at)),
-        _ => sort_by_name(&mut group_sessions, sort_order, |i| &i.title),
+        SortOrder::LastActivity => group_sessions.sort_by_key(|i| last_activity_session_key(i)),
+        SortOrder::AZ | SortOrder::ZA => {
+            sort_by_name(&mut group_sessions, sort_order, |i| &i.title)
+        }
     }
 
     for inst in group_sessions {
@@ -476,7 +524,12 @@ fn flatten_group(
             children_to_iterate
                 .sort_by_key(|g| Reverse(max_created_at_in_group(&g.path, instances)));
         }
-        _ => sort_by_name(&mut children_to_iterate, sort_order, |g| &g.name),
+        SortOrder::LastActivity => {
+            children_to_iterate.sort_by_key(|g| last_activity_group_key(&g.path, instances));
+        }
+        SortOrder::AZ | SortOrder::ZA => {
+            sort_by_name(&mut children_to_iterate, sort_order, |g| &g.name)
+        }
     }
 
     for child in children_to_iterate {
@@ -845,10 +898,46 @@ mod tests {
 
     #[test]
     fn test_sort_order_cycle() {
-        assert_eq!(SortOrder::Newest.cycle(), SortOrder::Oldest);
+        assert_eq!(SortOrder::Newest.cycle(), SortOrder::LastActivity);
+        assert_eq!(SortOrder::LastActivity.cycle(), SortOrder::Oldest);
         assert_eq!(SortOrder::Oldest.cycle(), SortOrder::AZ);
         assert_eq!(SortOrder::AZ.cycle(), SortOrder::ZA);
         assert_eq!(SortOrder::ZA.cycle(), SortOrder::Newest);
+    }
+
+    #[test]
+    fn test_sort_order_cycle_reverse() {
+        assert_eq!(SortOrder::Newest.cycle_reverse(), SortOrder::ZA);
+        assert_eq!(SortOrder::ZA.cycle_reverse(), SortOrder::AZ);
+        assert_eq!(SortOrder::AZ.cycle_reverse(), SortOrder::Oldest);
+        assert_eq!(SortOrder::Oldest.cycle_reverse(), SortOrder::LastActivity);
+        assert_eq!(SortOrder::LastActivity.cycle_reverse(), SortOrder::Newest);
+    }
+
+    #[test]
+    fn test_sort_last_activity_descending_with_none_last() {
+        use chrono::Duration;
+        let now = Utc::now();
+        let mut inst_recent = Instance::new("recent", "/tmp/r");
+        inst_recent.last_accessed_at = Some(now);
+        let mut inst_older = Instance::new("older", "/tmp/o");
+        inst_older.last_accessed_at = Some(now - Duration::hours(1));
+        let inst_never = Instance::new("never", "/tmp/n");
+        let instances = vec![inst_never, inst_older, inst_recent];
+        let tree = GroupTree::new_with_groups(&instances, &[]);
+
+        let items = flatten_tree(&tree, &instances, SortOrder::LastActivity);
+        let titles: Vec<_> = items
+            .iter()
+            .filter_map(|i| match i {
+                Item::Session { id, .. } => instances
+                    .iter()
+                    .find(|inst| &inst.id == id)
+                    .map(|inst| inst.title.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(titles, vec!["recent", "older", "never"]);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -710,6 +710,14 @@ impl Instance {
     /// Update status using pre-fetched pane metadata to avoid per-instance
     /// subprocess spawns. Falls back to subprocess calls if metadata is missing.
     pub fn update_status_with_metadata(&mut self, metadata: Option<&tmux::PaneMetadata>) {
+        let prev_status = self.status;
+        self.update_status_with_metadata_inner(metadata);
+        if self.status != prev_status {
+            self.last_accessed_at = Some(Utc::now());
+        }
+    }
+
+    fn update_status_with_metadata_inner(&mut self, metadata: Option<&tmux::PaneMetadata>) {
         if matches!(
             self.status,
             Status::Stopped | Status::Deleting | Status::Creating

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -44,6 +44,42 @@ fn spinner_starting(created_at: &DateTime<Utc>) -> &'static str {
         .current_frame()
 }
 
+/// Format a timestamp as a compact relative age (e.g. `3m`, `2h`, `4d`, `2mo`).
+/// Returns an empty string for `None` so callers can unconditionally substitute
+/// the result without guarding for absence.
+fn format_relative_age(ts: Option<DateTime<Utc>>) -> String {
+    let Some(ts) = ts else {
+        return String::new();
+    };
+    let now = Utc::now();
+    let secs = (now - ts).num_seconds();
+    if secs < 60 {
+        return "<1m".to_string();
+    }
+    let mins = secs / 60;
+    if mins < 60 {
+        return format!("{}m", mins);
+    }
+    let hours = mins / 60;
+    if hours < 24 {
+        return format!("{}h", hours);
+    }
+    let days = hours / 24;
+    if days < 30 {
+        return format!("{}d", days);
+    }
+    let months = days / 30;
+    format!("{}mo", months)
+}
+
+/// Minimum column width required to render the last-activity column.
+/// When the session list is narrower than this, the column is hidden entirely.
+const LAST_ACTIVITY_MIN_WIDTH: u16 = 50;
+
+/// Width reserved for the right-aligned last-activity column:
+/// 5 chars for the label (e.g. `"<1m"`, `"30mo"`) + 1 char left padding.
+const LAST_ACTIVITY_SLOT: usize = 6;
+
 impl HomeView {
     pub fn render(
         &mut self,
@@ -247,7 +283,7 @@ impl HomeView {
             let is_selected = abs_idx == self.cursor;
             let is_match =
                 !self.search_matches.is_empty() && self.search_matches.contains(&abs_idx);
-            let mut line = self.render_item_line(item, is_selected, is_match, theme);
+            let mut line = self.render_item_line(item, is_selected, is_match, theme, inner.width);
             if is_selected {
                 // Pad to full width so the selection background fills the entire row
                 let pad = (inner.width as usize).saturating_sub(line.width());
@@ -322,6 +358,7 @@ impl HomeView {
         is_selected: bool,
         is_match: bool,
         theme: &Theme,
+        list_width: u16,
     ) -> Line<'static> {
         let indent = get_indent(item.depth());
 
@@ -436,6 +473,21 @@ impl HomeView {
                         ));
                     }
                 }
+
+                // Last-activity column: right-aligned, fixed-width slot just
+                // before the terminal-mode/status badge. Hidden when the list
+                // pane is too narrow to justify spending the horizontal budget.
+                if list_width >= LAST_ACTIVITY_MIN_WIDTH {
+                    let age = format_relative_age(inst.last_accessed_at);
+                    // Reserve LAST_ACTIVITY_SLOT cells; right-align inside the
+                    // slot so columns line up across rows of varying title
+                    // length. Empty `age` still reserves space — keeping the
+                    // column aligned is why we don't conditionally skip per
+                    // row.
+                    let padded = format!("{:>width$}", age, width = LAST_ACTIVITY_SLOT);
+                    line_spans.push(Span::styled(padded, Style::default().fg(theme.dimmed)));
+                }
+
                 if self.view_mode == ViewMode::Terminal && inst.is_sandboxed() {
                     let mode = self.get_terminal_mode(id);
                     let mode_text = match mode {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1530,6 +1530,9 @@ fn test_o_key_cycles_sort_order_forward() {
     assert_eq!(env.view.sort_order, SortOrder::Newest);
 
     env.view.handle_key(key(KeyCode::Char('o')));
+    assert_eq!(env.view.sort_order, SortOrder::LastActivity);
+
+    env.view.handle_key(key(KeyCode::Char('o')));
     assert_eq!(env.view.sort_order, SortOrder::Oldest);
 
     env.view.handle_key(key(KeyCode::Char('o')));
@@ -1550,7 +1553,8 @@ fn test_ctrl_o_key_cycles_sort_order_backward() {
     let mut env = create_test_env_with_mixed_sessions();
     assert_eq!(env.view.sort_order, SortOrder::Newest);
 
-    // Ctrl+o cycles backward: Oldest -> ZA -> AZ -> Newest -> Oldest
+    // Ctrl+o cycles backward:
+    // Newest -> ZA -> AZ -> Oldest -> LastActivity -> Newest
     env.view
         .handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
     assert_eq!(env.view.sort_order, SortOrder::ZA);
@@ -1565,6 +1569,10 @@ fn test_ctrl_o_key_cycles_sort_order_backward() {
 
     env.view
         .handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
+    assert_eq!(env.view.sort_order, SortOrder::LastActivity);
+
+    env.view
+        .handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
     assert_eq!(env.view.sort_order, SortOrder::Newest);
 }
 
@@ -1576,7 +1584,8 @@ fn test_o_key_flat_items_sorted_az() {
     let mut env = create_test_env_with_mixed_sessions();
     assert_eq!(env.view.sort_order, SortOrder::Newest);
 
-    // Press 'o' twice to get to AZ (Newest -> Oldest -> AZ)
+    // Press 'o' three times to get to AZ (Newest -> LastActivity -> Oldest -> AZ)
+    env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     assert_eq!(env.view.sort_order, SortOrder::AZ);
@@ -1608,7 +1617,9 @@ fn test_o_key_flat_items_sorted_za() {
 
     let mut env = create_test_env_with_mixed_sessions();
 
-    // Press 'o' three times to get to ZA (Oldest -> Newest -> AZ -> ZA)
+    // Press 'o' four times to get to ZA
+    // (Newest -> LastActivity -> Oldest -> AZ -> ZA)
+    env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
@@ -1641,7 +1652,9 @@ fn test_o_key_flat_items_newest_preserves_insertion_order() {
 
     let mut env = create_test_env_with_mixed_sessions();
 
-    // Press 'o' four times to wrap back to Newest (Newest -> Oldest -> AZ -> ZA -> Newest)
+    // Press 'o' five times to wrap back to Newest
+    // (Newest -> LastActivity -> Oldest -> AZ -> ZA -> Newest)
+    env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
     env.view.handle_key(key(KeyCode::Char('o')));
@@ -1688,7 +1701,7 @@ fn test_o_key_clamps_cursor_when_list_shrinks() {
     assert!(filtered_count < initial_items);
 
     env.view.handle_key(key(KeyCode::Char('o')));
-    assert_eq!(env.view.sort_order, SortOrder::Oldest);
+    assert_eq!(env.view.sort_order, SortOrder::LastActivity);
 
     let valid_max = env.view.flat_items.len().saturating_sub(1);
     assert!(env.view.cursor <= valid_max);


### PR DESCRIPTION
## Description

Once the home list passes ~10 sessions it's hard to tell which ones are actually live vs dusty. `Instance.last_accessed_at` has been in the schema for a while but was never written — this PR starts writing it and surfaces it in the UI as a relative-time column + a new `SortOrder::LastActivity` sort axis.

**Column.** Session rows gain a right-aligned 6-cell "last activity" column just before the terminal-mode / status badge: `<1m`, `5m`, `3h`, `4d`, `2mo`. Hidden when the list pane is narrower than 50 cells to keep vertical splits and narrow terminals clean. Sessions that haven't been polled yet render blank so the column stays aligned.

**Sort.** New `SortOrder::LastActivity` (label `Recent`, serde `last_activity`). Forward cycle becomes `Newest → LastActivity → Oldest → AZ → ZA`. Descending order; sessions and groups with no recorded activity sink to the bottom.

**Write hook.** `last_accessed_at` is bumped to `Utc::now()` inside `Instance::update_status_with_metadata` whenever the status value actually changes — the single poll path every session already passes through, so writes don't scatter.

**Compatibility.** `last_accessed_at` is already `skip_serializing_if = Option::is_none`, so existing `sessions.json` files don't change shape. `SortOrder::LastActivity` is opt-in via the `o` / Ctrl+`o` cycle; default remains `Newest`. No new config fields.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

_UI change is an added column + new sort variant; happy to add a screenshot on request — the column renders as e.g. `3m`, `2h` right-aligned in the existing session row._

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:** Spec was authored by a human maintainer (me); implementation, tests, and this PR body were drafted by Claude. I reviewed the diff, ran the full test suite locally (`cargo build --release`, `cargo clippy --release`, `cargo test`: 1072 passed, 3 environmental failures that also fail on upstream/main — Docker not running + a pre-existing tmux capture flake), and verified the behavior fits the spec before pushing.

- [x] I am an AI Agent filling out this form (check box if true)

## Testing detail

- `cargo build --release` — clean
- `cargo clippy --release` — clean, no warnings
- `cargo fmt --check` — clean
- `cargo test` — 1072 passed; 3 unrelated failures (`containers::docker::*`, one tmux integration test) reproduce identically on `upstream/main` and are environmental (no Docker daemon on the test host, pre-existing tmux flake)
- Cycle tests in `src/tui/home/tests.rs` updated for the inserted variant (forward + reverse + AZ/ZA ordering). Added `test_sort_last_activity_descending_with_none_last` in `session/groups.rs` to lock the descending / None-last ordering.

## Files touched

- `src/session/config.rs` — new `LastActivity` variant + cycle/label arms
- `src/session/instance.rs` — write `last_accessed_at` on status change
- `src/session/groups.rs` — sort arms for ungrouped, roots, grouped sessions, nested groups + helpers for `(None-last, Reverse<Option<DateTime>>)`
- `src/tui/home/render.rs` — `format_relative_age` helper, column rendering with 50-cell width gate
- `src/tui/home/tests.rs` — cycle-count test updates