### PR TITLE
fix(tests): use ControlOrMeta+k for cross-platform Playwright compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ website/src/pages/docs/cli/*.md
 
 # Demo recording intermediate files
 *.cast
+/test-results

--- a/web/tests/command-palette.spec.ts
+++ b/web/tests/command-palette.spec.ts
@@ -5,7 +5,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
   });
 
@@ -28,7 +28,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
     await page.keyboard.press("Escape");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).not.toBeVisible();
@@ -38,7 +38,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
     await page.locator('[data-testid="command-palette-backdrop"]').click({
       position: { x: 10, y: 10 },
@@ -50,7 +50,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByRole("option", { name: /New session/i })).toBeVisible();
     await expect(page.getByRole("option", { name: /Go to dashboard/i })).toBeVisible();
     await expect(page.getByRole("option", { name: /Open settings/i })).toBeVisible();
@@ -60,7 +60,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await page.getByPlaceholder("Search actions, sessions, settings…").fill("settings");
     await expect(page.getByRole("option", { name: /Open settings/i })).toBeVisible();
     await expect(page.getByRole("option", { name: /New session/i })).not.toBeVisible();
@@ -70,7 +70,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await page.getByPlaceholder("Search actions, sessions, settings…").fill("zzzxxqqq");
     await expect(page.getByText("No matches")).toBeVisible();
   });
@@ -79,7 +79,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await page.getByPlaceholder("Search actions, sessions, settings…").fill("new session");
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("Enter");
@@ -92,7 +92,7 @@ test.describe("Command palette", () => {
     await page.getByLabel("Add project").first().click();
     await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
     await page.getByPlaceholder("Type to filter...").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();
   });
 
@@ -100,7 +100,7 @@ test.describe("Command palette", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.locator("body").click();
-    await page.keyboard.press("Control+k");
+    await page.keyboard.press("ControlOrMeta+k");
     await page.getByPlaceholder("Search actions, sessions, settings…").fill("About Agent");
     await page.keyboard.press("Enter");
     await expect(page.getByRole("heading", { name: "Agent of Empires" })).toBeVisible();


### PR DESCRIPTION
## Description

The Playwright command-palette tests use `Control+k` to open the palette, which fails on macOS because headless Chromium sets `navigator.platform` to `"MacIntel"`, making `IS_MAC=true` in the app — so only `Meta+k` works there.

Playwright has a built-in `ControlOrMeta` modifier alias that resolves to `Control` on Linux/Windows and `Meta` on macOS. Replacing `Control+k` with `ControlOrMeta+k` makes the tests pass on both platforms with no app changes.

Also adds `/test-results` to `.gitignore` (Playwright writes failure screenshots/traces there).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Sonnet via OpenCode

**Any Additional AI Details you'd like to share:** Investigated why tests passed in GHA (Linux) but failed locally (macOS). Root cause was `navigator.platform`-based `IS_MAC` detection in `useKeyboardShortcuts.ts`. Fix is one line per test: `Control+k` → `ControlOrMeta+k`.

- [x] I am an AI Agent filling out this form (check box if true)