### PR TITLE
feat: detect Claude fullscreen renderer to simplify mobile path

### DIFF
--- a/src/claude_settings.rs
+++ b/src/claude_settings.rs
@@ -1,0 +1,85 @@
+//! Read-only access to Claude Code's user settings.
+//!
+//! Used to detect when the user has opted into Claude Code's fullscreen
+//! (alt-screen) renderer via `/tui fullscreen`, so the web client can
+//! skip mobile workarounds that target the default main-screen renderer.
+
+use std::path::{Path, PathBuf};
+
+fn user_settings_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".claude").join("settings.json"))
+}
+
+/// True when the user has set Claude Code's `tui` setting to `"fullscreen"`
+/// in `~/.claude/settings.json`. Any other value, missing file, or parse
+/// error returns false.
+pub fn read_tui_fullscreen() -> bool {
+    user_settings_path()
+        .map(|p| read_tui_fullscreen_at(&p))
+        .unwrap_or(false)
+}
+
+fn read_tui_fullscreen_at(path: &Path) -> bool {
+    let Ok(contents) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(&contents) else {
+        return false;
+    };
+    value.get("tui").and_then(|v| v.as_str()) == Some("fullscreen")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    fn write_settings(contents: &str) -> NamedTempFile {
+        let mut f = NamedTempFile::new().unwrap();
+        f.write_all(contents.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn missing_file_returns_false() {
+        let path = std::path::Path::new("/nonexistent/aoe-test/settings.json");
+        assert!(!read_tui_fullscreen_at(path));
+    }
+
+    #[test]
+    fn fullscreen_returns_true() {
+        let f = write_settings(r#"{"tui": "fullscreen"}"#);
+        assert!(read_tui_fullscreen_at(f.path()));
+    }
+
+    #[test]
+    fn default_returns_false() {
+        let f = write_settings(r#"{"tui": "default"}"#);
+        assert!(!read_tui_fullscreen_at(f.path()));
+    }
+
+    #[test]
+    fn missing_key_returns_false() {
+        let f = write_settings(r#"{"theme": "dark"}"#);
+        assert!(!read_tui_fullscreen_at(f.path()));
+    }
+
+    #[test]
+    fn malformed_json_returns_false() {
+        let f = write_settings("{not valid json");
+        assert!(!read_tui_fullscreen_at(f.path()));
+    }
+
+    #[test]
+    fn fullscreen_among_other_keys_returns_true() {
+        let f = write_settings(r#"{"theme": "dark", "tui": "fullscreen", "model": "sonnet"}"#);
+        assert!(read_tui_fullscreen_at(f.path()));
+    }
+
+    #[test]
+    fn non_string_tui_returns_false() {
+        let f = write_settings(r#"{"tui": true}"#);
+        assert!(!read_tui_fullscreen_at(f.path()));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Agent of Empires library - Core functionality for the terminal session manager
 
 pub mod agents;
+pub mod claude_settings;
 pub mod cli;
 pub mod containers;
 pub mod git;

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -41,6 +41,11 @@ pub struct SessionResponse {
     pub notify_on_waiting: Option<bool>,
     pub notify_on_idle: Option<bool>,
     pub notify_on_error: Option<bool>,
+    /// True when the session is a Claude Code session AND the user has
+    /// enabled Claude's fullscreen renderer (`tui: "fullscreen"` in
+    /// `~/.claude/settings.json`). The web client uses this to skip
+    /// scrollback-tracking workarounds that target tmux copy-mode.
+    pub claude_fullscreen: bool,
 }
 
 #[derive(Serialize, Clone)]
@@ -84,13 +89,33 @@ impl From<&Instance> for SessionResponse {
             notify_on_waiting: inst.notify_on_waiting,
             notify_on_idle: inst.notify_on_idle,
             notify_on_error: inst.notify_on_error,
+            claude_fullscreen: false,
         }
+    }
+}
+
+/// Set `claude_fullscreen` on a response when the session is a Claude
+/// Code session and the user has enabled Claude's fullscreen renderer.
+/// Callers compute `fullscreen` once via
+/// `crate::claude_settings::read_tui_fullscreen()` to avoid repeated file
+/// reads when enriching a list.
+fn apply_claude_fullscreen(resp: &mut SessionResponse, fullscreen: bool) {
+    if fullscreen && resp.tool == "claude" {
+        resp.claude_fullscreen = true;
     }
 }
 
 pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionResponse>> {
     let instances = state.instances.read().await;
-    let mut sessions: Vec<SessionResponse> = instances.iter().map(SessionResponse::from).collect();
+    let claude_fullscreen = crate::claude_settings::read_tui_fullscreen();
+    let mut sessions: Vec<SessionResponse> = instances
+        .iter()
+        .map(|inst| {
+            let mut resp = SessionResponse::from(inst);
+            apply_claude_fullscreen(&mut resp, claude_fullscreen);
+            resp
+        })
+        .collect();
 
     // Resolve per-profile cleanup defaults with a TTL cache on AppState
     let cache = {
@@ -224,7 +249,8 @@ pub async fn rename_session(
         wt.branch = title;
     }
 
-    let response = SessionResponse::from(&*inst);
+    let mut response = SessionResponse::from(&*inst);
+    apply_claude_fullscreen(&mut response, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
 
     if let Ok(storage) = Storage::new(&profile) {
@@ -311,7 +337,8 @@ pub async fn update_session_notifications(
     apply(&mut inst.notify_on_idle, body.notify_on_idle);
     apply(&mut inst.notify_on_error, body.notify_on_error);
 
-    let response = SessionResponse::from(&*inst);
+    let mut response = SessionResponse::from(&*inst);
+    apply_claude_fullscreen(&mut response, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
 
     if let Ok(storage) = Storage::new(&profile) {
@@ -638,7 +665,8 @@ pub async fn create_session(
 
     match result {
         Ok(Ok(instance)) => {
-            let resp = SessionResponse::from(&instance);
+            let mut resp = SessionResponse::from(&instance);
+            apply_claude_fullscreen(&mut resp, crate::claude_settings::read_tui_fullscreen());
             let mut instances = state.instances.write().await;
             instances.push(instance);
             (
@@ -1371,6 +1399,29 @@ mod tests {
         assert_eq!(json["tool"], "claude");
         assert_eq!(json["status"], "Running");
         assert_eq!(json["is_sandboxed"], false);
+        // Default is false; populated only by handlers via apply_claude_fullscreen.
+        assert_eq!(json["claude_fullscreen"], false);
+    }
+
+    #[test]
+    fn apply_claude_fullscreen_sets_only_for_claude() {
+        let mut resp = SessionResponse::from(&make_test_instance());
+        assert_eq!(resp.tool, "claude");
+        apply_claude_fullscreen(&mut resp, true);
+        assert!(resp.claude_fullscreen);
+
+        let mut inst = make_test_instance();
+        inst.tool = "cursor".to_string();
+        let mut resp = SessionResponse::from(&inst);
+        apply_claude_fullscreen(&mut resp, true);
+        assert!(!resp.claude_fullscreen);
+    }
+
+    #[test]
+    fn apply_claude_fullscreen_no_op_when_setting_disabled() {
+        let mut resp = SessionResponse::from(&make_test_instance());
+        apply_claude_fullscreen(&mut resp, false);
+        assert!(!resp.claude_fullscreen);
     }
     // ── validate_diff_path: security regression tests ──────────────────────────
     //

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -55,8 +55,14 @@ pub struct CleanupDefaults {
     pub delete_sandbox: bool,
 }
 
-impl From<&Instance> for SessionResponse {
-    fn from(inst: &Instance) -> Self {
+impl SessionResponse {
+    /// Build a response from a session instance plus the user's current
+    /// Claude Code fullscreen-renderer preference.
+    ///
+    /// `claude_fullscreen` is the *user-level* setting (read once per
+    /// request via `crate::claude_settings::read_tui_fullscreen()`); it
+    /// surfaces on the response only when the session's agent is Claude.
+    pub fn from_instance(inst: &Instance, claude_fullscreen: bool) -> Self {
         Self {
             id: inst.id.clone(),
             title: inst.title.clone(),
@@ -89,19 +95,8 @@ impl From<&Instance> for SessionResponse {
             notify_on_waiting: inst.notify_on_waiting,
             notify_on_idle: inst.notify_on_idle,
             notify_on_error: inst.notify_on_error,
-            claude_fullscreen: false,
+            claude_fullscreen: claude_fullscreen && inst.tool == "claude",
         }
-    }
-}
-
-/// Set `claude_fullscreen` on a response when the session is a Claude
-/// Code session and the user has enabled Claude's fullscreen renderer.
-/// Callers compute `fullscreen` once via
-/// `crate::claude_settings::read_tui_fullscreen()` to avoid repeated file
-/// reads when enriching a list.
-fn apply_claude_fullscreen(resp: &mut SessionResponse, fullscreen: bool) {
-    if fullscreen && resp.tool == "claude" {
-        resp.claude_fullscreen = true;
     }
 }
 
@@ -110,11 +105,7 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
     let claude_fullscreen = crate::claude_settings::read_tui_fullscreen();
     let mut sessions: Vec<SessionResponse> = instances
         .iter()
-        .map(|inst| {
-            let mut resp = SessionResponse::from(inst);
-            apply_claude_fullscreen(&mut resp, claude_fullscreen);
-            resp
-        })
+        .map(|inst| SessionResponse::from_instance(inst, claude_fullscreen))
         .collect();
 
     // Resolve per-profile cleanup defaults with a TTL cache on AppState
@@ -249,8 +240,8 @@ pub async fn rename_session(
         wt.branch = title;
     }
 
-    let mut response = SessionResponse::from(&*inst);
-    apply_claude_fullscreen(&mut response, crate::claude_settings::read_tui_fullscreen());
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
 
     if let Ok(storage) = Storage::new(&profile) {
@@ -337,8 +328,8 @@ pub async fn update_session_notifications(
     apply(&mut inst.notify_on_idle, body.notify_on_idle);
     apply(&mut inst.notify_on_error, body.notify_on_error);
 
-    let mut response = SessionResponse::from(&*inst);
-    apply_claude_fullscreen(&mut response, crate::claude_settings::read_tui_fullscreen());
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
 
     if let Ok(storage) = Storage::new(&profile) {
@@ -665,8 +656,10 @@ pub async fn create_session(
 
     match result {
         Ok(Ok(instance)) => {
-            let mut resp = SessionResponse::from(&instance);
-            apply_claude_fullscreen(&mut resp, crate::claude_settings::read_tui_fullscreen());
+            let resp = SessionResponse::from_instance(
+                &instance,
+                crate::claude_settings::read_tui_fullscreen(),
+            );
             let mut instances = state.instances.write().await;
             instances.push(instance);
             (
@@ -1344,7 +1337,7 @@ mod tests {
     #[test]
     fn session_response_from_instance() {
         let inst = make_test_instance();
-        let resp = SessionResponse::from(&inst);
+        let resp = SessionResponse::from_instance(&inst, false);
 
         assert_eq!(resp.id, inst.id);
         assert_eq!(resp.title, "test-session");
@@ -1369,14 +1362,19 @@ mod tests {
             (Status::Starting, "Starting"),
         ] {
             inst.status = status;
-            assert_eq!(SessionResponse::from(&inst).status, expected);
+            assert_eq!(
+                SessionResponse::from_instance(&inst, false).status,
+                expected
+            );
         }
     }
 
     #[test]
     fn session_response_branch_from_worktree() {
         let mut inst = make_test_instance();
-        assert!(SessionResponse::from(&inst).branch.is_none());
+        assert!(SessionResponse::from_instance(&inst, false)
+            .branch
+            .is_none());
 
         inst.worktree_info = Some(crate::session::WorktreeInfo {
             branch: "feature/test".to_string(),
@@ -1385,7 +1383,9 @@ mod tests {
             created_at: chrono::Utc::now(),
         });
         assert_eq!(
-            SessionResponse::from(&inst).branch.as_deref(),
+            SessionResponse::from_instance(&inst, false)
+                .branch
+                .as_deref(),
             Some("feature/test")
         );
     }
@@ -1393,34 +1393,33 @@ mod tests {
     #[test]
     fn session_response_serializes_to_json() {
         let inst = make_test_instance();
-        let json = serde_json::to_value(SessionResponse::from(&inst)).unwrap();
+        let json = serde_json::to_value(SessionResponse::from_instance(&inst, false)).unwrap();
 
         assert!(json.get("id").is_some());
         assert_eq!(json["tool"], "claude");
         assert_eq!(json["status"], "Running");
         assert_eq!(json["is_sandboxed"], false);
-        // Default is false; populated only by handlers via apply_claude_fullscreen.
         assert_eq!(json["claude_fullscreen"], false);
     }
 
     #[test]
-    fn apply_claude_fullscreen_sets_only_for_claude() {
-        let mut resp = SessionResponse::from(&make_test_instance());
+    fn claude_fullscreen_set_for_claude_when_enabled() {
+        let resp = SessionResponse::from_instance(&make_test_instance(), true);
         assert_eq!(resp.tool, "claude");
-        apply_claude_fullscreen(&mut resp, true);
         assert!(resp.claude_fullscreen);
+    }
 
+    #[test]
+    fn claude_fullscreen_unset_for_non_claude_even_when_enabled() {
         let mut inst = make_test_instance();
         inst.tool = "cursor".to_string();
-        let mut resp = SessionResponse::from(&inst);
-        apply_claude_fullscreen(&mut resp, true);
+        let resp = SessionResponse::from_instance(&inst, true);
         assert!(!resp.claude_fullscreen);
     }
 
     #[test]
-    fn apply_claude_fullscreen_no_op_when_setting_disabled() {
-        let mut resp = SessionResponse::from(&make_test_instance());
-        apply_claude_fullscreen(&mut resp, false);
+    fn claude_fullscreen_unset_when_setting_disabled() {
+        let resp = SessionResponse::from_instance(&make_test_instance(), false);
         assert!(!resp.claude_fullscreen);
     }
     // ── validate_diff_path: security regression tests ──────────────────────────

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -73,8 +73,13 @@ pub fn append_pane_base_index_args(args: &mut Vec<String>, target: &str) {
 
 /// Append `; set-option -t <target> mouse on` to an in-flight tmux argument
 /// list so that mouse/wheel events are forwarded into tmux copy-mode.
-/// Required for the web dashboard's two-finger scroll on mobile, which
-/// emits SGR mouse-wheel escape sequences that tmux must interpret.
+///
+/// Required for the web dashboard's two-finger scroll on mobile when the
+/// underlying agent uses tmux copy-mode for scrollback (the default
+/// renderer for Claude Code, and all other agents). Claude Code's
+/// fullscreen renderer (`/tui fullscreen`) bypasses tmux copy-mode and
+/// handles wheel events itself, so the option is harmless but unused in
+/// that mode.
 pub fn append_mouse_on_args(args: &mut Vec<String>, target: &str) {
     args.extend([
         ";".to_string(),

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -36,7 +36,12 @@ export function TerminalView({ session }: Props) {
     exitScrollback,
     ctrlActiveRef,
     clearCtrlRef,
-  } = useTerminal(ensureState === "ready" ? session.id : null);
+  } = useTerminal(
+    ensureState === "ready" ? session.id : null,
+    "ws",
+    true,
+    session.claude_fullscreen,
+  );
   const { isMobile, keyboardOpen, keyboardHeight } = useMobileKeyboard();
   const [ctrlActive, setCtrlActive] = useState(false);
   const [termFocused, setTermFocused] = useState(false);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -52,6 +52,12 @@ export interface TerminalState {
 /**
  * Manages a wterm terminal connected to a PTY-relayed WebSocket.
  * Returns a ref to attach to a container div, plus connection state.
+ *
+ * `claudeFullscreen` is read at connect time (the connect effect's deps
+ * are intentionally only `[sessionId, wsPath]`). Toggling Claude's
+ * `/tui` setting mid-session won't take effect on the live wterm; the
+ * user has to reattach. That matches Claude Code itself, which also
+ * needs a restart to switch renderers.
  */
 export function useTerminal(
   sessionId: string | null,
@@ -572,8 +578,8 @@ export function useTerminal(
 
       // Fullscreen renderer path: Claude Code manages its own virtualized
       // scrollback inside the alt screen, so tmux copy-mode is never
-      // engaged. Skip the depth tracking and the pause/resume dance —
-      // just emit raw wheel sequences and let Claude's renderer handle
+      // engaged. Skip the depth tracking and the pause/resume dance.
+      // Just emit raw wheel sequences and let Claude's renderer handle
       // them. isInScrollback stays false; downstream UI (BackToLiveButton)
       // hides itself accordingly.
       if (claudeFullscreen) {

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -57,6 +57,7 @@ export function useTerminal(
   sessionId: string | null,
   wsPath: string = "ws",
   autoFocus: boolean = true,
+  claudeFullscreen: boolean = false,
 ) {
   const { settings, update } = useWebSettings();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -566,6 +567,23 @@ export function useTerminal(
     const WHEEL_DOWN_SEQ = "\x1b[<65;1;1M";
     let scrollbackDepth = 0;
     const sendWheel = (dir: "up" | "down", count: number) => {
+      const ws = wsRef.current;
+      if (ws?.readyState !== WebSocket.OPEN) return;
+
+      // Fullscreen renderer path: Claude Code manages its own virtualized
+      // scrollback inside the alt screen, so tmux copy-mode is never
+      // engaged. Skip the depth tracking and the pause/resume dance —
+      // just emit raw wheel sequences and let Claude's renderer handle
+      // them. isInScrollback stays false; downstream UI (BackToLiveButton)
+      // hides itself accordingly.
+      if (claudeFullscreen) {
+        const seq = dir === "up" ? WHEEL_UP_SEQ : WHEEL_DOWN_SEQ;
+        for (let i = 0; i < count; i++) {
+          ws.send(new TextEncoder().encode(seq));
+        }
+        return;
+      }
+
       let sendCount = count;
       const clampForMobile = isMobileViewport();
       if (dir === "up") {
@@ -581,8 +599,6 @@ export function useTerminal(
         scrollbackDepth = Math.max(0, scrollbackDepth - sendCount);
       }
       const seq = dir === "up" ? WHEEL_UP_SEQ : WHEEL_DOWN_SEQ;
-      const ws = wsRef.current;
-      if (ws?.readyState !== WebSocket.OPEN) return;
       for (let i = 0; i < sendCount; i++) {
         ws.send(new TextEncoder().encode(seq));
       }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -23,6 +23,11 @@ export interface SessionResponse {
   notify_on_waiting: boolean | null;
   notify_on_idle: boolean | null;
   notify_on_error: boolean | null;
+  /** True when this is a Claude Code session AND the user has enabled
+   *  Claude's fullscreen renderer (`tui: "fullscreen"` in
+   *  ~/.claude/settings.json). The mobile rendering path uses this to
+   *  skip scrollback-tracking workarounds that target tmux copy-mode. */
+  claude_fullscreen: boolean;
 }
 
 export interface CleanupDefaults {


### PR DESCRIPTION
## Description

Closes #828.

Claude Code 2.x ships a fullscreen renderer (`/tui fullscreen`, https://code.claude.com/docs/en/fullscreen) that uses the alt screen with virtualized scrollback. When enabled, several mobile rendering workarounds in aoe become unnecessary, because Claude manages its own scrollback and tmux copy-mode is never engaged:

- `scrollbackDepth` tracking + `pause_output`/`resume_output` dance in `web/src/hooks/useTerminal.ts`
- The mobile downward-wheel clamp that keeps depth ≥ 1 to prevent tmux's `-e` auto-exit
- The "Back to live" button (which targets tmux copy-mode exit)

This PR detects the user's preference and adapts.

**Approach: read, don't write.** aoe does not set `CLAUDE_CODE_NO_FLICKER` or mutate user settings. Claude Code owns the renderer choice via `/tui fullscreen` (which writes `tui: "fullscreen"` to `~/.claude/settings.json`); aoe just reads it and skips workarounds when fullscreen is active.

### What changes

**Server (Rust)**
- New `src/claude_settings.rs` — `read_tui_fullscreen()` reads `~/.claude/settings.json` and returns `true` iff `tui == "fullscreen"`. Returns `false` on missing file, malformed JSON, or any other value.
- New `claude_fullscreen: bool` field on `SessionResponse` in `src/server/api/sessions.rs`. Set to true only when both: agent is Claude AND the user has fullscreen enabled.
- `apply_claude_fullscreen` helper called from the four production handlers (`list_sessions`, `rename_session`, `update_session_notifications`, session-create) so the file is read at most once per request.
- Updated `mouse on` doc comment in `src/tmux/utils.rs` to reflect that the option is unused (but harmless) in fullscreen mode.

**Web client (TypeScript)**
- Mirrored `claude_fullscreen: boolean` on `SessionResponse` in `web/src/lib/types.ts`.
- New `claudeFullscreen` parameter on `useTerminal` (default `false`). When `true`, `sendWheel` emits raw wheel sequences and skips the entire scrollback-tracking branch.
- `TerminalView` passes `session.claude_fullscreen` through. `RightPanel`'s paired terminal connects to host/container shells (never Claude), so it stays at default `false`.
- `BackToLiveButton` auto-disables in fullscreen mode because `state.isInScrollback` never flips true on this code path.

### Out of scope

- Updating `aoe session capture` to read Claude's JSONL session files when fullscreen is on (worth a separate issue if anyone hits the alt-screen capture-pane regression).
- Auto-flipping the user's `tui` setting or setting `CLAUDE_CODE_NO_FLICKER=1` from aoe.
- Full settings-source merge across project / local / flag / policy layers (punt until reported — we only read `~/.claude/settings.json`).
- Removing the velocity cap / per-frame emit cap (kept as defensive code regardless of renderer).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (1269 lib tests + 7 new claude_settings tests + 3 new sessions tests; clippy clean; fmt clean; web tsc clean; web build succeeds)
- [x] Documentation was updated where necessary (`mouse on` doc comment in `src/tmux/utils.rs`)
- [ ] For UI changes: included screenshot or recording

**Note on UI verification:** the user-visible difference is the absence of the "Back to live" button on mobile when `/tui fullscreen` is active, plus the absence of `pause_output` / `resume_output` WebSocket messages on scroll. Both are negative-space changes (workarounds going away). Manual verification:
1. Set `tui: "fullscreen"` in `~/.claude/settings.json`.
2. Start a Claude session in aoe.
3. Open the web dashboard on mobile.
4. Scroll within the terminal; in DevTools, confirm via the WebSocket inspector that no `pause_output` / `resume_output` messages are sent (only raw wheel-up/down byte frames).
5. Confirm "Back to live" button does not appear.

I have not yet verified on a real mobile device — flagging in case you want to gate this on a manual smoke test before merge.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7) via the `/fix-github-issue` workflow.

**Any Additional AI Details you'd like to share:**
The issue (#828) and this PR were drafted by Claude during a session investigating tmux integration improvements. The investigation that surfaced the fullscreen renderer started from a `strings` dump of the Claude Code binary; specifics like the env var name `CLAUDE_CODE_NO_FLICKER`, the settings key `tui`, and the auto-disable note for `tmux -CC` are all from the binary, not training data. The implementation plan was written by Claude and the code was Claude-generated; @njbrake reviewed and authorized.

- [x] I am an AI Agent filling out this form (check box if true)