### PR TITLE
fix: warn on config parse errors instead of silently using defaults

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -87,7 +87,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         bail!("--repo requires --worktree to specify a branch\nTip: aoe add /path --repo /other -w branch-name");
     }
 
-    let config = repo_config::resolve_config_with_repo(profile, &path).unwrap_or_default();
+    let config = repo_config::resolve_config_with_repo_or_warn(profile, &path);
 
     // Preserve the original project path for hook trust checking.
     // `path` gets reassigned to the worktree/workspace directory below,

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -40,10 +40,6 @@ fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
     let (instances, groups) = storage.load_with_groups()?;
-    // Config is resolved per-session inside the loop (see below) so that
-    // repo-level overrides (e.g. delete_branch_on_cleanup) are respected.
-    // We keep a fallback for the case where no session matches.
-    let fallback_config = crate::session::resolve_config(profile).unwrap_or_default();
 
     let mut found = false;
     let mut removed_title = String::new();
@@ -57,11 +53,10 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
             found = true;
             removed_title = inst.title.clone();
 
-            let config = crate::session::repo_config::resolve_config_with_repo(
+            let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
                 profile,
                 std::path::Path::new(&inst.project_path),
-            )
-            .unwrap_or_else(|_| fallback_config.clone());
+            );
 
             // Run on_destroy hooks before cleanup so resources are still available.
             // Global/profile hooks are implicitly trusted; repo hooks require trust.
