### PR TITLE
feat(tui): responsive layout for narrow viewports (Mosh/iPhone)

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -349,6 +349,18 @@ impl App {
 
                             continue;
                         }
+                        Some(Ok(Event::Resize(_, _))) => {
+                            // Soft keyboard slides up/down on iPad/iPhone Mosh
+                            // (and ordinary terminal resizes) emit Resize. The
+                            // catch-all below would silently drop them, leaving
+                            // the screen mid-stale until the next refresh tick.
+                            // Sync the backend's internal size + redraw now so
+                            // viewport-driven layout (responsive::dialog_width,
+                            // STACKED_BREAKPOINT, etc.) re-evaluates.
+                            terminal.autoresize()?;
+                            terminal.draw(|f| self.render(f))?;
+                            continue;
+                        }
                         Some(Ok(_)) => {}
                         Some(Err(e)) => {
                             // IO error reading from the terminal (broken pipe,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -354,10 +354,10 @@ impl App {
                             // (and ordinary terminal resizes) emit Resize. The
                             // catch-all below would silently drop them, leaving
                             // the screen mid-stale until the next refresh tick.
-                            // Sync the backend's internal size + redraw now so
-                            // viewport-driven layout (responsive::dialog_width,
-                            // STACKED_BREAKPOINT, etc.) re-evaluates.
-                            terminal.autoresize()?;
+                            // Redraw now so viewport-driven layout
+                            // (responsive::dialog_width, STACKED_BREAKPOINT,
+                            // etc.) re-evaluates; ratatui's draw() autoresizes
+                            // internally before rendering.
                             terminal.draw(|f| self.render(f))?;
                             continue;
                         }

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -10,6 +10,7 @@ use crate::tui::styles::Theme;
 pub struct Preview;
 
 impl Preview {
+    #[allow(clippy::too_many_arguments)]
     pub fn render_terminal_preview(
         frame: &mut Frame,
         area: Rect,
@@ -18,62 +19,71 @@ impl Preview {
         cached_output: &str,
         scroll_offset: u16,
         theme: &Theme,
+        compact: bool,
     ) {
-        let info_height = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
-            4 // title + path + status + sandbox
+        // Compact mode (narrow viewports) skips the info header entirely:
+        // the outer block title already carries the session name + status,
+        // and on a phone every row of vertical space matters.
+        let output_area = if compact {
+            area
         } else {
-            3 // title + path + status
-        };
-        let chunks = Layout::default()
-            .direction(Direction::Vertical)
-            .constraints([
-                Constraint::Length(info_height), // Minimal info section
-                Constraint::Min(1),              // Output section
-            ])
-            .split(area);
+            let info_height = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+                4 // title + path + status + sandbox
+            } else {
+                3 // title + path + status
+            };
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(info_height), // Minimal info section
+                    Constraint::Min(1),              // Output section
+                ])
+                .split(area);
 
-        // Minimal info for terminal view
-        let mut info_lines = vec![
-            Line::from(vec![
-                Span::styled("Title:   ", Style::default().fg(theme.dimmed)),
-                Span::styled(&instance.title, Style::default().fg(theme.text).bold()),
-            ]),
-            Line::from(vec![
-                Span::styled("Path:    ", Style::default().fg(theme.dimmed)),
-                Span::styled(
-                    shorten_path(&instance.project_path),
-                    Style::default().fg(theme.text),
-                ),
-            ]),
-            Line::from(vec![
-                Span::styled("Status:  ", Style::default().fg(theme.dimmed)),
-                Span::styled(
-                    if terminal_running {
-                        "Running"
-                    } else {
-                        "Not started"
-                    },
-                    Style::default().fg(if terminal_running {
-                        theme.terminal_active
-                    } else {
-                        theme.dimmed
-                    }),
-                ),
-            ]),
-        ];
-        if let Some(sandbox) = &instance.sandbox_info {
-            if sandbox.enabled {
-                info_lines.push(Line::from(vec![
-                    Span::styled("Sandbox: ", Style::default().fg(theme.dimmed)),
-                    Span::styled(&sandbox.container_name, Style::default().fg(theme.sandbox)),
-                ]));
+            // Minimal info for terminal view
+            let mut info_lines = vec![
+                Line::from(vec![
+                    Span::styled("Title:   ", Style::default().fg(theme.dimmed)),
+                    Span::styled(&instance.title, Style::default().fg(theme.text).bold()),
+                ]),
+                Line::from(vec![
+                    Span::styled("Path:    ", Style::default().fg(theme.dimmed)),
+                    Span::styled(
+                        shorten_path(&instance.project_path),
+                        Style::default().fg(theme.text),
+                    ),
+                ]),
+                Line::from(vec![
+                    Span::styled("Status:  ", Style::default().fg(theme.dimmed)),
+                    Span::styled(
+                        if terminal_running {
+                            "Running"
+                        } else {
+                            "Not started"
+                        },
+                        Style::default().fg(if terminal_running {
+                            theme.terminal_active
+                        } else {
+                            theme.dimmed
+                        }),
+                    ),
+                ]),
+            ];
+            if let Some(sandbox) = &instance.sandbox_info {
+                if sandbox.enabled {
+                    info_lines.push(Line::from(vec![
+                        Span::styled("Sandbox: ", Style::default().fg(theme.dimmed)),
+                        Span::styled(&sandbox.container_name, Style::default().fg(theme.sandbox)),
+                    ]));
+                }
             }
-        }
-        let paragraph = Paragraph::new(info_lines);
-        frame.render_widget(paragraph, chunks[0]);
+            let paragraph = Paragraph::new(info_lines);
+            frame.render_widget(paragraph, chunks[0]);
+            chunks[1]
+        };
 
         // Output section
