### PR TITLE
fix: clarify existing-project session wizard title

### DIFF
--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -152,6 +152,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
   const currentStepDef = steps[state.currentStep];
   const isFirst = state.currentStep === 0;
   const isLast = currentStepDef?.id === "review";
+  const modalTitle = prefill?.skipToReview ? "New session" : "Add project";
 
   useEffect(() => {
     fetchAgents().then((a) => dispatch({ type: "SET_AGENTS", agents: a }));
@@ -234,7 +235,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div className="relative w-full max-w-lg bg-surface-800 border border-surface-700/30 rounded-xl flex flex-col max-h-[min(720px,90vh)]">
         <div className="flex items-center justify-between px-5 py-4 border-b border-surface-700/20">
-          <h1 className="text-sm font-medium text-text-secondary">Add project</h1>
+          <h1 className="text-sm font-medium text-text-secondary">{modalTitle}</h1>
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center text-text-dim hover:text-text-secondary cursor-pointer rounded-md hover:bg-surface-700/50 transition-colors" aria-label="Close">&times;</button>
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-5">


### PR DESCRIPTION
## Description
- clarify the session wizard title when the flow is opened from an existing project
- keep the existing Add project copy for the generic entry path
- closes #921

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the copy-only web UI change directly from issue triage for #921.

- [x] I am an AI Agent filling out this form (check box if true)
