### PR TITLE
fix(web): focus agent terminal instead of shell on new session

### DIFF
--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -60,7 +60,7 @@ function PairedTerminal({
     exitScrollback,
     ctrlActiveRef,
     clearCtrlRef,
-  } = useTerminal(ready ? sessionId : null, wsPath);
+  } = useTerminal(ready ? sessionId : null, wsPath, false);
   const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
 

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -46,7 +46,11 @@ export interface TerminalState {
  * Manages a wterm terminal connected to a PTY-relayed WebSocket.
  * Returns a ref to attach to a container div, plus connection state.
  */
-export function useTerminal(sessionId: string | null, wsPath: string = "ws") {
+export function useTerminal(
+  sessionId: string | null,
+  wsPath: string = "ws",
+  autoFocus: boolean = true,
+) {
   const { settings, update } = useWebSettings();
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<WTerm | null>(null);
@@ -258,7 +262,7 @@ export function useTerminal(sessionId: string | null, wsPath: string = "ws") {
           retryCountdown: 0,
           isPrimary: true,
         }));
-        term.focus();
+        if (autoFocus) term.focus();
         // Claim primary immediately so this client's resize is applied.
         // Without this, the first resize lands in "vacant" state (which
         // works) but a race with focus/visibility events could delay it.


### PR DESCRIPTION
## Description

When creating a new session in the web app, the cursor lands in the shell (paired) terminal instead of the agent terminal. This happens because both terminals call `term.focus()` when their WebSocket connects, and whichever connects last wins DOM focus. The shell terminal's `ensureTerminal()` API call can resolve after the agent terminal's `ensureSession()`, stealing focus.

Adds an `autoFocus` parameter to `useTerminal` (defaults to `true`) and passes `false` for the paired shell terminal. The agent terminal keeps auto-focus on connect; the shell terminal only gets focus on explicit user interaction (click/tap).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)