### PR TITLE
feat(web): toggle terminal focus with Cmd/Ctrl+`

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -320,15 +320,27 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const handleToggleTerminalFocus = useCallback(() => {
     if (!activeSessionId) return;
     // ContentSplit renders the right pane twice (desktop inline + mobile
-    // overlay); each instance mounts its own PairedTerminal. Detecting the
-    // current focus target by data-term attribute is robust against that
-    // duplication and against future panel reorderings.
-    const agentPanel = document.querySelector<HTMLElement>(
-      '[data-term="agent"]',
-    );
+    // overlay); each instance mounts its own PairedTerminal. Probing by
+    // data-term attribute is robust against that duplication and against
+    // future panel reorderings.
+    //
+    // Semantic: VSCode-like "Cmd+` opens/focuses the terminal." So if the
+    // user is NOT in the paired terminal, send them there; only flip back
+    // to agent when they're already in paired.
     const active = document.activeElement;
-    const inAgent = !!agentPanel && !!active && agentPanel.contains(active);
-    const target = inAgent ? "paired" : "agent";
+    const pairedPanels = document.querySelectorAll<HTMLElement>(
+      '[data-term="paired"]',
+    );
+    let inPaired = false;
+    if (active) {
+      for (const p of pairedPanels) {
+        if (p.contains(active)) {
+          inPaired = true;
+          break;
+        }
+      }
+    }
+    const target = inPaired ? "agent" : "paired";
 
     if (target === "paired" && diffCollapsed) {
       // Right panel is collapsed; paired terminal is unmounted. Set the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -319,13 +319,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const handleToggleTerminalFocus = useCallback(() => {
     if (!activeSessionId) return;
-    const panels = document.querySelectorAll<HTMLElement>(".term-panel");
+    // ContentSplit renders the right pane twice (desktop inline + mobile
+    // overlay); each instance mounts its own PairedTerminal. Detecting the
+    // current focus target by data-term attribute is robust against that
+    // duplication and against future panel reorderings.
+    const agentPanel = document.querySelector<HTMLElement>(
+      '[data-term="agent"]',
+    );
     const active = document.activeElement;
-    // Panel order in the DOM matches mount order: agent first, paired second.
-    // The paired panel only exists while the right panel is mounted.
-    const inPaired =
-      panels.length >= 2 && !!active && panels[1]!.contains(active);
-    const target = inPaired ? "agent" : "paired";
+    const inAgent = !!agentPanel && !!active && agentPanel.contains(active);
+    const target = inAgent ? "paired" : "agent";
 
     if (target === "paired" && diffCollapsed) {
       // Right panel is collapsed; paired terminal is unmounted. Set the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -335,8 +335,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       setDiffCollapsed(false);
       return;
     }
+    if (target === "agent" && selectedFilePath) {
+      // Agent terminal is hidden under the diff viewer; close the diff first
+      // so the wrapper un-hides, then dispatch on the next frame because
+      // focus() on a display:none element is a no-op.
+      setSelectedFilePath(null);
+      requestAnimationFrame(() => dispatchFocusTerminal("agent"));
+      return;
+    }
     dispatchFocusTerminal(target);
-  }, [activeSessionId, diffCollapsed]);
+  }, [activeSessionId, diffCollapsed, selectedFilePath]);
 
   useKeyboardShortcuts(
     useCallback(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,10 @@ import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
+import {
+  dispatchFocusTerminal,
+  setPendingTerminalFocus,
+} from "./lib/terminalFocus";
 import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
@@ -313,6 +317,27 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setShowAddProject(true);
   }, []);
 
+  const handleToggleTerminalFocus = useCallback(() => {
+    if (!activeSessionId) return;
+    const panels = document.querySelectorAll<HTMLElement>(".term-panel");
+    const active = document.activeElement;
+    // Panel order in the DOM matches mount order: agent first, paired second.
+    // The paired panel only exists while the right panel is mounted.
+    const inPaired =
+      panels.length >= 2 && !!active && panels[1]!.contains(active);
+    const target = inPaired ? "agent" : "paired";
+
+    if (target === "paired" && diffCollapsed) {
+      // Right panel is collapsed; paired terminal is unmounted. Set the
+      // pending intent so PairedTerminal grabs focus once it mounts and
+      // its PTY is ready, then expand the panel.
+      setPendingTerminalFocus("paired");
+      setDiffCollapsed(false);
+      return;
+    }
+    dispatchFocusTerminal(target);
+  }, [activeSessionId, diffCollapsed]);
+
   useKeyboardShortcuts(
     useCallback(
       () => ({
@@ -338,8 +363,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onPalette: () => setShowPalette((p) => !p),
         onToggleSidebar: () => setSidebarOpen((o) => !o),
         onToggleRightPanel: () => setDiffCollapsed((c) => !c),
+        onToggleTerminalFocus: handleToggleTerminalFocus,
       }),
-      [toggleDiff, showPalette, deletingWorkspaceId, showSettings, handleCloseSettings, navigate],
+      [toggleDiff, showPalette, deletingWorkspaceId, showSettings, handleCloseSettings, navigate, handleToggleTerminalFocus],
     ),
   );
 