@@ -79,9 +74,10 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                     }
                     Ok(crate::session::repo_config::HookTrustStatus::NeedsTrust { .. }) => {
                         // Repo hooks changed; fall back to global/profile only.
-                        on_destroy = crate::session::resolve_config(profile)
-                            .map(|c| c.hooks.on_destroy)
-                            .unwrap_or_default();
+                        on_destroy =
+                            crate::session::profile_config::resolve_config_or_warn(profile)
+                                .hooks
+                                .on_destroy;
                     }
                     _ => {}
                 }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -125,17 +125,12 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
         let mut fresh: HashMap<String, CleanupDefaults> = HashMap::new();
         for session in &sessions {
             fresh.entry(session.profile.clone()).or_insert_with(|| {
-                crate::session::resolve_config(&session.profile)
-                    .map(|cfg| CleanupDefaults {
-                        delete_worktree: cfg.worktree.auto_cleanup,
-                        delete_branch: cfg.worktree.delete_branch_on_cleanup,
-                        delete_sandbox: cfg.sandbox.auto_cleanup,
-                    })
-                    .unwrap_or(CleanupDefaults {
-                        delete_worktree: true,
-                        delete_branch: false,
-                        delete_sandbox: true,
-                    })
+                let cfg = crate::session::profile_config::resolve_config_or_warn(&session.profile);
+                CleanupDefaults {
+                    delete_worktree: cfg.worktree.auto_cleanup,
+                    delete_branch: cfg.worktree.delete_branch_on_cleanup,
+                    delete_sandbox: cfg.sandbox.auto_cleanup,
+                }
             });
         }
         *state.cleanup_defaults_cache.write().await = crate::server::CleanupDefaultsCache {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -576,7 +576,7 @@ pub async fn create_session(
         use crate::session::builder::{self, InstanceParams};
         use crate::session::Config;
 
-        let config = Config::load().unwrap_or_default();
+        let config = Config::load_or_warn();
         let sandbox_image = body.sandbox_image.unwrap_or_else(|| {
             if config.sandbox.default_image.is_empty() {
                 "ubuntu:latest".to_string()

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -109,7 +109,7 @@ pub async fn update_settings(
     }
 
     let result = tokio::task::spawn_blocking(move || {
-        let config = crate::session::Config::load().unwrap_or_default();
+        let config = crate::session::Config::load_or_warn();
         let mut current = serde_json::to_value(&config)?;
         if let (Some(current_obj), Some(update_obj)) = (current.as_object_mut(), body.as_object()) {
             for (key, value) in update_obj {
@@ -354,7 +354,7 @@ pub async fn docker_status() -> Json<DockerStatus> {
         let runtime = crate::containers::get_container_runtime();
         let available = runtime.is_available() && runtime.is_daemon_running();
         let runtime_name = if available {
-            let config = crate::session::Config::load().unwrap_or_default();
+            let config = crate::session::Config::load_or_warn();
             Some(
                 serde_json::to_value(config.sandbox.container_runtime)
                     .ok()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -342,7 +342,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
     // Push notifications: initialize only when the operator flag is on at
     // startup. Flipping it later requires a server restart to take effect.
-    let config = crate::session::resolve_config(profile).unwrap_or_default();
+    let config = crate::session::profile_config::resolve_config_or_warn(profile);
     let push_enabled = config.web.notifications_enabled;
     let push_state = if push_enabled {
         match crate::session::get_app_dir() {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -592,7 +592,7 @@ pub fn user_has_tmux_config() -> bool {
 
 /// Determine if status bar styling should be applied based on config and environment.
 pub fn should_apply_tmux_status_bar() -> bool {
-    let config = Config::load().unwrap_or_default();
+    let config = Config::load_or_warn();
     match config.tmux.status_bar {
         TmuxStatusBarMode::Enabled => true,
         TmuxStatusBarMode::Disabled => false,
@@ -603,7 +603,7 @@ pub fn should_apply_tmux_status_bar() -> bool {
 /// Determine if mouse support should be enabled based on config and environment.
 /// Returns Some(true) to enable, Some(false) to disable, None to not touch the setting.
 pub fn should_apply_tmux_mouse() -> Option<bool> {
-    let config = Config::load().unwrap_or_default();
+    let config = Config::load_or_warn();
     match config.tmux.mouse {
         TmuxMouseMode::Enabled => Some(true),
         TmuxMouseMode::Disabled => Some(false),
@@ -633,6 +633,18 @@ impl Config {
         let config: Config = toml::from_str(&content)?;
         Ok(config)
     }
+
+    /// Like [`Config::load`], but logs a warning on failure and returns defaults
+    /// instead of propagating the error.
+    pub fn load_or_warn() -> Self {
+        match Self::load() {
+            Ok(config) => config,
+            Err(e) => {
+                tracing::warn!("Failed to load global config, using defaults: {e}");
+                Config::default()
+            }
+        }
+    }
 }
 
 pub fn load_config() -> Result<Option<Config>> {
@@ -652,9 +664,12 @@ pub fn save_config(config: &Config) -> Result<()> {
 
 /// Load the user's default profile name, falling back to "default" on error.
 pub fn resolve_default_profile() -> String {
-    Config::load()
-        .map(|c| c.default_profile)
-        .unwrap_or_else(|_| "default".to_string())
+    let config = Config::load_or_warn();
+    if config.default_profile.is_empty() {
+        "default".to_string()
+    } else {
+        config.default_profile
+    }
 }
 
 /// Return `profile` if non-empty, otherwise the user's globally configured
@@ -670,11 +685,7 @@ pub fn effective_profile(profile: &str) -> String {
 }
 
 pub fn get_update_settings() -> UpdatesConfig {
-    load_config()
-        .ok()
-        .flatten()
-        .map(|c| c.updates)
-        .unwrap_or_default()
+    Config::load_or_warn().updates
 }
 
 pub fn get_claude_config_dir() -> Option<PathBuf> {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -689,7 +689,7 @@ pub fn get_update_settings() -> UpdatesConfig {
 }
 
 pub fn get_claude_config_dir() -> Option<PathBuf> {
-    let config = load_config().ok().flatten()?;
+    let config = Config::load_or_warn();
     config.claude.config_dir.map(|s| {
         if let Some(stripped) = s.strip_prefix("~/") {
             if let Some(home) = dirs::home_dir() {
@@ -733,6 +733,36 @@ mod tests {
             effective_profile(""),
             "alpha",
             "empty profile must fall back to the user's globally configured default",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_load_or_warn_returns_defaults_on_malformed_toml() {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        #[cfg(target_os = "linux")]
+        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let app_dir = temp_home.path().join(".agent-of-empires");
+
+        std::fs::create_dir_all(&app_dir).unwrap();
+        // Malformed: 'enabled_by_default' under [sandbox] expects a boolean.
+        std::fs::write(
+            app_dir.join("config.toml"),
+            "[sandbox]\nenabled_by_default = \"not-a-bool\"\n",
+        )
+        .unwrap();
+
+        let config = Config::load_or_warn();
+        // Defaults restored rather than propagated; the parse error is logged.
+        let defaults = Config::default();
+        assert_eq!(
+            config.sandbox.enabled_by_default,
+            defaults.sandbox.enabled_by_default,
         );
     }
 

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -618,7 +618,7 @@ pub fn should_apply_tmux_mouse() -> Option<bool> {
     }
 }
 
-fn config_path() -> Result<PathBuf> {
+pub(crate) fn config_path() -> Result<PathBuf> {
     Ok(get_app_dir()?.join("config.toml"))
 }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -201,9 +201,9 @@ fn run_on_destroy_hooks(instance: &Instance) {
     let project_path = Path::new(&instance.project_path);
 
     // Start with global+profile on_destroy hooks (implicitly trusted).
-    let mut resolved_on_destroy = crate::session::profile_config::resolve_config(profile)
-        .map(|c| c.hooks.on_destroy)
-        .unwrap_or_default();
+    let mut resolved_on_destroy = crate::session::profile_config::resolve_config_or_warn(profile)
+        .hooks
+        .on_destroy;
 
     // Check if repo has trusted hooks that override.
     match repo_config::check_hook_trust(project_path) {

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -321,9 +321,7 @@ fn resolved_sandbox_config(
     project_path: &std::path::Path,
 ) -> super::config::SandboxConfig {
     let resolved = super::config::effective_profile(profile);
-    super::repo_config::resolve_config_with_repo(&resolved, project_path)
-        .map(|c| c.sandbox)
-        .unwrap_or_default()
+    super::repo_config::resolve_config_with_repo_or_warn(&resolved, project_path).sandbox
 }
 
 /// Result of building docker exec environment arguments.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -831,9 +831,9 @@ impl Instance {
         }
 
         // Start with global+profile hooks as the base
-        let mut resolved_on_launch = super::profile_config::resolve_config(profile)
-            .map(|c| c.hooks.on_launch)
-            .unwrap_or_default();
+        let mut resolved_on_launch = super::profile_config::resolve_config_or_warn(profile)
+            .hooks
+            .on_launch;
 
         // Check if repo has trusted hooks that override
         match super::repo_config::check_hook_trust(Path::new(&self.project_path)) {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -181,6 +181,55 @@ pub fn set_default_profile(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// Probe the global config and the active profile's config at startup so the
+/// TUI can show a single user-visible warning when either fails to parse.
+/// `tracing::warn!` calls inside the `_or_warn` helpers are silently dropped
+/// in default TUI mode (no subscriber), so this gives users a chance to see
+/// that their settings have been ignored without needing `AGENT_OF_EMPIRES_DEBUG=1`.
+pub fn collect_startup_config_warnings(profile: &str) -> Option<String> {
+    let mut messages: Vec<String> = Vec::new();
+
+    let global_path_display = config::config_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| "config.toml".to_string());
+
+    let global_ok = match Config::load() {
+        Ok(_) => true,
+        Err(e) => {
+            messages.push(format!(
+                "Failed to load global config ({global_path_display}); using defaults.\n{e}"
+            ));
+            false
+        }
+    };
+
+    let effective = if profile.is_empty() {
+        if global_ok {
+            config::resolve_default_profile()
+        } else {
+            DEFAULT_PROFILE.to_string()
+        }
+    } else {
+        profile.to_string()
+    };
+
+    let profile_path_display = profile_config::get_profile_config_path(&effective)
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|_| format!("profiles/{effective}/config.toml"));
+
+    if let Err(e) = profile_config::load_profile_config(&effective) {
+        messages.push(format!(
+            "Failed to load profile config '{effective}' ({profile_path_display}); using defaults.\n{e}"
+        ));
+    }
+
+    if messages.is_empty() {
+        None
+    } else {
+        Some(messages.join("\n\n"))
+    }
+}
+
 // ── TUI heartbeat ──────────────────────────────────────────────────────────
 
 const TUI_HEARTBEAT_FILE: &str = "tui.active";
@@ -217,4 +266,67 @@ pub fn is_tui_active(threshold: Duration) -> bool {
         Err(_) => return false,
     };
     modified.elapsed().unwrap_or(Duration::MAX) < threshold
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn isolate_app_dir() -> tempfile::TempDir {
+        let temp_home = tempfile::TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        temp_home
+    }
+
+    fn app_dir(temp_home: &tempfile::TempDir) -> PathBuf {
+        #[cfg(target_os = "linux")]
+        let dir = temp_home.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let dir = temp_home.path().join(".agent-of-empires");
+        fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_clean() {
+        let _temp = isolate_app_dir();
+        // No config files written = defaults everywhere = no warning.
+        assert!(collect_startup_config_warnings("").is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_bad_global() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        fs::write(
+            dir.join("config.toml"),
+            "[sandbox]\nenabled_by_default = \"not-a-bool\"\n",
+        )
+        .unwrap();
+
+        let warning = collect_startup_config_warnings("").expect("expected a warning");
+        assert!(warning.contains("Failed to load global config"));
+        assert!(warning.contains("config.toml"));
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_startup_config_warnings_bad_profile() {
+        let temp = isolate_app_dir();
+        let dir = app_dir(&temp);
+        let profile_dir = dir.join("profiles").join("default");
+        fs::create_dir_all(&profile_dir).unwrap();
+        fs::write(
+            profile_dir.join("config.toml"),
+            "[worktree]\nenabled = \"not-a-bool\"\n",
+        )
+        .unwrap();
+
+        let warning = collect_startup_config_warnings("default").expect("expected a warning");
+        assert!(warning.contains("Failed to load profile config 'default'"));
+    }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,16 +29,17 @@ pub use instance::{
     Instance, SandboxInfo, Status, TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
 };
 pub use profile_config::{
-    load_profile_config, merge_configs, resolve_config, save_profile_config,
-    validate_check_interval, validate_memory_limit, validate_path_exists, validate_volume_format,
-    ClaudeConfigOverride, HooksConfigOverride, ProfileConfig, SandboxConfigOverride,
-    SessionConfigOverride, ThemeConfigOverride, TmuxConfigOverride, UpdatesConfigOverride,
-    WorktreeConfigOverride,
+    load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,
+    save_profile_config, validate_check_interval, validate_memory_limit, validate_path_exists,
+    validate_volume_format, ClaudeConfigOverride, HooksConfigOverride, ProfileConfig,
+    SandboxConfigOverride, SessionConfigOverride, ThemeConfigOverride, TmuxConfigOverride,
+    UpdatesConfigOverride, WorktreeConfigOverride,
 };
 pub use repo_config::{
     check_hook_trust, execute_hooks, execute_hooks_in_container, load_repo_config,
     merge_repo_config, profile_to_repo_config, repo_config_to_profile, resolve_config_with_repo,
-    save_repo_config, trust_repo, HookTrustStatus, HooksConfig, RepoConfig,
+    resolve_config_with_repo_or_warn, save_repo_config, trust_repo, HookTrustStatus, HooksConfig,
+    RepoConfig,
 };
 pub use storage::Storage;
 

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -259,6 +259,21 @@ pub fn resolve_config(profile: &str) -> Result<Config> {
     Ok(merge_configs(global, &profile_config))
 }
 
+/// Like [`resolve_config`], but logs a warning on failure and returns defaults
+/// instead of propagating the error.
+pub fn resolve_config_or_warn(profile: &str) -> Config {
+    match resolve_config(profile) {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to load config for profile '{}', using defaults: {e}",
+                profile
+            );
+            Config::default()
+        }
+    }
+}
+
 /// Apply sandbox config overrides to a target config.
 pub fn apply_sandbox_overrides(
     target: &mut super::config::SandboxConfig,

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -286,6 +286,22 @@ pub fn resolve_config_with_repo(profile: &str, project_path: &Path) -> Result<Co
     }
 }
 
+/// Like [`resolve_config_with_repo`], but logs a warning on failure and returns
+/// defaults instead of propagating the error.
+pub fn resolve_config_with_repo_or_warn(profile: &str, project_path: &Path) -> Config {
+    match resolve_config_with_repo(profile, project_path) {
+        Ok(config) => config,
+        Err(e) => {
+            tracing::warn!(
+                "Failed to load config for profile '{}' at '{}', using defaults: {e}",
+                profile,
+                project_path.display()
+            );
+            Config::default()
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Hook trust system
 // ---------------------------------------------------------------------------
@@ -464,7 +480,7 @@ pub fn check_hook_trust(project_path: &Path) -> Result<HookTrustStatus> {
 /// Resolve hooks from global+profile config when no repo hooks are defined.
 /// Returns `None` if no on_create or on_launch hooks are configured.
 pub fn resolve_global_profile_hooks(profile: &str) -> Option<HooksConfig> {
-    let config = super::profile_config::resolve_config(profile).ok()?;
+    let config = super::profile_config::resolve_config_or_warn(profile);
     if config.hooks.on_create.is_empty() && config.hooks.on_launch.is_empty() {
         None
     } else {
@@ -476,9 +492,7 @@ pub fn resolve_global_profile_hooks(profile: &str) -> Option<HooksConfig> {
 /// Repo hooks override (not append) global hooks per-field.
 /// Returns `None` if the merged result has no on_create or on_launch hooks.
 pub fn merge_hooks_with_config(profile: &str, repo_hooks: HooksConfig) -> Option<HooksConfig> {
-    let mut base = super::profile_config::resolve_config(profile)
-        .map(|c| c.hooks)
-        .unwrap_or_default();
+    let mut base = super::profile_config::resolve_config_or_warn(profile).hooks;
 
     if !repo_hooks.on_create.is_empty() {
         base.on_create = repo_hooks.on_create;

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -286,18 +286,21 @@ pub fn resolve_config_with_repo(profile: &str, project_path: &Path) -> Result<Co
     }
 }
 
-/// Like [`resolve_config_with_repo`], but logs a warning on failure and returns
-/// defaults instead of propagating the error.
+/// Like [`resolve_config_with_repo`], but logs a warning on failure and falls
+/// back gracefully instead of propagating the error: a malformed repo config
+/// degrades to the profile-merged config (preserving profile customization),
+/// and a malformed profile config degrades to defaults.
 pub fn resolve_config_with_repo_or_warn(profile: &str, project_path: &Path) -> Config {
-    match resolve_config_with_repo(profile, project_path) {
-        Ok(config) => config,
+    let base = super::profile_config::resolve_config_or_warn(profile);
+    match load_repo_config(project_path) {
+        Ok(Some(repo_config)) => merge_repo_config(base, &repo_config),
+        Ok(None) => base,
         Err(e) => {
             tracing::warn!(
-                "Failed to load config for profile '{}' at '{}', using defaults: {e}",
-                profile,
+                "Failed to load repo config at '{}', falling back to profile config: {e}",
                 project_path.display()
             );
-            Config::default()
+            base
         }
     }
 }

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -109,7 +109,7 @@ pub fn apply_all_tmux_options(
     use crate::tui::styles::load_theme;
 
     if should_apply_tmux_status_bar() {
-        let config = crate::session::config::Config::load().unwrap_or_default();
+        let config = crate::session::config::Config::load_or_warn();
         let theme_name = if config.theme.name.is_empty() {
             "empire"
         } else {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use super::home::{HomeView, TerminalMode};
 use super::styles::Theme;
-use crate::session::{get_update_settings, load_config, save_config};
+use crate::session::{get_update_settings, load_config, save_config, Config};
 use crate::tmux::AvailableTools;
 use crate::update::{check_for_update, UpdateInfo};
 
@@ -74,7 +74,7 @@ pub struct App {
 /// Check if the app version changed and return the previous version if changelog should be shown.
 /// This is called before App::new to allow async cache refresh.
 pub fn check_version_change() -> Result<Option<String>> {
-    let config = load_config()?.unwrap_or_default();
+    let config = Config::load_or_warn();
     let current_version = env!("CARGO_PKG_VERSION");
 
     if config.app_state.has_seen_welcome
@@ -87,7 +87,11 @@ pub fn check_version_change() -> Result<Option<String>> {
 }
 
 impl App {
-    pub fn new(profile: &str, available_tools: AvailableTools) -> Result<Self> {
+    pub fn new(
+        profile: &str,
+        available_tools: AvailableTools,
+        suppress_first_run_dialogs: bool,
+    ) -> Result<Self> {
         let no_agents = !available_tools.any_available();
         let active_profile = if profile.is_empty() {
             None // all-profiles mode
@@ -97,7 +101,7 @@ impl App {
         let mut home = HomeView::new(active_profile, available_tools)?;
 
         // Check if we need to show welcome or changelog dialogs
-        let mut config = load_config()?.unwrap_or_default();
+        let mut config = Config::load_or_warn();
 
         // Load theme from config, defaulting to empire if empty
         let theme_name = if config.theme.name.is_empty() {
@@ -115,6 +119,10 @@ impl App {
         if no_agents {
             // Show the no-agents onboarding dialog (takes priority over welcome/changelog)
             home.show_no_agents();
+        } else if suppress_first_run_dialogs {
+            // A startup warning will be shown by the caller; skip welcome and
+            // changelog so the warning is what the user sees first, and avoid
+            // overwriting a malformed config.toml with defaults via save_config.
         } else if !config.app_state.has_seen_welcome {
             home.show_welcome();
             config.app_state.has_seen_welcome = true;
@@ -218,7 +226,18 @@ impl App {
     }
 
     pub fn show_startup_warning(&mut self, message: &str) {
-        self.home.info_dialog = Some(crate::tui::dialogs::InfoDialog::new("Warning", message));
+        // Size the dialog to fit the message: borders + margin + button take
+        // ~5 rows; everything else is content. Width is wide enough for a
+        // typical config path on one line.
+        let line_count = message.lines().count() as u16;
+        let height = (line_count + 5).clamp(9, 30);
+        let width = 80;
+        // Warnings preempt onboarding dialogs so the user sees the problem
+        // before the welcome screen.
+        self.home.welcome_dialog = None;
+        self.home.changelog_dialog = None;
+        self.home.info_dialog =
+            Some(crate::tui::dialogs::InfoDialog::new("Warning", message).with_size(width, height));
     }
 
     pub fn set_theme(&mut self, name: &str) {
@@ -795,7 +814,7 @@ impl App {
                     && crate::agents::get_agent(&instance.tool)
                         .is_none_or(|a| a.instruction_flag.is_none())
                 {
-                    let config = load_config()?.unwrap_or_default();
+                    let config = Config::load_or_warn();
                     if !config.app_state.has_seen_custom_instruction_warning {
                         self.home.info_dialog = Some(
                             crate::tui::dialogs::InfoDialog::new(

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -226,18 +226,31 @@ impl App {
     }
 
     pub fn show_startup_warning(&mut self, message: &str) {
-        // Size the dialog to fit the message: borders + margin + button take
-        // ~5 rows; everything else is content. Width is wide enough for a
-        // typical config path on one line.
-        let line_count = message.lines().count() as u16;
-        let height = (line_count + 5).clamp(9, 30);
-        let width = 80;
+        // Size the dialog to fit the message after wrapping. The message area
+        // is `width - 4` columns wide (borders + 1-cell margin on each side),
+        // so each \n-separated line wraps to ceil(len / inner_width) visual
+        // rows. Borders + margin + the OK button take 6 rows.
+        const WIDTH: u16 = 80;
+        let inner_width = WIDTH.saturating_sub(4) as usize;
+        let visual_lines: usize = message
+            .lines()
+            .map(|l| {
+                if l.is_empty() {
+                    1
+                } else {
+                    l.len().div_ceil(inner_width)
+                }
+            })
+            .sum();
+        // +6 for borders/margin/button; +1 safety margin since byte-length
+        // wrap estimation under-counts when Paragraph word-wraps mid-line.
+        let height = ((visual_lines as u16).saturating_add(7)).clamp(9, 35);
         // Warnings preempt onboarding dialogs so the user sees the problem
         // before the welcome screen.
         self.home.welcome_dialog = None;
         self.home.changelog_dialog = None;
         self.home.info_dialog =
-            Some(crate::tui::dialogs::InfoDialog::new("Warning", message).with_size(width, height));
+            Some(crate::tui::dialogs::InfoDialog::new("Warning", message).with_size(WIDTH, height));
     }
 
     pub fn set_theme(&mut self, name: &str) {

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -49,17 +49,13 @@ pub struct UnifiedDeleteDialog {
 
 impl UnifiedDeleteDialog {
     pub fn new(session_title: String, config: DeleteDialogConfig, profile: &str) -> Self {
-        let user_config = config
-            .project_path
-            .as_ref()
-            .and_then(|p| {
-                crate::session::repo_config::resolve_config_with_repo(
-                    profile,
-                    std::path::Path::new(p),
-                )
-                .ok()
-            })
-            .unwrap_or_else(|| crate::session::resolve_config(profile).unwrap_or_default());
+        let user_config = match config.project_path.as_ref() {
+            Some(p) => crate::session::repo_config::resolve_config_with_repo_or_warn(
+                profile,
+                std::path::Path::new(p),
+            ),
+            None => crate::session::profile_config::resolve_config_or_warn(profile),
+        };
 
         let options = DeleteOptions {
             delete_worktree: config.worktree_branch.is_some() && user_config.worktree.auto_cleanup,

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -10,6 +10,8 @@ use crate::tui::styles::Theme;
 pub struct InfoDialog {
     title: String,
     message: String,
+    width: u16,
+    height: u16,
 }
 
 impl InfoDialog {
@@ -17,7 +19,18 @@ impl InfoDialog {
         Self {
             title: title.to_string(),
             message: message.to_string(),
+            width: 50,
+            height: 9,
         }
+    }
+
+    /// Customize the dialog's footprint. Useful for long, multi-paragraph
+    /// messages (e.g. the startup config-warning) that would clip at the
+    /// default 50x9.
+    pub fn with_size(mut self, width: u16, height: u16) -> Self {
+        self.width = width;
+        self.height = height;
+        self
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -28,7 +41,7 @@ impl InfoDialog {
     }
 
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let dialog_area = super::centered_rect(area, 50, 9);
+        let dialog_area = super::centered_rect(area, self.width, self.height);
 
         frame.render_widget(Clear, dialog_area);
 

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -15,8 +15,8 @@ use tui_input::Input;
 use super::DialogResult;
 use crate::containers::{self, ContainerRuntimeInterface};
 use crate::session::config::{DefaultTerminalMode, SandboxConfig};
+use crate::session::profile_config::resolve_config_or_warn;
 use crate::session::repo_config::HookProgress;
-use crate::session::resolve_config;
 #[cfg(test)]
 use crate::session::Config;
 use crate::tmux::AvailableTools;
@@ -310,11 +310,10 @@ impl NewSessionDialog {
         let docker_available = containers::get_container_runtime().is_available();
 
         // Load resolved config (global + profile + repo overrides from cwd)
-        let config = crate::session::repo_config::resolve_config_with_repo(
+        let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
             profile,
             std::path::Path::new(&current_dir),
-        )
-        .unwrap_or_else(|_| resolve_config(profile).unwrap_or_default());
+        );
 
         // Determine default tool index based on config
         let tool_index = if let Some(ref default_tool) = config.session.default_tool {
@@ -532,7 +531,7 @@ impl NewSessionDialog {
     fn reload_config_defaults(&mut self) {
         let profile = self.selected_profile().to_string();
         self.profile = profile.clone();
-        let config = resolve_config(&profile).unwrap_or_default();
+        let config = resolve_config_or_warn(&profile);
 
         // Reset tool index
         self.tool_index = if let Some(ref default_tool) = config.session.default_tool {
@@ -978,7 +977,7 @@ impl NewSessionDialog {
             {
                 self.sandbox_enabled = !self.sandbox_enabled;
                 if self.sandbox_enabled {
-                    let config = resolve_config(&self.profile).unwrap_or_default();
+                    let config = resolve_config_or_warn(&self.profile);
                     self.extra_env = config.sandbox.environment.clone();
                     self.inherited_settings = build_inherited_settings(&config.sandbox);
                 } else {
@@ -1339,7 +1338,7 @@ impl NewSessionDialog {
 
     fn reload_tool_config(&mut self) {
         let profile = self.selected_profile().to_string();
-        let config = resolve_config(&profile).unwrap_or_default();
+        let config = resolve_config_or_warn(&profile);
         let tool = self
             .available_tools
             .get(self.tool_index)

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -74,7 +74,7 @@ pub struct DiffView {
 impl DiffView {
     /// Create a new diff view for a repository
     pub fn new(repo_path: PathBuf) -> anyhow::Result<Self> {
-        let config = Config::load().unwrap_or_default();
+        let config = Config::load_or_warn();
 
         // Determine base branch
         let base_branch = config

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -7,7 +7,7 @@ use tui_input::Input;
 
 use super::{HomeView, TerminalMode, ViewMode};
 use crate::session::config::{load_config, save_config, GroupByMode, SortOrder};
-use crate::session::{list_profiles, repo_config, resolve_config, Item, Status};
+use crate::session::{list_profiles, repo_config, resolve_config_or_warn, Item, Status};
 use crate::tui::app::Action;
 #[cfg(feature = "serve")]
 use crate::tui::dialogs::ServeAction;
@@ -60,18 +60,15 @@ impl HomeView {
                         self.settings_view = None;
                         self.confirm_dialog = None;
                         self.settings_close_confirm = false;
-                        // Revert theme to saved config (undo any preview)
-                        if let Ok(config) =
-                            resolve_config(self.active_profile.as_deref().unwrap_or("default"))
-                        {
-                            let theme_name = if config.theme.name.is_empty() {
-                                "empire".to_string()
-                            } else {
-                                config.theme.name
-                            };
-                            return Some(Action::SetTheme(theme_name));
-                        }
-                        return None;
+                        let config = resolve_config_or_warn(
+                            self.active_profile.as_deref().unwrap_or("default"),
+                        );
+                        let theme_name = if config.theme.name.is_empty() {
+                            "empire".to_string()
+                        } else {
+                            config.theme.name
+                        };
+                        return Some(Action::SetTheme(theme_name));
                     }
                 }
             }
@@ -88,17 +85,14 @@ impl HomeView {
                     // Refresh config-dependent state in case settings changed
                     self.refresh_from_config();
                     // Reload theme from saved config
-                    if let Ok(config) =
-                        resolve_config(self.active_profile.as_deref().unwrap_or("default"))
-                    {
-                        let theme_name = if config.theme.name.is_empty() {
-                            "empire".to_string()
-                        } else {
-                            config.theme.name
-                        };
-                        return Some(Action::SetTheme(theme_name));
-                    }
-                    return None;
+                    let config =
+                        resolve_config_or_warn(self.active_profile.as_deref().unwrap_or("default"));
+                    let theme_name = if config.theme.name.is_empty() {
+                        "empire".to_string()
+                    } else {
+                        config.theme.name
+                    };
+                    return Some(Action::SetTheme(theme_name));
                 }
                 SettingsAction::UnsavedChangesWarning => {
                     // Show confirmation dialog

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -15,8 +15,8 @@ use tui_input::Input;
 
 use crate::session::{
     config::{load_config, save_config, GroupByMode, SortOrder},
-    flatten_tree, flatten_tree_all_profiles, resolve_config, DefaultTerminalMode, Group, GroupTree,
-    Instance, Item, Storage,
+    flatten_tree, flatten_tree_all_profiles, resolve_config_or_warn, DefaultTerminalMode, Group,
+    GroupTree, Instance, Item, Storage,
 };
 use crate::tmux::AvailableTools;
 
@@ -282,22 +282,13 @@ impl HomeView {
 
         // In unified mode, config comes from "default" profile
         let config_profile = active_profile.as_deref().unwrap_or("default");
-        let resolved = resolve_config(config_profile);
-        let default_terminal_mode = resolved
-            .as_ref()
-            .map(|config| match config.sandbox.default_terminal_mode {
-                DefaultTerminalMode::Host => TerminalMode::Host,
-                DefaultTerminalMode::Container => TerminalMode::Container,
-            })
-            .unwrap_or_default();
-        let sound_config = resolved
-            .as_ref()
-            .map(|config| config.sound.clone())
-            .unwrap_or_default();
-        let strict_hotkeys = resolved
-            .as_ref()
-            .map(|config| config.session.strict_hotkeys)
-            .unwrap_or(false);
+        let resolved = resolve_config_or_warn(config_profile);
+        let default_terminal_mode = match resolved.sandbox.default_terminal_mode {
+            DefaultTerminalMode::Host => TerminalMode::Host,
+            DefaultTerminalMode::Container => TerminalMode::Container,
+        };
+        let sound_config = resolved.sound.clone();
+        let strict_hotkeys = resolved.session.strict_hotkeys;
         let user_config = load_config().ok().flatten();
         let sort_order = user_config
             .as_ref()
@@ -1458,19 +1449,13 @@ impl HomeView {
     /// Call this after settings are saved to pick up any changes.
     pub fn refresh_from_config(&mut self) {
         let profile = self.active_profile.as_deref().unwrap_or("default");
-        if let Ok(config) = resolve_config(profile) {
-            // Refresh default terminal mode for sandboxed sessions
-            self.default_terminal_mode = match config.sandbox.default_terminal_mode {
-                DefaultTerminalMode::Host => TerminalMode::Host,
-                DefaultTerminalMode::Container => TerminalMode::Container,
-            };
-
-            // Refresh sound config
-            self.sound_config = config.sound.clone();
-
-            // Refresh strict-hotkeys mode
-            self.strict_hotkeys = config.session.strict_hotkeys;
-        }
+        let config = resolve_config_or_warn(profile);
+        self.default_terminal_mode = match config.sandbox.default_terminal_mode {
+            DefaultTerminalMode::Host => TerminalMode::Host,
+            DefaultTerminalMode::Container => TerminalMode::Container,
+        };
+        self.sound_config = config.sound.clone();
+        self.strict_hotkeys = config.session.strict_hotkeys;
     }
 
     /// Toggle terminal mode between Container and Host for a session

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -100,7 +100,22 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
 
     // Create app and run
     let mut app = App::new(profile, available_tools)?;
-    if let Some(warning) = startup_warning {
+
+    // Combine the caller-supplied startup warning (e.g., debug-log file
+    // failures) with any config-parse failures we detect at startup.
+    // `tracing::warn!` events from the `_or_warn` config helpers are dropped
+    // by default in TUI mode (no subscriber attached), so we surface them
+    // through the same InfoDialog channel here.
+    let combined_warning = match (
+        startup_warning,
+        crate::session::collect_startup_config_warnings(profile),
+    ) {
+        (Some(a), Some(b)) => Some(format!("{a}\n\n{b}")),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+    if let Some(warning) = combined_warning {
         app.show_startup_warning(&warning);
     }
     let result = app.run(&mut terminal).await;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -98,14 +98,16 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    // Create app and run
-    let mut app = App::new(profile, available_tools)?;
-
-    // Combine the caller-supplied startup warning (e.g., debug-log file
+    // Combine the caller-supplied startup warning (e.g. debug-log file
     // failures) with any config-parse failures we detect at startup.
     // `tracing::warn!` events from the `_or_warn` config helpers are dropped
     // by default in TUI mode (no subscriber attached), so we surface them
     // through the same InfoDialog channel here.
+    //
+    // Detected before `App::new` so we can suppress the first-run welcome /
+    // changelog dialogs when there's a warning, both for UX (the warning is
+    // the more important thing for the user to see) and to avoid overwriting
+    // a malformed config.toml with defaults via `save_config`.
     let combined_warning = match (
         startup_warning,
         crate::session::collect_startup_config_warnings(profile),
@@ -115,6 +117,9 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
         (None, Some(b)) => Some(b),
         (None, None) => None,
     };
+
+    // Create app and run
+    let mut app = App::new(profile, available_tools, combined_warning.is_some())?;
     if let Some(warning) = combined_warning {
         app.show_startup_warning(&warning);
     }


### PR DESCRIPTION
## Description

When a user's `config.toml` has a parse error (malformed TOML, invalid field types, etc.), the error was silently swallowed and replaced with default config values across 18+ call sites. The user had no indication their settings were being ignored.

This PR adds three warning-on-failure helpers that log a `tracing::warn!` with the profile name, file path, and parse error details before falling back to defaults:

- `resolve_config_or_warn()` — for profile config resolution (`src/session/profile_config.rs`)
- `resolve_config_with_repo_or_warn()` — for profile + repo resolution (`src/session/repo_config.rs`)
- `Config::load_or_warn()` — for direct global config loads (`src/session/config.rs`)

All silent `.unwrap_or_default()` / `.ok()?` / `if let Ok(..)` patterns on config resolution are replaced with the new helpers across 16 files.

**Before:** A typo in `config.toml` causes all settings to silently revert to defaults. No warning, no log, nothing.

**After:** The user sees: `WARN Failed to load config for profile 'default', using defaults: expected boolean for key 'sandbox.enabled_by_default' at line 5 column 1`

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test` — 1298+ tests passing)
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** opencode (glm-5.1)

**Any Additional AI Details you'd like to share:** Paired with a first-time OSS contributor. Walked through the bug, the codebase exploration, the fix strategy, and the contribution workflow step by step.

- [ ] I am an AI Agent filling out this form (check box if true)

Closes #595