### PR TITLE
fix: use links for sidebar session navigation

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1,5 +1,6 @@
 import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
+import { Link } from "react-router-dom";
 import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
 import {
   STATUS_DOT_CLASS,
@@ -98,6 +99,17 @@ function loadSavedWidth(): number {
   return DEFAULT_WIDTH;
 }
 
+function isPlainLeftClick(event: React.MouseEvent<HTMLAnchorElement>): boolean {
+  return (
+    event.button === 0 &&
+    !event.defaultPrevented &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.ctrlKey &&
+    !event.shiftKey
+  );
+}
+
 const SessionRow = memo(function SessionRow({
   workspace,
   isActive,
@@ -120,8 +132,13 @@ const SessionRow = memo(function SessionRow({
   });
   const label =
     workspace.branch ?? workspace.sessions[0]?.title ?? "default";
+  const runningSession = workspace.sessions.find((s) => isSessionActive(s));
   const firstSession = workspace.sessions[0];
   const sessionId = firstSession?.id;
+  const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
+  const sessionPath = navigationSessionId
+    ? `/session/${encodeURIComponent(navigationSessionId)}`
+    : "/";
   const isDeleting = sessionStatus === "Deleting";
   const notifyPreset = detectNotifyPreset(
     firstSession?.notify_on_waiting,
@@ -260,8 +277,18 @@ const SessionRow = memo(function SessionRow({
 
   return (
     <>
-      <button
-        onClick={() => { if (!longPressFired.current) onClick(); }}
+      <Link
+        to={sessionPath}
+        onClick={(e) => {
+          if (longPressFired.current) {
+            e.preventDefault();
+            return;
+          }
+          if (isPlainLeftClick(e)) {
+            e.preventDefault();
+            onClick();
+          }
+        }}
         onContextMenu={handleContextMenu}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
@@ -289,7 +316,7 @@ const SessionRow = memo(function SessionRow({
             {label}
           </span>
         </div>
-      </button>
+      </Link>
       {contextMenu && createPortal(
         <div
           ref={menuRef}

--- a/web/tests/diff-syntax-highlight.spec.ts
+++ b/web/tests/diff-syntax-highlight.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import { mockTerminalApis } from "./helpers/terminal-mocks";
 import type { Page } from "@playwright/test";
 
@@ -89,7 +90,7 @@ async function setupDiffMocks(page: Page) {
 /** Open a session and wait for the diff file list to load. */
 async function openSessionAndWaitForDiffList(page: Page) {
   await expect(page.locator("header")).toBeVisible();
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   // Wait for the file entry to appear in the diff panel (API fetch + render).
   await expect(page.getByText("example.ts").first()).toBeVisible({
     timeout: 10000,
@@ -204,7 +205,7 @@ test.describe("Diff syntax highlighting", () => {
 
     await page.goto("/");
     await expect(page.locator("header")).toBeVisible();
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
     await expect(page.getByText("data.xyz").first()).toBeVisible({
       timeout: 10000,
     });

--- a/web/tests/helpers/sidebar.ts
+++ b/web/tests/helpers/sidebar.ts
@@ -1,0 +1,17 @@
+import type { Page } from "@playwright/test";
+
+export async function clickSidebarSession(page: Page, title: string) {
+  const sessionLink = page.getByRole("link").filter({ hasText: title }).first();
+  try {
+    await sessionLink.waitFor({ state: "visible", timeout: 5_000 });
+    await sessionLink.click();
+    return;
+  } catch {
+    // Fall back to the pre-link sidebar implementation below.
+  }
+
+  // Older sidebar implementations rendered the repo-group header and the
+  // nested session row as buttons with the same text. The second match is the
+  // actual session row.
+  await page.locator("button").filter({ hasText: title }).nth(1).click();
+}

--- a/web/tests/init-resize-storm.spec.ts
+++ b/web/tests/init-resize-storm.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
 
 // Regression for #807. useTerminal.ts used to read term.cols/term.rows
@@ -36,7 +37,7 @@ function extractResizes(handle: MockHandle): ResizeMsg[] {
 }
 
 async function openSession(page: Page, handle: MockHandle) {
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await page
     .locator(".wterm")
     .first()

--- a/web/tests/keyboard-resize-stickiness.spec.ts
+++ b/web/tests/keyboard-resize-stickiness.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, devices, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
 
 // Regression for the SIGWINCH-on-every-soft-keyboard-cycle bug.
@@ -91,7 +92,7 @@ async function openSession(page: Page, handle: MockHandle) {
     await sidebarToggle.click();
     await page.waitForTimeout(200);
   }
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await page
     .locator('[data-term="agent"] .wterm')
     .waitFor({ state: "visible", timeout: 10_000 });

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, devices, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import { mockTerminalApis, seedSettings } from "./helpers/terminal-mocks";
 
 // Use iPhone 13 profile: pointer:coarse, hasTouch, correct viewport, WebKit UA.
@@ -75,10 +76,7 @@ async function openSession(page: Page) {
     await sidebarToggle.click();
     await page.waitForTimeout(300);
   }
-  // The session row is a button inside the expanded group. The group header
-  // is also a button with "pinch-test", so we need the second match (the
-  // indented session row), or target the button with role specifically.
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await page.locator(".wterm").waitFor({ state: "visible", timeout: 10_000 });
 }
 

--- a/web/tests/pinch-zoom-desktop.spec.ts
+++ b/web/tests/pinch-zoom-desktop.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -14,8 +15,7 @@ test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
 
 test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
   async function openSession(page: Page) {
-    // First match is the group header; second is the session row.
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
     await page
       .locator(".wterm")
       .first()

--- a/web/tests/pinch-zoom.spec.ts
+++ b/web/tests/pinch-zoom.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, devices, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -17,8 +18,7 @@ test.describe("Terminal pinch zoom (mobile)", () => {
       await sidebarToggle.click();
       await page.waitForTimeout(300);
     }
-    // First match is the group header; second is the session row.
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
     await page.locator(".wterm").waitFor({ state: "visible", timeout: 10_000 });
   }
 

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, devices, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -36,7 +37,7 @@ async function openSession(page: Page) {
     await sidebarToggle.click();
     await page.waitForTimeout(300);
   }
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await page.locator(".wterm").waitFor({ state: "visible", timeout: 10_000 });
 }
 

--- a/web/tests/terminal-focus-shortcut.spec.ts
+++ b/web/tests/terminal-focus-shortcut.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import { mockTerminalApis } from "./helpers/terminal-mocks";
 import { mkdirSync } from "node:fs";
 
@@ -9,7 +10,7 @@ async function shot(page: Page, name: string) {
 }
 
 async function openSession(page: Page) {
-  await page.locator('button:has-text("pinch-test")').nth(1).click();
+  await clickSidebarSession(page, "pinch-test");
   await expect(page.locator('[data-term="agent"]')).toHaveCount(1);
   await expect(page.locator('[data-term="agent"] .wterm')).toBeVisible();
 }
@@ -128,7 +129,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     });
 
     await page.goto("/");
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
     await expect(page.locator('[data-term="agent"]')).toHaveCount(1);
 
     // Press Cmd+` immediately while paired is still in its "Starting…"
@@ -152,7 +153,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     });
 
     await page.goto("/");
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
 
     // Wait for paired to be ready (its ensureTerminal isn't delayed); use
     // it as the focus source so target=agent.

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -31,7 +32,7 @@ function countSeq(handle: MockHandle, seq: string): number {
 
 test.describe("Terminal mouse-wheel scroll (desktop)", () => {
   async function openSession(page: Page, handle: MockHandle) {
-    await page.locator('button:has-text("pinch-test")').nth(1).click();
+    await clickSidebarSession(page, "pinch-test");
     await page
       .locator(".wterm")
       .first()

--- a/web/tests/ws-reconnect.spec.ts
+++ b/web/tests/ws-reconnect.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
 
 // Verifies useTerminal.ts reconnects after a WS drop and that the first
 // retry fires within the expected ~1s exponential-backoff window (not the
@@ -65,9 +66,7 @@ async function mockApisExceptWs(page: Page, sessionTitle: string) {
 async function openSession(page: Page, title: string) {
   await page.setViewportSize({ width: 1280, height: 720 });
   await page.goto("/");
-  // The sidebar renders a repo-group header and a nested session row with
-  // the same text. Click the nested (last) one to open the session.
-  await page.locator("button").filter({ hasText: title }).last().click();
+  await clickSidebarSession(page, title);
   await page.locator(".wterm").first().waitFor({ state: "visible", timeout: 10_000 });
 }
 


### PR DESCRIPTION
## Description
- replace sidebar session row buttons with real React Router links
- preserve the existing in-app left-click behavior while allowing cmd/ctrl-click and middle-click to use native browser link handling
- closes #930

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the sidebar link semantics update directly from issue triage for #930.

- [x] I am an AI Agent filling out this form (check box if true)
