### PR TITLE
feat(tui,web): fresh-idle pulse + configurable decay for Stop hook (#863)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,21 @@ jobs:
           echo ""
           echo "=== All evaluations passed ==="
 
+  vitest:
+    name: Vitest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: '22'
+      - name: Install dependencies
+        working-directory: web
+        run: npm ci
+      - name: Run Vitest unit tests
+        working-directory: web
+        run: npm run test:unit
+
   playwright:
     name: Playwright
     runs-on: ubuntu-latest

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -26,6 +26,11 @@ pub struct SessionResponse {
     pub yolo_mode: bool,
     pub created_at: String,
     pub last_accessed_at: Option<String>,
+    /// Wall-clock time of the most recent transition into Idle. Used by the
+    /// web dashboard to fade a freshly-stopped session's color toward neutral.
+    /// Distinct from `last_accessed_at`: viewing or messaging a session bumps
+    /// `last_accessed_at` but leaves `idle_entered_at` alone.
+    pub idle_entered_at: Option<String>,
     pub last_error: Option<String>,
     pub branch: Option<String>,
     pub main_repo_path: Option<String>,
@@ -73,6 +78,7 @@ impl SessionResponse {
             yolo_mode: inst.yolo_mode,
             created_at: inst.created_at.to_rfc3339(),
             last_accessed_at: inst.last_accessed_at.map(|t| t.to_rfc3339()),
+            idle_entered_at: inst.idle_entered_at.map(|t| t.to_rfc3339()),
             last_error: inst.last_error.clone(),
             branch: inst.worktree_info.as_ref().map(|w| w.branch.clone()),
             main_repo_path: inst

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -340,11 +340,12 @@ pub struct ThemeConfig {
     /// See `ColorMode` for the truecolor vs palette trade-off.
     #[serde(default)]
     pub color_mode: ColorMode,
-    /// Minutes over which a freshly-stopped Idle session's color decays
-    /// from `fresh_idle` to `idle`. Inside this window the row also gets
-    /// an animated `breathe` rattle and is included in the `w` keybind's
-    /// "needs attention" bucket. 0 disables the gradient entirely
-    /// (every Idle row renders as fully decayed slate immediately).
+    /// Minutes a freshly-stopped Idle session keeps the fresh-idle color
+    /// and animated `breathe` rattle before snapping back to the regular
+    /// static idle look. Sessions inside the window are also included in
+    /// the `w` keybind's "needs attention" bucket. 0 disables the
+    /// freshness signal entirely (every Idle row renders with the
+    /// regular static look the moment its Stop hook fires).
     #[serde(default = "default_idle_decay_minutes")]
     pub idle_decay_minutes: u64,
 }
@@ -847,9 +848,9 @@ mod tests {
 
     #[test]
     fn test_theme_config_idle_decay_zero_disables() {
-        // 0 is a valid setting that disables the gradient entirely.
-        // Verifying it round-trips cleanly so users can opt out without
-        // having to remove the field.
+        // 0 is a valid setting that disables the freshness signal
+        // entirely. Verifying it round-trips cleanly so users can opt
+        // out without having to remove the field.
         let toml = r#"
             idle_decay_minutes = 0
         "#;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -332,7 +332,7 @@ pub enum ColorMode {
     Palette,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThemeConfig {
     #[serde(default)]
     pub name: String,
@@ -340,6 +340,27 @@ pub struct ThemeConfig {
     /// See `ColorMode` for the truecolor vs palette trade-off.
     #[serde(default)]
     pub color_mode: ColorMode,
+    /// Minutes over which a freshly-stopped Idle session's color decays
+    /// from `fresh_idle` to `idle`. Inside this window the row also gets
+    /// an animated `breathe` rattle and is included in the `w` keybind's
+    /// "needs attention" bucket. 0 disables the gradient entirely
+    /// (every Idle row renders as fully decayed slate immediately).
+    #[serde(default = "default_idle_decay_minutes")]
+    pub idle_decay_minutes: u64,
+}
+
+impl Default for ThemeConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            color_mode: ColorMode::default(),
+            idle_decay_minutes: default_idle_decay_minutes(),
+        }
+    }
+}
+
+fn default_idle_decay_minutes() -> u64 {
+    20
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -801,6 +822,7 @@ mod tests {
     fn test_theme_config_default() {
         let theme = ThemeConfig::default();
         assert_eq!(theme.name, "");
+        assert_eq!(theme.idle_decay_minutes, 20);
     }
 
     #[test]
@@ -808,6 +830,31 @@ mod tests {
         let toml = r#"name = "dark""#;
         let theme: ThemeConfig = toml::from_str(toml).unwrap();
         assert_eq!(theme.name, "dark");
+        // Missing field falls back to the documented default so existing
+        // configs don't suddenly snap to "no decay" after upgrade.
+        assert_eq!(theme.idle_decay_minutes, 20);
+    }
+
+    #[test]
+    fn test_theme_config_idle_decay_override() {
+        let toml = r#"
+            name = "dracula"
+            idle_decay_minutes = 5
+        "#;
+        let theme: ThemeConfig = toml::from_str(toml).unwrap();
+        assert_eq!(theme.idle_decay_minutes, 5);
+    }
+
+    #[test]
+    fn test_theme_config_idle_decay_zero_disables() {
+        // 0 is a valid setting that disables the gradient entirely.
+        // Verifying it round-trips cleanly so users can opt out without
+        // having to remove the field.
+        let toml = r#"
+            idle_decay_minutes = 0
+        "#;
+        let theme: ThemeConfig = toml::from_str(toml).unwrap();
+        assert_eq!(theme.idle_decay_minutes, 0);
     }
 
     // Tests for UpdatesConfig

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -147,6 +147,19 @@ pub struct Instance {
     pub created_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_accessed_at: Option<DateTime<Utc>>,
+    /// Wall-clock time of the most recent transition into `Idle`. Used by the
+    /// TUI and web dashboard to fade a freshly-stopped session's color toward
+    /// neutral over `IDLE_DECAY_WINDOW`. Distinct from `last_accessed_at`,
+    /// which is also bumped on user interaction (a viewed session stays
+    /// "fresh" by design). `None` for non-Idle sessions or those that
+    /// transitioned before this field existed.
+    ///
+    /// Named `idle_entered_at` rather than `idle_since` to avoid collision
+    /// with `DwellState::idle_since` in `src/server/push.rs`, which is an
+    /// in-process `Instant` for push-notification dwell timing — a different
+    /// concept with a different type and lifetime.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_entered_at: Option<DateTime<Utc>>,
 
     // Git worktree integration
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -360,6 +373,7 @@ impl Instance {
             status: Status::Idle,
             created_at: Utc::now(),
             last_accessed_at: None,
+            idle_entered_at: None,
             worktree_info: None,
             workspace_info: None,
             sandbox_info: None,
@@ -381,6 +395,19 @@ impl Instance {
     /// timestamp reflects actual activity, not just status transitions.
     pub fn touch_last_accessed(&mut self) {
         self.last_accessed_at = Some(Utc::now());
+    }
+
+    /// Time elapsed since this session most recently transitioned into
+    /// `Idle`. `None` for non-Idle sessions, sessions with a missing
+    /// timestamp (legacy state), or sessions whose `idle_entered_at` is in
+    /// the future (clock skew). Negative deltas are clamped away rather than
+    /// returned as `Duration` since `chrono::Duration::to_std` rejects them.
+    pub fn idle_age(&self) -> Option<std::time::Duration> {
+        if self.status != Status::Idle {
+            return None;
+        }
+        let since = self.idle_entered_at?;
+        (Utc::now() - since).to_std().ok()
     }
 
     /// Return the profile that should drive config resolution for this
@@ -1307,7 +1334,13 @@ impl Instance {
         let prev_status = self.status;
         self.update_status_with_metadata_inner(metadata);
         if self.status != prev_status {
-            self.last_accessed_at = Some(Utc::now());
+            let now = Utc::now();
+            self.last_accessed_at = Some(now);
+            self.idle_entered_at = if self.status == Status::Idle {
+                Some(now)
+            } else {
+                None
+            };
         }
     }
 
@@ -1688,6 +1721,47 @@ mod tests {
 
         inst.parent_session_id = Some("parent123".to_string());
         assert!(inst.is_sub_session());
+    }
+
+    #[test]
+    fn test_idle_age_returns_none_for_non_idle() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Running;
+        inst.idle_entered_at = Some(Utc::now() - chrono::Duration::seconds(60));
+        // A Running session never has an idle age, even if a stale
+        // `idle_entered_at` timestamp is sitting around (e.g. a transition
+        // that bumped from Idle → Running but missed the cleanup path).
+        assert_eq!(inst.idle_age(), None);
+    }
+
+    #[test]
+    fn test_idle_age_returns_none_when_no_timestamp() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.idle_entered_at = None;
+        assert_eq!(inst.idle_age(), None);
+    }
+
+    #[test]
+    fn test_idle_age_returns_positive_duration() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        inst.idle_entered_at = Some(Utc::now() - chrono::Duration::seconds(5));
+        let age = inst.idle_age().expect("idle age should be present");
+        // Allow generous slack so the test isn't flaky on slow CI.
+        assert!(age.as_secs() >= 4 && age.as_secs() <= 30);
+    }
+
+    #[test]
+    fn test_idle_age_clamps_negative_to_none() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Idle;
+        // Future timestamp (clock skew, hand-crafted state). `to_std()` on a
+        // negative `chrono::Duration` returns Err, which we map to None so
+        // the gradient renderer sees "fully decayed" rather than panicking
+        // or treating the session as freshly stopped.
+        inst.idle_entered_at = Some(Utc::now() + chrono::Duration::seconds(60));
+        assert_eq!(inst.idle_age(), None);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -147,17 +147,19 @@ pub struct Instance {
     pub created_at: DateTime<Utc>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_accessed_at: Option<DateTime<Utc>>,
-    /// Wall-clock time of the most recent transition into `Idle`. Used by the
-    /// TUI and web dashboard to fade a freshly-stopped session's color toward
-    /// neutral over `IDLE_DECAY_WINDOW`. Distinct from `last_accessed_at`,
-    /// which is also bumped on user interaction (a viewed session stays
-    /// "fresh" by design). `None` for non-Idle sessions or those that
-    /// transitioned before this field existed.
+    /// Wall-clock time of the most recent transition into `Idle`. Used by
+    /// the TUI and web dashboard to highlight a freshly-stopped session
+    /// for the duration of the configured idle-decay window
+    /// (`Config.theme.idle_decay_minutes`); past the window the row drops
+    /// back to the regular static idle look. Distinct from
+    /// `last_accessed_at`, which is also bumped on user interaction (a
+    /// viewed session stays "fresh" by design). `None` for non-Idle
+    /// sessions or those that transitioned before this field existed.
     ///
     /// Named `idle_entered_at` rather than `idle_since` to avoid collision
     /// with `DwellState::idle_since` in `src/server/push.rs`, which is an
-    /// in-process `Instant` for push-notification dwell timing — a different
-    /// concept with a different type and lifetime.
+    /// in-process `Instant` for push-notification dwell timing — a
+    /// different concept with a different type and lifetime.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub idle_entered_at: Option<DateTime<Utc>>,
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1760,7 +1760,7 @@ mod tests {
         inst.status = Status::Idle;
         // Future timestamp (clock skew, hand-crafted state). `to_std()` on a
         // negative `chrono::Duration` returns Err, which we map to None so
-        // the gradient renderer sees "fully decayed" rather than panicking
+        // the freshness logic sees "fully decayed" rather than panicking
         // or treating the session as freshly stopped.
         inst.idle_entered_at = Some(Utc::now() + chrono::Duration::seconds(60));
         assert_eq!(inst.idle_age(), None);

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -50,6 +50,8 @@ pub struct ThemeConfigOverride {
     pub name: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub color_mode: Option<ColorMode>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub idle_decay_minutes: Option<u64>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -413,6 +415,9 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(ref color_mode) = theme_override.color_mode {
             global.theme.color_mode = color_mode.clone();
+        }
+        if let Some(idle_decay_minutes) = theme_override.idle_decay_minutes {
+            global.theme.idle_decay_minutes = idle_decay_minutes;
         }
     }
 

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -1,5 +1,7 @@
 //! Preview panel component
 
+use std::time::Duration;
+
 use ansi_to_tui::IntoText;
 use ratatui::prelude::*;
 use ratatui::widgets::*;
@@ -136,6 +138,7 @@ impl Preview {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render_with_cache(
         frame: &mut Frame,
         area: Rect,
@@ -143,6 +146,7 @@ impl Preview {
         cached_output: &str,
         scroll_offset: u16,
         theme: &Theme,
+        idle_decay_window: Duration,
         compact: bool,
     ) {
         if compact {
@@ -175,7 +179,7 @@ impl Preview {
             ])
             .split(area);
 
-        Self::render_info(frame, chunks[0], instance, theme);
+        Self::render_info(frame, chunks[0], instance, theme, idle_decay_window);
         Self::render_output_cached(
             frame,
             chunks[1],
@@ -187,7 +191,13 @@ impl Preview {
         );
     }
 
-    fn render_info(frame: &mut Frame, area: Rect, instance: &Instance, theme: &Theme) {
+    fn render_info(
+        frame: &mut Frame,
+        area: Rect,
+        instance: &Instance,
+        theme: &Theme,
+        idle_decay_window: Duration,
+    ) {
         let mut info_lines = Vec::new();
 
         // Profile and Tool on the same row to save vertical space
@@ -222,7 +232,9 @@ impl Preview {
                     Style::default().fg(match instance.status {
                         crate::session::Status::Running => theme.running,
                         crate::session::Status::Waiting => theme.waiting,
-                        crate::session::Status::Idle => theme.idle,
+                        crate::session::Status::Idle => {
+                            theme.idle_color_at_age(instance.idle_age(), idle_decay_window)
+                        }
                         crate::session::Status::Unknown => theme.waiting,
                         crate::session::Status::Stopped => theme.dimmed,
                         crate::session::Status::Error => theme.error,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1126,7 +1126,12 @@ impl HomeView {
             return;
         }
 
-        // Pass 1: forward-walk from cursor+1, wrapping, for the next Waiting session.
+        // Pass 1: forward-walk from cursor+1, wrapping, for the next Waiting
+        // session OR a freshly-stopped Idle session (within
+        // `idle_decay_window`). Both states are "needs your attention" and
+        // cycle together so repeated `w` taps move through the actionable
+        // backlog regardless of which hook fired.
+        let window = self.idle_decay_window;
         let start = (self.cursor + 1) % len;
         for i in 0..len - 1 {
             let idx = (start + i) % len;
@@ -1135,7 +1140,9 @@ impl HomeView {
                 _ => continue,
             };
             if let Some(inst) = self.get_instance(&id) {
-                if inst.status == Status::Waiting {
+                let is_actionable = inst.status == Status::Waiting
+                    || matches!(inst.idle_age(), Some(age) if age < window);
+                if is_actionable {
                     self.cursor = idx;
                     self.update_selected();
                     return;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -506,9 +506,9 @@ impl HomeView {
                     inst.last_start_time = prev.last_start_time;
                     inst.session_id_poller = prev.session_id_poller.clone();
                     // Carry the in-memory idle_entered_at across reloads
-                    // so the gradient doesn't snap back to fully-decayed
-                    // when the user toggles a setting that triggers a
-                    // reload mid-window.
+                    // so a freshly-stopped session doesn't lose its
+                    // freshness state when the user toggles a setting
+                    // that triggers a reload mid-window.
                     inst.idle_entered_at = prev.idle_entered_at;
                     // Use in-memory session_id if present; fallback to disk.
                     // In-memory state takes priority over disk: the poller

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -231,6 +231,12 @@ pub struct HomeView {
     // Sound config for state transition sounds
     pub(super) sound_config: crate::sound::SoundConfig,
 
+    /// Resolved decay window from `Config.theme.idle_decay_minutes`. Read
+    /// at startup and re-resolved on settings reload. Used by render to
+    /// drive the gradient + breathe rattle, and by the `w` keybind to
+    /// gate which Idle sessions are still "actionable".
+    pub(super) idle_decay_window: std::time::Duration,
+
     // When true, letter-based action hotkeys require SHIFT (guard against
     // dictation / stray keystrokes triggering destructive actions).
     pub(super) strict_hotkeys: bool,
@@ -289,6 +295,8 @@ impl HomeView {
         };
         let sound_config = resolved.sound.clone();
         let strict_hotkeys = resolved.session.strict_hotkeys;
+        let idle_decay_window =
+            crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
         let user_config = load_config().ok().flatten();
         let sort_order = user_config
             .as_ref()
@@ -373,6 +381,7 @@ impl HomeView {
             default_terminal_mode,
             sound_config,
             strict_hotkeys,
+            idle_decay_window,
             settings_view: None,
             settings_close_confirm: false,
             diff_view: None,
@@ -496,6 +505,11 @@ impl HomeView {
                     inst.last_error_check = prev.last_error_check;
                     inst.last_start_time = prev.last_start_time;
                     inst.session_id_poller = prev.session_id_poller.clone();
+                    // Carry the in-memory idle_entered_at across reloads
+                    // so the gradient doesn't snap back to fully-decayed
+                    // when the user toggles a setting that triggers a
+                    // reload mid-window.
+                    inst.idle_entered_at = prev.idle_entered_at;
                     // Use in-memory session_id if present; fallback to disk.
                     // In-memory state takes priority over disk: the poller
                     // may have updated the ID since last save.
@@ -612,9 +626,14 @@ impl HomeView {
                 if should_update {
                     let new_status = update.status;
                     let new_error = update.last_error;
+                    let new_idle_entered_at = update.idle_entered_at;
                     self.mutate_instance(&update.id, |inst| {
                         inst.status = new_status;
                         inst.last_error = new_error;
+                        // Propagate the timestamp the polling clone wrote;
+                        // see StatusPoller for why this isn't a simple
+                        // `inst.idle_entered_at = …` from inside the poll.
+                        inst.idle_entered_at = new_idle_entered_at;
                     });
 
                     if let Some(old) = old_status {
@@ -1456,6 +1475,8 @@ impl HomeView {
         };
         self.sound_config = config.sound.clone();
         self.strict_hotkeys = config.session.strict_hotkeys;
+        self.idle_decay_window =
+            crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
     }
 
     /// Toggle terminal mode between Container and Host for a session

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -233,8 +233,8 @@ pub struct HomeView {
 
     /// Resolved decay window from `Config.theme.idle_decay_minutes`. Read
     /// at startup and re-resolved on settings reload. Used by render to
-    /// drive the gradient + breathe rattle, and by the `w` keybind to
-    /// gate which Idle sessions are still "actionable".
+    /// drive the breathe rattle and fresh-idle color, and by the `w`
+    /// keybind to gate which Idle sessions are still "actionable".
     pub(super) idle_decay_window: std::time::Duration,
 
     // When true, letter-based action hotkeys require SHIFT (guard against

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -31,7 +31,7 @@ use super::dialogs::{
 };
 use super::diff::DiffView;
 use super::settings::SettingsView;
-use super::status_poller::StatusPoller;
+use super::status_poller::{StatusPoller, StatusUpdate};
 
 /// Extract a project group name from a session instance.
 /// Uses `worktree_info.main_repo_path` for worktree sessions (so all branches of the
@@ -610,43 +610,51 @@ impl HomeView {
     /// Apply any pending status updates from the background poller.
     /// Returns true if updates were applied.
     pub fn apply_status_updates(&mut self) -> bool {
-        use crate::session::Status;
-
         if let Some(updates) = self.status_poller.try_recv_updates() {
             for update in updates {
-                let old_status = self.get_instance(&update.id).map(|i| i.status);
-
-                let should_update = old_status.is_some_and(|s| {
-                    s != Status::Deleting
-                        && s != Status::Creating
-                        && s != Status::Stopped
-                        && update.status != Status::Stopped
-                });
-
-                if should_update {
-                    let new_status = update.status;
-                    let new_error = update.last_error;
-                    let new_idle_entered_at = update.idle_entered_at;
-                    self.mutate_instance(&update.id, |inst| {
-                        inst.status = new_status;
-                        inst.last_error = new_error;
-                        // Propagate the timestamp the polling clone wrote;
-                        // see StatusPoller for why this isn't a simple
-                        // `inst.idle_entered_at = …` from inside the poll.
-                        inst.idle_entered_at = new_idle_entered_at;
-                    });
-
-                    if let Some(old) = old_status {
-                        if old != new_status {
-                            crate::sound::play_for_transition(old, new_status, &self.sound_config);
-                        }
-                    }
-                }
+                self.apply_one_status_update(update);
             }
             self.pending_status_refresh = false;
             return true;
         }
         false
+    }
+
+    /// Apply a single status update from the poller. Extracted from the
+    /// channel-pulling loop in `apply_status_updates` so tests can drive
+    /// the apply path directly without having to push through the
+    /// background polling thread.
+    pub(super) fn apply_one_status_update(&mut self, update: StatusUpdate) {
+        use crate::session::Status;
+
+        let old_status = self.get_instance(&update.id).map(|i| i.status);
+        let should_update = old_status.is_some_and(|s| {
+            s != Status::Deleting
+                && s != Status::Creating
+                && s != Status::Stopped
+                && update.status != Status::Stopped
+        });
+        if !should_update {
+            return;
+        }
+
+        let new_status = update.status;
+        let new_error = update.last_error;
+        let new_idle_entered_at = update.idle_entered_at;
+        self.mutate_instance(&update.id, |inst| {
+            inst.status = new_status;
+            inst.last_error = new_error;
+            // Propagate the timestamp the polling clone wrote;
+            // see StatusPoller for why this isn't a simple
+            // `inst.idle_entered_at = …` from inside the poll.
+            inst.idle_entered_at = new_idle_entered_at;
+        });
+
+        if let Some(old) = old_status {
+            if old != new_status {
+                crate::sound::play_for_transition(old, new_status, &self.sound_config);
+            }
+        }
     }
 
     pub fn apply_deletion_results(&mut self) -> bool {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -138,6 +138,32 @@ const LAST_ACTIVITY_SLOT: usize = 6;
 /// horizontal budget on narrow panes.
 const LAST_ACTIVITY_RIGHT_MARGIN: usize = 1;
 
+/// Decide where the right-aligned activity column lives on a session row.
+///
+/// `prefix_width` is the display width of the spans already pushed (indent,
+/// icon, title, optional branch info). `list_width` is the inner width of
+/// the list pane. `badge_width` is 0 when no terminal-mode badge follows
+/// the column, otherwise the badge string's length.
+///
+/// Returns `Some(pad_len)` if the column fits with `LAST_ACTIVITY_SLOT` for
+/// the value, the badge after, and `LAST_ACTIVITY_RIGHT_MARGIN` of trailing
+/// space. The padding is what the row should push between the prefix and
+/// the column to right-align it. `None` means the row is too wide and the
+/// column should be skipped entirely (the title takes priority).
+fn activity_column_padding(
+    prefix_width: usize,
+    list_width: u16,
+    badge_width: usize,
+) -> Option<usize> {
+    let trailing = LAST_ACTIVITY_SLOT + badge_width + LAST_ACTIVITY_RIGHT_MARGIN;
+    let total = prefix_width.checked_add(trailing)?;
+    if total <= list_width as usize {
+        Some(list_width as usize - total)
+    } else {
+        None
+    }
+}
+
 impl HomeView {
     pub fn render(
         &mut self,
@@ -620,10 +646,9 @@ impl HomeView {
                 let badge_width = badge_text.map_or(0, |s| s.len());
 
                 let used_width: usize = line_spans.iter().map(|s| s.width()).sum();
-                let trailing = LAST_ACTIVITY_SLOT + badge_width + LAST_ACTIVITY_RIGHT_MARGIN;
-                let column_fits = used_width + trailing <= list_width as usize;
-                if column_fits {
-                    let pad_len = list_width as usize - used_width - trailing;
+                let column_pad = activity_column_padding(used_width, list_width, badge_width);
+                let column_fits = column_pad.is_some();
+                if let Some(pad_len) = column_pad {
                     if pad_len > 0 {
                         line_spans.push(Span::raw(" ".repeat(pad_len)));
                     }
@@ -1320,5 +1345,66 @@ mod tests {
     fn scroll_exceeds_cache_true_for_empty_cache() {
         // First render: nothing captured yet, so any request forces capture.
         assert!(scroll_exceeds_cache(0, 30, 0));
+    }
+
+    // -- activity_column_padding -------------------------------------------
+    //
+    // The column lives at `list_width - badge_width - SLOT - MARGIN`; the
+    // returned pad_len is what goes between the row prefix and the column
+    // to right-align it. None means the row is too wide and the column
+    // should be hidden so the title doesn't get clipped.
+
+    #[test]
+    fn activity_column_padding_short_title_with_room_to_spare() {
+        // 35-col pane, 12-col prefix, no badge: trailing reserves 6 (slot)
+        // + 0 (badge) + 1 (margin) = 7, total = 19, pad_len = 35 - 19 = 16.
+        assert_eq!(activity_column_padding(12, 35, 0), Some(16));
+    }
+
+    #[test]
+    fn activity_column_padding_exact_fit_yields_zero_pad() {
+        // Prefix ends right where the trailing block begins.
+        // list_width(20) - prefix(13) - trailing(7) = 0.
+        assert_eq!(activity_column_padding(13, 20, 0), Some(0));
+    }
+
+    #[test]
+    fn activity_column_padding_one_short_hides_column() {
+        // One column over budget: prefix(14) + trailing(7) = 21 > 20.
+        assert_eq!(activity_column_padding(14, 20, 0), None);
+    }
+
+    #[test]
+    fn activity_column_padding_accounts_for_terminal_mode_badge() {
+        // " [host]" is 7 chars. trailing = SLOT(6) + 7 + MARGIN(1) = 14.
+        // 35 - 14 - prefix(10) = 11.
+        assert_eq!(activity_column_padding(10, 35, 7), Some(11));
+        // " [container]" is 12 chars. trailing = 6 + 12 + 1 = 19.
+        // 35 - 19 - 10 = 6.
+        assert_eq!(activity_column_padding(10, 35, 12), Some(6));
+    }
+
+    #[test]
+    fn activity_column_padding_long_title_with_badge_hides_column() {
+        // The badge by itself fits but the column doesn't. The decision
+        // is per-row "show the column or not" — the badge gets its own
+        // unconditional render path.
+        // prefix(20) + slot(6) + badge(12) + margin(1) = 39 > 35.
+        assert_eq!(activity_column_padding(20, 35, 12), None);
+    }
+
+    #[test]
+    fn activity_column_padding_narrow_pane_short_title() {
+        // Was the regression: a 25-col pane was previously hidden by the
+        // old fixed-30 floor, even when there was easily room.
+        // prefix(8) + 7 trailing = 15 ≤ 25. Now shows.
+        assert_eq!(activity_column_padding(8, 25, 0), Some(10));
+    }
+
+    #[test]
+    fn activity_column_padding_saturates_on_overflow() {
+        // Defensive: prefix near usize::MAX must not wrap. The checked_add
+        // returns None which we map to "doesn't fit".
+        assert_eq!(activity_column_padding(usize::MAX, 1000, 0), None);
     }
 }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -80,6 +80,23 @@ fn spinner_starting(created_at: &DateTime<Utc>) -> &'static str {
         .current_frame()
 }
 
+/// Slow `breathe` rattle for a freshly-stopped Idle session. Reuses the
+/// same animation as Starting on purpose; differentiation is by color
+/// (Starting uses `theme.dimmed`, fresh-idle uses `theme.fresh_idle`).
+/// The longer interval reads as "gentle reminder" rather than "actively
+/// transitioning". Phase offset uses `idle_entered_at` when available so
+/// sessions that just stopped don't all sync to the same frame.
+fn spinner_idle_fresh(
+    created_at: &DateTime<Utc>,
+    idle_entered_at: Option<DateTime<Utc>>,
+) -> &'static str {
+    let offset_ts = idle_entered_at.unwrap_or(*created_at);
+    spinners::breathe()
+        .set_interval(Duration::from_millis(280))
+        .offset(session_offset(&offset_ts))
+        .current_frame()
+}
+
 /// Format a timestamp as a compact relative age (e.g. `3m`, `2h`, `4d`, `2mo`).
 /// Returns an empty string for `None` so callers can unconditionally substitute
 /// the result without guarding for absence.
@@ -111,18 +128,15 @@ fn format_relative_age(ts: Option<DateTime<Utc>>) -> String {
     format!("{}mo", months)
 }
 
-/// Minimum column width required to render the last-activity column.
-/// When the session list is narrower than this, the column is hidden entirely.
-/// Compared against `inner.width` (list pane minus 2-char border), so this is
-/// effectively `home_list_width - 2`. Keeping it at 30 lets the column appear
-/// for users who set `home_list_width` in the 35–45 range (the common narrow-
-/// pane setting) and for mobile clients with tight pane widths; the 6-char
-/// age slot plus ~24 chars for title/branch still fits comfortably.
-const LAST_ACTIVITY_MIN_WIDTH: u16 = 30;
-
-/// Width reserved for the right-aligned last-activity column:
-/// 5 chars for the label (e.g. `"<1m"`, `"30mo"`) + 1 char left padding.
+/// Width of the last-activity label slot itself: 5 chars for the value
+/// (e.g. `"<1m"`, `"30mo"`) + 1 char of left padding inside the slot.
 const LAST_ACTIVITY_SLOT: usize = 6;
+
+/// Trailing gap between the activity slot (or terminal-mode badge) and the
+/// pane's right border. One cell looks consistent with the breathing room
+/// other ratatui widgets leave around the rounded border without burning
+/// horizontal budget on narrow panes.
+const LAST_ACTIVITY_RIGHT_MARGIN: usize = 1;
 
 impl HomeView {
     pub fn render(
@@ -466,9 +480,23 @@ impl HomeView {
                 if let Some(inst) = self.get_instance(id) {
                     match self.view_mode {
                         ViewMode::Agent => {
+                            // For Idle sessions, decay color from `fresh_idle`
+                            // toward `idle` over `idle_decay_window`. A slow
+                            // `breathe` rattle replaces the static braille
+                            // glyph while we're inside the window, matching
+                            // the animated visual language of the other
+                            // attention-worthy states (Running, Waiting,
+                            // Starting). Also serves as a redundant cue for
+                            // colorblind users / monochrome terminals.
+                            let idle_age = inst.idle_age();
+                            let is_fresh_idle =
+                                matches!(idle_age, Some(age) if age < self.idle_decay_window);
                             let icon = match inst.status {
                                 Status::Running => spinner_running(&inst.created_at),
                                 Status::Waiting => spinner_waiting(&inst.created_at),
+                                Status::Idle if is_fresh_idle => {
+                                    spinner_idle_fresh(&inst.created_at, inst.idle_entered_at)
+                                }
                                 Status::Idle => ICON_IDLE,
                                 Status::Unknown => ICON_UNKNOWN,
                                 Status::Stopped => ICON_STOPPED,
@@ -480,7 +508,9 @@ impl HomeView {
                             let color = match inst.status {
                                 Status::Running => theme.running,
                                 Status::Waiting => theme.waiting,
-                                Status::Idle => theme.idle,
+                                Status::Idle => {
+                                    theme.idle_color_at_age(idle_age, self.idle_decay_window)
+                                }
                                 Status::Unknown => theme.waiting,
                                 Status::Stopped => theme.dimmed,
                                 Status::Error => theme.error,
@@ -556,27 +586,72 @@ impl HomeView {
                     }
                 }
 
-                // Last-activity column: right-aligned, fixed-width slot just
-                // before the terminal-mode/status badge. Hidden when the list
-                // pane is too narrow to justify spending the horizontal budget.
-                if list_width >= LAST_ACTIVITY_MIN_WIDTH {
-                    let age = format_relative_age(inst.last_accessed_at);
-                    // Reserve LAST_ACTIVITY_SLOT cells; right-align inside the
-                    // slot so columns line up across rows of varying title
-                    // length. Empty `age` still reserves space — keeping the
-                    // column aligned is why we don't conditionally skip per
-                    // row.
+                // Right edge of the row: optional terminal-mode badge, and
+                // an activity column (last-accessed for non-Idle rows,
+                // time-since-stop for Idle rows). Both pin to the pane's
+                // right edge so the column lines up vertically across the
+                // session list — without right-alignment each row would
+                // place its column at a different x depending on title
+                // length, which reads as visually noisy.
+                //
+                // Decision is per-row: show the column only if the prefix
+                // (indent + icon + title + branch info) plus the column
+                // slot and any badge fits inside `list_width`. On narrow
+                // panes a long title would otherwise clip the column or
+                // push it off-screen, so we hide the column for that row
+                // rather than mangle the title. The badge follows existing
+                // behavior (always pushed in Terminal+sandboxed mode).
+                //
+                // Idle-row note: column drives off `idle_entered_at`, not
+                // `last_accessed_at`. The latter is bumped by user
+                // interaction (attach, send-keys), which would lie about
+                // how long it's actually been since the agent stopped.
+                // Color tracks the fresh/decayed binary used by the icon so
+                // the readout fades in step.
+                let badge_text: Option<&'static str> =
+                    if self.view_mode == ViewMode::Terminal && inst.is_sandboxed() {
+                        Some(match self.get_terminal_mode(id) {
+                            TerminalMode::Container => " [container]",
+                            TerminalMode::Host => " [host]",
+                        })
+                    } else {
+                        None
+                    };
+                let badge_width = badge_text.map_or(0, |s| s.len());
+
+                let used_width: usize = line_spans.iter().map(|s| s.width()).sum();
+                let trailing = LAST_ACTIVITY_SLOT + badge_width + LAST_ACTIVITY_RIGHT_MARGIN;
+                let column_fits = used_width + trailing <= list_width as usize;
+                if column_fits {
+                    let pad_len = list_width as usize - used_width - trailing;
+                    if pad_len > 0 {
+                        line_spans.push(Span::raw(" ".repeat(pad_len)));
+                    }
+                    // Idle rows show time-since-stop (`idle_entered_at`)
+                    // since `last_accessed_at` would lie after attach/send.
+                    // Fall back to `last_accessed_at` when `idle_entered_at`
+                    // is missing — sessions that were Idle before this
+                    // field existed (or that haven't transitioned since
+                    // upgrade) shouldn't render a blank column. The
+                    // fallback timestamp is approximate but better than no
+                    // signal at all. Color stays `theme.dimmed` for every
+                    // status — the icon already carries the urgency
+                    // signal, so a colored timestamp would just add noise.
+                    let age_ts = if inst.status == Status::Idle {
+                        inst.idle_entered_at.or(inst.last_accessed_at)
+                    } else {
+                        inst.last_accessed_at
+                    };
+                    let age = format_relative_age(age_ts);
                     let padded = format!("{:>width$}", age, width = LAST_ACTIVITY_SLOT);
                     line_spans.push(Span::styled(padded, Style::default().fg(theme.dimmed)));
                 }
 
-                if self.view_mode == ViewMode::Terminal && inst.is_sandboxed() {
-                    let mode = self.get_terminal_mode(id);
-                    let mode_text = match mode {
-                        TerminalMode::Container => " [container]",
-                        TerminalMode::Host => " [host]",
-                    };
-                    line_spans.push(Span::styled(mode_text, Style::default().fg(theme.sandbox)));
+                if let Some(badge) = badge_text {
+                    line_spans.push(Span::styled(badge, Style::default().fg(theme.sandbox)));
+                }
+                if column_fits {
+                    line_spans.push(Span::raw(" ".repeat(LAST_ACTIVITY_RIGHT_MARGIN)));
                 }
             }
         }
@@ -741,10 +816,20 @@ impl HomeView {
                 .as_ref()
                 .and_then(|id| self.get_instance(id))
                 .map(|inst| {
+                    let idle_age = inst.idle_age();
+                    let is_fresh_idle =
+                        matches!(idle_age, Some(age) if age < self.idle_decay_window);
                     let (icon, icon_color) = match inst.status {
                         Status::Running => (spinner_running(&inst.created_at), theme.running),
                         Status::Waiting => (spinner_waiting(&inst.created_at), theme.waiting),
-                        Status::Idle => (ICON_IDLE, theme.idle),
+                        Status::Idle if is_fresh_idle => (
+                            spinner_idle_fresh(&inst.created_at, inst.idle_entered_at),
+                            theme.idle_color_at_age(idle_age, self.idle_decay_window),
+                        ),
+                        Status::Idle => (
+                            ICON_IDLE,
+                            theme.idle_color_at_age(idle_age, self.idle_decay_window),
+                        ),
                         Status::Unknown => (ICON_UNKNOWN, theme.waiting),
                         Status::Stopped => (ICON_STOPPED, theme.dimmed),
                         Status::Error => (ICON_ERROR, theme.error),
@@ -805,6 +890,7 @@ impl HomeView {
                                 &self.preview_cache.content,
                                 self.preview_scroll_offset,
                                 theme,
+                                self.idle_decay_window,
                                 compact,
                             );
                         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2644,3 +2644,118 @@ fn wants_text_selection_tracks_copy_friendly_surfaces() {
         assert!(!env.view.wants_text_selection());
     }
 }
+
+// -- apply_one_status_update -------------------------------------------------
+//
+// These guard the bug discovered in #872: the polling loop runs
+// `update_status_with_metadata` on a clone, then projects the result into
+// a `StatusUpdate`. The first version of that struct dropped the
+// freshly-set `idle_entered_at`, which meant the breathe rattle and
+// fresh-idle color never fired in the TUI even though everything looked
+// right via the API.
+
+#[test]
+#[serial]
+fn apply_status_update_propagates_idle_entered_at_into_live_instance() {
+    use crate::session::Status;
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+
+    // The instance was just created (Idle, no transition observed yet).
+    assert_eq!(env.view.get_instance(&id).unwrap().idle_entered_at, None);
+
+    // Simulate the poller observing a Stop hook: status stays Idle on
+    // disk but the wrapper writes `idle_entered_at` on the polling
+    // clone. The apply path must carry that timestamp into the live
+    // instance, otherwise nothing downstream sees it.
+    let now = chrono::Utc::now();
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Idle,
+        last_error: None,
+        idle_entered_at: Some(now),
+    });
+
+    let inst = env.view.get_instance(&id).unwrap();
+    assert_eq!(inst.status, Status::Idle);
+    assert_eq!(inst.idle_entered_at, Some(now));
+}
+
+#[test]
+#[serial]
+fn apply_status_update_clears_idle_entered_at_on_idle_to_running() {
+    use crate::session::Status;
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+
+    // Seed: session is Idle with a freshness timestamp set.
+    let stop_time = chrono::Utc::now() - chrono::Duration::seconds(60);
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Idle,
+        last_error: None,
+        idle_entered_at: Some(stop_time),
+    });
+    assert_eq!(
+        env.view.get_instance(&id).unwrap().idle_entered_at,
+        Some(stop_time)
+    );
+
+    // Transition Idle -> Running. The poller's wrapper clears
+    // `idle_entered_at` on the clone for non-Idle states; the apply
+    // path has to honor that, otherwise a Running session would still
+    // claim a freshness age.
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Running,
+        last_error: None,
+        idle_entered_at: None,
+    });
+
+    let inst = env.view.get_instance(&id).unwrap();
+    assert_eq!(inst.status, Status::Running);
+    assert_eq!(inst.idle_entered_at, None);
+    // And `idle_age()` must not synthesize one out of stale state.
+    assert_eq!(inst.idle_age(), None);
+}
+
+#[test]
+#[serial]
+fn apply_status_update_skips_terminal_states() {
+    use crate::session::Status;
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+
+    // Move the session into a terminal state that the apply path is
+    // supposed to leave alone.
+    env.view
+        .mutate_instance(&id, |inst| inst.status = Status::Deleting);
+    let stale_ts = chrono::Utc::now() - chrono::Duration::seconds(10);
+
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Idle,
+        last_error: None,
+        idle_entered_at: Some(stale_ts),
+    });
+
+    // Status and timestamp should both stay untouched.
+    let inst = env.view.get_instance(&id).unwrap();
+    assert_eq!(inst.status, Status::Deleting);
+    assert_eq!(inst.idle_entered_at, None);
+}

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -47,6 +47,7 @@ pub enum FieldKey {
     // Theme
     ThemeName,
     ThemeColorMode,
+    IdleDecayMinutes,
     // Updates
     CheckEnabled,
     CheckIntervalHours,
@@ -365,6 +366,12 @@ fn build_theme_fields(
         },
     );
 
+    let (idle_decay_minutes, idle_decay_override) = resolve_value(
+        scope,
+        global.theme.idle_decay_minutes,
+        theme.and_then(|t| t.idle_decay_minutes),
+    );
+
     vec![
         SettingField {
             key: FieldKey::ThemeName,
@@ -386,6 +393,18 @@ fn build_theme_fields(
             category: SettingsCategory::Theme,
             has_override: cm_has_override,
             inherited_display: cm_inherited,
+        },
+        SettingField {
+            key: FieldKey::IdleDecayMinutes,
+            label: "Idle Decay (minutes)",
+            description: "Minutes a freshly-stopped Idle session keeps the fresh-idle tint and animated icon before fading to neutral. Also gates the `w` keybind. 0 disables.",
+            value: FieldValue::Number(idle_decay_minutes),
+            category: SettingsCategory::Theme,
+            has_override: idle_decay_override,
+            inherited_display: inherited_if(
+                idle_decay_override,
+                FieldValue::Number(global.theme.idle_decay_minutes),
+            ),
         },
     ]
 }
@@ -1396,6 +1415,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
                 _ => crate::session::config::ColorMode::Truecolor,
             };
         }
+        (FieldKey::IdleDecayMinutes, FieldValue::Number(v)) => {
+            config.theme.idle_decay_minutes = *v;
+        }
         // Updates
         (FieldKey::CheckEnabled, FieldValue::Bool(v)) => config.updates.check_enabled = *v,
         (FieldKey::CheckIntervalHours, FieldValue::Number(v)) => {
@@ -1554,6 +1576,13 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 1 => crate::session::config::ColorMode::Palette,
                 _ => crate::session::config::ColorMode::Truecolor,
             });
+        }
+        (FieldKey::IdleDecayMinutes, FieldValue::Number(v)) => {
+            use crate::session::ThemeConfigOverride;
+            let t = config
+                .theme
+                .get_or_insert_with(ThemeConfigOverride::default);
+            t.idle_decay_minutes = Some(*v);
         }
         // Updates
         (FieldKey::CheckEnabled, FieldValue::Bool(v)) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -541,6 +541,11 @@ impl SettingsView {
                     t.color_mode = None;
                 }
             }
+            FieldKey::IdleDecayMinutes => {
+                if let Some(ref mut t) = config.theme {
+                    t.idle_decay_minutes = None;
+                }
+            }
             // Updates
             FieldKey::CheckEnabled => {
                 if let Some(ref mut u) = config.updates {

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -44,9 +44,9 @@ pub struct StatusUpdate {
     pub last_error: Option<String>,
     /// Snapshot of the polled clone's `idle_entered_at` after
     /// `update_status_with_metadata` ran. Propagating this field is what
-    /// keeps the gradient working in the TUI: without it, the wrapper's
-    /// timestamp write lives only on the polling clone and is lost when we
-    /// project the result back into a `StatusUpdate`.
+    /// keeps the freshness signal working in the TUI: without it, the
+    /// wrapper's timestamp write lives only on the polling clone and is
+    /// lost when we project the result back into a `StatusUpdate`.
     pub idle_entered_at: Option<DateTime<Utc>>,
 }
 
@@ -211,8 +211,9 @@ mod tests {
         // Regression: the polling loop runs `update_status_with_metadata`
         // on a clone, then projects the result into a `StatusUpdate`. If
         // `idle_entered_at` falls off the projection (the original bug),
-        // the gradient + filled-dot icon never fire in the TUI even
-        // though the wrapper sets the timestamp on the clone correctly.
+        // the breathe rattle + fresh-idle color never fire in the TUI
+        // even though the wrapper sets the timestamp on the clone
+        // correctly.
         let ts = Utc::now();
         let update = StatusUpdate {
             id: "abc".into(),

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -18,6 +18,8 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
+use chrono::{DateTime, Utc};
+
 use crate::session::{Instance, Status};
 
 /// Adaptive polling intervals (in cycles). 0 = never poll.
@@ -40,6 +42,12 @@ pub struct StatusUpdate {
     pub id: String,
     pub status: Status,
     pub last_error: Option<String>,
+    /// Snapshot of the polled clone's `idle_entered_at` after
+    /// `update_status_with_metadata` ran. Propagating this field is what
+    /// keeps the gradient working in the TUI: without it, the wrapper's
+    /// timestamp write lives only on the polling clone and is lost when we
+    /// project the result back into a `StatusUpdate`.
+    pub idle_entered_at: Option<DateTime<Utc>>,
 }
 
 /// Background thread that polls session status without blocking the UI
@@ -148,6 +156,7 @@ impl StatusPoller {
                                         id: inst.id,
                                         status: Status::Error,
                                         last_error: Some("Container is not running".to_string()),
+                                        idle_entered_at: None,
                                     });
                                 }
                             }
@@ -164,6 +173,7 @@ impl StatusPoller {
                         id: inst.id,
                         status: inst.status,
                         last_error: inst.last_error,
+                        idle_entered_at: inst.idle_entered_at,
                     })
                 })
                 .collect();
@@ -195,6 +205,23 @@ impl Default for StatusPoller {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn status_update_carries_idle_entered_at() {
+        // Regression: the polling loop runs `update_status_with_metadata`
+        // on a clone, then projects the result into a `StatusUpdate`. If
+        // `idle_entered_at` falls off the projection (the original bug),
+        // the gradient + filled-dot icon never fire in the TUI even
+        // though the wrapper sets the timestamp on the clone correctly.
+        let ts = Utc::now();
+        let update = StatusUpdate {
+            id: "abc".into(),
+            status: Status::Idle,
+            last_error: None,
+            idle_entered_at: Some(ts),
+        };
+        assert_eq!(update.idle_entered_at, Some(ts));
+    }
 
     #[test]
     fn test_polling_tier_hot() {

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -10,7 +10,7 @@
 mod palette;
 mod themes;
 
-pub use themes::Theme;
+pub use themes::{idle_decay_window, Theme};
 
 use std::path::PathBuf;
 use tracing::warn;

--- a/src/tui/styles/themes.rs
+++ b/src/tui/styles/themes.rs
@@ -8,8 +8,9 @@ use serde::{Deserialize, Serialize};
 use super::palette::color_to_palette;
 
 /// Convert the user-configured decay duration (minutes) into a `Duration`.
-/// `0` returns `Duration::ZERO`, which the rest of the gradient code treats
-/// as "fully decayed immediately" — a documented opt-out.
+/// `0` returns `Duration::ZERO`, which the freshness logic treats as
+/// "fully decayed immediately" — a documented opt-out: every Idle row
+/// renders with the static idle look the moment its Stop hook fires.
 pub fn idle_decay_window(minutes: u64) -> Duration {
     Duration::from_secs(minutes.saturating_mul(60))
 }
@@ -162,11 +163,11 @@ impl Theme {
 
             running: Color::Rgb(34, 197, 94),
             // Waiting sits at the brightest point in the brand ramp
-            // (amber-400) so it wins on luminance against the gradient's
-            // fresh-idle endpoint. Saturation alone wasn't enough on dark
-            // backgrounds — the deeper copper read as dimmer, not more
-            // urgent. fresh-idle drops one rung to amber-500 so the
-            // hierarchy is bright-amber > copper-amber > slate.
+            // (amber-400) so it wins on luminance against the fresh-idle
+            // color. Saturation alone wasn't enough on dark backgrounds —
+            // the deeper copper read as dimmer, not more urgent.
+            // Fresh-idle drops one rung to amber-500 so the hierarchy is
+            // bright-amber > copper-amber > slate.
             waiting: Color::Rgb(251, 191, 36),
             fresh_idle: Color::Rgb(245, 158, 11),
             idle: Color::Rgb(100, 116, 139),

--- a/src/tui/styles/themes.rs
+++ b/src/tui/styles/themes.rs
@@ -523,6 +523,15 @@ mod tests {
         // the bright surface). The check picks the comparison direction
         // off the theme's own background. Rec. 601 is good enough for a
         // pairwise sanity check, not a formal contrast metric.
+        //
+        // Heuristic limit: a custom user theme with a mid-tone background
+        // (luminance near the 128 cutoff) could fall on the wrong side of
+        // the dark/light split and fail this assertion in surprising
+        // ways. That's intentional — the test guards the 5 built-ins, not
+        // arbitrary user themes loaded from `~/.config/agent-of-empires/
+        // themes/*.toml`. If a custom-theme contributor needs to bypass
+        // this, they should pick `fresh_idle` themselves rather than rely
+        // on the test to validate it.
         fn luminance(c: Color) -> f32 {
             match c {
                 Color::Rgb(r, g, b) => 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32,

--- a/src/tui/styles/themes.rs
+++ b/src/tui/styles/themes.rs
@@ -1,9 +1,18 @@
 //! Built-in themes and the `Theme` palette struct.
 
+use std::time::Duration;
+
 use ratatui::style::Color;
 use serde::{Deserialize, Serialize};
 
 use super::palette::color_to_palette;
+
+/// Convert the user-configured decay duration (minutes) into a `Duration`.
+/// `0` returns `Duration::ZERO`, which the rest of the gradient code treats
+/// as "fully decayed immediately" — a documented opt-out.
+pub fn idle_decay_window(minutes: u64) -> Duration {
+    Duration::from_secs(minutes.saturating_mul(60))
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -35,6 +44,14 @@ pub struct Theme {
     pub running: Color,
     #[serde(with = "hex_color")]
     pub waiting: Color,
+    /// Color for a session within the idle decay window (just transitioned
+    /// to Idle, hasn't aged out yet). Held constant for the full window so
+    /// the breathe rattle's pulse stays visually consistent, then snaps to
+    /// `idle` once the window expires. Should sit between `waiting`
+    /// (brightest, "needs you NOW") and `idle` (dimmest, "no rush") on the
+    /// theme's perceived-attention scale.
+    #[serde(with = "hex_color")]
+    pub fresh_idle: Color,
     #[serde(with = "hex_color")]
     pub idle: Color,
     #[serde(with = "hex_color")]
@@ -75,6 +92,26 @@ impl Default for Theme {
 }
 
 impl Theme {
+    /// Color for an Idle session, given the elapsed time since it
+    /// transitioned to Idle and the user-configured decay window.
+    ///
+    /// Two-state binary: `fresh_idle` while age is inside the window,
+    /// `idle` once past it (or when age/window aren't usable: `None` age,
+    /// zero window). The pulse phase deliberately holds a constant color
+    /// — a continuous lerp under the breathe rattle reads as noisy. If we
+    /// ever want a gradient back, add an interpolator and call it here.
+    pub fn idle_color_at_age(&self, age: Option<Duration>, window: Duration) -> Color {
+        let Some(age) = age else {
+            return self.idle;
+        };
+        if window.is_zero() || age >= window {
+            return self.idle;
+        }
+        self.fresh_idle
+    }
+}
+
+impl Theme {
     /// Convert every `Color::Rgb` field to the nearest xterm-256 palette index
     /// (`Color::Indexed`). In-place. Idempotent: already-Indexed / named /
     /// Reset colors are untouched. Use when the downstream transport mangles
@@ -91,6 +128,7 @@ impl Theme {
         self.hint = color_to_palette(self.hint);
         self.running = color_to_palette(self.running);
         self.waiting = color_to_palette(self.waiting);
+        self.fresh_idle = color_to_palette(self.fresh_idle);
         self.idle = color_to_palette(self.idle);
         self.error = color_to_palette(self.error);
         self.terminal_active = color_to_palette(self.terminal_active);
@@ -123,7 +161,14 @@ impl Theme {
             hint: Color::Rgb(148, 163, 184),
 
             running: Color::Rgb(34, 197, 94),
+            // Waiting sits at the brightest point in the brand ramp
+            // (amber-400) so it wins on luminance against the gradient's
+            // fresh-idle endpoint. Saturation alone wasn't enough on dark
+            // backgrounds — the deeper copper read as dimmer, not more
+            // urgent. fresh-idle drops one rung to amber-500 so the
+            // hierarchy is bright-amber > copper-amber > slate.
             waiting: Color::Rgb(251, 191, 36),
+            fresh_idle: Color::Rgb(245, 158, 11),
             idle: Color::Rgb(100, 116, 139),
             error: Color::Rgb(239, 68, 68),
             terminal_active: Color::Rgb(13, 148, 136),
@@ -159,6 +204,7 @@ impl Theme {
 
             running: Color::Rgb(0, 255, 180),
             waiting: Color::Rgb(255, 180, 60),
+            fresh_idle: Color::Rgb(255, 123, 28),
             idle: Color::Rgb(60, 100, 70),
             error: Color::Rgb(255, 100, 80),
             terminal_active: Color::Rgb(130, 170, 255),
@@ -194,6 +240,7 @@ impl Theme {
 
             running: Color::Rgb(158, 206, 106),
             waiting: Color::Rgb(224, 175, 104),
+            fresh_idle: Color::Rgb(255, 158, 100),
             idle: Color::Rgb(86, 95, 137),
             error: Color::Rgb(247, 118, 142),
             terminal_active: Color::Rgb(122, 162, 247),
@@ -228,7 +275,11 @@ impl Theme {
             hint: Color::Rgb(32, 159, 181),
 
             running: Color::Rgb(64, 160, 43),
-            waiting: Color::Rgb(223, 142, 29),
+            // Light theme: darker = more attention. Waiting takes the
+            // deepest peach, fresh_idle the mid amber, idle the lightest
+            // slate so the row visibly fades into the page over time.
+            waiting: Color::Rgb(254, 100, 11),
+            fresh_idle: Color::Rgb(223, 142, 29),
             idle: Color::Rgb(156, 160, 176),
             error: Color::Rgb(210, 15, 57),
             terminal_active: Color::Rgb(30, 102, 245),
@@ -266,6 +317,7 @@ impl Theme {
 
             running: Color::Rgb(80, 250, 123),
             waiting: Color::Rgb(255, 184, 108),
+            fresh_idle: Color::Rgb(255, 121, 80),
             idle: Color::Rgb(98, 114, 164),
             error: Color::Rgb(255, 85, 85),
             terminal_active: Color::Rgb(139, 233, 253),
@@ -357,6 +409,7 @@ mod tests {
             theme.hint,
             theme.running,
             theme.waiting,
+            theme.fresh_idle,
             theme.idle,
             theme.error,
             theme.terminal_active,
@@ -419,5 +472,92 @@ mod tests {
         // Multi-byte UTF-8 that happens to be 6 bytes must not panic
         assert!(hex_color::parse_hex_color("\u{00e9}\u{00e9}\u{00e9}").is_err());
         assert!(hex_color::parse_hex_color("#\u{00e9}\u{00e9}\u{00e9}").is_err());
+    }
+
+    #[test]
+    fn idle_color_at_age_boundaries() {
+        let theme = Theme::empire();
+        let window = idle_decay_window(20);
+        // No timestamp = decayed.
+        assert_eq!(theme.idle_color_at_age(None, window), theme.idle);
+        // Zero age = fresh.
+        assert_eq!(
+            theme.idle_color_at_age(Some(Duration::ZERO), window),
+            theme.fresh_idle
+        );
+        // Inside the window = fresh.
+        assert_eq!(
+            theme.idle_color_at_age(Some(window / 2), window),
+            theme.fresh_idle
+        );
+        // At the boundary clamps to decayed (age >= window).
+        assert_eq!(theme.idle_color_at_age(Some(window), window), theme.idle);
+        // Past the window = decayed.
+        assert_eq!(
+            theme.idle_color_at_age(Some(window + Duration::from_secs(60)), window),
+            theme.idle
+        );
+    }
+
+    #[test]
+    fn idle_color_at_age_zero_window_disables_freshness() {
+        // window = 0 is the documented opt-out: every Idle row renders
+        // as fully decayed regardless of age. No pulse, no fresh tint.
+        let theme = Theme::empire();
+        assert_eq!(
+            theme.idle_color_at_age(Some(Duration::from_secs(1)), Duration::ZERO),
+            theme.idle
+        );
+        assert_eq!(
+            theme.idle_color_at_age(Some(Duration::from_secs(1_000_000)), Duration::ZERO),
+            theme.idle
+        );
+    }
+
+    #[test]
+    fn theme_attention_hierarchy_holds() {
+        // Visual hierarchy: Waiting is the most attention-grabbing state;
+        // fresh-idle sits one rung dimmer; decayed idle blends in. On dark
+        // backgrounds "more attention" means HIGHER perceived luminance;
+        // on light backgrounds it means LOWER (the warm hues read against
+        // the bright surface). The check picks the comparison direction
+        // off the theme's own background. Rec. 601 is good enough for a
+        // pairwise sanity check, not a formal contrast metric.
+        fn luminance(c: Color) -> f32 {
+            match c {
+                Color::Rgb(r, g, b) => 0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32,
+                _ => 0.0,
+            }
+        }
+        for (name, theme) in [
+            ("empire", Theme::empire()),
+            ("phosphor", Theme::phosphor()),
+            ("tokyo_night_storm", Theme::tokyo_night_storm()),
+            ("catppuccin_latte", Theme::catppuccin_latte()),
+            ("dracula", Theme::dracula()),
+        ] {
+            let bg = luminance(theme.background);
+            let dark_bg = bg < 128.0;
+            let cmp = |label_a, a, label_b, b| {
+                if dark_bg {
+                    assert!(
+                        a > b,
+                        "{name} (dark bg): {label_a} luminance {a:.1} should exceed {label_b} {b:.1}"
+                    );
+                } else {
+                    assert!(
+                        a < b,
+                        "{name} (light bg): {label_a} luminance {a:.1} should be below {label_b} {b:.1}"
+                    );
+                }
+            };
+            let w = luminance(theme.waiting);
+            let f = luminance(theme.fresh_idle);
+            let i = luminance(theme.idle);
+            // Waiting beats fresh-idle.
+            cmp("waiting", w, "fresh_idle", f);
+            // Fresh-idle beats fully-decayed idle.
+            cmp("fresh_idle", f, "idle", i);
+        }
     }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -9,7 +9,8 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "test:unit": "vitest run"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.2",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -163,7 +163,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const handleSelectWorkspace = (workspaceId: string) => {
     const ws = workspaces.find((w) => w.id === workspaceId);
     if (ws) {
-      const running = ws.sessions.find((s) => isSessionActive(s.status));
+      const running = ws.sessions.find((s) => isSessionActive(s));
       const picked = running?.id ?? ws.sessions[0]?.id ?? null;
       if (picked) {
         navigate(`/session/${encodeURIComponent(picked)}`);

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -25,7 +25,7 @@ export function Dashboard({
     let errors = 0;
     for (const s of sessions) {
       projects.add(s.main_repo_path || s.project_path);
-      if (isSessionActive(s.status)) active++;
+      if (isSessionActive(s)) active++;
       if (s.status === "Waiting") waiting++;
       if (s.status === "Error") errors++;
     }

--- a/web/src/components/StatusGlyph.tsx
+++ b/web/src/components/StatusGlyph.tsx
@@ -31,22 +31,23 @@ const STATIC_GLYPH: Record<SessionStatus, string> = {
 };
 
 /** Slowed-down `breathe` rattle for a freshly-stopped Idle session.
- *  Reuses the same animation as Starting on purpose; differentiation is by
- *  color (Starting=dimmed, fresh-idle=amber gradient). The longer interval
- *  (vs Starting) reads as "gentle reminder" rather than "actively
- *  transitioning". */
+ *  Reuses the same animation as Starting on purpose; differentiation is
+ *  by color (Starting uses `--color-text-muted`, fresh-idle uses
+ *  `--color-status-fresh-idle`). The longer interval (vs Starting) reads
+ *  as "gentle reminder" rather than "actively transitioning". */
 const FRESH_IDLE_RATTLE = { frames: RATTLES.breathe!.frames, interval: 280 };
 
 /** Animated status glyph that cycles through rattles frames.
  *  Each instance offsets by `createdAt` so spinners look unique.
  *
- *  When `idleEnteredAt` is within the gradient window, an Idle session
- *  renders an animated `breathe` rattle in the gradient color, matching
- *  the visual language of the other attention-worthy states (Running,
- *  Waiting, Starting all animate). Without the rattle the row would be the
- *  only static-glyph state in the "needs attention" bucket, which reads
- *  inconsistent. The motion also serves as a redundant cue alongside the
- *  color decay for colorblind users / monochrome terminals. */
+ *  When `idleEnteredAt` is within the decay window, an Idle session
+ *  renders an animated `breathe` rattle styled with
+ *  `--color-status-fresh-idle`. The motion matches the visual language of
+ *  the other attention-worthy states (Running, Waiting, Starting all
+ *  animate); without it the row would be the only static-glyph state in
+ *  the "needs attention" bucket, which reads inconsistent. The shape
+ *  variation also serves as a redundant cue alongside color for
+ *  colorblind users and monochrome terminals. */
 export function StatusGlyph({
   status,
   createdAt,

--- a/web/src/components/StatusGlyph.tsx
+++ b/web/src/components/StatusGlyph.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { SessionStatus } from "../lib/types";
+import { isFreshIdle } from "../lib/session";
 
 /** Animated spinner frames from rattles (https://github.com/vyfor/rattles) */
 const RATTLES: Record<string, { frames: string[]; interval: number }> = {
@@ -29,17 +30,40 @@ const STATIC_GLYPH: Record<SessionStatus, string> = {
   Creating: "⠀",
 };
 
+/** Slowed-down `breathe` rattle for a freshly-stopped Idle session.
+ *  Reuses the same animation as Starting on purpose; differentiation is by
+ *  color (Starting=dimmed, fresh-idle=amber gradient). The longer interval
+ *  (vs Starting) reads as "gentle reminder" rather than "actively
+ *  transitioning". */
+const FRESH_IDLE_RATTLE = { frames: RATTLES.breathe!.frames, interval: 280 };
+
 /** Animated status glyph that cycles through rattles frames.
- *  Each instance offsets by `createdAt` so spinners look unique. */
+ *  Each instance offsets by `createdAt` so spinners look unique.
+ *
+ *  When `idleEnteredAt` is within the gradient window, an Idle session
+ *  renders an animated `breathe` rattle in the gradient color, matching
+ *  the visual language of the other attention-worthy states (Running,
+ *  Waiting, Starting all animate). Without the rattle the row would be the
+ *  only static-glyph state in the "needs attention" bucket, which reads
+ *  inconsistent. The motion also serves as a redundant cue alongside the
+ *  color decay for colorblind users / monochrome terminals. */
 export function StatusGlyph({
   status,
   createdAt,
+  idleEnteredAt,
 }: {
   status: SessionStatus;
   createdAt: string | null;
+  idleEnteredAt?: string | null;
 }) {
+  const isFresh =
+    status === "Idle" && isFreshIdle({ status, idle_entered_at: idleEnteredAt ?? null });
   const rattleKey = STATUS_RATTLE[status];
-  const rattle = rattleKey ? RATTLES[rattleKey] : undefined;
+  const rattle = isFresh
+    ? FRESH_IDLE_RATTLE
+    : rattleKey
+      ? RATTLES[rattleKey]
+      : undefined;
   const parsed = createdAt ? Date.parse(createdAt) : 0;
   const epoch = Number.isNaN(parsed) ? 0 : parsed;
   const [frame, setFrame] = useState(() => {
@@ -57,6 +81,8 @@ export function StatusGlyph({
     return () => clearInterval(id);
   }, [rattle, epoch]);
 
-  if (!rattle) return <>{STATIC_GLYPH[status]}</>;
+  if (!rattle) {
+    return <>{STATIC_GLYPH[status]}</>;
+  }
   return <>{rattle.frames[frame]}</>;
 }

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1,7 +1,11 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
-import { STATUS_DOT_CLASS, STATUS_TEXT_CLASS, isSessionActive } from "../lib/session";
+import {
+  STATUS_DOT_CLASS,
+  getStatusTextClass,
+  isSessionActive,
+} from "../lib/session";
 import { renameSession, setSessionNotifications } from "../lib/api";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
@@ -36,13 +40,33 @@ interface Props {
   readOnly?: boolean;
 }
 
-function bestSession(ws: Workspace): { status: SessionStatus; createdAt: string | null } {
-  const running = ws.sessions.find((s) => isSessionActive(s.status));
-  if (running) return { status: running.status, createdAt: running.created_at };
+function bestSession(
+  ws: Workspace,
+): {
+  status: SessionStatus;
+  createdAt: string | null;
+  idleEnteredAt: string | null;
+} {
+  const running = ws.sessions.find((s) => isSessionActive(s));
+  if (running)
+    return {
+      status: running.status,
+      createdAt: running.created_at,
+      idleEnteredAt: running.idle_entered_at ?? null,
+    };
   const error = ws.sessions.find((s) => s.status === "Error");
-  if (error) return { status: "Error", createdAt: error.created_at };
+  if (error)
+    return {
+      status: "Error",
+      createdAt: error.created_at,
+      idleEnteredAt: null,
+    };
   const first = ws.sessions[0];
-  return { status: first?.status ?? "Unknown", createdAt: first?.created_at ?? null };
+  return {
+    status: first?.status ?? "Unknown",
+    createdAt: first?.created_at ?? null,
+    idleEnteredAt: first?.idle_entered_at ?? null,
+  };
 }
 
 /** Derive which of the three context-menu presets best describes a
@@ -89,8 +113,11 @@ const SessionRow = memo(function SessionRow({
   readOnly?: boolean;
   indented?: boolean;
 }) {
-  const { status: sessionStatus, createdAt } = bestSession(workspace);
-  const textClass = STATUS_TEXT_CLASS[sessionStatus] ?? "text-status-idle";
+  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(workspace);
+  const textClass = getStatusTextClass({
+    status: sessionStatus,
+    idle_entered_at: idleEnteredAt,
+  });
   const label =
     workspace.branch ?? workspace.sessions[0]?.title ?? "default";
   const firstSession = workspace.sessions[0];
@@ -252,9 +279,13 @@ const SessionRow = memo(function SessionRow({
           <span
             className={`text-sm shrink-0 leading-none font-mono ${textClass}`}
           >
-            <StatusGlyph status={sessionStatus} createdAt={createdAt} />
+            <StatusGlyph
+              status={sessionStatus}
+              createdAt={createdAt}
+              idleEnteredAt={idleEnteredAt}
+            />
           </span>
-          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive(sessionStatus) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
             {label}
           </span>
         </div>

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -29,7 +29,7 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
     for (const [id, groupSessions] of groups) {
       const first = groupSessions[0]!;
       const agents = [...new Set(groupSessions.map((s) => s.tool))];
-      const status = groupSessions.some((s) => isSessionActive(s.status))
+      const status = groupSessions.some((s) => isSessionActive(s))
         ? "active"
         : "idle";
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -67,7 +67,15 @@
 
   /* Semantic Status */
   --color-status-running: #22c55e;
+  /* Waiting (blocked on user input) is the brightest amber in the brand
+     ramp so it wins on luminance against the gradient's fresh-idle
+     endpoint — saturation alone reads as DIMMER on dark backgrounds. */
   --color-status-waiting: #fbbf24;
+  /* Color of an Idle session whose Stop fired within the decay window.
+     Held constant for the full window (then snaps to `--color-status-idle`)
+     so the breathe rattle's pulse stays visually consistent. One rung
+     dimmer than waiting so the hierarchy reads bright > amber > slate. */
+  --color-status-fresh-idle: #f59e0b;
   --color-status-idle: #71717a;
   --color-status-error: #ef4444;
   --color-status-starting: #f59e0b;

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -68,8 +68,8 @@
   /* Semantic Status */
   --color-status-running: #22c55e;
   /* Waiting (blocked on user input) is the brightest amber in the brand
-     ramp so it wins on luminance against the gradient's fresh-idle
-     endpoint — saturation alone reads as DIMMER on dark backgrounds. */
+     ramp so it wins on luminance against fresh-idle. Saturation alone
+     reads as DIMMER on dark backgrounds, so we lean on luminance. */
   --color-status-waiting: #fbbf24;
   /* Color of an Idle session whose Stop fired within the decay window.
      Held constant for the full window (then snaps to `--color-status-idle`)

--- a/web/src/lib/session.test.ts
+++ b/web/src/lib/session.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  IDLE_DECAY_WINDOW_MS,
+  getStatusDotClass,
+  getStatusTextClass,
+  idleAgeMs,
+  isFreshIdle,
+  isSessionActive,
+} from "./session";
+import type { SessionResponse, SessionStatus } from "./types";
+
+const NOW = Date.parse("2026-05-01T12:00:00Z");
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date(NOW));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function session(
+  status: SessionStatus,
+  idleEnteredAt: string | null,
+): Pick<SessionResponse, "status" | "idle_entered_at"> {
+  return { status, idle_entered_at: idleEnteredAt };
+}
+
+describe("idleAgeMs", () => {
+  it("returns null for non-Idle sessions", () => {
+    expect(idleAgeMs(session("Running", new Date(NOW - 1000).toISOString()))).toBeNull();
+  });
+
+  it("returns null when idle_entered_at is missing", () => {
+    expect(idleAgeMs(session("Idle", null))).toBeNull();
+  });
+
+  it("returns null when idle_entered_at is unparseable", () => {
+    expect(idleAgeMs(session("Idle", "not-a-date"))).toBeNull();
+  });
+
+  it("returns null for future timestamps (clock skew)", () => {
+    // Clock skew between server and browser must not look like a fresh idle.
+    expect(
+      idleAgeMs(session("Idle", new Date(NOW + 60_000).toISOString())),
+    ).toBeNull();
+  });
+
+  it("returns elapsed milliseconds for past Idle transition", () => {
+    expect(
+      idleAgeMs(session("Idle", new Date(NOW - 5_000).toISOString())),
+    ).toBe(5_000);
+  });
+});
+
+describe("isFreshIdle", () => {
+  it("is true within the decay window", () => {
+    expect(
+      isFreshIdle(session("Idle", new Date(NOW - 60_000).toISOString())),
+    ).toBe(true);
+  });
+
+  it("is false past the decay window", () => {
+    expect(
+      isFreshIdle(
+        session("Idle", new Date(NOW - IDLE_DECAY_WINDOW_MS - 1).toISOString()),
+      ),
+    ).toBe(false);
+  });
+
+  it("is false for non-Idle sessions even with a recent timestamp", () => {
+    expect(
+      isFreshIdle(session("Running", new Date(NOW - 1_000).toISOString())),
+    ).toBe(false);
+  });
+});
+
+describe("getStatusDotClass", () => {
+  it("uses fresh-idle class when within window", () => {
+    expect(
+      getStatusDotClass(session("Idle", new Date(NOW - 1_000).toISOString())),
+    ).toBe("bg-status-fresh-idle");
+  });
+
+  it("falls back to idle class past the window", () => {
+    expect(
+      getStatusDotClass(
+        session("Idle", new Date(NOW - IDLE_DECAY_WINDOW_MS - 1_000).toISOString()),
+      ),
+    ).toBe("bg-status-idle");
+  });
+
+  it("preserves non-Idle classes regardless of idle_entered_at", () => {
+    expect(
+      getStatusDotClass(session("Waiting", new Date(NOW - 1_000).toISOString())),
+    ).toBe("bg-status-waiting");
+  });
+});
+
+describe("getStatusTextClass", () => {
+  it("uses fresh-idle class when within window", () => {
+    expect(
+      getStatusTextClass(session("Idle", new Date(NOW - 1_000).toISOString())),
+    ).toBe("text-status-fresh-idle");
+  });
+
+  it("falls back to idle class past the window", () => {
+    expect(getStatusTextClass(session("Idle", null))).toBe("text-status-idle");
+  });
+});
+
+describe("isSessionActive", () => {
+  it("treats fresh-idle as active", () => {
+    expect(
+      isSessionActive(session("Idle", new Date(NOW - 1_000).toISOString())),
+    ).toBe(true);
+  });
+
+  it("treats decayed Idle as inactive", () => {
+    expect(
+      isSessionActive(
+        session("Idle", new Date(NOW - IDLE_DECAY_WINDOW_MS - 1_000).toISOString()),
+      ),
+    ).toBe(false);
+  });
+
+  it("retains the legacy string-only API for callers without idle_entered_at", () => {
+    // Some callers (legacy paths, unit tests) still pass a bare status. The
+    // overload must keep classifying Running/Waiting/Starting as active.
+    expect(isSessionActive("Running")).toBe(true);
+    expect(isSessionActive("Idle")).toBe(false);
+  });
+});

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -1,4 +1,10 @@
-import type { SessionStatus } from "./types";
+import type { SessionResponse, SessionStatus } from "./types";
+
+/** How long a Stop-hooked Idle session keeps decaying from `fresh_idle` to
+ *  `idle`. After this window the color is fully neutral and the session is
+ *  no longer in the "needs attention" bucket. Mirrors the Rust constant
+ *  `IDLE_DECAY_WINDOW` in src/tui/styles/themes.rs. */
+export const IDLE_DECAY_WINDOW_MS = 20 * 60 * 1000;
 
 /** Tailwind class for status dot background color by session status */
 export const STATUS_DOT_CLASS: Record<SessionStatus, string> = {
@@ -26,7 +32,68 @@ export const STATUS_TEXT_CLASS: Record<SessionStatus, string> = {
   Creating: "text-status-starting",
 };
 
-/** Whether a session status means the agent is actively doing something */
-export function isSessionActive(status: SessionStatus): boolean {
-  return status === "Running" || status === "Waiting" || status === "Starting";
+/** Milliseconds since this session most recently transitioned into Idle.
+ *  Returns null for non-Idle sessions, sessions without an
+ *  `idle_entered_at` timestamp (legacy state), or timestamps in the future
+ *  (clock skew). */
+export function idleAgeMs(
+  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+): number | null {
+  if (session.status !== "Idle") return null;
+  if (!session.idle_entered_at) return null;
+  const since = Date.parse(session.idle_entered_at);
+  if (Number.isNaN(since)) return null;
+  const age = Date.now() - since;
+  return age >= 0 ? age : null;
+}
+
+/** True when the session is Idle and within `IDLE_DECAY_WINDOW_MS` of the
+ *  Stop hook. Treated as "needs attention" alongside Waiting. */
+export function isFreshIdle(
+  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+): boolean {
+  const age = idleAgeMs(session);
+  return age !== null && age < IDLE_DECAY_WINDOW_MS;
+}
+
+/** Background-color class for a session's status dot. Returns the standard
+ *  status class for non-Idle states; for Idle, picks a fresh / decayed tier
+ *  based on `idle_entered_at`. Two tiers (rather than continuous color-mix)
+ *  keeps the class set static so Tailwind's JIT picks them up reliably. */
+export function getStatusDotClass(
+  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+): string {
+  if (session.status === "Idle" && isFreshIdle(session)) {
+    return "bg-status-fresh-idle";
+  }
+  return STATUS_DOT_CLASS[session.status] ?? "bg-status-idle";
+}
+
+/** Text-color class equivalent of `getStatusDotClass`. */
+export function getStatusTextClass(
+  session: Pick<SessionResponse, "status" | "idle_entered_at">,
+): string {
+  if (session.status === "Idle" && isFreshIdle(session)) {
+    return "text-status-fresh-idle";
+  }
+  return STATUS_TEXT_CLASS[session.status] ?? "text-status-idle";
+}
+
+/** Whether a session status means the agent is actively doing something or
+ *  has just finished and is awaiting the user's next prompt. Fresh-idle is
+ *  bucketed with active so dashboard counts and filters surface it. */
+export function isSessionActive(
+  session:
+    | Pick<SessionResponse, "status" | "idle_entered_at">
+    | SessionStatus,
+): boolean {
+  if (typeof session === "string") {
+    return session === "Running" || session === "Waiting" || session === "Starting";
+  }
+  return (
+    session.status === "Running" ||
+    session.status === "Waiting" ||
+    session.status === "Starting" ||
+    isFreshIdle(session)
+  );
 }

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -1,9 +1,13 @@
 import type { SessionResponse, SessionStatus } from "./types";
 
-/** How long a Stop-hooked Idle session keeps decaying from `fresh_idle` to
- *  `idle`. After this window the color is fully neutral and the session is
- *  no longer in the "needs attention" bucket. Mirrors the Rust constant
- *  `IDLE_DECAY_WINDOW` in src/tui/styles/themes.rs. */
+/** How long a Stop-hooked Idle session keeps the freshness signal active
+ *  (animated icon, fresh-idle color, "needs attention" bucketing). After
+ *  this window the row drops back to the regular static idle look.
+ *  Hard-coded mirror of the Rust default
+ *  (`Config.theme.idle_decay_minutes`, default 20 min). The dashboard
+ *  doesn't currently fetch the server's configured value; if the user
+ *  customizes it via the TUI, the web side stays at this default until we
+ *  wire `idle_decay_minutes` into the `/api/config` payload. */
 export const IDLE_DECAY_WINDOW_MS = 20 * 60 * 1000;
 
 /** Tailwind class for status dot background color by session status */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -9,6 +9,11 @@ export interface SessionResponse {
   yolo_mode: boolean;
   created_at: string;
   last_accessed_at: string | null;
+  /** Wall-clock time of the most recent transition into Idle. Used by the
+   *  dashboard to fade a freshly-stopped session's color toward neutral.
+   *  Distinct from `last_accessed_at`: viewing or messaging a session bumps
+   *  `last_accessed_at` but leaves `idle_entered_at` alone. */
+  idle_entered_at: string | null;
   last_error: string | null;
   branch: string | null;
   main_repo_path: string | null;

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
@@ -7,5 +8,12 @@ export default defineConfig({
   build: {
     outDir: "dist",
     emptyOutDir: true,
+  },
+  // Vitest unit tests live alongside source as `*.test.ts(x)`. Playwright
+  // suites under `tests/` use the same `.spec.ts` extension Playwright
+  // expects but aren't valid vitest tests, so we explicitly exclude them.
+  test: {
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    exclude: ["tests/**", "node_modules/**", "dist/**"],
   },
 });


### PR DESCRIPTION
## Description

Closes #863. The RFC asked how to surface freshly-stopped Claude turns: a Stop hook moves a session to Idle, which today reads identical to a session that has been quiet for hours. The `w` keybind misses these actionable rows.

**Approach:** keep `Stop -> Idle` semantics, but mark transitions into Idle with a serialized `idle_entered_at` timestamp on `Instance`. Inside a configurable decay window (default 20 min), the row pulses with a slow `breathe` rattle in the theme's new `fresh_idle` color and is included in `w`'s "needs attention" cycle. Past the window it snaps to the regular static idle look. The freshness signal is binary by design (constant color while pulsing, snap on expiry); the breathe rattle is the only continuous element. Theme palettes were reordered so `waiting > fresh_idle > idle` reads correctly on both dark and light backgrounds, with a structural `theme_attention_hierarchy_holds` test that picks the comparison direction off the theme's own background luminance.

**Activity column** also got smarter: pinned to the right border with a 1-cell margin (consistent x across rows so they line up vertically), shows time-since-stop for Idle rows (vs `last_accessed_at`, which lies after attach/send), drops only when a long title would clip it, and falls back to `last_accessed_at` for legacy Idle sessions that pre-date `idle_entered_at`. Color stays `theme.dimmed` for every status; the icon already carries the urgency signal.

**Configurability:** `Settings -> Theme -> Idle Decay (minutes)` or `[theme] idle_decay_minutes` in `config.toml`. `0` disables the freshness signal entirely. Per-profile override is wired through `ThemeConfigOverride` and `merge_configs`.

**Bug fix discovered while testing:** the TUI `StatusPoller` runs status updates on a clone of each Instance and then projects the result into a `StatusUpdate` carrying only `{id, status, last_error}`. `idle_entered_at` was being written on the clone and discarded every poll, which meant the freshness signal never fired in the actual TUI. Fixed by adding `idle_entered_at` to `StatusUpdate` and writing it through `apply_status_updates`. The `aoe serve` path was unaffected (operates on the live instance directly), which is why the API-level e2e passed even when the TUI looked broken. Regression test in `status_poller.rs::status_update_carries_idle_entered_at` guards against the field falling off the projection again.

**Other touches:**
- `theme.fresh_idle` field added to `Theme` struct, `downsample_to_palette`, and the structural-guard test. All 5 built-in themes updated.
- Web side mirrors the changes: `idle_entered_at` on `SessionResponse`, `IDLE_DECAY_WINDOW_MS` (hard-coded mirror; #874 tracks the work to read this from `/api/settings`), `bg-status-fresh-idle` / `text-status-fresh-idle` Tailwind classes, breathe rattle in `StatusGlyph` for fresh-idle rows.
- Reload path preserves `idle_entered_at` so settings toggles don't reset the freshness state mid-window.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(Recording to be attached separately as a follow-up comment.)

### How tested

- `cargo fmt --check`, `cargo clippy --features serve --all-targets` clean
- `cargo test --lib` / `cargo test --features serve --lib`: 1338 / 1493 pass. 4 pre-existing `session::capture::tests::test_capture_hermes_*` failures that need a `sqlite3` binary not present in the dev sandbox (verified failing on `main` too, untouched by this PR).
- `cd web && npx tsc -b && npm run build` clean. `npx vitest run src/lib/session.test.ts`: 16 cases pass (`idleAgeMs`, `isFreshIdle`, class helpers, `isSessionActive` overload).
- End-to-end against a real `aoe serve` instance with simulated Stop hooks at `/tmp/aoe-hooks/{id}/status`: confirmed `Running -> Idle` populates `idle_entered_at` on disk and over the API, persists across rename-driven saves, and reloads correctly across restarts.
- Manual TUI walk on a real session: status icon flips to breathe rattle on Stop, age column reads `5m`, `12m` etc., decays to static `⠒` at the configured boundary; `o` and `g` cycle as expected.

### Out of scope (deliberate)

- No `W` reverse-jump keybind.
- No backfill of `idle_entered_at` for sessions Idle at upgrade time. The column gracefully falls back to `last_accessed_at` until they next transition.
- Push notifications unchanged: `notify_on_idle` already fires "Session finished" on Stop; the freshness signal is a complementary in-dashboard cue, not a duplicate.
- Web dashboard reads a hard-coded mirror of the decay window (#874 will wire it to `/api/settings`).

### Follow-up issues filed during this PR

- #873: surface the active sort in the list-pane title (currently only visible via `?` help overlay), and drop the `[all]` profile tag when no filter is applied.
- #874: web dashboard should read `idle_decay_minutes` from `/api/settings` instead of using the hard-coded `IDLE_DECAY_WINDOW_MS` mirror.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, paired interactively. Several design rounds in the issue thread plus several "I tried it and X looks wrong" iterations during implementation.

**Any Additional AI Details you'd like to share:** Every design decision (Option A/B/C in the RFC, breathe rattle vs. static glyph, configurable vs. const window, gradient vs. binary color, right-edge alignment, theme luminance hierarchy, whether to colorize the timestamp column, whether to right-margin the column, whether to fall back to `last_accessed_at` for legacy rows) was driven by the human. Claude drafted and refactored the code. Two follow-up doc-cleanup commits scrub stale "gradient" wording that was left over from the originally-planned continuous color interpolation.

- [x] I am an AI Agent filling out this form (check box if true)