### PR TITLE
fix(session): read opencode session list from SQLite, not subprocess

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "rattles",
  "regex",
  "reqwest",
+ "rusqlite",
  "rust-embed",
  "serde",
  "serde_json",
@@ -92,6 +93,18 @@ dependencies = [
  "tui-input",
  "unicode-width",
  "uuid",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -961,6 +974,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fancy-regex"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1253,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1251,6 +1285,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -1833,6 +1876,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2882,6 +2936,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,12 @@ futures-util = "0.3"
 # Temporary files and directories
 tempfile = "3.14"
 
+# Local SQLite reader for opencode's session store. Bundled to avoid a
+# system libsqlite3 dependency. Used to read session state without spawning
+# `opencode session list`, which leaks a 4.5MB /tmp/.<hash>.so per invocation
+# via opencode's bun:ffi OpenTUI extract path (see anomalyco/opencode#6523).
+rusqlite = { version = "0.32", features = ["bundled"] }
+
 # Web server (optional, behind "serve" feature)
 axum = { version = "0.8", features = ["ws"], optional = true }
 tower-http = { version = "0.6", features = ["fs"], optional = true }

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -953,12 +953,23 @@ fn select_opencode_session(
     let session_entries: Vec<serde_json::Value> =
         serde_json::from_str(trimmed).context("Failed to parse OpenCode session list JSON")?;
 
-    let matching = filter_agent_sessions(
-        &session_entries,
-        Some(match_path),
-        exclusion,
-        launch_time_ms,
-    );
+    select_opencode_session_from_values(&session_entries, match_path, exclusion, launch_time_ms)
+}
+
+/// Pick the best opencode session from already-parsed entries.
+///
+/// Shared by the JSON (subprocess) path and the SQLite (direct read) path.
+/// Each entry must expose `id`, `directory`, and `updated` keys; the SQLite
+/// reader synthesizes that shape from the `session` table so this filter
+/// behaves identically across both sources.
+fn select_opencode_session_from_values(
+    session_entries: &[serde_json::Value],
+    match_path: &str,
+    exclusion: &HashSet<String>,
+    launch_time_ms: Option<f64>,
+) -> Result<String> {
+    let matching =
+        filter_agent_sessions(session_entries, Some(match_path), exclusion, launch_time_ms);
 
     matching
         .first()
@@ -967,18 +978,120 @@ fn select_opencode_session(
         .ok_or_else(|| anyhow::anyhow!("No OpenCode sessions found matching project path"))
 }
 
-/// Capture an OpenCode session ID by running `opencode session list --format json`,
-/// parsing the output, and matching by CWD. Returns error (not fallback) when
-/// no unexcluded session matches.
+/// Resolve the path to opencode's local SQLite session store.
+///
+/// Honors `XDG_DATA_HOME` first, then falls back to `$HOME/.local/share`.
+/// Mirrors opencode's own data-dir resolution so the file we read is the
+/// one opencode is writing.
+fn opencode_db_path() -> Result<PathBuf> {
+    if let Ok(xdg) = std::env::var("XDG_DATA_HOME") {
+        if !xdg.is_empty() {
+            return Ok(PathBuf::from(xdg).join("opencode").join("opencode.db"));
+        }
+    }
+    let home =
+        std::env::var("HOME").context("HOME is not set; cannot resolve opencode SQLite path")?;
+    Ok(PathBuf::from(home)
+        .join(".local")
+        .join("share")
+        .join("opencode")
+        .join("opencode.db"))
+}
+
+/// Load opencode's session rows from its SQLite store at `db_path`.
+///
+/// Selects `id`, `directory`, and `time_updated` from the `session` table
+/// and reshapes each row to match the JSON the CLI would emit (`id`,
+/// `directory`, `updated`). An `Err` here means the DB is unreadable
+/// (missing, locked, schema mismatch, IO) and the caller should fall back
+/// to the subprocess path. An `Ok` with an empty `Vec` is authoritative:
+/// opencode genuinely has no sessions, so we should NOT fall back; the
+/// subprocess would leak `/tmp/.<hash>.so` for the same empty answer.
+fn read_opencode_sessions_from_sqlite_at(db_path: &Path) -> Result<Vec<serde_json::Value>> {
+    use rusqlite::{Connection, OpenFlags};
+
+    if !db_path.exists() {
+        anyhow::bail!("opencode DB not found at {}", db_path.display());
+    }
+
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .with_context(|| format!("Failed to open opencode DB at {}", db_path.display()))?;
+    conn.busy_timeout(Duration::from_millis(100))
+        .context("Failed to set opencode DB busy timeout")?;
+
+    let mut stmt = conn
+        .prepare("SELECT id, directory, time_updated FROM session ORDER BY time_updated DESC")
+        .context("opencode session table schema mismatch")?;
+
+    let rows = stmt
+        .query_map([], |row| {
+            let id: String = row.get(0)?;
+            let directory: String = row.get(1)?;
+            let time_updated: i64 = row.get(2)?;
+            Ok(serde_json::json!({
+                "id": id,
+                "directory": directory,
+                "updated": time_updated as f64,
+            }))
+        })
+        .context("Failed to query opencode session table")?;
+
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    for row in rows {
+        entries.push(row.context("Failed to read opencode session row")?);
+    }
+    Ok(entries)
+}
+
+fn log_opencode_sqlite_fallback_once(err: &anyhow::Error) {
+    use std::sync::Once;
+    static LOG_ONCE: Once = Once::new();
+    LOG_ONCE.call_once(|| {
+        tracing::warn!(
+            "opencode SQLite read failed ({}); falling back to `opencode session list`. \
+             That subprocess leaks /tmp/.<hash>.so files via bun:ffi (see anomalyco/opencode#6523).",
+            err
+        );
+    });
+}
+
+/// Capture an OpenCode session ID, preferring a direct SQLite read.
 ///
 /// `launch_time_ms` is the lower bound on the session's `updated` timestamp,
 /// used to ignore stale sessions left over from prior runs. Pass `None` for
 /// retroactive capture on TUI startup, when the launch time isn't known.
+///
+/// Reads `~/.local/share/opencode/opencode.db` (or `$XDG_DATA_HOME/opencode/`)
+/// first. If the DB exists and is readable, its result is authoritative
+/// (including "no match found"); we do NOT fall back to the subprocess in
+/// that case, because every `opencode session list` invocation leaks a
+/// 4.5MB OpenTUI shared library to `/tmp/.<hash>-NNNNNNNN.so` via bun:ffi
+/// (anomalyco/opencode#6523), and the subprocess would just return the
+/// same empty answer. Only fall back when the read itself fails (DB
+/// missing, locked, schema drift, IO).
 pub(crate) fn try_capture_opencode_session_id(
     project_path: &str,
     exclusion: &HashSet<String>,
     launch_time_ms: Option<f64>,
 ) -> Result<String> {
+    let entries_or_fallback =
+        opencode_db_path().and_then(|p| read_opencode_sessions_from_sqlite_at(&p));
+
+    match entries_or_fallback {
+        Ok(entries) => {
+            return select_opencode_session_from_values(
+                &entries,
+                project_path,
+                exclusion,
+                launch_time_ms,
+            );
+        }
+        Err(e) => log_opencode_sqlite_fallback_once(&e),
+    }
+
     let mut cmd = std::process::Command::new("opencode");
     cmd.args(["session", "list", "--format", "json"])
         .current_dir(project_path);
@@ -3305,5 +3418,123 @@ mod tests {
     #[test]
     fn test_hermes_session_id_format_valid() {
         assert!(is_valid_session_id("20260429_193246_adcddd"));
+    }
+
+    fn create_opencode_test_db(rows: &[(&str, &str, i64)]) -> (tempfile::TempDir, PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE session (
+                id TEXT PRIMARY KEY,
+                directory TEXT NOT NULL,
+                time_updated INTEGER NOT NULL
+            );",
+        )
+        .unwrap();
+        for (id, directory, ts) in rows {
+            conn.execute(
+                "INSERT INTO session (id, directory, time_updated) VALUES (?1, ?2, ?3)",
+                rusqlite::params![id, directory, ts],
+            )
+            .unwrap();
+        }
+        (dir, db_path)
+    }
+
+    #[test]
+    fn test_opencode_sqlite_picks_most_recent_match() {
+        let project = std::env::current_dir().unwrap();
+        let project_str = project.to_string_lossy().to_string();
+        let other = "/tmp/other-project";
+        let (_dir, db_path) = create_opencode_test_db(&[
+            ("ses_old", &project_str, 1_000_000),
+            ("ses_other", other, 9_999_999),
+            ("ses_new", &project_str, 2_000_000),
+        ]);
+
+        let entries = read_opencode_sessions_from_sqlite_at(&db_path).unwrap();
+        let result =
+            select_opencode_session_from_values(&entries, &project_str, &HashSet::new(), None)
+                .unwrap();
+        assert_eq!(result, "ses_new");
+    }
+
+    #[test]
+    fn test_opencode_sqlite_excludes_known_ids() {
+        let project = std::env::current_dir().unwrap();
+        let project_str = project.to_string_lossy().to_string();
+        let (_dir, db_path) = create_opencode_test_db(&[
+            ("ses_skip", &project_str, 2_000_000),
+            ("ses_keep", &project_str, 1_000_000),
+        ]);
+
+        let mut exclusion = HashSet::new();
+        exclusion.insert("ses_skip".to_string());
+        let entries = read_opencode_sessions_from_sqlite_at(&db_path).unwrap();
+        let result =
+            select_opencode_session_from_values(&entries, &project_str, &exclusion, None).unwrap();
+        assert_eq!(result, "ses_keep");
+    }
+
+    #[test]
+    fn test_opencode_sqlite_respects_launch_time_floor() {
+        let project = std::env::current_dir().unwrap();
+        let project_str = project.to_string_lossy().to_string();
+        let (_dir, db_path) = create_opencode_test_db(&[
+            ("ses_stale", &project_str, 1_000),
+            ("ses_fresh", &project_str, 5_000),
+        ]);
+
+        let entries = read_opencode_sessions_from_sqlite_at(&db_path).unwrap();
+        let result = select_opencode_session_from_values(
+            &entries,
+            &project_str,
+            &HashSet::new(),
+            Some(2_000.0),
+        )
+        .unwrap();
+        assert_eq!(result, "ses_fresh");
+    }
+
+    #[test]
+    fn test_opencode_sqlite_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("does-not-exist.db");
+        let result = read_opencode_sessions_from_sqlite_at(&db_path);
+        assert!(result.is_err(), "missing DB must Err so caller falls back");
+    }
+
+    #[test]
+    fn test_opencode_sqlite_schema_mismatch_errors_for_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("opencode.db");
+        let conn = rusqlite::Connection::open(&db_path).unwrap();
+        // Missing required columns; the prepare() should fail and we should
+        // bubble up an error so the caller falls back to the subprocess path.
+        conn.execute_batch("CREATE TABLE session (id TEXT PRIMARY KEY);")
+            .unwrap();
+        drop(conn);
+
+        let result = read_opencode_sessions_from_sqlite_at(&db_path);
+        assert!(
+            result.is_err(),
+            "schema mismatch must Err so caller falls back"
+        );
+    }
+
+    #[test]
+    fn test_opencode_sqlite_no_matching_directory_returns_no_match_not_infra_error() {
+        // Critical for not re-introducing the leak: when the DB is readable
+        // but no session matches, the inner reader must succeed (so the
+        // public function does NOT fall back to the leaky subprocess), and
+        // the selector returns the genuine "no match" error.
+        let (_dir, db_path) = create_opencode_test_db(&[("ses_x", "/elsewhere", 1)]);
+        let entries = read_opencode_sessions_from_sqlite_at(&db_path)
+            .expect("readable DB must Ok even when no rows match the project path");
+        assert_eq!(entries.len(), 1);
+        let result =
+            select_opencode_session_from_values(&entries, "/different", &HashSet::new(), None);
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
> _Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Fixes #904. Memory leak under aoe non-sandbox mode with opencode: ~4.5MB files like `/tmp/.f9ef7ff75feb77fe-00000000.so` accumulate over time. At 60s steady-state polling that's ~270MB/hour per active session, ~2GB in an 8-hour day.

**Root cause** (verified empirically). opencode is built with `bun --compile` and bundles the [OpenTUI](https://github.com/anomalyco/opentui) Zig native renderer as an embedded `bun:ffi` library. Bun extracts that library to `/tmp/.<hash>-NNNNNNNN.so` on every process startup and never unlinks it on exit. Every invocation of every opencode subcommand (`--version`, `--help`, `session list`) leaks exactly one tempfile. This is a known, currently unresolved upstream bug: anomalyco/opencode#6523, anomalyco/opencode#16996, anomalyco/opencode#13479.

**Why aoe and not other agents.** `claude` is also Bun-compiled but ships no embedded FFI native lib, so its subcommands leak zero. opencode is the only aoe-supported tool that embeds a Bun-FFI native lib that the runtime extracts on startup.

**Why aoe and not opencode-by-itself.** aoe's session-resume poller (`src/session/capture.rs:try_capture_opencode_session_id`, `src/session/poller.rs:48-51`) spawns `opencode session list --format json` every poll tick. Steady-state interval is 60s. Each poll spawns a fresh subprocess, each subprocess leaks one ~4.5MB file.

**Why sandbox mode is unaffected.** The sandbox path routes through `docker exec opencode session list`; leaks land in the container's ephemeral `/tmp` and disappear with the container.

**The fix.** Read opencode's local SQLite store at `$XDG_DATA_HOME/opencode/opencode.db` directly. The `session` table exposes `id`, `directory`, `time_updated`, which is exactly what `select_opencode_session` needs. Same row shape (synthesized to match the CLI JSON), same filtering pipeline, no subprocess, no `/tmp` pressure, ~100x faster per poll.

The fallback to the subprocess path is preserved, but only fires on infrastructure errors (DB missing, locked, schema drift); a readable DB with no matching session is authoritative and does not fall back, because the subprocess would just leak for the same empty answer.

Sandbox path (`try_capture_opencode_session_id_in_container`) is intentionally unchanged.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How tested

- 6 new unit tests in `src/session/capture.rs` covering: most-recent match, exclusion set, launch-time floor, missing DB, schema mismatch, and the critical "readable DB with no match must NOT fall back" contract.
- `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib` all pass locally.
- Verified empirically against the real opencode binary that the SQLite path leaks zero `/tmp/.<hash>-*.so` files across 60s of real `SessionPoller` polling and 3 minutes of full `aoe` TUI runtime, where the unfixed subprocess path leaks 1:1 with invocations.

## Tradeoffs

- Adds `rusqlite = { version = "0.32", features = ["bundled"] }`. `bundled` ships its own libsqlite3, no new system dependency. Adds roughly 250KB to the release binary.
- Couples to opencode's current `session` table schema. If opencode renames or drops the columns we read, we degrade to the subprocess path with a one-shot `tracing::warn!` log; we do not panic.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:**
Used Claude Code to investigate the issue, locate the upstream root cause, design the fix, and write the implementation and tests. Schema decisions, fallback semantics (specifically the "no match is authoritative" contract), the choice to leave sandbox mode unchanged, and the bundled-rusqlite tradeoff were all reviewed and approved by me before the code was written.

- [x] I am an AI Agent filling out this form (check box if true)