### PR TITLE
fix(tmux): remove case folding from crush spinner detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,24 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@72016aa8156cf95d2cc22f88e29a51a31e958dfc # v2.7.12
+      - name: Check (default features)
+        run: cargo check
+      - name: Check (serve feature)
+        run: |
+          # The serve feature build.rs needs npm to build the web frontend.
+          # Supply a stub via AOE_WEB_DIST so we don't need Node.js just for
+          # a compile check.
+          stub=$(mktemp -d)
+          printf '<!doctype html>' > "$stub/index.html"
+          AOE_WEB_DIST="$stub" cargo check --features serve
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
@@ -46,6 +64,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@72016aa8156cf95d2cc22f88e29a51a31e958dfc # v2.7.12
       - run: cargo clippy -- -D warnings
 
   deny:

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -132,6 +132,14 @@ const CLAUDE_CURSOR_HOOK_EVENTS: &[HookEvent] = &[
     },
 ];
 
+/// Hook events for crush. crush supports only PreToolUse (as of crush v0.2.0);
+/// idle status is instead detected via spinner parsing in detect_crush_status.
+const CRUSH_HOOK_EVENTS: &[HookEvent] = &[HookEvent {
+    name: "PreToolUse",
+    matcher: None,
+    status: Some("running"),
+}];
+
 pub const AGENTS: &[AgentDef] = &[
     AgentDef {
         name: "claude",
@@ -370,9 +378,12 @@ pub const AGENTS: &[AgentDef] = &[
         container_env: &[],
         hook_config: Some(AgentHookConfig {
             settings_rel_path: ".local/share/crush/crush.json",
-            events: CLAUDE_CURSOR_HOOK_EVENTS,
+            events: CRUSH_HOOK_EVENTS,
         }),
+        resume_strategy: ResumeStrategy::Unsupported,
         host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "go install github.com/charmbracelet/crush@latest",
     },
 ];
 
@@ -475,7 +486,6 @@ mod tests {
             hermes.install_hint,
             "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
         );
-    }
     }
 
     #[test]

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -358,6 +358,22 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint:
             "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash",
     },
+    AgentDef {
+        name: "crush",
+        binary: "crush",
+        aliases: &["charmbracelet/crush", "charmbracelet-crush"],
+        detection: DetectionMethod::Which("crush"),
+        yolo: Some(YoloMode::AlwaysYolo),
+        instruction_flag: None,
+        set_default_command: false,
+        detect_status: status_detection::detect_crush_status,
+        container_env: &[],
+        hook_config: Some(AgentHookConfig {
+            settings_rel_path: ".local/share/crush/crush.json",
+            events: CLAUDE_CURSOR_HOOK_EVENTS,
+        }),
+        host_only: false,
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -441,6 +457,7 @@ mod tests {
         assert_eq!(get_agent("droid").unwrap().binary, "droid");
         assert_eq!(get_agent("settl").unwrap().binary, "settl");
         assert_eq!(get_agent("hermes").unwrap().binary, "hermes");
+        assert_eq!(get_agent("crush").unwrap().binary, "crush");
     }
 
     #[test]
@@ -459,6 +476,7 @@ mod tests {
             "curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
         );
     }
+    }
 
     #[test]
     fn test_get_agent_unknown() {
@@ -472,7 +490,7 @@ mod tests {
             names,
             vec![
                 "claude", "opencode", "vibe", "codex", "gemini", "cursor", "copilot", "pi",
-                "droid", "settl", "hermes"
+                "droid", "settl", "hermes", "crush"
             ]
         );
     }
