### PR TITLE
feat(web): expose full settings surface in web UI

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -21,8 +21,10 @@ pub use sessions::{
     update_session_notifications, CleanupDefaults, SessionResponse,
 };
 pub use system::{
-    browse_filesystem, docker_status, filesystem_home, get_about, get_settings, list_agents,
-    list_devices, list_groups, list_profiles, list_themes, update_settings,
+    browse_filesystem, create_profile, default_profile, delete_profile, docker_status,
+    filesystem_home, get_about, get_profile_settings, get_settings, list_agents, list_devices,
+    list_groups, list_profiles, list_sounds, list_themes, rename_profile, update_profile_settings,
+    update_settings,
 };
 
 const SHELL_METACHARACTERS: &[char] = &[
@@ -42,10 +44,34 @@ pub(super) fn validate_no_shell_injection(value: &str, field_name: &str) -> Resu
 
 pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
     "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
+    // web: audited 2026-04-24, contains only boolean notification toggles
+    // (notifications_enabled, notify_on_waiting, notify_on_idle, notify_on_error).
+    // No shell commands, no binary paths, no RCE surface.
+    "web",
 ];
 
 pub(super) const SESSION_BLOCKED_FIELDS: &[&str] =
     &["agent_command_override", "agent_extra_args", "extra_env"];
+
+/// Validate that a profile name contains only safe characters.
+/// Rejects path traversal attempts (../, /) and shell metacharacters.
+pub(super) fn validate_profile_name(name: &str) -> Result<(), String> {
+    if name.is_empty() {
+        return Err("Profile name cannot be empty".to_string());
+    }
+    if name.len() > 64 {
+        return Err("Profile name must be 64 characters or fewer".to_string());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+    {
+        return Err(
+            "Profile name must contain only letters, digits, hyphens, and underscores".to_string(),
+        );
+    }
+    Ok(())
+}
 
 #[cfg(test)]
 mod tests {
@@ -118,14 +144,17 @@ mod tests {
         // hooks bypass the trust prompt that gates repo hooks.
         let expected: &[&str] = &[
             "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
+            // web: audited 2026-04-24. WebConfig has 4 boolean fields
+            // (notifications_enabled, notify_on_waiting, notify_on_idle,
+            // notify_on_error). No shell commands, no binary paths.
+            "web",
         ];
         assert_eq!(
             ALLOWED_SETTINGS_SECTIONS.len(),
             expected.len(),
             "ALLOWED_SETTINGS_SECTIONS size changed — adding a section widens \
              the API write surface and must be reviewed as a security change. \
-             In particular, do NOT add 'hooks' or 'web' without auditing the \
-             RCE surface."
+             In particular, do NOT add 'hooks' without auditing the RCE surface."
         );
         for section in expected {
             assert!(
@@ -141,6 +170,25 @@ mod tests {
              repo-hook trust prompt and run arbitrary shell commands on session \
              start (local RCE)"
         );
+    }
+
+    #[test]
+    fn profile_name_rejects_path_traversal() {
+        assert!(validate_profile_name("../etc").is_err());
+        assert!(validate_profile_name("foo/bar").is_err());
+        assert!(validate_profile_name("..").is_err());
+        assert!(validate_profile_name(".hidden").is_err());
+        assert!(validate_profile_name("").is_err());
+        assert!(validate_profile_name(&"a".repeat(65)).is_err());
+    }
+
+    #[test]
+    fn profile_name_accepts_valid_names() {
+        assert!(validate_profile_name("default").is_ok());
+        assert!(validate_profile_name("work").is_ok());
+        assert!(validate_profile_name("my-profile").is_ok());
+        assert!(validate_profile_name("profile_2").is_ok());
+        assert!(validate_profile_name("A").is_ok());
     }
 
     #[test]

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -50,8 +50,16 @@ pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
     "web",
 ];
 
-pub(super) const SESSION_BLOCKED_FIELDS: &[&str] =
-    &["agent_command_override", "agent_extra_args", "extra_env"];
+pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
+    "agent_command_override",
+    "agent_extra_args",
+    "extra_env",
+    // custom_agents maps names to arbitrary shell commands (e.g., "ssh -t host claude").
+    // agent_detect_as maps names to detection targets but is part of the agent config
+    // surface that should only be editable locally.
+    "custom_agents",
+    "agent_detect_as",
+];
 
 /// Validate that a profile name contains only safe characters.
 /// Rejects path traversal attempts (../, /) and shell metacharacters.
@@ -193,11 +201,19 @@ mod tests {
 
     #[test]
     fn session_blocked_fields_are_pinned() {
-        // These three fields let an API caller swap the agent binary,
-        // append arbitrary argv, or inject environment variables — all
-        // command-injection vectors. If Rust renames the field it must
-        // be renamed here in the same commit, not replaced.
-        let expected: &[&str] = &["agent_command_override", "agent_extra_args", "extra_env"];
+        // These fields let an API caller swap the agent binary,
+        // append arbitrary argv, inject environment variables, or define
+        // custom agent commands — all command-injection vectors. If Rust
+        // renames a field it must be renamed here in the same commit.
+        let expected: &[&str] = &[
+            "agent_command_override",
+            "agent_extra_args",
+            "extra_env",
+            // custom_agents: maps agent names to arbitrary shell commands
+            "custom_agents",
+            // agent_detect_as: part of the agent config surface
+            "agent_detect_as",
+        ];
         assert_eq!(
             SESSION_BLOCKED_FIELDS.len(),
             expected.len(),

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -7,7 +7,7 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
-use super::{ALLOWED_SETTINGS_SECTIONS, SESSION_BLOCKED_FIELDS};
+use super::{validate_profile_name, ALLOWED_SETTINGS_SECTIONS, SESSION_BLOCKED_FIELDS};
 
 // --- Agents ---
 
@@ -79,7 +79,19 @@ pub async fn get_settings(
     }
 }
 
-pub async fn update_settings(Json(body): Json<serde_json::Value>) -> impl IntoResponse {
+pub async fn update_settings(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
     // Validate that only allowed sections are being updated
     if let Some(obj) = body.as_object() {
         for key in obj.keys() {
@@ -380,4 +392,279 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         behind_tunnel: state.behind_tunnel,
         profile: state.profile.clone(),
     })
+}
+
+// --- Profile management ---
+
+#[derive(Deserialize)]
+pub struct CreateProfileBody {
+    pub name: String,
+}
+
+pub async fn create_profile(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateProfileBody>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate_profile_name(&body.name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
+        )
+            .into_response();
+    }
+    match tokio::task::spawn_blocking(move || crate::session::create_profile(&body.name)).await {
+        Ok(Ok(())) => (StatusCode::CREATED, Json(serde_json::json!({"ok": true}))).into_response(),
+        Ok(Err(e)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "create_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn delete_profile(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    if name == state.profile {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "active_profile", "message": "Cannot delete the active profile"})),
+        )
+            .into_response();
+    }
+    match tokio::task::spawn_blocking(move || crate::session::delete_profile(&name)).await {
+        Ok(Ok(())) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
+        Ok(Err(e)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "delete_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct RenameProfileBody {
+    pub new_name: String,
+}
+
+pub async fn rename_profile(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Json(body): Json<RenameProfileBody>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate_profile_name(&body.new_name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
+        )
+            .into_response();
+    }
+    let old = name;
+    let new = body.new_name;
+    match tokio::task::spawn_blocking(move || crate::session::rename_profile(&old, &new)).await {
+        Ok(Ok(())) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
+        Ok(Err(e)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "rename_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DefaultProfileBody {
+    pub name: String,
+}
+
+pub async fn default_profile(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<DefaultProfileBody>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    let name = body.name;
+    match tokio::task::spawn_blocking(move || crate::session::set_default_profile(&name)).await {
+        Ok(Ok(())) => (StatusCode::OK, Json(serde_json::json!({"ok": true}))).into_response(),
+        Ok(Err(e)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "update_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn get_profile_settings(
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    if let Err(e) = validate_profile_name(&name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
+        )
+            .into_response();
+    }
+    let result =
+        tokio::task::spawn_blocking(move || crate::session::load_profile_config(&name)).await;
+    match result {
+        Ok(Ok(config)) => match serde_json::to_value(&config) {
+            Ok(val) => (StatusCode::OK, Json(val)).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "serialize_failed", "message": e.to_string()})),
+            )
+                .into_response(),
+        },
+        Ok(Err(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "load_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+pub async fn update_profile_settings(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(name): axum::extract::Path<String>,
+    Json(body): Json<serde_json::Value>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate_profile_name(&name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
+        )
+            .into_response();
+    }
+    // Validate allowed sections
+    if let Some(obj) = body.as_object() {
+        for key in obj.keys() {
+            if !ALLOWED_SETTINGS_SECTIONS.contains(&key.as_str()) {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "validation_failed",
+                        "message": format!("Settings section '{}' is not allowed via the web API.", key)
+                    })),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let result = tokio::task::spawn_blocking(move || {
+        let config = crate::session::load_profile_config(&name).unwrap_or_default();
+        let mut current = serde_json::to_value(&config)?;
+        if let (Some(current_obj), Some(update_obj)) = (current.as_object_mut(), body.as_object()) {
+            for (key, value) in update_obj {
+                let mut value = value.clone();
+                if key == "session" {
+                    if let Some(session_obj) = value.as_object_mut() {
+                        for blocked in SESSION_BLOCKED_FIELDS {
+                            session_obj.remove(*blocked);
+                        }
+                    }
+                }
+                current_obj.insert(key.clone(), value);
+            }
+        }
+        let config: crate::session::ProfileConfig = serde_json::from_value(current)?;
+        crate::session::save_profile_config(&name, &config)?;
+        Ok::<_, anyhow::Error>(config)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(config)) => match serde_json::to_value(&config) {
+            Ok(val) => (StatusCode::OK, Json(val)).into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "serialize_failed", "message": e.to_string()})),
+            )
+                .into_response(),
+        },
+        Ok(Err(e)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "update_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "internal", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+// --- Sounds ---
+
+pub async fn list_sounds() -> Json<Vec<String>> {
+    Json(crate::sound::list_available_sounds())
 }

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -192,20 +192,25 @@ pub struct ProfileInfo {
 
 pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<ProfileInfo>> {
     let profiles = crate::session::list_profiles().unwrap_or_default();
-    let active = &state.profile;
+    // Treat empty profile (server launched without --profile) as "default"
+    let active = if state.profile.is_empty() {
+        "default"
+    } else {
+        &state.profile
+    };
     let mut result: Vec<ProfileInfo> = profiles
         .into_iter()
         .map(|name| {
-            let is_default = name == *active;
+            let is_default = name == active;
             ProfileInfo { name, is_default }
         })
         .collect();
     // Ensure the active profile appears even if list_profiles missed it
-    if !result.iter().any(|p| p.name == *active) {
+    if !active.is_empty() && !result.iter().any(|p| p.name == active) {
         result.insert(
             0,
             ProfileInfo {
-                name: active.clone(),
+                name: active.to_string(),
                 is_default: true,
             },
         );

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -653,7 +653,23 @@ pub async fn update_profile_settings(
                         }
                     }
                 }
-                current_obj.insert(key.clone(), value);
+                // Deep merge within sections so that sending a single field
+                // (e.g. {"session": {"yolo_mode_default": true}}) only sets
+                // that field as a profile override, preserving other existing
+                // overrides instead of replacing the entire section.
+                if let Some(existing) = current_obj.get_mut(key) {
+                    if let (Some(existing_obj), Some(new_obj)) =
+                        (existing.as_object_mut(), value.as_object())
+                    {
+                        for (k, v) in new_obj {
+                            existing_obj.insert(k.clone(), v.clone());
+                        }
+                    } else {
+                        current_obj.insert(key.clone(), value);
+                    }
+                } else {
+                    current_obj.insert(key.clone(), value);
+                }
             }
         }
         let config: crate::session::ProfileConfig = serde_json::from_value(current)?;

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -449,6 +449,13 @@ pub async fn delete_profile(
         )
             .into_response();
     }
+    if let Err(e) = validate_profile_name(&name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
+        )
+            .into_response();
+    }
     if name == state.profile {
         return (
             StatusCode::BAD_REQUEST,
@@ -487,6 +494,13 @@ pub async fn rename_profile(
             Json(
                 serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
             ),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate_profile_name(&name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
         )
             .into_response();
     }
@@ -529,6 +543,13 @@ pub async fn default_profile(
             Json(
                 serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
             ),
+        )
+            .into_response();
+    }
+    if let Err(e) = validate_profile_name(&body.name) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "validation_failed", "message": e})),
         )
             .into_response();
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -689,7 +689,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 }
 
 fn build_router(state: Arc<AppState>) -> Router {
-    use axum::routing::{get, patch, post};
+    use axum::routing::{delete, get, patch, post};
 
     Router::new()
         // Sessions
@@ -718,8 +718,18 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         // Agents
         .route("/api/agents", get(api::list_agents))
-        // Wizard support
-        .route("/api/profiles", get(api::list_profiles))
+        // Profiles
+        .route(
+            "/api/profiles",
+            get(api::list_profiles).post(api::create_profile),
+        )
+        .route("/api/profiles/{name}", delete(api::delete_profile))
+        .route(
+            "/api/profiles/{name}/settings",
+            get(api::get_profile_settings).patch(api::update_profile_settings),
+        )
+        .route("/api/profiles/{name}/rename", patch(api::rename_profile))
+        .route("/api/default-profile", patch(api::default_profile))
         .route("/api/filesystem/browse", get(api::browse_filesystem))
         .route("/api/filesystem/home", get(api::filesystem_home))
         .route("/api/git/branches", get(api::list_branches))
@@ -732,6 +742,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_settings).patch(api::update_settings),
         )
         .route("/api/themes", get(api::list_themes))
