### PR TITLE
fix(serve): stop daemon child from self-detecting via its own PID file

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -201,12 +201,18 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     // non-daemon write below before its own port-bind eventually failed; the
     // post-exit cleanup would then delete the (now-foreground) PID file and
     // orphan the real daemon.
+    //
+    // Skip the bail if the PID file already points to our own process: that
+    // means we are the daemonized child that start_daemon() just spawned and
+    // pre-populated the file for, not a competing instance.
     if let Some(existing) = daemon_pid() {
-        bail!(
-            "A serve daemon is already running (PID {}). \
-             Stop it first with `aoe serve --stop`.",
-            existing
-        );
+        if existing != std::process::id() {
+            bail!(
+                "A serve daemon is already running (PID {}). \
+                 Stop it first with `aoe serve --stop`.",
+                existing
+            );
+        }
     }
 
     let is_localhost = args.host == "localhost"

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -10,9 +10,57 @@
 //! ```
 #![cfg(feature = "serve")]
 
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
 use serial_test::serial;
 
 use crate::harness::{require_tmux, TuiTestHarness};
+
+/// Resolve the daemon's PID file inside the harness's isolated home.
+/// Mirrors `crate::session::get_app_dir`'s platform split.
+fn daemon_pid_path(h: &TuiTestHarness) -> PathBuf {
+    let dir = if cfg!(target_os = "linux") {
+        h.home_path().join(".config").join("agent-of-empires")
+    } else {
+        h.home_path().join(".agent-of-empires")
+    };
+    dir.join("serve.pid")
+}
+
+/// Bind a TCP listener to an ephemeral port, drop it, and return the port.
+/// Tiny TOCTOU window before the daemon binds, but acceptable for a serial
+/// test.
+fn pick_free_port() -> u16 {
+    let l = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    l.local_addr().expect("local_addr").port()
+}
+
+/// Poll until the daemon accepts a TCP connection on `port`. The parent
+/// `aoe serve --daemon` returns as soon as it has spawned the child, so a
+/// successful exit doesn't prove the child bound the port; this is the
+/// real signal that the daemon is up.
+fn wait_for_port(port: u16, timeout: Duration) -> bool {
+    let start = Instant::now();
+    while start.elapsed() < timeout {
+        if TcpStream::connect_timeout(
+            &format!("127.0.0.1:{}", port).parse().unwrap(),
+            Duration::from_millis(200),
+        )
+        .is_ok()
+        {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+/// True iff the kernel still has a process with this PID.
+fn pid_alive(pid: i32) -> bool {
+    nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None).is_ok()
+}
 
 /// Pressing `R` from the home screen opens the serve ModePicker,
 /// which must render both cards (Local + Internet) and surface the
@@ -56,4 +104,70 @@ fn tui_serve_dialog_escape_returns_home() {
     h.send_keys("Escape");
     // Home-screen footer is the tell that we've returned.
     h.wait_for("No sessions yet");
+}
+
+/// `aoe serve --daemon` must spawn a child that actually binds the port and
+/// stays alive. Regression guard for the self-detection bug where the parent
+/// pre-wrote the child's PID into `serve.pid`, then the child re-entered
+/// `run()`, found its own PID via `daemon_pid()`, and bailed with
+/// "A serve daemon is already running" — about itself.
+#[test]
+#[serial]
+fn cli_serve_daemon_starts_and_stops_cleanly() {
+    let h = TuiTestHarness::new("serve_daemon_lifecycle");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+
+    let pid_path = daemon_pid_path(&h);
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {} (child likely self-detected and exited).\n\
+         pid file exists: {}\n\
+         serve.log:\n{}",
+        port,
+        pid_path.exists(),
+        std::fs::read_to_string(pid_path.with_file_name("serve.log")).unwrap_or_default(),
+    );
+
+    let pid: i32 = std::fs::read_to_string(&pid_path)
+        .expect("serve.pid should exist after daemon starts")
+        .trim()
+        .parse()
+        .expect("serve.pid should contain a valid integer");
+    assert!(
+        pid_alive(pid),
+        "child PID {} not alive after port bind",
+        pid
+    );
+
+    let stop = h.run_cli(&["serve", "--stop"]);
+    assert!(
+        stop.status.success(),
+        "aoe serve --stop failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&stop.stdout),
+        String::from_utf8_lossy(&stop.stderr),
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while pid_alive(pid) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    assert!(
+        !pid_alive(pid),
+        "daemon PID {} still alive after --stop",
+        pid
+    );
+    assert!(
+        !pid_path.exists(),
+        "serve.pid should be cleaned up after --stop, found at {}",
+        pid_path.display()
+    );
 }


### PR DESCRIPTION
`aoe serve --daemon` was failing silently after #820 added an early `daemon_pid()` guard at the top of `run()`. The daemon-spawn flow is:

1. Parent runs `aoe serve --daemon`, passes the new guard (no PID file), reaches `start_daemon()`, spawns a child running `aoe serve --port ...` (no `--daemon`), then writes the child's PID into `serve.pid` and exits.
2. The child re-enters `run()` and hits the same guard. `daemon_pid()` reads `serve.pid`, finds the child's own PID, `kill(self, 0)` succeeds, `verify_pid_is_aoe(self)` returns true, and the child bails with "A serve daemon is already running (PID N)" -- about itself -- before binding the port.

Skip the bail when the existing PID equals our own process id: that case can only arise when we are the daemon child the parent just spawned. Other paths (foreground `aoe serve` while a daemon runs, duplicate `aoe serve --daemon`) still bail correctly because the existing PID belongs to a different process.

Adds an e2e regression test that runs `aoe serve --daemon`, waits for the child to bind the port, then stops it. With the bug present, the child writes the self-detection error into `serve.log` and exits before the port is bound, so the test fails with that exact diagnostic.

## Description
<!-- Describe your changes and the problem they solve -->


## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [ ] I understand the code I am submitting
- [ ] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**


**Any Additional AI Details you'd like to share:**


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [ ] I am an AI Agent filling out this form (check box if true)
