### PR TITLE
feat(cli): aoe session restart --all

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -209,7 +209,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 
 * `start` — Start a session's tmux process
 * `stop` — Stop session process
-* `restart` — Restart session
+* `restart` — Restart session (or all sessions with `--all`)
 * `attach` — Attach to session interactively
 * `show` — Show session details
 * `rename` — Rename a session
@@ -245,13 +245,20 @@ Stop session process
 
 ## `aoe session restart`
 
-Restart session
+Restart session (or all sessions with `--all`)
 
-**Usage:** `aoe session restart <IDENTIFIER>`
+**Usage:** `aoe session restart [OPTIONS] [IDENTIFIER]`
 
 ###### **Arguments:**
 
-* `<IDENTIFIER>` — Session ID or title
+* `<IDENTIFIER>` — Session ID or title (required unless `--all` is passed)
+
+###### **Options:**
+
+* `--all` — Restart every session in the active profile. Useful after `aoe update`, after editing `sandbox.environment`, after a Docker hiccup, or after changing a hook. Mutually exclusive with `identifier`
+* `--parallel <PARALLEL>` — Concurrency cap for `--all`. Restarting many sandboxed sessions in parallel pressures dockerd, so the default is intentionally modest. Ignored when `--all` is not set
+
+  Default value: `3`
 
 
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -250,10 +250,16 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     // Clone each target into its worker; we'll write the (mutated) copy back
     // by index after the worker returns. Workers never touch the shared Vec.
+    // `source_profile` is runtime-only (skip_serializing) so storage-loaded
+    // instances always come back blank; rehydrate it from the storage profile
+    // so start-time config resolution honors the right profile's overrides
+    // (sandbox.environment, on_launch hooks, etc.).
     let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
     for id in &target_ids {
         if let Some(idx) = instances.iter().position(|i| &i.id == id) {
-            targets.push((idx, instances[idx].clone()));
+            let mut clone = instances[idx].clone();
+            clone.source_profile = profile.to_string();
+            targets.push((idx, clone));
         }
     }
 
