### PR TITLE
fix(tui): use actual tmux prefix in welcome dialog and status bar

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -11,6 +11,7 @@ pub use session::Session;
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub use status_detection::detect_status_from_content;
 pub use terminal_session::{ContainerTerminalSession, TerminalSession};
+pub use utils::tmux_prefix_display;
 
 #[cfg(any(test, feature = "test-support"))]
 #[doc(hidden)]

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -63,11 +63,12 @@ pub fn apply_status_bar(
     set_session_option(session_name, "status-right-length", "80")?;
 
     set_session_option(session_name, "status-style", &format!("bg={bg},fg={fg}"))?;
+    let prefix = crate::tmux::utils::tmux_prefix_display();
     set_session_option(
         session_name,
         "status-left",
         &format!(
-            " #[fg={accent},bold]#S#[fg={fg},nobold] \u{2502} #[fg={hint}]Ctrl+b d#[fg={hint}] to detach ",
+            " #[fg={accent},bold]#S#[fg={fg},nobold] \u{2502} #[fg={hint}]{prefix} d#[fg={hint}] to detach ",
         ),
     )?;
     set_session_option(session_name, "status-left-length", "50")?;

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -158,6 +158,30 @@ pub fn is_pane_running_shell(session_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// Returns the tmux prefix key formatted for display (e.g. "Ctrl+a", "Ctrl+b").
+/// Reads `tmux show-option -gv prefix`; falls back to "Ctrl+b" if tmux is
+/// unavailable or the option can't be parsed.
+pub fn tmux_prefix_display() -> String {
+    let raw = Command::new("tmux")
+        .args(["show-option", "-gv", "prefix"])
+        .output()
+        .ok()
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .unwrap_or_default();
+
+    // tmux reports prefix as e.g. "C-b", "C-a", "M-b". Convert to display form.
+    if let Some(key) = raw.strip_prefix("C-") {
+        format!("Ctrl+{}", key.to_uppercase())
+    } else if let Some(key) = raw.strip_prefix("M-") {
+        format!("Alt+{}", key.to_uppercase())
+    } else if !raw.is_empty() {
+        raw
+    } else {
+        "Ctrl+b".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -1,6 +1,7 @@
 //! tmux utility functions
 
 use std::process::Command;
+use std::sync::OnceLock;
 
 pub fn strip_ansi(content: &str) -> String {
     let mut result = content.to_string();
@@ -159,24 +160,34 @@ pub fn is_pane_running_shell(session_name: &str) -> bool {
 }
 
 /// Returns the tmux prefix key formatted for display (e.g. "Ctrl+a", "Ctrl+b").
-/// Reads `tmux show-option -gv prefix`; falls back to "Ctrl+b" if tmux is
-/// unavailable or the option can't be parsed.
-pub fn tmux_prefix_display() -> String {
-    let raw = Command::new("tmux")
-        .args(["show-option", "-gv", "prefix"])
-        .output()
-        .ok()
-        .and_then(|o| String::from_utf8(o.stdout).ok())
-        .map(|s| s.trim().to_string())
-        .unwrap_or_default();
+/// Reads `tmux show-option -gv prefix` once on first call and caches the
+/// result; falls back to "Ctrl+b" if tmux is unavailable or the option can't
+/// be parsed. The prefix can't change while AOE is running, so caching avoids
+/// per-render-frame subprocess calls from the welcome dialog.
+pub fn tmux_prefix_display() -> &'static str {
+    static CACHE: OnceLock<String> = OnceLock::new();
+    CACHE.get_or_init(|| {
+        let raw = Command::new("tmux")
+            .args(["show-option", "-gv", "prefix"])
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_default();
+        format_tmux_prefix(&raw)
+    })
+}
 
-    // tmux reports prefix as e.g. "C-b", "C-a", "M-b". Convert to display form.
+/// Convert tmux's raw prefix notation (e.g. "C-a", "M-b", "F12") to the
+/// display form shown in UI hints. Preserves case from tmux so users see the
+/// same letter they typed in `~/.tmux.conf`.
+fn format_tmux_prefix(raw: &str) -> String {
     if let Some(key) = raw.strip_prefix("C-") {
-        format!("Ctrl+{}", key.to_uppercase())
+        format!("Ctrl+{key}")
     } else if let Some(key) = raw.strip_prefix("M-") {
-        format!("Alt+{}", key.to_uppercase())
+        format!("Alt+{key}")
     } else if !raw.is_empty() {
-        raw
+        raw.to_string()
     } else {
         "Ctrl+b".to_string()
     }
@@ -287,5 +298,36 @@ mod tests {
                 "{cmd} should not be recognized as a shell"
             );
         }
+    }
+
+    #[test]
+    fn test_format_tmux_prefix_ctrl() {
+        assert_eq!(format_tmux_prefix("C-a"), "Ctrl+a");
+        assert_eq!(format_tmux_prefix("C-b"), "Ctrl+b");
+        assert_eq!(format_tmux_prefix("C-Space"), "Ctrl+Space");
+    }
+
+    #[test]
+    fn test_format_tmux_prefix_alt() {
+        assert_eq!(format_tmux_prefix("M-x"), "Alt+x");
+    }
+
+    #[test]
+    fn test_format_tmux_prefix_preserves_case() {
+        // tmux returns the prefix in whatever case the user wrote it; preserve
+        // it so the displayed hint matches their muscle memory.
+        assert_eq!(format_tmux_prefix("C-A"), "Ctrl+A");
+        assert_eq!(format_tmux_prefix("C-b"), "Ctrl+b");
+    }
+
+    #[test]
+    fn test_format_tmux_prefix_special_keys() {
+        assert_eq!(format_tmux_prefix("F12"), "F12");
+        assert_eq!(format_tmux_prefix("Space"), "Space");
+    }
+
+    #[test]
+    fn test_format_tmux_prefix_empty_falls_back() {
+        assert_eq!(format_tmux_prefix(""), "Ctrl+b");
     }
 }

--- a/src/tui/dialogs/welcome.rs
+++ b/src/tui/dialogs/welcome.rs
@@ -67,10 +67,7 @@ impl WelcomeDialog {
                 ),
             ]),
             Line::from(""),
-            Line::from(Span::styled(
-                note,
-                Style::default().fg(theme.hint).italic(),
-            )),
+            Line::from(Span::styled(note, Style::default().fg(theme.hint).italic())),
             Line::from(""),
             Line::from(Span::styled(
                 "Press ? anytime for full keyboard shortcuts.",

--- a/src/tui/dialogs/welcome.rs
+++ b/src/tui/dialogs/welcome.rs
@@ -42,26 +42,25 @@ impl WelcomeDialog {
             .constraints([Constraint::Min(1), Constraint::Length(2)])
             .split(inner);
 
+        let prefix = crate::tmux::tmux_prefix_display();
+        let detach_key = format!("  {} then d   ", prefix);
+        let scroll_key = format!("  {} then [   ", prefix);
+        let note = format!("Note: Press {}, release, THEN press the next key.", prefix);
+
         let content = vec![
             Line::from("When you attach or start an AOE session, "),
             Line::from("you're working directly in tmux."),
             Line::from("Essential tmux commands:"),
             Line::from(""),
             Line::from(vec![
-                Span::styled(
-                    "  Ctrl+b then d   ",
-                    Style::default().fg(theme.title).bold(),
-                ),
+                Span::styled(detach_key, Style::default().fg(theme.title).bold()),
                 Span::styled(
                     "Detach (exit without stopping)",
                     Style::default().fg(theme.text),
                 ),
             ]),
             Line::from(vec![
-                Span::styled(
-                    "  Ctrl+b then [   ",
-                    Style::default().fg(theme.title).bold(),
-                ),
+                Span::styled(scroll_key, Style::default().fg(theme.title).bold()),
                 Span::styled(
                     "Scroll mode (arrows to scroll, q to exit)",
                     Style::default().fg(theme.text),
@@ -69,7 +68,7 @@ impl WelcomeDialog {
             ]),
             Line::from(""),
             Line::from(Span::styled(
-                "Note: Press Ctrl+b, release, THEN press the next key.",
+                note,
                 Style::default().fg(theme.hint).italic(),
             )),
             Line::from(""),


### PR DESCRIPTION
## Description

AOE hardcodes `Ctrl+b` as the tmux prefix in two places:
- The first-run **welcome dialog** (`src/tui/dialogs/welcome.rs`)
- The **session status bar** injected into every agent session (`src/tmux/status_bar.rs`)

Users who configure a non-default tmux prefix (e.g. `Ctrl+a`, which is common) see misleading detach instructions. This fix reads the actual configured prefix at runtime via `tmux show-option -gv prefix` and displays it correctly.

### Changes

- **`src/tmux/utils.rs`**: Added `tmux_prefix_display()` — reads `tmux show-option -gv prefix`, converts tmux notation (`C-a`, `M-b`) to human-readable form (`Ctrl+a`, `Alt+b`), falls back to `Ctrl+b` if tmux is unavailable.
- **`src/tmux/mod.rs`**: Re-exports `tmux_prefix_display` from the public API.
- **`src/tui/dialogs/welcome.rs`**: Welcome dialog now calls `tmux_prefix_display()` for all three prefix references (detach key, scroll key, and the note line).
- **`src/tmux/status_bar.rs`**: `apply_status_bar()` now calls `tmux_prefix_display()` so the `status-left` injected into each agent session shows the correct prefix.

### Root cause

Reported by a user whose tmux prefix is `C-a`. The status bar displayed `Ctrl+b d to detach`; pressing `Ctrl+b d` did nothing; pressing the actual prefix `Ctrl+a d` worked. The mismatch caused confusion about whether AOE itself was broken.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- `cargo test` passes (existing `test_enter_submits`, `test_esc_submits`, `test_space_submits`, `test_other_keys_continue` in `welcome.rs` all green)
- Manually verified on a machine with `prefix = C-a`: welcome dialog shows `Ctrl+a then d`, status bar shows `Ctrl+a d to detach`
- Fallback tested: with tmux not on PATH, `tmux_prefix_display()` returns `Ctrl+b`

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Sonnet 4.6 (Claude Code)

**Any Additional AI Details you'd like to share:** Used for implementation and PR writeup; logic and testing verified by the submitting developer.

- [ ] I am an AI Agent filling out this form (check box if true)