### PR TITLE
fix: remove topbar settings action

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -522,7 +522,6 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onOpenPalette={() => setShowPalette(true)}
         onToggleDiff={toggleDiff}
         diffCollapsed={diffCollapsed}
-        onOpenSettings={handleOpenSettings}
         onOpenHelp={handleOpenHelp}
         onOpenAbout={handleOpenAbout}
         onLogout={onLogout}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -10,7 +10,6 @@ interface Props {
   onOpenPalette: () => void;
   onToggleDiff: () => void;
   diffCollapsed: boolean;
-  onOpenSettings: () => void;
   onOpenHelp: () => void;
   onOpenAbout: () => void;
   onLogout: () => void;
@@ -26,7 +25,6 @@ export function TopBar({
   onOpenPalette,
   onToggleDiff,
   diffCollapsed,
-  onOpenSettings,
   onOpenHelp,
   onOpenAbout,
   onLogout,
@@ -39,13 +37,12 @@ export function TopBar({
 
   const overflowItems = useMemo<OverflowItem[]>(() => {
     const items: OverflowItem[] = [
-      { label: "Settings", onClick: onOpenSettings },
       { label: "Help", onClick: onOpenHelp },
       { label: "About", onClick: onOpenAbout },
     ];
     if (loginRequired) items.push({ label: "Sign out", onClick: onLogout });
     return items;
-  }, [onOpenSettings, onOpenHelp, onOpenAbout, onLogout, loginRequired]);
+  }, [onOpenHelp, onOpenAbout, onLogout, loginRequired]);
 
   return (
     <header className="h-12 bg-surface-800 border-b border-surface-700/20 flex items-center px-3 shrink-0 gap-2">

--- a/web/tests/top-bar.spec.ts
+++ b/web/tests/top-bar.spec.ts
@@ -10,29 +10,21 @@ test.describe("Top bar", () => {
     await expect(page.getByRole("button", { name: "More options" })).toBeVisible();
   });
 
-  test("overflow menu opens on click and exposes Settings", async ({ page }) => {
+  test("overflow menu opens on click and exposes help actions", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.getByRole("button", { name: "More options" }).click();
-    await expect(page.getByRole("menuitem", { name: "Settings" })).toBeVisible();
     await expect(page.getByRole("menuitem", { name: "Help" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "About" })).toBeVisible();
   });
 
   test("overflow menu closes on outside click", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
     await page.getByRole("button", { name: "More options" }).click();
-    await expect(page.getByRole("menuitem", { name: "Settings" })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Help" })).toBeVisible();
     await page.mouse.click(300, 300);
-    await expect(page.getByRole("menuitem", { name: "Settings" })).not.toBeVisible();
-  });
-
-  test("overflow Settings triggers settings view", async ({ page }) => {
-    await page.setViewportSize({ width: 1280, height: 720 });
-    await page.goto("/");
-    await page.getByRole("button", { name: "More options" }).click();
-    await page.getByRole("menuitem", { name: "Settings" }).click();
-    await expect(page.getByRole("button", { name: /Back/i })).toBeVisible();
+    await expect(page.getByRole("menuitem", { name: "Help" })).not.toBeVisible();
   });
 
   test("overflow Help opens help overlay", async ({ page }) => {


### PR DESCRIPTION
## Description
- remove the topbar Settings overflow action
- keep the sidebar Settings entry as the single in-app settings entry point
- closes #925

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the navigation cleanup directly from issue triage for #925.

- [x] I am an AI Agent filling out this form (check box if true)
