### PR TITLE
fix(web): enable mouse wheel scrolling in desktop terminal pane

### DIFF
--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -652,26 +652,47 @@ export function useTerminal(sessionId: string | null, wsPath: string = "ws") {
     };
     viewport.addEventListener("click", onClickCapture, true);
 
-    // Trackpad pinch fires wheel events with ctrlKey=true
+    // Mouse wheel: Ctrl+wheel = zoom (trackpad pinch), plain wheel = scroll.
+    // wterm has no built-in wheel handling and tmux manages its own scrollback,
+    // so we convert wheel events to SGR mouse-wheel escape sequences (same
+    // mechanism the touch handler uses).
     let wheelAccum = 0;
+    let scrollWheelAccum = 0;
     let wheelPersistTimer: ReturnType<typeof setTimeout> | null = null;
     const onWheel = (e: WheelEvent) => {
-      if (!e.ctrlKey) return;
       e.preventDefault();
-      wheelAccum -= e.deltaY * WHEEL_ZOOM_SENSITIVITY;
-      if (Math.abs(wheelAccum) < 1) return;
-      const delta = Math.trunc(wheelAccum);
-      wheelAccum -= delta;
-      const base = currentPendingOrLiveSize();
-      const next = clampFont(Math.round(base + delta));
-      if (next === base) return;
-      scheduleFontSize(next);
-      if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
-      wheelPersistTimer = setTimeout(() => {
-        flushFontSize();
-        persistFontSize(currentFontSize());
-        wheelPersistTimer = null;
-      }, WHEEL_PERSIST_DEBOUNCE_MS);
+
+      if (e.ctrlKey) {
+        // Trackpad pinch fires wheel events with ctrlKey=true
+        wheelAccum -= e.deltaY * WHEEL_ZOOM_SENSITIVITY;
+        if (Math.abs(wheelAccum) < 1) return;
+        const delta = Math.trunc(wheelAccum);
+        wheelAccum -= delta;
+        const base = currentPendingOrLiveSize();
+        const next = clampFont(Math.round(base + delta));
+        if (next === base) return;
+        scheduleFontSize(next);
+        if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
+        wheelPersistTimer = setTimeout(() => {
+          flushFontSize();
+          persistFontSize(currentFontSize());
+          wheelPersistTimer = null;
+        }, WHEEL_PERSIST_DEBOUNCE_MS);
+        return;
+      }
+
+      // Plain scroll: convert to SGR mouse-wheel sequences for tmux
+      scrollWheelAccum += e.deltaY;
+      const step = pxPerWheel();
+      const rawWheels = Math.trunc(scrollWheelAccum / step);
+      const wheels = Math.max(
+        -MAX_WHEELS_PER_FRAME,
+        Math.min(MAX_WHEELS_PER_FRAME, rawWheels),
+      );
+      if (wheels !== 0) {
+        sendWheel(wheels > 0 ? "down" : "up", Math.abs(wheels));
+        scrollWheelAccum -= wheels * step;
+      }
     };
     viewport.addEventListener("wheel", onWheel, { passive: false });
 

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -4,7 +4,13 @@ import type { Page } from "@playwright/test";
 // REST API and route the PTY WebSocket so the wterm terminal mounts and the
 // gesture handlers in useTerminal.ts are exercised against the real frontend.
 