@@ -494,6 +512,8 @@ mod tests {
         assert_eq!(resolve_tool_name("settlers"), Some("settl"));
         assert_eq!(resolve_tool_name("catan"), Some("settl"));
         assert_eq!(resolve_tool_name("hermes"), Some("hermes"));
+        assert_eq!(resolve_tool_name("crush"), Some("crush"));
+        assert_eq!(resolve_tool_name("charmbracelet/crush"), Some("crush"));
         assert_eq!(resolve_tool_name(""), Some("claude"));
         assert_eq!(resolve_tool_name("agent"), Some("cursor"));
         assert_eq!(resolve_tool_name("unknown-tool"), None);
@@ -510,6 +530,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("droid")), 9);
         assert_eq!(settings_index_from_name(Some("settl")), 10);
         assert_eq!(settings_index_from_name(Some("hermes")), 11);
+        assert_eq!(settings_index_from_name(Some("crush")), 12);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -520,6 +541,7 @@ mod tests {
         assert_eq!(name_from_settings_index(9), Some("droid"));
         assert_eq!(name_from_settings_index(10), Some("settl"));
         assert_eq!(name_from_settings_index(11), Some("hermes"));
+        assert_eq!(name_from_settings_index(12), Some("crush"));
         assert_eq!(name_from_settings_index(99), None);
     }
 

--- a/src/migrations/v002_seed_sandbox_from_volumes.rs
+++ b/src/migrations/v002_seed_sandbox_from_volumes.rs
@@ -42,6 +42,10 @@ const VOLUME_MIGRATIONS: &[VolumeMigration] = &[
         sandbox_rel: ".gemini/sandbox",
     },
     VolumeMigration {
+        volume_name: "aoe-crush-auth",
+        sandbox_rel: ".local/share/crush/sandbox",
+    },
+    VolumeMigration {
         volume_name: "aoe-vibe-auth",
         sandbox_rel: ".vibe/sandbox",
     },

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -169,6 +169,18 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         clean_files: &[],
     },
     AgentConfigMount {
+        tool_name: "crush",
+        host_rel: ".local/share/crush",
+        container_suffix: ".local/share/crush",
+        skip_entries: &["sandbox"],
+        seed_files: &[],
+        copy_dirs: &[],
+        keychain_credential: None,
+        home_seed_files: &[],
+        preserve_files: &[],
+        clean_files: &[],
+    },
+    AgentConfigMount {
         tool_name: "copilot",
         host_rel: ".copilot",
         container_suffix: ".copilot",

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2008,6 +2008,13 @@ mod tests {
     }
 
     #[test]
+    fn test_get_tool_command_crush() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "crush".to_string();
+        assert_eq!(inst.get_tool_command(), "crush");
+    }
+
+    #[test]
     fn test_get_tool_command_unknown_tool() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "unknown".to_string();

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -563,13 +563,13 @@ pub fn detect_hermes_status(_content: &str) -> Status {
     Status::Idle
 }
 
-/// settl status is detected via hooks (TOML-based), not tmux pane parsing.
+/// settl status is detected via hooks (JSON-based), not tmux pane parsing.
 /// This stub exists so the agent registry has a valid function pointer.
 pub fn detect_settl_status(_content: &str) -> Status {
     Status::Idle
 }
 
