### PR TITLE
fix: clarify workflow preset picker

### DIFF
--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -134,7 +134,10 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
       {/* Profile selector */}
       {showProfilePicker && (
         <div className="mb-5">
-          <label className="block text-sm text-text-dim mb-1.5">Profile</label>
+          <label className="block text-sm text-text-dim mb-1.5">Workflow preset</label>
+          <p className="text-xs text-text-dim mb-2">
+            Profiles preload tool, sandbox, auto-approve, and env defaults for common workflows.
+          </p>
           <select
             value={data.profile}
             onChange={(e) => handleProfileChange(e.target.value)}
@@ -148,7 +151,7 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
             ))}
           </select>
           {data.profile && data.profileDirty && (
-            <p className="text-xs text-brand-500 mt-1">(Custom) Settings differ from profile defaults</p>
+            <p className="text-xs text-brand-500 mt-1">(Custom) Settings differ from preset defaults</p>
           )}
         </div>
       )}


### PR DESCRIPTION
## Description
- relabel the web profile picker as a workflow preset picker during session creation
- add copy explaining that profiles preload tool, sandbox, auto-approve, and env defaults
- clarify the dirty-state message so it reads as a preset override rather than an opaque profile mismatch
- closes #929

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the workflow-preset wording change directly from issue triage for #929.

- [x] I am an AI Agent filling out this form (check box if true)
