### PR TITLE
fix(serve): strip tmux DEC alternate charset to work around wterm#49

### DIFF
--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -172,7 +172,36 @@ async fn handle_terminal_ws(
     };
 
     let mut cmd = CommandBuilder::new("tmux");
-    cmd.args(["attach-session", "-t", &tmux_name]);
+    // Workaround for vercel-labs/wterm#49 (SCS not implemented). Tmux uses
+    // the DEC alternate character set to draw '─', '│', and corner glyphs
+    // for pane separators (and Claude Code does the same for its dialog
+    // borders). Without SCS support wterm renders the literal 'q', 'x',
+    // and so on, producing the long "qqqq…" rows in the web dashboard.
+    //
+    // Strip smacs/rmacs/acsc so tmux can't pick the SCS encoding, and
+    // mark the terminal as U8 so tmux uses its UTF-8/ASCII fallback when
+    // rendering box-drawing cells. With wterm 0.1.x the practical effect
+    // is ASCII fallback ('-'/'+'/'|'), which is a clean separator glyph
+    // and a major improvement over the literal 'q'. `-a` appends to
+    // tmux's existing overrides; the pattern matches any 256-color
+    // terminal type aoe might attach as. Idempotent: the override is a
+    // server option, so reapplying on every attach is harmless.
+    //
+    // Affects all clients of this tmux server, including the user's TUI
+    // direct attach. Modern terminal emulators render '-'/'+'/'|' as
+    // recognizable separators, so the TUI experience degrades from
+    // "fancy box-drawing" to "ASCII box-drawing"; that's a worthwhile
+    // tradeoff while wterm is missing SCS. Remove when wterm ships it.
+    cmd.args([
+        "set-option",
+        "-as",
+        "terminal-overrides",
+        "*256col*:U8=1:smacs@:rmacs@:acsc@",
+        ";",
+        "attach-session",
+        "-t",
+        &tmux_name,
+    ]);
     cmd.env("TERM", "xterm-256color");
     // Allow nesting: unset TMUX so the attach works when aoe serve runs inside tmux
     cmd.env_remove("TMUX");


### PR DESCRIPTION
> _Authored by Claude (Anthropic) through a debug session with @njbrake._

## Description

The most-visible web rendering corruption in #830 and #831 — the long rows of literal 'q' characters at the top of Claude's workspace-trust dialog and around every tmux pane border — is caused by [vercel-labs/wterm#49](https://github.com/vercel-labs/wterm/issues/49). wterm doesn't implement DEC SCS (alternate character set), so when tmux emits `\x1b(0qqq…\x1b(B` to draw '─'/'│'/corners, wterm renders the literal `q` instead of the line glyph.

This PR works around it on the host side by appending a `terminal-overrides` entry to tmux on every web-side `tmux attach-session`. The override strips `smacs`/`rmacs`/`acsc` and marks the terminal as `U8`, which prevents tmux from picking the SCS encoding for 256-color terminals. With wterm 0.1.x the practical fallback is ASCII (`-`/`+`/`|`) — a clean, recognizable separator glyph that wterm renders correctly. Remove the override once wterm ships SCS support.

## What changed

- `src/server/ws.rs`: chains a `set-option -as terminal-overrides '*256col*:U8=1:smacs@:rmacs@:acsc@' \;` before the `attach-session` invocation. The pattern matches xterm-256color, screen-256color, tmux-256color, etc. — any 256-color terminal type aoe might attach as. `-a` appends to tmux's existing overrides rather than clobbering them. Idempotent: the override is a server option, so reapplying on every attach is harmless.

## Verification

End-to-end test on a real `aoe serve` + tmux + claude session through Chromium at 1920×1080 and 3000×1200 (after installing tmux in the sandbox):

| Check | Before this PR | After |
|---|---|---|
| `\x1b(0` sequences in the WebSocket byte stream | 6+ per frame | 0 |
| Consecutive `q` runs (≥5) in the rendered DOM | yes (multiple rows) | 0 |
| Claude's gold separator at the top of the workspace-trust dialog | `qqqqqqqq…` | `--------…` |
| Tmux pane separators in the side panels | `qqqqqqqq…` | `--------…` |

Local checks: `cargo build --features serve` ✓, `cargo test --features serve --lib server::ws` (10/10 pass) ✓, `cargo fmt --check` ✓, `cargo clippy --features serve --no-deps` (no warnings) ✓.

## Tradeoffs / what to watch

The `terminal-overrides` option is server-scope in tmux, so the override is also visible to a user's **TUI direct attach** to the same tmux server (not just the web). Modern terminals (iTerm2, Terminal.app, Ghostty, kitty, alacritty) all render ASCII `-`/`+`/`|` as clean separators, so this degrades the TUI from "fancy Unicode/SCS box-drawing" to "ASCII box-drawing." Worthwhile tradeoff until wterm ships SCS — but worth knowing if you're picky about how the TUI looks on your terminal.

If a user has a `~/.tmux.conf` that sets its own `terminal-overrides`, our `-a`-appended entry coexists with theirs without conflict; tmux applies all matching overrides in order.

## What this PR does and doesn't address

- **Fixes:** the wterm#49 / `qqqq` rendering — the conspicuous bug in #830 / #831.
- **Doesn't fix:** the other wterm gaps surfaced during the broader investigation, all of which are upstream-only:
  - vercel-labs/wterm#54 (wide chars / EAW) — latent in claude/codex output through tmux, not visible.
  - vercel-labs/wterm#55 (mouse + focus events ignored) — active for cursor-agent and codex, contributes to selection unresponsiveness in mouse-driven menus.
  - vercel-labs/wterm#56 (256×256 grid cap) — preventive workaround in PR #832.
  - vercel-labs/wterm#57 (synchronized output ignored) — doesn't reach wterm through tmux's screen-256color terminfo, so no host-side workaround needed (closed PR #836).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(Empirical end-to-end before/after table above stands in for a screenshot pair; happy to attach the actual PNG diff if you'd like.)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (Anthropic), via Claude Code, in a debug session with @njbrake.

**Any Additional AI Details you'd like to share:**
The hypothesis came out of a real `aoe serve` + tmux + claude end-to-end run after the earlier byte-stream investigation. The fix was tested by re-running the same end-to-end harness with the `terminal-overrides` change applied and counting `\x1b(0` sequences and `qqqq` runs in the captured WebSocket bytes.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #830, #831.
Refs vercel-labs/wterm#49.