### PR TITLE
fix(web): sync agent_session_id back to in-memory state after restart

### DIFF
--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -19,7 +19,6 @@ For sandboxed (Docker) sessions, the poller runs the same scan inside the contai
 ## What's not covered (yet)
 
 - Other agents (OpenCode, Codex, Gemini, Vibe, Pi). They're tracked behind separate follow-up PRs; their sessions still launch fresh until then.
-- Web dashboard. The web "restart session" path doesn't yet apply resume flags; use the TUI for resume-aware restarts.
 
 ## Manual override
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -690,6 +690,23 @@ pub async fn create_session(
 
 // --- Ensure agent session ---
 
+/// Copy fields the start path mutated on the working `Instance` clone back
+/// onto the in-memory `state.instances` entry after a successful restart.
+///
+/// `agent_session_id` is the load-bearing one: Claude's `acquire_session_id`
+/// generates a fresh UUID at launch time and `persist_session_id` writes it
+/// to disk, but the in-memory state lives in a separate Vec that the 2s
+/// status poller refreshes from disk on its own cadence. Without this sync,
+/// a rapid second restart inside that window would see a stale
+/// `agent_session_id = None` and generate (and persist) a new UUID,
+/// silently orphaning the previous Claude conversation.
+fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
+    live.status = started.status;
+    live.last_error = None;
+    live.agent_session_id = started.agent_session_id.clone();
+    live.last_start_time = started.last_start_time;
+}
+
 /// Ensure the main agent tmux session is alive, restarting it if dead.
 ///
 /// Mirrors the TUI's `attach_session` restart logic: checks the actual tmux
@@ -817,8 +834,7 @@ pub async fn ensure_session(
         Ok(Ok(started)) => {
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
-                inst.status = started.status;
-                inst.last_error = None;
+                apply_post_restart_sync(inst, &started);
             }
             (
                 StatusCode::OK,
@@ -1422,6 +1438,53 @@ mod tests {
     fn claude_fullscreen_unset_when_setting_disabled() {
         let resp = SessionResponse::from_instance(&make_test_instance(), false);
         assert!(!resp.claude_fullscreen);
+    }
+
+    #[test]
+    fn apply_post_restart_sync_propagates_agent_session_id() {
+        // Models the rapid double-restart case: in-memory state is stale
+        // (agent_session_id = None) because the 2s status poller hasn't
+        // refreshed yet, while the just-finished restart produced a Claude
+        // UUID via acquire_session_id. The sync must propagate that ID so a
+        // second ensure_session within the poller window doesn't generate a
+        // fresh UUID and orphan the persisted Claude conversation.
+        let mut live = make_test_instance();
+        live.status = Status::Stopped;
+        live.last_error = Some("prior failure".to_string());
+        live.agent_session_id = None;
+        live.last_start_time = None;
+
+        let mut started = make_test_instance();
+        started.status = Status::Starting;
+        started.agent_session_id = Some("claude-uuid-restart".to_string());
+        started.last_start_time = Some(std::time::Instant::now());
+
+        apply_post_restart_sync(&mut live, &started);
+
+        assert_eq!(live.status, Status::Starting);
+        assert!(live.last_error.is_none());
+        assert_eq!(
+            live.agent_session_id.as_deref(),
+            Some("claude-uuid-restart")
+        );
+        assert_eq!(live.last_start_time, started.last_start_time);
+    }
+
+    #[test]
+    fn apply_post_restart_sync_overwrites_stale_session_id() {
+        // If somehow the in-memory ID was non-None and the start path
+        // produced a different (newer) ID, the sync must use the newer one.
+        // Belt-and-suspenders: in practice acquire_session_id reuses an
+        // existing ID, but the contract here is "started wins."
+        let mut live = make_test_instance();
+        live.agent_session_id = Some("stale-id".to_string());
+
+        let mut started = make_test_instance();
+        started.agent_session_id = Some("fresh-id".to_string());
+
+        apply_post_restart_sync(&mut live, &started);
+
+        assert_eq!(live.agent_session_id.as_deref(), Some("fresh-id"));
     }
     // ── validate_diff_path: security regression tests ──────────────────────────
     //


### PR DESCRIPTION
## Description

The web `POST /api/sessions/{id}/ensure` restart path calls `Instance::start_with_size_opts`, which goes through `apply_session_flags` and `acquire_session_id` exactly like the TUI path, so Claude's `--resume` flag is already applied in the common case. The 2-second status poller refreshes `state.instances` from disk on its own cadence, which usually keeps the in-memory `agent_session_id` in sync.

The gap: after `ensure_session` returns, only `status` and `last_error` were copied from the just-restarted clone back to the in-memory instance. A rapid second restart inside the 2s status-poller window would see a stale `agent_session_id = None` and generate a fresh Claude UUID via `acquire_session_id`, then `persist_session_id` would overwrite the previously-persisted ID, silently orphaning the prior Claude conversation.

This PR extracts the post-restart sync into `apply_post_restart_sync` and propagates `agent_session_id` plus `last_start_time` so the in-memory state matches what the start path produced. Two unit tests pin the contract: the rapid double-restart scenario and the "started wins" overwrite case.

Also drops the now-incorrect "Web dashboard. The web 'restart session' path doesn't yet apply resume flags" line from `docs/guides/session-resume.md`.

Note: The original issue framed this as "web doesn't apply resume flags at all". On read, the bigger claim turned out to be inaccurate against current code; the in-memory sync gap is the actually-extant bug. Investigation notes were shared with @njbrake before scoping the PR.

Fixes #845

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (n/a, no UI changes)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code (1M context).

**Any Additional AI Details you'd like to share:**
Investigation, code change, tests, and PR text drafted by Claude in dialogue with @njbrake. The original issue body claimed the web path didn't go through `Instance::start` at all; reading the code together, we confirmed it does, and narrowed the actual bug to the in-memory sync gap fixed here. @njbrake reviewed each step, picked option B (keep the issue, scope down to the real bug + docs) over option A (close as already-mostly-working), and approved before commit/push.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)