### PR TITLE
feat: persist serve passphrase and open session on notification tap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,13 @@ Keep the script ephemeral unless promoted to `web/tests/` with a mobile Playwrig
   - **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/` (defaults to `~/.config/agent-of-empires/`)
   - **macOS/Windows**: `~/.agent-of-empires/`
 - Keep user data out of commits. For repo-local experiments, use ignored paths like `./.agent-of-empires/`, `.env`, and `.mcp.json`.
+- `aoe serve` writes several files to the app dir while running. All are owner-only (0600) where they contain secrets. The daemon cleans them up on shutdown; `daemon_pid()`'s stale-PID check sweeps them otherwise.
+  - `serve.pid`: daemon PID for `--stop` and reattach detection.
+  - `serve.url`: primary URL (includes the auth token) plus alternates.
+  - `serve.mode`: `tunnel` / `tailscale` / `local`.
+  - `serve.log`: daemon stdout/stderr tail.
+  - `serve.passphrase`: plaintext Tunnel passphrase, so the TUI can show it on reopen across restarts.
+  - `serve.last_mode`, `serve.last_port`: picker defaults across launches.
 
 ## Data Migrations
 

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -162,6 +162,7 @@ pub fn daemon_pid() -> Option<u32> {
                     let _ = std::fs::remove_file(dir.join("serve.url"));
                     let _ = std::fs::remove_file(dir.join("serve.log"));
                     let _ = std::fs::remove_file(dir.join("serve.mode"));
+                    let _ = std::fs::remove_file(dir.join("serve.passphrase"));
                 }
                 None
             }
@@ -306,6 +307,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.mode"));
+                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
             }
         }
     }
@@ -480,6 +482,7 @@ fn stop_daemon() -> Result<()> {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.log"));
                 let _ = std::fs::remove_file(dir.join("serve.mode"));
+                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
             }
             println!("Stopped aoe serve daemon (PID {})", pid);
         }
@@ -490,6 +493,7 @@ fn stop_daemon() -> Result<()> {
                 let _ = std::fs::remove_file(dir.join("serve.url"));
                 let _ = std::fs::remove_file(dir.join("serve.log"));
                 let _ = std::fs::remove_file(dir.join("serve.mode"));
+                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
             }
             println!("Daemon was not running (stale PID file cleaned up)");
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -294,6 +294,15 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         info!("Passphrase login enabled (second-factor authentication)");
     }
 
+    // Persist the plaintext passphrase so the TUI can display it on
+    // reopen, including after a TUI restart or when the daemon was
+    // started from the CLI. Owner-only perms; cleaned up on shutdown.
+    if let Some(pp) = passphrase {
+        if let Ok(app_dir) = crate::session::get_app_dir() {
+            write_secret_file(&app_dir.join("serve.passphrase"), pp);
+        }
+    }
+
     // Push notifications: initialize only when the operator flag is on at
     // startup. Flipping it later requires a server restart to take effect.
     let config = crate::session::resolve_config(profile).unwrap_or_default();
@@ -631,6 +640,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // Clean up tunnel (cancels health monitor, then sends SIGTERM to cloudflared)
     if let Some(handle) = tunnel_handle {
         handle.shutdown().await;
+    }
+
+    if let Ok(app_dir) = crate::session::get_app_dir() {
+        let _ = std::fs::remove_file(app_dir.join("serve.passphrase"));
     }
 
     Ok(())

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -104,11 +104,35 @@ fn remember_passphrase(pp: &str) {
     }
 }
 
-fn recall_passphrase() -> Option<String> {
+fn recall_passphrase_in_memory() -> Option<String> {
     LAST_SPAWNED_PASSPHRASE.lock().ok()?.clone()
 }
 
+fn recall_passphrase() -> Option<String> {
+    if let Some(pp) = recall_passphrase_in_memory() {
+        return Some(pp);
+    }
+    // Fall back to the on-disk file written by the server on startup.
+    // Lets the TUI display the passphrase after a restart or when the
+    // daemon was launched from the CLI (not this TUI process).
+    let dir = crate::session::get_app_dir().ok()?;
+    let raw = std::fs::read_to_string(dir.join("serve.passphrase")).ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 fn forget_passphrase() {
+    forget_passphrase_in_memory();
+    if let Ok(dir) = crate::session::get_app_dir() {
+        let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+    }
+}
+
+fn forget_passphrase_in_memory() {
     if let Ok(mut guard) = LAST_SPAWNED_PASSPHRASE.lock() {
         *guard = None;
     }
@@ -633,11 +657,20 @@ impl ServeDialog {
                 let mode = *mode;
                 let urls = read_serve_urls();
                 if !urls.is_empty() {
+                    // If we entered Starting without a passphrase (e.g.
+                    // the TUI reattached to a daemon started elsewhere),
+                    // retry the disk fallback now that the server has had
+                    // time to finish startup and write serve.passphrase.
+                    let pp = match passphrase.clone() {
+                        Some(pp) => Some(pp),
+                        None if matches!(mode, ServeMode::Tunnel) => recall_passphrase(),
+                        None => None,
+                    };
                     self.state = ServeDialogState::Active {
                         mode,
                         urls,
                         url_index: 0,
-                        passphrase: passphrase.clone(),
+                        passphrase: pp,
                         opened_at: Instant::now(),
                         log_tail: initial_log_tail(),
                         log_offset: log_file_size(),
@@ -2300,26 +2333,27 @@ mod tests {
 
     // These tests share the module-global LAST_SPAWNED_PASSPHRASE, so they
     // are combined into one #[test] to avoid cross-test interference when
-    // cargo runs them in parallel.
+    // cargo runs them in parallel. Uses the in-memory helpers so we don't
+    // touch the user's real serve.passphrase file during `cargo test`.
     #[test]
     fn passphrase_cache_roundtrip() {
-        forget_passphrase();
-        assert_eq!(recall_passphrase(), None);
+        forget_passphrase_in_memory();
+        assert_eq!(recall_passphrase_in_memory(), None);
 
         remember_passphrase("four word diceware phrase");
         assert_eq!(
-            recall_passphrase().as_deref(),
+            recall_passphrase_in_memory().as_deref(),
             Some("four word diceware phrase")
         );
 
         remember_passphrase("a different phrase later");
         assert_eq!(
-            recall_passphrase().as_deref(),
+            recall_passphrase_in_memory().as_deref(),
             Some("a different phrase later")
         );
 
-        forget_passphrase();
-        assert_eq!(recall_passphrase(), None);
+        forget_passphrase_in_memory();
+        assert_eq!(recall_passphrase_in_memory(), None);
     }
 
     #[test]

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -110,6 +110,7 @@ fn recall_passphrase_in_memory() -> Option<String> {
 
 fn recall_passphrase() -> Option<String> {
     if let Some(pp) = recall_passphrase_in_memory() {
+        tracing::debug!("passphrase recalled from in-memory cache");
         return Some(pp);
     }
     // Fall back to the on-disk file written by the server on startup.
@@ -121,6 +122,7 @@ fn recall_passphrase() -> Option<String> {
     if trimmed.is_empty() {
         None
     } else {
+        tracing::debug!("passphrase recalled from serve.passphrase on disk");
         Some(trimmed.to_string())
     }
 }
@@ -833,12 +835,15 @@ fn spawn_daemon(
     let exe =
         std::env::current_exe().map_err(|e| format!("Could not resolve aoe binary path: {}", e))?;
 
-    // Delete stale serve.url / serve.mode from a previous hard-killed
-    // daemon before launching. Without this, Starting-state polling could
-    // latch onto the old URL before the new daemon writes the new one.
+    // Delete stale serve.url / serve.mode / serve.passphrase from a
+    // previous hard-killed daemon before launching. Without this,
+    // Starting-state polling could latch onto the old URL before the
+    // new daemon writes the new one, and the TUI could briefly display
+    // the previous tunnel's passphrase before the new one is written.
     if let Ok(dir) = crate::session::get_app_dir() {
         let _ = std::fs::remove_file(dir.join("serve.url"));
         let _ = std::fs::remove_file(dir.join("serve.mode"));
+        let _ = std::fs::remove_file(dir.join("serve.passphrase"));
     }
 
     // Reuse the port from the last TUI-launched daemon so the user can

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,11 @@ import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
+import {
+  OPEN_SESSION_EVENT,
+  readSessionFromUrl,
+  writeSessionToUrl,
+} from "./lib/sessionRoute";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -67,7 +72,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
     null,
   );
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  // Seed from `?session=<id>` so deep links and notification taps land on
+  // the right session before the sessions list has finished loading.
+  const [activeSessionId, setActiveSessionId] = useState<string | null>(() =>
+    readSessionFromUrl(),
+  );
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const [diffCollapsed, setDiffCollapsed] = useState(
     () => window.innerWidth < 768,
@@ -82,7 +91,20 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   );
   const keyboardProxyRef = useRef<HTMLTextAreaElement>(null);
 
-  const activeWorkspace = workspaces.find((w) => w.id === activeWorkspaceId);
+  // Prefer workspace lookup by ID; fall back to finding the workspace
+  // that contains activeSessionId so a URL-seeded session (notification
+  // tap) renders even before handleSelectSession has run to set the
+  // workspace ID explicitly.
+  const activeWorkspace = useMemo(() => {
+    const byId = activeWorkspaceId
+      ? workspaces.find((w) => w.id === activeWorkspaceId)
+      : undefined;
+    if (byId) return byId;
+    if (!activeSessionId) return undefined;
+    return workspaces.find((w) =>
+      w.sessions.some((s) => s.id === activeSessionId),
+    );
+  }, [workspaces, activeWorkspaceId, activeSessionId]);
   const activeSession = activeWorkspace?.sessions.find(
     (s) => s.id === activeSessionId,
   );
@@ -119,6 +141,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     if (ws) {
       setActiveWorkspaceId(ws.id);
       setActiveSessionId(sessionId);
+      writeSessionToUrl(sessionId);
       focusKeyboardProxy();
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
@@ -129,13 +152,41 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     const ws = workspaces.find((w) => w.id === workspaceId);
     if (ws) {
       const running = ws.sessions.find((s) => isSessionActive(s.status));
-      setActiveSessionId(running?.id ?? ws.sessions[0]?.id ?? null);
+      const picked = running?.id ?? ws.sessions[0]?.id ?? null;
+      setActiveSessionId(picked);
+      writeSessionToUrl(picked);
     }
     focusKeyboardProxy();
     if (window.innerWidth < 768) {
       setSidebarOpen(false);
     }
   };
+
+  // Sync browser back/forward to selection state.
+  useEffect(() => {
+    const onPop = () => {
+      const id = readSessionFromUrl();
+      setActiveSessionId(id);
+      if (!id) setActiveWorkspaceId(null);
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  // In-app toast forwarded from the service worker sets this event when
+  // the user taps it; navigate to the session that triggered the push.
+  useEffect(() => {
+    const onOpen = (e: Event) => {
+      const detail = (e as CustomEvent).detail as
+        | { sessionId?: string }
+        | undefined;
+      if (detail?.sessionId) {
+        handleSelectSession(detail.sessionId);
+      }
+    };
+    window.addEventListener(OPEN_SESSION_EVENT, onOpen);
+    return () => window.removeEventListener(OPEN_SESSION_EVENT, onOpen);
+  }, [handleSelectSession]);
 
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
   const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
@@ -168,6 +219,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     if (wasActive) {
       setActiveWorkspaceId(null);
       setActiveSessionId(null);
+      writeSessionToUrl(null);
     }
 
     const result = await deleteSession(sessionId, options);
@@ -233,6 +285,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const handleGoDashboard = useCallback(() => {
     setActiveWorkspaceId(null);
     setActiveSessionId(null);
+    writeSessionToUrl(null);
     setShowSettings(false);
     setSelectedFilePath(null);
   }, []);
@@ -410,7 +463,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       <div className="flex flex-1 min-h-0">
         <WorkspaceSidebar
           groups={groups}
-          activeId={activeWorkspaceId}
+          activeId={activeWorkspace?.id ?? null}
           open={sidebarOpen}
           onToggle={() => setSidebarOpen(false)}
           onSelect={handleSelectWorkspace}
@@ -436,6 +489,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             if (session) {
               injectSession(session);
               setActiveSessionId(session.id);
+              writeSessionToUrl(session.id);
               // Key format must match useWorkspaces grouping key
               const repoPath = (session.main_repo_path ?? session.project_path).replace(/\/+$/, "");
               const wsId = `${repoPath}::${session.branch ?? "__default__"}`;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -162,12 +162,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
   };
 
-  // Sync browser back/forward to selection state.
+  // Sync browser back/forward to selection state. We always clear
+  // activeWorkspaceId so the activeWorkspace memo re-derives it from
+  // the URL-provided session. Otherwise back/forward across workspaces
+  // leaves a stale workspace ID, the memo returns the wrong workspace,
+  // the session lookup fails, and the app renders the dashboard.
   useEffect(() => {
     const onPop = () => {
-      const id = readSessionFromUrl();
-      setActiveSessionId(id);
-      if (!id) setActiveWorkspaceId(null);
+      setActiveSessionId(readSessionFromUrl());
+      setActiveWorkspaceId(null);
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);

--- a/web/src/components/Toasts.tsx
+++ b/web/src/components/Toasts.tsx
@@ -9,11 +9,13 @@ import {
   type ReactNode,
 } from "react";
 import { toastBus, type ToastApi, type ToastKind } from "../lib/toastBus";
+import { requestOpenSession } from "../lib/sessionRoute";
 
 interface Toast {
   id: number;
   kind: ToastKind;
   message: string;
+  sessionId?: string;
 }
 
 const ToastContext = createContext<ToastApi | null>(null);
@@ -37,6 +39,18 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     [dismiss],
   );
 
+  // Pushes a toast with an associated session so tapping it jumps to
+  // that session. Kept internal to this module since only the SW push
+  // handler uses it.
+  const pushWithSession = useCallback(
+    (message: string, sessionId: string) => {
+      const id = nextId.current++;
+      setToasts((t) => [...t, { id, kind: "info", message, sessionId }]);
+      setTimeout(() => dismiss(id), TOAST_LIFETIME_MS);
+    },
+    [dismiss],
+  );
+
   const api = useMemo<ToastApi>(
     () => ({
       push,
@@ -54,44 +68,68 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     if (typeof navigator === "undefined" || !navigator.serviceWorker) return;
     const handler = (event: MessageEvent) => {
       const data = event.data as
-        | { type?: string; payload?: { title?: string; body?: string } }
+        | {
+            type?: string;
+            payload?: {
+              title?: string;
+              body?: string;
+              session_id?: string;
+            };
+          }
         | null;
       if (!data || data.type !== "aoe-push" || !data.payload) return;
       const title = data.payload.title ?? "Agent of Empires";
       const body = data.payload.body ?? "";
       const message = body ? `${title}: ${body}` : title;
-      push(message, "info");
+      const sessionId = data.payload.session_id;
+      if (sessionId) {
+        pushWithSession(message, sessionId);
+      } else {
+        push(message, "info");
+      }
     };
     navigator.serviceWorker.addEventListener("message", handler);
     return () => {
       navigator.serviceWorker.removeEventListener("message", handler);
     };
-  }, [push]);
+  }, [push, pushWithSession]);
 
   return (
     <ToastContext.Provider value={api}>
       {children}
       <div className="fixed bottom-4 right-4 z-[80] flex flex-col gap-2 max-w-[92vw] sm:max-w-sm">
-        {toasts.map((t) => (
-          <div
-            key={t.id}
-            role={t.kind === "error" ? "alert" : "status"}
-            className={`flex items-start gap-2 px-3 py-2 rounded-md border shadow-lg animate-slide-up text-sm ${
-              t.kind === "error"
-                ? "bg-status-error/10 border-status-error/40 text-status-error"
-                : "bg-surface-800 border-surface-700 text-text-primary"
-            }`}
-          >
-            <span className="flex-1 break-words">{t.message}</span>
-            <button
-              onClick={() => dismiss(t.id)}
-              className="text-text-dim hover:text-text-secondary cursor-pointer"
-              aria-label="Dismiss"
+        {toasts.map((t) => {
+          const clickable = !!t.sessionId;
+          const onToastClick = () => {
+            if (!t.sessionId) return;
+            requestOpenSession(t.sessionId);
+            dismiss(t.id);
+          };
+          return (
+            <div
+              key={t.id}
+              role={t.kind === "error" ? "alert" : "status"}
+              onClick={clickable ? onToastClick : undefined}
+              className={`flex items-start gap-2 px-3 py-2 rounded-md border shadow-lg animate-slide-up text-sm ${
+                t.kind === "error"
+                  ? "bg-status-error/10 border-status-error/40 text-status-error"
+                  : "bg-surface-800 border-surface-700 text-text-primary"
+              } ${clickable ? "cursor-pointer hover:bg-surface-700 transition-colors" : ""}`}
             >
-              &times;
-            </button>
-          </div>
-        ))}
+              <span className="flex-1 break-words">{t.message}</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  dismiss(t.id);
+                }}
+                className="text-text-dim hover:text-text-secondary cursor-pointer"
+                aria-label="Dismiss"
+              >
+                &times;
+              </button>
+            </div>
+          );
+        })}
       </div>
     </ToastContext.Provider>
   );

--- a/web/src/lib/sessionRoute.ts
+++ b/web/src/lib/sessionRoute.ts
@@ -1,0 +1,39 @@
+// Tiny URL-based routing for the active session. We avoid pulling in a
+// router library for one query param. The URL is `?session=<id>` when a
+// session is active, or no query when on the dashboard. Notification
+// clicks land on `?session=<id>` (see sw.js) and this module is what
+// makes that URL actually select the session.
+
+export const SESSION_PARAM = "session";
+
+export function readSessionFromUrl(): string | null {
+  if (typeof window === "undefined") return null;
+  return new URLSearchParams(window.location.search).get(SESSION_PARAM);
+}
+
+export function writeSessionToUrl(sessionId: string | null): void {
+  if (typeof window === "undefined") return;
+  const url = new URL(window.location.href);
+  if (sessionId) {
+    url.searchParams.set(SESSION_PARAM, sessionId);
+  } else {
+    url.searchParams.delete(SESSION_PARAM);
+  }
+  const next = url.pathname + url.search + url.hash;
+  const current =
+    window.location.pathname + window.location.search + window.location.hash;
+  if (next !== current) {
+    window.history.pushState({}, "", next);
+  }
+}
+
+// Custom event dispatched when an in-app toast (for a focused PWA
+// client) is tapped. App listens and selects the session.
+export const OPEN_SESSION_EVENT = "aoe-open-session";
+
+export function requestOpenSession(sessionId: string): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent(OPEN_SESSION_EVENT, { detail: { sessionId } }),
+  );
+}


### PR DESCRIPTION
## Description

Two related tweaks for the web-serve UX.

**1. TUI serve popup always shows the passphrase**

The passphrase cache was a process-local static Mutex, so shift+R would show `(set when the daemon started — check the shell that ran \`aoe serve\`)` after a TUI restart or when the daemon had been launched from the CLI. The server now writes the plaintext passphrase to `$APP_DIR/serve.passphrase` (mode 0600) on startup, and the TUI falls back to that file when its in-memory cache is empty. Cleaned up on graceful shutdown, `aoe serve --stop`, and stale-PID teardown.

Trade-off: plaintext passphrase on disk in the user's app dir, owner-only. The alternative was keeping the placeholder, which made the dialog unhelpful for anyone whose daemon outlived the TUI.

**2. Web notifications open the session that triggered them**

The service worker already sets `data.url = /?session=<id>` on push payloads and navigates to it on tap, but the app ignored the query param. Now:

- `?session=<id>` is read on mount and used to seed `activeSessionId`.
- The workspace is derived from the session when only the session ID is known (URL seed), so the terminal renders without an extra round-trip through `handleSelectSession`.
- URL stays in sync with selection via `history.pushState` on select / create / dashboard.
- `popstate` listener keeps state aligned with browser back/forward.
- Focused-tab push payloads are shown as in-app toasts (existing behavior). Those toasts are now clickable and dispatch a custom event that App listens for, calling `handleSelectSession`.

No router library added — one query param didn't warrant it.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib`: 1217 passing; `tsc --noEmit` and `vite build` clean)
- [ ] Documentation was updated where necessary (none needed; behavioral tweaks to existing features)
- [ ] For UI changes: included screenshot or recording

**Test notes:** Verified cargo/tsc/vite builds locally. Did not smoke-test end-to-end against a phone with live push notifications — worth verifying that tapping a notification on iOS/Android actually lands on the right session.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Claude drafted the implementation from the spec; njbrake reviewed and signed off.

- [x] I am an AI Agent filling out this form (check box if true)