### PR TITLE
feat(push): suppress notifications when user is actively using aoe

### DIFF
--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -14,7 +14,11 @@ A shared 60-second post-send cooldown per session prevents rapid re-buzzing when
 
 Each session also has per-session overrides that beat the server-wide defaults: you can enable `Idle` notifications only on the one long-running session you care about, for example, without flooding yourself every time any session finishes.
 
-Notifications only fire when the dashboard is NOT currently focused in the foreground — if you're actively watching the app, we suppress the push and show an in-app toast instead.
+Notifications are suppressed when you're already looking at aoe:
+
+- **Dashboard focused (per-device):** if the PWA browser tab is visible and focused, that device skips the OS notification and shows an in-app toast instead.
+- **TUI active (all devices):** if the `aoe` TUI is running on the same machine as the server, all push notifications to all devices are suppressed. The TUI writes a heartbeat file (`$app_dir/tui.active`) every 10 seconds; the push consumer skips delivery when the file was modified within the last 30 seconds.
+- **Web dashboard active (all devices):** if any browser has the web dashboard open and is making authenticated API requests, all push notifications are suppressed. The auth middleware stamps the last request time; the push consumer skips delivery when a request arrived within the last 30 seconds. This means using the dashboard on your laptop prevents notifications from firing on your phone.
 
 ## Stable HTTPS for persistent PWA installs (read this first if using mobile)
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -269,6 +269,10 @@ pub async fn auth_middleware(
         // Record success
         state.rate_limiter.record_success(client_ip).await;
 
+        // Stamp web activity so the push consumer can suppress
+        // notifications when the dashboard is actively in use.
+        state.touch_web_activity();
+
         // Propagate the matched token's SHA-256 hash as a request extension
         // so downstream handlers (especially /api/push/*) can filter and
         // attribute subscriptions by owner without re-extracting the token.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -216,6 +216,11 @@ pub struct AppState {
     /// primary client's resize messages are applied to its PTY, preventing
     /// multiple browser viewports from fighting over the tmux window size.
     pub session_primaries: Arc<RwLock<std::collections::HashMap<String, String>>>,
+    /// Epoch-millis timestamp of the most recent authenticated API request.
+    /// Updated by auth middleware on every successful auth. The push consumer
+    /// checks this to suppress notifications when someone is actively using
+    /// the web dashboard (on any device).
+    pub last_web_activity: std::sync::atomic::AtomicI64,
 }
 
 impl AppState {
@@ -235,6 +240,31 @@ impl AppState {
             .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
             .clone()
     }
+
+    /// Record that an authenticated web client just made a request.
+    pub fn touch_web_activity(&self) {
+        self.last_web_activity.store(
+            epoch_millis(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    /// Returns true if an authenticated web request arrived within `threshold`.
+    pub fn web_active_within(&self, threshold: std::time::Duration) -> bool {
+        let last = self.last_web_activity.load(std::sync::atomic::Ordering::Relaxed);
+        if last == 0 {
+            return false;
+        }
+        let elapsed_ms = epoch_millis() - last;
+        elapsed_ms >= 0 && (elapsed_ms as u64) < threshold.as_millis() as u64
+    }
+}
+
+fn epoch_millis() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as i64
 }
 
 // ── Server ──────────────────────────────────────────────────────────────────
@@ -342,6 +372,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push: push_state,
         push_enabled,
         web_config: config.web.clone(),
+        last_web_activity: std::sync::atomic::AtomicI64::new(0),
     });
 
     let app = build_router(state.clone());

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -542,6 +542,25 @@ async fn fire_due_pushes(
         return;
     }
 
+    // Suppress pushes when the user is actively using aoe (TUI or web
+    // dashboard). They can already see session state changes in real
+    // time, so OS-level push notifications are noise.
+    let suppress_reason = if crate::session::is_tui_active(std::time::Duration::from_secs(30)) {
+        Some("TUI is active")
+    } else if app_state.web_active_within(std::time::Duration::from_secs(30)) {
+        Some("web dashboard is active")
+    } else {
+        None
+    };
+    if let Some(reason) = suppress_reason {
+        tracing::debug!(
+            "push: suppressed {} notification(s), {}",
+            to_fire.len(),
+            reason,
+        );
+        return;
+    }
+
     // Snapshot instances once; fire_due_pushes holds no locks across
     // the tokio::spawn boundary below.
     let instances = app_state.instances.read().await.clone();

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -501,6 +501,24 @@ async fn fire_due_pushes(
     };
     let push = push.clone();
 
+    // Suppress pushes when the user is actively using aoe (TUI or web
+    // dashboard). They can already see session state changes in real
+    // time, so OS-level push notifications are noise. Checked BEFORE
+    // the dwell collection loop so that dwell timers are preserved:
+    // when the user stops using aoe, any session that has been waiting
+    // past the dwell threshold fires on the next tick.
+    let suppress_reason = if crate::session::is_tui_active(std::time::Duration::from_secs(30)) {
+        Some("TUI is active")
+    } else if app_state.web_active_within(std::time::Duration::from_secs(30)) {
+        Some("web dashboard is active")
+    } else {
+        None
+    };
+    if let Some(reason) = suppress_reason {
+        tracing::debug!("push: suppressed, {}", reason);
+        return;
+    }
+
     let now = std::time::Instant::now();
     // Collect (instance_id, title, event) tuples to fire. Firing mutates
     // the dwell map (clear `*_since`, set `last_notified`) so we collect
