### PR TITLE
fix(cli): use 'aoe' instead of 'agent-of-empires' in CLI hints

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -477,11 +477,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     } else {
         println!();
         println!("Next steps:");
-        println!(
-            "  agent-of-empires session start {}   # Start the session",
-            final_title
-        );
-        println!("  agent-of-empires                         # Open TUI and press Enter to attach");
+        println!("  aoe session start {}   # Start the session", final_title);
+        println!("  aoe                         # Open TUI and press Enter to attach");
     }
 
     Ok(())

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -100,7 +100,7 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
         let all_groups = group_tree.get_all_groups();
         if all_groups.is_empty() {
             println!("No groups found.");
-            println!("Create one with: agent-of-empires group create <name>");
+            println!("Create one with: aoe group create <name>");
             return Ok(());
         }
 

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -70,7 +70,7 @@ async fn list_profiles() -> Result<()> {
 
     if profiles.is_empty() {
         println!("No profiles found.");
-        println!("Run 'agent-of-empires' to create the default profile automatically.");
+        println!("Run 'aoe' to create the default profile automatically.");
         return Ok(());
     }
 
@@ -90,7 +90,7 @@ async fn list_profiles() -> Result<()> {
 async fn create_profile(name: &str) -> Result<()> {
     session::create_profile(name)?;
     println!("✓ Created profile: {}", name);
-    println!("  Use with: agent-of-empires -p {}", name);
+    println!("  Use with: aoe -p {}", name);
     Ok(())
 }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -237,7 +237,7 @@ async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     if !tmux_session.exists() {
         bail!(
-            "Session is not running. Start it first with: agent-of-empires session start {}",
+            "Session is not running. Start it first with: aoe session start {}",
             args.identifier
         );
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -307,7 +307,7 @@ impl HomeView {
                 Line::from("No sessions yet").style(Style::default().fg(theme.dimmed)),
                 Line::from(""),
                 Line::from("Press 'n' to create one").style(Style::default().fg(theme.hint)),
-                Line::from("or 'agent-of-empires add .'").style(Style::default().fg(theme.hint)),
+                Line::from("or 'aoe add .'").style(Style::default().fg(theme.hint)),
             ];
             let para = Paragraph::new(empty_text).alignment(Alignment::Center);
             frame.render_widget(para, inner);

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -46,6 +46,34 @@ fn test_cli_add_and_list() {
     );
 }
 
+/// Regression test for #848: `aoe add` "Next steps" hint should reference
+/// the actual binary name (`aoe`), not the long project name.
+#[test]
+#[serial]
+fn test_cli_add_next_steps_uses_aoe_binary_name() {
+    let h = TuiTestHarness::new("cli_add_next_steps_name");
+    let project = h.project_path();
+
+    let add_output = h.run_cli(&["add", project.to_str().unwrap(), "-t", "NextStepsName"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add_output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&add_output.stdout);
+    assert!(
+        stdout.contains("aoe session start NextStepsName"),
+        "expected 'aoe session start' hint in next steps.\nOutput:\n{}",
+        stdout
+    );
+    assert!(
+        !stdout.contains("agent-of-empires session start"),
+        "next steps should not reference the old 'agent-of-empires' name.\nOutput:\n{}",
+        stdout
+    );
+}
+
 #[test]
 #[serial]
 fn test_cli_add_invalid_path() {


### PR DESCRIPTION
## Description

The "Next steps" output after `aoe add` told users to run `agent-of-empires session start ...`, but the binary is named `aoe`. While auditing the codebase for similar issues per the issue's "scrub for others" request, found the same stale reference in five other user-facing strings.

**User-facing strings updated:**
- `src/cli/add.rs` — both "Next steps" hints (the exact ones reported)
- `src/cli/session.rs` — `bail!` message in `session attach` when the session is not running
- `src/cli/profile.rs` — empty-profile-list hint and "Use with: ... -p NAME" after `profile create`
- `src/cli/group.rs` — empty-group-list hint
- `src/tui/home/render.rs` — TUI empty-state hint when there are no sessions

Other `agent-of-empires` references in `src/` were left alone because they refer to the actual config directory (`.agent-of-empires/`), GitHub URLs, or HTTP user-agent strings.

Adds an e2e regression test (`test_cli_add_next_steps_uses_aoe_binary_name`) that asserts `aoe add` stdout contains the new hint and not the old name.

Fixes #848

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace --lib` (1446 passed), and `cargo test --test e2e cli::` (16 passed) all clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Used Claude Code to grep for stale references and make the edits; reviewed the diff and ran the full test suite.

- [x] I am an AI Agent filling out this form (check box if true)