### PR TITLE
feat(web): add URL-based routing for dashboard views

### DIFF
--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -597,7 +597,7 @@ async fn fire_due_pushes(
         let payload = super::push_send::PushPayload {
             title: title.to_string(),
             body,
-            url: format!("/?session={}", instance_id),
+            url: format!("/session/{}", instance_id),
             tag: format!("session-{}", instance_id),
             session_id: instance_id.clone(),
         };

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -16,6 +16,7 @@
         "cmdk": "^1.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "react-router-dom": "^7.14.2",
         "shiki": "^4.0.2",
         "tailwindcss": "^4.2.2"
       },
@@ -3117,6 +3118,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4465,6 +4479,44 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -4529,6 +4581,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shiki": {
       "version": "4.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -20,6 +20,7 @@
     "cmdk": "^1.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "react-router-dom": "^7.14.2",
     "shiki": "^4.0.2",
     "tailwindcss": "^4.2.2"
   },

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMatch, useNavigate } from "react-router-dom";
 import { isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { useWorkspaces } from "./hooks/useWorkspaces";
@@ -10,11 +11,7 @@ import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
-import {
-  OPEN_SESSION_EVENT,
-  readSessionFromUrl,
-  writeSessionToUrl,
-} from "./lib/sessionRoute";
+import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -88,25 +85,24 @@ export default function App() {
 }
 
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
+  const navigate = useNavigate();
+  const sessionMatch = useMatch("/session/:sessionId");
+  const settingsRootMatch = useMatch("/settings");
+  const settingsTabMatch = useMatch("/settings/:tab");
+  const activeSessionId = sessionMatch?.params.sessionId ?? null;
+  const showSettings = settingsRootMatch !== null || settingsTabMatch !== null;
+  const settingsTab = settingsTabMatch?.params.tab ?? null;
+
   const { sessions, error, injectSession, setSessionStatus } = useSessions();
   const workspaces = useWorkspaces(sessions);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
 
-  const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(
-    null,
-  );
-  // Seed from `?session=<id>` so deep links and notification taps land on
-  // the right session before the sessions list has finished loading.
-  const [activeSessionId, setActiveSessionId] = useState<string | null>(() =>
-    readSessionFromUrl(),
-  );
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
   const [diffCollapsed, setDiffCollapsed] = useState(
     () => window.innerWidth < 768,
   );
   const [showAddProject, setShowAddProject] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
-  const [showSettings, setShowSettings] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(
@@ -114,20 +110,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   );
   const keyboardProxyRef = useRef<HTMLTextAreaElement>(null);
 
-  // Prefer workspace lookup by ID; fall back to finding the workspace
-  // that contains activeSessionId so a URL-seeded session (notification
-  // tap) renders even before handleSelectSession has run to set the
-  // workspace ID explicitly.
   const activeWorkspace = useMemo(() => {
-    const byId = activeWorkspaceId
-      ? workspaces.find((w) => w.id === activeWorkspaceId)
-      : undefined;
-    if (byId) return byId;
     if (!activeSessionId) return undefined;
     return workspaces.find((w) =>
       w.sessions.some((s) => s.id === activeSessionId),
     );
-  }, [workspaces, activeWorkspaceId, activeSessionId]);
+  }, [workspaces, activeSessionId]);
   const activeSession = activeWorkspace?.sessions.find(
     (s) => s.id === activeSessionId,
   );
@@ -162,44 +150,28 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const handleSelectSession = useCallback((sessionId: string) => {
     const ws = workspaces.find((w) => w.sessions.some((s) => s.id === sessionId));
     if (ws) {
-      setActiveWorkspaceId(ws.id);
-      setActiveSessionId(sessionId);
-      writeSessionToUrl(sessionId);
+      navigate(`/session/${encodeURIComponent(sessionId)}`);
       focusKeyboardProxy();
-      setShowSettings(false);
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
-  }, [workspaces]);
+  }, [navigate, workspaces]);
 
   const handleSelectWorkspace = (workspaceId: string) => {
-    setActiveWorkspaceId(workspaceId);
     const ws = workspaces.find((w) => w.id === workspaceId);
     if (ws) {
       const running = ws.sessions.find((s) => isSessionActive(s.status));
       const picked = running?.id ?? ws.sessions[0]?.id ?? null;
-      setActiveSessionId(picked);
-      writeSessionToUrl(picked);
+      if (picked) {
+        navigate(`/session/${encodeURIComponent(picked)}`);
+      } else {
+        navigate("/");
+      }
     }
     focusKeyboardProxy();
-    setShowSettings(false);
     if (window.innerWidth < 768) {
       setSidebarOpen(false);
     }
   };
