### PR TITLE
fix(web): cancel momentum decay on exitScrollback

### DIFF
--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -82,6 +82,10 @@ export function useTerminal(
   // Populated inside the effect; `exitScrollback()` uses it to reset the
   // mobile scroll-depth counter when the user escapes copy-mode.
   const resetScrollbackDepthRef = useRef<(() => void) | null>(null);
+  // Populated inside the effect; `exitScrollback()` uses it to cancel any
+  // in-flight momentum decay so post-flick wheel-ups don't immediately
+  // re-enter scrollback after the user taps "Back to live".
+  const cancelMomentumRef = useRef<(() => void) | null>(null);
   // Mirror of state.isInScrollback so the resize callback (which lives
   // inside the WTerm options closure) can read the latest value without
   // re-creating the terminal. Updated by an effect below.
@@ -739,6 +743,7 @@ export function useTerminal(
         momentumRaf = null;
       }
     };
+    cancelMomentumRef.current = cancelMomentum;
 
     const onTouchStart = (e: TouchEvent) => {
       cancelMomentum();
@@ -1065,6 +1070,11 @@ export function useTerminal(
   // auto-resumes on disconnect as a safety net, so forgetting this is
   // annoying but not permanent.
   const exitScrollback = useCallback(() => {
+    // Cancel any in-flight momentum decay first. Otherwise a tap that
+    // lands while a fast flick is still emitting wheel-ups would let the
+    // next decay frame call sendWheel("up", ...), which re-sets
+    // isInScrollback: true and the button reappears.
+    cancelMomentumRef.current?.();
     const ws = wsRef.current;
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -132,6 +132,56 @@ test.describe("Mobile scrollback exit", () => {
       .toBe(true);
   });
 
+  test("button stays hidden after tap even with in-flight momentum", async ({
+    page,
+  }) => {
+    // Regression: a fast swipe pegs momentum velocity at MAX_VELOCITY,
+    // and the requestAnimationFrame decay keeps emitting wheel-ups for
+    // hundreds of ms after touchend. If exitScrollback doesn't cancel
+    // that momentum, the next decay frame calls sendWheel("up") and
+    // re-flips isInScrollback: true — the button reappears mid-poll.
+    await installTerminalSpies(page);
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { mobileFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+
+    // Aggressive swipe: large per-step dy (75px) saturates velocity at
+    // MAX_VELOCITY=2.0 px/ms even when synthetic touchmoves arrive tens
+    // of ms apart (Playwright IPC roundtrip). Without saturation, slow
+    // local environments wouldn't generate enough momentum to repro.
+    const cx = 160;
+    let cy = 600;
+    await fireTouches(page, "touchstart", [{ x: cx, y: cy }]);
+    const steps = 8;
+    const travel = 600;
+    for (let i = 1; i <= steps; i++) {
+      cy = 600 - (i * travel) / steps;
+      await fireTouches(page, "touchmove", [{ x: cx, y: cy }]);
+    }
+    await fireTouches(page, "touchend", []);
+
+    const btn = page.getByRole("button", { name: "Back to live" });
+    await expect(btn).toBeVisible();
+
+    // Click immediately, while momentum is still decaying.
+    await btn.click();
+    const upsAtClick = countSeq(handle, WHEEL_UP_SEQ);
+
+    // Button must stay gone across the full momentum window (~700ms +
+    // slack). toHaveCount with timeout would pass on the first frame; we
+    // need to verify it stays at 0 across multiple animation frames.
+    for (let i = 0; i < 10; i++) {
+      await page.waitForTimeout(100);
+      await expect(btn).toHaveCount(0);
+    }
+
+    // And no additional wheel-ups should have been emitted after exit
+    // (would prove momentum kept running and would re-enter scrollback).
+    expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(upsAtClick);
+  });
+
   test("scroll-down clamp: fewer wheel-downs sent than wheel-ups", async ({
     page,
   }) => {

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -139,7 +139,7 @@ test.describe("Mobile scrollback exit", () => {
     // and the requestAnimationFrame decay keeps emitting wheel-ups for
     // hundreds of ms after touchend. If exitScrollback doesn't cancel
     // that momentum, the next decay frame calls sendWheel("up") and
-    // re-flips isInScrollback: true — the button reappears mid-poll.
+    // re-flips isInScrollback: true, so the button reappears mid-poll.
     await installTerminalSpies(page);
     const handle = await mockTerminalApis(page);
     await page.goto("/");


### PR DESCRIPTION
## Description

The CI Playwright run on commit 942ffb6 hit a flaky failure in `web/tests/scrollback-exit.spec.ts:75` ("Mobile scrollback exit > button appears after swipe-up and sends Escape on tap"). After tapping "Back to live", the test expected the button to disappear within 5s, but it stayed visible for the full timeout (the failure log shows `9 × locator resolved to 1 element`).

**Root cause:** a race between `exitScrollback` and the touch-momentum decay loop in `useTerminal`. When the user (or test) flicks fast, `onTouchEnd` kicks off a `requestAnimationFrame`-driven decay that keeps emitting wheel-up sequences for ~700 ms. Each decay frame calls `sendWheel("up", ...)`, which unconditionally `setState`s `isInScrollback: true`. If the user taps "Back to live" while momentum is still in flight, `exitScrollback` flips the state to `false` but the next decay frame flips it right back, so the button reappears and the user is stuck in scrollback until momentum naturally decays. This is also a real-user UX bug on a real device after a fast flick, not just a test flake.

**Fix:** expose `cancelMomentum` via a ref (mirroring the existing `resetScrollbackDepthRef` pattern) and call it from `exitScrollback` before the Escape send. This guarantees no further wheel events are synthesized after an explicit exit.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(No visible UI change — same button, same behavior on click; this just makes the click reliable when momentum is still in flight.)

### Tests

- `cd web && npx tsc -b` — clean
- `cd web && npx eslint src/hooks/useTerminal.ts tests/scrollback-exit.spec.ts` — clean
- `cd web && npx playwright test` — 96 passed, 2 skipped
- New regression test (`scrollback-exit.spec.ts:135`, "button stays hidden after tap even with in-flight momentum") explicitly asserts that no further wheel-up sequences are emitted after `exitScrollback`, across the full ~700 ms momentum window.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**
Diagnosis and fix were produced by an AI agent investigating the failed CI run on `main` (commit 942ffb6). Local Playwright reruns confirmed the fix doesn't regress the existing suite; the local environment didn't reliably reproduce the CI race (different IPC/scheduler timing — the same gotcha noted in `AGENTS.md`'s Playwright recipe), so the regression test is a contract check rather than a guaranteed local repro.

- [x] I am an AI Agent filling out this form (check box if true)