### PR TITLE
fix(agents): correct install hints for pi, vibe, droid, and settl

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -157,7 +157,7 @@ pub const AGENTS: &[AgentDef] = &[
         hook_config: None,
         host_only: false,
         send_keys_enter_delay_ms: 0,
-        install_hint: "pip install vibe-tool",
+        install_hint: "pip install mistral-vibe",
     },
     AgentDef {
         name: "codex",
@@ -265,7 +265,7 @@ pub const AGENTS: &[AgentDef] = &[
         hook_config: None,
         host_only: false,
         send_keys_enter_delay_ms: 0,
-        install_hint: "pip install pi-agent",
+        install_hint: "npm install -g @mariozechner/pi-coding-agent",
     },
     AgentDef {
         name: "droid",
@@ -280,7 +280,7 @@ pub const AGENTS: &[AgentDef] = &[
         hook_config: None,
         host_only: false,
         send_keys_enter_delay_ms: 0,
-        install_hint: "npm install -g @anthropic-ai/droid",
+        install_hint: "npm install -g droid",
     },
     AgentDef {
         name: "settl",
@@ -480,6 +480,16 @@ mod tests {
             Some("npm install -g @anthropic-ai/claude-code")
         );
         assert_eq!(install_hint("codex"), Some("npm install -g @openai/codex"));
+        // Pi is distributed via npm, not pip (issue #818).
+        assert_eq!(
+            install_hint("pi"),
+            Some("npm install -g @mariozechner/pi-coding-agent")
+        );
+        // Mistral Vibe's PyPI package is `mistral-vibe`, not `vibe-tool`.
+        assert_eq!(install_hint("vibe"), Some("pip install mistral-vibe"));
+        // Factory's Droid CLI npm package is `droid`; `@anthropic-ai/droid`
+        // does not exist on the registry.
+        assert_eq!(install_hint("droid"), Some("npm install -g droid"));
         assert!(install_hint("unknown").is_none());
     }
 }

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -295,7 +295,7 @@ pub const AGENTS: &[AgentDef] = &[
         hook_config: None,
         host_only: true,
         send_keys_enter_delay_ms: 0,
-        install_hint: "see https://settl.dev/docs/install",
+        install_hint: "brew install --cask mozilla-ai/tap/settl",
     },
 ];
 
@@ -490,6 +490,11 @@ mod tests {
         // Factory's Droid CLI npm package is `droid`; `@anthropic-ai/droid`
         // does not exist on the registry.
         assert_eq!(install_hint("droid"), Some("npm install -g droid"));
+        // settl ships via the mozilla-ai Homebrew tap (settl.dev is unrelated).
+        assert_eq!(
+            install_hint("settl"),
+            Some("brew install --cask mozilla-ai/tap/settl")
+        );
         assert!(install_hint("unknown").is_none());
     }
 }


### PR DESCRIPTION
## Description

Pi's `install_hint` in `src/agents.rs` said `pip install pi-agent`, but Pi is an npm package (`@mariozechner/pi-coding-agent`); the old hint pointed at a non-existent PyPI package. While auditing the rest of the agent registry as the issue requested, I found three more hints with the same root cause:

| Agent | Before | After | Why |
|-------|--------|-------|-----|
| `pi` | `pip install pi-agent` | `npm install -g @mariozechner/pi-coding-agent` | Issue #818 — Pi is npm-only, no PyPI package exists |
| `vibe` | `pip install vibe-tool` | `pip install mistral-vibe` | The real PyPI package from Mistral AI is `mistral-vibe` |
| `droid` | `npm install -g @anthropic-ai/droid` | `npm install -g droid` | Droid is from Factory.ai, not Anthropic; `@anthropic-ai/droid` returns 404 on the npm registry. Factory ships as `droid` (v0.109.1, maintainers `*@factory.ai`) |
| `settl` | `see https://settl.dev/docs/install` | `brew install --cask mozilla-ai/tap/settl` | `settl.dev` is an unrelated real estate platform; the real project lives at github.com/mozilla-ai/settl and ships via the mozilla-ai Homebrew tap |

The remaining six hints (`claude`, `opencode`, `codex`, `gemini`, `cursor`, `copilot`) were verified against npm/PyPI and official docs and left unchanged.

Fixes #818

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Verified with:
- `cargo fmt --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (1114 passed)

The bug-fix test (`test_install_hint_lookup` in `src/agents.rs`) now asserts the corrected hints for `pi`, `vibe`, `droid`, and `settl` — without the fix, the `pi` assertion fails against the old `pip install pi-agent` value.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Used to verify each provider's install command against npm registry, PyPI, and official docs in parallel, then write the minimal fix and test.

- [x] I am an AI Agent filling out this form (check box if true)