--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -29,6 +29,7 @@ export function HelpOverlay({ onClose }: Props) {
     { key: `${modKey}K`, desc: "Open command palette" },
     { key: `${modKey}B`, desc: "Toggle left sidebar" },
     { key: `${modKey}${optKey}B`, desc: "Toggle right panel" },
+    { key: `${modKey}\``, desc: "Toggle agent / shell terminal focus" },
     { key: "n", desc: "New session" },
     { key: "D", desc: "Toggle diff panel" },
     { key: "s", desc: "Toggle settings" },

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -10,6 +10,7 @@ import type { RichDiffFile, SessionResponse } from "../lib/types";
 import {
   FOCUS_TERMINAL_EVENT,
   consumePendingTerminalFocus,
+  setPendingTerminalFocus,
   type FocusTerminalDetail,
 } from "../lib/terminalFocus";
 import "@wterm/dom/css";
@@ -158,20 +159,28 @@ function PairedTerminal({
     activate();
   }, [termRef, keyboardOpen, activate]);
 
+  // Returns true if focus was applied. Callers can fall back to the pending
+  // latch when the textarea isn't in the DOM yet (PTY still booting).
   const focusSelf = useCallback(() => {
     const ta = termRef.current?.element.querySelector("textarea");
-    if (ta instanceof HTMLElement) ta.focus();
+    if (ta instanceof HTMLElement) {
+      ta.focus();
+      return true;
+    }
+    return false;
   }, [termRef]);
 
   // Cmd+` shortcut focuses this terminal when "paired" is the dispatched
-  // target. While the right panel is collapsed this component is unmounted,
-  // so the shortcut handler stashes the intent and we consume it on first
-  // ready render after expanding.
+  // target. The component might be mounted but its PTY not yet ready (the
+  // initial ensureTerminal round-trip), in which case focusSelf() can't
+  // find a textarea, so we latch the intent for the ready-effect below.
+  // While the right panel is collapsed this component is unmounted entirely;
+  // App.tsx sets the latch directly in that case.
   useEffect(() => {
     const onFocusEvent = (e: Event) => {
       const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
       if (detail?.target !== "paired") return;
-      focusSelf();
+      if (!focusSelf()) setPendingTerminalFocus("paired");
     };
     window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
     return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -7,6 +7,11 @@ import { BackToLiveButton } from "./BackToLiveButton";
 import { KeyboardFab } from "./KeyboardFab";
 import { ensureTerminal } from "../lib/api";
 import type { RichDiffFile, SessionResponse } from "../lib/types";
+import {
+  FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  type FocusTerminalDetail,
+} from "../lib/terminalFocus";
 import "@wterm/dom/css";
 
 const VSPLIT_STORAGE_KEY = "aoe-right-vsplit";
@@ -152,6 +157,30 @@ function PairedTerminal({
     }
     activate();
   }, [termRef, keyboardOpen, activate]);
+
+  const focusSelf = useCallback(() => {
+    const ta = termRef.current?.element.querySelector("textarea");
+    if (ta instanceof HTMLElement) ta.focus();
+  }, [termRef]);
+
+  // Cmd+` shortcut focuses this terminal when "paired" is the dispatched
+  // target. While the right panel is collapsed this component is unmounted,
+  // so the shortcut handler stashes the intent and we consume it on first
+  // ready render after expanding.
+  useEffect(() => {
+    const onFocusEvent = (e: Event) => {
+      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
+      if (detail?.target !== "paired") return;
+      focusSelf();
+    };
+    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+  }, [focusSelf]);
+
+  useEffect(() => {
+    if (!ready) return;
+    if (consumePendingTerminalFocus("paired")) focusSelf();
+  }, [ready, focusSelf]);
 
   if (!ready) {
     return (

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -224,6 +224,7 @@ function PairedTerminal({
         </div>
       )}
       <div
+        data-term="paired"
         className={`flex-1 overflow-hidden bg-surface-950 relative md:rounded-lg term-panel${termFocused ? " term-focused" : ""}`}
         onFocus={() => setTermFocused(true)}
         onBlur={() => setTermFocused(false)}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -12,6 +12,10 @@ import { BackToLiveButton } from "./BackToLiveButton";
 import { KeyboardFab } from "./KeyboardFab";
 import { ensureSession } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
+import {
+  FOCUS_TERMINAL_EVENT,
+  type FocusTerminalDetail,
+} from "../lib/terminalFocus";
 import "@wterm/dom/css";
 
 interface Props {
@@ -182,6 +186,18 @@ export function TerminalView({ session }: Props) {
       document.removeEventListener("scroll", onScroll, true);
       cancelAnimationFrame(raf);
     };
+  }, [termRef]);
+
+  // Cmd+` shortcut focuses this terminal when "agent" is the dispatched target.
+  useEffect(() => {
+    const onFocusEvent = (e: Event) => {
+      const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
+      if (detail?.target !== "agent") return;
+      const ta = termRef.current?.element.querySelector("textarea");
+      if (ta instanceof HTMLElement) ta.focus();
+    };
+    window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
+    return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
   }, [termRef]);
 
   // On initial connect, auto-open the keyboard.

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -322,6 +322,7 @@ export function TerminalView({ session }: Props) {
       )}
 
       <div
+        data-term="agent"
         className={`flex-1 overflow-hidden bg-surface-950 relative md:rounded-lg term-panel${termFocused ? " term-focused" : ""}`}
         onFocus={() => setTermFocused(true)}
         onBlur={() => setTermFocused(false)}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -14,6 +14,8 @@ import { ensureSession } from "../lib/api";
 import type { SessionResponse } from "../lib/types";
 import {
   FOCUS_TERMINAL_EVENT,
+  consumePendingTerminalFocus,
+  setPendingTerminalFocus,
   type FocusTerminalDetail,
 } from "../lib/terminalFocus";
 import "@wterm/dom/css";
@@ -188,17 +190,33 @@ export function TerminalView({ session }: Props) {
     };
   }, [termRef]);
 
