### PR TITLE
feat(tui): mouse scroll and position indicator for preview pane

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -251,9 +251,16 @@ impl App {
                             continue;
                         }
                         Some(Ok(Event::Mouse(mouse))) => {
+                            let hit_scroll_target = if self.home.is_diff_open() {
+                                self.home.hit_diff(mouse.column, mouse.row)
+                            } else if self.home.has_selected_session() {
+                                self.home.hit_preview(mouse.column, mouse.row)
+                            } else {
+                                false
+                            };
                             let handled = match mouse.kind {
-                                MouseEventKind::ScrollUp => self.home.handle_scroll_up(),
-                                MouseEventKind::ScrollDown => self.home.handle_scroll_down(),
+                                MouseEventKind::ScrollUp if hit_scroll_target => self.home.handle_scroll_up(),
+                                MouseEventKind::ScrollDown if hit_scroll_target => self.home.handle_scroll_down(),
                                 _ => false,
                             };
                             if handled {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -2,8 +2,8 @@
 
 use anyhow::Result;
 use crossterm::event::{
-    DisableBracketedPaste, EnableBracketedPaste, Event, EventStream, KeyCode, KeyEvent,
-    KeyModifiers,
+    DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
+    EventStream, KeyCode, KeyEvent, KeyModifiers, MouseEventKind,
 };
 use futures_util::StreamExt;
 use ratatui::prelude::*;
@@ -113,6 +113,7 @@ impl App {
             terminal.backend_mut(),
             crossterm::terminal::LeaveAlternateScreen,
             DisableBracketedPaste,
+            DisableMouseCapture,
             crossterm::cursor::Show
         )?;
         std::io::Write::flush(terminal.backend_mut())?;
@@ -133,6 +134,7 @@ impl App {
             terminal.backend_mut(),
             crossterm::terminal::EnterAlternateScreen,
             EnableBracketedPaste,
+            EnableMouseCapture,
             crossterm::cursor::Hide
         )?;
         std::io::Write::flush(terminal.backend_mut())?;
@@ -248,7 +250,17 @@ impl App {
                             }
                             continue;
                         }
-                        Some(Ok(Event::Mouse(_))) => continue,
+                        Some(Ok(Event::Mouse(mouse))) => {
+                            let handled = match mouse.kind {
+                                MouseEventKind::ScrollUp => self.home.handle_scroll_up(),
+                                MouseEventKind::ScrollDown => self.home.handle_scroll_down(),
+                                _ => false,
+                            };
+                            if handled {
+                                terminal.draw(|f| self.render(f))?;
+                            }
+                            continue;
+                        }
                         Some(Ok(Event::Paste(text))) => {
                             self.home.handle_paste(&text);
 

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -16,6 +16,7 @@ impl Preview {
         instance: &Instance,
         terminal_running: bool,
         cached_output: &str,
+        scroll_offset: u16,
         theme: &Theme,
     ) {
         let info_height = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
@@ -72,11 +73,27 @@ impl Preview {
         frame.render_widget(paragraph, chunks[0]);
 
         // Output section
-        let block = Block::default()
+        let visible_height = chunks[1].height.saturating_sub(1) as usize;
+        let parsed_output = if terminal_running && !cached_output.is_empty() {
+            Some(parse_output_text(cached_output))
+        } else {
+            None
+        };
+        let line_count = parsed_output.as_ref().map_or(0, |t| t.lines.len());
+
+        let mut block = Block::default()
             .borders(Borders::TOP)
             .border_style(Style::default().fg(theme.border))
             .title(" Terminal Output ")
             .title_style(Style::default().fg(theme.dimmed));
+        if let Some(indicator) = format_scroll_indicator(line_count, visible_height, scroll_offset)
+        {
+            block = block.title_top(
+                Line::from(indicator)
+                    .right_aligned()
+                    .style(Style::default().fg(theme.dimmed)),
+            );
+        }
 
         let inner = block.inner(chunks[1]);
         frame.render_widget(block, chunks[1]);
@@ -86,27 +103,19 @@ impl Preview {
                 .style(Style::default().fg(theme.dimmed))
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
-        } else if cached_output.is_empty() {
+        } else if let Some(output_text) = parsed_output {
+            let paragraph_scroll = compute_scroll(line_count, visible_height, scroll_offset);
+
+            let paragraph = Paragraph::new(output_text)
+                .style(Style::default().fg(theme.text))
+                .scroll((paragraph_scroll, 0));
+
+            frame.render_widget(paragraph, inner);
+        } else {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
-        } else {
-            let output_text = parse_output_text(cached_output);
-            let line_count = output_text.lines.len();
-            let visible_height = inner.height as usize;
-
-            let scroll_offset = if line_count > visible_height {
-                (line_count - visible_height) as u16
-            } else {
-                0
-            };
-
-            let paragraph = Paragraph::new(output_text)
-                .style(Style::default().fg(theme.text))
-                .scroll((scroll_offset, 0));
-
-            frame.render_widget(paragraph, inner);
         }
     }
 
@@ -115,6 +124,7 @@ impl Preview {
         area: Rect,
         instance: &Instance,
         cached_output: &str,
+        scroll_offset: u16,
         theme: &Theme,
     ) {
         // 3 base lines (profile+tool / path / status) + optional sandbox + optional worktree block
@@ -135,7 +145,14 @@ impl Preview {
             .split(area);
 
         Self::render_info(frame, chunks[0], instance, theme);
-        Self::render_output_cached(frame, chunks[1], instance, cached_output, theme);
+        Self::render_output_cached(
+            frame,
+            chunks[1],
+            instance,
+            cached_output,
+            scroll_offset,
+            theme,
+        );
     }
 
     fn render_info(frame: &mut Frame, area: Rect, instance: &Instance, theme: &Theme) {
@@ -225,13 +242,30 @@ impl Preview {
         area: Rect,
         instance: &Instance,
         cached_output: &str,
+        scroll_offset: u16,
         theme: &Theme,
     ) {
-        let block = Block::default()
+        let visible_height = area.height.saturating_sub(1) as usize;
+        let parsed_output = if instance.last_error.is_none() && !cached_output.is_empty() {
+            Some(parse_output_text(cached_output))
+        } else {
+            None
+        };
+        let line_count = parsed_output.as_ref().map_or(0, |t| t.lines.len());
+
+        let mut block = Block::default()
             .borders(Borders::TOP)
             .border_style(Style::default().fg(theme.border))
             .title(" Output ")
             .title_style(Style::default().fg(theme.dimmed));
+        if let Some(indicator) = format_scroll_indicator(line_count, visible_height, scroll_offset)
+        {
+            block = block.title_top(
+                Line::from(indicator)
+                    .right_aligned()
+                    .style(Style::default().fg(theme.dimmed)),
+            );
+        }
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -253,30 +287,47 @@ impl Preview {
             return;
         }
 
-        if cached_output.is_empty() {
+        if let Some(output_text) = parsed_output {
+            let paragraph_scroll = compute_scroll(line_count, visible_height, scroll_offset);
+
+            let paragraph = Paragraph::new(output_text)
+                .style(Style::default().fg(theme.text))
+                .scroll((paragraph_scroll, 0));
+
+            frame.render_widget(paragraph, inner);
+        } else {
             let hint = Paragraph::new("No output available")
                 .style(Style::default().fg(theme.dimmed))
                 .alignment(Alignment::Center);
             frame.render_widget(hint, inner);
-        } else {
-            let output_text = parse_output_text(cached_output);
-            let line_count = output_text.lines.len();
-            let visible_height = inner.height as usize;
-
-            // Scroll to show the bottom of the content
-            let scroll_offset = if line_count > visible_height {
-                (line_count - visible_height) as u16
-            } else {
-                0
-            };
-
-            let paragraph = Paragraph::new(output_text)
-                .style(Style::default().fg(theme.text))
-                .scroll((scroll_offset, 0));
-
-            frame.render_widget(paragraph, inner);
         }
     }
+}
+
+/// Pick the row offset passed to `Paragraph::scroll`. Zero user offset shows
+/// the bottom of the cached pane (live-follow). A positive offset scrolls the
+/// same number of lines back, saturating at the top of the capture.
+fn compute_scroll(line_count: usize, visible_height: usize, user_offset: u16) -> u16 {
+    if line_count <= visible_height {
+        return 0;
+    }
+    let bottom = (line_count - visible_height) as u16;
+    bottom.saturating_sub(user_offset)
+}
+
+/// Render a tmux-style ` [offset/max] ` indicator when the user has scrolled
+/// back. Returns `None` while live-following or when the content fits in view.
+fn format_scroll_indicator(
+    line_count: usize,
+    visible_height: usize,
+    user_offset: u16,
+) -> Option<String> {
+    if user_offset == 0 || line_count <= visible_height {
+        return None;
+    }
+    let max_offset = (line_count - visible_height) as u16;
+    let clamped = user_offset.min(max_offset);
+    Some(format!(" [{}/{}] ", clamped, max_offset))
 }
 
 fn parse_output_text(content: &str) -> Text<'static> {
@@ -376,5 +427,52 @@ mod tests {
                 assert_eq!(shortened, "~/projects/");
             }
         }
+    }
+
+    #[test]
+    fn compute_scroll_live_follow_when_content_fits() {
+        assert_eq!(compute_scroll(5, 10, 0), 0);
+        assert_eq!(compute_scroll(5, 10, 20), 0);
+    }
+
+    #[test]
+    fn compute_scroll_sticks_to_bottom_with_zero_offset() {
+        assert_eq!(compute_scroll(100, 20, 0), 80);
+    }
+
+    #[test]
+    fn compute_scroll_walks_back_by_offset() {
+        assert_eq!(compute_scroll(100, 20, 15), 65);
+    }
+
+    #[test]
+    fn compute_scroll_saturates_at_top() {
+        assert_eq!(compute_scroll(100, 20, 500), 0);
+    }
+
+    #[test]
+    fn scroll_indicator_hidden_when_live() {
+        assert_eq!(format_scroll_indicator(100, 20, 0), None);
+    }
+
+    #[test]
+    fn scroll_indicator_hidden_when_content_fits() {
+        assert_eq!(format_scroll_indicator(10, 20, 5), None);
+    }
+
+    #[test]
+    fn scroll_indicator_reports_position_and_max() {
+        assert_eq!(
+            format_scroll_indicator(100, 20, 15),
+            Some(" [15/80] ".to_string())
+        );
+    }
+
+    #[test]
+    fn scroll_indicator_clamps_to_max() {
+        assert_eq!(
+            format_scroll_indicator(100, 20, 500),
+            Some(" [80/80] ".to_string())
+        );
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1140,7 +1140,6 @@ impl HomeView {
     /// content instead.
     pub fn handle_scroll_up(&mut self) -> bool {
         const STEP: u16 = 3;
-        const MAX_PREVIEW_SCROLL: u16 = 2000;
         if let Some(ref mut diff) = self.diff_view {
             diff.scroll_up(STEP);
             return true;
@@ -1148,8 +1147,34 @@ impl HomeView {
         if self.selected_session.is_none() || self.has_dialog() {
             return false;
         }
+
+        let active_cache = match self.view_mode {
+            ViewMode::Agent => &self.preview_cache,
+            ViewMode::Terminal => {
+                let terminal_mode = self
+                    .selected_session
+                    .as_ref()
+                    .and_then(|id| self.get_instance(id))
+                    .map(|inst| {
+                        if inst.is_sandboxed() {
+                            self.get_terminal_mode(&inst.id)
+                        } else {
+                            TerminalMode::Host
+                        }
+                    })
+                    .unwrap_or(TerminalMode::Host);
+                match terminal_mode {
+                    TerminalMode::Container => &self.container_terminal_preview_cache,
+                    TerminalMode::Host => &self.terminal_preview_cache,
+                }
+            }
+        };
+
+        let visible_height = active_cache.dimensions.1.saturating_sub(1) as usize;
+        let real_max = active_cache.captured_lines.saturating_sub(visible_height) as u16;
+
         let new_offset = self.preview_scroll_offset.saturating_add(STEP);
-        let clamped = new_offset.min(MAX_PREVIEW_SCROLL);
+        let clamped = new_offset.min(real_max);
         if clamped == self.preview_scroll_offset {
             return false;
         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1039,6 +1039,7 @@ impl HomeView {
 
     pub(super) fn update_selected(&mut self) {
         if let Some(item) = self.flat_items.get(self.cursor) {
+            let prev_session = self.selected_session.clone();
             match item {
                 Item::Session { id, .. } => {
                     self.selected_session = Some(id.clone());
@@ -1050,6 +1051,9 @@ impl HomeView {
                     self.selected_group = Some(path.clone());
                     self.selected_group_profile = self.profile_for_cursor(self.cursor);
                 }
+            }
+            if self.selected_session != prev_session {
+                self.preview_scroll_offset = 0;
             }
         }
     }
@@ -1112,6 +1116,47 @@ impl HomeView {
         if let Err(e) = self.save() {
             tracing::error!("Failed to save group state: {}", e);
         }
+    }
+
+    /// Scroll the preview pane up by one mouse-wheel step. Returns `true` if
+    /// the UI should redraw. When the diff view is open, scroll the diff
+    /// content instead.
+    pub fn handle_scroll_up(&mut self) -> bool {
+        const STEP: u16 = 3;
+        const MAX_PREVIEW_SCROLL: u16 = 2000;
+        if let Some(ref mut diff) = self.diff_view {
+            diff.scroll_up(STEP);
+            return true;
+        }
+        if self.selected_session.is_none() || self.has_dialog() {
+            return false;
+        }
+        let new_offset = self.preview_scroll_offset.saturating_add(STEP);
+        let clamped = new_offset.min(MAX_PREVIEW_SCROLL);
+        if clamped == self.preview_scroll_offset {
+            return false;
+        }
+        self.preview_scroll_offset = clamped;
+        true
+    }
+
+    /// Scroll the preview pane down by one mouse-wheel step. Returns `true`
+    /// if the UI should redraw. When the diff view is open, scroll the diff
+    /// content instead.
+    pub fn handle_scroll_down(&mut self) -> bool {
+        const STEP: u16 = 3;
+        if let Some(ref mut diff) = self.diff_view {
+            diff.scroll_down(STEP);
+            return true;
+        }
+        if self.selected_session.is_none() || self.has_dialog() {
+            return false;
+        }
+        if self.preview_scroll_offset == 0 {
+            return false;
+        }
+        self.preview_scroll_offset = self.preview_scroll_offset.saturating_sub(STEP);
+        true
     }
 
     /// Route a bracketed paste event to the active text input dialog.
@@ -1279,10 +1324,7 @@ impl HomeView {
         let has_hooks = hooks
             .as_ref()
             .is_some_and(|h| !h.on_create.is_empty() || !h.on_launch.is_empty());
-        let has_worktree = data
-            .worktree_branch
-            .as_ref()
-            .is_some_and(|b| !b.is_empty());
+        let has_worktree = data.worktree_branch.as_ref().is_some_and(|b| !b.is_empty());
 
         if data.sandbox || has_hooks || has_worktree {
             self.request_creation(data, hooks);

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1,6 +1,7 @@
 //! Input handling for HomeView
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::prelude::Position;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
@@ -19,6 +20,22 @@ use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::settings::{SettingsAction, SettingsView};
 
 impl HomeView {
+    pub fn is_diff_open(&self) -> bool {
+        self.diff_view.is_some()
+    }
+
+    pub fn has_selected_session(&self) -> bool {
+        self.selected_session.is_some()
+    }
+
+    pub fn hit_preview(&self, col: u16, row: u16) -> bool {
+        self.preview_area.contains(Position::from((col, row)))
+    }
+
+    pub fn hit_diff(&self, col: u16, row: u16) -> bool {
+        self.diff_area.contains(Position::from((col, row)))
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> Option<Action> {
         // Handle unsaved changes confirmation for settings (shown over settings view)
         if self.settings_close_confirm {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -82,6 +82,9 @@ pub(super) struct PreviewCache {
     pub(super) content: String,
     pub(super) last_refresh: Instant,
     pub(super) dimensions: (u16, u16),
+    /// Scroll offset the cache was captured at. Used to invalidate the cache
+    /// when the user scrolls past the currently captured history window.
+    pub(super) scroll_offset: u16,
 }
 
 impl Default for PreviewCache {
@@ -91,6 +94,7 @@ impl Default for PreviewCache {
             content: String::new(),
             last_refresh: Instant::now(),
             dimensions: (0, 0),
+            scroll_offset: 0,
         }
     }
 }
@@ -208,6 +212,10 @@ pub struct HomeView {
     pub(super) preview_cache: PreviewCache,
     pub(super) terminal_preview_cache: PreviewCache,
     pub(super) container_terminal_preview_cache: PreviewCache,
+
+    /// Mouse wheel offset for the preview pane, in lines back from the bottom.
+    /// Reset to 0 whenever the selected session changes.
+    pub(super) preview_scroll_offset: u16,
 
     // Terminal mode for sandboxed sessions (per-session, ephemeral)
     pub(super) terminal_modes: HashMap<String, TerminalMode>,
@@ -360,6 +368,7 @@ impl HomeView {
             preview_cache: PreviewCache::default(),
             terminal_preview_cache: PreviewCache::default(),
             container_terminal_preview_cache: PreviewCache::default(),
+            preview_scroll_offset: 0,
             terminal_modes: HashMap::new(),
             default_terminal_mode,
             sound_config,
@@ -1064,6 +1073,7 @@ impl HomeView {
         self.preview_cache = PreviewCache::default();
         self.terminal_preview_cache = PreviewCache::default();
         self.container_terminal_preview_cache = PreviewCache::default();
+        self.preview_scroll_offset = 0;
         // Clear search since match indices are invalid with new flat_items
         if self.search_active {
             self.search_active = false;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -86,6 +86,11 @@ pub(super) struct PreviewCache {
     /// Scroll offset the cache was captured at. Used to invalidate the cache
     /// when the user scrolls past the currently captured history window.
     pub(super) scroll_offset: u16,
+    /// Number of lines that were captured into `content`. Used together with
+    /// the BUFFER reserve so consecutive wheel ticks don't trigger a fresh
+    /// `tmux capture-pane` subprocess while the cached window still covers
+    /// the requested scroll.
+    pub(super) captured_lines: usize,
 }
 
 impl Default for PreviewCache {
@@ -96,6 +101,7 @@ impl Default for PreviewCache {
             last_refresh: Instant::now(),
             dimensions: (0, 0),
             scroll_offset: 0,
+            captured_lines: 0,
         }
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -10,6 +10,7 @@ mod tests;
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
 
+use ratatui::prelude::Rect;
 use tui_input::Input;
 
 use crate::session::{
@@ -216,6 +217,8 @@ pub struct HomeView {
     /// Mouse wheel offset for the preview pane, in lines back from the bottom.
     /// Reset to 0 whenever the selected session changes.
     pub(super) preview_scroll_offset: u16,
+    pub(super) preview_area: Rect,
+    pub(super) diff_area: Rect,
 
     // Terminal mode for sandboxed sessions (per-session, ephemeral)
     pub(super) terminal_modes: HashMap<String, TerminalMode>,
@@ -369,6 +372,8 @@ impl HomeView {
             terminal_preview_cache: PreviewCache::default(),
             container_terminal_preview_cache: PreviewCache::default(),
             preview_scroll_offset: 0,
+            preview_area: Rect::default(),
+            diff_area: Rect::default(),
             terminal_modes: HashMap::new(),
             default_terminal_mode,
             sound_config,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -83,9 +83,6 @@ pub(super) struct PreviewCache {
     pub(super) content: String,
     pub(super) last_refresh: Instant,
     pub(super) dimensions: (u16, u16),
-    /// Scroll offset the cache was captured at. Used to invalidate the cache
-    /// when the user scrolls past the currently captured history window.
-    pub(super) scroll_offset: u16,
     /// Number of lines that were captured into `content`. Used together with
     /// the BUFFER reserve so consecutive wheel ticks don't trigger a fresh
     /// `tmux capture-pane` subprocess while the cached window still covers
@@ -100,7 +97,6 @@ impl Default for PreviewCache {
             content: String::new(),
             last_refresh: Instant::now(),
             dimensions: (0, 0),
-            scroll_offset: 0,
             captured_lines: 0,
         }
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -48,6 +48,16 @@ fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset:
     needed > cache_captured_lines
 }
 
+/// Clamp the user's preview scroll offset to what the freshly captured pane
+/// can actually render. Prevents the offset from drifting into "phantom"
+/// territory (M3 from the multi-AI review) when tmux history is shorter than
+/// `MAX_PREVIEW_SCROLL`.
+fn clamp_scroll_to_capture(scroll_offset: u16, captured_lines: usize, area_height: u16) -> u16 {
+    let visible = area_height.saturating_sub(1) as usize;
+    let real_max = captured_lines.saturating_sub(visible) as u16;
+    scroll_offset.min(real_max)
+}
+
 fn spinner_running(created_at: &DateTime<Utc>) -> &'static str {
     spinners::dots()
         .set_interval(Duration::from_millis(220))
@@ -581,6 +591,11 @@ impl HomeView {
                     self.preview_cache.dimensions = (width, height);
                     self.preview_cache.last_refresh = Instant::now();
                     self.preview_cache.scroll_offset = scroll_offset;
+                    self.preview_scroll_offset = clamp_scroll_to_capture(
+                        self.preview_scroll_offset,
+                        self.preview_cache.captured_lines,
+                        height,
+                    );
                 }
             }
         }
@@ -624,6 +639,11 @@ impl HomeView {
                     self.terminal_preview_cache.dimensions = (width, height);
                     self.terminal_preview_cache.last_refresh = Instant::now();
                     self.terminal_preview_cache.scroll_offset = scroll_offset;
+                    self.preview_scroll_offset = clamp_scroll_to_capture(
+                        self.preview_scroll_offset,
+                        self.terminal_preview_cache.captured_lines,
+                        height,
+                    );
                 }
             }
         }
@@ -667,6 +687,11 @@ impl HomeView {
                     self.container_terminal_preview_cache.dimensions = (width, height);
                     self.container_terminal_preview_cache.last_refresh = Instant::now();
                     self.container_terminal_preview_cache.scroll_offset = scroll_offset;
+                    self.preview_scroll_offset = clamp_scroll_to_capture(
+                        self.preview_scroll_offset,
+                        self.container_terminal_preview_cache.captured_lines,
+                        height,
+                    );
                 }
             }
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -23,6 +23,14 @@ fn session_offset(created_at: &DateTime<Utc>) -> usize {
     created_at.timestamp_millis() as usize
 }
 
+/// Number of pane lines to capture for the preview, accounting for the user's
+/// scrollback offset. A small buffer is added so moderate scrolls don't force a
+/// fresh capture on every wheel tick.
+fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
+    const BUFFER: u16 = 20;
+    height.saturating_add(scroll_offset).saturating_add(BUFFER) as usize
+}
+
 fn spinner_running(created_at: &DateTime<Utc>) -> &'static str {
     spinners::dots()
         .set_interval(Duration::from_millis(220))
@@ -494,6 +502,7 @@ impl HomeView {
     fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250; // Refresh preview 4x/second max
 
+        let scroll_offset = self.preview_scroll_offset;
         let session_changed = match &self.selected_session {
             Some(id) => self.preview_cache.session_id.as_ref() != Some(id),
             None => false,
@@ -501,19 +510,22 @@ impl HomeView {
         let dims_changed = self.preview_cache.dimensions != (width, height);
         let timer_expired =
             self.preview_cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS;
+        let offset_changed = self.preview_cache.scroll_offset != scroll_offset;
 
-        let needs_refresh =
-            self.selected_session.is_some() && (session_changed || dims_changed || timer_expired);
+        let needs_refresh = self.selected_session.is_some()
+            && (session_changed || dims_changed || timer_expired || offset_changed);
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
+                    let capture_lines = capture_lines_for(height, scroll_offset);
                     self.preview_cache.content = inst
-                        .capture_output_with_size(height as usize, width, height)
+                        .capture_output_with_size(capture_lines, width, height)
                         .unwrap_or_default();
                     self.preview_cache.session_id = Some(id.clone());
                     self.preview_cache.dimensions = (width, height);
                     self.preview_cache.last_refresh = Instant::now();
+                    self.preview_cache.scroll_offset = scroll_offset;
                 }
             }
         }
@@ -523,10 +535,12 @@ impl HomeView {
     fn refresh_terminal_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250;
 
+        let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
             Some(id) => {
                 self.terminal_preview_cache.session_id.as_ref() != Some(id)
                     || self.terminal_preview_cache.dimensions != (width, height)
+                    || self.terminal_preview_cache.scroll_offset != scroll_offset
                     || self
                         .terminal_preview_cache
                         .last_refresh
@@ -540,13 +554,15 @@ impl HomeView {
         if needs_refresh {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
+                    let capture_lines = capture_lines_for(height, scroll_offset);
                     self.terminal_preview_cache.content = inst
                         .terminal_tmux_session()
-                        .and_then(|s| s.capture_pane(height as usize))
+                        .and_then(|s| s.capture_pane(capture_lines))
                         .unwrap_or_default();
                     self.terminal_preview_cache.session_id = Some(id.clone());
                     self.terminal_preview_cache.dimensions = (width, height);
                     self.terminal_preview_cache.last_refresh = Instant::now();
+                    self.terminal_preview_cache.scroll_offset = scroll_offset;
                 }
             }
         }
@@ -556,10 +572,12 @@ impl HomeView {
     fn refresh_container_terminal_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250;
 
+        let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
             Some(id) => {
                 self.container_terminal_preview_cache.session_id.as_ref() != Some(id)
                     || self.container_terminal_preview_cache.dimensions != (width, height)
+                    || self.container_terminal_preview_cache.scroll_offset != scroll_offset
                     || self
                         .container_terminal_preview_cache
                         .last_refresh
@@ -573,13 +591,15 @@ impl HomeView {
         if needs_refresh {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
+                    let capture_lines = capture_lines_for(height, scroll_offset);
                     self.container_terminal_preview_cache.content = inst
                         .container_terminal_tmux_session()
-                        .and_then(|s| s.capture_pane(height as usize))
+                        .and_then(|s| s.capture_pane(capture_lines))
                         .unwrap_or_default();
                     self.container_terminal_preview_cache.session_id = Some(id.clone());
                     self.container_terminal_preview_cache.dimensions = (width, height);
                     self.container_terminal_preview_cache.last_refresh = Instant::now();
+                    self.container_terminal_preview_cache.scroll_offset = scroll_offset;
                 }
             }
         }
@@ -627,6 +647,7 @@ impl HomeView {
                                 inner,
                                 inst,
                                 &self.preview_cache.content,
+                                self.preview_scroll_offset,
                                 theme,
                             );
                         }
@@ -695,6 +716,7 @@ impl HomeView {
                             inst,
                             terminal_running,
                             preview_content,
+                            self.preview_scroll_offset,
                             theme,
                         );
                     }
@@ -985,5 +1007,20 @@ mod tests {
     fn format_relative_age_months() {
         let ts = Utc::now() - chrono::Duration::days(60);
         assert_eq!(format_relative_age(Some(ts)), "2mo");
+    }
+
+    #[test]
+    fn capture_lines_for_adds_buffer_to_height() {
+        assert_eq!(capture_lines_for(30, 0), 50);
+    }
+
+    #[test]
+    fn capture_lines_for_extends_by_scroll_offset() {
+        assert_eq!(capture_lines_for(30, 200), 250);
+    }
+
+    #[test]
+    fn capture_lines_for_saturates_instead_of_overflowing() {
+        assert_eq!(capture_lines_for(u16::MAX, u16::MAX), u16::MAX as usize);
     }
 }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -590,7 +590,6 @@ impl HomeView {
                     self.preview_cache.session_id = Some(id.clone());
                     self.preview_cache.dimensions = (width, height);
                     self.preview_cache.last_refresh = Instant::now();
-                    self.preview_cache.scroll_offset = scroll_offset;
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.preview_cache.captured_lines,
@@ -638,7 +637,6 @@ impl HomeView {
                     self.terminal_preview_cache.session_id = Some(id.clone());
                     self.terminal_preview_cache.dimensions = (width, height);
                     self.terminal_preview_cache.last_refresh = Instant::now();
-                    self.terminal_preview_cache.scroll_offset = scroll_offset;
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.terminal_preview_cache.captured_lines,
@@ -686,7 +684,6 @@ impl HomeView {
                     self.container_terminal_preview_cache.session_id = Some(id.clone());
                     self.container_terminal_preview_cache.dimensions = (width, height);
                     self.container_terminal_preview_cache.last_refresh = Instant::now();
-                    self.container_terminal_preview_cache.scroll_offset = scroll_offset;
                     self.preview_scroll_offset = clamp_scroll_to_capture(
                         self.preview_scroll_offset,
                         self.container_terminal_preview_cache.captured_lines,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -944,6 +944,12 @@ impl HomeView {
             Span::styled(" ?", key_style),
             Span::styled(" Help ", desc_style),
             Span::styled("│", sep_style),
+            // Mouse capture is enabled globally, which disables the terminal's
+            // native drag-to-select. Surface the modifier-key workaround so
+            // users don't think copy-paste is broken.
+            Span::styled(" ⌥/Shift+drag", key_style),
+            Span::styled(" Select ", desc_style),
+            Span::styled("│", sep_style),
             Span::styled(if strict { " Q" } else { " q" }, key_style),
             Span::styled(" Quit", desc_style),
         ]);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -23,12 +23,29 @@ fn session_offset(created_at: &DateTime<Utc>) -> usize {
     created_at.timestamp_millis() as usize
 }
 
+/// Extra rows captured beyond the visible window so moderate scrolls don't
+/// force a fresh capture on every wheel tick. Cache invalidation uses the same
+/// reserve to decide when the captured window can no longer cover the
+/// requested scroll.
+const CAPTURE_BUFFER: u16 = 20;
+
 /// Number of pane lines to capture for the preview, accounting for the user's
 /// scrollback offset. A small buffer is added so moderate scrolls don't force a
 /// fresh capture on every wheel tick.
 fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
-    const BUFFER: u16 = 20;
-    height.saturating_add(scroll_offset).saturating_add(BUFFER) as usize
+    height
+        .saturating_add(scroll_offset)
+        .saturating_add(CAPTURE_BUFFER) as usize
+}
+
+/// Decide whether the cached capture window still covers the requested scroll.
+/// Returns true when the cache must be re-captured because the visible window
+/// (plus BUFFER headroom) would run past the end of the captured content.
+fn scroll_exceeds_cache(cache_captured_lines: usize, height: u16, scroll_offset: u16) -> bool {
+    let needed = (height as usize)
+        .saturating_add(scroll_offset as usize)
+        .saturating_add(CAPTURE_BUFFER as usize);
+    needed > cache_captured_lines
 }
 
 fn spinner_running(created_at: &DateTime<Utc>) -> &'static str {
@@ -542,18 +559,24 @@ impl HomeView {
         let dims_changed = self.preview_cache.dimensions != (width, height);
         let timer_expired =
             self.preview_cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS;
-        let offset_changed = self.preview_cache.scroll_offset != scroll_offset;
+        // Only re-capture for scroll when the cached window can no longer
+        // cover the requested offset. Wheel ticks inside the BUFFER headroom
+        // re-render from the existing content without forking tmux.
+        let scroll_exceeds =
+            scroll_exceeds_cache(self.preview_cache.captured_lines, height, scroll_offset);
 
         let needs_refresh = self.selected_session.is_some()
-            && (session_changed || dims_changed || timer_expired || offset_changed);
+            && (session_changed || dims_changed || timer_expired || scroll_exceeds);
 
         if needs_refresh {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
                     let capture_lines = capture_lines_for(height, scroll_offset);
-                    self.preview_cache.content = inst
+                    let content = inst
                         .capture_output_with_size(capture_lines, width, height)
                         .unwrap_or_default();
+                    self.preview_cache.captured_lines = content.lines().count();
+                    self.preview_cache.content = content;
                     self.preview_cache.session_id = Some(id.clone());
                     self.preview_cache.dimensions = (width, height);
                     self.preview_cache.last_refresh = Instant::now();
@@ -572,7 +595,11 @@ impl HomeView {
             Some(id) => {
                 self.terminal_preview_cache.session_id.as_ref() != Some(id)
                     || self.terminal_preview_cache.dimensions != (width, height)
-                    || self.terminal_preview_cache.scroll_offset != scroll_offset
+                    || scroll_exceeds_cache(
+                        self.terminal_preview_cache.captured_lines,
+                        height,
+                        scroll_offset,
+                    )
                     || self
                         .terminal_preview_cache
                         .last_refresh
@@ -587,10 +614,12 @@ impl HomeView {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
                     let capture_lines = capture_lines_for(height, scroll_offset);
-                    self.terminal_preview_cache.content = inst
+                    let content = inst
                         .terminal_tmux_session()
                         .and_then(|s| s.capture_pane(capture_lines))
                         .unwrap_or_default();
+                    self.terminal_preview_cache.captured_lines = content.lines().count();
+                    self.terminal_preview_cache.content = content;
                     self.terminal_preview_cache.session_id = Some(id.clone());
                     self.terminal_preview_cache.dimensions = (width, height);
                     self.terminal_preview_cache.last_refresh = Instant::now();
@@ -609,7 +638,11 @@ impl HomeView {
             Some(id) => {
                 self.container_terminal_preview_cache.session_id.as_ref() != Some(id)
                     || self.container_terminal_preview_cache.dimensions != (width, height)
-                    || self.container_terminal_preview_cache.scroll_offset != scroll_offset
+                    || scroll_exceeds_cache(
+                        self.container_terminal_preview_cache.captured_lines,
+                        height,
+                        scroll_offset,
+                    )
                     || self
                         .container_terminal_preview_cache
                         .last_refresh
@@ -624,10 +657,12 @@ impl HomeView {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
                     let capture_lines = capture_lines_for(height, scroll_offset);
-                    self.container_terminal_preview_cache.content = inst
+                    let content = inst
                         .container_terminal_tmux_session()
                         .and_then(|s| s.capture_pane(capture_lines))
                         .unwrap_or_default();
+                    self.container_terminal_preview_cache.captured_lines = content.lines().count();
+                    self.container_terminal_preview_cache.content = content;
                     self.container_terminal_preview_cache.session_id = Some(id.clone());
                     self.container_terminal_preview_cache.dimensions = (width, height);
                     self.container_terminal_preview_cache.last_refresh = Instant::now();
@@ -1062,5 +1097,38 @@ mod tests {
     #[test]
     fn capture_lines_for_saturates_instead_of_overflowing() {
         assert_eq!(capture_lines_for(u16::MAX, u16::MAX), u16::MAX as usize);
+    }
+
+    #[test]
+    fn scroll_exceeds_cache_false_when_buffer_covers_small_scroll() {
+        // Cache was captured at scroll=0 with height=30, so
+        // capture_lines_for(30, 0) = 30 + 0 + BUFFER(20) = 50 lines.
+        // A wheel tick to scroll_offset=3 needs 30 + 3 + 20 = 53, but the
+        // existing BUFFER reserve is what we check: the predicate should
+        // only trip when `height + scroll + BUFFER > captured_lines`.
+        //
+        // With captured_lines = 60 (capture returned extra pane history),
+        // small scroll increments must NOT force a re-capture.
+        let height = 30u16;
+        let captured = 60usize;
+        assert!(!scroll_exceeds_cache(captured, height, 0));
+        assert!(!scroll_exceeds_cache(captured, height, 3));
+        assert!(!scroll_exceeds_cache(captured, height, 9));
+    }
+
+    #[test]
+    fn scroll_exceeds_cache_true_when_scroll_runs_past_captured_window() {
+        // Once the requested visible window + BUFFER exceeds captured_lines,
+        // the cache can no longer cover the scroll and must be re-captured.
+        let height = 30u16;
+        let captured = 60usize;
+        // height(30) + scroll(20) + BUFFER(20) = 70 > 60 → recapture.
+        assert!(scroll_exceeds_cache(captured, height, 20));
+    }
+
+    #[test]
+    fn scroll_exceeds_cache_true_for_empty_cache() {
+        // First render: nothing captured yet, so any request forces capture.
+        assert!(scroll_exceeds_cache(0, 30, 0));
     }
 }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -112,6 +112,10 @@ impl HomeView {
         }
 
         // Diff view takes over the whole screen
+        if self.diff_view.is_some() {
+            self.preview_area = Rect::default();
+            self.diff_area = self.active_diff_area(area);
+        }
         if let Some(ref mut diff) = self.diff_view {
             // Compute diff for selected file if not cached
             let _ = diff.get_current_diff();
@@ -200,6 +204,34 @@ impl HomeView {
             profile_picker_dialog,
             send_message_dialog,
         );
+    }
+
+    fn active_diff_area(&self, area: Rect) -> Rect {
+        let Some(diff) = &self.diff_view else {
+            return Rect::default();
+        };
+
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(3),
+                Constraint::Min(10),
+                Constraint::Length(3),
+            ])
+            .split(area);
+        let content_area = layout[1];
+        let effective_file_list_width = diff
+            .file_list_width
+            .min(content_area.width.saturating_sub(40))
+            .max(5);
+        let panes = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Length(effective_file_list_width),
+                Constraint::Min(40),
+            ])
+            .split(content_area);
+        Block::default().borders(Borders::ALL).inner(panes[1])
     }
 
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -623,6 +655,8 @@ impl HomeView {
             .padding(Padding::horizontal(1));
 
         let inner = block.inner(area);
+        self.preview_area = inner;
+        self.diff_area = Rect::default();
         frame.render_widget(block, area);
 
         match self.view_mode {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -15,7 +15,7 @@ pub use app::*;
 
 use anyhow::Result;
 use crossterm::{
-    event::{DisableBracketedPaste, EnableBracketedPaste},
+    event::{DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
@@ -89,7 +89,12 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    execute!(
+        stdout,
+        EnterAlternateScreen,
+        EnableBracketedPaste,
+        EnableMouseCapture
+    )?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -107,7 +112,8 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableBracketedPaste
+        DisableBracketedPaste,
+        DisableMouseCapture
     )?;
     terminal.show_cursor()?;
 


### PR DESCRIPTION
## Description

Adds mouse-wheel scrolling to the session preview pane (and diff view) with a tmux-copy-mode-style `[offset/max]` indicator in the top-right of the output block when scrolled back. The indicator hides while live-following at the bottom.

While the feature was small, a multi-AI consensus review (Gemini 3.1 Pro Preview + OpenAI Codex CLI) surfaced four issues worth fixing before merge. Each issue was patched by whoever raised it, verified, and folded in on top of the feature commit.

**Commit series (5):**

| # | Commit | What |
|---|--------|------|
| 1 | `feat(tui): mouse scroll and position indicator for preview pane` | Core feature. Enables `EnableMouseCapture`, routes `ScrollUp/Down` through `HomeView`, grows tmux capture with offset, renders `[X/Y]` indicator. |
| 2 | `docs(tui): add text-select modifier hint to status bar` | **M1** — `EnableMouseCapture` intercepts drag, which disables native text selection. Adds a dim footer segment documenting the `⌥/Shift+drag: Select` workaround. |
| 3 | `fix(tui): route mouse wheel by pane coordinates` | **M4** — previously scrolling anywhere in the TUI (tree navigator, footer, header) dispatched to the preview pane. Now tracks preview/diff `Rect` during render and gates routing on `Rect::contains`. |
| 4 | `perf(tui): skip preview recapture when BUFFER covers scroll` | **M2** — previously every wheel tick forked a fresh `tmux capture-pane` (and `docker exec` for sandboxed sessions). Now reuses the cached window when `height + scroll + CAPTURE_BUFFER ≤ captured_lines`. |
| 5 | `fix(tui): clamp preview scroll offset to captured content max` | **M3** — previously clamped only to `MAX_PREVIEW_SCROLL = 2000`, so the offset could drift far past renderable content. Now picks the active `PreviewCache` by view mode and clamps to `captured_lines - visible_height`. |

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass — `cargo test --lib` reports **1109 passed** (3 new tests covering `scroll_exceeds_cache` behavior)
- [x] Documentation was updated where necessary — footer hint for the Option/Shift text-select modifier
- [x] For UI changes: included screenshot or recording — *not included; happy to attach on request*

<img width="1042" height="426" alt="스크린샷 2026-04-24 오후 10 48 22" src="https://github.com/user-attachments/assets/b2b2ead7-e967-4264-be6a-3ae8f87f3d4c" />

**Verification run locally:**
- `cargo fmt --check` ✅
- `cargo clippy --profile dev-release --no-deps --lib` ✅ (no new warnings)
- `cargo test --lib` ✅ 1109 passed, 0 failed

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
- **Claude Opus 4.7 (Claude Code)** — wrote the initial feature commit, M1, and M2.
- **Gemini 3.1 Pro Preview** — independently reviewed the feature, surfaced **M3** (phantom/overscroll state), then implemented the M3 fix in an isolated worktree.
- **OpenAI Codex CLI (`codex exec --sandbox workspace-write`)** — independently reviewed the feature, surfaced **M4** (global mouse wheel routing), then implemented the M4 fix in an isolated worktree.

**Any Additional AI Details you'd like to share:**

Workflow was a simple multi-AI consensus validation: one reviewer wrote the feature, two external reviewers validated the review, findings that gained 2-of-2 independent confirmation (M3) were given highest confidence. Each fix ran in its own git worktree in parallel, verified locally (`cargo fmt` / `clippy` / `test`), then merged back to main as separate commits. Final diff was re-tested end-to-end.

- [x] I am an AI Agent filling out this form (check box if true)
