### PR TITLE
fix: rustfmt + rustls-webpki security advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2881,9 +2881,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -3347,7 +3347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -243,15 +243,15 @@ impl AppState {
 
     /// Record that an authenticated web client just made a request.
     pub fn touch_web_activity(&self) {
-        self.last_web_activity.store(
-            epoch_millis(),
-            std::sync::atomic::Ordering::Relaxed,
-        );
+        self.last_web_activity
+            .store(epoch_millis(), std::sync::atomic::Ordering::Relaxed);
     }
 
     /// Returns true if an authenticated web request arrived within `threshold`.
     pub fn web_active_within(&self, threshold: std::time::Duration) -> bool {
-        let last = self.last_web_activity.load(std::sync::atomic::Ordering::Relaxed);
+        let last = self
+            .last_web_activity
+            .load(std::sync::atomic::Ordering::Relaxed);
         if last == 0 {
             return false;
         }


### PR DESCRIPTION
## Description

Fixes two CI failures on main:

1. **Format**: `cargo fmt` violations in `src/server/mod.rs` (lines 243, 253) introduced in #773
2. **Supply Chain**: RUSTSEC-2026-0104 vulnerability in `rustls-webpki` v0.103.12 (reachable panic in CRL parsing). Updated to v0.103.13 via `cargo update -p rustls-webpki`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)