### PR TITLE
fix(web): apply selected profile's overrides when launching sessions

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -212,6 +212,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     };
 
     let mut instance = Instance::new(&final_title, path.to_str().unwrap_or(""));
+    instance.source_profile = profile.to_string();
 
     if let Some(group) = &group_path {
         instance.group_path = group.trim().to_string();

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -142,6 +142,10 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // `source_profile` is runtime-only (skip_serializing) so storage-loaded
+    // instances always come back blank; rehydrate it from the storage profile
+    // so start-time config resolution honors the right profile's overrides.
+    instances[idx].source_profile = profile.to_string();
     instances[idx].start_with_size(crate::terminal::get_size())?;
     let title = instances[idx].title.clone();
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -661,6 +661,18 @@ pub fn resolve_default_profile() -> String {
         .unwrap_or_else(|_| "default".to_string())
 }
 
+/// Return `profile` if non-empty, otherwise the user's globally configured
+/// default profile. Used at start-time config-resolution sites that prefer
+/// an instance's `source_profile` but tolerate it being unset (e.g. tests
+/// or pre-`source_profile`-wiring callers).
+pub fn effective_profile(profile: &str) -> String {
+    if profile.is_empty() {
+        resolve_default_profile()
+    } else {
+        profile.to_string()
+    }
+}
+
 pub fn get_update_settings() -> UpdatesConfig {
     load_config()
         .ok()

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -697,6 +697,38 @@ pub fn get_claude_config_dir() -> Option<PathBuf> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_effective_profile_returns_input_when_non_empty() {
+        // Non-empty input is passed through verbatim, regardless of what's
+        // configured globally as the default. No filesystem access needed.
+        assert_eq!(effective_profile("personal"), "personal");
+        assert_eq!(effective_profile("default"), "default");
+        assert_eq!(effective_profile("alpha-beta_v2"), "alpha-beta_v2");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_effective_profile_falls_back_to_global_default_when_empty() {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        #[cfg(target_os = "linux")]
+        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let app_dir = temp_home.path().join(".agent-of-empires");
+
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(app_dir.join("config.toml"), r#"default_profile = "alpha""#).unwrap();
+
+        assert_eq!(
+            effective_profile(""),
+            "alpha",
+            "empty profile must fall back to the user's globally configured default",
+        );
+    }
+
     // Tests for Config defaults
     #[test]
     fn test_config_default() {

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -807,11 +807,7 @@ pub(crate) fn build_container_config(
     let mut volumes = project_volumes;
 
     let sandbox_config = {
-        let resolved_profile = if profile.is_empty() {
-            super::config::resolve_default_profile()
-        } else {
-            profile.to_string()
-        };
+        let resolved_profile = super::config::effective_profile(profile);
         match super::repo_config::resolve_config_with_repo(&resolved_profile, project_path) {
             Ok(c) => {
                 tracing::debug!(

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -766,6 +766,10 @@ pub(crate) fn refresh_agent_configs() {
 }
 
 /// Build a full `ContainerConfig` for creating a sandboxed container.
+///
+/// `profile` selects which profile's overrides (volumes, mount_ssh, volume_ignores)
+/// are merged on top of the global config. An empty `profile` falls back to the
+/// user's globally configured default profile.
 pub(crate) fn build_container_config(
     project_path_str: &str,
     sandbox_info: &SandboxInfo,
@@ -773,6 +777,7 @@ pub(crate) fn build_container_config(
     is_yolo_mode: bool,
     instance_id: &str,
     workspace_info: Option<&super::WorkspaceInfo>,
+    profile: &str,
 ) -> Result<ContainerConfig> {
     let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Could not find home directory"))?;
 
@@ -802,8 +807,12 @@ pub(crate) fn build_container_config(
     let mut volumes = project_volumes;
 
     let sandbox_config = {
-        let profile = super::config::resolve_default_profile();
-        match super::repo_config::resolve_config_with_repo(&profile, project_path) {
+        let resolved_profile = if profile.is_empty() {
+            super::config::resolve_default_profile()
+        } else {
+            profile.to_string()
+        };
+        match super::repo_config::resolve_config_with_repo(&resolved_profile, project_path) {
             Ok(c) => {
                 tracing::debug!(
                     "Loaded sandbox config: extra_volumes={:?}, mount_ssh={}, volume_ignores={:?}",
@@ -2178,6 +2187,7 @@ extra_volumes = ["/host/data:/container/data:ro"]
             false,
             "test-instance-id",
             None,
+            "",
         )
         .unwrap();
 
@@ -2291,6 +2301,7 @@ volume_ignores = ["target", "node_modules"]
             false,
             "test-instance-id",
             None,
+            "",
         )
         .unwrap();
 
@@ -2381,6 +2392,7 @@ volume_ignores = ["target"]
             false,
             "test-instance-id",
             None,
+            "",
         )
         .unwrap();
 

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2228,6 +2228,154 @@ extra_volumes = ["/host/data:/container/data:ro"]
         );
     }
 
+    /// Regression test: when an instance was created under a non-default profile,
+    /// `build_container_config` must resolve sandbox overrides (extra_volumes here)
+    /// against THAT profile, not the user's globally configured default profile.
+    /// Pre-fix, the TUI's container creation flow always picked up the global
+    /// default's volumes regardless of which profile the session was launched under.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_uses_passed_profile_not_global_default() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        #[cfg(target_os = "linux")]
+        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let app_dir = temp_home.path().join(".agent-of-empires");
+
+        let profiles_dir = app_dir.join("profiles");
+        fs::create_dir_all(profiles_dir.join("default")).unwrap();
+        fs::create_dir_all(profiles_dir.join("personal")).unwrap();
+
+        // Global config selects "default" as the user's currently-active profile.
+        fs::create_dir_all(&app_dir).unwrap();
+        fs::write(
+            app_dir.join("config.toml"),
+            r#"default_profile = "default""#,
+        )
+        .unwrap();
+
+        // Two profiles with distinct extra_volumes so we can tell which one resolved.
+        fs::write(
+            profiles_dir.join("default").join("config.toml"),
+            r#"
+[sandbox]
+extra_volumes = ["/host/default-only:/container/default-only:ro"]
+"#,
+        )
+        .unwrap();
+        fs::write(
+            profiles_dir.join("personal").join("config.toml"),
+            r#"
+[sandbox]
+extra_volumes = ["/host/personal-only:/container/personal-only:ro"]
+"#,
+        )
+        .unwrap();
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+        let project_path_str = project_dir.path().to_str().unwrap();
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let has_volume = |config: &crate::containers::container_interface::ContainerConfig,
+                          host: &str,
+                          container: &str|
+         -> bool {
+            config
+                .volumes
+                .iter()
+                .any(|v| v.host_path == host && v.container_path == container)
+        };
+
+        // Passing "personal" must resolve the personal profile's extra_volumes
+        // and NOT the default profile's.
+        let cfg_personal = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            "claude",
+            false,
+            "test-instance-id",
+            None,
+            "personal",
+        )
+        .unwrap();
+        assert!(
+            has_volume(
+                &cfg_personal,
+                "/host/personal-only",
+                "/container/personal-only"
+            ),
+            "personal profile mount missing for profile=personal, got volumes: {:?}",
+            cfg_personal
+                .volumes
+                .iter()
+                .map(|v| (&v.host_path, &v.container_path))
+                .collect::<Vec<_>>(),
+        );
+        assert!(
+            !has_volume(
+                &cfg_personal,
+                "/host/default-only",
+                "/container/default-only"
+            ),
+            "default profile mount must NOT leak into profile=personal, got volumes: {:?}",
+            cfg_personal
+                .volumes
+                .iter()
+                .map(|v| (&v.host_path, &v.container_path))
+                .collect::<Vec<_>>(),
+        );
+
+        // Passing "default" must resolve the default profile's extra_volumes.
+        let cfg_default = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            "claude",
+            false,
+            "test-instance-id",
+            None,
+            "default",
+        )
+        .unwrap();
+        assert!(
+            has_volume(
+                &cfg_default,
+                "/host/default-only",
+                "/container/default-only"
+            ),
+            "default profile mount missing for profile=default",
+        );
+
+        // Empty profile must fall back to the user's globally configured default,
+        // preserving prior behavior for callers without a profile in hand.
+        let cfg_empty = build_container_config(
+            project_path_str,
+            &sandbox_info,
+            "claude",
+            false,
+            "test-instance-id",
+            None,
+            "",
+        )
+        .unwrap();
+        assert!(
+            has_volume(&cfg_empty, "/host/default-only", "/container/default-only"),
+            "empty profile must fall back to global default",
+        );
+    }
+
     /// Regression test for #597: volume_ignores must apply to the parent repo
     /// mount as well as the worktree mount in sibling-worktree sessions.
     #[test]

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -313,10 +313,19 @@ pub(crate) fn collect_environment(
     result
 }
 
-/// Resolve the effective sandbox config by merging global + active profile + repo.
-fn resolved_sandbox_config(project_path: &std::path::Path) -> super::config::SandboxConfig {
-    let profile = super::config::resolve_default_profile();
-    super::repo_config::resolve_config_with_repo(&profile, project_path)
+/// Resolve the effective sandbox config by merging global + the given profile + repo.
+/// An empty `profile` falls back to the user's globally configured default profile,
+/// preserving prior behavior for callers that don't track per-instance profile (e.g. tests).
+fn resolved_sandbox_config(
+    profile: &str,
+    project_path: &std::path::Path,
+) -> super::config::SandboxConfig {
+    let resolved = if profile.is_empty() {
+        super::config::resolve_default_profile()
+    } else {
+        profile.to_string()
+    };
+    super::repo_config::resolve_config_with_repo(&resolved, project_path)
         .map(|c| c.sandbox)
         .unwrap_or_default()
 }
@@ -349,13 +358,15 @@ pub(crate) struct DockerExecEnv {
 /// The `docker run` path (container creation) is protected separately via
 /// `Command::env()` in `run_create`, which keeps secrets out of argv entirely.
 pub(crate) fn build_docker_env_args(
+    profile: &str,
     sandbox: &SandboxInfo,
     project_path: &std::path::Path,
 ) -> DockerExecEnv {
-    let sandbox_config = resolved_sandbox_config(project_path);
+    let sandbox_config = resolved_sandbox_config(profile, project_path);
 
     tracing::debug!(
-        "build_docker_env_args: config.sandbox.environment={:?}, extra_env={:?}",
+        "build_docker_env_args: profile={:?}, config.sandbox.environment={:?}, extra_env={:?}",
+        profile,
         sandbox_config.environment,
         sandbox.extra_env
     );
@@ -396,6 +407,95 @@ pub(crate) fn build_docker_env_args(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression test: when an instance is created under a non-default profile and
+    /// has no per-session `extra_env` overrides, the docker env args must come from
+    /// THAT profile's `sandbox.environment`, not from the user's globally configured
+    /// default profile. Pre-fix, the web flow surfaced this as "personal profile's
+    /// GH_TOKEN was ignored when launching from the web app."
+    #[test]
+    #[serial_test::serial]
+    fn test_build_docker_env_args_uses_passed_profile_not_global_default() {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        // Determine app dir layout (matches session::get_app_dir_path).
+        #[cfg(target_os = "linux")]
+        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let app_dir = temp_home.path().join(".agent-of-empires");
+
+        let profiles_dir = app_dir.join("profiles");
+        std::fs::create_dir_all(profiles_dir.join("default")).unwrap();
+        std::fs::create_dir_all(profiles_dir.join("personal")).unwrap();
+
+        // Global config sets the "currently active" default profile.
+        std::fs::write(
+            app_dir.join("config.toml"),
+            r#"default_profile = "default""#,
+        )
+        .unwrap();
+
+        // Two profiles with distinct env values; both use literal values so the
+        // test does not depend on inherited host env vars.
+        std::fs::write(
+            profiles_dir.join("default").join("config.toml"),
+            r#"
+[sandbox]
+environment = ["GH_TOKEN=read_only_token"]
+"#,
+        )
+        .unwrap();
+        std::fs::write(
+            profiles_dir.join("personal").join("config.toml"),
+            r#"
+[sandbox]
+environment = ["GH_TOKEN=write_token"]
+"#,
+        )
+        .unwrap();
+
+        // Sandbox info with no per-session overrides forces the fallback path
+        // through `sandbox_config.environment` — the buggy path pre-fix.
+        let sandbox = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+        let project_path = temp_home.path().join("nonexistent_project");
+
+        let result_personal = build_docker_env_args("personal", &sandbox, &project_path);
+        assert!(
+            result_personal.docker_args.contains("GH_TOKEN='write_token'"),
+            "passing profile=\"personal\" should resolve personal profile's env, got: {}",
+            result_personal.docker_args,
+        );
+
+        let result_default = build_docker_env_args("default", &sandbox, &project_path);
+        assert!(
+            result_default
+                .docker_args
+                .contains("GH_TOKEN='read_only_token'"),
+            "passing profile=\"default\" should resolve default profile's env, got: {}",
+            result_default.docker_args,
+        );
+
+        // Empty profile must fall back to the user's globally configured default,
+        // preserving prior behavior for callers without a profile in hand.
+        let result_empty = build_docker_env_args("", &sandbox, &project_path);
+        assert!(
+            result_empty
+                .docker_args
+                .contains("GH_TOKEN='read_only_token'"),
+            "empty profile must fall back to global default, got: {}",
+            result_empty.docker_args,
+        );
+    }
 
     #[test]
     fn test_redact_env_values_docker_flags() {
@@ -718,7 +818,7 @@ mod tests {
             extra_env: Some(vec!["AOE_TEST_TOKEN=$AOE_TEST_TOKEN".to_string()]),
             custom_instruction: None,
         };
-        let result = build_docker_env_args(&sandbox, std::path::Path::new("/nonexistent"));
+        let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // docker_args should have the key but NOT the secret value
         assert!(
             result.docker_args.contains("-e AOE_TEST_TOKEN"),
@@ -753,7 +853,7 @@ mod tests {
             extra_env: Some(vec!["MY_MAPPED=$AOE_TEST_SOURCE".to_string()]),
             custom_instruction: None,
         };
-        let result = build_docker_env_args(&sandbox, std::path::Path::new("/nonexistent"));
+        let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
             result.docker_args.contains("-e MY_MAPPED"),
             "Expected -e MY_MAPPED in docker_args: {}",
@@ -788,7 +888,7 @@ mod tests {
             extra_env: Some(vec!["AOE_TEST_BARE".to_string()]),
             custom_instruction: None,
         };
-        let result = build_docker_env_args(&sandbox, std::path::Path::new("/nonexistent"));
+        let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
             result.docker_args.contains("-e AOE_TEST_BARE"),
             "Expected -e AOE_TEST_BARE in docker_args: {}",
@@ -822,7 +922,7 @@ mod tests {
             extra_env: Some(vec!["MY_LITERAL=some_value".to_string()]),
             custom_instruction: None,
         };
-        let result = build_docker_env_args(&sandbox, std::path::Path::new("/nonexistent"));
+        let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         assert!(
             result.docker_args.contains("MY_LITERAL="),
             "Expected MY_LITERAL=value in docker_args: {}",
@@ -855,7 +955,7 @@ mod tests {
             ]),
             custom_instruction: None,
         };
-        let result = build_docker_env_args(&sandbox, std::path::Path::new("/nonexistent"));
+        let result = build_docker_env_args("", &sandbox, std::path::Path::new("/nonexistent"));
         // Secret: key only in docker_args, value in exports
         assert!(result.docker_args.contains("-e AOE_TEST_SECRET"));
         assert!(!result.docker_args.contains("mysecret"));

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -314,17 +314,13 @@ pub(crate) fn collect_environment(
 }
 
 /// Resolve the effective sandbox config by merging global + the given profile + repo.
-/// An empty `profile` falls back to the user's globally configured default profile,
-/// preserving prior behavior for callers that don't track per-instance profile (e.g. tests).
+/// An empty `profile` falls back to the user's globally configured default profile
+/// via [`super::config::effective_profile`].
 fn resolved_sandbox_config(
     profile: &str,
     project_path: &std::path::Path,
 ) -> super::config::SandboxConfig {
-    let resolved = if profile.is_empty() {
-        super::config::resolve_default_profile()
-    } else {
-        profile.to_string()
-    };
+    let resolved = super::config::effective_profile(profile);
     super::repo_config::resolve_config_with_repo(&resolved, project_path)
         .map(|c| c.sandbox)
         .unwrap_or_default()
@@ -458,7 +454,7 @@ environment = ["GH_TOKEN=write_token"]
         .unwrap();
 
         // Sandbox info with no per-session overrides forces the fallback path
-        // through `sandbox_config.environment` — the buggy path pre-fix.
+        // through `sandbox_config.environment`, which is the buggy path pre-fix.
         let sandbox = SandboxInfo {
             enabled: true,
             container_id: None,
@@ -471,7 +467,9 @@ environment = ["GH_TOKEN=write_token"]
 
         let result_personal = build_docker_env_args("personal", &sandbox, &project_path);
         assert!(
-            result_personal.docker_args.contains("GH_TOKEN='write_token'"),
+            result_personal
+                .docker_args
+                .contains("GH_TOKEN='write_token'"),
             "passing profile=\"personal\" should resolve personal profile's env, got: {}",
             result_personal.docker_args,
         );

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -300,7 +300,11 @@ impl Instance {
         let container = self.get_container_for_instance()?;
         let sandbox = self.sandbox_info.as_ref().unwrap();
 
-        let env_info = build_docker_env_args(sandbox, std::path::Path::new(&self.project_path));
+        let env_info = build_docker_env_args(
+            &self.source_profile,
+            sandbox,
+            std::path::Path::new(&self.project_path),
+        );
         let env_part = if env_info.docker_args.is_empty() {
             String::new()
         } else {
@@ -402,8 +406,15 @@ impl Instance {
         let on_launch_hooks = if skip_on_launch {
             None
         } else {
-            // Start with global+profile hooks as the base
-            let profile = super::config::resolve_default_profile();
+            // Start with global+profile hooks as the base. Use the instance's
+            // source_profile so profile-specific on_launch hooks fire for sessions
+            // created under that profile, not just whichever profile is currently
+            // set as the global default.
+            let profile = if self.source_profile.is_empty() {
+                super::config::resolve_default_profile()
+            } else {
+                self.source_profile.clone()
+            };
             let mut resolved_on_launch = super::profile_config::resolve_config(&profile)
                 .map(|c| c.hooks.on_launch)
                 .unwrap_or_default();
@@ -499,7 +510,11 @@ impl Instance {
                 }
             }
 
-            let env_info = build_docker_env_args(sandbox, std::path::Path::new(&self.project_path));
+            let env_info = build_docker_env_args(
+                &self.source_profile,
+                sandbox,
+                std::path::Path::new(&self.project_path),
+            );
             // AOE_INSTANCE_ID is not secret, goes directly in docker args
             let docker_args = format!("{} -e AOE_INSTANCE_ID={}", env_info.docker_args, self.id);
             let env_part = format!("{} ", docker_args);
@@ -660,6 +675,7 @@ impl Instance {
             self.is_yolo_mode(),
             &self.id,
             self.workspace_info.as_ref(),
+            &self.source_profile,
         )
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -188,6 +188,13 @@ impl Instance {
         self.last_accessed_at = Some(Utc::now());
     }
 
+    /// Return the profile that should drive config resolution for this
+    /// instance, falling back to the user's globally configured default
+    /// when `source_profile` was never populated (e.g. legacy callers).
+    pub fn effective_profile(&self) -> String {
+        super::config::effective_profile(&self.source_profile)
+    }
+
     pub fn is_sub_session(&self) -> bool {
         self.parent_session_id.is_some()
     }
@@ -410,11 +417,7 @@ impl Instance {
             // source_profile so profile-specific on_launch hooks fire for sessions
             // created under that profile, not just whichever profile is currently
             // set as the global default.
-            let profile = if self.source_profile.is_empty() {
-                super::config::resolve_default_profile()
-            } else {
-                self.source_profile.clone()
-            };
+            let profile = self.effective_profile();
             let mut resolved_on_launch = super::profile_config::resolve_config(&profile)
                 .map(|c| c.hooks.on_launch)
                 .unwrap_or_default();

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -122,6 +122,12 @@ impl CreationPoller {
         };
 
         let mut instance = build_result.instance;
+        // Tag the instance with its profile NOW, before container creation or any
+        // hook execution. Downstream config-resolution sites (build_container_config,
+        // on_launch hook resolution, build_docker_env_args) read source_profile to
+        // pick the right profile's overrides; if it's left blank they'd silently
+        // fall back to the global default profile.
+        instance.source_profile = profile.clone();
         let created_worktree = build_result.created_worktree;
         let created_workspace_worktrees = build_result.created_workspace_worktrees;
 

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -47,7 +47,7 @@ type Action =
   | { type: "SET_GROUPS"; groups: GroupInfo[] }
   | { type: "SET_PROFILES"; profiles: ProfileInfo[] }
   | { type: "SET_DOCKER"; available: boolean }
-  | { type: "APPLY_PROFILE_DEFAULTS"; yoloMode: boolean; sandboxEnabled: boolean; tool: string };
+  | { type: "APPLY_PROFILE_DEFAULTS"; yoloMode: boolean; sandboxEnabled: boolean; tool: string; extraEnv: string[] };
 
 const initialData: WizardData = {
   path: "", title: "", group: "", tool: "claude", profile: "",
@@ -61,7 +61,7 @@ function reducer(state: WizardState, action: Action): WizardState {
     case "SET_FIELD": {
       const newData = { ...state.data, [action.field]: action.value };
       // Mark as dirty when user manually edits agent-step fields after a profile was chosen
-      if (state.data.profile && ["yoloMode", "sandboxEnabled", "tool"].includes(action.field)) {
+      if (state.data.profile && ["yoloMode", "sandboxEnabled", "tool", "extraEnv"].includes(action.field)) {
         newData.profileDirty = true;
       }
       return { ...state, data: newData, error: null };
@@ -90,6 +90,7 @@ function reducer(state: WizardState, action: Action): WizardState {
           yoloMode: action.yoloMode,
           sandboxEnabled: action.sandboxEnabled,
           tool: action.tool || state.data.tool,
+          extraEnv: action.extraEnv,
           profileDirty: false,
         },
       };
@@ -170,7 +171,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
     dispatch({ type: "SET_FIELD", field, value });
   }, []);
 
-  const handleApplyProfileDefaults = useCallback((defaults: { yoloMode: boolean; sandboxEnabled: boolean; tool: string }) => {
+  const handleApplyProfileDefaults = useCallback((defaults: { yoloMode: boolean; sandboxEnabled: boolean; tool: string; extraEnv: string[] }) => {
     dispatch({ type: "APPLY_PROFILE_DEFAULTS", ...defaults });
   }, []);
 

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -25,7 +25,7 @@ interface Props {
   agents: AgentInfo[];
   profiles: ProfileInfo[];
   dockerAvailable: boolean;
-  onApplyProfileDefaults: (defaults: { yoloMode: boolean; sandboxEnabled: boolean; tool: string }) => void;
+  onApplyProfileDefaults: (defaults: { yoloMode: boolean; sandboxEnabled: boolean; tool: string; extraEnv: string[] }) => void;
 }
 
 function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (v: boolean) => void; disabled?: boolean }) {
@@ -73,10 +73,17 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
       if (settings) {
         const session = settings.session as Record<string, unknown> | undefined;
         const sandbox = settings.sandbox as Record<string, unknown> | undefined;
+        // Pre-populate sandbox env from the profile so the user can see and edit
+        // it before submission; without this, an empty extra_env is sent and the
+        // backend falls back to the wrong (globally-default) profile's env vars.
+        const env = Array.isArray(sandbox?.environment)
+          ? (sandbox.environment as unknown[]).filter((v): v is string => typeof v === "string")
+          : [];
         onApplyProfileDefaults({
           yoloMode: (session?.yolo_mode_default as boolean) ?? false,
           sandboxEnabled: (sandbox?.enabled_by_default as boolean) ?? false,
           tool: (session?.default_tool as string) || data.tool,
+          extraEnv: env,
         });
       }
     } catch {


### PR DESCRIPTION
## Description

When creating a session via the web app under a non-default profile, the session was launched with the **globally configured default profile's** sandbox env vars, `on_launch` hooks, and volume settings. The user-visible symptom: a `personal` profile's `GH_TOKEN` (write) was ignored in favor of the `default` profile's `GH_TOKEN` (read).

### Root cause

Three start-time call sites resolved config via `resolve_default_profile()` (which returns `Config.default_profile` — the user's *globally* selected default) instead of the instance's `source_profile`:

- `src/session/environment.rs::resolved_sandbox_config` — feeds `docker exec` env via `build_docker_env_args`
- `src/session/instance.rs:406` — `on_launch` hook resolution
- `src/session/container_config.rs::build_container_config` — `docker run` volumes, `mount_ssh`, `volume_ignores`

The merge system in `profile_config::merge_configs` was correct; callers just weren't passing it the right profile.

### Why TUI didn't surface this

The TUI's new-session dialog pre-populates `extra_env` from the selected profile's resolved sandbox config (`src/tui/dialogs/new_session/mod.rs:355,559,982`). On submit, that non-empty list is stored on `SandboxInfo.extra_env`, which `collect_environment` uses directly, bypassing the buggy `resolved_sandbox_config()` fallback. The web wizard did not do this pre-population, so it always hit the fallback. The on_launch and container_config bugs were silent in both UIs whenever `source_profile != global_default_profile`.

### Fix

**Backend (Rust):**
- `resolved_sandbox_config` and `build_docker_env_args` take `profile: &str`; empty falls back to `resolve_default_profile()` for callers without a profile in hand (e.g. tests).
- Instance start paths pass `&self.source_profile`.
- `on_launch` hook resolution uses `self.source_profile` with empty fallback.
- `build_container_config` takes `profile: &str` and passes it to repo+profile config resolution.

**Web (parity with TUI):**
- `handleProfileChange` in `AgentStep.tsx` now copies `settings.sandbox.environment` into `data.extraEnv` so the user sees and can edit the env list before submission. `APPLY_PROFILE_DEFAULTS` and the dirty-tracking list extended accordingly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

### Tests

- New regression test `test_build_docker_env_args_uses_passed_profile_not_global_default` (environment.rs) creates two profiles with distinct `GH_TOKEN` values, sets the global default to `default`, and asserts `build_docker_env_args("personal", ...)` resolves the personal profile's env. Pre-fix path would fail; passes now.
- `cargo test --lib`: 1110 passed, 0 failed.
- `cargo clippy --features serve --all-targets`: clean.
- `tsc --noEmit` + `npm run build`: clean.

### Manual

- Not yet recorded end-to-end against a live `aoe serve`. Happy to add a Playwright recipe per the AGENTS.md guidance if reviewers prefer.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**
Investigation, fix, and regression test were drafted with AI assistance and reviewed by me.

- [x] I am an AI Agent filling out this form (check box if true)