+        .route("/api/sounds", get(api::list_sounds))
         // Push notifications
         .route("/api/push/status", get(push::get_status))
         .route(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -467,19 +467,21 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       <DisconnectBanner />
 
       <div className="flex flex-1 min-h-0">
-        <WorkspaceSidebar
-          groups={groups}
-          activeId={activeWorkspace?.id ?? null}
-          open={sidebarOpen}
-          onToggle={() => setSidebarOpen(false)}
-          onSelect={handleSelectWorkspace}
-          onToggleRepo={toggleRepoCollapsed}
-          onNew={() => { setWizardPrefill(undefined); setShowAddProject(true); }}
-          onCreateSession={handleCreateSession}
-          onSettings={() => { setShowSettings((s) => !s); if (window.innerWidth < 768) setSidebarOpen(false); }}
-          onDeleteSession={handleDeleteSession}
-          readOnly={serverAbout?.read_only}
-        />
+        {!showSettings && (
+          <WorkspaceSidebar
+            groups={groups}
+            activeId={activeWorkspace?.id ?? null}
+            open={sidebarOpen}
+            onToggle={() => setSidebarOpen(false)}
+            onSelect={handleSelectWorkspace}
+            onToggleRepo={toggleRepoCollapsed}
+            onNew={() => { setWizardPrefill(undefined); setShowAddProject(true); }}
+            onCreateSession={handleCreateSession}
+            onSettings={() => { setShowSettings((s) => !s); if (window.innerWidth < 768) setSidebarOpen(false); }}
+            onDeleteSession={handleDeleteSession}
+            readOnly={serverAbout?.read_only}
+          />
+        )}
 
         <div className="flex-1 flex flex-col min-h-0 min-w-0">
           {renderContent()}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -46,7 +46,7 @@ export function SettingsView({ onClose }: Props) {
     loadSettings();
   }, [loadSettings]);
 
