### PR TITLE
fix(session): eliminate TOCTOU in poller tmux session name capture

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1079,7 +1079,8 @@ impl Instance {
             .tmux_session()
             .map(|s| s.name().to_string())
             .unwrap_or_default();
-        let mut poller = SessionPoller::new(tmux_session_name.clone());
+        let cb_tmux_name = tmux_session_name.clone();
+        let mut poller = SessionPoller::new(tmux_session_name);
         let instance_id = self.id.clone();
         let initial_known = self.agent_session_id.clone();
 
@@ -1186,10 +1187,6 @@ impl Instance {
         };
 
         let cb_instance_id = self.id.clone();
-        let cb_tmux_name = self
-            .tmux_session()
-            .map(|s| s.name().to_string())
-            .unwrap_or_default();
 
         let on_change: Box<dyn Fn(&str) + Send + 'static> = Box::new(move |new_id: &str| {
             tracing::info!("Session ID changed for {}: {}", cb_instance_id, new_id);


### PR DESCRIPTION
## Description

Eliminates a time-of-check/time-of-use gap in `maybe_start_poller()` where `tmux_session()` was called twice: once to initialize the `SessionPoller` and again ~100 lines later for the `on_change` callback. If the tmux session disappeared between the two calls, the poller would hold the real name while the callback got an empty string, causing `publish_session_to_tmux_env` to silently no-op.

Now the session name is captured once, cloned for the callback, and moved into the poller (also eliminating one redundant String allocation).

Extracted from #382.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via OpenCode)

- [x] I am an AI Agent filling out this form (check box if true)