### PR TITLE
fix(tui): keep TUI responsive during worktree creation

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1268,8 +1268,9 @@ impl HomeView {
     }
 
     /// Create a session with optional hooks. Delegates to the background
-    /// `CreationPoller` when hooks are present (to avoid freezing the TUI on
-    /// slow commands like `npm install`) or when the session is sandboxed.
+    /// `CreationPoller` when hooks are present, when the session is sandboxed,
+    /// or when a worktree branch is requested (to avoid freezing the TUI on
+    /// slow git hooks like `post-checkout`).
     fn create_session_with_hooks(
         &mut self,
         data: NewSessionData,
@@ -1278,8 +1279,12 @@ impl HomeView {
         let has_hooks = hooks
             .as_ref()
             .is_some_and(|h| !h.on_create.is_empty() || !h.on_launch.is_empty());
+        let has_worktree = data
+            .worktree_branch
+            .as_ref()
+            .is_some_and(|b| !b.is_empty());
 
-        if data.sandbox || has_hooks {
+        if data.sandbox || has_hooks || has_worktree {
             self.request_creation(data, hooks);
             return None;
         }


### PR DESCRIPTION
## Description

When creating a session with a new worktree, if git hooks (e.g. `post-checkout`) are configured, the TUI freezes until the hooks complete. This happens because worktree creation without aoe hooks or sandbox mode runs synchronously on the UI thread, and `git worktree add` triggers git's own hooks which can take arbitrary time.

The fix routes worktree session creation through the existing background `CreationPoller`, which already handles worktree creation correctly with stub instances, progress tracking, and cancel support. The user sees a "Creating" stub in the session list while the worktree setup runs off-thread, and can continue interacting with other sessions.

**Root cause:** `create_session_with_hooks` in `src/tui/home/input.rs` only delegated to the background `CreationPoller` when aoe hooks or sandbox mode were active. Plain worktree creation ran synchronously via `git worktree add` → `.output()`, blocking the TUI event loop during git hook execution.

**Fix:** Added a `has_worktree` check to the routing condition so any session with a worktree branch always goes through the `CreationPoller`.

Closes #789

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)