-/// crush status is detected via hooks (TOML-based) or by parsing the spinner.
+/// crush status is detected via hooks (JSON-based) or by parsing the spinner.
 pub fn detect_crush_status(raw_content: &str) -> Status {
     let lines: Vec<&str> = raw_content.lines().collect();
     let last_lines = if lines.len() > 10 {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -571,18 +571,16 @@ pub fn detect_settl_status(_content: &str) -> Status {
 
 /// crush status is detected via hooks (TOML-based) or by parsing the spinner.
 pub fn detect_crush_status(raw_content: &str) -> Status {
-    let content = raw_content.to_lowercase();
-    let lines: Vec<&str> = content.lines().collect();
+    let lines: Vec<&str> = raw_content.lines().collect();
     let last_lines = if lines.len() > 10 {
         &lines[lines.len() - 10..]
     } else {
         &lines[..]
     };
-    let last_lines_lower = last_lines.join("\n").to_lowercase();
+    let last_lines_joined = last_lines.join("\n");
 
-    // Check for running indicators
     for spinner in SPINNER_CHARS {
-        if last_lines_lower.contains(spinner) {
+        if last_lines_joined.contains(spinner) {
             return Status::Running;
         }
     }
@@ -641,6 +639,25 @@ pub fn detect_gemini_status(raw_content: &str) -> Status {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_detect_crush_status_running_on_spinner() {
+        for spinner in SPINNER_CHARS {
+            assert_eq!(
+                detect_crush_status(spinner),
+                Status::Running,
+                "spinner char '{spinner}' should be detected as Running"
+            );
+        }
+    }
+
+    #[test]
+    fn test_detect_crush_status_idle_on_plain_text() {
+        assert_eq!(detect_crush_status(""), Status::Idle);
+        assert_eq!(detect_crush_status("Some output"), Status::Idle);
+        assert_eq!(detect_crush_status("file saved successfully"), Status::Idle);
+        assert_eq!(detect_crush_status("ready\n> "), Status::Idle);
+    }
 
     #[test]
     fn test_detect_cursor_status_is_stub() {

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -569,6 +569,27 @@ pub fn detect_settl_status(_content: &str) -> Status {
     Status::Idle
 }
 
+/// crush status is detected via hooks (TOML-based) or by parsing the spinner.
+pub fn detect_crush_status(raw_content: &str) -> Status {
+    let content = raw_content.to_lowercase();
+    let lines: Vec<&str> = content.lines().collect();
+    let last_lines = if lines.len() > 10 {
+        &lines[lines.len() - 10..]
+    } else {
+        &lines[..]
+    };
+    let last_lines_lower = last_lines.join("\n").to_lowercase();
+
+    // Check for running indicators
+    for spinner in SPINNER_CHARS {
+        if last_lines_lower.contains(spinner) {
+            return Status::Running;
+        }
+    }
+
+    Status::Idle
+}
+
 pub fn detect_gemini_status(raw_content: &str) -> Status {
     let content = raw_content.to_lowercase();
     let lines: Vec<&str> = content.lines().collect();

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -330,7 +330,7 @@ mod tests {
     #[test]
     fn test_is_shell_command_rejects_agent_binaries() {
         for cmd in [
-            "claude", "opencode", "codex", "gemini", "cursor", "droid", "sleep", "python",
+            "claude", "opencode", "codex", "gemini", "cursor", "droid", "sleep", "python", "crush",
         ] {
             assert!(
                 !is_shell_command(cmd),


### PR DESCRIPTION

## Summary

- **crush agent definition fixes**: Corrected `TOML-based` → `JSON-based` in crush/settl detection comments, created `CRUSH_HOOK_EVENTS` with only `PreToolUse` (crush v0.2.0 supports this sole hook event), and added three missing `AgentDef` struct fields (`resume_strategy`, `send_keys_enter_delay_ms`, `install_hint`)
- **Remove case folding from crush spinner detection**: `detect_crush_status` was lowercasing pane content and then checking against case-sensitive spinner characters, which could cause false negatives. Removed the `to_lowercase()` call and added test coverage for spinner detection
- **CI**: Added `cargo check` job verifying both default and `serve` features, and added `rust-cache` to the existing `clippy` job
- **Syntax fix**: Removed duplicate closing brace in agents test module that caused `cargo fmt` failure

## Test plan

- [x] `cargo fmt --check` passes
- [ ] `cargo test` (CI)
- [ ] `cargo clippy` (CI)
- [ ] `cargo check` default features (CI)
- [ ] `cargo check --features serve` (CI)
- [x] Manual: verified crush spinner detection unit tests cover both Running and Idle states

## PR Type

- [x] Bug Fix
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** DeepSeek V4 Pro via Crush

- [x] I am an AI Agent filling out this form


💘 Generated with Crush