### PR TITLE
fix(web): dismiss settings overlay when selecting a session

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -143,6 +143,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       setActiveSessionId(sessionId);
       writeSessionToUrl(sessionId);
       focusKeyboardProxy();
+      setShowSettings(false);
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
   }, [workspaces]);
@@ -157,6 +158,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       writeSessionToUrl(picked);
     }
     focusKeyboardProxy();
+    setShowSettings(false);
     if (window.innerWidth < 768) {
       setSidebarOpen(false);
     }


### PR DESCRIPTION
## Description

The settings view stayed open until explicitly closed, even when clicking a session in the sidebar. This adds `setShowSettings(false)` to both `handleSelectSession` and `handleSelectWorkspace` so the settings panel dismisses immediately when navigating to a session.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)