-  const save = useCallback(
+  const sendSave = useCallback(
     async (section: string, data: Record<string, unknown>) => {
       setSaving(true);
       setSaveError(null);
@@ -74,6 +74,10 @@ export function SettingsView({ onClose }: Props) {
   const worktree = (settings?.worktree ?? {}) as Record<string, unknown>;
   const web = (settings?.web ?? {}) as Record<string, unknown>;
 
+  // Central save-by-field: updates local display immediately, then sends
+  // only the changed field to the API. Profile mode sends a field-level
+  // delta (backend deep merges) so inherited values stay inherited.
+  // Global mode sends the full section (backend replaces the section).
   const saveField = (
     section: string,
     sectionData: Record<string, unknown>,
@@ -82,8 +86,22 @@ export function SettingsView({ onClose }: Props) {
   ) => {
     const updated = { ...sectionData, [field]: value };
     updateLocal({ [section]: updated });
-    save(section, updated);
+    if (selectedProfile) {
+      sendSave(section, { [field]: value });
+    } else {
+      sendSave(section, updated);
+    }
   };
+
+  // Field-level save for sub-components: they call onSaveField(section, field, value)
+  // and the parent handles global vs profile semantics.
+  const saveSubField = useCallback(
+    (section: string, field: string, value: unknown) => {
+      const sectionData = (settings?.[section] ?? {}) as Record<string, unknown>;
+      saveField(section, sectionData, field, value);
+    },
+    [settings, selectedProfile, sendSave, loadSettings],
+  );
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
@@ -292,16 +310,16 @@ export function SettingsView({ onClose }: Props) {
             </CollapsibleSection>
 
             {/* Theme */}
-            <ThemeSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+            <ThemeSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
 
             {/* Sound */}
-            <SoundSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+            <SoundSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
 
             {/* Tmux */}
-            <TmuxSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+            <TmuxSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
 
             {/* Updates */}
-            <UpdateSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+            <UpdateSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
           </>
         )}
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -3,125 +3,120 @@ import { ConnectedDevices } from "./ConnectedDevices";
 import { NotificationSettings } from "./NotificationSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { TerminalSettings } from "./TerminalSettings";
-import { getSettings, updateSettings } from "../lib/api";
+import {
+  getSettings,
+  updateSettings,
+  updateProfileSettings,
+} from "../lib/api";
+import {
+  CollapsibleSection,
+  ListField,
+  SelectField,
+  TextField,
+  ToggleField,
+} from "./settings/FormFields";
+import { ThemeSettings } from "./settings/ThemeSettings";
+import { SoundSettings } from "./settings/SoundSettings";
+import { UpdateSettings } from "./settings/UpdateSettings";
+import { TmuxSettings } from "./settings/TmuxSettings";
+import { ProfileSelector } from "./settings/ProfileSelector";
 
 interface Props {
   onClose: () => void;
 }
 
-function CollapsibleSection({ title, badge, children, defaultOpen = false }: {
-  title: string;
-  badge?: string;
-  children: React.ReactNode;
-  defaultOpen?: boolean;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="border border-surface-700/40 rounded-lg overflow-hidden">
-      <button
-        onClick={() => setOpen(!open)}
-        className="flex items-center justify-between w-full px-4 py-3 bg-surface-850 hover:bg-surface-800 cursor-pointer transition-colors text-left"
-      >
-        <div className="flex items-center gap-2">
-          <svg className={`w-3 h-3 text-text-dim transition-transform ${open ? "rotate-90" : ""}`} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-            <path d="M4.5 2l4.5 4-4.5 4" />
-          </svg>
-          <span className="text-sm font-medium text-text-primary">{title}</span>
-          {badge && <span className="text-[10px] font-mono text-text-dim bg-surface-700 px-1.5 py-0.5 rounded">{badge}</span>}
-        </div>
-      </button>
-      {open && <div className="px-4 py-4 space-y-4 border-t border-surface-700/20">{children}</div>}
-    </div>
-  );
-}
-
-function ToggleField({ label, description, checked, onChange }: {
-  label: string;
-  description?: string;
-  checked: boolean;
-  onChange: (v: boolean) => void;
-}) {
-  return (
-    <div className="flex items-center justify-between gap-3">
-      <div>
-        <div className="text-sm text-text-primary">{label}</div>
-        {description && <div className="text-xs text-text-dim mt-0.5">{description}</div>}
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={() => onChange(!checked)}
-        className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full transition-colors cursor-pointer ${checked ? "bg-brand-600" : "bg-surface-700"}`}
-      >
-        <span className={`inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${checked ? "translate-x-5" : "translate-x-1"}`} />
-      </button>
-    </div>
-  );
-}
-
-function TextField({ label, value, onChange, placeholder, mono }: {
-  label: string;
-  value: string;
-  onChange: (v: string) => void;
-  placeholder?: string;
-  mono?: boolean;
-}) {
-  return (
-    <div>
-      <label className="block text-sm text-text-dim mb-1">{label}</label>
-      <input
-        type="text"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        placeholder={placeholder}
-        className={`w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none ${mono ? "font-mono" : ""}`}
-      />
-    </div>
-  );
-}
-
 export function SettingsView({ onClose }: Props) {
-  const [settings, setSettings] = useState<Record<string, unknown> | null>(null);
+  const [settings, setSettings] = useState<Record<string, unknown> | null>(
+    null,
+  );
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState<string | null>(null);
+
+  const loadSettings = useCallback(() => {
+    const loader = selectedProfile
+      ? getSettings(selectedProfile)
+      : getSettings();
+    loader.then((s) => {
+      if (s) setSettings(s);
+    });
+  }, [selectedProfile]);
 
   useEffect(() => {
-    getSettings().then((s) => { if (s) setSettings(s); });
-  }, []);
+    loadSettings();
+  }, [loadSettings]);
 
-  const save = useCallback(async (section: string, data: Record<string, unknown>) => {
-    setSaving(true);
-    await updateSettings({ [section]: data });
-    setSaving(false);
-  }, []);
+  const save = useCallback(
+    async (section: string, data: Record<string, unknown>) => {
+      setSaving(true);
+      setSaveError(null);
+      const ok = selectedProfile
+        ? await updateProfileSettings(selectedProfile, { [section]: data })
+        : await updateSettings({ [section]: data });
+      setSaving(false);
+      if (!ok) {
+        setSaveError("Failed to save, please try again");
+        loadSettings();
+      }
+    },
+    [selectedProfile, loadSettings],
+  );
+
+  const updateLocal = useCallback(
+    (patch: Record<string, unknown>) => {
+      if (settings) setSettings({ ...settings, ...patch });
+    },
+    [settings],
+  );
 
   const session = (settings?.session ?? {}) as Record<string, unknown>;
   const sandbox = (settings?.sandbox ?? {}) as Record<string, unknown>;
   const worktree = (settings?.worktree ?? {}) as Record<string, unknown>;
+  const web = (settings?.web ?? {}) as Record<string, unknown>;
+
+  const saveField = (
+    section: string,
+    sectionData: Record<string, unknown>,
+    field: string,
+    value: unknown,
+  ) => {
+    const updated = { ...sectionData, [field]: value };
+    updateLocal({ [section]: updated });
+    save(section, updated);
+  };
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
       <div className="h-12 bg-surface-850 border-b border-surface-700 flex items-center px-4 shrink-0">
-        <button onClick={onClose} className="text-brand-500 mr-3 cursor-pointer text-sm">&larr; Back</button>
+        <button
+          onClick={onClose}
+          className="text-brand-500 mr-3 cursor-pointer text-sm"
+        >
+          &larr; Back
+        </button>
         <span className="text-sm font-semibold text-text-bright">Settings</span>
-        {saving && <span className="ml-2 text-xs text-text-dim">Saving...</span>}
+        {saving && (
+          <span className="ml-2 text-xs text-text-dim">Saving...</span>
+        )}
+        {saveError && (
+          <span className="ml-2 text-xs text-red-400">{saveError}</span>
+        )}
       </div>
 
       <div className="flex-1 overflow-y-auto p-6 max-w-[600px] space-y-4">
-        <SecuritySettings />
-        <NotificationSettings />
-        <TerminalSettings />
+        <ProfileSelector
+          selectedProfile={selectedProfile}
+          onSelect={setSelectedProfile}
+        />
 
         {settings && (
           <>
-            <CollapsibleSection title="Session Defaults">
+            {/* Session Defaults */}
+            <CollapsibleSection title="Session Defaults" defaultOpen>
               <TextField
                 label="Default agent"
                 value={(session.default_tool as string) ?? ""}
-                onChange={(v) => {
-                  setSettings({ ...settings, session: { ...session, default_tool: v || null } });
-                  save("session", { ...session, default_tool: v || null });
-                }}
+                onChange={(v) => saveField("session", session, "default_tool", v || null)}
                 placeholder="Auto-detect"
                 mono
               />
@@ -129,113 +124,224 @@ export function SettingsView({ onClose }: Props) {
                 label="YOLO mode by default"
                 description="New sessions skip permission prompts"
                 checked={(session.yolo_mode_default as boolean) ?? false}
-                onChange={(v) => {
-                  setSettings({ ...settings, session: { ...session, yolo_mode_default: v } });
-                  save("session", { ...session, yolo_mode_default: v });
-                }}
+                onChange={(v) => saveField("session", session, "yolo_mode_default", v)}
+              />
+              <ToggleField
+                label="Strict hotkeys"
+                description="Require SHIFT on letter-based TUI hotkeys to prevent accidental actions"
+                checked={(session.strict_hotkeys as boolean) ?? false}
+                onChange={(v) => saveField("session", session, "strict_hotkeys", v)}
+              />
+              <ToggleField
+                label="Agent status hooks"
+                description="Install status-detection hooks into agent settings files for reliable status tracking"
+                checked={(session.agent_status_hooks as boolean) ?? true}
+                onChange={(v) => saveField("session", session, "agent_status_hooks", v)}
               />
             </CollapsibleSection>
 
+            {/* Sandbox Defaults */}
             <CollapsibleSection title="Sandbox Defaults" badge="advanced">
               <ToggleField
                 label="Sandbox enabled by default"
                 description="Run new sessions in a Docker container"
                 checked={(sandbox.enabled_by_default as boolean) ?? false}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, enabled_by_default: v } });
-                  save("sandbox", { ...sandbox, enabled_by_default: v });
-                }}
+                onChange={(v) => saveField("sandbox", sandbox, "enabled_by_default", v)}
               />
               <TextField
                 label="Default container image"
                 value={(sandbox.default_image as string) ?? ""}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, default_image: v } });
-                  save("sandbox", { ...sandbox, default_image: v });
-                }}
+                onChange={(v) => saveField("sandbox", sandbox, "default_image", v)}
                 placeholder="ghcr.io/njbrake/aoe-sandbox:latest"
                 mono
+              />
+              <SelectField
+                label="Default terminal mode"
+                value={(sandbox.default_terminal_mode as string) ?? "host"}
+                onChange={(v) => saveField("sandbox", sandbox, "default_terminal_mode", v)}
+                options={[
+                  { value: "host", label: "Host" },
+                  { value: "container", label: "Container" },
+                ]}
+              />
+              <SelectField
+                label="Container runtime"
+                value={(sandbox.container_runtime as string) ?? "docker"}
+                onChange={(v) => saveField("sandbox", sandbox, "container_runtime", v)}
+                options={[
+                  { value: "docker", label: "Docker" },
+                  { value: "apple_container", label: "Apple Container" },
+                ]}
               />
               <TextField
                 label="CPU limit"
                 value={(sandbox.cpu_limit as string) ?? ""}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, cpu_limit: v || null } });
-                  save("sandbox", { ...sandbox, cpu_limit: v || null });
-                }}
+                onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
                 placeholder="e.g. 4"
               />
               <TextField
                 label="Memory limit"
                 value={(sandbox.memory_limit as string) ?? ""}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, memory_limit: v || null } });
-                  save("sandbox", { ...sandbox, memory_limit: v || null });
-                }}
+                onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
                 placeholder="e.g. 8g"
               />
               <ToggleField
                 label="Mount SSH keys"
                 description="Mount ~/.ssh into sandbox containers"
                 checked={(sandbox.mount_ssh as boolean) ?? false}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, mount_ssh: v } });
-                  save("sandbox", { ...sandbox, mount_ssh: v });
-                }}
+                onChange={(v) => saveField("sandbox", sandbox, "mount_ssh", v)}
               />
               <ToggleField
                 label="Auto cleanup"
                 description="Remove containers when sessions are deleted"
                 checked={(sandbox.auto_cleanup as boolean) ?? true}
-                onChange={(v) => {
-                  setSettings({ ...settings, sandbox: { ...sandbox, auto_cleanup: v } });
-                  save("sandbox", { ...sandbox, auto_cleanup: v });
+                onChange={(v) => saveField("sandbox", sandbox, "auto_cleanup", v)}
+              />
+              <TextField
+                label="Custom instruction"
+                description="Text appended to the agent system prompt in sandboxed sessions"
+                value={(sandbox.custom_instruction as string) ?? ""}
+                onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
+                placeholder="Additional instructions for the agent..."
+                multiline
+              />
+              <ListField
+                label="Environment variables"
+                description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
+                items={(sandbox.environment as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
+                placeholder="KEY or KEY=VALUE"
+                validate={(v) => {
+                  if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
+                    return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
+                  return null;
                 }}
+              />
+              <ListField
+                label="Extra volumes"
+                description="Additional volume mounts (host:container[:ro])"
+                items={(sandbox.extra_volumes as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
+                placeholder="/host/path:/container/path"
+                validate={(v) => {
+                  if (!v.includes(":")) return "Must contain ':' (host:container)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Port mappings"
+                description="Port forwarding (host:container)"
+                items={(sandbox.port_mappings as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
+                placeholder="3000:3000"
+                validate={(v) => {
+                  if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
+                  return null;
+                }}
+              />
+              <ListField
+                label="Volume ignores"
+                description="Directories excluded from host bind mount"
+                items={(sandbox.volume_ignores as string[]) ?? []}
+                onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
+                placeholder="node_modules"
               />
             </CollapsibleSection>
 
+            {/* Worktree Config */}
             <CollapsibleSection title="Worktree Config" badge="advanced">
               <ToggleField
                 label="Worktrees enabled"
                 description="Create git worktrees for new sessions"
                 checked={(worktree.enabled as boolean) ?? false}
-                onChange={(v) => {
-                  setSettings({ ...settings, worktree: { ...worktree, enabled: v } });
-                  save("worktree", { ...worktree, enabled: v });
-                }}
+                onChange={(v) => saveField("worktree", worktree, "enabled", v)}
               />
               <TextField
                 label="Path template"
                 value={(worktree.path_template as string) ?? ""}
-                onChange={(v) => {
-                  setSettings({ ...settings, worktree: { ...worktree, path_template: v } });
-                  save("worktree", { ...worktree, path_template: v });
-                }}
+                onChange={(v) => saveField("worktree", worktree, "path_template", v)}
                 placeholder="../{repo-name}-worktrees/{branch}"
+                mono
+              />
+              <TextField
+                label="Bare repo path template"
+                value={(worktree.bare_repo_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
+                placeholder="./{branch}"
+                mono
+              />
+              <TextField
+                label="Workspace path template"
+                value={(worktree.workspace_path_template as string) ?? ""}
+                onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
+                placeholder="../{branch}-workspace-{session-id}"
                 mono
               />
               <ToggleField
                 label="Auto cleanup"
                 description="Delete worktrees when sessions are removed"
                 checked={(worktree.auto_cleanup as boolean) ?? true}
-                onChange={(v) => {
-                  setSettings({ ...settings, worktree: { ...worktree, auto_cleanup: v } });
-                  save("worktree", { ...worktree, auto_cleanup: v });
-                }}
+                onChange={(v) => saveField("worktree", worktree, "auto_cleanup", v)}
               />
               <ToggleField
                 label="Delete branch on cleanup"
                 description="Also delete the git branch when cleaning up a worktree"
                 checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
-                onChange={(v) => {
-                  setSettings({ ...settings, worktree: { ...worktree, delete_branch_on_cleanup: v } });
-                  save("worktree", { ...worktree, delete_branch_on_cleanup: v });
-                }}
+                onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
               />
             </CollapsibleSection>
+
+            {/* Theme */}
+            <ThemeSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+
+            {/* Sound */}
+            <SoundSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+
+            {/* Tmux */}
+            <TmuxSettings settings={settings} onSave={save} onUpdate={updateLocal} />
+
+            {/* Updates */}
+            <UpdateSettings settings={settings} onSave={save} onUpdate={updateLocal} />
           </>
         )}
 
+        {/* Notifications (browser push + server defaults) */}
+        <NotificationSettings />
+
+        {settings && (
+          <CollapsibleSection
+            title="Notification Defaults"
+            subtitle="Controls which session events trigger push notifications on the server."
+          >
+            <ToggleField
+              label="Push notifications enabled"
+              description="Server-wide kill switch for push notifications"
+              checked={(web.notifications_enabled as boolean) ?? true}
+              onChange={(v) => saveField("web", web, "notifications_enabled", v)}
+            />
+            <ToggleField
+              label="Notify on waiting"
+              description="Send push when a session needs input"
+              checked={(web.notify_on_waiting as boolean) ?? true}
+              onChange={(v) => saveField("web", web, "notify_on_waiting", v)}
+            />
+            <ToggleField
+              label="Notify on idle"
+              description="Send push when a session finishes"
+              checked={(web.notify_on_idle as boolean) ?? false}
+              onChange={(v) => saveField("web", web, "notify_on_idle", v)}
+            />
+            <ToggleField
+              label="Notify on error"
+              description="Send push when a session errors"
+              checked={(web.notify_on_error as boolean) ?? true}
+              onChange={(v) => saveField("web", web, "notify_on_error", v)}
+            />
+          </CollapsibleSection>
+        )}
+
+        <TerminalSettings />
+        <SecuritySettings />
         <ConnectedDevices />
       </div>
     </div>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -7,7 +7,6 @@ import {
   fetchProfiles,
   getSettings,
   setDefaultProfile,
-  updateSettings,
   updateProfileSettings,
 } from "../lib/api";
 import type { ProfileInfo } from "../lib/types";
@@ -60,12 +59,16 @@ export function SettingsView({ onClose }: Props) {
   );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [selectedProfile, setSelectedProfile] = useState<string | null>(null);
+  const [selectedProfile, setSelectedProfile] = useState("default");
   const [activeTab, setActiveTab] = useState<TabId>("session");
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
 
   useEffect(() => {
-    fetchProfiles().then(setProfiles);
+    fetchProfiles().then((p) => {
+      setProfiles(p);
+      const active = p.find((pr) => pr.is_default);
+      if (active) setSelectedProfile(active.name);
+    });
   }, []);
 
   const defaultProfile = profiles.find((p) => p.is_default)?.name ?? "default";
@@ -76,10 +79,7 @@ export function SettingsView({ onClose }: Props) {
   };
 
   const loadSettings = useCallback(() => {
-    const loader = selectedProfile
-      ? getSettings(selectedProfile)
-      : getSettings();
-    loader.then((s) => {
+    getSettings(selectedProfile).then((s) => {
       if (s) setSettings(s);
     });
   }, [selectedProfile]);
@@ -92,9 +92,7 @@ export function SettingsView({ onClose }: Props) {
     async (section: string, data: Record<string, unknown>) => {
       setSaving(true);
       setSaveError(null);
-      const ok = selectedProfile
-        ? await updateProfileSettings(selectedProfile, { [section]: data })
-        : await updateSettings({ [section]: data });
+      const ok = await updateProfileSettings(selectedProfile, { [section]: data });
       setSaving(false);
       if (!ok) {
         setSaveError("Failed to save, please try again");
@@ -122,13 +120,8 @@ export function SettingsView({ onClose }: Props) {
     field: string,
     value: unknown,
   ) => {
-    const updated = { ...sectionData, [field]: value };
-    updateLocal({ [section]: updated });
-    if (selectedProfile) {
-      sendSave(section, { [field]: value });
-    } else {
-      sendSave(section, updated);
-    }
+    updateLocal({ [section]: { ...sectionData, [field]: value } });
+    sendSave(section, { [field]: value });
   };
 
   const saveSubField = useCallback(

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -406,7 +406,7 @@ export function SettingsView({ onClose }: Props) {
               className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
                 activeTab === tab.id
                   ? "text-brand-500 border-b-2 border-brand-500"
-                  : "text-text-dim hover:text-text-primary"
+                  : "text-text-secondary hover:text-text-primary"
               }`}
             >
               {tab.label}
@@ -426,7 +426,7 @@ export function SettingsView({ onClose }: Props) {
               className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
                 activeTab === tab.id
                   ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
-                  : "text-text-dim hover:text-text-primary hover:bg-surface-800/50"
+                  : "text-text-secondary hover:text-text-primary hover:bg-surface-800/50"
               }`}
             >
               {tab.label}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -394,7 +394,7 @@ export function SettingsView({ onClose }: Props) {
         {saveError && (
           <span className="ml-2 text-xs text-red-400">{saveError}</span>
         )}
-        <div className="ml-auto">
+        <div className="flex-1 flex justify-center">
           <ProfileSelector
             selectedProfile={selectedProfile}
             onSelect={setSelectedProfile}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -35,19 +35,27 @@ type TabId =
   | "security"
   | "devices";
 
-const TABS: { id: TabId; label: string }[] = [
-  { id: "session", label: "Session" },
-  { id: "sandbox", label: "Sandbox" },
-  { id: "worktree", label: "Worktree" },
-  { id: "theme", label: "Theme" },
-  { id: "sound", label: "Sound" },
-  { id: "tmux", label: "Tmux" },
-  { id: "updates", label: "Updates" },
-  { id: "notifications", label: "Notifications" },
-  { id: "terminal", label: "Terminal" },
-  { id: "security", label: "Security" },
-  { id: "devices", label: "Devices" },
+type SidebarItem =
+  | { kind: "tab"; id: TabId; label: string }
+  | { kind: "divider"; label: string };
+
+const SIDEBAR: SidebarItem[] = [
+  { kind: "divider", label: "General" },
+  { kind: "tab", id: "session", label: "Session" },
+  { kind: "tab", id: "sandbox", label: "Sandbox" },
+  { kind: "tab", id: "worktree", label: "Worktree" },
+  { kind: "tab", id: "theme", label: "Theme" },
+  { kind: "tab", id: "sound", label: "Sound" },
+  { kind: "tab", id: "tmux", label: "Tmux" },
+  { kind: "tab", id: "updates", label: "Updates" },
+  { kind: "divider", label: "Web Dashboard" },
+  { kind: "tab", id: "notifications", label: "Notifications" },
+  { kind: "tab", id: "terminal", label: "Terminal" },
+  { kind: "tab", id: "security", label: "Security" },
+  { kind: "tab", id: "devices", label: "Devices" },
 ];
+
+const TABS = SIDEBAR.filter((s): s is { kind: "tab"; id: TabId; label: string } => s.kind === "tab");
 
 interface Props {
   onClose: () => void;
@@ -419,20 +427,24 @@ export function SettingsView({ onClose }: Props) {
 
       {/* Mobile tabs (horizontal scroll) */}
       <div className="md:hidden border-b border-surface-700 bg-surface-850 overflow-x-auto">
-        <div className="flex">
-          {TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
-                activeTab === tab.id
-                  ? "text-brand-500 border-b-2 border-brand-500"
-                  : "text-text-secondary hover:text-text-primary"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+        <div className="flex items-center">
+          {SIDEBAR.map((item) =>
+            item.kind === "divider" ? (
+              <div key={item.label} className="h-4 w-px bg-surface-700 mx-1 shrink-0" />
+            ) : (
+              <button
+                key={item.id}
+                onClick={() => setActiveTab(item.id)}
+                className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
+                  activeTab === item.id
+                    ? "text-brand-500 border-b-2 border-brand-500"
+                    : "text-text-secondary hover:text-text-primary"
+                }`}
+              >
+                {item.label}
+              </button>
+            ),
+          )}
         </div>
       </div>
 
@@ -440,19 +452,28 @@ export function SettingsView({ onClose }: Props) {
       <div className="flex-1 flex min-h-0">
         {/* Side tabs (desktop only) */}
         <nav className="hidden md:flex flex-col w-44 shrink-0 border-r border-surface-700 bg-surface-850 py-2 overflow-y-auto">
-          {TABS.map((tab) => (
-            <button
-              key={tab.id}
-              onClick={() => setActiveTab(tab.id)}
-              className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
-                activeTab === tab.id
-                  ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
-                  : "text-text-secondary hover:text-text-primary hover:bg-surface-800/50"
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+          {SIDEBAR.map((item, i) =>
+            item.kind === "divider" ? (
+              <div
+                key={item.label}
+                className={`px-4 pt-3 pb-1 text-[10px] font-mono uppercase tracking-widest text-text-dim ${i > 0 ? "mt-2 border-t border-surface-700/40" : ""}`}
+              >
+                {item.label}
+              </div>
+            ) : (
+              <button
+                key={item.id}
+                onClick={() => setActiveTab(item.id)}
+                className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
+                  activeTab === item.id
+                    ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
+                    : "text-text-secondary hover:text-text-primary hover:bg-surface-800/50"
+                }`}
+              >
+                {item.label}
+              </button>
+            ),
+          )}
         </nav>
 
         {/* Content area */}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -4,10 +4,13 @@ import { NotificationSettings } from "./NotificationSettings";
 import { SecuritySettings } from "./SecuritySettings";
 import { TerminalSettings } from "./TerminalSettings";
 import {
+  fetchProfiles,
   getSettings,
+  setDefaultProfile,
   updateSettings,
   updateProfileSettings,
 } from "../lib/api";
+import type { ProfileInfo } from "../lib/types";
 import {
   ListField,
   SelectField,
@@ -59,6 +62,18 @@ export function SettingsView({ onClose }: Props) {
   const [saveError, setSaveError] = useState<string | null>(null);
   const [selectedProfile, setSelectedProfile] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>("session");
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+
+  useEffect(() => {
+    fetchProfiles().then(setProfiles);
+  }, []);
+
+  const defaultProfile = profiles.find((p) => p.is_default)?.name ?? "default";
+
+  const handleSetDefault = async (name: string) => {
+    const ok = await setDefaultProfile(name);
+    if (ok) fetchProfiles().then(setProfiles);
+  };
 
   const loadSettings = useCallback(() => {
     const loader = selectedProfile
@@ -133,6 +148,13 @@ export function SettingsView({ onClose }: Props) {
       case "session":
         return (
           <div className="space-y-4">
+            <SelectField
+              label="Default profile"
+              description="Profile used for new sessions"
+              value={defaultProfile}
+              onChange={(v) => handleSetDefault(v)}
+              options={profiles.map((p) => ({ value: p.name, label: p.name }))}
+            />
             <TextField
               label="Default agent"
               value={(session.default_tool as string) ?? ""}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -9,7 +9,6 @@ import {
   updateProfileSettings,
 } from "../lib/api";
 import {
-  CollapsibleSection,
   ListField,
   SelectField,
   TextField,
@@ -20,6 +19,33 @@ import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
 import { ProfileSelector } from "./settings/ProfileSelector";
+
+type TabId =
+  | "session"
+  | "sandbox"
+  | "worktree"
+  | "theme"
+  | "sound"
+  | "tmux"
+  | "updates"
+  | "notifications"
+  | "terminal"
+  | "security"
+  | "devices";
+
+const TABS: { id: TabId; label: string }[] = [
+  { id: "session", label: "Session" },
+  { id: "sandbox", label: "Sandbox" },
+  { id: "worktree", label: "Worktree" },
+  { id: "theme", label: "Theme" },
+  { id: "sound", label: "Sound" },
+  { id: "tmux", label: "Tmux" },
+  { id: "updates", label: "Updates" },
+  { id: "notifications", label: "Notifications" },
+  { id: "terminal", label: "Terminal" },
+  { id: "security", label: "Security" },
+  { id: "devices", label: "Devices" },
+];
 
 interface Props {
   onClose: () => void;
@@ -32,6 +58,7 @@ export function SettingsView({ onClose }: Props) {
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [selectedProfile, setSelectedProfile] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<TabId>("session");
 
   const loadSettings = useCallback(() => {
     const loader = selectedProfile
@@ -74,10 +101,6 @@ export function SettingsView({ onClose }: Props) {
   const worktree = (settings?.worktree ?? {}) as Record<string, unknown>;
   const web = (settings?.web ?? {}) as Record<string, unknown>;
 
-  // Central save-by-field: updates local display immediately, then sends
-  // only the changed field to the API. Profile mode sends a field-level
-  // delta (backend deep merges) so inherited values stay inherited.
-  // Global mode sends the full section (backend replaces the section).
   const saveField = (
     section: string,
     sectionData: Record<string, unknown>,
@@ -93,8 +116,6 @@ export function SettingsView({ onClose }: Props) {
     }
   };
 
-  // Field-level save for sub-components: they call onSaveField(section, field, value)
-  // and the parent handles global vs profile semantics.
   const saveSubField = useCallback(
     (section: string, field: string, value: unknown) => {
       const sectionData = (settings?.[section] ?? {}) as Record<string, unknown>;
@@ -103,8 +124,262 @@ export function SettingsView({ onClose }: Props) {
     [settings, selectedProfile, sendSave, loadSettings],
   );
 
+  const renderTabContent = () => {
+    if (!settings && activeTab !== "notifications" && activeTab !== "terminal" && activeTab !== "security" && activeTab !== "devices") {
+      return <div className="text-sm text-text-dim">Loading settings...</div>;
+    }
+
+    switch (activeTab) {
+      case "session":
+        return (
+          <div className="space-y-4">
+            <TextField
+              label="Default agent"
+              value={(session.default_tool as string) ?? ""}
+              onChange={(v) => saveField("session", session, "default_tool", v || null)}
+              placeholder="Auto-detect"
+              mono
+            />
+            <ToggleField
+              label="YOLO mode by default"
+              description="New sessions skip permission prompts"
+              checked={(session.yolo_mode_default as boolean) ?? false}
+              onChange={(v) => saveField("session", session, "yolo_mode_default", v)}
+            />
+            <ToggleField
+              label="Strict hotkeys"
+              description="Require SHIFT on letter-based TUI hotkeys to prevent accidental actions"
+              checked={(session.strict_hotkeys as boolean) ?? false}
+              onChange={(v) => saveField("session", session, "strict_hotkeys", v)}
+            />
+            <ToggleField
+              label="Agent status hooks"
+              description="Install status-detection hooks into agent settings files for reliable status tracking"
+              checked={(session.agent_status_hooks as boolean) ?? true}
+              onChange={(v) => saveField("session", session, "agent_status_hooks", v)}
+            />
+          </div>
+        );
+
+      case "sandbox":
+        return (
+          <div className="space-y-4">
+            <ToggleField
+              label="Sandbox enabled by default"
+              description="Run new sessions in a Docker container"
+              checked={(sandbox.enabled_by_default as boolean) ?? false}
+              onChange={(v) => saveField("sandbox", sandbox, "enabled_by_default", v)}
+            />
+            <TextField
+              label="Default container image"
+              value={(sandbox.default_image as string) ?? ""}
+              onChange={(v) => saveField("sandbox", sandbox, "default_image", v)}
+              placeholder="ghcr.io/njbrake/aoe-sandbox:latest"
+              mono
+            />
+            <SelectField
+              label="Default terminal mode"
+              value={(sandbox.default_terminal_mode as string) ?? "host"}
+              onChange={(v) => saveField("sandbox", sandbox, "default_terminal_mode", v)}
+              options={[
+                { value: "host", label: "Host" },
+                { value: "container", label: "Container" },
+              ]}
+            />
+            <SelectField
+              label="Container runtime"
+              value={(sandbox.container_runtime as string) ?? "docker"}
+              onChange={(v) => saveField("sandbox", sandbox, "container_runtime", v)}
+              options={[
+                { value: "docker", label: "Docker" },
+                { value: "apple_container", label: "Apple Container" },
+              ]}
+            />
+            <TextField
+              label="CPU limit"
+              value={(sandbox.cpu_limit as string) ?? ""}
+              onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
+              placeholder="e.g. 4"
+            />
+            <TextField
+              label="Memory limit"
+              value={(sandbox.memory_limit as string) ?? ""}
+              onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
+              placeholder="e.g. 8g"
+            />
+            <ToggleField
+              label="Mount SSH keys"
+              description="Mount ~/.ssh into sandbox containers"
+              checked={(sandbox.mount_ssh as boolean) ?? false}
+              onChange={(v) => saveField("sandbox", sandbox, "mount_ssh", v)}
+            />
+            <ToggleField
+              label="Auto cleanup"
+              description="Remove containers when sessions are deleted"
+              checked={(sandbox.auto_cleanup as boolean) ?? true}
+              onChange={(v) => saveField("sandbox", sandbox, "auto_cleanup", v)}
+            />
+            <TextField
+              label="Custom instruction"
+              description="Text appended to the agent system prompt in sandboxed sessions"
+              value={(sandbox.custom_instruction as string) ?? ""}
+              onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
+              placeholder="Additional instructions for the agent..."
+              multiline
+            />
+            <ListField
+              label="Environment variables"
+              description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
+              items={(sandbox.environment as string[]) ?? []}
+              onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
+              placeholder="KEY or KEY=VALUE"
+              validate={(v) => {
+                if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
+                  return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
+                return null;
+              }}
+            />
+            <ListField
+              label="Extra volumes"
+              description="Additional volume mounts (host:container[:ro])"
+              items={(sandbox.extra_volumes as string[]) ?? []}
+              onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
+              placeholder="/host/path:/container/path"
+              validate={(v) => {
+                if (!v.includes(":")) return "Must contain ':' (host:container)";
+                return null;
+              }}
+            />
+            <ListField
+              label="Port mappings"
+              description="Port forwarding (host:container)"
+              items={(sandbox.port_mappings as string[]) ?? []}
+              onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
+              placeholder="3000:3000"
+              validate={(v) => {
+                if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
+                return null;
+              }}
+            />
+            <ListField
+              label="Volume ignores"
+              description="Directories excluded from host bind mount"
+              items={(sandbox.volume_ignores as string[]) ?? []}
+              onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
+              placeholder="node_modules"
+            />
+          </div>
+        );
+
+      case "worktree":
+        return (
+          <div className="space-y-4">
+            <ToggleField
+              label="Worktrees enabled"
+              description="Create git worktrees for new sessions"
+              checked={(worktree.enabled as boolean) ?? false}
+              onChange={(v) => saveField("worktree", worktree, "enabled", v)}
+            />
+            <TextField
+              label="Path template"
+              value={(worktree.path_template as string) ?? ""}
+              onChange={(v) => saveField("worktree", worktree, "path_template", v)}
+              placeholder="../{repo-name}-worktrees/{branch}"
+              mono
+            />
+            <TextField
+              label="Bare repo path template"
+              value={(worktree.bare_repo_path_template as string) ?? ""}
+              onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
+              placeholder="./{branch}"
+              mono
+            />
+            <TextField
+              label="Workspace path template"
+              value={(worktree.workspace_path_template as string) ?? ""}
+              onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
+              placeholder="../{branch}-workspace-{session-id}"
+              mono
+            />
+            <ToggleField
+              label="Auto cleanup"
+              description="Delete worktrees when sessions are removed"
+              checked={(worktree.auto_cleanup as boolean) ?? true}
+              onChange={(v) => saveField("worktree", worktree, "auto_cleanup", v)}
+            />
+            <ToggleField
+              label="Delete branch on cleanup"
+              description="Also delete the git branch when cleaning up a worktree"
+              checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
+              onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
+            />
+          </div>
+        );
+
+      case "theme":
+        return <ThemeSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "sound":
+        return <SoundSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "tmux":
+        return <TmuxSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "updates":
+        return <UpdateSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+
+      case "notifications":
+        return (
+          <div className="space-y-6">
+            <NotificationSettings />
+            {settings && (
+              <div className="space-y-4">
+                <h4 className="text-xs font-mono uppercase tracking-widest text-text-muted">
+                  Server Defaults
+                </h4>
+                <p className="text-xs text-text-dim">
+                  Controls which session events trigger push notifications on the server.
+                </p>
+                <ToggleField
+                  label="Push notifications enabled"
+                  description="Server-wide kill switch for push notifications"
+                  checked={(web.notifications_enabled as boolean) ?? true}
+                  onChange={(v) => saveField("web", web, "notifications_enabled", v)}
+                />
+                <ToggleField
+                  label="Notify on waiting"
+                  description="Send push when a session needs input"
+                  checked={(web.notify_on_waiting as boolean) ?? true}
+                  onChange={(v) => saveField("web", web, "notify_on_waiting", v)}
+                />
+                <ToggleField
+                  label="Notify on idle"
+                  description="Send push when a session finishes"
+                  checked={(web.notify_on_idle as boolean) ?? false}
+                  onChange={(v) => saveField("web", web, "notify_on_idle", v)}
+                />
+                <ToggleField
+                  label="Notify on error"
+                  description="Send push when a session errors"
+                  checked={(web.notify_on_error as boolean) ?? true}
+                  onChange={(v) => saveField("web", web, "notify_on_error", v)}
+                />
+              </div>
+            )}
+          </div>
+        );
+
+      case "terminal":
+        return <TerminalSettings />;
+      case "security":
+        return <SecuritySettings />;
+      case "devices":
+        return <ConnectedDevices />;
+    }
+  };
+
+  const currentTabLabel = TABS.find((t) => t.id === activeTab)?.label ?? "";
+
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
+      {/* Header */}
       <div className="h-12 bg-surface-850 border-b border-surface-700 flex items-center px-4 shrink-0">
         <button
           onClick={onClose}
@@ -121,246 +396,58 @@ export function SettingsView({ onClose }: Props) {
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6 w-full max-w-2xl mx-auto space-y-4">
-        <ProfileSelector
-          selectedProfile={selectedProfile}
-          onSelect={setSelectedProfile}
-        />
+      {/* Mobile tabs (horizontal scroll) */}
+      <div className="md:hidden border-b border-surface-700 bg-surface-850 overflow-x-auto">
+        <div className="flex">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
+                activeTab === tab.id
+                  ? "text-brand-500 border-b-2 border-brand-500"
+                  : "text-text-dim hover:text-text-primary"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
-        {settings && (
-          <>
-            {/* Session Defaults */}
-            <CollapsibleSection title="Session Defaults" defaultOpen>
-              <TextField
-                label="Default agent"
-                value={(session.default_tool as string) ?? ""}
-                onChange={(v) => saveField("session", session, "default_tool", v || null)}
-                placeholder="Auto-detect"
-                mono
-              />
-              <ToggleField
-                label="YOLO mode by default"
-                description="New sessions skip permission prompts"
-                checked={(session.yolo_mode_default as boolean) ?? false}
-                onChange={(v) => saveField("session", session, "yolo_mode_default", v)}
-              />
-              <ToggleField
-                label="Strict hotkeys"
-                description="Require SHIFT on letter-based TUI hotkeys to prevent accidental actions"
-                checked={(session.strict_hotkeys as boolean) ?? false}
-                onChange={(v) => saveField("session", session, "strict_hotkeys", v)}
-              />
-              <ToggleField
-                label="Agent status hooks"
-                description="Install status-detection hooks into agent settings files for reliable status tracking"
-                checked={(session.agent_status_hooks as boolean) ?? true}
-                onChange={(v) => saveField("session", session, "agent_status_hooks", v)}
-              />
-            </CollapsibleSection>
+      {/* Desktop: sidebar tabs + content */}
+      <div className="flex-1 flex min-h-0">
+        {/* Side tabs (desktop only) */}
+        <nav className="hidden md:flex flex-col w-44 shrink-0 border-r border-surface-700 bg-surface-850 py-2 overflow-y-auto">
+          {TABS.map((tab) => (
+            <button
+              key={tab.id}
+              onClick={() => setActiveTab(tab.id)}
+              className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
+                activeTab === tab.id
+                  ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"
+                  : "text-text-dim hover:text-text-primary hover:bg-surface-800/50"
+              }`}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </nav>
 
-            {/* Sandbox Defaults */}
-            <CollapsibleSection title="Sandbox Defaults" badge="advanced">
-              <ToggleField
-                label="Sandbox enabled by default"
-                description="Run new sessions in a Docker container"
-                checked={(sandbox.enabled_by_default as boolean) ?? false}
-                onChange={(v) => saveField("sandbox", sandbox, "enabled_by_default", v)}
-              />
-              <TextField
-                label="Default container image"
-                value={(sandbox.default_image as string) ?? ""}
-                onChange={(v) => saveField("sandbox", sandbox, "default_image", v)}
-                placeholder="ghcr.io/njbrake/aoe-sandbox:latest"
-                mono
-              />
-              <SelectField
-                label="Default terminal mode"
-                value={(sandbox.default_terminal_mode as string) ?? "host"}
-                onChange={(v) => saveField("sandbox", sandbox, "default_terminal_mode", v)}
-                options={[
-                  { value: "host", label: "Host" },
-                  { value: "container", label: "Container" },
-                ]}
-              />
-              <SelectField
-                label="Container runtime"
-                value={(sandbox.container_runtime as string) ?? "docker"}
-                onChange={(v) => saveField("sandbox", sandbox, "container_runtime", v)}
-                options={[
-                  { value: "docker", label: "Docker" },
-                  { value: "apple_container", label: "Apple Container" },
-                ]}
-              />
-              <TextField
-                label="CPU limit"
-                value={(sandbox.cpu_limit as string) ?? ""}
-                onChange={(v) => saveField("sandbox", sandbox, "cpu_limit", v || null)}
-                placeholder="e.g. 4"
-              />
-              <TextField
-                label="Memory limit"
-                value={(sandbox.memory_limit as string) ?? ""}
-                onChange={(v) => saveField("sandbox", sandbox, "memory_limit", v || null)}
-                placeholder="e.g. 8g"
-              />
-              <ToggleField
-                label="Mount SSH keys"
-                description="Mount ~/.ssh into sandbox containers"
-                checked={(sandbox.mount_ssh as boolean) ?? false}
-                onChange={(v) => saveField("sandbox", sandbox, "mount_ssh", v)}
-              />
-              <ToggleField
-                label="Auto cleanup"
-                description="Remove containers when sessions are deleted"
-                checked={(sandbox.auto_cleanup as boolean) ?? true}
-                onChange={(v) => saveField("sandbox", sandbox, "auto_cleanup", v)}
-              />
-              <TextField
-                label="Custom instruction"
-                description="Text appended to the agent system prompt in sandboxed sessions"
-                value={(sandbox.custom_instruction as string) ?? ""}
-                onChange={(v) => saveField("sandbox", sandbox, "custom_instruction", v || null)}
-                placeholder="Additional instructions for the agent..."
-                multiline
-              />
-              <ListField
-                label="Environment variables"
-                description="Variables passed to sandbox containers (KEY or KEY=VALUE)"
-                items={(sandbox.environment as string[]) ?? []}
-                onChange={(items) => saveField("sandbox", sandbox, "environment", items)}
-                placeholder="KEY or KEY=VALUE"
-                validate={(v) => {
-                  if (!/^[A-Za-z_][A-Za-z0-9_]*(=.*)?$/.test(v))
-                    return "Must be KEY or KEY=VALUE (letters, digits, underscores)";
-                  return null;
-                }}
-              />
-              <ListField
-                label="Extra volumes"
-                description="Additional volume mounts (host:container[:ro])"
-                items={(sandbox.extra_volumes as string[]) ?? []}
-                onChange={(items) => saveField("sandbox", sandbox, "extra_volumes", items)}
-                placeholder="/host/path:/container/path"
-                validate={(v) => {
-                  if (!v.includes(":")) return "Must contain ':' (host:container)";
-                  return null;
-                }}
-              />
-              <ListField
-                label="Port mappings"
-                description="Port forwarding (host:container)"
-                items={(sandbox.port_mappings as string[]) ?? []}
-                onChange={(items) => saveField("sandbox", sandbox, "port_mappings", items)}
-                placeholder="3000:3000"
-                validate={(v) => {
-                  if (!/^\d+:\d+$/.test(v)) return "Must be port:port (e.g. 3000:3000)";
-                  return null;
-                }}
-              />
-              <ListField
-                label="Volume ignores"
-                description="Directories excluded from host bind mount"
-                items={(sandbox.volume_ignores as string[]) ?? []}
-                onChange={(items) => saveField("sandbox", sandbox, "volume_ignores", items)}
-                placeholder="node_modules"
-              />
-            </CollapsibleSection>
-
-            {/* Worktree Config */}
-            <CollapsibleSection title="Worktree Config" badge="advanced">
-              <ToggleField
-                label="Worktrees enabled"
-                description="Create git worktrees for new sessions"
-                checked={(worktree.enabled as boolean) ?? false}
-                onChange={(v) => saveField("worktree", worktree, "enabled", v)}
-              />
-              <TextField
-                label="Path template"
-                value={(worktree.path_template as string) ?? ""}
-                onChange={(v) => saveField("worktree", worktree, "path_template", v)}
-                placeholder="../{repo-name}-worktrees/{branch}"
-                mono
-              />
-              <TextField
-                label="Bare repo path template"
-                value={(worktree.bare_repo_path_template as string) ?? ""}
-                onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
-                placeholder="./{branch}"
-                mono
-              />
-              <TextField
-                label="Workspace path template"
-                value={(worktree.workspace_path_template as string) ?? ""}
-                onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
-                placeholder="../{branch}-workspace-{session-id}"
-                mono
-              />
-              <ToggleField
-                label="Auto cleanup"
-                description="Delete worktrees when sessions are removed"
-                checked={(worktree.auto_cleanup as boolean) ?? true}
-                onChange={(v) => saveField("worktree", worktree, "auto_cleanup", v)}
-              />
-              <ToggleField
-                label="Delete branch on cleanup"
-                description="Also delete the git branch when cleaning up a worktree"
-                checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
-                onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
-              />
-            </CollapsibleSection>
-
-            {/* Theme */}
-            <ThemeSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
-
-            {/* Sound */}
-            <SoundSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
-
-            {/* Tmux */}
-            <TmuxSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
-
-            {/* Updates */}
-            <UpdateSettings settings={settings} onSaveField={saveSubField} onUpdate={updateLocal} />
-          </>
-        )}
-
-        {/* Notifications (browser push + server defaults) */}
-        <NotificationSettings />
-
-        {settings && (
-          <CollapsibleSection
-            title="Notification Defaults"
-            subtitle="Controls which session events trigger push notifications on the server."
-          >
-            <ToggleField
-              label="Push notifications enabled"
-              description="Server-wide kill switch for push notifications"
-              checked={(web.notifications_enabled as boolean) ?? true}
-              onChange={(v) => saveField("web", web, "notifications_enabled", v)}
+        {/* Content area */}
+        <div className="flex-1 overflow-y-auto">
+          <div className="p-6 max-w-2xl space-y-5">
+            {/* Profile selector + tab heading */}
+            <ProfileSelector
+              selectedProfile={selectedProfile}
+              onSelect={setSelectedProfile}
             />
-            <ToggleField
-              label="Notify on waiting"
-              description="Send push when a session needs input"
-              checked={(web.notify_on_waiting as boolean) ?? true}
-              onChange={(v) => saveField("web", web, "notify_on_waiting", v)}
-            />
-            <ToggleField
-              label="Notify on idle"
-              description="Send push when a session finishes"
-              checked={(web.notify_on_idle as boolean) ?? false}
-              onChange={(v) => saveField("web", web, "notify_on_idle", v)}
-            />
-            <ToggleField
-              label="Notify on error"
-              description="Send push when a session errors"
-              checked={(web.notify_on_error as boolean) ?? true}
-              onChange={(v) => saveField("web", web, "notify_on_error", v)}
-            />
-          </CollapsibleSection>
-        )}
 
-        <TerminalSettings />
-        <SecuritySettings />
-        <ConnectedDevices />
+            <h2 className="text-lg font-semibold text-text-bright">{currentTabLabel}</h2>
+
+            {renderTabContent()}
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -121,7 +121,7 @@ export function SettingsView({ onClose }: Props) {
         )}
       </div>
 
-      <div className="flex-1 overflow-y-auto p-6 max-w-[600px] space-y-4">
+      <div className="flex-1 overflow-y-auto p-6 w-full max-w-2xl mx-auto space-y-4">
         <ProfileSelector
           selectedProfile={selectedProfile}
           onSelect={setSelectedProfile}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -394,6 +394,12 @@ export function SettingsView({ onClose }: Props) {
         {saveError && (
           <span className="ml-2 text-xs text-red-400">{saveError}</span>
         )}
+        <div className="ml-auto">
+          <ProfileSelector
+            selectedProfile={selectedProfile}
+            onSelect={setSelectedProfile}
+          />
+        </div>
       </div>
 
       {/* Mobile tabs (horizontal scroll) */}
@@ -437,12 +443,6 @@ export function SettingsView({ onClose }: Props) {
         {/* Content area */}
         <div className="flex-1 overflow-y-auto">
           <div className="p-6 max-w-2xl mx-auto space-y-5">
-            {/* Profile selector + tab heading */}
-            <ProfileSelector
-              selectedProfile={selectedProfile}
-              onSelect={setSelectedProfile}
-            />
-
             <h2 className="text-lg font-semibold text-text-bright">{currentTabLabel}</h2>
 
             {renderTabContent()}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -436,7 +436,7 @@ export function SettingsView({ onClose }: Props) {
 
         {/* Content area */}
         <div className="flex-1 overflow-y-auto">
-          <div className="p-6 max-w-2xl space-y-5">
+          <div className="p-6 max-w-2xl mx-auto space-y-5">
             {/* Profile selector + tab heading */}
             <ProfileSelector
               selectedProfile={selectedProfile}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -605,7 +605,7 @@ export function WorkspaceSidebar({
         <div className="border-t border-surface-700/20 p-2">
           <button
             onClick={onSettings}
-            className="w-8 h-8 flex items-center justify-center text-text-dim hover:text-text-secondary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
             title="Settings"
             aria-label="Settings"
           >

--- a/web/src/components/settings/FormFields.tsx
+++ b/web/src/components/settings/FormFields.tsx
@@ -1,0 +1,385 @@
+import { useState } from "react";
+
+export function CollapsibleSection({
+  title,
+  subtitle,
+  badge,
+  children,
+  defaultOpen = false,
+}: {
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="border border-surface-700/40 rounded-lg overflow-hidden">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex items-center justify-between w-full px-4 py-3 bg-surface-850 hover:bg-surface-800 cursor-pointer transition-colors text-left"
+      >
+        <div className="flex items-center gap-2">
+          <svg
+            className={`w-3 h-3 text-text-dim transition-transform ${open ? "rotate-90" : ""}`}
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M4.5 2l4.5 4-4.5 4" />
+          </svg>
+          <div>
+            <span className="text-sm font-medium text-text-primary">
+              {title}
+            </span>
+            {subtitle && (
+              <div className="text-[11px] text-text-dim mt-0.5">
+                {subtitle}
+              </div>
+            )}
+          </div>
+          {badge && (
+            <span className="text-[10px] font-mono text-text-dim bg-surface-700 px-1.5 py-0.5 rounded">
+              {badge}
+            </span>
+          )}
+        </div>
+      </button>
+      {open && (
+        <div className="px-4 py-4 space-y-4 border-t border-surface-700/20">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ToggleField({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string;
+  description?: string;
+  checked: boolean;
+  onChange: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div>
+        <div className="text-sm text-text-primary">{label}</div>
+        {description && (
+          <div className="text-xs text-text-dim mt-0.5">{description}</div>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-10 shrink-0 items-center rounded-full transition-colors cursor-pointer ${checked ? "bg-brand-600" : "bg-surface-700"}`}
+      >
+        <span
+          className={`inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${checked ? "translate-x-5" : "translate-x-1"}`}
+        />
+      </button>
+    </div>
+  );
+}
+
+export function TextField({
+  label,
+  description,
+  value,
+  onChange,
+  placeholder,
+  mono,
+  multiline,
+}: {
+  label: string;
+  description?: string;
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  mono?: boolean;
+  multiline?: boolean;
+}) {
+  const cls = `w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none ${mono ? "font-mono" : ""}`;
+  return (
+    <div>
+      <label className="block text-sm text-text-dim mb-1">{label}</label>
+      {description && (
+        <div className="text-xs text-text-dim mb-1">{description}</div>
+      )}
+      {multiline ? (
+        <textarea
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          rows={3}
+          className={cls + " resize-y"}
+        />
+      ) : (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className={cls}
+        />
+      )}
+    </div>
+  );
+}
+
+export function SelectField({
+  label,
+  description,
+  value,
+  onChange,
+  options,
+}: {
+  label: string;
+  description?: string;
+  value: string;
+  onChange: (v: string) => void;
+  options: { value: string; label: string }[];
+}) {
+  return (
+    <div>
+      <label className="block text-sm text-text-dim mb-1">{label}</label>
+      {description && (
+        <div className="text-xs text-text-dim mb-1">{description}</div>
+      )}
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+      >
+        {options.map((opt) => (
+          <option key={opt.value} value={opt.value}>
+            {opt.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+export function NumberField({
+  label,
+  description,
+  value,
+  onChange,
+  min,
+  max,
+}: {
+  label: string;
+  description?: string;
+  value: number;
+  onChange: (v: number) => void;
+  min?: number;
+  max?: number;
+}) {
+  return (
+    <div>
+      <label className="block text-sm text-text-dim mb-1">{label}</label>
+      {description && (
+        <div className="text-xs text-text-dim mb-1">{description}</div>
+      )}
+      <input
+        type="number"
+        value={value}
+        onChange={(e) => {
+          const n = Number(e.target.value);
+          if (!isNaN(n)) onChange(n);
+        }}
+        min={min}
+        max={max}
+        className="w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+      />
+    </div>
+  );
+}
+
+export function SliderField({
+  label,
+  description,
+  value,
+  onChange,
+  min,
+  max,
+  step,
+  formatValue,
+}: {
+  label: string;
+  description?: string;
+  value: number;
+  onChange: (v: number) => void;
+  min: number;
+  max: number;
+  step: number;
+  formatValue?: (v: number) => string;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-sm text-text-dim">{label}</label>
+        <span className="text-sm font-mono text-text-primary">
+          {formatValue ? formatValue(value) : value}
+        </span>
+      </div>
+      {description && (
+        <div className="text-xs text-text-dim mb-1">{description}</div>
+      )}
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full accent-brand-600 h-1.5"
+      />
+    </div>
+  );
+}
+
+export function ListField({
+  label,
+  description,
+  items,
+  onChange,
+  placeholder,
+  validate,
+}: {
+  label: string;
+  description?: string;
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder?: string;
+  validate?: (value: string) => string | null;
+}) {
+  const [adding, setAdding] = useState(false);
+  const [draft, setDraft] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    if (validate) {
+      const err = validate(trimmed);
+      if (err) {
+        setError(err);
+        return;
+      }
+    }
+    onChange([...items, trimmed]);
+    setDraft("");
+    setError(null);
+    setAdding(false);
+  };
+
+  const remove = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-sm text-text-dim">{label}</label>
+        {!adding && (
+          <button
+            onClick={() => setAdding(true)}
+            className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer"
+          >
+            + Add
+          </button>
+        )}
+      </div>
+      {description && (
+        <div className="text-xs text-text-dim mb-2">{description}</div>
+      )}
+      {items.length === 0 && !adding && (
+        <div className="text-xs text-text-dim italic py-2">
+          No items configured
+        </div>
+      )}
+      <div className="space-y-1 max-h-[320px] overflow-y-auto">
+        {items.map((item, i) => (
+          <div
+            key={i}
+            className="flex items-center justify-between gap-2 px-2 py-1.5 bg-surface-900 rounded group"
+          >
+            <span className="text-sm font-mono text-text-primary truncate">
+              {item}
+            </span>
+            <button
+              onClick={() => remove(i)}
+              className="text-text-dim hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer shrink-0"
+              title="Remove"
+            >
+              <svg
+                className="w-3.5 h-3.5"
+                viewBox="0 0 16 16"
+                fill="currentColor"
+              >
+                <path d="M5.5 5.5A.5.5 0 0 1 6 6v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m2.5 0a.5.5 0 0 1 .5.5v6a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m3 .5a.5.5 0 0 0-1 0v6a.5.5 0 0 0 1 0z" />
+                <path d="M14.5 3a1 1 0 0 1-1 1H13v9a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V4h-.5a1 1 0 0 1 0-2H6a1 1 0 0 1 1-1h2a1 1 0 0 1 1 1h3.5a1 1 0 0 1 1 1M4.118 4 4 4.059V13a1 1 0 0 0 1 1h6a1 1 0 0 0 1-1V4.059L11.882 4z" />
+              </svg>
+            </button>
+          </div>
+        ))}
+      </div>
+      {adding && (
+        <div className="mt-2">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => {
+                setDraft(e.target.value);
+                setError(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+                if (e.key === "Escape") {
+                  setAdding(false);
+                  setDraft("");
+                  setError(null);
+                }
+              }}
+              placeholder={placeholder}
+              autoFocus
+              className={`flex-1 bg-surface-900 border rounded-md px-3 py-1.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:outline-none ${error ? "border-red-500" : "border-surface-700 focus:border-brand-600"}`}
+            />
+            <button
+              onClick={submit}
+              className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-sm font-medium text-surface-950 cursor-pointer"
+            >
+              Add
+            </button>
+            <button
+              onClick={() => {
+                setAdding(false);
+                setDraft("");
+                setError(null);
+              }}
+              className="px-2 py-1.5 text-sm text-text-dim hover:text-text-primary cursor-pointer"
+            >
+              Cancel
+            </button>
+          </div>
+          {error && (
+            <div className="text-xs text-red-400 mt-1">{error}</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/FormFields.tsx
+++ b/web/src/components/settings/FormFields.tsx
@@ -109,6 +109,17 @@ export function TextField({
   mono?: boolean;
   multiline?: boolean;
 }) {
+  const [local, setLocal] = useState(value);
+  const [focused, setFocused] = useState(false);
+
+  // Sync from parent when not focused (external updates)
+  if (!focused && local !== value) setLocal(value);
+
+  const commit = () => {
+    if (local !== value) onChange(local);
+    setFocused(false);
+  };
+
   const cls = `w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none ${mono ? "font-mono" : ""}`;
   return (
     <div>
@@ -118,8 +129,11 @@ export function TextField({
       )}
       {multiline ? (
         <textarea
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={commit}
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); commit(); } }}
           placeholder={placeholder}
           rows={3}
           className={cls + " resize-y"}
@@ -127,8 +141,11 @@ export function TextField({
       ) : (
         <input
           type="text"
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
+          value={local}
+          onChange={(e) => setLocal(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={commit}
+          onKeyDown={(e) => { if (e.key === "Enter") commit(); }}
           placeholder={placeholder}
           className={cls}
         />
@@ -186,6 +203,17 @@ export function NumberField({
   min?: number;
   max?: number;
 }) {
+  const [local, setLocal] = useState(String(value));
+  const [focused, setFocused] = useState(false);
+
+  if (!focused && local !== String(value)) setLocal(String(value));
+
+  const commit = () => {
+    const n = Number(local);
+    if (!isNaN(n) && n !== value) onChange(n);
+    setFocused(false);
+  };
+
   return (
     <div>
       <label className="block text-sm text-text-dim mb-1">{label}</label>
@@ -194,11 +222,11 @@ export function NumberField({
       )}
       <input
         type="number"
-        value={value}
-        onChange={(e) => {
-          const n = Number(e.target.value);
-          if (!isNaN(n)) onChange(n);
-        }}
+        value={local}
+        onChange={(e) => setLocal(e.target.value)}
+        onFocus={() => setFocused(true)}
+        onBlur={commit}
+        onKeyDown={(e) => { if (e.key === "Enter") commit(); }}
         min={min}
         max={max}
         className="w-full bg-surface-900 border border-surface-700 rounded-md px-3 py-2 text-sm text-text-primary focus:border-brand-600 focus:outline-none"

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -16,7 +16,8 @@ interface Props {
 export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
   const [creating, setCreating] = useState(false);
-  const [newName, setNewName] = useState("");
+  const [renaming, setRenaming] = useState(false);
+  const [inputValue, setInputValue] = useState("");
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(() => {
@@ -29,21 +30,48 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
 
   const activeProfile = profiles.find((p) => p.is_default);
 
+  const validateName = (name: string): string | null => {
+    if (!name) return "Name is required";
+    if (!/^[a-zA-Z0-9_-]+$/.test(name))
+      return "Only letters, digits, hyphens, and underscores";
+    return null;
+  };
+
   const handleCreate = async () => {
-    const trimmed = newName.trim();
-    if (!trimmed) return;
-    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
-      setError("Only letters, digits, hyphens, and underscores");
+    const trimmed = inputValue.trim();
+    const err = validateName(trimmed);
+    if (err) {
+      setError(err);
       return;
     }
     const ok = await createProfile(trimmed);
     if (ok) {
-      setCreating(false);
-      setNewName("");
-      setError(null);
+      closeInput();
       load();
     } else {
       setError("Failed to create profile");
+    }
+  };
+
+  const handleRename = async () => {
+    if (!selectedProfile) return;
+    const trimmed = inputValue.trim();
+    if (trimmed === selectedProfile) {
+      closeInput();
+      return;
+    }
+    const err = validateName(trimmed);
+    if (err) {
+      setError(err);
+      return;
+    }
+    const ok = await renameProfile(selectedProfile, trimmed);
+    if (ok) {
+      onSelect(trimmed);
+      closeInput();
+      load();
+    } else {
+      setError("Failed to rename profile");
     }
   };
 
@@ -56,19 +84,36 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
     }
   };
 
-  const handleRename = async (name: string) => {
-    const newN = prompt("New name:", name);
-    if (!newN || newN === name) return;
-    const ok = await renameProfile(name, newN);
-    if (ok) {
-      if (selectedProfile === name) onSelect(newN);
-      load();
-    }
-  };
-
   const handleSetDefault = async (name: string) => {
     const ok = await setDefaultProfile(name);
     if (ok) load();
+  };
+
+  const closeInput = () => {
+    setCreating(false);
+    setRenaming(false);
+    setInputValue("");
+    setError(null);
+  };
+
+  const startRename = () => {
+    if (!selectedProfile) return;
+    setRenaming(true);
+    setCreating(false);
+    setInputValue(selectedProfile);
+    setError(null);
+  };
+
+  const startCreate = () => {
+    setCreating(true);
+    setRenaming(false);
+    setInputValue("");
+    setError(null);
+  };
+
+  const submitInput = () => {
+    if (creating) handleCreate();
+    else if (renaming) handleRename();
   };
 
   return (
@@ -89,47 +134,50 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
           ))}
         </select>
         <button
-          onClick={() => setCreating(!creating)}
+          onClick={startCreate}
           className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer shrink-0"
         >
           + New
         </button>
       </div>
 
-      {creating && (
+      {(creating || renaming) && (
         <div className="mt-2 flex gap-2">
           <input
             type="text"
-            value={newName}
+            value={inputValue}
             onChange={(e) => {
-              setNewName(e.target.value);
+              setInputValue(e.target.value);
               setError(null);
             }}
             onKeyDown={(e) => {
-              if (e.key === "Enter") handleCreate();
-              if (e.key === "Escape") {
-                setCreating(false);
-                setError(null);
-              }
+              if (e.key === "Enter") submitInput();
+              if (e.key === "Escape") closeInput();
             }}
-            placeholder="Profile name"
+            placeholder={creating ? "Profile name" : "New name"}
             autoFocus
             className={`flex-1 bg-surface-900 border rounded-md px-2 py-1.5 text-sm text-text-primary focus:outline-none ${error ? "border-red-500" : "border-surface-700 focus:border-brand-600"}`}
           />
           <button
-            onClick={handleCreate}
+            onClick={submitInput}
             className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-sm font-medium text-surface-950 cursor-pointer"
           >
-            Create
+            {creating ? "Create" : "Rename"}
+          </button>
+          <button
+            onClick={closeInput}
+            className="px-2 py-1.5 text-sm text-text-dim hover:text-text-primary cursor-pointer"
+          >
+            Cancel
           </button>
         </div>
       )}
       {error && <div className="text-xs text-red-400 mt-1">{error}</div>}
 
-      {selectedProfile && (
+      {selectedProfile && !creating && !renaming && (
         <div className="mt-2 flex gap-2 text-xs">
           <button
-            onClick={() => handleRename(selectedProfile)}
+            onClick={startRename}
             className="text-text-dim hover:text-text-primary cursor-pointer"
           >
             Rename

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -8,8 +8,8 @@ import {
 import type { ProfileInfo } from "../../lib/types";
 
 interface Props {
-  selectedProfile: string | null;
-  onSelect: (profile: string | null) => void;
+  selectedProfile: string;
+  onSelect: (profile: string) => void;
 }
 
 export function ProfileSelector({ selectedProfile, onSelect }: Props) {
@@ -28,6 +28,8 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
     load();
   }, [load]);
 
+  const activeProfile = profiles.find((p) => p.is_default);
+
   // Close panel on outside click
   useEffect(() => {
     if (!creating && !renaming) return;
@@ -39,8 +41,6 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [creating, renaming]);
-
-  const activeProfile = profiles.find((p) => p.is_default);
 
   const validateName = (name: string): string | null => {
     if (!name) return "Name is required";
@@ -59,7 +59,6 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   };
 
   const handleRename = async () => {
-    if (!selectedProfile) return;
     const trimmed = inputValue.trim();
     if (trimmed === selectedProfile) { closeInput(); return; }
     const err = validateName(trimmed);
@@ -73,7 +72,9 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
     if (!confirm(`Delete profile "${name}"?`)) return;
     const ok = await deleteProfile(name);
     if (ok) {
-      if (selectedProfile === name) onSelect(null);
+      // Fall back to the default profile
+      const fallback = activeProfile?.name ?? "default";
+      if (selectedProfile === name) onSelect(fallback === name ? "default" : fallback);
       load();
     }
   };
@@ -86,7 +87,6 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   };
 
   const startRename = () => {
-    if (!selectedProfile) return;
     setRenaming(true);
     setCreating(false);
     setInputValue(selectedProfile);
@@ -110,11 +110,10 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
       <div className="flex items-center gap-2">
         <label className="text-sm font-medium text-text-secondary shrink-0">Profile</label>
         <select
-          value={selectedProfile ?? ""}
-          onChange={(e) => onSelect(e.target.value || null)}
+          value={selectedProfile}
+          onChange={(e) => onSelect(e.target.value)}
           className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-40"
         >
-          <option value="">Global</option>
           {profiles.map((p) => (
             <option key={p.name} value={p.name}>
               {p.name}
@@ -128,7 +127,7 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
         >
           + New
         </button>
-        {selectedProfile && !creating && !renaming && (
+        {!creating && !renaming && (
           <>
             <button
               onClick={startRename}
@@ -150,7 +149,6 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
         )}
       </div>
 
-      {/* Inline create/rename input */}
       {(creating || renaming) && (
         <div className="absolute right-0 top-full mt-1 z-10 bg-surface-850 border border-surface-700 rounded-lg p-3 shadow-lg min-w-[280px]">
           <div className="flex gap-2">

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -123,7 +123,7 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
           <option value="">Global</option>
           {profiles.map((p) => (
             <option key={p.name} value={p.name}>
-              {p.name}{p.is_default ? " (active)" : ""}
+              {p.name}
             </option>
           ))}
         </select>

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  createProfile,
+  deleteProfile,
+  fetchProfiles,
+  renameProfile,
+  setDefaultProfile,
+} from "../../lib/api";
+import type { ProfileInfo } from "../../lib/types";
+
+interface Props {
+  selectedProfile: string | null;
+  onSelect: (profile: string | null) => void;
+}
+
+export function ProfileSelector({ selectedProfile, onSelect }: Props) {
+  const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    fetchProfiles().then(setProfiles);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const activeProfile = profiles.find((p) => p.is_default);
+
+  const handleCreate = async () => {
+    const trimmed = newName.trim();
+    if (!trimmed) return;
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+      setError("Only letters, digits, hyphens, and underscores");
+      return;
+    }
+    const ok = await createProfile(trimmed);
+    if (ok) {
+      setCreating(false);
+      setNewName("");
+      setError(null);
+      load();
+    } else {
+      setError("Failed to create profile");
+    }
+  };
+
+  const handleDelete = async (name: string) => {
+    if (!confirm(`Delete profile "${name}"?`)) return;
+    const ok = await deleteProfile(name);
+    if (ok) {
+      if (selectedProfile === name) onSelect(null);
+      load();
+    }
+  };
+
+  const handleRename = async (name: string) => {
+    const newN = prompt("New name:", name);
+    if (!newN || newN === name) return;
+    const ok = await renameProfile(name, newN);
+    if (ok) {
+      if (selectedProfile === name) onSelect(newN);
+      load();
+    }
+  };
+
+  const handleSetDefault = async (name: string) => {
+    const ok = await setDefaultProfile(name);
+    if (ok) load();
+  };
+
+  return (
+    <div className="border border-surface-700/40 rounded-lg px-4 py-3 bg-surface-850">
+      <div className="flex items-center gap-3">
+        <label className="text-sm text-text-dim shrink-0">Profile</label>
+        <select
+          value={selectedProfile ?? ""}
+          onChange={(e) => onSelect(e.target.value || null)}
+          className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+        >
+          <option value="">Global (all profiles)</option>
+          {profiles.map((p) => (
+            <option key={p.name} value={p.name}>
+              {p.name}
+              {p.is_default ? " (active)" : ""}
+            </option>
+          ))}
+        </select>
+        <button
+          onClick={() => setCreating(!creating)}
+          className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer shrink-0"
+        >
+          + New
+        </button>
+      </div>
+
+      {creating && (
+        <div className="mt-2 flex gap-2">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => {
+              setNewName(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreate();
+              if (e.key === "Escape") {
+                setCreating(false);
+                setError(null);
+              }
+            }}
+            placeholder="Profile name"
+            autoFocus
+            className={`flex-1 bg-surface-900 border rounded-md px-2 py-1.5 text-sm text-text-primary focus:outline-none ${error ? "border-red-500" : "border-surface-700 focus:border-brand-600"}`}
+          />
+          <button
+            onClick={handleCreate}
+            className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-sm font-medium text-surface-950 cursor-pointer"
+          >
+            Create
+          </button>
+        </div>
+      )}
+      {error && <div className="text-xs text-red-400 mt-1">{error}</div>}
+
+      {selectedProfile && (
+        <div className="mt-2 flex gap-2 text-xs">
+          <button
+            onClick={() => handleRename(selectedProfile)}
+            className="text-text-dim hover:text-text-primary cursor-pointer"
+          >
+            Rename
+          </button>
+          {!activeProfile || activeProfile.name !== selectedProfile ? (
+            <>
+              <span className="text-surface-700">|</span>
+              <button
+                onClick={() => handleSetDefault(selectedProfile)}
+                className="text-text-dim hover:text-text-primary cursor-pointer"
+              >
+                Set as default
+              </button>
+              <span className="text-surface-700">|</span>
+              <button
+                onClick={() => handleDelete(selectedProfile)}
+                className="text-text-dim hover:text-red-400 cursor-pointer"
+              >
+                Delete
+              </button>
+            </>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -4,7 +4,6 @@ import {
   deleteProfile,
   fetchProfiles,
   renameProfile,
-  setDefaultProfile,
 } from "../../lib/api";
 import type { ProfileInfo } from "../../lib/types";
 
@@ -79,11 +78,6 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
     }
   };
 
-  const handleSetDefault = async (name: string) => {
-    const ok = await setDefaultProfile(name);
-    if (ok) load();
-  };
-
   const closeInput = () => {
     setCreating(false);
     setRenaming(false);
@@ -144,22 +138,13 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
               Rename
             </button>
             {(!activeProfile || activeProfile.name !== selectedProfile) && (
-              <>
-                <button
-                  onClick={() => handleSetDefault(selectedProfile)}
-                  className="text-xs text-text-dim hover:text-text-primary cursor-pointer"
-                  title="Set as default profile"
-                >
-                  Default
-                </button>
-                <button
-                  onClick={() => handleDelete(selectedProfile)}
-                  className="text-xs text-text-dim hover:text-red-400 cursor-pointer"
-                  title="Delete profile"
-                >
-                  Delete
-                </button>
-              </>
+              <button
+                onClick={() => handleDelete(selectedProfile)}
+                className="text-xs text-text-dim hover:text-red-400 cursor-pointer"
+                title="Delete profile"
+              >
+                Delete
+              </button>
             )}
           </>
         )}

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   createProfile,
   deleteProfile,
@@ -19,6 +19,7 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   const [renaming, setRenaming] = useState(false);
   const [inputValue, setInputValue] = useState("");
   const [error, setError] = useState<string | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
 
   const load = useCallback(() => {
     fetchProfiles().then(setProfiles);
@@ -27,6 +28,18 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   useEffect(() => {
     load();
   }, [load]);
+
+  // Close panel on outside click
+  useEffect(() => {
+    if (!creating && !renaming) return;
+    const handler = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        closeInput();
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [creating, renaming]);
 
   const activeProfile = profiles.find((p) => p.is_default);
 
@@ -40,39 +53,21 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   const handleCreate = async () => {
     const trimmed = inputValue.trim();
     const err = validateName(trimmed);
-    if (err) {
-      setError(err);
-      return;
-    }
+    if (err) { setError(err); return; }
     const ok = await createProfile(trimmed);
-    if (ok) {
-      closeInput();
-      load();
-    } else {
-      setError("Failed to create profile");
-    }
+    if (ok) { closeInput(); load(); }
+    else setError("Failed to create profile");
   };
 
   const handleRename = async () => {
     if (!selectedProfile) return;
     const trimmed = inputValue.trim();
-    if (trimmed === selectedProfile) {
-      closeInput();
-      return;
-    }
+    if (trimmed === selectedProfile) { closeInput(); return; }
     const err = validateName(trimmed);
-    if (err) {
-      setError(err);
-      return;
-    }
+    if (err) { setError(err); return; }
     const ok = await renameProfile(selectedProfile, trimmed);
-    if (ok) {
-      onSelect(trimmed);
-      closeInput();
-      load();
-    } else {
-      setError("Failed to rename profile");
-    }
+    if (ok) { onSelect(trimmed); closeInput(); load(); }
+    else setError("Failed to rename profile");
   };
 
   const handleDelete = async (name: string) => {
@@ -117,19 +112,18 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   };
 
   return (
-    <div className="border border-surface-700/40 rounded-lg px-4 py-3 bg-surface-850">
-      <div className="flex items-center gap-3">
-        <label className="text-sm text-text-dim shrink-0">Profile</label>
+    <div className="relative" ref={panelRef}>
+      <div className="flex items-center gap-2">
+        <label className="text-xs text-text-dim shrink-0">Profile</label>
         <select
           value={selectedProfile ?? ""}
           onChange={(e) => onSelect(e.target.value || null)}
-          className="flex-1 bg-surface-900 border border-surface-700 rounded-md px-2 py-1.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-xs text-text-primary focus:border-brand-600 focus:outline-none w-36"
         >
-          <option value="">Global (all profiles)</option>
+          <option value="">Global</option>
           {profiles.map((p) => (
             <option key={p.name} value={p.name}>
-              {p.name}
-              {p.is_default ? " (active)" : ""}
+              {p.name}{p.is_default ? " (active)" : ""}
             </option>
           ))}
         </select>
@@ -137,69 +131,63 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
           onClick={startCreate}
           className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer shrink-0"
         >
-          + New
+          +
         </button>
+        {selectedProfile && !creating && !renaming && (
+          <>
+            <button
+              onClick={startRename}
+              className="text-xs text-text-dim hover:text-text-primary cursor-pointer"
+              title="Rename profile"
+            >
+              Rename
+            </button>
+            {(!activeProfile || activeProfile.name !== selectedProfile) && (
+              <>
+                <button
+                  onClick={() => handleSetDefault(selectedProfile)}
+                  className="text-xs text-text-dim hover:text-text-primary cursor-pointer"
+                  title="Set as default profile"
+                >
+                  Default
+                </button>
+                <button
+                  onClick={() => handleDelete(selectedProfile)}
+                  className="text-xs text-text-dim hover:text-red-400 cursor-pointer"
+                  title="Delete profile"
+                >
+                  Delete
+                </button>
+              </>
+            )}
+          </>
+        )}
       </div>
 
+      {/* Inline create/rename input */}
       {(creating || renaming) && (
-        <div className="mt-2 flex gap-2">
-          <input
-            type="text"
-            value={inputValue}
-            onChange={(e) => {
-              setInputValue(e.target.value);
-              setError(null);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") submitInput();
-              if (e.key === "Escape") closeInput();
-            }}
-            placeholder={creating ? "Profile name" : "New name"}
-            autoFocus
-            className={`flex-1 bg-surface-900 border rounded-md px-2 py-1.5 text-sm text-text-primary focus:outline-none ${error ? "border-red-500" : "border-surface-700 focus:border-brand-600"}`}
-          />
-          <button
-            onClick={submitInput}
-            className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-sm font-medium text-surface-950 cursor-pointer"
-          >
-            {creating ? "Create" : "Rename"}
-          </button>
-          <button
-            onClick={closeInput}
-            className="px-2 py-1.5 text-sm text-text-dim hover:text-text-primary cursor-pointer"
-          >
-            Cancel
-          </button>
-        </div>
-      )}
-      {error && <div className="text-xs text-red-400 mt-1">{error}</div>}
-
-      {selectedProfile && !creating && !renaming && (
-        <div className="mt-2 flex gap-2 text-xs">
-          <button
-            onClick={startRename}
-            className="text-text-dim hover:text-text-primary cursor-pointer"
-          >
-            Rename
-          </button>
-          {!activeProfile || activeProfile.name !== selectedProfile ? (
-            <>
-              <span className="text-surface-700">|</span>
-              <button
-                onClick={() => handleSetDefault(selectedProfile)}
-                className="text-text-dim hover:text-text-primary cursor-pointer"
-              >
-                Set as default
-              </button>
-              <span className="text-surface-700">|</span>
-              <button
-                onClick={() => handleDelete(selectedProfile)}
-                className="text-text-dim hover:text-red-400 cursor-pointer"
-              >
-                Delete
-              </button>
-            </>
-          ) : null}
+        <div className="absolute right-0 top-full mt-1 z-10 bg-surface-850 border border-surface-700 rounded-lg p-3 shadow-lg min-w-[280px]">
+          <div className="flex gap-2">
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => { setInputValue(e.target.value); setError(null); }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitInput();
+                if (e.key === "Escape") closeInput();
+              }}
+              placeholder={creating ? "Profile name" : "New name"}
+              autoFocus
+              className={`flex-1 bg-surface-900 border rounded-md px-2 py-1.5 text-sm text-text-primary focus:outline-none ${error ? "border-red-500" : "border-surface-700 focus:border-brand-600"}`}
+            />
+            <button
+              onClick={submitInput}
+              className="px-3 py-1.5 rounded-md bg-brand-600 hover:bg-brand-500 text-xs font-medium text-surface-950 cursor-pointer"
+            >
+              {creating ? "Create" : "Rename"}
+            </button>
+          </div>
+          {error && <div className="text-xs text-red-400 mt-1">{error}</div>}
         </div>
       )}
     </div>

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -114,11 +114,11 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
   return (
     <div className="relative" ref={panelRef}>
       <div className="flex items-center gap-2">
-        <label className="text-xs text-text-dim shrink-0">Profile</label>
+        <label className="text-sm font-medium text-text-secondary shrink-0">Profile</label>
         <select
           value={selectedProfile ?? ""}
           onChange={(e) => onSelect(e.target.value || null)}
-          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-xs text-text-primary focus:border-brand-600 focus:outline-none w-36"
+          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-40"
         >
           <option value="">Global</option>
           {profiles.map((p) => (
@@ -129,9 +129,10 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
         </select>
         <button
           onClick={startCreate}
-          className="text-xs text-brand-500 hover:text-brand-400 cursor-pointer shrink-0"
+          className="text-sm text-brand-500 hover:text-brand-400 cursor-pointer shrink-0 font-medium px-1.5"
+          title="Create new profile"
         >
-          +
+          + New
         </button>
         {selectedProfile && !creating && !renaming && (
           <>

--- a/web/src/components/settings/SoundSettings.tsx
+++ b/web/src/components/settings/SoundSettings.tsx
@@ -2,17 +2,16 @@ import { CollapsibleSection, SelectField, SliderField, TextField, ToggleField } 
 
 interface Props {
   settings: Record<string, unknown>;
-  onSave: (section: string, data: Record<string, unknown>) => void;
+  onSaveField: (section: string, field: string, value: unknown) => void;
   onUpdate: (patch: Record<string, unknown>) => void;
 }
 
-export function SoundSettings({ settings, onSave, onUpdate }: Props) {
+export function SoundSettings({ settings, onSaveField, onUpdate }: Props) {
   const sound = (settings.sound ?? {}) as Record<string, unknown>;
 
   const save = (field: string, value: unknown) => {
-    const updated = { ...sound, [field]: value };
-    onUpdate({ sound: updated });
-    onSave("sound", updated);
+    onUpdate({ sound: { ...sound, [field]: value } });
+    onSaveField("sound", field, value);
   };
 
   const enabled = (sound.enabled as boolean) ?? false;

--- a/web/src/components/settings/SoundSettings.tsx
+++ b/web/src/components/settings/SoundSettings.tsx
@@ -1,0 +1,87 @@
+import { CollapsibleSection, SelectField, SliderField, TextField, ToggleField } from "./FormFields";
+
+interface Props {
+  settings: Record<string, unknown>;
+  onSave: (section: string, data: Record<string, unknown>) => void;
+  onUpdate: (patch: Record<string, unknown>) => void;
+}
+
+export function SoundSettings({ settings, onSave, onUpdate }: Props) {
+  const sound = (settings.sound ?? {}) as Record<string, unknown>;
+
+  const save = (field: string, value: unknown) => {
+    const updated = { ...sound, [field]: value };
+    onUpdate({ sound: updated });
+    onSave("sound", updated);
+  };
+
+  const enabled = (sound.enabled as boolean) ?? false;
+
+  return (
+    <CollapsibleSection
+      title="Sound"
+      subtitle="Audio alerts play on the server host machine, not in your browser."
+    >
+      <ToggleField
+        label="Enabled"
+        description="Play sounds on session status changes"
+        checked={enabled}
+        onChange={(v) => save("enabled", v)}
+      />
+      {enabled && (
+        <>
+          <SelectField
+            label="Mode"
+            value={
+              typeof sound.mode === "string"
+                ? sound.mode
+                : typeof sound.mode === "object" && sound.mode !== null
+                  ? "specific"
+                  : "random"
+            }
+            onChange={(v) =>
+              save("mode", v === "random" ? "random" : { specific: "" })
+            }
+            options={[
+              { value: "random", label: "Random" },
+              { value: "specific", label: "Specific" },
+            ]}
+          />
+          <SliderField
+            label="Volume"
+            value={(sound.volume as number) ?? 1.0}
+            onChange={(v) => save("volume", v)}
+            min={0.1}
+            max={1.5}
+            step={0.1}
+            formatValue={(v) => v.toFixed(1)}
+          />
+          <TextField
+            label="On start"
+            description="Sound file for session start"
+            value={(sound.on_start as string) ?? ""}
+            onChange={(v) => save("on_start", v || null)}
+            placeholder="e.g. startup.wav"
+            mono
+          />
+          <TextField
+            label="On waiting"
+            description="Sound when session needs input"
+            value={(sound.on_waiting as string) ?? ""}
+            onChange={(v) => save("on_waiting", v || null)}
+            placeholder="e.g. waiting.wav"
+            mono
+          />
+          <TextField
+            label="On error"
+            description="Sound when session errors"
+            value={(sound.on_error as string) ?? ""}
+            onChange={(v) => save("on_error", v || null)}
+            placeholder="e.g. error.wav"
+            mono
+          />
+        </>
+      )}
+    </CollapsibleSection>
+  );
+}

--- a/web/src/components/settings/SoundSettings.tsx
+++ b/web/src/components/settings/SoundSettings.tsx
@@ -1,4 +1,4 @@
-import { CollapsibleSection, SelectField, SliderField, TextField, ToggleField } from "./FormFields";
+import { SelectField, SliderField, TextField, ToggleField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
@@ -17,10 +17,10 @@ export function SoundSettings({ settings, onSaveField, onUpdate }: Props) {
   const enabled = (sound.enabled as boolean) ?? false;
 
   return (
-    <CollapsibleSection
-      title="Sound"
-      subtitle="Audio alerts play on the server host machine, not in your browser."
-    >
+    <div className="space-y-4">
+      <p className="text-xs text-text-dim">
+        Audio alerts play on the server host machine, not in your browser.
+      </p>
       <ToggleField
         label="Enabled"
         description="Play sounds on session status changes"
@@ -81,6 +81,6 @@ export function SoundSettings({ settings, onSaveField, onUpdate }: Props) {
           />
         </>
       )}
-    </CollapsibleSection>
+    </div>
   );
 }

--- a/web/src/components/settings/ThemeSettings.tsx
+++ b/web/src/components/settings/ThemeSettings.tsx
@@ -4,11 +4,11 @@ import { CollapsibleSection, SelectField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
-  onSave: (section: string, data: Record<string, unknown>) => void;
+  onSaveField: (section: string, field: string, value: unknown) => void;
   onUpdate: (patch: Record<string, unknown>) => void;
 }
 
-export function ThemeSettings({ settings, onSave, onUpdate }: Props) {
+export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
   const [themes, setThemes] = useState<string[]>([]);
   const theme = (settings.theme ?? {}) as Record<string, unknown>;
 
@@ -17,9 +17,8 @@ export function ThemeSettings({ settings, onSave, onUpdate }: Props) {
   }, []);
 
   const save = (field: string, value: unknown) => {
-    const updated = { ...theme, [field]: value };
-    onUpdate({ theme: updated });
-    onSave("theme", updated);
+    onUpdate({ theme: { ...theme, [field]: value } });
+    onSaveField("theme", field, value);
   };
 
   return (

--- a/web/src/components/settings/ThemeSettings.tsx
+++ b/web/src/components/settings/ThemeSettings.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { fetchThemes } from "../../lib/api";
-import { CollapsibleSection, SelectField } from "./FormFields";
+import { SelectField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
@@ -22,10 +22,10 @@ export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
   };
 
   return (
-    <CollapsibleSection
-      title="Theme"
-      subtitle="These settings apply to the TUI (local tmux sessions), not the web dashboard."
-    >
+    <div className="space-y-4">
+      <p className="text-xs text-text-dim">
+        These settings apply to the TUI (local tmux sessions), not the web dashboard.
+      </p>
       <SelectField
         label="Theme"
         value={(theme.name as string) ?? ""}
@@ -44,6 +44,6 @@ export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
           { value: "palette", label: "Palette (256 colors)" },
         ]}
       />
-    </CollapsibleSection>
+    </div>
   );
 }

--- a/web/src/components/settings/ThemeSettings.tsx
+++ b/web/src/components/settings/ThemeSettings.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { fetchThemes } from "../../lib/api";
+import { CollapsibleSection, SelectField } from "./FormFields";
+
+interface Props {
+  settings: Record<string, unknown>;
+  onSave: (section: string, data: Record<string, unknown>) => void;
+  onUpdate: (patch: Record<string, unknown>) => void;
+}
+
+export function ThemeSettings({ settings, onSave, onUpdate }: Props) {
+  const [themes, setThemes] = useState<string[]>([]);
+  const theme = (settings.theme ?? {}) as Record<string, unknown>;
+
+  useEffect(() => {
+    fetchThemes().then(setThemes);
+  }, []);
+
+  const save = (field: string, value: unknown) => {
+    const updated = { ...theme, [field]: value };
+    onUpdate({ theme: updated });
+    onSave("theme", updated);
+  };
+
+  return (
+    <CollapsibleSection
+      title="Theme"
+      subtitle="These settings apply to the TUI (local tmux sessions), not the web dashboard."
+    >
+      <SelectField
+        label="Theme"
+        value={(theme.name as string) ?? ""}
+        onChange={(v) => save("name", v)}
+        options={[
+          { value: "", label: "Default" },
+          ...themes.map((t) => ({ value: t, label: t })),
+        ]}
+      />
+      <SelectField
+        label="Color mode"
+        value={(theme.color_mode as string) ?? "truecolor"}
+        onChange={(v) => save("color_mode", v)}
+        options={[
+          { value: "truecolor", label: "Truecolor (24-bit RGB)" },
+          { value: "palette", label: "Palette (256 colors)" },
+        ]}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/web/src/components/settings/TmuxSettings.tsx
+++ b/web/src/components/settings/TmuxSettings.tsx
@@ -2,17 +2,16 @@ import { CollapsibleSection, SelectField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
-  onSave: (section: string, data: Record<string, unknown>) => void;
+  onSaveField: (section: string, field: string, value: unknown) => void;
   onUpdate: (patch: Record<string, unknown>) => void;
 }
 
-export function TmuxSettings({ settings, onSave, onUpdate }: Props) {
+export function TmuxSettings({ settings, onSaveField, onUpdate }: Props) {
   const tmux = (settings.tmux ?? {}) as Record<string, unknown>;
 
   const save = (field: string, value: unknown) => {
-    const updated = { ...tmux, [field]: value };
-    onUpdate({ tmux: updated });
-    onSave("tmux", updated);
+    onUpdate({ tmux: { ...tmux, [field]: value } });
+    onSaveField("tmux", field, value);
   };
 
   const modeOptions = [

--- a/web/src/components/settings/TmuxSettings.tsx
+++ b/web/src/components/settings/TmuxSettings.tsx
@@ -1,0 +1,45 @@
+import { CollapsibleSection, SelectField } from "./FormFields";
+
+interface Props {
+  settings: Record<string, unknown>;
+  onSave: (section: string, data: Record<string, unknown>) => void;
+  onUpdate: (patch: Record<string, unknown>) => void;
+}
+
+export function TmuxSettings({ settings, onSave, onUpdate }: Props) {
+  const tmux = (settings.tmux ?? {}) as Record<string, unknown>;
+
+  const save = (field: string, value: unknown) => {
+    const updated = { ...tmux, [field]: value };
+    onUpdate({ tmux: updated });
+    onSave("tmux", updated);
+  };
+
+  const modeOptions = [
+    { value: "auto", label: "Auto" },
+    { value: "enabled", label: "Enabled" },
+    { value: "disabled", label: "Disabled" },
+  ];
+
+  return (
+    <CollapsibleSection
+      title="Tmux"
+      subtitle="These settings apply to the TUI (local tmux sessions), not the web dashboard."
+    >
+      <SelectField
+        label="Status bar"
+        description="Show tmux status bar in sessions"
+        value={(tmux.status_bar as string) ?? "auto"}
+        onChange={(v) => save("status_bar", v)}
+        options={modeOptions}
+      />
+      <SelectField
+        label="Mouse support"
+        description="Enable mouse in tmux sessions"
+        value={(tmux.mouse as string) ?? "auto"}
+        onChange={(v) => save("mouse", v)}
+        options={modeOptions}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/web/src/components/settings/TmuxSettings.tsx
+++ b/web/src/components/settings/TmuxSettings.tsx
@@ -1,4 +1,4 @@
-import { CollapsibleSection, SelectField } from "./FormFields";
+import { SelectField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
@@ -21,10 +21,10 @@ export function TmuxSettings({ settings, onSaveField, onUpdate }: Props) {
   ];
 
   return (
-    <CollapsibleSection
-      title="Tmux"
-      subtitle="These settings apply to the TUI (local tmux sessions), not the web dashboard."
-    >
+    <div className="space-y-4">
+      <p className="text-xs text-text-dim">
+        These settings apply to the TUI (local tmux sessions), not the web dashboard.
+      </p>
       <SelectField
         label="Status bar"
         description="Show tmux status bar in sessions"
@@ -39,6 +39,6 @@ export function TmuxSettings({ settings, onSaveField, onUpdate }: Props) {
         onChange={(v) => save("mouse", v)}
         options={modeOptions}
       />
-    </CollapsibleSection>
+    </div>
   );
 }

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -2,17 +2,16 @@ import { CollapsibleSection, NumberField, ToggleField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
-  onSave: (section: string, data: Record<string, unknown>) => void;
+  onSaveField: (section: string, field: string, value: unknown) => void;
   onUpdate: (patch: Record<string, unknown>) => void;
 }
 
-export function UpdateSettings({ settings, onSave, onUpdate }: Props) {
+export function UpdateSettings({ settings, onSaveField, onUpdate }: Props) {
   const updates = (settings.updates ?? {}) as Record<string, unknown>;
 
   const save = (field: string, value: unknown) => {
-    const updated = { ...updates, [field]: value };
-    onUpdate({ updates: updated });
-    onSave("updates", updated);
+    onUpdate({ updates: { ...updates, [field]: value } });
+    onSaveField("updates", field, value);
   };
 
   return (

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -1,4 +1,4 @@
-import { CollapsibleSection, NumberField, ToggleField } from "./FormFields";
+import { NumberField, ToggleField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
@@ -15,7 +15,7 @@ export function UpdateSettings({ settings, onSaveField, onUpdate }: Props) {
   };
 
   return (
-    <CollapsibleSection title="Updates">
+    <div className="space-y-4">
       <ToggleField
         label="Check for updates"
         description="Periodically check for new versions"
@@ -40,6 +40,6 @@ export function UpdateSettings({ settings, onSaveField, onUpdate }: Props) {
         checked={(updates.notify_in_cli as boolean) ?? true}
         onChange={(v) => save("notify_in_cli", v)}
       />
-    </CollapsibleSection>
+    </div>
   );
 }

--- a/web/src/components/settings/UpdateSettings.tsx
+++ b/web/src/components/settings/UpdateSettings.tsx
@@ -1,0 +1,46 @@
+import { CollapsibleSection, NumberField, ToggleField } from "./FormFields";
+
+interface Props {
+  settings: Record<string, unknown>;
+  onSave: (section: string, data: Record<string, unknown>) => void;
+  onUpdate: (patch: Record<string, unknown>) => void;
+}
+
+export function UpdateSettings({ settings, onSave, onUpdate }: Props) {
+  const updates = (settings.updates ?? {}) as Record<string, unknown>;
+
+  const save = (field: string, value: unknown) => {
+    const updated = { ...updates, [field]: value };
+    onUpdate({ updates: updated });
+    onSave("updates", updated);
+  };
+
+  return (
+    <CollapsibleSection title="Updates">
+      <ToggleField
+        label="Check for updates"
+        description="Periodically check for new versions"
+        checked={(updates.check_enabled as boolean) ?? true}
+        onChange={(v) => save("check_enabled", v)}
+      />
+      <ToggleField
+        label="Auto update"
+        description="Automatically install updates when available"
+        checked={(updates.auto_update as boolean) ?? false}
+        onChange={(v) => save("auto_update", v)}
+      />
+      <NumberField
+        label="Check interval (hours)"
+        value={(updates.check_interval_hours as number) ?? 24}
+        onChange={(v) => save("check_interval_hours", Math.max(1, v))}
+        min={1}
+      />
+      <ToggleField
+        label="Notify in CLI"
+        description="Show update notifications in the terminal"
+        checked={(updates.notify_in_cli as boolean) ?? true}
+        onChange={(v) => save("notify_in_cli", v)}
+      />
+    </CollapsibleSection>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -121,6 +121,101 @@ export async function updateSettings(
   }
 }
 
+// --- Profile management ---
+
+export async function createProfile(name: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/profiles", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function deleteProfile(name: string): Promise<boolean> {
+  try {
+    const res = await fetch(`/api/profiles/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function renameProfile(
+  name: string,
+  newName: string,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `/api/profiles/${encodeURIComponent(name)}/rename`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ new_name: newName }),
+      },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export async function setDefaultProfile(name: string): Promise<boolean> {
+  try {
+    const res = await fetch("/api/default-profile", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export function getProfileSettings(
+  name: string,
+): Promise<Record<string, unknown> | null> {
+  return fetchJson<Record<string, unknown>>(
+    `/api/profiles/${encodeURIComponent(name)}/settings`,
+  );
+}
+
+export async function updateProfileSettings(
+  name: string,
+  updates: Record<string, unknown>,
+): Promise<boolean> {
+  try {
+    const res = await fetch(
+      `/api/profiles/${encodeURIComponent(name)}/settings`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(updates),
+      },
+    );
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// --- Themes & Sounds ---
+
+export async function fetchThemes(): Promise<string[]> {
+  return (await fetchJson<string[]>("/api/themes")) ?? [];
+}
+
+export async function fetchSounds(): Promise<string[]> {
+  return (await fetchJson<string[]>("/api/sounds")) ?? [];
+}
+
 // --- About / server info ---
 
 export interface ServerAbout {


### PR DESCRIPTION
## Description

Closes #675. Web-first users no longer need to drop into the TUI to configure most of the app. Expands the web settings from ~12 fields (3 categories) to ~40 fields across all 9 config categories, with a tabbed navigation layout and full profile management.

### Settings UX
- **Tabbed sidebar navigation**: side tabs on desktop, horizontal scroll tabs on mobile
- **Section dividers**: "General" (session, sandbox, worktree, theme, sound, tmux, updates) vs "Web Dashboard" (notifications, terminal, security, devices)
- **Sidebar hides** when settings is open; content centered in viewport
- **Profile selector** in header bar with inline create/rename and dropdown
- **Default profile** dropdown moved to Session tab where it belongs
- **Save on blur/enter** for text and number fields (no more PATCH-per-keystroke)
- **Save error handling** with inline error display and state revert

### Backend
- Add `web` to `ALLOWED_SETTINGS_SECTIONS` (audited: boolean notification toggles only)
- Profile management API: create, delete, rename, set-default, per-profile settings CRUD
- Deep merge for profile settings so field-level updates don't convert inherited values into overrides
- Strict `[a-zA-Z0-9_-]` profile name validation to prevent path traversal
- Fix existing bug: add `read_only` guard to `update_settings`
- Add `custom_agents` and `agent_detect_as` to `SESSION_BLOCKED_FIELDS` (RCE vectors)
- Fix empty-string profile ghost entry when server launches without `--profile`
- Add `GET /api/sounds` endpoint
- Update all pinned security regression tests

### Frontend Components
- Reusable form fields: ToggleField, TextField, SelectField, NumberField, SliderField, ListField
- Section components: ThemeSettings, SoundSettings, TmuxSettings, UpdateSettings (TUI-only disclaimers)
- ProfileSelector with inline create/rename inputs
- Expanded Session (strict_hotkeys, agent_status_hooks, default profile)
- Expanded Sandbox (terminal mode, runtime, custom instruction, env vars, volumes, ports, ignores)
- Expanded Worktree (bare repo + workspace templates)
- Server-side notification defaults merged into Notifications tab

### Security (found and fixed during self-review)
- 3 path traversal vulnerabilities (missing `validate_profile_name` on delete/rename/default)
- 1 RCE vector (`custom_agents` not in `SESSION_BLOCKED_FIELDS`)

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Testing

- `cargo build --features serve`: clean
- `cargo test --features serve --lib`: 1235 tests pass
- `cargo clippy --features serve`: clean
- `npx tsc --noEmit`: clean
- Visual verification via Playwright screenshots across tabs

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 (1M context) via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)