### PR TITLE
feat(git): fetch remote before creating worktrees

### DIFF
--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -534,26 +534,12 @@ pub fn list_branches(repo_path: &Path) -> Result<Vec<String>> {
     Ok(branches)
 }
 
-/// Get the default branch name (main or master)
+/// Get the default branch name (main or master).
+/// Delegates to `GitWorktree::detect_default_branch` which also checks
+/// remote tracking refs as a fallback.
 pub fn get_default_branch(repo_path: &Path) -> Result<String> {
-    let repo = super::open_repo_at(repo_path)?;
-
-    // Try to find main first, then master
-    for name in &["main", "master"] {
-        if repo.find_branch(name, git2::BranchType::Local).is_ok() {
-            return Ok(name.to_string());
-        }
-    }
-
-    // Fall back to first branch
-    if let Some(branch) = repo.branches(Some(git2::BranchType::Local))?.next() {
-        let (branch, _) = branch?;
-        if let Some(name) = branch.name()? {
-            return Ok(name.to_string());
-        }
-    }
-
-    Err(GitError::BranchNotFound("No branches found".to_string()))
+    let git_wt = super::GitWorktree::new(repo_path.to_path_buf())?;
+    git_wt.detect_default_branch()
 }
 
 #[cfg(test)]

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1714,11 +1714,8 @@ mod tests {
 
         // Clone to get a local repo with an "origin" remote
         let local_dir = TempDir::new().unwrap();
-        let _local = git2::Repository::clone(
-            remote_dir.path().to_str().unwrap(),
-            local_dir.path(),
-        )
-        .unwrap();
+        let _local =
+            git2::Repository::clone(remote_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
 
         let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
         // Fetching a branch that doesn't exist on the remote should succeed silently

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1629,4 +1629,166 @@ mod tests {
     fn test_parse_owner_empty_url() {
         assert_eq!(parse_owner_from_remote_url(""), None);
     }
+
+    // --- detect_default_branch tests ---
+
+    #[test]
+    fn test_detect_default_branch_returns_main() {
+        // setup_test_repo creates a repo with HEAD on main (git2 default)
+        let (dir, _repo) = setup_test_repo();
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        // git2::Repository::init creates an initial branch based on init.defaultBranch
+        // or "master". Either way, it should be detected.
+        let result = git_wt.detect_default_branch().unwrap();
+        assert!(
+            result == "main" || result == "master",
+            "expected main or master, got: {result}"
+        );
+    }
+
+    #[test]
+    fn test_detect_default_branch_finds_master_when_no_main() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        // Create a commit on a "master" branch explicitly
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("refs/heads/master"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        // If there's also a "main" from init, remove it
+        if let Ok(mut main_branch) = repo.find_branch("main", git2::BranchType::Local) {
+            let _ = main_branch.delete();
+        }
+
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        assert_eq!(git_wt.detect_default_branch().unwrap(), "master");
+    }
+
+    #[test]
+    fn test_detect_default_branch_falls_back_to_first_branch() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("refs/heads/develop"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        // Remove main and master if they exist
+        if let Ok(mut b) = repo.find_branch("main", git2::BranchType::Local) {
+            let _ = b.delete();
+        }
+        if let Ok(mut b) = repo.find_branch("master", git2::BranchType::Local) {
+            let _ = b.delete();
+        }
+
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        let result = git_wt.detect_default_branch().unwrap();
+        assert_eq!(result, "develop");
+    }
+
+    // --- fetch_branch tests ---
+
+    #[test]
+    fn test_fetch_branch_ok_when_no_remote() {
+        let (dir, _repo) = setup_test_repo();
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        // No remote configured, fetch should return Ok (silent failure)
+        assert!(git_wt.fetch_branch("origin", "main").is_ok());
+    }
+
+    #[test]
+    fn test_fetch_branch_ok_when_branch_missing_on_remote() {
+        let remote_dir = TempDir::new().unwrap();
+        let _remote = git2::Repository::init_bare(remote_dir.path()).unwrap();
+
+        // Clone to get a local repo with an "origin" remote
+        let local_dir = TempDir::new().unwrap();
+        let _local = git2::Repository::clone(
+            remote_dir.path().to_str().unwrap(),
+            local_dir.path(),
+        )
+        .unwrap();
+
+        let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
+        // Fetching a branch that doesn't exist on the remote should succeed silently
+        assert!(git_wt.fetch_branch("origin", "nonexistent-branch").is_ok());
+    }
+
+    // --- create_worktree fetch integration test ---
+
+    #[test]
+    fn test_create_worktree_branches_from_remote_after_fetch() {
+        // Create a bare "remote" repo with an initial commit on main
+        let remote_dir = TempDir::new().unwrap();
+        let remote = git2::Repository::init_bare(remote_dir.path()).unwrap();
+
+        // Point HEAD at refs/heads/main so clone creates a local "main" branch
+        remote.set_head("refs/heads/main").unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let blob_oid = remote.blob(b"hello").unwrap();
+            let mut tb = remote.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob_oid, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree = remote.find_tree(tree_id).unwrap();
+        let initial_oid = remote
+            .commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[])
+            .unwrap();
+
+        // Clone it locally
+        let local_dir = TempDir::new().unwrap();
+        git2::Repository::clone(remote_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
+
+        // Add a second commit to the remote (local is now 1 commit behind)
+        let blob2 = remote.blob(b"world").unwrap();
+        let mut tb2 = remote.treebuilder(Some(&tree)).unwrap();
+        tb2.insert("file2.txt", blob2, 0o100644).unwrap();
+        let tree2_id = tb2.write().unwrap();
+        let tree2 = remote.find_tree(tree2_id).unwrap();
+        let initial_commit = remote.find_commit(initial_oid).unwrap();
+        let remote_head_oid = remote
+            .commit(
+                Some("refs/heads/main"),
+                &sig,
+                &sig,
+                "second commit",
+                &tree2,
+                &[&initial_commit],
+            )
+            .unwrap();
+
+        // Verify local is behind: local main should still be at initial_oid
+        let local_repo = git2::Repository::open(local_dir.path()).unwrap();
+        let local_main = local_repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap();
+        assert_eq!(local_main.get().peel_to_commit().unwrap().id(), initial_oid);
+
+        // Create a new worktree branch via create_worktree
+        let wt_parent = TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("test-fetch-wt");
+        let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
+        git_wt
+            .create_worktree("new-feature", &wt_path, true)
+            .unwrap();
+
+        // The new branch should be based on the remote's latest commit,
+        // not the stale local HEAD
+        let new_branch = local_repo
+            .find_branch("new-feature", git2::BranchType::Local)
+            .unwrap();
+        let branch_commit_id = new_branch.get().peel_to_commit().unwrap().id();
+        assert_eq!(
+            branch_commit_id, remote_head_oid,
+            "new branch should be based on remote HEAD ({remote_head_oid}), \
+             not stale local HEAD ({initial_oid})"
+        );
+    }
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -268,10 +268,7 @@ impl GitWorktree {
                         if let Some(mut stderr) = child.stderr.take() {
                             let mut msg = String::new();
                             let _ = std::io::Read::read_to_string(&mut stderr, &mut msg);
-                            tracing::warn!(
-                                "git fetch {remote}/{branch} failed: {}",
-                                msg.trim()
-                            );
+                            tracing::warn!("git fetch {remote}/{branch} failed: {}", msg.trim());
                         }
                     }
                     return Ok(());
@@ -378,9 +375,7 @@ impl GitWorktree {
                         })
                 })
                 .ok_or_else(|| {
-                    GitError::WorktreeCommandFailed(
-                        "No commits found to branch from".to_string(),
-                    )
+                    GitError::WorktreeCommandFailed("No commits found to branch from".to_string())
                 })?;
             let commit = repo.find_commit(commit_oid)?;
             repo.branch(branch, &commit, false)?;

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -11,6 +11,11 @@ pub mod template;
 use error::{GitError, Result};
 use template::{resolve_template, TemplateVars};
 
