### PR TITLE
fix(tui): remove exec before wrapped command to fix pane death on launch for custom sandboxes

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -505,12 +505,7 @@ impl Instance {
             let env_part = format!("{} ", docker_args);
             let wrapped =
                 wrap_command_ignore_suspend(&container.exec_command(Some(&env_part), &tool_cmd));
-            if env_info.exports.is_empty() {
-                Some(wrapped)
-            } else {
-                let exports = env_info.exports.join("; ");
-                Some(format!("{}; {}", exports, wrapped))
-            }
+            Some(prepend_exports(&env_info.exports, wrapped))
         } else {
             // Run on_launch hooks on host for non-sandboxed sessions
             if let Some(ref hook_cmds) = on_launch_hooks {
@@ -1005,6 +1000,23 @@ fn wrap_command_ignore_suspend(cmd: &str) -> String {
     )
 }
 
+/// Prepend shell `export` statements to an already-wrapped sandbox command.
+///
+/// `wrapped` MUST be the output of `wrap_command_ignore_suspend`, which
+/// guarantees a leading `exec`. This function therefore MUST NOT add another
+/// `exec` of its own: in bash, `exec exec <cmd>` searches PATH for a binary
+/// literally named `exec`, fails with exit 127, and kills the tmux pane on
+/// every sandboxed launch. zsh-on-macOS happens to tolerate the double-exec,
+/// which is why this regression hid for several days after #757 added the
+/// leading `exec` to `wrap_command_ignore_suspend`. See PR #819.
+fn prepend_exports(exports: &[String], wrapped: String) -> String {
+    if exports.is_empty() {
+        wrapped
+    } else {
+        format!("{}; {}", exports.join("; "), wrapped)
+    }
+}
+
 /// Check whether captured pane content indicates a living agent rather than
 /// a bare shell prompt. Used to prevent `is_shell_stale()` from producing
 /// false `Error` status when the agent binary is a shell wrapper or spawns
@@ -1127,6 +1139,42 @@ mod tests {
             "wrapped command should contain the escaped env var assignment: {}",
             wrapped,
         );
+    }
+
+    #[test]
+    #[serial_test::serial(shell_env)]
+    fn test_prepend_exports_does_not_double_exec() {
+        // Regression: `wrap_command_ignore_suspend` always emits a string
+        // starting with `exec` (since #757). `prepend_exports` MUST NOT add
+        // another `exec`, because bash interprets `exec exec <cmd>` as
+        // "exec a binary literally named `exec`", fails with exit 127, and
+        // kills the pane on every sandboxed launch. zsh-on-macOS happens
+        // to tolerate the double-exec, which is why this regression hid
+        // for several days after #757 merged. See PR #819.
+        std::env::set_var("SHELL", "/bin/bash");
+        let wrapped = wrap_command_ignore_suspend("docker exec -it container claude");
+        assert!(
+            wrapped.starts_with("exec "),
+            "test invariant: wrapped must start with `exec ` (else this test \
+             is misaligned with wrap_command_ignore_suspend's contract): {}",
+            wrapped,
+        );
+
+        let exports = vec![
+            "export TERM='xterm-256color'".to_string(),
+            "export COLORTERM='truecolor'".to_string(),
+        ];
+        let session_cmd = prepend_exports(&exports, wrapped);
+
+        assert!(
+            !session_cmd.contains("exec exec"),
+            "session cmd must not contain `exec exec` -- bash exits 127 on it: {}",
+            session_cmd,
+        );
+
+        // Empty exports must pass through unchanged.
+        let wrapped2 = wrap_command_ignore_suspend("docker exec -it container claude");
+        assert_eq!(prepend_exports(&[], wrapped2.clone()), wrapped2);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -508,11 +508,6 @@ impl Instance {
             if env_info.exports.is_empty() {
                 Some(wrapped)
             } else {
-                // Prepend shell exports for inherited env vars before the
-                // wrapped command. Do NOT use `exec` here: TERM and COLORTERM
-                // are always Inherit entries, so exports is never empty, and
-                // `exec {shell} -lc ...` inside a tmux session command produces
-                // a double-exec-into-login-shell that kills the pane on startup.
                 let exports = env_info.exports.join("; ");
                 Some(format!("{}; {}", exports, wrapped))
             }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -508,14 +508,13 @@ impl Instance {
             if env_info.exports.is_empty() {
                 Some(wrapped)
             } else {
-                // Prepend shell exports for secret env vars. The outer shell
-                // runs the exports (builtins), then `exec` replaces it with
-                // the wrapped command. This keeps secret values out of all
-                // long-lived process argv: the outer shell's argv (which
-                // contains the export values) disappears in milliseconds
-                // when exec replaces the process image.
+                // Prepend shell exports for inherited env vars before the
+                // wrapped command. Do NOT use `exec` here: TERM and COLORTERM
+                // are always Inherit entries, so exports is never empty, and
+                // `exec {shell} -lc ...` inside a tmux session command produces
+                // a double-exec-into-login-shell that kills the pane on startup.
                 let exports = env_info.exports.join("; ");
-                Some(format!("{}; exec {}", exports, wrapped))
+                Some(format!("{}; {}", exports, wrapped))
             }
         } else {
             // Run on_launch hooks on host for non-sandboxed sessions


### PR DESCRIPTION
## Description
As far as I can tell, every sandboxed session is currently broken at startup. TERM and COLORTERM are
always added as Inherit env entries, so the export prefix is never empty,
causing the double-exec-into-login-shell path to always run. The exec           
before the wrapped command combined with wrap_command_ignore_suspend's own
login shell (-lc) killed the tmux pane immediately on every sandboxed launch

`wrap_command_ignore_suspend` already produces a command starting with `exec`:

```
exec bash -lc 'stty susp undef; exec env docker exec -it <container> claude'
```

That becomes `wrapped`. The exports prefix then prepended another `exec` in front of it:

**Before:**
```
export TERM=xterm-256color; export COLORTERM=truecolor; exec exec bash -lc 'stty susp undef; exec env docker exec -it <container> claude'
```

**After:**
```
export TERM=xterm-256color; export COLORTERM=truecolor; exec bash -lc 'stty susp undef; exec env docker exec -it <container> claude'
```

**Why before breaks:** `exec` is a shell builtin — it doesn't exist as a standalone binary on PATH. So `exec exec bash ...` tells the shell to replace itself with a program literally named `exec`, which can't be found, so it exits with "command not found" and the pane dies immediately. The fix just removes the redundant `exec` from the exports prefix, since `wrapped` already has one.

## Pane death before vs pane working after
Lmk if you want a video or anything for better fleshed-out evidence.

**Before:**
<img width="2560" height="1440" alt="pane_death" src="https://github.com/user-attachments/assets/48a99024-1907-432c-ac01-5128c236e60a" />


**After:**
<img width="2560" height="1440" alt="pane_working" src="https://github.com/user-attachments/assets/8c64231c-77d0-42e8-b94e-30b9e2d4090f" />


## PR Type

- [ ] New Feature
- [X] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [X] I understand the code I am submitting
- [X] New and existing tests pass
- [X] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [] AI was used for drafting/refactoring
- [X] This is fully AI-generated

<!-- If AI was used, please share details -->
claude 4.7


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)
