### PR TITLE
fix(server): replace blocking I/O in async functions with tokio equivalents

### DIFF
--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -192,7 +192,7 @@ pub fn daemon_pid() -> Option<u32> {
 
 pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     if args.stop {
-        return stop_daemon();
+        return stop_daemon().await;
     }
 
     // Refuse to start a second instance (daemon or foreground) while another
@@ -257,12 +257,14 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     // it's available, so requiring cloudflared up front would falsely reject
     // Tailscale-only setups (issue #813).
     let host = if args.remote {
-        if cloudflared_required(
-            args.no_tailscale,
-            args.tunnel_name.is_some(),
-            crate::server::tunnel::tailscale_available_sync(),
-        ) {
-            crate::server::tunnel::check_cloudflared()?;
+        let tailscale_ok =
+            tokio::task::spawn_blocking(crate::server::tunnel::tailscale_available_sync)
+                .await
+                .unwrap_or(false);
+        if cloudflared_required(args.no_tailscale, args.tunnel_name.is_some(), tailscale_ok) {
+            tokio::task::spawn_blocking(crate::server::tunnel::check_cloudflared)
+                .await
+                .map_err(|e| anyhow::anyhow!(e))??;
         }
         // Force localhost since the tunnel connects to localhost
         "127.0.0.1".to_string()
@@ -320,7 +322,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
 
     // Write PID file for non-daemon mode too (so --stop works either way)
     if let Ok(path) = pid_file_path() {
-        let _ = std::fs::write(&path, std::process::id().to_string());
+        let _ = tokio::fs::write(&path, std::process::id().to_string()).await;
     }
 
     let result = crate::server::start_server(crate::server::ServerConfig {
@@ -342,17 +344,18 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     // still belongs to this process. A newer daemon spawn may have
     // overwritten it; removing their file would orphan them.
     if let Ok(path) = pid_file_path() {
-        let is_ours = std::fs::read_to_string(&path)
+        let is_ours = tokio::fs::read_to_string(&path)
+            .await
             .ok()
             .and_then(|s| s.trim().parse::<u32>().ok())
             .is_some_and(|pid| pid == std::process::id());
         if is_ours {
-            let _ = std::fs::remove_file(&path);
+            let _ = tokio::fs::remove_file(&path).await;
             if let Ok(dir) = crate::session::get_app_dir() {
-                let _ = std::fs::remove_file(dir.join("serve.url"));
-                let _ = std::fs::remove_file(dir.join("serve.log"));
-                let _ = std::fs::remove_file(dir.join("serve.mode"));
-                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+                let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }
         }
     }
@@ -455,7 +458,7 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     Ok(())
 }
 
-fn stop_daemon() -> Result<()> {
+async fn stop_daemon() -> Result<()> {
     let path = pid_file_path()?;
 
     if !path.exists() {
@@ -465,7 +468,7 @@ fn stop_daemon() -> Result<()> {
         );
     }
 
-    let pid_str = std::fs::read_to_string(&path)?;
+    let pid_str = tokio::fs::read_to_string(&path).await?;
     let pid: i32 = pid_str
         .trim()
         .parse()
@@ -473,7 +476,7 @@ fn stop_daemon() -> Result<()> {
 
     // Verify PID belongs to an aoe process on all platforms
     if !verify_pid_is_aoe(pid) {
-        std::fs::remove_file(&path)?;
+        tokio::fs::remove_file(&path).await?;
         bail!(
             "PID {} belongs to a different process (stale PID file). Cleaned up.",
             pid
@@ -492,7 +495,7 @@ fn stop_daemon() -> Result<()> {
             // races with the dying daemon and can orphan it.
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
             loop {
-                std::thread::sleep(std::time::Duration::from_millis(50));
+                tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                 match nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None) {
                     Err(nix::errno::Errno::ESRCH) => break,
                     _ if std::time::Instant::now() >= deadline => {
@@ -501,7 +504,7 @@ fn stop_daemon() -> Result<()> {
                             nix::unistd::Pid::from_raw(pid),
                             nix::sys::signal::Signal::SIGKILL,
                         );
-                        std::thread::sleep(std::time::Duration::from_millis(50));
+                        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
                         break;
                     }
                     _ => {}
@@ -509,23 +512,23 @@ fn stop_daemon() -> Result<()> {
             }
             // The daemon's own cleanup may have already removed some
             // of these; that's fine.
-            let _ = std::fs::remove_file(&path);
+            let _ = tokio::fs::remove_file(&path).await;
             if let Ok(dir) = crate::session::get_app_dir() {
-                let _ = std::fs::remove_file(dir.join("serve.url"));
-                let _ = std::fs::remove_file(dir.join("serve.log"));
-                let _ = std::fs::remove_file(dir.join("serve.mode"));
-                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+                let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }
             println!("Stopped aoe serve daemon (PID {})", pid);
         }
         Err(nix::errno::Errno::ESRCH) => {
             // Process doesn't exist; clean up stale PID file
-            std::fs::remove_file(&path)?;
+            tokio::fs::remove_file(&path).await?;
             if let Ok(dir) = crate::session::get_app_dir() {
-                let _ = std::fs::remove_file(dir.join("serve.url"));
-                let _ = std::fs::remove_file(dir.join("serve.log"));
-                let _ = std::fs::remove_file(dir.join("serve.mode"));
-                let _ = std::fs::remove_file(dir.join("serve.passphrase"));
+                let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
+                let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }
             println!("Daemon was not running (stale PID file cleaned up)");
         }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -129,7 +129,7 @@ impl TokenManager {
 
         // Persist to disk
         if let Ok(app_dir) = crate::session::get_app_dir() {
-            write_secret_file(&app_dir.join("serve.token"), &new_token);
+            write_secret_file(&app_dir.join("serve.token"), &new_token).await;
         }
 
         info!("Auth token rotated (previous token valid for 5 more minutes)");
@@ -314,7 +314,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         );
         None
     } else {
-        Some(load_or_generate_token()?)
+        Some(load_or_generate_token().await?)
     };
 
     let token_lifetime = if remote {
@@ -336,7 +336,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // started from the CLI. Owner-only perms; cleaned up on shutdown.
     if let Some(pp) = passphrase {
         if let Ok(app_dir) = crate::session::get_app_dir() {
-            write_secret_file(&app_dir.join("serve.passphrase"), pp);
+            write_secret_file(&app_dir.join("serve.passphrase"), pp).await;
         }
     }
 
@@ -490,12 +490,12 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         // backward-compatible with any consumer that does `head -1 serve.url`,
         // and the TUI parses both single- and multi-URL formats.
         if let Ok(app_dir) = crate::session::get_app_dir() {
-            write_secret_file(&app_dir.join("serve.url"), &tunnel_url_with_token);
+            write_secret_file(&app_dir.join("serve.url"), &tunnel_url_with_token).await;
             // serve.mode lets the TUI reattach to a running daemon and
             // render the right transport label: "tunnel" for Cloudflare,
             // "tailscale" for Tailscale Funnel, "local" for local-only.
             let mode = format!("{}\n", handle.mode_label());
-            let _ = std::fs::write(app_dir.join("serve.mode"), mode);
+            let _ = tokio::fs::write(app_dir.join("serve.mode"), mode).await;
         }
 
         // Start health monitor (uses CancellationToken internally)
@@ -553,8 +553,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 contents.push_str(url);
                 contents.push('\n');
             }
-            write_secret_file(&app_dir.join("serve.url"), &contents);
-            let _ = std::fs::write(app_dir.join("serve.mode"), "local\n");
+            write_secret_file(&app_dir.join("serve.url"), &contents).await;
+            let _ = tokio::fs::write(app_dir.join("serve.mode"), "local\n").await;
         }
 
         None
@@ -607,7 +607,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 {
                     let url_with_token = format!("{}/?token={}", base_url, token);
                     if let Ok(app_dir) = crate::session::get_app_dir() {
-                        write_secret_file(&app_dir.join("serve.url"), &url_with_token);
+                        write_secret_file(&app_dir.join("serve.url"), &url_with_token).await;
                     }
                 }
 
@@ -700,7 +700,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     }
 
     if let Ok(app_dir) = crate::session::get_app_dir() {
-        let _ = std::fs::remove_file(app_dir.join("serve.passphrase"));
+        let _ = tokio::fs::remove_file(app_dir.join("serve.passphrase")).await;
     }
 
     Ok(())
@@ -958,23 +958,23 @@ pub fn discover_tagged_ips() -> Vec<(IpKind, std::net::Ipv4Addr)> {
 
 /// Write a file with owner-only permissions (0600) to protect secrets.
 #[cfg(unix)]
-fn write_secret_file(path: &std::path::Path, contents: &str) {
-    use std::os::unix::fs::OpenOptionsExt;
-    if let Ok(mut file) = std::fs::OpenOptions::new()
+async fn write_secret_file(path: &std::path::Path, contents: &str) {
+    use tokio::io::AsyncWriteExt;
+    let opts = tokio::fs::OpenOptions::new()
         .write(true)
         .create(true)
         .truncate(true)
         .mode(0o600)
         .open(path)
-    {
-        use std::io::Write;
-        let _ = file.write_all(contents.as_bytes());
+        .await;
+    if let Ok(mut file) = opts {
+        let _ = file.write_all(contents.as_bytes()).await;
     }
 }
 
 #[cfg(not(unix))]
-fn write_secret_file(path: &std::path::Path, contents: &str) {
-    let _ = std::fs::write(path, contents);
+async fn write_secret_file(path: &std::path::Path, contents: &str) {
+    let _ = tokio::fs::write(path, contents).await;
 }
 
 /// Generate a cryptographically random 64-character hex token (256 bits of entropy).
@@ -997,18 +997,18 @@ fn is_valid_token_format(token: &str) -> bool {
 
 /// Load an existing auth token from disk if it's less than 24 hours old,
 /// otherwise generate a fresh one and persist it.
-fn load_or_generate_token() -> anyhow::Result<String> {
+async fn load_or_generate_token() -> anyhow::Result<String> {
     let app_dir = crate::session::get_app_dir()?;
     let token_path = app_dir.join("serve.token");
 
     // Try to reuse existing token if fresh enough
-    if let Ok(metadata) = std::fs::metadata(&token_path) {
+    if let Ok(metadata) = tokio::fs::metadata(&token_path).await {
         if let Ok(modified) = metadata.modified() {
             let age = std::time::SystemTime::now()
                 .duration_since(modified)
                 .unwrap_or_default();
             if age < std::time::Duration::from_secs(24 * 60 * 60) {
-                if let Ok(token) = std::fs::read_to_string(&token_path) {
+                if let Ok(token) = tokio::fs::read_to_string(&token_path).await {
                     let token = token.trim().to_string();
                     if !token.is_empty() && is_valid_token_format(&token) {
                         return Ok(token);
@@ -1019,7 +1019,7 @@ fn load_or_generate_token() -> anyhow::Result<String> {
     }
 
     let token = generate_token();
-    write_secret_file(&token_path, &token);
+    write_secret_file(&token_path, &token).await;
     Ok(token)
 }
 

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -293,13 +293,13 @@ impl SubscriptionStore {
         let all: Vec<Subscription> = self.subs.read().await.values().cloned().collect();
         let body = serde_json::to_string_pretty(&all)?;
         let tmp = self.path.with_extension("json.tmp");
-        std::fs::write(&tmp, &body)?;
+        tokio::fs::write(&tmp, &body).await?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
+            tokio::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600)).await?;
         }
-        std::fs::rename(&tmp, &self.path)?;
+        tokio::fs::rename(&tmp, &self.path).await?;
         Ok(())
     }
 }

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -1,7 +1,7 @@
 //! Self-update: detect install method, perform update.
 
 use anyhow::{Context, Result};
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -197,6 +197,8 @@ async fn download_tarball(
     dest: &Path,
     mut on_progress: Option<&mut dyn FnMut(u64, Option<u64>)>,
 ) -> Result<()> {
+    use tokio::io::AsyncWriteExt;
+
     let client = reqwest::Client::builder()
         .user_agent("agent-of-empires")
         .timeout(std::time::Duration::from_secs(300))
@@ -207,19 +209,20 @@ async fn download_tarball(
     }
     let total = response.content_length();
     let mut stream = response.bytes_stream();
-    let mut file = std::fs::File::create(dest)
+    let mut file = tokio::fs::File::create(dest)
+        .await
         .with_context(|| format!("creating download file at {}", dest.display()))?;
     let mut downloaded: u64 = 0;
     use futures_util::StreamExt;
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
-        file.write_all(&chunk)?;
+        file.write_all(&chunk).await?;
         downloaded += chunk.len() as u64;
         if let Some(cb) = on_progress.as_deref_mut() {
             cb(downloaded, total);
         }
     }
-    file.sync_all()?;
+    file.flush().await?;
     Ok(())
 }
 

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -222,7 +222,7 @@ async fn download_tarball(
             cb(downloaded, total);
         }
     }
-    file.flush().await?;
+    file.sync_all().await?;
     Ok(())
 }
 

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{Context, Result};
 use serde::Deserialize;
-use std::io::{ErrorKind, Write};
+use std::io::ErrorKind;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};


### PR DESCRIPTION
## Description

Converts all blocking `std::fs`, `std::thread::sleep`, and `std::process::Command` calls inside async functions to their tokio equivalents, preventing tokio worker thread starvation under concurrent load.

### Changes

| File | What changed |
|---|---|
| `src/server/push.rs` | `persist()`: `std::fs::write/set_permissions/rename` -> `tokio::fs` |
| `src/server/mod.rs` | `write_secret_file` + `load_or_generate_token` made async, all 7 call sites updated |
| `src/cli/serve.rs` | `stop_daemon` made async, `thread::sleep` -> `tokio::time::sleep`, all fs ops -> `tokio::fs`, tunnel checks wrapped in `spawn_blocking` |
| `src/update/install.rs` | `download_tarball`: `std::fs::File` -> `tokio::fs::File` + `AsyncWriteExt`, `sync_all` for crash safety |

### Not changed (already correct)

- `src/server/api/git.rs` and `src/server/api/system.rs` -- already wrapped in `spawn_blocking`
- TUI code (sync event loop, not tokio)
- Dedicated `std::thread::spawn` contexts (`src/tmux/session.rs`, `src/session/poller.rs`)

### Known remaining (out of scope)

- `PushState::init` calls `VapidKeypair::load_or_generate` (sync, uses fs2 file locking) from `start_server`. Only fires once at startup; wrapping in `spawn_blocking` is the right fix but requires restructuring the init flow.

Cross-validated via independent Oracle agent review.

Closes #911

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- `cargo build --features serve` -- compiles
- `cargo build` (TUI-only) -- compiles
- `cargo clippy --features serve -- -D warnings` -- clean
- `cargo fmt` -- clean
- `cargo test --features serve --lib` -- 1553 tests pass

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6

- [x] I am an AI Agent filling out this form (check box if true)