+  // Returns true if focus was applied. Mirrors PairedTerminal so the same
+  // pending-latch fallback covers both terminals when the wterm hasn't
+  // mounted yet (ensureSession round-trip on a fresh session).
+  const focusSelf = useCallback(() => {
+    const ta = termRef.current?.element.querySelector("textarea");
+    if (ta instanceof HTMLElement) {
+      ta.focus();
+      return true;
+    }
+    return false;
+  }, [termRef]);
+
   // Cmd+` shortcut focuses this terminal when "agent" is the dispatched target.
   useEffect(() => {
     const onFocusEvent = (e: Event) => {
       const detail = (e as CustomEvent<FocusTerminalDetail>).detail;
       if (detail?.target !== "agent") return;
-      const ta = termRef.current?.element.querySelector("textarea");
-      if (ta instanceof HTMLElement) ta.focus();
+      if (!focusSelf()) setPendingTerminalFocus("agent");
     };
     window.addEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
     return () => window.removeEventListener(FOCUS_TERMINAL_EVENT, onFocusEvent);
-  }, [termRef]);
+  }, [focusSelf]);
+
+  useEffect(() => {
+    if (ensureState !== "ready") return;
+    if (consumePendingTerminalFocus("agent")) focusSelf();
+  }, [ensureState, focusSelf]);
 
   // On initial connect, auto-open the keyboard.
   useEffect(() => {

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,7 @@ interface ShortcutActions {
   onPalette: () => void;
   onToggleSidebar: () => void;
   onToggleRightPanel: () => void;
+  onToggleTerminalFocus: () => void;
 }
 
 /**
@@ -38,6 +39,15 @@ export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
         e.preventDefault();
         e.stopPropagation();
         actions.onPalette();
+        return;
+      }
+
+      // Toggle terminal focus: Cmd+` (Mac) / Ctrl+` (other), works everywhere.
+      // Use e.code so layouts where backtick lives behind a modifier still match.
+      if (mod && !e.shiftKey && !e.altKey && e.code === "Backquote") {
+        e.preventDefault();
+        e.stopPropagation();
+        actions.onToggleTerminalFocus();
         return;
       }
 

--- a/web/src/hooks/useKeyboardShortcuts.ts
+++ b/web/src/hooks/useKeyboardShortcuts.ts
@@ -44,9 +44,11 @@ export function useKeyboardShortcuts(getActions: () => ShortcutActions) {
 
       // Toggle terminal focus: Cmd+` (Mac) / Ctrl+` (other), works everywhere.
       // Use e.code so layouts where backtick lives behind a modifier still match.
+      // No stopPropagation: preventDefault is enough to suppress the browser's
+      // own Cmd+` window cycling, and we don't want to silently shadow other
+      // doc-level listeners that might want this combo.
       if (mod && !e.shiftKey && !e.altKey && e.code === "Backquote") {
         e.preventDefault();
-        e.stopPropagation();
         actions.onToggleTerminalFocus();
         return;
       }

--- a/web/src/lib/terminalFocus.test.ts
+++ b/web/src/lib/terminalFocus.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  consumePendingTerminalFocus,
+  setPendingTerminalFocus,
+} from "./terminalFocus";
+
+describe("terminalFocus pending intent", () => {
+  beforeEach(() => {
+    // Drain any leftover pending intent between tests.
+    consumePendingTerminalFocus("agent");
+    consumePendingTerminalFocus("paired");
+  });
+
+  it("consumePendingTerminalFocus only fires once per set", () => {
+    setPendingTerminalFocus("paired");
+    expect(consumePendingTerminalFocus("paired")).toBe(true);
+    expect(consumePendingTerminalFocus("paired")).toBe(false);
+  });
+
+  it("consumePendingTerminalFocus does not match a different target", () => {
+    setPendingTerminalFocus("paired");
+    expect(consumePendingTerminalFocus("agent")).toBe(false);
+    // The pending intent is still there for the right target.
+    expect(consumePendingTerminalFocus("paired")).toBe(true);
+  });
+
+  it("setting a new target overwrites the previous pending intent", () => {
+    setPendingTerminalFocus("paired");
+    setPendingTerminalFocus("agent");
+    expect(consumePendingTerminalFocus("paired")).toBe(false);
+    expect(consumePendingTerminalFocus("agent")).toBe(true);
+  });
+});

--- a/web/src/lib/terminalFocus.ts
+++ b/web/src/lib/terminalFocus.ts
@@ -1,0 +1,35 @@
+export const FOCUS_TERMINAL_EVENT = "aoe:focus-terminal";
+
+export type TerminalFocusTarget = "agent" | "paired";
+
+export interface FocusTerminalDetail {
+  target: TerminalFocusTarget;
+}
+
+export function dispatchFocusTerminal(target: TerminalFocusTarget) {
+  window.dispatchEvent(
+    new CustomEvent<FocusTerminalDetail>(FOCUS_TERMINAL_EVENT, {
+      detail: { target },
+    }),
+  );
+}
+
+// When the right panel is collapsed, the paired terminal is unmounted, so
+// dispatching a focus event before the panel re-renders has no listener to
+// receive it. The shortcut handler stashes the intent here, and PairedTerminal
+// consumes it once it mounts and its PTY becomes ready.
+let pendingFocus: TerminalFocusTarget | null = null;
+
+export function setPendingTerminalFocus(target: TerminalFocusTarget) {
+  pendingFocus = target;
+}
+
+export function consumePendingTerminalFocus(
+  target: TerminalFocusTarget,
+): boolean {
+  if (pendingFocus === target) {
+    pendingFocus = null;
+    return true;
+  }
+  return false;
+}

--- a/web/tests/terminal-focus-shortcut.spec.ts
+++ b/web/tests/terminal-focus-shortcut.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockTerminalApis } from "./helpers/terminal-mocks";
+
+// Desktop viewport so the right diff/shell panel mounts inline (collapse
+// default is window.innerWidth < 768).
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+async function openSession(page: Page) {
+  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  // ContentSplit renders the right pane twice (desktop inline + mobile
+  // overlay), so two PairedTerminal instances mount. Plus the agent.
+  await expect(page.locator('[data-term="agent"]')).toHaveCount(1);
+  await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
+  // Both terminals must finish their ensureSession / ensureTerminal
+  // round-trips before the wterm textarea exists for focus.
+  await expect(page.locator('[data-term="agent"] .wterm')).toBeVisible();
+  await expect(page.locator('[data-term="paired"] .wterm').first()).toBeVisible();
+}
+
+// Returns "agent", "paired", or null based on which panel currently
+// contains document.activeElement.
+async function focusedPanel(page: Page): Promise<"agent" | "paired" | null> {
+  return page.evaluate(() => {
+    const active = document.activeElement;
+    if (!active) return null;
+    if (document.querySelector('[data-term="agent"]')?.contains(active)) {
+      return "agent";
+    }
+    const paired = document.querySelectorAll('[data-term="paired"]');
+    for (const p of paired) {
+      if (p.contains(active)) return "paired";
+    }
+    return null;
+  });
+}
+
+// Focus the wterm textarea inside the panel matching the data-term value.
+// On desktop the visible paired panel is the one inside the `hidden md:flex`
+// wrapper; .first() picks the desktop instance (its wrapper is rendered
+// before the mobile one in JSX order).
+async function focusPanel(page: Page, kind: "agent" | "paired") {
+  await page
+    .locator(`[data-term="${kind}"]`)
+    .first()
+    .locator("textarea")
+    .focus();
+}
+
+test.describe("Cmd/Ctrl+` toggles terminal focus", () => {
+  test("toggles between agent and paired with the right panel open", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page);
+
+    // Anchor focus in the agent terminal so the toggle direction is
+    // deterministic.
+    await focusPanel(page, "agent");
+    await expect.poll(() => focusedPanel(page)).toBe("agent");
+
+    // Cmd+` (Control here; the handler accepts metaKey OR ctrlKey off-Mac,
+    // and Linux Chromium reports navigator.platform = Linux).
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedPanel(page)).toBe("paired");
+
+    // And back the other way.
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedPanel(page)).toBe("agent");
+  });
+
+  test("focuses paired terminal when nothing is focused yet", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page);
+
+    // No explicit focus — document.activeElement is the body. The handler
+    // treats "not in agent" as the toggle source, so the first press lands
+    // focus in the paired panel.
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedPanel(page)).toBe("paired");
+  });
+
+  test("expands collapsed right panel and focuses paired terminal", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page);
+
+    // Collapse the right panel via the existing Ctrl+Alt+B shortcut, which
+    // unmounts all PairedTerminal instances.
+    await page.keyboard.press("Control+Alt+b");
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(0);
+
+    // Focus the agent terminal so the toggle target becomes "paired".
+    await focusPanel(page, "agent");
+    await expect.poll(() => focusedPanel(page)).toBe("agent");
+
+    // Press Cmd+` — sets the pending-focus latch, expands the right
+    // panel, and once PairedTerminal mounts + ensureTerminal resolves,
+    // the latch is consumed and focus moves to paired.
+    await page.keyboard.press("Control+`");
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
+    await expect.poll(() => focusedPanel(page)).toBe("paired");
+  });
+});

--- a/web/tests/terminal-focus-shortcut.spec.ts
+++ b/web/tests/terminal-focus-shortcut.spec.ts
@@ -1,25 +1,20 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockTerminalApis } from "./helpers/terminal-mocks";
+import { mkdirSync } from "node:fs";
 
-// Desktop viewport so the right diff/shell panel mounts inline (collapse
-// default is window.innerWidth < 768).
-test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+const SHOTS_DIR = "../target/focus-shortcut-screenshots";
+mkdirSync(SHOTS_DIR, { recursive: true });
+async function shot(page: Page, name: string) {
+  await page.screenshot({ path: `${SHOTS_DIR}/${name}` });
+}
 
 async function openSession(page: Page) {
   await page.locator('button:has-text("pinch-test")').nth(1).click();
-  // ContentSplit renders the right pane twice (desktop inline + mobile
-  // overlay), so two PairedTerminal instances mount. Plus the agent.
   await expect(page.locator('[data-term="agent"]')).toHaveCount(1);
-  await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
-  // Both terminals must finish their ensureSession / ensureTerminal
-  // round-trips before the wterm textarea exists for focus.
   await expect(page.locator('[data-term="agent"] .wterm')).toBeVisible();
-  await expect(page.locator('[data-term="paired"] .wterm').first()).toBeVisible();
 }
 
-// Returns "agent", "paired", or null based on which panel currently
-// contains document.activeElement.
-async function focusedPanel(page: Page): Promise<"agent" | "paired" | null> {
+async function focusedKind(page: Page): Promise<"agent" | "paired" | null> {
   return page.evaluate(() => {
     const active = document.activeElement;
     if (!active) return null;
@@ -34,76 +29,273 @@ async function focusedPanel(page: Page): Promise<"agent" | "paired" | null> {
   });
 }
 
-// Focus the wterm textarea inside the panel matching the data-term value.
-// On desktop the visible paired panel is the one inside the `hidden md:flex`
-// wrapper; .first() picks the desktop instance (its wrapper is rendered
-// before the mobile one in JSX order).
-async function focusPanel(page: Page, kind: "agent" | "paired") {
-  await page
-    .locator(`[data-term="${kind}"]`)
-    .first()
-    .locator("textarea")
-    .focus();
+async function focusKind(page: Page, kind: "agent" | "paired") {
+  const target = kind === "paired" ? "paired-visible" : "agent";
+  if (target === "agent") {
+    await page
+      .locator('[data-term="agent"]')
+      .first()
+      .locator("textarea")
+      .focus();
+    return;
+  }
+  // Pick the visible paired panel: on desktop the inline copy
+  // (md:flex), on mobile the slide-in (md:hidden by default desktop).
+  // Filter by visibility so we hit whichever the user would actually use.
+  const visiblePaired = page.locator('[data-term="paired"]:visible').first();
+  await visiblePaired.locator("textarea").focus();
 }
 
-test.describe("Cmd/Ctrl+` toggles terminal focus", () => {
+// Push focus off any panel so we can test the "from outside" behavior.
+async function blurAll(page: Page) {
+  await page.evaluate(() => {
+    const a = document.activeElement as HTMLElement | null;
+    a?.blur?.();
+    document.body.focus();
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────
+//  Desktop scenarios
+// ────────────────────────────────────────────────────────────────────
+test.describe("Cmd/Ctrl+` desktop", () => {
+  test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
   test("toggles between agent and paired with the right panel open", async ({
     page,
-  }) => {
+  }, testInfo) => {
     await mockTerminalApis(page);
     await page.goto("/");
     await openSession(page);
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
 
-    // Anchor focus in the agent terminal so the toggle direction is
-    // deterministic.
-    await focusPanel(page, "agent");
-    await expect.poll(() => focusedPanel(page)).toBe("agent");
+    await focusKind(page, "agent");
+    await expect.poll(() => focusedKind(page)).toBe("agent");
+    await shot(page, "01-agent-focused.png");
 
-    // Cmd+` (Control here; the handler accepts metaKey OR ctrlKey off-Mac,
-    // and Linux Chromium reports navigator.platform = Linux).
     await page.keyboard.press("Control+`");
-    await expect.poll(() => focusedPanel(page)).toBe("paired");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+    await shot(page, "02-paired-focused.png");
 
-    // And back the other way.
     await page.keyboard.press("Control+`");
-    await expect.poll(() => focusedPanel(page)).toBe("agent");
+    await expect.poll(() => focusedKind(page)).toBe("agent");
+    await shot(page, "03-back-to-agent.png");
   });
 
-  test("focuses paired terminal when nothing is focused yet", async ({
+  test("first press from outside any terminal lands in paired (VSCode-like)", async ({
     page,
   }) => {
     await mockTerminalApis(page);
     await page.goto("/");
     await openSession(page);
+    await blurAll(page);
+    await expect.poll(() => focusedKind(page)).toBe(null);
 
-    // No explicit focus — document.activeElement is the body. The handler
-    // treats "not in agent" as the toggle source, so the first press lands
-    // focus in the paired panel.
+    // Semantic match for VSCode's Ctrl+` "open/focus the terminal": from
+    // outside both panes, focus lands in paired (the secondary shell).
     await page.keyboard.press("Control+`");
-    await expect.poll(() => focusedPanel(page)).toBe("paired");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
   });
 
-  test("expands collapsed right panel and focuses paired terminal", async ({
+  test("expands collapsed right panel and focuses paired (latch)", async ({
     page,
-  }) => {
+  }, testInfo) => {
     await mockTerminalApis(page);
     await page.goto("/");
     await openSession(page);
 
-    // Collapse the right panel via the existing Ctrl+Alt+B shortcut, which
-    // unmounts all PairedTerminal instances.
     await page.keyboard.press("Control+Alt+b");
     await expect(page.locator('[data-term="paired"]')).toHaveCount(0);
+    await shot(page, "04-collapsed.png");
 
-    // Focus the agent terminal so the toggle target becomes "paired".
-    await focusPanel(page, "agent");
-    await expect.poll(() => focusedPanel(page)).toBe("agent");
-
-    // Press Cmd+` — sets the pending-focus latch, expands the right
-    // panel, and once PairedTerminal mounts + ensureTerminal resolves,
-    // the latch is consumed and focus moves to paired.
+    await focusKind(page, "agent");
     await page.keyboard.press("Control+`");
     await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
-    await expect.poll(() => focusedPanel(page)).toBe("paired");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+    await shot(page, "05-expanded-paired-focused.png");
+  });
+
+  test("paired latch fires once ensureTerminal resolves (slow paired)", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    // Override the host-shell ensure with a 1500ms delay BEFORE goto.
+    // Routes are matched in reverse registration order, so this wins over
+    // the wildcard inside mockTerminalApis.
+    await page.route("**/api/sessions/*/terminal", async (r) => {
+      await new Promise((res) => setTimeout(res, 1500));
+      await r.fulfill({ status: 200, body: "" });
+    });
+
+    await page.goto("/");
+    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await expect(page.locator('[data-term="agent"]')).toHaveCount(1);
+
+    // Press Cmd+` immediately while paired is still in its "Starting…"
+    // state. focusSelf in PairedTerminal can't find a textarea, so the
+    // listener calls setPendingTerminalFocus("paired").
+    await focusKind(page, "agent");
+    await page.keyboard.press("Control+`");
+
+    // Within 3s the ensureTerminal mock returns, ready flips true,
+    // the consume-on-ready effect fires, focus lands in paired.
+    await expect.poll(() => focusedKind(page), { timeout: 3000 }).toBe("paired");
+  });
+
+  test("agent latch fires once ensureSession resolves (slow agent)", async ({
+    page,
+  }) => {
+    await mockTerminalApis(page);
+    await page.route("**/api/sessions/*/ensure", async (r) => {
+      await new Promise((res) => setTimeout(res, 1500));
+      await r.fulfill({ json: { ok: true } });
+    });
+
+    await page.goto("/");
+    await page.locator('button:has-text("pinch-test")').nth(1).click();
+
+    // Wait for paired to be ready (its ensureTerminal isn't delayed); use
+    // it as the focus source so target=agent.
+    const paired = page.locator('[data-term="paired"]:visible').first();
+    await expect(paired.locator(".wterm")).toBeVisible();
+    await paired.locator("textarea").focus();
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+
+    // Agent terminal still mounted as "Starting session..." so its wterm
+    // textarea doesn't exist yet. Press Cmd+` → target=agent → listener
+    // sets the pending latch.
+    await page.keyboard.press("Control+`");
+
+    // ensureSession resolves, ensureState flips to ready, consume effect
+    // fires, focus lands on agent.
+    await expect.poll(() => focusedKind(page), { timeout: 3000 }).toBe("agent");
+  });
+
+  test("with diff viewer open, Cmd+` to agent closes the diff", async ({
+    page,
+  }, testInfo) => {
+    await mockTerminalApis(page);
+    // Provide one file in the diff list. Don't mock the file content
+    // endpoint — DiffFileViewer can render an error state and the test
+    // only cares about selectedFilePath being set (which hides the agent
+    // wrapper).
+    await page.route("**/api/sessions/*/diff/files", (r) =>
+      r.fulfill({
+        json: {
+          files: [
+            {
+              path: "src/foo.ts",
+              old_path: null,
+              status: "modified",
+              additions: 3,
+              deletions: 1,
+            },
+          ],
+          base_branch: "main",
+          warning: null,
+        },
+      }),
+    );
+
+    await page.goto("/");
+    await openSession(page);
+
+    // Click the file in the diff list.
+    await page.locator('button:has-text("foo.ts")').first().click();
+    // The agent terminal wrapper is now className="hidden". The
+    // [data-term="agent"] node still exists but inside a hidden parent.
+    await shot(page, "06-diff-open.png");
+
+    await focusKind(page, "paired");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+
+    // Press Cmd+` → handler clears selectedFilePath, then rAF-dispatches.
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedKind(page)).toBe("agent");
+    await shot(page, "07-after-toggle-agent.png");
+  });
+
+  test("rapid repeated presses end in a stable state", async ({ page }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page);
+    await focusKind(page, "agent");
+
+    // 11 toggles total = odd flips from agent → paired.
+    for (let i = 0; i < 11; i++) {
+      await page.keyboard.press("Control+`");
+    }
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+  });
+
+  test("term-focused CSS class follows the focused panel", async ({ page }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page);
+
+    await focusKind(page, "agent");
+    await expect(
+      page.locator('[data-term="agent"]').first(),
+    ).toHaveClass(/term-focused/);
+
+    await page.keyboard.press("Control+`");
+    // The visible paired panel should pick up term-focused.
+    await expect(
+      page.locator('[data-term="paired"]:visible').first(),
+    ).toHaveClass(/term-focused/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+//  Mobile scenario — proves the data-term fix
+// ────────────────────────────────────────────────────────────────────
+test.describe("Cmd/Ctrl+` mobile", () => {
+  test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
+
+  test("toggle works correctly on a mobile viewport", async ({ page }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+    // Sidebar is collapsed on mobile by default; open it to access the
+    // session list.
+    await page.getByRole("button", { name: "Toggle sidebar" }).click();
+    await openSession(page);
+
+    // Right panel starts collapsed on mobile; expand it via the existing
+    // shortcut so the slide-in mounts.
+    await page.keyboard.press("Control+Alt+b");
+    await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
+
+    // Focus the visible paired (mobile slide-in). On a mobile viewport
+    // the desktop-inline copy has md:flex hidden, so :visible filters to
+    // the slide-in instance.
+    await focusKind(page, "paired");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedKind(page)).toBe("agent");
+
+    await page.keyboard.press("Control+`");
+    await expect.poll(() => focusedKind(page)).toBe("paired");
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────
+//  Help overlay documents the shortcut
+// ────────────────────────────────────────────────────────────────────
+test.describe("Help overlay", () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test("lists the new Cmd+` shortcut row", async ({ page }) => {
+    await mockTerminalApis(page);
+    await page.goto("/");
+
+    // Open the help overlay via the TopBar "More options" menu rather than
+    // pressing "?" — synthetic key events for `?` proved finicky across
+    // keyboard layouts and the menu path is what users actually use.
+    await page.getByRole("button", { name: "More options" }).click();
+    await page.getByRole("menuitem", { name: "Help" }).click();
+
+    const row = page.getByText("Toggle agent / shell terminal focus");
+    await expect(row).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description

Adds a VSCode-style **Cmd/Ctrl+`** shortcut that toggles focus between the agent terminal (left pane) and the shell terminal (right pane) in the web dashboard. This brings TUI parity for keyboard-driven users who were asking for `t` / `c` on the web (#833) — but matched to the web layout, where the two terminals are split spatially rather than swapped in place.

When the right panel is collapsed, the shortcut expands it and focuses the paired terminal once its PTY becomes ready. A small module-level pending-focus latch handles the unmount → mount gap, since the shortcut handler can't dispatch to a listener that doesn't exist yet.

The shortcut works regardless of input focus (like `Cmd+K`), and uses `e.code === "Backquote"` so non-US keyboard layouts (where backtick lives behind a modifier) still match.

Fixes #833

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

UI changes here are a keyboard shortcut with no visual surface beyond the new HelpOverlay row; happy to record one if reviewers want.

### Verification

- `npx tsc -b` clean
- `npx vitest run src/lib/` → 11 passed (3 new in `terminalFocus.test.ts`)
- `npm run lint` → 18 pre-existing problems before/after; no new lint errors in modified files
- `npm run build` clean
- Pre-commit hook (`cargo build`, `cargo fmt --check`) passed

### Manual test plan

- Open a session in the web dashboard with the right panel expanded; press Cmd+\` (Mac) / Ctrl+\` (Linux/Win): focus moves from agent terminal → shell terminal.
- Press Cmd+\` again: focus moves shell → agent.
- Collapse the right panel, then press Cmd+\`: panel expands, shell terminal gets focus once it's ready.
- With focus already in shell, collapsing then re-pressing returns focus to the now-mounted agent.
- Press Cmd+K (palette) and Cmd+B (sidebar) to confirm no regression on the existing global shortcuts.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-7, 1M context), via the `/fix-github-issue` skill

**Any Additional AI Details you'd like to share:** Issue context and the owner's narrowed scope from the comment thread were used to design the focus-toggle behavior; implementation followed existing patterns in `useKeyboardShortcuts.ts` (e.code-based detection, `mod` modifier helper, works-everywhere-vs-input-only split).

- [x] I am an AI Agent filling out this form (check box if true)