@@ -348,6 +354,10 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // `source_profile` is runtime-only (skip_serializing) so storage-loaded
+    // instances always come back blank; rehydrate it from the storage profile
+    // so restart-time config resolution honors the right profile's overrides.
+    instances[idx].source_profile = profile.to_string();
     instances[idx].restart_with_size(crate::terminal::get_size())?;
     let title = instances[idx].title.clone();
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -14,8 +14,8 @@ pub enum SessionCommands {
     /// Stop session process
     Stop(SessionIdArgs),
 
-    /// Restart session
-    Restart(SessionIdArgs),
+    /// Restart session (or all sessions with `--all`)
+    Restart(RestartArgs),
 
     /// Attach to session interactively
     Attach(SessionIdArgs),
@@ -40,6 +40,25 @@ pub enum SessionCommands {
 pub struct SessionIdArgs {
     /// Session ID or title
     identifier: String,
+}
+
+#[derive(Args)]
+pub struct RestartArgs {
+    /// Session ID or title (required unless `--all` is passed)
+    pub identifier: Option<String>,
+
+    /// Restart every session in the active profile. Useful after
+    /// `aoe update`, after editing `sandbox.environment`, after a
+    /// Docker hiccup, or after changing a hook. Mutually exclusive
+    /// with `identifier`.
+    #[arg(long, conflicts_with = "identifier")]
+    pub all: bool,
+
+    /// Concurrency cap for `--all`. Restarting many sandboxed
+    /// sessions in parallel pressures dockerd, so the default is
+    /// intentionally modest. Ignored when `--all` is not set.
+    #[arg(long, default_value_t = 3)]
+    pub parallel: usize,
 }
 
 #[derive(Args)]
@@ -131,7 +150,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
     match command {
         SessionCommands::Start(args) => start_session(profile, args).await,
         SessionCommands::Stop(args) => stop_session(profile, args).await,
-        SessionCommands::Restart(args) => restart_session(profile, args).await,
+        SessionCommands::Restart(args) => restart_session_dispatch(profile, args).await,
         SessionCommands::Attach(args) => attach_session(profile, args).await,
         SessionCommands::Show(args) => show_session(profile, args).await,
         SessionCommands::Capture(args) => capture_session(profile, args).await,
@@ -203,6 +222,20 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()> {
+    if args.all {
+        return restart_all_sessions(profile, args.parallel).await;
+    }
+    let identifier = args
+        .identifier
+        .ok_or_else(|| anyhow::anyhow!("session identifier required (or pass --all)"))?;
+    restart_session(profile, SessionIdArgs { identifier }).await
+}
+
+async fn restart_all_sessions(_profile: &str, _parallel: usize) -> Result<()> {
+    bail!("--all not yet implemented")
 }
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
@@ -539,4 +572,65 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         None => println!("✓ Cleared session ID for '{}'", title),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod restart_args_tests {
+    use super::SessionCommands;
+    use clap::Parser;
+
+    #[derive(Parser)]
+    struct Cli {
+        #[command(subcommand)]
+        cmd: SessionCommands,
+    }
+
+    #[test]
+    fn restart_with_identifier_still_parses() {
+        let cli = Cli::try_parse_from(["aoe", "restart", "claude-3"])
+            .expect("identifier-only must parse");
+        match cli.cmd {
+            SessionCommands::Restart(args) => {
+                assert!(!args.all);
+                assert_eq!(args.identifier.as_deref(), Some("claude-3"));
+                assert_eq!(args.parallel, 3);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn restart_all_alone_parses() {
+        let cli = Cli::try_parse_from(["aoe", "restart", "--all"]).expect("--all alone must parse");
+        match cli.cmd {
+            SessionCommands::Restart(args) => {
+                assert!(args.all);
+                assert!(args.identifier.is_none());
+                assert_eq!(args.parallel, 3);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn restart_all_with_parallel_parses() {
+        let cli = Cli::try_parse_from(["aoe", "restart", "--all", "--parallel", "5"])
+            .expect("--all --parallel must parse");
+        match cli.cmd {
+            SessionCommands::Restart(args) => {
+                assert!(args.all);
+                assert_eq!(args.parallel, 5);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn restart_identifier_and_all_conflicts() {
+        let result = Cli::try_parse_from(["aoe", "restart", "claude-3", "--all"]);
+        assert!(
+            result.is_err(),
+            "passing both identifier and --all should error"
+        );
+    }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -234,7 +234,7 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
     restart_session(profile, SessionIdArgs { identifier }).await
 }
 
-async fn restart_all_sessions(profile: &str, _parallel: usize) -> Result<()> {
+async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let storage = Storage::new(profile)?;
     let (mut instances, groups) = storage.load_with_groups()?;
 
@@ -246,15 +246,60 @@ async fn restart_all_sessions(profile: &str, _parallel: usize) -> Result<()> {
 
     let total = target_ids.len();
     let size = crate::terminal::get_size();
+    let parallel = parallel.max(1);
+
+    // Clone each target into its worker; we'll write the (mutated) copy back
+    // by index after the worker returns. Workers never touch the shared Vec.
+    let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
+    for id in &target_ids {
+        if let Some(idx) = instances.iter().position(|i| &i.id == id) {
+            targets.push((idx, instances[idx].clone()));
+        }
+    }
+
+    let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
+    let mut join_set: tokio::task::JoinSet<(
+        usize,
+        String,
+        Option<crate::session::Instance>,
+        Result<()>,
+    )> = tokio::task::JoinSet::new();
+
+    for (idx, mut inst) in targets {
+        let permit_sem = semaphore.clone();
+        join_set.spawn(async move {
+            let _permit = permit_sem
+                .acquire_owned()
+                .await
+                .expect("semaphore not closed");
+            let title = inst.title.clone();
+            let res = tokio::task::spawn_blocking(move || {
+                let result = inst.restart_with_size(size);
+                (inst, result)
+            })
+            .await;
+            match res {
+                Ok((inst, result)) => (idx, title, Some(inst), result),
+                Err(join_err) => (
+                    idx,
+                    title,
+                    None,
+                    Err(anyhow::anyhow!("worker panicked: {}", join_err)),
+                ),
+            }
+        });
+    }
+
     let mut succeeded: Vec<String> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
 
-    for id in target_ids {
-        let Some(idx) = instances.iter().position(|i| i.id == id) else {
-            continue;
-        };
-        let title = instances[idx].title.clone();
-        match instances[idx].restart_with_size(size) {
+    while let Some(joined) = join_set.join_next().await {
+        let (idx, title, inst_opt, result) =
+            joined.expect("JoinSet shouldn't panic on join itself");
+        if let Some(inst) = inst_opt {
+            instances[idx] = inst;
+        }
+        match result {
             Ok(()) => succeeded.push(title),
             Err(e) => failed.push((title, e.to_string())),
         }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -234,8 +234,60 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
     restart_session(profile, SessionIdArgs { identifier }).await
 }
 
-async fn restart_all_sessions(_profile: &str, _parallel: usize) -> Result<()> {
-    bail!("--all not yet implemented")
+async fn restart_all_sessions(profile: &str, _parallel: usize) -> Result<()> {
+    let storage = Storage::new(profile)?;
+    let (mut instances, groups) = storage.load_with_groups()?;
+
+    let target_ids = pick_targets_for_restart_all(&instances);
+    if target_ids.is_empty() {
+        println!("No sessions to restart in profile '{}'.", profile);
+        return Ok(());
+    }
+
+    let total = target_ids.len();
+    let size = crate::terminal::get_size();
+    let mut succeeded: Vec<String> = Vec::new();
+    let mut failed: Vec<(String, String)> = Vec::new();
+
+    for id in target_ids {
+        let Some(idx) = instances.iter().position(|i| i.id == id) else {
+            continue;
+        };
+        let title = instances[idx].title.clone();
+        match instances[idx].restart_with_size(size) {
+            Ok(()) => succeeded.push(title),
+            Err(e) => failed.push((title, e.to_string())),
+        }
+    }
+
+    let group_tree = GroupTree::new_with_groups(&instances, &groups);
+    storage.save_with_groups(&instances, &group_tree)?;
+
+    println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
+    for title in &succeeded {
+        println!("  · {}", title);
+    }
+    if !failed.is_empty() {
+        println!("✗ {} failed:", failed.len());
+        for (title, err) in &failed {
+            println!("  · {}: {}", title, err);
+        }
+        bail!("{} session(s) failed to restart", failed.len());
+    }
+
+    Ok(())
+}
+
+/// Sessions in `Deleting` or `Creating` are mid-transition; restarting them
+/// would race the deletion/boot path. Everything else is fair game; agents
+/// have their own resume-or-restart logic on the next start.
+fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<String> {
+    use crate::session::Status;
+    instances
+        .iter()
+        .filter(|i| !matches!(i.status, Status::Deleting | Status::Creating))
+        .map(|i| i.id.clone())
+        .collect()
 }
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
@@ -632,5 +684,51 @@ mod restart_args_tests {
             result.is_err(),
             "passing both identifier and --all should error"
         );
+    }
+}
+
+#[cfg(test)]
+mod target_filter_tests {
+    use super::pick_targets_for_restart_all;
+    use crate::session::{Instance, Status};
+
+    fn instance_with_status(id: &str, status: Status) -> Instance {
+        let mut inst = Instance::new(id, "/tmp");
+        inst.id = id.to_string();
+        inst.status = status;
+        inst
+    }
+
+    #[test]
+    fn skips_deleting_and_creating() {
+        let instances = vec![
+            instance_with_status("running", Status::Running),
+            instance_with_status("idle", Status::Idle),
+            instance_with_status("stopped", Status::Stopped),
+            instance_with_status("error", Status::Error),
+            instance_with_status("waiting", Status::Waiting),
+            instance_with_status("starting", Status::Starting),
+            instance_with_status("unknown", Status::Unknown),
+            instance_with_status("deleting", Status::Deleting),
+            instance_with_status("creating", Status::Creating),
+        ];
+        let mut picked = pick_targets_for_restart_all(&instances);
+        picked.sort();
+        let mut expected = vec![
+            "error".to_string(),
+            "idle".to_string(),
+            "running".to_string(),
+            "starting".to_string(),
+            "stopped".to_string(),
+            "unknown".to_string(),
+            "waiting".to_string(),
+        ];
+        expected.sort();
+        assert_eq!(picked, expected);
+    }
+
+    #[test]
+    fn empty_input_yields_empty_targets() {
+        assert!(pick_targets_for_restart_all(&[]).is_empty());
     }
 }


### PR DESCRIPTION
## Description

Implements `aoe session restart --all` per the spec in #855. Generic primitive: bounce every session in the active profile in one call. Useful after `aoe update`, after editing `sandbox.environment`, after a Docker hiccup, after changing a hook, or after rotating Claude credentials externally; these are all currently a hand-loop over `aoe session restart <id>`.

```
aoe session restart --all [--parallel <n>]
```

- `--all`: mutually exclusive with the positional `IDENTIFIER`.
- `--parallel`: concurrency cap. Default 3 (dockerd pressure on sandboxed sessions).
- Skips sessions in `Deleting` or `Creating` (mid-transition; restarting them races their existing state machine).
- Single `sessions.json` write at end. Workers clone their `Instance`, mutate, and the dispatcher writes the mutated copy back to `instances[idx]` only after every worker has joined. The shared `Vec<Instance>` is never touched concurrently.

Per-agent session resume (#838, #850, #851, #852, #853, #854) is preserved automatically: each worker calls the same `Instance::restart_with_size` that single-session restart already calls, so the existing resume contract carries over for free.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/cli/reference.md` regenerated via `cargo xtask gen-docs`)
- [ ] For UI changes: included screenshot or recording (N/A; CLI-only)

## How tested

- `cargo test --lib` (1408 passed; the only failing tests on first run were `containers::runtime::tests::test_image_exists_locally_with_common_image` and `test_ensure_image_uses_local_image`, which pull `hello-world` from Docker Hub and were rate-limited; passed on retry. They are unrelated to this branch and pre-existing.)
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt -- --check` clean.
- New unit coverage in `src/cli/session.rs`:
  - `restart_args_tests`: 4 cases covering arg-parsing for `--all`, `--parallel`, conflict with positional identifier, default parallelism.
  - `target_filter_tests`: 2 cases covering `pick_targets_for_restart_all` (Deleting/Creating excluded; empty input).

## Open questions for review

1. Default `--parallel` is 3. Spec floated 3-4. Open to bumping if you want.
2. Sequential fallback was considered (`--parallel 1`) but kept the same code path; the semaphore degrades to one-at-a-time naturally.
3. No e2e test added yet; happy to add one if you want it before merge (would need `tests/e2e/` to gain a multi-session fixture; not currently in the harness).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7) for drafting; human review and direction throughout.

- [x] I am an AI Agent filling out this form (check box if true)