### PR TITLE
feat(ci): add Playwright tests to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,30 @@ jobs:
           echo ""
           echo "=== All evaluations passed ==="
 
+  playwright:
+    name: Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+      - name: Install dependencies and build
+        working-directory: web
+        run: npm ci && npm run build
+      - name: Install Playwright browsers
+        working-directory: web
+        run: npx playwright install --with-deps chromium
+      - name: Run Playwright tests
+        working-directory: web
+        run: npx playwright test
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: web/playwright-report/
+          retention-days: 14
+
   website:
     name: Website Build
     runs-on: ubuntu-latest

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -2,7 +2,9 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  testIgnore: ["**/ensure-session-restart*"],
   timeout: 30000,
+  retries: process.env.CI ? 1 : 0,
   use: {
     baseURL: "http://localhost:4173",
     headless: true,
@@ -11,8 +13,9 @@ export default defineConfig({
   webServer: {
     command: "npx vite preview --port 4173",
     port: 4173,
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
   },
+  reporter: process.env.CI ? [["html", { open: "never" }], ["github"]] : "list",
   projects: [
     {
       name: "chromium",

--- a/web/tests/command-palette.spec.ts
+++ b/web/tests/command-palette.spec.ts
@@ -89,9 +89,9 @@ test.describe("Command palette", () => {
   test("opens from within a focused input", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await page.getByRole("button", { name: "Add project" }).first().click();
+    await page.getByLabel("Add project").first().click();
     await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
-    await page.getByPlaceholder("/path/to/your/project").click();
+    await page.getByPlaceholder("Type to filter...").click();
     await page.keyboard.press("Control+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
   });

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -6,9 +6,9 @@ test.describe("Dashboard layout", () => {
     await expect(page.locator("header")).toBeVisible();
   });
 
-  test("shows fallback title when no workspace selected", async ({ page }) => {
+  test("shows branded home screen with logo text", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Agent of Empires")).toBeVisible();
+    await expect(page.getByText("empires", { exact: false })).toBeVisible();
   });
 
   test("shows branded home screen with action panes", async ({ page }) => {
@@ -29,8 +29,7 @@ test.describe("Sidebar", () => {
   test("sidebar visible on desktop by default", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await expect(page.getByRole("button", { name: "+ New Session" })).toBeVisible();
-    await expect(page.getByPlaceholder("Search... (/)")).toBeVisible();
+    await expect(page.getByLabel("Add project")).toBeVisible();
   });
 
   test("sidebar toggle button exists", async ({ page }) => {
@@ -41,14 +40,14 @@ test.describe("Sidebar", () => {
   test("sidebar can be toggled closed and open on desktop", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    const newBtn = page.getByRole("button", { name: "+ New Session" });
-    await expect(newBtn).toBeVisible();
+    const addBtn = page.getByLabel("Add project");
+    await expect(addBtn).toBeVisible();
 
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(newBtn).not.toBeVisible();
+    await expect(addBtn).not.toBeVisible();
 
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(newBtn).toBeVisible();
+    await expect(addBtn).toBeVisible();
   });
 });
 
@@ -56,13 +55,13 @@ test.describe("Create session from home screen", () => {
   test("'Open project' pane opens session wizard", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
   });
 
   test("'Clone URL' pane opens wizard on Clone tab", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Clone URL").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
     // Should be on the Clone tab, showing the URL input
     await expect(page.getByPlaceholder("https://github.com/user/repo.git")).toBeVisible();
   });
@@ -70,35 +69,34 @@ test.describe("Create session from home screen", () => {
   test("opens with keyboard shortcut n", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    // Click body first to ensure keyboard events reach the app
     await page.locator("body").click();
     await page.keyboard.press("n");
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
   });
 
   test("wizard closes on cancel", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
     await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.getByRole("heading", { name: "New Session" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
   });
 
   test("wizard closes on escape", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(page.getByRole("heading", { name: "New Session" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
   });
 
   test("wizard closes on backdrop click", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
     // Click the backdrop (top-left corner, outside the modal)
     await page.mouse.click(10, 10);
-    await expect(page.getByRole("heading", { name: "New Session" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
   });
 });
 
@@ -111,8 +109,7 @@ test.describe("Settings", () => {
   test("settings opens on click", async ({ page }) => {
     await page.goto("/");
     await page.getByRole("button", { name: "Settings" }).click();
-    // Settings view shows loading state (no backend in test)
-    await expect(page.getByText("Loading settings...")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Back/i })).toBeVisible();
   });
 
   test("settings opens with keyboard shortcut s", async ({ page }) => {
@@ -120,7 +117,7 @@ test.describe("Settings", () => {
     await page.goto("/");
     await page.locator("body").click();
     await page.keyboard.press("s");
-    await expect(page.getByText("Loading settings...")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Back/i })).toBeVisible();
   });
 });
 
@@ -137,11 +134,10 @@ test.describe("Keyboard shortcuts", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    // Dispatch a ? keydown event directly since Shift+/ handling varies by layout
     await page.evaluate(() => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "?", bubbles: true }));
     });
-    await expect(page.getByRole("heading", { name: "Keyboard Shortcuts" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Help" })).toBeVisible();
   });
 
   test("escape closes help overlay", async ({ page }) => {
@@ -151,9 +147,9 @@ test.describe("Keyboard shortcuts", () => {
     await page.evaluate(() => {
       document.dispatchEvent(new KeyboardEvent("keydown", { key: "?", bubbles: true }));
     });
-    await expect(page.getByRole("heading", { name: "Keyboard Shortcuts" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Help" })).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(page.getByRole("heading", { name: "Keyboard Shortcuts" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "Help" })).not.toBeVisible();
   });
 });
 
@@ -161,8 +157,9 @@ test.describe("Mobile responsive", () => {
   test("sidebar closed by default on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
-    // Sidebar button should not be visible (sidebar closed)
-    await expect(page.getByRole("button", { name: "+ New Session" })).not.toBeVisible();
+    // Sidebar is translated off-screen on mobile (not display:none), so
+    // use toBeInViewport rather than toBeVisible.
+    await expect(page.getByLabel("Add project")).not.toBeInViewport();
     // Home screen content visible
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
   });
@@ -178,17 +175,17 @@ test.describe("Mobile responsive", () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByRole("button", { name: "+ New Session" })).toBeVisible();
+    await expect(page.getByLabel("Add project")).toBeInViewport();
   });
 
-  test("sidebar has close button on mobile", async ({ page }) => {
+  test("sidebar closes via toggle on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    const closeBtn = page.getByRole("button", { name: "\u00d7" });
-    await expect(closeBtn).toBeVisible();
-    await closeBtn.click();
-    await expect(page.getByRole("button", { name: "+ New Session" })).not.toBeVisible();
+    await expect(page.getByLabel("Add project")).toBeInViewport();
+    // Toggle the sidebar closed again
+    await page.getByRole("button", { name: "Toggle sidebar" }).click();
+    await expect(page.getByLabel("Add project")).not.toBeInViewport();
   });
 
   test("settings gear accessible on mobile", async ({ page }) => {
@@ -201,27 +198,27 @@ test.describe("Mobile responsive", () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "New Session" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
   });
 });
 
 test.describe("Design system", () => {
-  test("uses warm navy background", async ({ page }) => {
+  test("uses dark surface background", async ({ page }) => {
     await page.goto("/");
     const bg = await page.evaluate(() =>
       getComputedStyle(document.body).backgroundColor,
     );
-    // #0f172a = rgb(15, 23, 42)
-    expect(bg).toContain("15");
-    expect(bg).not.toBe("rgb(13, 17, 23)");
+    // surface-900 = #1c1c1f = rgb(28, 28, 31)
+    expect(bg).toContain("28");
+    expect(bg).not.toBe("rgb(255, 255, 255)");
   });
 
-  test("loads DM Sans body font", async ({ page }) => {
+  test("loads Geist Sans body font", async ({ page }) => {
     await page.goto("/");
     const fonts = await page.evaluate(() =>
       getComputedStyle(document.body).fontFamily,
     );
-    expect(fonts.toLowerCase()).toContain("dm sans");
+    expect(fonts.toLowerCase()).toContain("geist");
   });
 
   test("focus-visible ring appears on keyboard navigation", async ({ page }) => {

--- a/web/tests/pinch-zoom-desktop.spec.ts
+++ b/web/tests/pinch-zoom-desktop.spec.ts
@@ -14,10 +14,8 @@ test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
 
 test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
   async function openSession(page: Page) {
-    await page
-      .getByRole("button", { name: /pinch-test claude/ })
-      .first()
-      .click();
+    // First match is the group header; second is the session row.
+    await page.locator('button:has-text("pinch-test")').nth(1).click();
     await page
       .locator(".wterm")
       .first()

--- a/web/tests/pinch-zoom.spec.ts
+++ b/web/tests/pinch-zoom.spec.ts
@@ -11,10 +11,14 @@ test.use({ ...devices["iPhone 13"] });
 
 test.describe("Terminal pinch zoom (mobile)", () => {
   async function openSession(page: Page) {
-    await page
-      .getByRole("button", { name: /pinch-test claude/ })
-      .first()
-      .click();
+    // On mobile the sidebar is collapsed; open it first.
+    const sidebarToggle = page.getByRole("button", { name: "Toggle sidebar" });
+    if (await sidebarToggle.isVisible()) {
+      await sidebarToggle.click();
+      await page.waitForTimeout(300);
+    }
+    // First match is the group header; second is the session row.
+    await page.locator('button:has-text("pinch-test")').nth(1).click();
     await page.locator(".wterm").waitFor({ state: "visible", timeout: 10_000 });
   }
 

--- a/web/tests/top-bar.spec.ts
+++ b/web/tests/top-bar.spec.ts
@@ -15,7 +15,7 @@ test.describe("Top bar", () => {
     await page.goto("/");
     await page.getByRole("button", { name: "More options" }).click();
     await expect(page.getByRole("menuitem", { name: "Settings" })).toBeVisible();
-    await expect(page.getByRole("menuitem", { name: "Keyboard shortcuts" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Help" })).toBeVisible();
   });
 
   test("overflow menu closes on outside click", async ({ page }) => {
@@ -35,12 +35,12 @@ test.describe("Top bar", () => {
     await expect(page.getByRole("button", { name: /Back/i })).toBeVisible();
   });
 
-  test("overflow Keyboard shortcuts opens help overlay", async ({ page }) => {
+  test("overflow Help opens help overlay", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.getByRole("button", { name: "More options" }).click();
-    await page.getByRole("menuitem", { name: "Keyboard shortcuts" }).click();
-    await expect(page.getByRole("heading", { name: "Keyboard Shortcuts" })).toBeVisible();
+    await page.getByRole("menuitem", { name: "Help" }).click();
+    await expect(page.getByRole("heading", { name: "Help" })).toBeVisible();
   });
 
   test("overflow About opens About modal with links", async ({ page }) => {


### PR DESCRIPTION
## Description

Closes #764. Adds a Playwright CI job to GitHub Actions and fixes all stale test selectors so the suite passes cleanly (75 pass, 2 skipped webkit-only, 0 failures).

**What changed:**

1. **CI workflow** (`.github/workflows/ci.yml`): New `playwright` job that builds the web frontend, installs Chromium, runs all Playwright tests, and uploads the HTML report as an artifact.

2. **Playwright config** (`web/playwright.config.ts`):
   - `testIgnore` for `ensure-session-restart` (requires compiled Rust binary + tmux, not feasible in the frontend-only CI job)
   - 1 retry in CI to absorb flakiness
   - GitHub Actions reporter for inline annotations
   - `reuseExistingServer: false` in CI

3. **Test selector fixes** across 5 test files: The UI was redesigned since these tests were written. Updated all stale selectors:
   - "New Session" heading → "Add project" (wizard was renamed)
   - "+ New Session" button → `aria-label="Add project"`
   - "Keyboard shortcuts" menu item → "Help"
   - "Loading settings..." → Back button presence check
   - "DM Sans" font assertion → "Geist Sans"
   - `#0f172a` background → `#1c1c1f` (surface-900)
   - Pinch-zoom session selectors: use `nth(1)` to skip group header button
   - Mobile sidebar visibility: `toBeInViewport()` instead of `toBeVisible()` (sidebar uses CSS transform, not display:none)

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

```
$ npx playwright test
  2 skipped
  75 passed (19.3s)
```

The 2 skipped tests are webkit-only mobile proxy input tests (we only run chromium in CI). The `ensure-session-restart` tests are excluded via `testIgnore` since they need a compiled `aoe` binary.

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)