-
-  // Sync browser back/forward to selection state. We always clear
-  // activeWorkspaceId so the activeWorkspace memo re-derives it from
-  // the URL-provided session. Otherwise back/forward across workspaces
-  // leaves a stale workspace ID, the memo returns the wrong workspace,
-  // the session lookup fails, and the app renders the dashboard.
-  useEffect(() => {
-    const onPop = () => {
-      setActiveSessionId(readSessionFromUrl());
-      setActiveWorkspaceId(null);
-    };
-    window.addEventListener("popstate", onPop);
-    return () => window.removeEventListener("popstate", onPop);
-  }, []);
 
   // In-app toast forwarded from the service worker sets this event when
   // the user taps it; navigate to the session that triggered the push.
@@ -245,9 +217,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setSessionStatus(sessionId, "Deleting");
 
     if (wasActive) {
-      setActiveWorkspaceId(null);
-      setActiveSessionId(null);
-      writeSessionToUrl(null);
+      navigate("/");
     }
 
     const result = await deleteSession(sessionId, options);
@@ -259,7 +229,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     }
 
     toastBus.handler?.info("Session deleted");
-  }, [deletingSession, activeSessionId, setSessionStatus]);
+  }, [deletingSession, activeSessionId, setSessionStatus, navigate]);
 
   const handleCreateSession = useCallback((repoPath: string) => {
     const projectSessions = sessions
@@ -290,17 +260,22 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   }, []);
 
   const handleGoDashboard = useCallback(() => {
-    setActiveWorkspaceId(null);
-    setActiveSessionId(null);
-    writeSessionToUrl(null);
-    setShowSettings(false);
+    navigate("/");
     setSelectedFilePath(null);
-  }, []);
+  }, [navigate]);
 
   const handleOpenSettings = useCallback(() => {
-    setShowSettings(true);
+    navigate("/settings");
     if (window.innerWidth < 768) setSidebarOpen(false);
-  }, []);
+  }, [navigate]);
+
+  const handleCloseSettings = useCallback(() => {
+    if (activeSessionId) {
+      navigate(`/session/${encodeURIComponent(activeSessionId)}`);
+    } else {
+      navigate("/");
+    }
+  }, [navigate, activeSessionId]);
 
   const handleOpenHelp = useCallback(() => {
     setShowHelp(true);
@@ -354,17 +329,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           }
           setShowAddProject(false);
           setShowHelp(false);
-          setShowSettings(false);
+          if (showSettings) handleCloseSettings();
           setShowAbout(false);
           setSelectedFilePath(null);
         },
         onHelp: () => setShowHelp((h) => !h),
-        onSettings: () => setShowSettings((s) => !s),
+        onSettings: () => (showSettings ? handleCloseSettings() : navigate("/settings")),
         onPalette: () => setShowPalette((p) => !p),
         onToggleSidebar: () => setSidebarOpen((o) => !o),
         onToggleRightPanel: () => setDiffCollapsed((c) => !c),
       }),
-      [toggleDiff, showPalette, deletingWorkspaceId],
+      [toggleDiff, showPalette, deletingWorkspaceId, showSettings, handleCloseSettings, navigate],
     ),
   );
 