-        let visible_height = chunks[1].height.saturating_sub(1) as usize;
+        let visible_height = output_area.height.saturating_sub(1) as usize;
         let parsed_output = if terminal_running && !cached_output.is_empty() {
             Some(parse_output_text(cached_output))
         } else {
@@ -81,22 +91,29 @@ impl Preview {
         };
         let line_count = parsed_output.as_ref().map_or(0, |t| t.lines.len());
 
-        let mut block = Block::default()
-            .borders(Borders::TOP)
-            .border_style(Style::default().fg(theme.border))
-            .title(" Terminal Output ")
-            .title_style(Style::default().fg(theme.dimmed));
-        if let Some(indicator) = format_scroll_indicator(line_count, visible_height, scroll_offset)
-        {
-            block = block.title_top(
-                Line::from(indicator)
-                    .right_aligned()
-                    .style(Style::default().fg(theme.dimmed)),
-            );
-        }
-
-        let inner = block.inner(chunks[1]);
-        frame.render_widget(block, chunks[1]);
+        // Compact mode: no inner separator/title; the outer block already
+        // names the session. Scroll indicator is dropped to save a row.
+        let inner = if compact {
+            output_area
+        } else {
+            let mut block = Block::default()
+                .borders(Borders::TOP)
+                .border_style(Style::default().fg(theme.border))
+                .title(" Terminal Output ")
+                .title_style(Style::default().fg(theme.dimmed));
+            if let Some(indicator) =
+                format_scroll_indicator(line_count, visible_height, scroll_offset)
+            {
+                block = block.title_top(
+                    Line::from(indicator)
+                        .right_aligned()
+                        .style(Style::default().fg(theme.dimmed)),
+                );
+            }
+            let inner = block.inner(output_area);
+            frame.render_widget(block, output_area);
+            inner
+        };
 
         if !terminal_running {
             let hint = Paragraph::new("Press Enter to start terminal")
@@ -126,7 +143,21 @@ impl Preview {
         cached_output: &str,
         scroll_offset: u16,
         theme: &Theme,
+        compact: bool,
     ) {
+        if compact {
+            Self::render_output_cached(
+                frame,
+                area,
+                instance,
+                cached_output,
+                scroll_offset,
+                theme,
+                true,
+            );
+            return;
+        }
+
         // 3 base lines (profile+tool / path / status) + optional sandbox + optional worktree block
         let base = 3;
         let sandbox_lines = if instance.is_sandboxed() { 1 } else { 0 };
@@ -152,6 +183,7 @@ impl Preview {
             cached_output,
             scroll_offset,
             theme,
+            false,
         );
     }
 
@@ -244,6 +276,7 @@ impl Preview {
         cached_output: &str,
         scroll_offset: u16,
         theme: &Theme,
+        compact: bool,
     ) {
         let visible_height = area.height.saturating_sub(1) as usize;
         let parsed_output = if instance.last_error.is_none() && !cached_output.is_empty() {
@@ -253,22 +286,30 @@ impl Preview {
         };
         let line_count = parsed_output.as_ref().map_or(0, |t| t.lines.len());
 
-        let mut block = Block::default()
-            .borders(Borders::TOP)
-            .border_style(Style::default().fg(theme.border))
-            .title(" Output ")
-            .title_style(Style::default().fg(theme.dimmed));
-        if let Some(indicator) = format_scroll_indicator(line_count, visible_height, scroll_offset)
-        {
-            block = block.title_top(
-                Line::from(indicator)
-                    .right_aligned()
-                    .style(Style::default().fg(theme.dimmed)),
-            );
-        }
-
-        let inner = block.inner(area);
-        frame.render_widget(block, area);
+        // Compact mode skips the inner separator/title; the outer block
+        // already names the session and scroll indicator is omitted to
+        // free a row.
+        let inner = if compact {
+            area
+        } else {
+            let mut block = Block::default()
+                .borders(Borders::TOP)
+                .border_style(Style::default().fg(theme.border))
+                .title(" Output ")
+                .title_style(Style::default().fg(theme.dimmed));
+            if let Some(indicator) =
+                format_scroll_indicator(line_count, visible_height, scroll_offset)
+            {
+                block = block.title_top(
+                    Line::from(indicator)
+                        .right_aligned()
+                        .style(Style::default().fg(theme.dimmed)),
+                );
+            }
+            let inner = block.inner(area);
+            frame.render_widget(block, area);
+            inner
+        };
 
         if let Some(error) = &instance.last_error {
             let mut error_lines: Vec<Line> = vec![

--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::*;
 use ratatui_textarea::TextArea;
 
 use super::DialogResult;
+use crate::tui::responsive;
 use crate::tui::styles::Theme;
 
 pub struct SendMessageDialog {
@@ -62,10 +63,12 @@ impl SendMessageDialog {
     }
 
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        // 2 for borders + 1 per content line, min 3 (single line), max 12
+        // 2 for borders + 1 per content line, min 3 (single line), max 12,
+        // capped to viewport so the popover never paints under the iOS soft
+        // keyboard if Event::Resize lands mid-render.
         let content_lines = self.text_area.lines().len() as u16;
-        let height = (content_lines + 2).clamp(3, 12);
-        let dialog_width = (area.width * 80 / 100).max(60).min(area.width);
+        let height = (content_lines + 2).clamp(3, 12).min(area.height.max(3));
+        let dialog_width = responsive::dialog_width(area.width);
         let dialog_area = super::centered_rect(area, dialog_width, height);
 
         frame.render_widget(Clear, dialog_area);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::session::config::GroupByMode;
 use crate::session::{Item, Status};
 use crate::tui::components::{HelpOverlay, Preview};
+use crate::tui::responsive;
 use crate::tui::styles::Theme;
 use crate::update::UpdateInfo;
 
@@ -179,23 +180,41 @@ impl HomeView {
             .constraints(constraints)
             .split(area);
 
-        // Layout: left panel (list) and right panel (preview)
-        // On small screens, cap list width so the preview pane gets adequate space
+        // Below STACKED_BREAKPOINT (60 cols), put the list above the preview
+        // instead of side-by-side — iPhone-portrait Mosh zoomed out is ~50
+        // cols, where a 40-col preview floor leaves no usable list width.
         let available_width = main_chunks[0].width;
-        let effective_list_width = self
-            .list_width
-            .min(available_width.saturating_sub(40))
-            .max(10);
-        let chunks = Layout::default()
-            .direction(Direction::Horizontal)
-            .constraints([
-                Constraint::Length(effective_list_width),
-                Constraint::Min(40),
-            ])
-            .split(main_chunks[0]);
+        if available_width < responsive::STACKED_BREAKPOINT {
+            let main_height = main_chunks[0].height;
+            let list_height = responsive::stacked_list_height(main_height);
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(list_height),
+                    Constraint::Min(responsive::STACKED_PREVIEW_MIN),
+                ])
+                .split(main_chunks[0]);
 
-        self.render_list(frame, chunks[0], theme);
-        self.render_preview(frame, chunks[1], theme);
+            self.render_list(frame, chunks[0], theme);
+            self.render_preview(frame, chunks[1], theme);
+        } else {
+            // Side-by-side: cap list width so the preview pane keeps its
+            // usability floor (PREVIEW_MIN_WIDTH).
+            let effective_list_width = self
+                .list_width
+                .min(available_width.saturating_sub(responsive::PREVIEW_MIN_WIDTH))
+                .max(10);
+            let chunks = Layout::default()
+                .direction(Direction::Horizontal)
+                .constraints([
+                    Constraint::Length(effective_list_width),
+                    Constraint::Min(responsive::PREVIEW_MIN_WIDTH),
+                ])
+                .split(main_chunks[0]);
+
+            self.render_list(frame, chunks[0], theme);
+            self.render_preview(frame, chunks[1], theme);
+        }
         self.render_status_bar(frame, main_chunks[1], theme);
 
         if let Some(info) = update_info {
@@ -937,114 +956,124 @@ impl HomeView {
         let key_style = Style::default().fg(theme.accent).bold();
         let desc_style = Style::default().fg(theme.dimmed);
         let sep_style = Style::default().fg(theme.border);
+        let strict = self.strict_hotkeys;
 
-        let mut spans: Vec<Span> = Vec::new();
+        // Priority-tagged shortcut groups. Lower priority = kept longer when
+        // the footer can't fit everything (iPhone Mosh landscape is ~80 cols,
+        // where the full label set used to truncate Help/Quit). Essentials
+        // (Nav / Enter / Help / Quit / Serve indicator) survive first;
+        // Diff / Search / Mode / Group drop first. Groups render in the
+        // declared order; a │ separator is inserted between kept groups
+        // at render time.
+        let mk = |key: &str, desc: &str| -> Vec<Span<'static>> {
+            vec![
+                Span::styled(format!(" {}", key), key_style),
+                Span::styled(format!(" {} ", desc), desc_style),
+            ]
+        };
+
+        let mut groups: Vec<(u8, Vec<Span<'static>>)> = Vec::new();
 
         // Serve indicator: shown only when the `aoe serve` daemon is live.
         // The TUI does not own the daemon, so we probe the PID file each
         // render. Mode comes from a PID-keyed cache so we don't read the
-        // serve.mode file from disk on every frame; the cache invalidates
-        // whenever the daemon PID changes (restart / fresh spawn).
+        // serve.mode file from disk on every frame.
         #[cfg(feature = "serve")]
         {
             let mode_label = crate::cli::serve::cached_serve_mode_label();
-            // cached_serve_mode_label() returns None both for "no daemon"
-            // and "daemon but mode unknown", so check the daemon PID to
-            // distinguish — only render the indicator when there's a
-            // daemon, with the mode tag if we have it.
             if crate::cli::serve::daemon_pid().is_some() {
                 let label = match mode_label {
                     Some(m) => format!(" \u{25CF} Serving ({}) ", m),
                     None => " \u{25CF} Serving ".to_string(),
                 };
-                spans.extend([
-                    Span::styled(label, Style::default().fg(theme.running).bold()),
-                    Span::styled("│", sep_style),
-                ]);
+                groups.push((
+                    0,
+                    vec![Span::styled(
+                        label,
+                        Style::default().fg(theme.running).bold(),
+                    )],
+                ));
             }
         }
 
-        spans.extend([
-            Span::styled(" j/k", key_style),
-            Span::styled(" Nav ", desc_style),
-        ]);
+        groups.push((0, mk("j/k", "Nav")));
+
         if let Some(enter_action_text) = match self.flat_items.get(self.cursor) {
             Some(Item::Group {
                 collapsed: true, ..
-            }) => Some(" Expand "),
+            }) => Some("Expand"),
             Some(Item::Group {
                 collapsed: false, ..
-            }) => Some(" Collapse "),
-            Some(Item::Session { .. }) => Some(" Attach "),
+            }) => Some("Collapse"),
+            Some(Item::Session { .. }) => Some("Attach"),
             None => None,
         } {
-            spans.extend([
-                Span::styled("│", sep_style),
-                Span::styled(" Enter", key_style),
-                Span::styled(enter_action_text, desc_style),
-            ])
+            groups.push((0, mk("Enter", enter_action_text)));
         }
-        let strict = self.strict_hotkeys;
-        spans.extend([
-            Span::styled("│", sep_style),
-            Span::styled(if strict { " T" } else { " t" }, key_style),
-            Span::styled(" View ", desc_style),
-            Span::styled("│", sep_style),
-            Span::styled(if strict { " ^G" } else { " g" }, key_style),
-            Span::styled(" Group ", desc_style),
-        ]);
 
-        // Show c: container/host hint for sandboxed sessions in Terminal view
+        groups.push((2, mk(if strict { "T" } else { "t" }, "View")));
+        groups.push((3, mk(if strict { "^G" } else { "g" }, "Group")));
+
+        // c: container/host toggle hint for sandboxed sessions in Terminal view
         if self.view_mode == ViewMode::Terminal {
             if let Some(id) = &self.selected_session {
                 if let Some(inst) = self.get_instance(id) {
                     if inst.is_sandboxed() {
-                        spans.extend([
-                            Span::styled("│", sep_style),
-                            Span::styled(if strict { " C" } else { " c" }, key_style),
-                            Span::styled(" Mode ", desc_style),
-                        ]);
+                        groups.push((4, mk(if strict { "C" } else { "c" }, "Mode")));
                     }
                 }
             }
         }
 
-        spans.extend([
-            Span::styled("│", sep_style),
-            Span::styled(if strict { " N" } else { " n" }, key_style),
-            Span::styled(" New ", desc_style),
-        ]);
+        groups.push((2, mk(if strict { "N" } else { "n" }, "New")));
 
         if self.selected_session.is_some() {
-            spans.extend([
-                Span::styled("│", sep_style),
-                Span::styled(if strict { " M" } else { " m" }, key_style),
-                Span::styled(" Msg ", desc_style),
-            ]);
+            groups.push((3, mk(if strict { "M" } else { "m" }, "Msg")));
         }
-
         if !self.flat_items.is_empty() {
-            spans.extend([
-                Span::styled("│", sep_style),
-                Span::styled(if strict { " D" } else { " d" }, key_style),
-                Span::styled(" Del ", desc_style),
-            ]);
+            groups.push((3, mk(if strict { "D" } else { "d" }, "Del")));
         }
 
-        spans.extend([
-            Span::styled("│", sep_style),
-            Span::styled(" /", key_style),
-            Span::styled(" Search ", desc_style),
-            Span::styled("│", sep_style),
-            Span::styled(if strict { " ^D" } else { " D" }, key_style),
-            Span::styled(" Diff ", desc_style),
-            Span::styled("│", sep_style),
-            Span::styled(" ?", key_style),
-            Span::styled(" Help ", desc_style),
-            Span::styled("│", sep_style),
-            Span::styled(if strict { " Q" } else { " q" }, key_style),
-            Span::styled(" Quit", desc_style),
-        ]);
+        groups.push((4, mk("/", "Search")));
+        groups.push((4, mk(if strict { "^D" } else { "D" }, "Diff")));
+        groups.push((0, mk("?", "Help")));
+        groups.push((0, mk(if strict { "Q" } else { "q" }, "Quit")));
+
+        // Greedy pack by priority. Width of a group = sum of span char counts;
+        // separator between kept groups adds 1 col each.
+        let widths: Vec<usize> = groups
+            .iter()
+            .map(|(_, g)| g.iter().map(|s| s.content.chars().count()).sum::<usize>())
+            .collect();
+        let avail = area.width as usize;
+
+        let mut order: Vec<usize> = (0..groups.len()).collect();
+        order.sort_by_key(|&i| groups[i].0);
+
+        let mut keep = vec![false; groups.len()];
+        let mut used = 0usize;
+        let mut count = 0usize;
+        for i in order {
+            let sep = if count == 0 { 0 } else { 1 };
+            if used + widths[i] + sep <= avail {
+                keep[i] = true;
+                used += widths[i] + sep;
+                count += 1;
+            }
+        }
+
+        let mut spans: Vec<Span> = Vec::new();
+        let mut first = true;
+        for (i, (_, group)) in groups.into_iter().enumerate() {
+            if !keep[i] {
+                continue;
+            }
+            if !first {
+                spans.push(Span::styled("│", sep_style));
+            }
+            spans.extend(group);
+            first = false;
+        }
 
         let status = Paragraph::new(Line::from(spans)).style(Style::default().bg(theme.selection));
         frame.render_widget(status, area);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -721,21 +721,59 @@ impl HomeView {
     }
 
     fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let title = match self.view_mode {
-            ViewMode::Agent => " Preview ",
-            ViewMode::Terminal => " Terminal Preview ",
-        };
+        let compact = area.width < responsive::STACKED_BREAKPOINT;
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Agent => (theme.border, theme.title),
             ViewMode::Terminal => (theme.terminal_border, theme.terminal_border),
         };
-        let block = Block::default()
+
+        let mut block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(border_color))
-            .title(title)
-            .title_style(Style::default().fg(title_color))
             .padding(Padding::horizontal(1));
+
+        // In compact mode, hoist session name + status icon into the
+        // outer title so the (now omitted) info header isn't missed.
+        let compact_title: Option<Line> = if compact {
+            self.selected_session
+                .as_ref()
+                .and_then(|id| self.get_instance(id))
+                .map(|inst| {
+                    let (icon, icon_color) = match inst.status {
+                        Status::Running => (spinner_running(&inst.created_at), theme.running),
+                        Status::Waiting => (spinner_waiting(&inst.created_at), theme.waiting),
+                        Status::Idle => (ICON_IDLE, theme.idle),
+                        Status::Unknown => (ICON_UNKNOWN, theme.waiting),
+                        Status::Stopped => (ICON_STOPPED, theme.dimmed),
+                        Status::Error => (ICON_ERROR, theme.error),
+                        Status::Starting => (spinner_starting(&inst.created_at), theme.dimmed),
+                        Status::Deleting => (ICON_DELETING, theme.waiting),
+                        Status::Creating => (spinner_starting(&inst.created_at), theme.accent),
+                    };
+                    Line::from(vec![
+                        Span::raw(" "),
+                        Span::styled(icon, Style::default().fg(icon_color)),
+                        Span::raw(" "),
+                        Span::styled(inst.title.clone(), Style::default().fg(title_color).bold()),
+                        Span::raw(" "),
+                    ])
+                })
+        } else {
+            None
+        };
+
+        if let Some(line) = compact_title {
+            block = block.title(line);
+        } else {
+            let title = match self.view_mode {
+                ViewMode::Agent => " Preview ",
+                ViewMode::Terminal => " Terminal Preview ",
+            };
+            block = block
+                .title(title)
+                .title_style(Style::default().fg(title_color));
+        }
 
         let inner = block.inner(area);
         self.preview_area = inner;
@@ -766,6 +804,7 @@ impl HomeView {
                                 &self.preview_cache.content,
                                 self.preview_scroll_offset,
                                 theme,
+                                compact,
                             );
                         }
                     } else {
@@ -835,6 +874,7 @@ impl HomeView {
                             preview_content,
                             self.preview_scroll_offset,
                             theme,
+                            compact,
                         );
                     }
                 } else {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -181,7 +181,7 @@ impl HomeView {
             .split(area);
 
         // Below STACKED_BREAKPOINT (60 cols), put the list above the preview
-        // instead of side-by-side — iPhone-portrait Mosh zoomed out is ~50
+        // instead of side-by-side; iPhone-portrait Mosh zoomed out is ~50
         // cols, where a 40-col preview floor leaves no usable list width.
         let available_width = main_chunks[0].width;
         if available_width < responsive::STACKED_BREAKPOINT {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -180,9 +180,10 @@ impl HomeView {
             .constraints(constraints)
             .split(area);
 
-        // Below STACKED_BREAKPOINT (60 cols), put the list above the preview
-        // instead of side-by-side; iPhone-portrait Mosh zoomed out is ~50
-        // cols, where a 40-col preview floor leaves no usable list width.
+        // Below STACKED_BREAKPOINT (80 cols), put the list above the preview
+        // instead of side-by-side. At 80 cols a side-by-side preview is only
+        // ~45 cols (with default list_width 35), too cramped for output;
+        // stacking gives the preview the full width.
         let available_width = main_chunks[0].width;
         if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,7 @@ mod deletion_poller;
 pub mod dialogs;
 pub mod diff;
 mod home;
+pub(crate) mod responsive;
 pub mod settings;
 mod status_poller;
 pub(crate) mod styles;

--- a/src/tui/responsive.rs
+++ b/src/tui/responsive.rs
@@ -1,0 +1,119 @@
+//! Viewport breakpoints and layout helpers for narrow terminals.
+//!
+//! aoe runs over Mosh on phones and tablets where the viewport can be
+//! anywhere from ~26 cols (iPhone-portrait Mosh, soft keyboard up) to
+//! ~250 cols (full-screen desktop). All width/height-driven layout
+//! decisions live here so the device-class assumptions are visible in
+//! one file rather than scattered as magic numbers across render code.
+//!
+//! Why named constants and not raw ratios?
+//! - ratatui's `Constraint::Length` is the right tool for fixed-cost
+//!   chrome (borders, footers, status bar). A "70% border" is nonsense.
+//! - Ratios are right for content panes but only above a usability
+//!   floor: 33% of 30 cols is 10 cols, which can't render a tmux
+//!   capture. Each constant below has a "below this it stops working"
+//!   reason in its doc comment.
+//! - The bug pattern these replace was *unnamed* hard numbers in render
+//!   code, not the use of fixed sizes per se.
+
+/// Below this width, the home view switches from side-by-side
+/// (list | preview) to stacked (list above preview).
+///
+/// iPhone-portrait Mosh zoomed out is ~50 cols. Side-by-side with a
+/// 40-col preview floor leaves ~10 cols for the list, which can't
+/// render a session title plus the status badge.
+pub const STACKED_BREAKPOINT: u16 = 60;
+
+/// Minimum width the preview pane needs to render a tmux capture
+/// without hash-soup wrapping. Used as the side-by-side preview floor.
+pub const PREVIEW_MIN_WIDTH: u16 = 40;
+
+/// In stacked mode the list takes 1/N of vertical space.
+pub const STACKED_LIST_HEIGHT_FRACTION: u16 = 3;
+
+/// Lower bound on stacked-mode list height. Below this the list can't
+/// show selection + 1 neighbor + spinner row.
+pub const STACKED_LIST_HEIGHT_MIN: u16 = 5;
+
+/// Upper bound on stacked-mode list height — keeps the preview from
+/// being squeezed on tall viewports.
+pub const STACKED_LIST_HEIGHT_MAX: u16 = 12;
+
+/// Lower bound on stacked-mode preview height. Below this the
+/// selection header + 1 row of capture get clipped.
+pub const STACKED_PREVIEW_MIN: u16 = 8;
+
+/// Send-message dialog targets this percentage of viewport width.
+pub const DIALOG_TARGET_PCT: u16 = 80;
+
+/// Below this width, the dialog takes the full viewport (truncates but
+/// stays visible). The 26-col floor is the width of the title hints
+/// (" Enter send Esc cancel " plus rounded borders) — below that the
+/// hints disappear regardless of clamp choice, so taking the full
+/// viewport at least preserves the message area.
+pub const DIALOG_MIN_WIDTH: u16 = 26;
+
+/// Cap on dialog width so it doesn't sprawl across wide desktops.
+pub const DIALOG_MAX_WIDTH: u16 = 80;
+
+/// Compute send-message dialog width for a given viewport width.
+///
+/// Below [`DIALOG_MIN_WIDTH`], take the full viewport.
+/// Otherwise target [`DIALOG_TARGET_PCT`] of viewport, clamped to
+/// `[DIALOG_MIN_WIDTH, DIALOG_MAX_WIDTH]`.
+pub fn dialog_width(viewport_width: u16) -> u16 {
+    if viewport_width <= DIALOG_MIN_WIDTH {
+        viewport_width
+    } else {
+        ((viewport_width as u32 * DIALOG_TARGET_PCT as u32 / 100) as u16)
+            .clamp(DIALOG_MIN_WIDTH, DIALOG_MAX_WIDTH)
+            .min(viewport_width)
+    }
+}
+
+/// Compute stacked-mode list pane height for a given main-region height.
+pub fn stacked_list_height(main_height: u16) -> u16 {
+    (main_height / STACKED_LIST_HEIGHT_FRACTION)
+        .clamp(STACKED_LIST_HEIGHT_MIN, STACKED_LIST_HEIGHT_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dialog_width_iphone_portrait() {
+        // ~50 cols (iPhone-portrait Mosh zoomed out): 80% = 40, clamped
+        // up to MIN_WIDTH 26 — so we get 40.
+        assert_eq!(dialog_width(50), 40);
+    }
+
+    #[test]
+    fn dialog_width_under_min_takes_full_viewport() {
+        // soft keyboard up on iPhone: 22 cols → 22 (truncate but visible).
+        assert_eq!(dialog_width(22), 22);
+        assert_eq!(dialog_width(DIALOG_MIN_WIDTH), DIALOG_MIN_WIDTH);
+    }
+
+    #[test]
+    fn dialog_width_caps_at_max() {
+        // Wide desktop: 80% of 200 = 160, capped to MAX_WIDTH 80.
+        assert_eq!(dialog_width(200), DIALOG_MAX_WIDTH);
+    }
+
+    #[test]
+    fn dialog_width_does_not_exceed_viewport() {
+        // Any viewport ≥ MIN — width never exceeds viewport.
+        for w in DIALOG_MIN_WIDTH..=DIALOG_MAX_WIDTH * 2 {
+            assert!(dialog_width(w) <= w, "dialog_width({w}) > {w}");
+        }
+    }
+
+    #[test]
+    fn stacked_list_height_clamped() {
+        assert_eq!(stacked_list_height(10), STACKED_LIST_HEIGHT_MIN);
+        assert_eq!(stacked_list_height(15), 5);
+        assert_eq!(stacked_list_height(30), 10);
+        assert_eq!(stacked_list_height(60), STACKED_LIST_HEIGHT_MAX);
+    }
+}

--- a/src/tui/responsive.rs
+++ b/src/tui/responsive.rs
@@ -35,7 +35,7 @@ pub const STACKED_LIST_HEIGHT_FRACTION: u16 = 3;
 /// show selection + 1 neighbor + spinner row.
 pub const STACKED_LIST_HEIGHT_MIN: u16 = 5;
 
-/// Upper bound on stacked-mode list height — keeps the preview from
+/// Upper bound on stacked-mode list height; keeps the preview from
 /// being squeezed on tall viewports.
 pub const STACKED_LIST_HEIGHT_MAX: u16 = 12;
 
@@ -48,7 +48,7 @@ pub const DIALOG_TARGET_PCT: u16 = 80;
 
 /// Below this width, the dialog takes the full viewport (truncates but
 /// stays visible). The 26-col floor is the width of the title hints
-/// (" Enter send Esc cancel " plus rounded borders) — below that the
+/// (" Enter send Esc cancel " plus rounded borders); below that the
 /// hints disappear regardless of clamp choice, so taking the full
 /// viewport at least preserves the message area.
 pub const DIALOG_MIN_WIDTH: u16 = 26;
@@ -83,8 +83,8 @@ mod tests {
 
     #[test]
     fn dialog_width_iphone_portrait() {
-        // ~50 cols (iPhone-portrait Mosh zoomed out): 80% = 40, clamped
-        // up to MIN_WIDTH 26 — so we get 40.
+        // ~50 cols (iPhone-portrait Mosh zoomed out): 80% of 50 = 40,
+        // above MIN_WIDTH 26 so the clamp is a no-op.
         assert_eq!(dialog_width(50), 40);
     }
 
@@ -103,7 +103,7 @@ mod tests {
 
     #[test]
     fn dialog_width_does_not_exceed_viewport() {
-        // Any viewport ≥ MIN — width never exceeds viewport.
+        // Any viewport ≥ MIN; width never exceeds viewport.
         for w in DIALOG_MIN_WIDTH..=DIALOG_MAX_WIDTH * 2 {
             assert!(dialog_width(w) <= w, "dialog_width({w}) > {w}");
         }

--- a/src/tui/responsive.rs
+++ b/src/tui/responsive.rs
@@ -17,12 +17,16 @@
 //!   code, not the use of fixed sizes per se.
 
 /// Below this width, the home view switches from side-by-side
-/// (list | preview) to stacked (list above preview).
+/// (list | preview) to stacked (list above preview), and the preview
+/// pane drops its info header in favor of just the session title +
+/// status icon in the outer block title.
 ///
-/// iPhone-portrait Mosh zoomed out is ~50 cols. Side-by-side with a
-/// 40-col preview floor leaves ~10 cols for the list, which can't
-/// render a session title plus the status badge.
-pub const STACKED_BREAKPOINT: u16 = 60;
+/// 80 is the conventional "narrow terminal" boundary: at default
+/// list_width (35), side-by-side preview at viewport 80 is 45 cols,
+/// barely usable; below that the floor binds and both panes lose. A
+/// full-width stacked preview reads better than a 45-col side-by-side
+/// one, and phone widths (Mosh landscape, Termius) live in this range.
+pub const STACKED_BREAKPOINT: u16 = 80;
 
 /// Minimum width the preview pane needs to render a tmux capture
 /// without hash-soup wrapping. Used as the side-by-side preview floor.


### PR DESCRIPTION
## Description

aoe is increasingly used over Mosh on phones and tablets. Several layout assumptions silently break below ~80 cols and become unusable below ~50 — Help/Quit truncate off the right edge of the status bar, the side-by-side panes leave ~10 cols for the session list on iPhone-portrait, and the send-message popover loses its title hints below 26 cols. The iOS soft keyboard slide-up/down also emits Resize events that the TUI's event loop currently drops, so layout stays stale until the next refresh tick.

This PR centralizes the device-class assumptions in a new `tui::responsive` module and wires four call sites to it:

1. **Home view layout** (`home/render.rs`): switches to a stacked layout (list above preview) below `STACKED_BREAKPOINT` (60 cols). Above that, side-by-side keeps a `PREVIEW_MIN_WIDTH` (40) floor as before.
2. **Status bar** (`home/render.rs`): rewritten as priority-tagged groups greedy-packed to `area.width`. Essentials (Nav / Enter / Help / Quit) are priority 0 and survive longest; Search / Diff / Mode / Group are priority 4 and drop first.
3. **Send-message dialog** (`dialogs/send_message.rs`): uses `responsive::dialog_width()`, which targets 80% of viewport clamped to `[DIALOG_MIN_WIDTH=26, DIALOG_MAX_WIDTH=80]`. Below 26 cols the dialog takes the full viewport so it stays visible (truncates instead of disappearing).
4. **Event loop** (`app.rs`): handles `Event::Resize` explicitly with `terminal.autoresize()` + immediate redraw so all three layout decisions re-evaluate on viewport changes.

### Why named constants and not pure ratios?

ratatui's `Constraint::Length` is the right tool for fixed-cost chrome (borders, footers). Ratios alone don't help for layout floors — 33% of 30 cols is 10 cols, which can't render anything useful. The bug pattern this replaces was *unnamed* hard numbers in render code, not the use of fixed sizes per se. Each constant in `tui::responsive` carries a doc comment explaining the device class and the failure mode below the threshold, so the assumptions are visible in one file rather than scattered across multiple render modules.

### Filing as draft

Filing draft because this fixes a specific class of mobile-Mosh issues that are easier to demo than describe — happy to record a short asciinema if you'd like to see the before/after on iPhone-portrait Mosh, or to split the four sub-changes into separate PRs if that's easier to review.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo test --lib\`: 1302 passed, 2 docker-only failures unrelated)
- [x] Documentation was updated where necessary (rationale lives in \`tui::responsive\` doc comments)
- [ ] For UI changes: included screenshot or recording — happy to add asciinema recordings on request

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7) for refactoring the call-site magic numbers into a centralized \`tui::responsive\` module and packing the priority-tagged status bar.

**Any Additional AI Details you'd like to share:** The five underlying fixes (stacked layout, list-on-top correction, Event::Resize handler, width-adaptive status bar, dialog responsive width) were authored over the past several weeks against real Mosh-on-iPhone usage; this PR is the upstreamable refactor that pulls them onto a single feature branch with a centralized constants module instead of magic numbers per render call.

- [ ] I am an AI Agent filling out this form (check box if true)