### PR TITLE
fix(tui): show $AOE_INSTANCE_ID in hooks install dialog example

### DIFF
--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -104,7 +104,9 @@ impl HooksInstallDialog {
             "Each hook runs:",
             Style::default().bold(),
         )));
-        lines.push(Line::from("  printf {status} > /tmp/aoe-hooks/$ID/status"));
+        lines.push(Line::from(
+            "  printf {status} > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status",
+        ));
 
         lines.push(Line::from(""));
         lines.push(Line::from(
@@ -278,6 +280,25 @@ mod tests {
         assert!(text.contains("PreToolUse"));
         assert!(text.contains("Stop"));
         assert!(text.contains("Notification"));
+    }
+
+    #[test]
+    fn test_content_uses_aoe_instance_id_in_example() {
+        let dialog = HooksInstallDialog::new("claude");
+        let lines = dialog.build_content_lines();
+        let text: String = lines
+            .iter()
+            .map(|l| l.to_string())
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(
+            text.contains("/tmp/aoe-hooks/$AOE_INSTANCE_ID/status"),
+            "example command must reference the real env var: {text}"
+        );
+        assert!(
+            !text.contains("/tmp/aoe-hooks/$ID/"),
+            "example command must not use the bogus $ID placeholder: {text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

The hooks install dialog (`src/tui/dialogs/hooks_install.rs:107`) displayed the wrong env var in its "Each hook runs:" example:

```
printf {status} > /tmp/aoe-hooks/$ID/status
```

The actual hook command generated by `src/hooks/mod.rs:28` uses `$AOE_INSTANCE_ID`. `$ID` is not a variable AoE sets anywhere, so the dialog misled users inspecting or debugging hook behavior. The very next line in the dialog already correctly references `$AOE_INSTANCE_ID`, so the example was inconsistent with itself.

This swaps the example to `$AOE_INSTANCE_ID` and adds a regression test (`test_content_uses_aoe_instance_id_in_example`) that asserts the dialog text uses the real var and never the bogus `$ID/` placeholder.

Fixes #817

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

<!-- This is a one-line text change inside an existing dialog; no recording needed. -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:**
Used Claude Code via the `/fix-github-issue` skill to investigate the issue, make the one-line fix, and add a regression test.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)