@@ -386,7 +361,13 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const renderContent = () => {
     if (showSettings) {
-      return <SettingsView onClose={() => setShowSettings(false)} />;
+      return (
+        <SettingsView
+          tab={settingsTab}
+          onClose={handleCloseSettings}
+          onSelectTab={(t) => navigate(`/settings/${t}`)}
+        />
+      );
     }
 
     if (!activeWorkspace || !activeSession) {
@@ -477,7 +458,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onToggleRepo={toggleRepoCollapsed}
             onNew={() => { setWizardPrefill(undefined); setShowAddProject(true); }}
             onCreateSession={handleCreateSession}
-            onSettings={() => { setShowSettings((s) => !s); if (window.innerWidth < 768) setSidebarOpen(false); }}
+            onSettings={handleOpenSettings}
             onDeleteSession={handleDeleteSession}
             readOnly={serverAbout?.read_only}
           />
@@ -494,12 +475,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           onCreated={(session?: SessionResponse) => {
             if (session) {
               injectSession(session);
-              setActiveSessionId(session.id);
-              writeSessionToUrl(session.id);
-              // Key format must match useWorkspaces grouping key
-              const repoPath = (session.main_repo_path ?? session.project_path).replace(/\/+$/, "");
-              const wsId = `${repoPath}::${session.branch ?? "__default__"}`;
-              setActiveWorkspaceId(wsId);
+              navigate(`/session/${encodeURIComponent(session.id)}`);
               if (window.innerWidth < 768) setSidebarOpen(false);
             }
             setShowAddProject(false);

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -59,16 +59,24 @@ const TABS = SIDEBAR.filter((s): s is { kind: "tab"; id: TabId; label: string } 
 
 interface Props {
   onClose: () => void;
+  tab: string | null;
+  onSelectTab: (tab: TabId) => void;
 }
 
-export function SettingsView({ onClose }: Props) {
+const TAB_IDS = new Set<TabId>(TABS.map((t) => t.id));
+
+function isTabId(value: unknown): value is TabId {
+  return typeof value === "string" && TAB_IDS.has(value as TabId);
+}
+
+export function SettingsView({ onClose, tab, onSelectTab }: Props) {
   const [settings, setSettings] = useState<Record<string, unknown> | null>(
     null,
   );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [selectedProfile, setSelectedProfile] = useState("default");
-  const [activeTab, setActiveTab] = useState<TabId>("session");
+  const activeTab: TabId = isTabId(tab) ? tab : "session";
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
 
   useEffect(() => {
@@ -434,7 +442,7 @@ export function SettingsView({ onClose }: Props) {
             ) : (
               <button
                 key={item.id}
-                onClick={() => setActiveTab(item.id)}
+                onClick={() => onSelectTab(item.id)}
                 className={`px-4 py-2.5 text-xs font-medium whitespace-nowrap cursor-pointer transition-colors ${
                   activeTab === item.id
                     ? "text-brand-500 border-b-2 border-brand-500"
@@ -463,7 +471,7 @@ export function SettingsView({ onClose }: Props) {
             ) : (
               <button
                 key={item.id}
-                onClick={() => setActiveTab(item.id)}
+                onClick={() => onSelectTab(item.id)}
                 className={`px-4 py-2 text-sm text-left cursor-pointer transition-colors ${
                   activeTab === item.id
                     ? "text-brand-500 bg-surface-800 border-r-2 border-brand-500"

--- a/web/src/lib/legacySessionRedirect.ts
+++ b/web/src/lib/legacySessionRedirect.ts
@@ -1,0 +1,15 @@
+// Migrate `?session=<id>` URLs (used before path-based routing) to
+// `/session/<id>`. Notification taps from older builds and bookmarks
+// still land on the legacy form, so this rewrite runs once at boot
+// before the router mounts.
+
+if (typeof window !== "undefined") {
+  const params = new URLSearchParams(window.location.search);
+  const sessionId = params.get("session");
+  if (sessionId) {
+    params.delete("session");
+    const remaining = params.toString();
+    const next = `/session/${encodeURIComponent(sessionId)}${remaining ? `?${remaining}` : ""}${window.location.hash}`;
+    window.history.replaceState(null, "", next);
+  }
+}

--- a/web/src/lib/sessionRoute.ts
+++ b/web/src/lib/sessionRoute.ts
@@ -1,34 +1,6 @@
-// Tiny URL-based routing for the active session. We avoid pulling in a
-// router library for one query param. The URL is `?session=<id>` when a
-// session is active, or no query when on the dashboard. Notification
-// clicks land on `?session=<id>` (see sw.js) and this module is what
-// makes that URL actually select the session.
-
-export const SESSION_PARAM = "session";
-
-export function readSessionFromUrl(): string | null {
-  if (typeof window === "undefined") return null;
-  return new URLSearchParams(window.location.search).get(SESSION_PARAM);
-}
-
-export function writeSessionToUrl(sessionId: string | null): void {
-  if (typeof window === "undefined") return;
-  const url = new URL(window.location.href);
-  if (sessionId) {
-    url.searchParams.set(SESSION_PARAM, sessionId);
-  } else {
-    url.searchParams.delete(SESSION_PARAM);
-  }
-  const next = url.pathname + url.search + url.hash;
-  const current =
-    window.location.pathname + window.location.search + window.location.hash;
-  if (next !== current) {
-    window.history.pushState({}, "", next);
-  }
-}
-
 // Custom event dispatched when an in-app toast (for a focused PWA
-// client) is tapped. App listens and selects the session.
+// client) is tapped. App listens and navigates to the session.
+
 export const OPEN_SESSION_EVENT = "aoe-open-session";
 
 export function requestOpenSession(sessionId: string): void {

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,9 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 // Imported first so the URL `?token=` capture runs before any fetch or render.
 import "./lib/token";
+// Migrate legacy `?session=X` URLs before the router mounts.
+import "./lib/legacySessionRedirect";
+import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import { ToastBusBridge, ToastProvider } from "./components/Toasts";
 import { installFetchErrorToasts } from "./lib/fetchInterceptor";
@@ -17,7 +20,9 @@ createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ToastProvider>
       <ToastBusBridge />
-      <App />
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
     </ToastProvider>
   </StrictMode>,
 );

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+
+// Verifies URL-based routing: deep links land on the right view, refresh
+// preserves location, and back/forward replays history.
+test.describe("URL routing", () => {
+  test("'/' renders the dashboard home screen", async ({ page }) => {
+    await page.goto("/");
+    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page).toHaveURL("/");
+  });
+
+  test("'/settings' renders settings on first load", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page.getByText("Settings", { exact: true }).first()).toBeVisible();
+    await expect(page).toHaveURL("/settings");
+  });
+
+  test("settings tab is reflected in the URL", async ({ page }) => {
+    await page.goto("/settings/theme");
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible();
+    await expect(page).toHaveURL("/settings/theme");
+  });
+
+  test("refresh on /settings keeps user on settings", async ({ page }) => {
+    await page.goto("/settings");
+    await expect(page.getByText("Settings", { exact: true }).first()).toBeVisible();
+    await page.reload();
+    await expect(page.getByText("Settings", { exact: true }).first()).toBeVisible();
+    await expect(page).toHaveURL("/settings");
+  });
+
+  test("'/session/<id>' for an unknown session falls back to dashboard", async ({ page }) => {
+    // No backend, sessions list is empty, so the route still matches but
+    // the resolver finds no session and the dashboard renders. Importantly
+    // the URL stays put so a real backend can later resolve it.
+    await page.goto("/session/does-not-exist");
+    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page).toHaveURL("/session/does-not-exist");
+  });
+
+  test("legacy '?session=X' URL is rewritten to '/session/X'", async ({ page }) => {
+    await page.goto("/?session=abc-123");
+    await expect(page).toHaveURL("/session/abc-123");
+  });
+
+  test("browser back navigates dashboard ↔ settings", async ({ page }) => {
+    await page.goto("/");
+    await page.goto("/settings");
+    await expect(page).toHaveURL("/settings");
+    await page.goBack();
+    await expect(page).toHaveURL("/");
+    await page.goForward();
+    await expect(page).toHaveURL("/settings");
+  });
+});


### PR DESCRIPTION
Replace state-based view switching with react-router-dom so refreshing preserves location, settings/sessions are deep-linkable, and browser back/forward work as expected.

Routes:
- /                  Dashboard
- /settings          Settings (default tab)
- /settings/:tab     Settings with deep-linked tab
- /session/:id       Session view

Auth overlays (LoginPage, TokenEntryPage) and modals (About, Help, Command Palette, Delete dialog) remain state-based: the auth overlays preserve the intended URL on login, and the modals have no shareable state.

The diff panel toggle and selected file stay as UI state, since collapse state is a per-device preference rather than navigation.

Migration: a one-shot redirect rewrites legacy ?session=X URLs (still in queued iOS notifications and PWA bookmarks) to /session/X before the router mounts. The push notification URL the server emits now uses the new format.

Fixes #794

## Description
<!-- Describe your changes and the problem they solve -->


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] I understand the code I am submitting
- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)
