### PR TITLE
fix: replace deprecated GenericArray::as_slice with as_ref

### DIFF
--- a/src/server/push_send.rs
+++ b/src/server/push_send.rs
@@ -168,7 +168,7 @@ pub fn encrypt_aes128gcm(subscription: &Subscription, plaintext: &[u8]) -> Resul
     info1.extend_from_slice(&p_ua_bytes);
     info1.extend_from_slice(p_as_bytes);
 
-    let hk1 = Hkdf::<Sha256>::new(Some(&auth_secret), shared_bytes.as_slice());
+    let hk1 = Hkdf::<Sha256>::new(Some(&auth_secret), shared_bytes.as_ref());
     let mut ikm = [0u8; 32];
     hk1.expand(&info1, &mut ikm)
         .map_err(|e| anyhow!("HKDF expand for IKM: {}", e))?;


### PR DESCRIPTION
## Description

Silences a deprecation warning emitted by `p256` / `generic-array` 0.x in `src/server/push_send.rs`:

```
warning: use of deprecated method `p256::elliptic_curve::generic_array::GenericArray::<T, N>::as_slice`: please upgrade to generic-array 1.x
   --> src/server/push_send.rs:171:68
    |
171 |     let hk1 = Hkdf::<Sha256>::new(Some(&auth_secret), shared_bytes.as_slice());
```

`shared_bytes` is a `&FieldBytes` (a `GenericArray<u8, U32>`). `as_ref()` returns the same `&[u8]` via `AsRef<[u8]>` without the deprecation, so this is the minimal fix while staying on generic-array 0.x (which `p256 0.13` still pins).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Tested locally with `cargo build` and `cargo build --features serve`; the warning is gone and `cargo clippy --features serve --lib` is clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**

One-line change identified and applied by Claude; verified by hand and via local build.

- [x] I am an AI Agent filling out this form (check box if true)