@@ -539,25 +557,6 @@ async fn fire_due_pushes(
     }
 
     if to_fire.is_empty() {
-        return;
-    }
-
-    // Suppress pushes when the user is actively using aoe (TUI or web
-    // dashboard). They can already see session state changes in real
-    // time, so OS-level push notifications are noise.
-    let suppress_reason = if crate::session::is_tui_active(std::time::Duration::from_secs(30)) {
-        Some("TUI is active")
-    } else if app_state.web_active_within(std::time::Duration::from_secs(30)) {
-        Some("web dashboard is active")
-    } else {
-        None
-    };
-    if let Some(reason) = suppress_reason {
-        tracing::debug!(
-            "push: suppressed {} notification(s), {}",
-            to_fire.len(),
-            reason,
-        );
         return;
     }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -42,6 +42,7 @@ pub use storage::Storage;
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
+use std::time::Duration;
 
 pub const DEFAULT_PROFILE: &str = "default";
 
@@ -174,4 +175,42 @@ pub fn set_default_profile(name: &str) -> Result<()> {
     config.default_profile = name.to_string();
     save_config(&config)?;
     Ok(())
+}
+
+// ── TUI heartbeat ──────────────────────────────────────────────────────────
+
+const TUI_HEARTBEAT_FILE: &str = "tui.active";
+
+/// Write (or touch) the TUI heartbeat file so the push consumer knows the
+/// TUI is currently running. Called periodically from the TUI event loop.
+pub fn write_tui_heartbeat() {
+    if let Ok(dir) = get_app_dir() {
+        let _ = fs::write(dir.join(TUI_HEARTBEAT_FILE), b"");
+    }
+}
+
+/// Remove the heartbeat file on TUI exit.
+pub fn clear_tui_heartbeat() {
+    if let Ok(dir) = get_app_dir() {
+        let _ = fs::remove_file(dir.join(TUI_HEARTBEAT_FILE));
+    }
+}
+
+/// Returns true if the TUI heartbeat file was modified within `threshold`.
+/// Used by the push consumer to suppress notifications when the user is
+/// actively watching the TUI.
+pub fn is_tui_active(threshold: Duration) -> bool {
+    let dir = match get_app_dir() {
+        Ok(d) => d,
+        Err(_) => return false,
+    };
+    let meta = match fs::metadata(dir.join(TUI_HEARTBEAT_FILE)) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    let modified = match meta.modified() {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+    modified.elapsed().unwrap_or(Duration::MAX) < threshold
 }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -202,10 +202,16 @@ impl App {
         let mut last_status_refresh = std::time::Instant::now();
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
+        let mut last_heartbeat = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
         const SPINNER_REDRAW_INTERVAL: Duration = Duration::from_millis(120);
+        const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+        // Signal that the TUI is active so the web push consumer can
+        // suppress notifications while the user is watching the dashboard.
+        crate::session::write_tui_heartbeat();
 
         loop {
             // Force full redraw if needed (e.g., after returning from tmux).
@@ -327,6 +333,11 @@ impl App {
                 self.home.reload()?;
                 last_disk_refresh = std::time::Instant::now();
                 refresh_needed = true;
+            }
+
+            if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
+                crate::session::write_tui_heartbeat();
+                last_heartbeat = std::time::Instant::now();
             }
 
             // Animated spinners (rattles) need periodic redraws, but only at

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -111,6 +111,8 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     }
     let result = app.run(&mut terminal).await;
 
+    crate::session::clear_tui_heartbeat();
+
     // Restore terminal
     disable_raw_mode()?;
     execute!(


### PR DESCRIPTION
## Description

Push notifications exist to get your attention when you're away from aoe. When you're already looking at session state (via TUI or web dashboard), OS-level push notifications are unnecessary noise. This adds two server-side suppression signals so that all push delivery is skipped when the user is actively engaged:

**TUI heartbeat** — the TUI writes `$app_dir/tui.active` every 10 seconds and clears it on exit. If the file's mtime is within 30 seconds, the push consumer skips delivery to all devices.

**Web dashboard activity** — the auth middleware stamps an `AtomicI64` epoch-millis timestamp on every authenticated request. Since the dashboard auto-polls session status, this stays fresh while any browser tab is open. If a request arrived within 30 seconds, the push consumer skips delivery. This means using the dashboard on your laptop suppresses notifications on your phone.

Both complement the existing per-device service-worker suppression (which shows in-app toasts instead of OS notifications when the PWA tab is focused).

### Files changed

- `src/session/mod.rs` — heartbeat helpers (`write_tui_heartbeat`, `clear_tui_heartbeat`, `is_tui_active`)
- `src/tui/app.rs` — write heartbeat on startup + every 10s in event loop
- `src/tui/mod.rs` — clear heartbeat on exit
- `src/server/mod.rs` — `last_web_activity` atomic field on `AppState`, `touch_web_activity()` and `web_active_within()` methods
- `src/server/auth.rs` — stamp web activity on successful auth
- `src/server/push.rs` — check both signals before firing; log suppression reason at debug level
- `docs/push-notifications.md` — document all three suppression layers

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)