### PR TITLE
fix: clarify worktree template setting descriptions

### DIFF
--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -313,6 +313,7 @@ export function SettingsView({ onClose, tab, onSelectTab }: Props) {
             />
             <TextField
               label="Path template"
+              description="Template for worktree directories in regular repos ({repo-name}, {branch})"
               value={(worktree.path_template as string) ?? ""}
               onChange={(v) => saveField("worktree", worktree, "path_template", v)}
               placeholder="../{repo-name}-worktrees/{branch}"
@@ -320,6 +321,7 @@ export function SettingsView({ onClose, tab, onSelectTab }: Props) {
             />
             <TextField
               label="Bare repo path template"
+              description="Template for worktree directories in bare repos ({branch})"
               value={(worktree.bare_repo_path_template as string) ?? ""}
               onChange={(v) => saveField("worktree", worktree, "bare_repo_path_template", v)}
               placeholder="./{branch}"
@@ -327,6 +329,7 @@ export function SettingsView({ onClose, tab, onSelectTab }: Props) {
             />
             <TextField
               label="Workspace path template"
+              description="Template for multi-repo workspace directories ({branch}, {session-id})"
               value={(worktree.workspace_path_template as string) ?? ""}
               onChange={(v) => saveField("worktree", worktree, "workspace_path_template", v)}
               placeholder="../{branch}-workspace-{session-id}"


### PR DESCRIPTION
## Description
- add short descriptions for the worktree path template settings in web settings
- clarify the difference between regular worktree paths, bare repo worktree paths, and multi-repo workspace paths
- closes #926

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the web settings copy update directly from issue triage for #926.

- [x] I am an AI Agent filling out this form (check box if true)
