### PR TITLE
fix(web,serve): stop login-required token loop, refresh serve.url on rotation

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -581,6 +581,11 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         // rotation. Behavior otherwise matches the original: wait one
         // lifetime, rotate, wait 300s grace, clear previous.
         let rot_state = state.clone();
+        // The tunnel URL is stable across the daemon's lifetime (Tailscale
+        // and named CF tunnels are stable; quick CF rotates only on
+        // restart, which is outside this task's scope). Capture once so
+        // the rotation task can rebuild `serve.url` with the new token.
+        let rot_base_url: Option<String> = tunnel_handle.as_ref().map(|h| h.url.clone());
         tokio::spawn(async move {
             loop {
                 let lifetime = rot_state.token_manager.lifetime_secs().await;
@@ -592,6 +597,19 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 let pre_rotate_current = rot_state.token_manager.current_token().await;
                 rot_state.token_manager.rotate().await;
                 let post_rotate_current = rot_state.token_manager.current_token().await;
+
+                // Refresh `serve.url` so the TUI display and the QR-code
+                // URL stay in sync with the rotated token. Without this
+                // the TUI keeps showing `?token=<old>`, which is invalid
+                // 5 minutes after rotation (end of grace period).
+                if let (Some(base_url), Some(token)) =
+                    (rot_base_url.as_ref(), post_rotate_current.as_ref())
+                {
+                    let url_with_token = format!("{}/?token={}", base_url, token);
+                    if let Ok(app_dir) = crate::session::get_app_dir() {
+                        write_secret_file(&app_dir.join("serve.url"), &url_with_token);
+                    }
+                }
 
                 if let Some(push) = rot_state.push.as_ref() {
                     let mut valid_hashes: Vec<[u8; 32]> = Vec::new();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,11 @@ import type { SessionResponse } from "./lib/types";
 import { Dashboard } from "./components/Dashboard";
 import { LoginPage } from "./components/LoginPage";
 import { TokenEntryPage } from "./components/TokenEntryPage";
-import { TOKEN_EXPIRED_EVENT } from "./lib/fetchInterceptor";
+import {
+  LOGIN_REQUIRED_EVENT,
+  TOKEN_EXPIRED_EVENT,
+  resetTokenExpired,
+} from "./lib/fetchInterceptor";
 import { AboutModal } from "./components/AboutModal";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { DisconnectBanner } from "./components/DisconnectBanner";
@@ -45,6 +49,22 @@ export default function App() {
     const onTokenExpired = () => setTokenExpired(true);
     window.addEventListener(TOKEN_EXPIRED_EVENT, onTokenExpired);
     return () => window.removeEventListener(TOKEN_EXPIRED_EVENT, onTokenExpired);
+  }, []);
+
+  // The token is fine but the passphrase login session is missing or expired.
+  // Hide TokenEntryPage (if open) and let LoginPage take over by flipping
+  // loginAuthenticated. Without clearing tokenExpired here, App's render
+  // order would keep showing TokenEntryPage on top of LoginPage and the
+  // user would loop on "Invalid token" while pasting a token that's fine.
+  useEffect(() => {
+    const onLoginRequired = () => {
+      setTokenExpired(false);
+      setLoginRequired(true);
+      setLoginAuthenticated(false);
+    };
+    window.addEventListener(LOGIN_REQUIRED_EVENT, onLoginRequired);
+    return () =>
+      window.removeEventListener(LOGIN_REQUIRED_EVENT, onLoginRequired);
   }, []);
 
   useEffect(() => {
@@ -65,6 +85,8 @@ export default function App() {
 
   const handleLoginSuccess = () => {
     setLoginAuthenticated(true);
+    // Reset dedup flags so a future session expiry can re-fire the event.
+    resetTokenExpired();
   };
 
   const handleLogout = async () => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,11 +51,9 @@ export default function App() {
     return () => window.removeEventListener(TOKEN_EXPIRED_EVENT, onTokenExpired);
   }, []);
 
-  // The token is fine but the passphrase login session is missing or expired.
-  // Hide TokenEntryPage (if open) and let LoginPage take over by flipping
-  // loginAuthenticated. Without clearing tokenExpired here, App's render
-  // order would keep showing TokenEntryPage on top of LoginPage and the
-  // user would loop on "Invalid token" while pasting a token that's fine.
+  // Clearing tokenExpired here matters: the render order below shows
+  // TokenEntryPage above LoginPage, so without the reset a token that's
+  // actually fine would keep getting shown the wrong screen.
   useEffect(() => {
     const onLoginRequired = () => {
       setTokenExpired(false);

--- a/web/src/components/TokenEntryPage.tsx
+++ b/web/src/components/TokenEntryPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from "react";
 import { saveToken } from "../lib/token";
 import { resetTokenExpired } from "../lib/fetchInterceptor";
-import { fetchAbout } from "../lib/api";
+import { verifyToken } from "../lib/api";
 
 interface Props {
   onSuccess: () => void;
@@ -43,10 +43,13 @@ export function TokenEntryPage({ onSuccess }: Props) {
     saveToken(token);
     resetTokenExpired();
 
-    // Verify by calling a lightweight endpoint
-    const about = await fetchAbout();
+    // /api/login/status is exempt from the passphrase session check, so a
+    // token-good-but-passphrase-missing paste verifies as success here and
+    // App.tsx routes to LoginPage. A session-gated endpoint would 401 and
+    // look like a token rejection.
+    const verified = await verifyToken();
 
-    if (about) {
+    if (verified) {
       onSuccess();
     } else {
       // The interceptor already cleared localStorage on 401. Reset the

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -362,6 +362,20 @@ export async function loginStatus(): Promise<{
   );
 }
 
+/** Verify the auth token via a session-exempt endpoint (`/api/login/status`).
+ *  Returning `true` means the token authenticated; the caller still has to
+ *  consult `loginStatus()` to decide between the main app and LoginPage.
+ *  Used by the token entry page so a valid-token-but-needs-passphrase paste
+ *  is accepted instead of being misread as a token rejection. */
+export async function verifyToken(): Promise<boolean> {
+  try {
+    const res = await fetch("/api/login/status");
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function login(
   passphrase: string,
 ): Promise<{ ok: boolean; error?: string }> {

--- a/web/src/lib/fetchInterceptor.test.ts
+++ b/web/src/lib/fetchInterceptor.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { classifyAuthError } from "./fetchInterceptor";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("classifyAuthError", () => {
+  it("returns null for non-401 responses", async () => {
+    expect(await classifyAuthError(jsonResponse(200, { ok: true }))).toBeNull();
+    expect(await classifyAuthError(jsonResponse(403, { error: "x" }))).toBeNull();
+    expect(await classifyAuthError(jsonResponse(500, { error: "x" }))).toBeNull();
+  });
+
+  // Regression: when the server returns 401 with `error: "login_required"`
+  // (token valid, passphrase session missing), the client must NOT treat
+  // this as a token rejection. Without this distinction the user pastes
+  // a fresh token, the server responds login_required, and the SPA loops
+  // them back to the token-entry page with "Invalid token" forever.
+  it("classifies 401 login_required as login_required", async () => {
+    const res = jsonResponse(401, {
+      error: "login_required",
+      message: "Passphrase login required",
+    });
+    expect(await classifyAuthError(res)).toBe("login_required");
+  });
+
+  it("classifies 401 unauthorized as unauthorized", async () => {
+    const res = jsonResponse(401, {
+      error: "unauthorized",
+      message: "Invalid or missing auth token",
+    });
+    expect(await classifyAuthError(res)).toBe("unauthorized");
+  });
+
+  it("falls back to unauthorized on non-JSON 401 body", async () => {
+    const res = new Response("not json", { status: 401 });
+    expect(await classifyAuthError(res)).toBe("unauthorized");
+  });
+
+  it("falls back to unauthorized on JSON 401 without an error field", async () => {
+    const res = jsonResponse(401, { message: "no error key" });
+    expect(await classifyAuthError(res)).toBe("unauthorized");
+  });
+
+  // The classifier clones before reading; the original body must remain
+  // readable so downstream handlers (fetchJson, etc.) can still parse it.
+  it("leaves the original response body readable", async () => {
+    const res = jsonResponse(401, { error: "login_required" });
+    await classifyAuthError(res);
+    const body = await res.json();
+    expect(body).toEqual({ error: "login_required" });
+  });
+});

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -76,10 +76,8 @@ export function installFetchErrorToasts(): void {
         const authError = await classifyAuthError(res);
         if (authError === "login_required") {
           handleLoginRequired();
-        } else if (getToken()) {
-          handleTokenRejected();
         } else {
-          handleNoToken();
+          handleTokenAuthFailure();
         }
       }
       if (isApi && res.status >= 500 && !isServerDown()) {
@@ -106,23 +104,14 @@ export function installFetchErrorToasts(): void {
   };
 }
 
-// On 401 with a token present, the stored token is dead (server restart,
-// rotated past grace period, or revoked). Clear it once and show the token
-// entry page. We dedupe so a burst of concurrent 401s produces one event.
+// 401 with no `login_required` body: token is dead, missing, or revoked.
+// Clear localStorage (idempotent if no token) and show the token entry
+// page. Dedupe so a burst of concurrent 401s produces one event.
 let tokenExpiredDispatched = false;
-function handleTokenRejected(): void {
+function handleTokenAuthFailure(): void {
   clearToken();
   if (tokenExpiredDispatched) return;
   tokenExpiredDispatched = true;
-  window.dispatchEvent(new CustomEvent(TOKEN_EXPIRED_EVENT));
-}
-
-// On 401 with no token at all (cookie expired AND localStorage cleared).
-// Show the token entry page so the user can paste their token.
-let noTokenDispatched = false;
-function handleNoToken(): void {
-  if (noTokenDispatched) return;
-  noTokenDispatched = true;
   window.dispatchEvent(new CustomEvent(TOKEN_EXPIRED_EVENT));
 }
 
@@ -141,7 +130,6 @@ function handleLoginRequired(): void {
  *  the passphrase login. */
 export function resetTokenExpired(): void {
   tokenExpiredDispatched = false;
-  noTokenDispatched = false;
   loginRequiredDispatched = false;
 }
 

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -6,6 +6,32 @@ import { clearToken, getToken, saveToken } from "./token";
  *  listens for this to show the token entry page instead of just a toast. */
 export const TOKEN_EXPIRED_EVENT = "aoe:token-expired";
 
+/** Dispatched on `window` when the token is valid but the second-factor
+ *  passphrase login session is missing or expired. App.tsx listens for this
+ *  to show the login (passphrase) page. Distinct from token-expired so the
+ *  client doesn't bounce the user to the token-entry page when the real
+ *  problem is a missing login session; without this distinction, a user
+ *  pastes a valid token, the server returns 401 `login_required`, the
+ *  client treats it as token rejection, and the loop never escapes. */
+export const LOGIN_REQUIRED_EVENT = "aoe:login-required";
+
+/** Inspect a 401 response body to decide whether the auth failure is a token
+ *  problem (`unauthorized`) or a missing passphrase login session
+ *  (`login_required`). Cloning the response keeps the original body
+ *  consumable by downstream readers. Returns null for non-401 inputs. */
+export async function classifyAuthError(
+  res: Response,
+): Promise<"login_required" | "unauthorized" | null> {
+  if (res.status !== 401) return null;
+  try {
+    const data = (await res.clone().json()) as { error?: unknown };
+    if (data && data.error === "login_required") return "login_required";
+  } catch {
+    // Body wasn't JSON or already consumed; fall through to unauthorized.
+  }
+  return "unauthorized";
+}
+
 /**
  * Install a global fetch wrapper that:
  * 1. Injects `Authorization: Bearer <token>` when we have a stored token.
@@ -52,7 +78,10 @@ export function installFetchErrorToasts(): void {
         if (rotated) saveToken(rotated);
       }
       if (res.status === 401 && isApi) {
-        if (getToken()) {
+        const authError = await classifyAuthError(res);
+        if (authError === "login_required") {
+          handleLoginRequired();
+        } else if (getToken()) {
           handleTokenRejected();
         } else {
           handleNoToken();
@@ -102,11 +131,24 @@ function handleNoToken(): void {
   window.dispatchEvent(new CustomEvent(TOKEN_EXPIRED_EVENT));
 }
 
+// On 401 with `error: "login_required"` the token is fine; only the
+// passphrase login session is missing. Do NOT clear the token; the user
+// just needs to authenticate the second factor. Dedup so a burst of
+// concurrent 401s produces one event.
+let loginRequiredDispatched = false;
+function handleLoginRequired(): void {
+  if (loginRequiredDispatched) return;
+  loginRequiredDispatched = true;
+  window.dispatchEvent(new CustomEvent(LOGIN_REQUIRED_EVENT));
+}
+
 /** Reset the dedup flags so a new 401 after re-authentication will be
- *  caught again. Called when the user submits a new token. */
+ *  caught again. Called when the user submits a new token or completes
+ *  the passphrase login. */
 export function resetTokenExpired(): void {
   tokenExpiredDispatched = false;
   noTokenDispatched = false;
+  loginRequiredDispatched = false;
 }
 
 // Inject Authorization header without clobbering anything the caller set.

--- a/web/src/lib/fetchInterceptor.ts
+++ b/web/src/lib/fetchInterceptor.ts
@@ -6,19 +6,14 @@ import { clearToken, getToken, saveToken } from "./token";
  *  listens for this to show the token entry page instead of just a toast. */
 export const TOKEN_EXPIRED_EVENT = "aoe:token-expired";
 
-/** Dispatched on `window` when the token is valid but the second-factor
- *  passphrase login session is missing or expired. App.tsx listens for this
- *  to show the login (passphrase) page. Distinct from token-expired so the
- *  client doesn't bounce the user to the token-entry page when the real
- *  problem is a missing login session; without this distinction, a user
- *  pastes a valid token, the server returns 401 `login_required`, the
- *  client treats it as token rejection, and the loop never escapes. */
+/** Dispatched on `window` when the token is valid but the passphrase login
+ *  session is missing or expired. App.tsx listens to show the LoginPage
+ *  instead of the TokenEntryPage, so a valid token isn't wrongly cleared. */
 export const LOGIN_REQUIRED_EVENT = "aoe:login-required";
 
-/** Inspect a 401 response body to decide whether the auth failure is a token
- *  problem (`unauthorized`) or a missing passphrase login session
- *  (`login_required`). Cloning the response keeps the original body
- *  consumable by downstream readers. Returns null for non-401 inputs. */
+/** Classify a 401 body as `login_required` or `unauthorized`. Clones the
+ *  response so downstream readers (fetchJson, etc.) can still parse the
+ *  body. Non-401 returns null. */
 export async function classifyAuthError(
   res: Response,
 ): Promise<"login_required" | "unauthorized" | null> {
@@ -131,10 +126,9 @@ function handleNoToken(): void {
   window.dispatchEvent(new CustomEvent(TOKEN_EXPIRED_EVENT));
 }
 
-// On 401 with `error: "login_required"` the token is fine; only the
-// passphrase login session is missing. Do NOT clear the token; the user
-// just needs to authenticate the second factor. Dedup so a burst of
-// concurrent 401s produces one event.
+// On 401 `login_required` the token is fine; only the second factor is
+// missing. Don't clear the token. Dedupe so a burst of concurrent 401s
+// produces one event.
 let loginRequiredDispatched = false;
 function handleLoginRequired(): void {
   if (loginRequiredDispatched) return;


### PR DESCRIPTION
## Description

> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

Bundle of related auth-flow fixes uncovered while debugging a PWA-after-restart loop on Tailscale Funnel.

### 1. Login-required 401 no longer loops the user on token entry (primary fix)

When `aoe serve --remote` enforces a passphrase (required by [`src/cli/serve.rs:309-314`](https://github.com/njbrake/agent-of-empires/blob/main/src/cli/serve.rs#L309-L314)), `auth_middleware` returns `401 {\"error\":\"login_required\"}` whenever the Bearer token validates but the `aoe_session` cookie is missing or expired ([`src/server/auth.rs:316-324`](https://github.com/njbrake/agent-of-empires/blob/main/src/server/auth.rs#L316-L324)). The web client's `fetchInterceptor` was treating every 401 on `/api/*` as a dead token: it cleared `localStorage` and bounced the user to `TokenEntryPage`. Pasting the (correct) new token then hit `/api/about`, returned the same `401 login_required`, and the loop never escaped.

Fix:
- Add `classifyAuthError(res)` to peek at the 401 body (cloned, original body stays readable) and split it into `\"login_required\"` vs `\"unauthorized\"`.
- Add `LOGIN_REQUIRED_EVENT`. The interceptor dispatches it for `login_required` 401s and explicitly does **not** clear the token.
- `App.tsx` listens for the event and flips `tokenExpired=false`, `loginRequired=true`, `loginAuthenticated=false` so `LoginPage` takes over.

This also fixes the analogous case where the 30-day login session expires mid-use: instead of bouncing to token entry, the user now gets the passphrase prompt.

### 2. TokenEntryPage verifies via the session-exempt endpoint

`TokenEntryPage` previously verified the pasted token by hitting `/api/about`, which is gated by both factors. With a passphrase configured and no session cookie, that endpoint returned `401 login_required` and looked like a token rejection. Switched to `/api/login/status`, which is in the login-exempt list ([`src/server/auth.rs:301`](https://github.com/njbrake/agent-of-empires/blob/main/src/server/auth.rs#L301)). Now a token-good-but-passphrase-missing paste verifies as success here; `App.tsx` routes to `LoginPage` via the existing `handleTokenSuccess → loginStatus()` flow.

This is belt-and-suspenders with fix #1: the interceptor handles in-app session expiry, and the entry page handles fresh paste.

### 3. `serve.url` refreshes on token rotation

`TokenManager::rotate` was writing `serve.token` but not `serve.url` ([`src/server/mod.rs:122-136`](https://github.com/njbrake/agent-of-empires/blob/main/src/server/mod.rs#L122-L136)). After the 4-hour rotation in remote mode, the TUI kept displaying `?token=<old>`. Copying that URL worked for five minutes (grace period) and then silently failed. The rotation task now rebuilds `serve.url` with the new token using the same `{base}/?token={tok}` format used at startup.

### 4. Unify `handleNoToken` and `handleTokenRejected`

While adding the `login_required` dispatcher, noticed the existing two were duplicates: both dispatched `TOKEN_EXPIRED_EVENT` with their own dedup flag. `clearToken()` is idempotent, so the no-token branch was redundant. Collapsed into `handleTokenAuthFailure()` with a single dedup flag.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (39/39 vitest, 120/120 server-module Rust tests; 4 pre-existing `session::capture::tests::test_capture_hermes_*` failures need `sqlite3` in PATH and are unrelated)
- [x] Documentation was updated where necessary (n/a, no user-visible doc surface)
- [ ] For UI changes: included screenshot or recording (the visible change is \"LoginPage shows instead of TokenEntryPage\" in the bad-cookie case; reproduces only against a real `--remote` daemon)

## How tested

- `cd web && npx vitest run` — 39/39 passing, including 6 new tests for `classifyAuthError`.
- `cd web && npx tsc -b` — clean.
- `cargo check --features serve`, `cargo clippy --features serve -- -D warnings`, `cargo fmt --check` — clean.
- `cargo test --lib --features serve server::` — 120/120 passing.
- ESLint on changed files: no new errors.
- No live e2e: the full Tailscale Funnel + cookie-loss reproduction wasn't run from the sandbox. The regression test pins the wire contract (`error: \"login_required\"` vs `error: \"unauthorized\"`) so the next breakage is caught.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context) via `/investigate` then implementation.

**Any Additional AI Details you'd like to share:** Root-caused via systematic walk through `src/server/auth.rs`, `src/server/login.rs`, and `web/src/lib/fetchInterceptor.ts`. Implementation reviewed against the existing two-factor flow before committing. Self-review surfaced the rotation, verifier, and dedup-handler issues, all addressed in a follow-up commit on this PR.

- [x] I am an AI Agent filling out this form (check box if true)