### PR TITLE
feat(api): POST /sessions/{id}/send + GET /sessions/{id}/output

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,113 @@
+# HTTP API Reference
+
+`aoe serve` exposes a small HTTP API so external orchestrators (other
+agents, MCP tools, CI scripts) can drive sessions without attaching to
+a terminal. This page documents the orchestration endpoints. The web
+dashboard uses the same API surface plus additional internal routes.
+
+## Authentication
+
+All endpoints require a token unless the server was started with
+`--no-auth`. The token is the one printed by `aoe serve` (or visible
+in the TUI's Serve panel). Three transports are accepted:
+
+| Transport | Example |
+| --- | --- |
+| Bearer header (recommended for clients) | `Authorization: Bearer <token>` |
+| Query parameter | `?token=<token>` |
+| Cookie | `aoe_token=<token>` (set automatically by the dashboard) |
+
+Read-only mode (`aoe serve --read-only`) blocks every write endpoint
+with `403 read_only`. Read endpoints work normally.
+
+## POST /api/sessions/{id}/send
+
+Type a message into the agent and press Enter, the same way the TUI's
+send-message dialog and the `aoe send` CLI do. Honors the per-agent
+paste-burst delay (e.g. Codex needs ~150 ms between text and Enter so
+its burst-detection window expires before Enter arrives).
+
+**Request body** (JSON)
+
+```json
+{ "message": "review the diff and pick the smallest fix" }
+```
+
+`message` is sent literally. Newlines inside the string are sent as
+shift-Enter (line break in the agent's input box) and a final Enter
+submits the whole message.
+
+**Responses**
+
+| Status | Body | When |
+| --- | --- | --- |
+| `200` | `{"sent": true}` | Keys delivered to the tmux pane |
+| `400` | `{"error": "message_empty"}` | `message` is empty or whitespace-only |
+| `403` | `{"error": "read_only"}` | Server is in read-only mode |
+| `404` | `{"error": "not_found"}` | No session with that id |
+| `409` | `{"error": "session_not_running"}` | Session exists but the tmux pane is gone |
+| `500` | `{"error": "tmux_error"}` or `{"error": "internal"}` | Unexpected failure (logged server-side) |
+
+Concurrent POSTs to the same `id` are serialized server-side, so two
+orchestrators racing on the same session won't interleave keystrokes
+inside the pane. Concurrent POSTs to *different* ids run in parallel.
+
+**Example**
+
+```bash
+curl -sS -X POST \
+  -H "Authorization: Bearer $AOE_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"summarize the failing test"}' \
+  "http://localhost:7777/api/sessions/abc123/send"
+```
+
+## GET /api/sessions/{id}/output
+
+Snapshot of the session's tmux pane. Use this after `send` to read
+what the agent printed back, or as a polling read-only view.
+
+**Query parameters**
+
+| Name | Default | Notes |
+| --- | --- | --- |
+| `lines` | `200` | Number of trailing lines to capture. Clamped to `1..=2000`. |
+| `format` | `text` | `text` strips ANSI escape sequences. `ansi` returns the raw pane bytes (use this if your client renders color). |
+
+**Responses**
+
+| Status | Body | When |
+| --- | --- | --- |
+| `200` | `{"id": "...", "lines": N, "format": "text", "content": "..."}` | Pane captured |
+| `400` | `{"error": "format_invalid", "allowed": ["text", "ansi"]}` | `format` was something other than `text` or `ansi` |
+| `404` | `{"error": "not_found"}` | No session with that id |
+| `409` | `{"error": "session_not_running"}` | Session exists but the tmux pane is gone |
+| `500` | `{"error": "tmux_error"}` or `{"error": "internal"}` | Unexpected failure |
+
+`output` does not require write access, so it works under
+`--read-only`.
+
+**Example**
+
+```bash
+curl -sS \
+  -H "Authorization: Bearer $AOE_TOKEN" \
+  "http://localhost:7777/api/sessions/abc123/output?lines=80&format=text"
+```
+
+## Driving a session as a subagent
+
+Together, `send` and `output` are the minimum primitive needed to run
+an aoe session as a controlled subagent. A typical loop:
+
+1. `POST /api/sessions/{id}/send` with the prompt.
+2. Poll `GET /api/sessions/{id}/output` until the pane content
+   stabilizes (no change between two reads spaced ~1 s apart) or the
+   session list shows the session's `status` back at `Idle`.
+3. Capture the trailing region of `content` as the agent's reply.
+
+For long-running prompts, prefer polling status via
+`GET /api/sessions` over polling `output`, then read `output` once
+when status returns to `Idle`. Status transitions are also broadcast
+to push subscribers if the dashboard's push notifications are
+configured.

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -174,7 +174,7 @@ aoe serve --daemon
 
 The server embeds an axum web server that serves a React frontend and provides:
 
-- REST API for session listing and control (`/api/sessions`)
+- REST API for session listing and control (`/api/sessions`); see the [HTTP API Reference](../api.md) for the orchestration endpoints (`send`, `output`)
 - WebSocket PTY relay for terminal streaming (`/sessions/:id/ws`)
 - Token-based authentication via cookie, query parameter, or WebSocket protocol header
 - Rate limiting, token rotation, and device tracking

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -17,8 +17,9 @@ mod system;
 pub use git::{clone_repo, list_branches};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
-    list_sessions, rename_session, session_diff_file, session_diff_files,
-    update_session_notifications, CleanupDefaults, SessionResponse,
+    list_sessions, read_output, rename_session, send_message, session_diff_file,
+    session_diff_files, update_session_notifications, CleanupDefaults, OutputQuery,
+    SendMessageRequest, SessionResponse,
 };
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1532,3 +1532,225 @@ mod tests {
         assert!(ok.is_ok(), "expected Ok, got {:?}", ok);
     }
 }