+/// Default remote name used for fetch-before-worktree-create.
+/// Hardcoded for now; if multi-remote support is needed (e.g., "upstream"
+/// vs personal fork), this is the place to parameterize.
+const FETCH_REMOTE: &str = "origin";
+
 /// Open a git repository at the given path without searching parent directories.
 /// Unlike `git2::Repository::discover`, this does not walk up the directory tree,
 /// preventing unrelated ancestor repos (e.g., a dotfile-managed home directory)
@@ -301,8 +306,9 @@ impl GitWorktree {
     }
 
     /// Detect the default branch name by checking local branches and remote
-    /// tracking refs for "main" or "master".
-    fn detect_default_branch(&self) -> Result<String> {
+    /// tracking refs for "main" or "master". Falls back to the first local
+    /// branch if neither exists.
+    pub fn detect_default_branch(&self) -> Result<String> {
         let repo = open_repo_at(&self.repo_path)?;
 
         for name in &["main", "master"] {
@@ -312,7 +318,7 @@ impl GitWorktree {
         }
 
         for name in &["main", "master"] {
-            let remote_ref = format!("origin/{name}");
+            let remote_ref = format!("{FETCH_REMOTE}/{name}");
             if repo
                 .find_branch(&remote_ref, git2::BranchType::Remote)
                 .is_ok()
@@ -349,10 +355,10 @@ impl GitWorktree {
             let db = self
                 .detect_default_branch()
                 .unwrap_or_else(|_| "main".to_string());
-            self.fetch_branch("origin", &db)?;
+            self.fetch_branch(FETCH_REMOTE, &db)?;
             Some(db)
         } else {
-            self.fetch_branch("origin", branch)?;
+            self.fetch_branch(FETCH_REMOTE, branch)?;
             None
         };
 
@@ -362,7 +368,7 @@ impl GitWorktree {
             // Branch from origin/<default> so new branches start from the
             // latest remote state. Falls back to local HEAD if no remote
             // exists, then to any local branch (bare repo with broken HEAD).
-            let remote_ref = format!("origin/{default_branch}");
+            let remote_ref = format!("{FETCH_REMOTE}/{default_branch}");
             let commit_oid = repo
                 .find_branch(&remote_ref, git2::BranchType::Remote)
                 .ok()

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -338,24 +338,23 @@ impl GitWorktree {
         // For new branches, fetch the default branch (main/master) to use as
         // the base. For existing branches, fetch that specific branch.
         // Fails silently on network errors, falling back to local refs.
-        if create_branch {
-            let default_branch = self
+        let default_branch = if create_branch {
+            let db = self
                 .detect_default_branch()
                 .unwrap_or_else(|_| "main".to_string());
-            self.fetch_branch("origin", &default_branch)?;
+            self.fetch_branch("origin", &db)?;
+            Some(db)
         } else {
             self.fetch_branch("origin", branch)?;
-        }
+            None
+        };
 
         let repo = open_repo_at(&self.repo_path)?;
 
-        if create_branch {
+        if let Some(default_branch) = default_branch {
             // Branch from origin/<default> so new branches start from the
             // latest remote state. Falls back to local HEAD if no remote
             // exists, then to any local branch (bare repo with broken HEAD).
-            let default_branch = self
-                .detect_default_branch()
-                .unwrap_or_else(|_| "main".to_string());
             let remote_ref = format!("origin/{default_branch}");
             let commit_oid = repo
                 .find_branch(&remote_ref, git2::BranchType::Remote)

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -244,6 +244,90 @@ impl GitWorktree {
         Some(git_or_bare_dir.to_path_buf())
     }
 
+    /// Fetch a specific branch from a remote. Fails silently on network errors
+    /// or missing remotes (logs a warning), so callers can fall back to local state.
+    /// Stdin is piped to null to prevent SSH passphrase prompts from hanging.
+    /// Times out after 10 seconds.
+    pub fn fetch_branch(&self, remote: &str, branch: &str) -> Result<()> {
+        let mut child = std::process::Command::new("git")
+            .args(["fetch", remote, branch])
+            .current_dir(&self.repo_path)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+
+        let timeout = std::time::Duration::from_secs(10);
+        let start = std::time::Instant::now();
+        let poll_interval = std::time::Duration::from_millis(100);
+
+        loop {
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    if !status.success() {
+                        if let Some(mut stderr) = child.stderr.take() {
+                            let mut msg = String::new();
+                            let _ = std::io::Read::read_to_string(&mut stderr, &mut msg);
+                            tracing::warn!(
+                                "git fetch {remote}/{branch} failed: {}",
+                                msg.trim()
+                            );
+                        }
+                    }
+                    return Ok(());
+                }
+                Ok(None) => {
+                    if start.elapsed() > timeout {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        tracing::warn!(
+                            "git fetch {remote}/{branch} timed out after {}s",
+                            timeout.as_secs()
+                        );
+                        return Ok(());
+                    }
+                    std::thread::sleep(poll_interval);
+                }
+                Err(e) => {
+                    tracing::warn!("git fetch {remote}/{branch} error: {e}");
+                    return Ok(());
+                }
+            }
+        }
+    }
+
+    /// Detect the default branch name by checking local branches and remote
+    /// tracking refs for "main" or "master".
+    fn detect_default_branch(&self) -> Result<String> {
+        let repo = open_repo_at(&self.repo_path)?;
+
+        for name in &["main", "master"] {
+            if repo.find_branch(name, git2::BranchType::Local).is_ok() {
+                return Ok(name.to_string());
+            }
+        }
+
+        for name in &["main", "master"] {
+            let remote_ref = format!("origin/{name}");
+            if repo
+                .find_branch(&remote_ref, git2::BranchType::Remote)
+                .is_ok()
+            {
+                return Ok(name.to_string());
+            }
+        }
+
+        if let Some(Ok((branch, _))) = repo.branches(Some(git2::BranchType::Local))?.next() {
+            if let Ok(Some(name)) = branch.name() {
+                return Ok(name.to_string());
+            }
+        }
+
+        Err(GitError::BranchNotFound(
+            "No default branch found".to_string(),
+        ))
+    }
+
     pub fn create_worktree(&self, branch: &str, path: &Path, create_branch: bool) -> Result<()> {
         if path.exists() {
             return Err(GitError::WorktreeAlreadyExists(path.to_path_buf()));
@@ -253,25 +337,51 @@ impl GitWorktree {
         // previously used by a now-deleted worktree directory.
         self.prune_worktrees()?;
 
+        // Fetch from remote so the worktree starts from the latest state.
+        // For new branches, fetch the default branch (main/master) to use as
+        // the base. For existing branches, fetch that specific branch.
+        // Fails silently on network errors, falling back to local refs.
+        if create_branch {
+            let default_branch = self
+                .detect_default_branch()
+                .unwrap_or_else(|_| "main".to_string());
+            self.fetch_branch("origin", &default_branch)?;
+        } else {
+            self.fetch_branch("origin", branch)?;
+        }
+
         let repo = open_repo_at(&self.repo_path)?;
 
         if create_branch {
-            // Find a commit to branch from. Try HEAD first, fall back to any
-            // existing branch. Bare repos often have HEAD pointing to a
-            // non-existent default branch (e.g., HEAD -> master but only main
-            // exists), so the fallback is necessary.
-            let commit_oid = if let Ok(head) = repo.head() {
-                head.peel_to_commit()?.id()
-            } else {
-                repo.branches(Some(git2::BranchType::Local))?
-                    .filter_map(|b| b.ok())
-                    .find_map(|(b, _)| b.get().target())
-                    .ok_or_else(|| {
-                        GitError::WorktreeCommandFailed(
-                            "No commits found to branch from".to_string(),
-                        )
-                    })?
-            };
+            // Branch from origin/<default> so new branches start from the
+            // latest remote state. Falls back to local HEAD if no remote
+            // exists, then to any local branch (bare repo with broken HEAD).
+            let default_branch = self
+                .detect_default_branch()
+                .unwrap_or_else(|_| "main".to_string());
+            let remote_ref = format!("origin/{default_branch}");
+            let commit_oid = repo
+                .find_branch(&remote_ref, git2::BranchType::Remote)
+                .ok()
+                .and_then(|b| b.get().target())
+                .or_else(|| {
+                    repo.head()
+                        .ok()
+                        .and_then(|h| h.peel_to_commit().ok())
+                        .map(|c| c.id())
+                })
+                .or_else(|| {
+                    repo.branches(Some(git2::BranchType::Local))
+                        .ok()
+                        .and_then(|mut branches| {
+                            branches.find_map(|b| b.ok().and_then(|(b, _)| b.get().target()))
+                        })
+                })
+                .ok_or_else(|| {
+                    GitError::WorktreeCommandFailed(
+                        "No commits found to branch from".to_string(),
+                    )
+                })?;
             let commit = repo.find_commit(commit_oid)?;
             repo.branch(branch, &commit, false)?;
         } else {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -249,13 +249,20 @@ impl GitWorktree {
     /// Stdin is piped to null to prevent SSH passphrase prompts from hanging.
     /// Times out after 10 seconds.
     pub fn fetch_branch(&self, remote: &str, branch: &str) -> Result<()> {
-        let mut child = std::process::Command::new("git")
+        let mut child = match std::process::Command::new("git")
             .args(["fetch", remote, branch])
             .current_dir(&self.repo_path)
             .stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::piped())
-            .spawn()?;
+            .spawn()
+        {
+            Ok(child) => child,
+            Err(e) => {
+                tracing::warn!("git fetch {remote}/{branch} spawn failed: {e}");
+                return Ok(());
+            }
+        };
 
         let timeout = std::time::Duration::from_secs(10);
         let start = std::time::Instant::now();


### PR DESCRIPTION
## Description

New worktree branches were created from local HEAD, which could be stale if the user hadn't pulled recently. This silently caused branches to start N commits behind `origin/main`, leading to unnecessary merge conflicts and rebasing downstream.

Now `create_worktree()` always fetches the relevant branch from origin before creating the worktree:

- **New branches** (`create_branch=true`): fetches the default branch (main/master) and branches from `origin/<default>` instead of local HEAD
- **Existing branches** (`create_branch=false`): fetches that specific branch before checkout

The fetch is designed to be invisible and safe:
- stdin piped to null (prevents SSH passphrase prompts from hanging)
- 10-second timeout (caps worst-case latency for broken networks)
- Falls back silently to local refs on any failure (network error, no remote, timeout)
- Repos with no remote configured work exactly as before

This follows the same pattern as `prune_worktrees()`, which also runs unconditionally before every worktree creation as a correctness operation. No configuration needed.

Inspired by [emdash](https://github.com/generalaction/emdash)'s approach of always branching from `origin/<branch>` after fetching, rather than relying on potentially stale local state.

### New methods on `GitWorktree`:
- `fetch_branch(remote, branch)`: targeted fetch with timeout and silent failure
- `detect_default_branch()`: checks local then remote refs for main/master

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Researched emdash's worktree management patterns, analyzed the existing codebase's worktree creation flow, and iterated on the design (initially had a configurable `auto_fetch` setting, simplified to always-on after research showed it should be a correctness operation like `prune_worktrees()`).

- [x] I am an AI Agent filling out this form (check box if true)