### PR TITLE
fix: UTF-8 safe truncate_id

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,15 +63,43 @@ pub fn truncate(s: &str, max: usize) -> String {
 }
 
 pub fn truncate_id(id: &str, max_len: usize) -> &str {
-    let char_count = id.chars().count();
-    if char_count <= max_len {
-        id
-    } else {
-        let byte_pos = id
-            .char_indices()
-            .nth(max_len)
-            .map(|(i, _)| i)
-            .unwrap_or(id.len());
-        &id[..byte_pos]
+    match id.char_indices().nth(max_len) {
+        Some((byte_pos, _)) => &id[..byte_pos],
+        None => id,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_id_shorter_than_max_returns_input() {
+        assert_eq!(truncate_id("abc", 8), "abc");
+    }
+
+    #[test]
+    fn truncate_id_equal_to_max_returns_input() {
+        assert_eq!(truncate_id("abcdefgh", 8), "abcdefgh");
+    }
+
+    #[test]
+    fn truncate_id_ascii_truncates_to_max_chars() {
+        assert_eq!(truncate_id("abcdefghij", 8), "abcdefgh");
+    }
+
+    #[test]
+    fn truncate_id_multibyte_does_not_panic_and_respects_char_boundary() {
+        // "café" is 4 chars / 5 bytes. The naive byte-slice version would have
+        // panicked on max_len=4 mid-codepoint.
+        assert_eq!(truncate_id("café", 3), "caf");
+        assert_eq!(truncate_id("café", 4), "café");
+        assert_eq!(truncate_id("café", 10), "café");
+    }
+
+    #[test]
+    fn truncate_id_zero_max_returns_empty() {
+        assert_eq!(truncate_id("abc", 0), "");
+        assert_eq!(truncate_id("café", 0), "");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -63,9 +63,15 @@ pub fn truncate(s: &str, max: usize) -> String {
 }
 
 pub fn truncate_id(id: &str, max_len: usize) -> &str {
-    if id.len() > max_len {
-        &id[..max_len]
-    } else {
+    let char_count = id.chars().count();
+    if char_count <= max_len {
         id
+    } else {
+        let byte_pos = id
+            .char_indices()
+            .nth(max_len)
+            .map(|(i, _)| i)
+            .unwrap_or(id.len());
+        &id[..byte_pos]
     }
 }


### PR DESCRIPTION
## Description

Fixes a potential UTF-8 slicing panic in `truncate_id`.

* Uses character boundaries instead of byte slicing to safely handle multi-byte UTF-8 strings
* Preserves existing behavior for ASCII inputs
* Change is isolated to `src/cli/mod.rs` with no additional features

## Checklist

* [x] I understand the code I am submitting
* [x] I have tested this change locally
* [x] I have updated relevant documentation (if applicable)