+
+// ============================================================================
+// Send + read-output endpoints
+//
+// Together these are the minimum primitive an external orchestrator needs to
+// run an aoe session as a controlled subagent: push a prompt in, read the
+// pane back. Mirrors what the TUI's send-message dialog and pane preview do,
+// without requiring keyboard or websocket attach.
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct SendMessageRequest {
+    pub message: String,
+}
+
+pub async fn send_message(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(req): Json<SendMessageRequest>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({"error": "read_only"})),
+        )
+            .into_response();
+    }
+
+    if req.message.trim().is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "message_empty"})),
+        )
+            .into_response();
+    }
+
+    let instances = state.instances.read().await;
+    let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found"})),
+        )
+            .into_response();
+    };
+    drop(instances);
+
+    let tool = instance.tool.clone();
+    let message = req.message;
+    let send_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
+        let tmux_session = instance.tmux_session()?;
+        if !tmux_session.exists() {
+            anyhow::bail!("session_not_running");
+        }
+        let delay = crate::agents::send_keys_enter_delay(&tool);
+        tmux_session.send_keys_with_delay(&message, delay)?;
+        Ok(())
+    })
+    .await;
+
+    match send_result {
+        Ok(Ok(())) => {
+            // Stamp last_accessed_at so the activity column reflects API-driven
+            // interaction the same way TUI/web interaction does.
+            let mut instances = state.instances.write().await;
+            if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                i.touch_last_accessed();
+            }
+            // Best-effort persist; tmux send already succeeded so a save miss
+            // shouldn't fail the whole call.
+            let profile = state.profile.clone();
+            let snapshot: Vec<Instance> = instances.clone();
+            drop(instances);
+            tokio::task::spawn_blocking(move || {
+                if let Ok(storage) = Storage::new(&profile) {
+                    if let Err(e) = storage.save(&snapshot) {
+                        tracing::warn!("send_message: persist failed: {e}");
+                    }
+                }
+            });
+            (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response()
+        }
+        Ok(Err(e)) => {
+            let msg = e.to_string();
+            if msg.contains("session_not_running") {
+                (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({"error": "session_not_running"})),
+                )
+                    .into_response()
+            } else {
+                tracing::error!("send_message: tmux error for {id}: {e}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "tmux_error"})),
+                )
+                    .into_response()
+            }
+        }
+        Err(e) => {
+            tracing::error!("send_message: blocking task panicked for {id}: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct OutputQuery {
+    #[serde(default = "default_output_lines")]
+    pub lines: u32,
+    #[serde(default = "default_output_format")]
+    pub format: String,
+}
+
+fn default_output_lines() -> u32 {
+    200
+}
+
+fn default_output_format() -> String {
+    "text".to_string()
+}
+
+pub async fn read_output(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    axum::extract::Query(q): axum::extract::Query<OutputQuery>,
+) -> impl IntoResponse {
+    let lines = (q.lines as usize).clamp(1, 2000);
+    let want_ansi = match q.format.as_str() {
+        "ansi" => true,
+        "text" => false,
+        _ => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "format_invalid",
+                    "allowed": ["text", "ansi"]
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let instances = state.instances.read().await;
+    let Some(instance) = instances.iter().find(|i| i.id == id).cloned() else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found"})),
+        )
+            .into_response();
+    };
+    drop(instances);
+
+    let capture_result = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
+        let tmux_session = instance.tmux_session()?;
+        if !tmux_session.exists() {
+            return Ok(String::new());
+        }
+        let raw = tmux_session.capture_pane(lines)?;
+        if want_ansi {
+            Ok(raw)
+        } else {
+            Ok(crate::tmux::utils::strip_ansi(&raw))
+        }
+    })
+    .await;
+
+    match capture_result {
+        Ok(Ok(content)) => (
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "id": id,
+                "lines": lines,
+                "format": q.format,
+                "content": content,
+            })),
+        )
+            .into_response(),
+        Ok(Err(e)) => {
+            tracing::error!("read_output: tmux error for {id}: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "tmux_error"})),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            tracing::error!("read_output: blocking task panicked for {id}: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "internal"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod send_output_tests {
+    use super::*;
+
+    #[test]
+    fn output_query_default_constants() {
+        assert_eq!(default_output_lines(), 200);
+        assert_eq!(default_output_format(), "text");
+    }
+
+    #[test]
+    fn send_message_request_requires_message_field() {
+        let r: Result<SendMessageRequest, _> = serde_json::from_str("{}");
+        assert!(r.is_err(), "missing message must reject");
+    }
+
+    #[test]
+    fn send_message_request_accepts_message() {
+        let r: SendMessageRequest = serde_json::from_str("{\"message\":\"hello\"}").unwrap();
+        assert_eq!(r.message, "hello");
+    }
+}

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1547,6 +1547,11 @@ pub struct SendMessageRequest {
     pub message: String,
 }
 
+enum SendKeysError {
+    NotRunning,
+    Tmux(anyhow::Error),
+}
+
 pub async fn send_message(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1578,15 +1583,24 @@ pub async fn send_message(
     };
     drop(instances);
 
+    // Serialize concurrent sends (and other tmux mutations) for this id.
+    // Without this, two POSTs racing against the same session would issue
+    // overlapping `tmux send-keys -l` invocations and the bytes can interleave
+    // inside the pane.
+    let inst_lock = state.instance_lock(&id).await;
+    let _guard = inst_lock.lock().await;
+
     let tool = instance.tool.clone();
     let message = req.message;
-    let send_result = tokio::task::spawn_blocking(move || -> anyhow::Result<()> {
-        let tmux_session = instance.tmux_session()?;
+    let send_result = tokio::task::spawn_blocking(move || -> Result<(), SendKeysError> {
+        let tmux_session = instance.tmux_session().map_err(SendKeysError::Tmux)?;
         if !tmux_session.exists() {
-            anyhow::bail!("session_not_running");
+            return Err(SendKeysError::NotRunning);
         }
         let delay = crate::agents::send_keys_enter_delay(&tool);
-        tmux_session.send_keys_with_delay(&message, delay)?;
+        tmux_session
+            .send_keys_with_delay(&message, delay)
+            .map_err(SendKeysError::Tmux)?;
         Ok(())
     })
     .await;
@@ -1596,39 +1610,44 @@ pub async fn send_message(
             // Stamp last_accessed_at so the activity column reflects API-driven
             // interaction the same way TUI/web interaction does.
             let mut instances = state.instances.write().await;
-            if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+            let profile = if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
                 i.touch_last_accessed();
-            }
-            // Best-effort persist; tmux send already succeeded so a save miss
-            // shouldn't fail the whole call.
-            let profile = state.profile.clone();
-            let snapshot: Vec<Instance> = instances.clone();
+                i.source_profile.clone()
+            } else {
+                // Session was deleted between the send and the stamp; nothing
+                // left to persist.
+                return (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response();
+            };
+            // Persist only the target session's profile, mirroring the pattern
+            // used by rename/delete. Saving `state.instances` wholesale would
+            // write every profile's sessions into one profile's storage file.
+            let profile_instances: Vec<Instance> = instances
+                .iter()
+                .filter(|i| i.source_profile == profile)
+                .cloned()
+                .collect();
             drop(instances);
             tokio::task::spawn_blocking(move || {
                 if let Ok(storage) = Storage::new(&profile) {
-                    if let Err(e) = storage.save(&snapshot) {
+                    if let Err(e) = storage.save(&profile_instances) {
                         tracing::warn!("send_message: persist failed: {e}");
                     }
                 }
             });
             (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response()
         }
-        Ok(Err(e)) => {
-            let msg = e.to_string();
-            if msg.contains("session_not_running") {
-                (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({"error": "session_not_running"})),
-                )
-                    .into_response()
-            } else {
-                tracing::error!("send_message: tmux error for {id}: {e}");
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": "tmux_error"})),
-                )
-                    .into_response()
-            }
+        Ok(Err(SendKeysError::NotRunning)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "session_not_running"})),
+        )
+            .into_response(),
+        Ok(Err(SendKeysError::Tmux(e))) => {
+            tracing::error!("send_message: tmux error for {id}: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "tmux_error"})),
+            )
+                .into_response()
         }
         Err(e) => {
             tracing::error!("send_message: blocking task panicked for {id}: {e}");
@@ -1655,6 +1674,11 @@ fn default_output_lines() -> u32 {
 
 fn default_output_format() -> String {
     "text".to_string()
+}
+
+enum CaptureError {
+    NotRunning,
+    Tmux(anyhow::Error),
 }
 
 pub async fn read_output(
@@ -1688,12 +1712,14 @@ pub async fn read_output(
     };
     drop(instances);
 
-    let capture_result = tokio::task::spawn_blocking(move || -> anyhow::Result<String> {
-        let tmux_session = instance.tmux_session()?;
+    let capture_result = tokio::task::spawn_blocking(move || -> Result<String, CaptureError> {
+        let tmux_session = instance.tmux_session().map_err(CaptureError::Tmux)?;
         if !tmux_session.exists() {
-            return Ok(String::new());
+            return Err(CaptureError::NotRunning);
         }
-        let raw = tmux_session.capture_pane(lines)?;
+        let raw = tmux_session
+            .capture_pane(lines)
+            .map_err(CaptureError::Tmux)?;
         if want_ansi {
             Ok(raw)
         } else {
@@ -1713,7 +1739,12 @@ pub async fn read_output(
             })),
         )
             .into_response(),
-        Ok(Err(e)) => {
+        Ok(Err(CaptureError::NotRunning)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "session_not_running"})),
+        )
+            .into_response(),
+        Ok(Err(CaptureError::Tmux(e))) => {
             tracing::error!("read_output: tmux error for {id}: {e}");
             (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -707,6 +707,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/sessions/{id}/diff/file", get(api::session_diff_file))
         .route("/api/sessions/{id}/ensure", post(api::ensure_session))
+        .route("/api/sessions/{id}/send", post(api::send_message))
+        .route("/api/sessions/{id}/output", get(api::read_output))
         .route(
             "/api/sessions/{id}/notifications",
             patch(api::update_session_notifications),

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -132,6 +132,13 @@ const PAGES = [
     description:
       "Complete command-line reference for the aoe CLI tool.",
   },
+  {
+    source: "docs/api.md",
+    dest: "docs/api.md",
+    title: "HTTP API Reference",
+    description:
+      "REST endpoints for driving Agent of Empires sessions from external orchestrators.",
+  },
 ];
 
 // Every known docs path → website URL, used for link rewriting.
@@ -144,6 +151,7 @@ const URL_MAP = {
   "docs/development.md": "/docs/development/",
   "docs/guides/configuration.md": "/docs/guides/configuration/",
   "docs/cli/reference.md": "/docs/cli/reference/",
+  "docs/api.md": "/docs/api/",
   // Guides
   "docs/guides/diff-view.md": "/guides/diff-view/",
   "docs/guides/repo-config.md": "/guides/repo-config/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -36,6 +36,7 @@ export const docsNav: NavSection[] = [
     title: "Reference",
     items: [
       { title: "CLI Reference", href: "/docs/cli/reference/" },
+      { title: "HTTP API Reference", href: "/docs/api/" },
       { title: "Configuration", href: "/docs/guides/configuration/" },
     ],
   },


### PR DESCRIPTION
## Description

Adds two REST endpoints to the `aoe serve` API so an external orchestrator can drive a session without attaching a websocket or keyboard:

- `POST /api/sessions/{id}/send` — accepts `{\"message\": \"...\"}`, sends keys into the tmux pane via the same path the TUI send-message dialog uses (delay tuned per-tool via `agents::send_keys_enter_delay`). Touches `last_accessed_at` and persists like a TUI send. Errors: 403 `read_only`, 400 `message_empty`, 404 `not_found`, 409 `session_not_running`, 500 on tmux failure.
- `GET /api/sessions/{id}/output` — returns the current tmux pane capture as plain text. Errors: 404, 409 same as above.

Together these are the minimum primitive needed to run aoe sessions as controlled subagents from another process. Discussed with @njbrake in issue #855 — opening as draft per his suggestion.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve`)
- [ ] Documentation was updated where necessary (will follow up if endpoint contract is approved)
- [ ] For UI changes: included screenshot or recording (N/A — backend only)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Sonnet/Opus)

**Any Additional AI Details you'd like to share:**
Implementation pattern (spawn_blocking, error mapping, last_accessed_at touch, snapshot-then-persist) was hand-written; AI assisted with axum response plumbing and conformance to surrounding code style.

- [x] I am an AI Agent filling out this form (check box if true)