-export async function mockTerminalApis(page: Page) {
+export interface MockHandle {
+  /** Raw bytes received from the page via WebSocket (PTY data + JSON messages). */
+  wsMessages: Buffer[];
+}
+
+export async function mockTerminalApis(page: Page): Promise<MockHandle> {
+  const handle: MockHandle = { wsMessages: [] };
   await page.route("**/api/login/status", (r) =>
     r.fulfill({ json: { required: false, authenticated: true } }),
   );
@@ -56,8 +62,9 @@ export async function mockTerminalApis(page: Page) {
     );
   }
   await page.routeWebSocket(/\/sessions\/.*\/(ws|container-ws)$/, (ws) => {
-    ws.onMessage(() => {
-      /* absorb keystrokes / resize JSON */
+    ws.onMessage((msg) => {
+      if (Buffer.isBuffer(msg)) handle.wsMessages.push(msg);
+      else handle.wsMessages.push(Buffer.from(msg));
     });
     setTimeout(() => {
       try {
@@ -67,6 +74,7 @@ export async function mockTerminalApis(page: Page) {
       }
     }, 50);
   });
+  return handle;
 }
 
 // Install a WebSocket constructor spy and a localStorage.setItem spy on

--- a/web/tests/pinch-zoom-desktop.spec.ts
+++ b/web/tests/pinch-zoom-desktop.spec.ts
@@ -91,7 +91,7 @@ test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
       .toBeLessThan(14);
   });
 
-  test("wheel without ctrlKey is ignored (native scroll path)", async ({
+  test("wheel without ctrlKey does not change font size (scrolls terminal instead)", async ({
     page,
   }) => {
     await installTerminalSpies(page);

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  mockTerminalApis,
+  installTerminalSpies,
+  seedSettings,
+  type MockHandle,
+} from "./helpers/terminal-mocks";
+
+// Desktop viewport: exercises the mouse-wheel → SGR scroll path that only
+// exists for non-touch (pointer: fine) users.
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+// SGR mouse-wheel escape sequences as raw bytes:
+//   wheel up:   ESC [ < 64 ; 1 ; 1 M
+//   wheel down: ESC [ < 65 ; 1 ; 1 M
+const WHEEL_UP_SEQ = "\x1b[<64;1;1M";
+const WHEEL_DOWN_SEQ = "\x1b[<65;1;1M";
+
+function countSeq(handle: MockHandle, seq: string): number {
+  const needle = Buffer.from(seq);
+  let count = 0;
+  for (const msg of handle.wsMessages) {
+    let idx = 0;
+    while ((idx = msg.indexOf(needle, idx)) !== -1) {
+      count++;
+      idx += needle.length;
+    }
+  }
+  return count;
+}
+
+test.describe("Terminal mouse-wheel scroll (desktop)", () => {
+  async function openSession(page: Page, handle: MockHandle) {
+    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await page
+      .locator(".wterm")
+      .first()
+      .waitFor({ state: "visible", timeout: 10_000 });
+    // Wait for the WebSocket to deliver at least one message (the app sends
+    // resize/activate on connect). Until readyState is OPEN, sendWheel
+    // silently drops messages.
+    await expect
+      .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+      .toBeGreaterThan(0);
+  }
+
+  async function fireWheel(
+    page: Page,
+    opts: { deltaY: number; ctrlKey?: boolean; times?: number },
+  ) {
+    await page.evaluate(
+      ({ deltaY, ctrlKey, times }) => {
+        const target = document.querySelector<HTMLElement>(".wterm");
+        if (!target) throw new Error(".wterm not mounted");
+        for (let i = 0; i < (times ?? 1); i++) {
+          target.dispatchEvent(
+            new WheelEvent("wheel", {
+              bubbles: true,
+              cancelable: true,
+              deltaY,
+              ctrlKey: ctrlKey ?? false,
+            }),
+          );
+        }
+      },
+      opts,
+    );
+  }
+
+  test("scroll down sends SGR wheel-down escape sequences", async ({
+    page,
+  }) => {
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page, handle);
+    handle.wsMessages.length = 0;
+
+    // deltaY > 0 = scroll down. Fire enough events to exceed pxPerWheel
+    // threshold (fontSize 14 * LINES_PER_WHEEL 2 = 28px per wheel tick).
+    // deltaY=120 is a typical single mouse wheel notch on most browsers.
+    await fireWheel(page, { deltaY: 120, times: 3 });
+
+    // WebSocket message delivery from page to Playwright handler is async;
+    // poll briefly so the assertion doesn't race the message capture.
+    await expect
+      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 2_000 })
+      .toBeGreaterThan(0);
+    expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
+  });
+
+  test("scroll up sends SGR wheel-up escape sequences", async ({ page }) => {
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page, handle);
+    handle.wsMessages.length = 0;
+
+    // deltaY < 0 = scroll up
+    await fireWheel(page, { deltaY: -120, times: 3 });
+
+    await expect
+      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 2_000 })
+      .toBeGreaterThan(0);
+    expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
+  });
+
+  test("scroll does not change font size", async ({ page }) => {
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page, handle);
+
+    await page.evaluate(() => {
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__ = [];
+    });
+
+    await fireWheel(page, { deltaY: -120, times: 5 });
+
+    // Wait longer than the 400ms debounce to confirm no font size change leaked
+    await page.waitForTimeout(500);
+    const writes = await page.evaluate(() =>
+      (window as unknown as { __LS_WRITES__: string[] }).__LS_WRITES__.filter(
+        (w) => w.includes("desktopFontSize"),
+      ),
+    );
+    expect(writes).toEqual([]);
+
+    const fontSize = await page.evaluate(() => {
+      const raw = localStorage.getItem("aoe-web-settings");
+      return raw ? JSON.parse(raw).desktopFontSize : null;
+    });
+    expect(fontSize).toBe(14);
+  });
+
+  test("Ctrl+wheel still zooms (not scroll)", async ({ page }) => {
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page, handle);
+    handle.wsMessages.length = 0;
+
+    // Ctrl+wheel should zoom, not scroll
+    await fireWheel(page, { deltaY: -60, ctrlKey: true, times: 2 });
+
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const raw = localStorage.getItem("aoe-web-settings");
+            return raw ? JSON.parse(raw).desktopFontSize : null;
+          }),
+        { timeout: 2_000 },
+      )
+      .toBeGreaterThan(14);
+
+    // No SGR scroll sequences should have been sent
+    const scrollCount =
+      countSeq(handle, WHEEL_UP_SEQ) + countSeq(handle, WHEEL_DOWN_SEQ);
+    expect(scrollCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Description

Mouse wheel scrolling over the terminal pane in the web dashboard did nothing on desktop. The `onWheel` handler in `useTerminal.ts` only handled `Ctrl+wheel` (trackpad pinch-to-zoom) and returned early for plain wheel events. Since wterm has no built-in wheel handling and tmux manages its own scrollback buffer via SGR mouse-wheel escape sequences, there was no code path to convert desktop wheel events into terminal scroll commands.

The fix converts plain wheel events to `sendWheel()` calls using the same SGR sequence mechanism (`\x1b[<64;1;1M` / `\x1b[<65;1;1M`) that the mobile touch handler already uses. Ctrl+wheel zoom behavior is unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- 4 new Playwright tests in `web/tests/wheel-scroll.spec.ts`:
  - scroll down sends SGR wheel-down sequences
  - scroll up sends SGR wheel-up sequences
  - plain scroll does not change font size
  - Ctrl+wheel still zooms (not scroll)
- All 79 existing tests pass (237/237 across 3x repeat-each, 0 failures)
- `cargo check --features serve` clean
- TypeScript + Vite build clean

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)