### PR TITLE
feat(tui): shorten home title to 'aoe', show full name in help footer

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -172,7 +172,7 @@ impl HelpOverlay {
 
         frame.render_widget(Clear, dialog_area);
 
-        let version = format!(" v{} ", env!("CARGO_PKG_VERSION"));
+        let version = format!(" Agent of Empires v{} ", env!("CARGO_PKG_VERSION"));
         let block = Block::default()
             .style(Style::default().bg(theme.background))
             .borders(Borders::ALL)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -295,7 +295,7 @@ impl HomeView {
             ""
         };
         let title = match self.view_mode {
-            ViewMode::Agent => format!(" AOE [{}]{} ", self.active_profile_display(), group_suffix),
+            ViewMode::Agent => format!(" aoe [{}]{} ", self.active_profile_display(), group_suffix),
             ViewMode::Terminal => format!(
                 " Terminals [{}]{} ",
                 self.active_profile_display(),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -295,11 +295,7 @@ impl HomeView {
             ""
         };
         let title = match self.view_mode {
-            ViewMode::Agent => format!(
-                " Agent of Empires [{}]{} ",
-                self.active_profile_display(),
-                group_suffix
-            ),
+            ViewMode::Agent => format!(" AOE [{}]{} ", self.active_profile_display(), group_suffix),
             ViewMode::Terminal => format!(
                 " Terminals [{}]{} ",
                 self.active_profile_display(),

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -11,7 +11,7 @@ fn test_new_session_dialog_opens() {
     let mut h = TuiTestHarness::new("new_dialog");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.send_keys("n");
     h.wait_for("Title");
     h.assert_screen_contains("Path");
@@ -25,7 +25,7 @@ fn test_new_session_dialog_escape_cancels() {
     let mut h = TuiTestHarness::new("new_esc");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.send_keys("n");
     h.wait_for("Title");
 
@@ -82,7 +82,7 @@ fn test_creating_stub_appears_during_hook_execution() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
 
     // Open new session dialog and fill in the path.
     h.send_keys("n");
@@ -108,7 +108,7 @@ fn test_creating_stub_cancelled_with_ctrl_c() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
 
     // Create a session with a slow hook.
     h.send_keys("n");
@@ -137,7 +137,7 @@ fn test_creating_blocks_second_session_creation() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
 
     // Start creating a session.
     h.send_keys("n");
@@ -171,7 +171,7 @@ fn test_quit_during_creation_shows_confirm() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
 
     // Start creating a session.
     h.send_keys("n");

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -74,7 +74,7 @@ fn tui_serve_dialog_opens_to_mode_picker() {
     let mut h = TuiTestHarness::new("serve_mode_picker");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.send_keys("R");
 
     h.wait_for("How should this be reachable?");
@@ -97,7 +97,7 @@ fn tui_serve_dialog_escape_returns_home() {
     let mut h = TuiTestHarness::new("serve_mode_picker_esc");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.send_keys("R");
     h.wait_for("How should this be reachable?");
 

--- a/tests/e2e/tui_launch.rs
+++ b/tests/e2e/tui_launch.rs
@@ -11,7 +11,7 @@ fn test_tui_launches_and_shows_home_screen() {
     let mut h = TuiTestHarness::new("launch");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.assert_screen_contains("No sessions yet");
     // Status bar navigation hints should be visible.
     h.assert_screen_contains("Nav");
@@ -25,7 +25,7 @@ fn test_tui_quit_with_q() {
     let mut h = TuiTestHarness::new("quit");
     h.spawn_tui();
 
-    h.wait_for("Agent of Empires");
+    h.wait_for(" aoe [");
     h.send_keys("q");
     h.wait_for_exit(Duration::from_secs(5));
     assert!(!h.session_alive(), "session should have exited after 'q'");


### PR DESCRIPTION
## Description

The top-left home title in the TUI now reads `aoe [profile]` instead of the longer `Agent of Empires [profile]` so it fits better on narrow viewports (Mosh on iPhone, etc.). The full product name is preserved in the help overlay's bottom-right footer alongside the version, so the brand still appears somewhere visible without crowding the main view.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Two small string edits in `src/tui/home/render.rs` and `src/tui/components/help.rs`, drafted via Claude Code.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)