### PR TITLE
fix(web): buffer DEC ?2026 BSU/ESU updates as wterm workaround

### DIFF
--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -32,6 +32,45 @@ const RESIZE_DEBOUNCE_MS = 50;
 // a small margin. After the first resize lands the debounce drops to
 // RESIZE_DEBOUNCE_MS so live splitter drags still feel responsive.
 const INITIAL_SETTLE_MS = 250;
+// DEC private mode 2026 (synchronized output, BSU/ESU). wterm doesn't
+// implement it: setPrivateMode falls through `else => {}`, and writes are
+// rendered as soon as wterm's internal rAF fires. Modern TUIs (codex,
+// claude, neovim, btop) bracket frame updates with `\x1b[?2026h` ...
+// `\x1b[?2026l` so a single frame paints atomically. When the bracketed
+// content spans multiple PTY reads (large frame, slow link, scroll-paint),
+// each WebSocket message lands in a separate JS task and triggers its own
+// rAF render — the user sees half-drawn frames.
+//
+// Workaround: parse incoming bytes for the BSU/ESU markers ourselves and
+// hold writes between them so wterm sees one term.write per frame. Filed
+// upstream at vercel-labs/wterm#57; remove when wterm ships native sync
+// support. Spec: gitlab.com/gnachman/iterm2/-/wikis/synchronized-updates-spec
+const BSU_BYTES = new TextEncoder().encode("\x1b[?2026h");
+const ESU_BYTES = new TextEncoder().encode("\x1b[?2026l");
+// Spec recommends ~150ms cap. If the agent opens a BSU and never closes
+// it (crash, missed flush), we force-flush so the terminal doesn't appear
+// frozen. 150ms is well above one-frame budgets on real agents.
+const SYNC_FLUSH_TIMEOUT_MS = 150;
+
+/**
+ * Find the first occurrence of `needle` in `haystack` starting at `start`.
+ * Returns -1 if not found. Plain bytewise scan; fine for the 8-byte BSU/ESU
+ * markers we look for.
+ */
+function indexOfBytes(
+  haystack: Uint8Array,
+  needle: Uint8Array,
+  start: number,
+): number {
+  if (needle.length === 0 || haystack.length - start < needle.length) return -1;
+  outer: for (let i = start; i <= haystack.length - needle.length; i++) {
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) continue outer;
+    }
+    return i;
+  }
+  return -1;
+}
 
 export interface TerminalState {
   connected: boolean;
@@ -319,6 +358,63 @@ export function useTerminal(
 
     termRef.current = term;
 
+    // DEC ?2026 synchronized-output workaround. See top-of-file comment
+    // on BSU_BYTES for the failure mode this prevents. Holds bytes
+    // between BSU and ESU so wterm's internal rAF coalesces them into
+    // one paint. State is per-WebSocket-connection (re-created on every
+    // reconnect via the useEffect re-run).
+    let inSyncUpdate = false;
+    let syncBuffer: Uint8Array[] = [];
+    let syncTimer: ReturnType<typeof setTimeout> | null = null;
+    const flushSyncBuffer = () => {
+      if (syncTimer) {
+        clearTimeout(syncTimer);
+        syncTimer = null;
+      }
+      inSyncUpdate = false;
+      if (syncBuffer.length === 0) return;
+      let total = 0;
+      for (const c of syncBuffer) total += c.length;
+      const flat = new Uint8Array(total);
+      let off = 0;
+      for (const c of syncBuffer) {
+        flat.set(c, off);
+        off += c.length;
+      }
+      syncBuffer = [];
+      term.write(flat);
+    };
+    const writeWithSyncBuffer = (data: Uint8Array) => {
+      let cursor = 0;
+      while (cursor < data.length) {
+        if (!inSyncUpdate) {
+          const pos = indexOfBytes(data, BSU_BYTES, cursor);
+          if (pos < 0) {
+            term.write(data.subarray(cursor));
+            return;
+          }
+          // Pass through everything up to and including the BSU marker,
+          // then start buffering the rest of this chunk.
+          term.write(data.subarray(cursor, pos + BSU_BYTES.length));
+          cursor = pos + BSU_BYTES.length;
+          inSyncUpdate = true;
+          if (syncTimer) clearTimeout(syncTimer);
+          syncTimer = setTimeout(flushSyncBuffer, SYNC_FLUSH_TIMEOUT_MS);
+        } else {
+          const pos = indexOfBytes(data, ESU_BYTES, cursor);
+          if (pos < 0) {
+            // No ESU in this chunk: buffer the rest, wait for more.
+            syncBuffer.push(data.subarray(cursor));
+            return;
+          }
+          syncBuffer.push(data.subarray(cursor, pos + ESU_BYTES.length));
+          cursor = pos + ESU_BYTES.length;
+          flushSyncBuffer();
+          // Keep iterating: bytes after this ESU may contain another BSU.
+        }
+      }
+    };
+
     // Two iOS patches for wterm's textarea:
     // 1. Move from -9999px to 0,0 so iOS shows the soft keyboard on focus.
     // 2. Fix backspace repeat: wterm calls preventDefault() on all keydown
@@ -462,7 +558,7 @@ export function useTerminal(
 
       ws.onmessage = (event: MessageEvent) => {
         if (event.data instanceof ArrayBuffer) {
-          term.write(new Uint8Array(event.data));
+          writeWithSyncBuffer(new Uint8Array(event.data));
         } else if (typeof event.data === "string") {
           // Check for server control messages before writing to terminal
           try {
@@ -475,6 +571,9 @@ export function useTerminal(
           } catch {
             // Not JSON, treat as terminal text
           }
+          // String messages bypass the BSU/ESU buffer: the server only
+          // sends UTF-8 text for non-binary control messages; PTY bytes
+          // always arrive as ArrayBuffer.
           term.write(event.data);
         }
       };
@@ -992,6 +1091,7 @@ export function useTerminal(
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
+      if (syncTimer) clearTimeout(syncTimer);
       wsRef.current?.close();
       term.destroy();
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -7,10 +7,18 @@ import type { Page } from "@playwright/test";
 export interface MockHandle {
   /** Raw bytes received from the page via WebSocket (PTY data + JSON messages). */
   wsMessages: Buffer[];
+  /**
+   * Push bytes to the page's WebSocket as if they came from the PTY. Set
+   * by the route handler once the page connects; before the first
+   * connection it is a no-op so tests can install it before navigating.
+   * If multiple PTY sockets are opened (the dashboard mounts two), this
+   * targets whichever connected most recently.
+   */
+  push: (data: Buffer | string) => void;
 }
 
 export async function mockTerminalApis(page: Page): Promise<MockHandle> {
-  const handle: MockHandle = { wsMessages: [] };
+  const handle: MockHandle = { wsMessages: [], push: () => {} };
   await page.route("**/api/login/status", (r) =>
     r.fulfill({ json: { required: false, authenticated: true } }),
   );
@@ -66,6 +74,13 @@ export async function mockTerminalApis(page: Page): Promise<MockHandle> {
       if (Buffer.isBuffer(msg)) handle.wsMessages.push(msg);
       else handle.wsMessages.push(Buffer.from(msg));
     });
+    handle.push = (data) => {
+      try {
+        ws.send(typeof data === "string" ? Buffer.from(data) : data);
+      } catch {
+        // socket already closed — safe to ignore
+      }
+    };
     setTimeout(() => {
       try {
         ws.send(Buffer.from("$ "));

--- a/web/tests/wterm-sync-output.spec.ts
+++ b/web/tests/wterm-sync-output.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+
+// Workaround regression for the wterm DEC ?2026 (BSU/ESU) gap. wterm
+// silently ignores the synchronized-output mode toggles, so when an agent
+// brackets a multi-chunk frame redraw with `\x1b[?2026h` ... `\x1b[?2026l`,
+// each chunk lands in a separate JS task and triggers its own rAF render
+// (half-drawn frames). useTerminal must buffer bytes between BSU and ESU
+// so wterm sees one term.write per frame.
+
+const desktop = { width: 1280, height: 800 };
+test.use({ viewport: desktop, hasTouch: false });
+
+const BSU = "\x1b[?2026h";
+const ESU = "\x1b[?2026l";
+
+async function openSession(page: Page, handle: MockHandle) {
+  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await page
+    .locator(".wterm")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect
+    .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+    .toBeGreaterThan(0);
+}
+
+// Read the first terminal's row content. Reads via DOM textContent so we're
+// observing what the user would see in the browser, not wterm's internal
+// state. Joins all term-row elements with `|` so we can match across rows.
+async function readScreen(page: Page): Promise<string> {
+  return await page.locator(".wterm").first().evaluate((el) => {
+    const rows = el.querySelectorAll(".term-row");
+    return Array.from(rows, (r) => r.textContent ?? "").join("|");
+  });
+}
+
+test.describe("wterm BSU/ESU buffering workaround", () => {
+  test("frame split across BSU…ESU is held until ESU and rendered atomically", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    // Stage a known starting state.
+    handle.push(Buffer.from("\x1b[2J\x1b[Hbefore"));
+    await expect
+      .poll(() => readScreen(page), { timeout: 2_000 })
+      .toContain("before");
+
+    // Open a synchronized update, then push the partial frame in two
+    // separate WS messages. The intermediate state ("middle1middle2"
+    // overwriting "before") must NOT be visible until ESU arrives.
+    handle.push(Buffer.from(BSU + "\x1b[H\x1b[2Kmiddle1"));
+    // Give the page a generous chance to render if the workaround is
+    // broken; if the buffering is working, this wait is wasted but safe.
+    await page.waitForTimeout(80);
+    let mid = await readScreen(page);
+    expect(
+      mid,
+      `Frame should be held during BSU. Saw partial state: ${mid}`,
+    ).not.toContain("middle1");
+    expect(mid).toContain("before");
+
+    handle.push(Buffer.from("middle2"));
+    await page.waitForTimeout(40);
+    mid = await readScreen(page);
+    expect(mid, `Frame still held mid-BSU. Saw: ${mid}`).not.toContain(
+      "middle1middle2",
+    );
+    expect(mid).toContain("before");
+
+    // ESU should release the buffered bytes and the terminal should now
+    // show the post-ESU state.
+    handle.push(Buffer.from(ESU));
+    await expect
+      .poll(() => readScreen(page), { timeout: 2_000 })
+      .toContain("middle1middle2");
+  });
+
+  test("BSU without ESU flushes after the safety timeout", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    handle.push(Buffer.from("\x1b[2J\x1b[Hidle"));
+    await expect
+      .poll(() => readScreen(page), { timeout: 2_000 })
+      .toContain("idle");
+
+    // Send BSU + content but never close it. After ~150ms the workaround
+    // should force-flush so the terminal isn't permanently held.
+    handle.push(Buffer.from(BSU + "\x1b[H\x1b[2Kunclosed"));
+
+    // Just after the push, the buffer should still be holding.
+    await page.waitForTimeout(40);
+    expect(await readScreen(page)).not.toContain("unclosed");
+
+    // After the safety timeout (150ms in the workaround), it flushes.
+    await expect
+      .poll(() => readScreen(page), { timeout: 1_500 })
+      .toContain("unclosed");
+  });
+
+  test("bytes outside any BSU pass through immediately", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    handle.push(Buffer.from("\x1b[2J\x1b[Hhello"));
+    // Without any BSU/ESU markers, this should land synchronously
+    // (modulo the existing rAF) — a short poll succeeds quickly.
+    await expect
+      .poll(() => readScreen(page), { timeout: 1_000 })
+      .toContain("hello");
+  });
+});


### PR DESCRIPTION
## Description

Workaround for vercel-labs/wterm#57. wterm silently ignores DEC private mode 2026 (synchronized output, BSU/ESU): writes land in wterm's renderer as soon as its internal rAF fires. Modern TUIs (codex, claude, neovim, btop) use this mode to bracket atomic frame updates so a single frame paints in one go. When the bracketed content spans multiple PTY reads — large frame, slow link, scroll-paint — each WebSocket message lands in a separate JS task and triggers its own rAF render, and the user sees half-drawn frames.

Parse the BSU/ESU markers in `useTerminal.ts` and hold writes between them so wterm receives one `term.write` per frame. Force-flush after 150ms (per the spec's recommended cap) if a host opens BSU and never closes it. Bytes outside any BSU pass through unchanged, so agents that never use the mode incur no behavior change.

This is the second of three workarounds for wterm gaps surfaced while investigating #830 / #831:
- #832 (already merged-or-pending) caps the PTY at wterm's 256x256 grid (workaround for vercel-labs/wterm#56).
- This PR addresses synchronized output (workaround for vercel-labs/wterm#57).
- vercel-labs/wterm#54 (wide chars) and #55 (mouse + focus events) remain upstream-only — no host-side workaround possible.

### What changed

- `web/src/hooks/useTerminal.ts`: adds `BSU_BYTES` / `ESU_BYTES` / `SYNC_FLUSH_TIMEOUT_MS` constants, an `indexOfBytes` helper, and a per-WebSocket-connection `writeWithSyncBuffer` state machine. Wired into the binary path of `ws.onmessage`. String messages bypass the buffer (the server only sends UTF-8 for control messages; PTY bytes always arrive as ArrayBuffer). Timer is cleared on effect teardown.
- `web/tests/helpers/terminal-mocks.ts`: extends `MockHandle` with a `push()` function so tests can inject arbitrary PTY bytes from the WS mock. The route handler assigns it on each connection (last-wins if multiple sockets are opened, which is fine for these tests).
- `web/tests/wterm-sync-output.spec.ts`: three new regressions —
  1. A frame split across BSU…ESU is held until ESU and rendered atomically.
  2. BSU without ESU flushes after the 150ms safety timeout.
  3. Bytes outside any BSU pass through immediately.

### What this fixes / doesn't fix

- **Fixes:** mid-frame partial-paint artifacts when a TUI brackets its frame redraws with `?2026h` / `?2026l` and the bracketed content spans multiple PTY reads. Codex emits ~25 of these pairs in its first 8s of startup output (measured via `script(1)` against a real PTY). Claude uses a related variant.
- **Does not fix:** the wide-char misalignment (vercel-labs/wterm#54), missing mouse / focus events (vercel-labs/wterm#55), or any other rendering issues attributable to wterm gaps that don't go through the synchronized-output mode.

The contribution of this gap to the specific symptoms in #830/#831 is unproven without a side-by-side render comparison; this PR removes one likely contributor.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Manual checks run locally:
- `npm run build` ✓
- `tsc -b` ✓
- `eslint` on changed files ✓
- `npx playwright test tests/wterm-sync-output.spec.ts` (3/3 pass) ✓
- Full Playwright suite ✓ (one flaky Chromium SIGSEGV on retry, unrelated)

(No UI screenshot included: this is a buffering change with no new UI surface. The Playwright tests are the verification.)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (Anthropic), via Claude Code, in a debug session with @njbrake.

**Any Additional AI Details you'd like to share:**
The synchronized-output gap was identified by capturing real PTY byte streams from `codex`, `claude`, and `cursor-agent` with `script(1)` and analyzing them for the patterns wterm doesn't handle. The 150ms safety-flush timeout matches the recommendation in the iTerm2 synchronized-updates spec.

- [x] I am an AI Agent filling out this form (check box if true)

Refs vercel-labs/wterm#57.