### PR TITLE
fix(web): avoid leaking IME pre-edit keys

### DIFF
--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -337,6 +337,31 @@ export function useTerminal(
     // iOS can't show a paste popup on it. Use the toolbar Paste button.
     const BACKSPACE_SEED = "\u200B";
     let wtermTextarea: HTMLTextAreaElement | null = null;
+    const setupPrintableInputGuard = () => {
+      const textarea = termEl.querySelector("textarea");
+      if (!textarea) return;
+
+      textarea.addEventListener(
+        "keydown",
+        (e: KeyboardEvent) => {
+          if (
+            e.key.length !== 1 ||
+            e.altKey ||
+            e.ctrlKey ||
+            e.metaKey
+          ) {
+            return;
+          }
+
+          // Let the browser's input/composition events produce printable
+          // text. macOS IMEs can emit the first pinyin keydown before
+          // compositionstart, and wterm would otherwise send that Latin
+          // pre-edit character to the PTY.
+          e.stopImmediatePropagation();
+        },
+        true,
+      );
+    };
     const setupMobileTextarea = () => {
       if (!isMobileViewport()) return;
       wtermTextarea = termEl.querySelector("textarea");
@@ -392,6 +417,7 @@ export function useTerminal(
       .init()
       .then(() => {
         if (!connectOnReady) return;
+        setupPrintableInputGuard();
         setupMobileTextarea();
         connect();
       })

--- a/web/tests/terminal-ime.spec.ts
+++ b/web/tests/terminal-ime.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, type Page } from "@playwright/test";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+import { clickSidebarSession } from "./helpers/sidebar";
 
 test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
 
 async function openSession(page: Page, handle: MockHandle) {
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await page
     .locator(".wterm")
     .first()

--- a/web/tests/terminal-ime.spec.ts
+++ b/web/tests/terminal-ime.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect, type Page } from "@playwright/test";
+import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
+
+test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
+
+async function openSession(page: Page, handle: MockHandle) {
+  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await page
+    .locator(".wterm")
+    .first()
+    .waitFor({ state: "visible", timeout: 10_000 });
+  await expect
+    .poll(() => handle.wsMessages.length, { timeout: 5_000 })
+    .toBeGreaterThan(0);
+}
+
+function sentText(handle: MockHandle, start: number) {
+  return handle.wsMessages
+    .slice(start)
+    .map((msg) => msg.toString("utf8"));
+}
+
+test.describe("Terminal IME input", () => {
+  test("plain printable keys still send text", async ({ page }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    const start = handle.wsMessages.length;
+    await page.locator(".wterm").first().locator("textarea").focus();
+    await page.keyboard.type("a");
+
+    await expect
+      .poll(() => sentText(handle, start), { timeout: 5_000 })
+      .toContain("a");
+  });
+
+  test("macOS Chinese composition sends only the committed text", async ({
+    page,
+  }) => {
+    const handle = await mockTerminalApis(page);
+    await page.goto("/");
+    await openSession(page, handle);
+
+    const start = handle.wsMessages.length;
+    await page.evaluate(() => {
+      const ta = document.querySelector<HTMLTextAreaElement>(".wterm textarea");
+      if (!ta) throw new Error("wterm textarea not found");
+      ta.focus();
+
+      ta.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "n",
+          code: "KeyN",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      ta.dispatchEvent(
+        new CompositionEvent("compositionstart", {
+          data: "",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      ta.dispatchEvent(
+        new CompositionEvent("compositionupdate", {
+          data: "n",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+      ta.dispatchEvent(
+        new CompositionEvent("compositionend", {
+          data: "你好",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    await expect
+      .poll(() => sentText(handle, start), { timeout: 5_000 })
+      .toContain("你好");
+    expect(sentText(handle, start)).not.toContain("n");
+  });
+});


### PR DESCRIPTION
  ## Description

  Fixes desktop browser IME input in the web terminal so pinyin pre-edit keys are not sent to the PTY before the committed Chinese text.

  For example, typing `你好` with a macOS Chinese IME previously produced `n你好` in the web terminal. The browser could emit the first printable keydown before `compositionstart`, and
  wterm forwarded it immediately.

  This changes the web terminal input path so plain printable keydown events are not forwarded directly; text is instead produced through browser input/composition events.

  ## PR Type

  - [ ] New Feature
  - [x] Bug Fix
  - [ ] Refactor
  - [ ] Documentation
  - [ ] Infrastructure / CI

  ## Checklist

  - [x] I understand the code I am submitting
  - [x] New and existing tests pass
  - [ ] Documentation was updated where necessary
  - [ ] For UI changes: included screenshot or recording

  ## AI Usage

  - [ ] No AI was used
  - [x] AI was used for drafting/refactoring
  - [ ] This is fully AI-generated

  **AI Model/Tool used:**

  OpenAI Codex

  **Any Additional AI Details you'd like to share:**

  Used Codex to investigate the IME input path, implement the fix, and add Playwright regression coverage. The fix was manually verified on macOS by building `./target/release/aoe serve`
  and confirming Chinese input no longer inserts the leading pinyin letter.

  **NOTE:**
  When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your
  AI :)

  - [x] I am an AI Agent filling out this form (check box if true)