### PR TITLE
fix(web): pin terminal scroll on wterm scrollTop reset

### DIFF
--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -109,6 +109,38 @@ function PairedTerminal({
     };
   }, [keyboardHeight, keyboardOpen, termRef]);
 
+  // Pin scrollTop on wterm scrollTop=0 mid-session resets (same fix
+  // as TerminalView). See that file for the rationale; this mirror
+  // covers the side terminal pane in the diff viewer.
+  const isInScrollbackRef = useRef(state.isInScrollback);
+  useEffect(() => {
+    isInScrollbackRef.current = state.isInScrollback;
+  }, [state.isInScrollback]);
+  useEffect(() => {
+    let raf = 0;
+    const onScroll = (e: Event) => {
+      const el = termRef.current?.element;
+      if (!el) return;
+      const target = e.target as Node | null;
+      if (target !== el && !(target && el.contains(target))) return;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        if (isInScrollbackRef.current) return;
+        const elNow = termRef.current?.element;
+        if (!elNow) return;
+        const max = Math.max(0, elNow.scrollHeight - elNow.clientHeight);
+        if (elNow.scrollTop < max - 1) {
+          elNow.scrollTop = elNow.scrollHeight;
+        }
+      });
+    };
+    document.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    return () => {
+      document.removeEventListener("scroll", onScroll, true);
+      cancelAnimationFrame(raf);
+    };
+  }, [termRef]);
+
   const toggleKeyboard = useCallback(() => {
     const term = termRef.current;
     if (!term) return;

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -135,6 +135,50 @@ export function TerminalView({ session }: Props) {
     };
   }, [keyboardHeight, keyboardOpen, termRef]);
 
+  // wterm sometimes resets scrollTop=0 mid-session when its renderer
+  // redraws (observed on backspace), and its post-render scroll-to-
+  // bottom skips because _isScrolledToBottom() reads stale dimensions
+  // on the same task. Result: scrollHeight grows past clientHeight
+  // while scrollTop stays at 0, so the cursor falls below the visible
+  // region until the next keyboard open/close kicks the fix above.
+  //
+  // The reset fires a scroll event, so listen at document level
+  // (capture phase, since scroll events don't bubble) and resolve
+  // termRef.current.element at scroll time. State.connected can flip
+  // true before wterm finishes init, and the scroll's target may be a
+  // descendant of wterm's root, so attach-time element resolution
+  // misses both cases. The rAF debounce lets wterm's own scroll
+  // handler flip isInScrollback first when the user actually scrolls,
+  // so we don't fight legitimate scrollback entry.
+  const isInScrollbackRef = useRef(state.isInScrollback);
+  useEffect(() => {
+    isInScrollbackRef.current = state.isInScrollback;
+  }, [state.isInScrollback]);
+  useEffect(() => {
+    let raf = 0;
+    const onScroll = (e: Event) => {
+      const el = termRef.current?.element;
+      if (!el) return;
+      const target = e.target as Node | null;
+      if (target !== el && !(target && el.contains(target))) return;
+      cancelAnimationFrame(raf);
+      raf = requestAnimationFrame(() => {
+        if (isInScrollbackRef.current) return;
+        const elNow = termRef.current?.element;
+        if (!elNow) return;
+        const max = Math.max(0, elNow.scrollHeight - elNow.clientHeight);
+        if (elNow.scrollTop < max - 1) {
+          elNow.scrollTop = elNow.scrollHeight;
+        }
+      });
+    };
+    document.addEventListener("scroll", onScroll, { passive: true, capture: true });
+    return () => {
+      document.removeEventListener("scroll", onScroll, true);
+      cancelAnimationFrame(raf);
+    };
+  }, [termRef]);
+
   // On initial connect, auto-open the keyboard.
   useEffect(() => {
     if (!isMobile || !state.connected) return;


### PR DESCRIPTION
## Description

Fixes a mobile-only bug where the agent terminal's prompt/cursor would slip below the visible region after typing, particularly after backspace, and stay hidden until the soft keyboard opened or closed.

Root cause: `@wterm/dom` occasionally resets `scrollTop` to `0` mid-session when its renderer redraws, and its post-render auto-scroll skips because `_isScrolledToBottom()` reads stale dimensions on the same task. The result is `scrollHeight > clientHeight` while `scrollTop === 0`, leaving the cursor row clipped off-screen. There is already a workaround for this race on viewport changes (the keyboard open/close path); this PR extends the same protection to mid-session redraws.

Approach: listen for `scroll` events at the document level (capture phase, since scroll events don't bubble) and snap `scrollTop` back to `scrollHeight` when drift is detected. The element reference is resolved at scroll time, not attach time, which avoids two races: `state.connected` flipping `true` before wterm finishes init, and the scroll target sometimes being a descendant of `wterm.element`. The handler bails on `state.isInScrollback` so it doesn't fight the user when they intentionally scroll up; one rAF of debounce gives wterm's own scroll handler a frame to flip that flag first.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## How tested

- iPhone Firefox (portrait): typing then backspace consistently triggered the bug pre-fix; with the fix the prompt stays visible and the wterm element stays pinned to the bottom.
- `cargo test`, `tsc -b`, `eslint` pass (only pre-existing unrelated lint warnings).
- Scrollback path verified: scrolling up engages `state.isInScrollback` and the listener no-ops, so the fix doesn't interfere with scrollback entry.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:**
The fix landed after a few iterations: a `MutationObserver` approach was tried first but never fired because `@wterm/dom` renders to canvas; a polling fallback worked but introduced visible jitter; the document-level scroll listener with target-resolved-at-scroll-time is the version that works without polling and without the attach race.

- [x] I am an AI Agent filling out this form (check box if true)