### PR TITLE
fix: separate session title from branch

### DIFF
--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -207,6 +207,10 @@ pub struct RenameSessionBody {
     pub title: String,
 }
 
+fn apply_session_title_rename(inst: &mut Instance, title: String) {
+    inst.title = title;
+}
+
 pub async fn rename_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -234,12 +238,7 @@ pub async fn rename_session(
         );
     };
 
-    inst.title = title.clone();
-    // Also update the worktree branch name in metadata (cosmetic only;
-    // the actual git branch is not renamed on disk).
-    if let Some(ref mut wt) = inst.worktree_info {
-        wt.branch = title;
-    }
+    apply_session_title_rename(inst, title.clone());
 
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
@@ -1438,6 +1437,25 @@ mod tests {
     fn claude_fullscreen_unset_when_setting_disabled() {
         let resp = SessionResponse::from_instance(&make_test_instance(), false);
         assert!(!resp.claude_fullscreen);
+    }
+
+    #[test]
+    fn rename_updates_title_without_changing_worktree_branch() {
+        let mut inst = make_test_instance();
+        inst.worktree_info = Some(crate::session::WorktreeInfo {
+            branch: "feature/test".to_string(),
+            main_repo_path: "/tmp/repo".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+        });
+
+        apply_session_title_rename(&mut inst, "Renamed Session".to_string());
+
+        assert_eq!(inst.title, "Renamed Session");
+        assert_eq!(
+            inst.worktree_info.as_ref().map(|wt| wt.branch.as_str()),
+            Some("feature/test")
+        );
     }
 
     #[test]

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -254,7 +254,10 @@ const SessionRow = memo(function SessionRow({
   const commitRename = async () => {
     setRenaming(false);
     const trimmed = renameValue.trim();
-    if (!trimmed || trimmed === label || !sessionId) return;
+    // Compare against the current title, not the displayed label: when a
+    // single session has no title yet, label is the branch and accepting
+    // the prefilled value should still set the title.
+    if (!trimmed || trimmed === sessionTitle || !sessionId) return;
     await renameSession(sessionId, trimmed);
   };
 
@@ -463,6 +466,7 @@ function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
   return (
     ws.displayName.toLowerCase().includes(q) ||
     ws.projectPath.toLowerCase().includes(q) ||
+    (ws.branch?.toLowerCase().includes(q) ?? false) ||
     ws.agents.some((a) => a.toLowerCase().includes(q)) ||
     ws.sessions.some((s) => s.title.toLowerCase().includes(q))
   );

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -118,9 +118,16 @@ const SessionRow = memo(function SessionRow({
     status: sessionStatus,
     idle_entered_at: idleEnteredAt,
   });
-  const label =
-    workspace.branch ?? workspace.sessions[0]?.title ?? "default";
   const firstSession = workspace.sessions[0];
+  const singleSession = workspace.sessions.length === 1;
+  const sessionTitle = firstSession?.title.trim() ?? "";
+  const branchLabel = workspace.branch ?? null;
+  const label = singleSession
+    ? sessionTitle || branchLabel || "default"
+    : branchLabel || sessionTitle || "default";
+  const subtitle = singleSession && sessionTitle && branchLabel && sessionTitle !== branchLabel
+    ? branchLabel
+    : null;
   const sessionId = firstSession?.id;
   const isDeleting = sessionStatus === "Deleting";
   const notifyPreset = detectNotifyPreset(
@@ -223,7 +230,7 @@ const SessionRow = memo(function SessionRow({
   const startRename = () => {
     if (renaming) return;
     setContextMenu(null);
-    setRenameValue(label);
+    setRenameValue(sessionTitle || label);
     setRenaming(true);
   };
 
@@ -285,9 +292,16 @@ const SessionRow = memo(function SessionRow({
               idleEnteredAt={idleEnteredAt}
             />
           </span>
-          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
-            {label}
-          </span>
+          <div className="min-w-0 flex-1">
+            <span className={`block text-[13px] md:text-[14px] truncate ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+              {label}
+            </span>
+            {subtitle && (
+              <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitle}>
+                {subtitle}
+              </span>
+            )}
+          </div>
         </div>
       </button>
       {contextMenu && createPortal(

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -237,7 +237,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
           />
         );
       case "review":
-        return <ReviewStep data={state.data} isSubmitting={state.isSubmitting} error={state.error} onSubmit={handleSubmit} onJumpTo={jumpTo} steps={steps} />;
+        return <ReviewStep data={state.data} onChange={handleChange} isSubmitting={state.isSubmitting} error={state.error} onSubmit={handleSubmit} onJumpTo={jumpTo} steps={steps} />;
       default:
         return null;
     }

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -6,6 +6,7 @@ import type { StepDef, StepId } from "./StepIndicator";
 import { ProjectStep } from "./steps/ProjectStep";
 import { AgentStep } from "./steps/AgentStep";
 import { ReviewStep } from "./steps/ReviewStep";
+import { applyBranchOverride, getSubmittedBranch } from "./sessionNames";
 
 export interface WizardData {
   path: string;
@@ -67,7 +68,12 @@ function reducer(state: WizardState, action: Action): WizardState {
         newData.worktreeBranch = String(action.value);
       }
       if (action.field === "worktreeBranch") {
-        newData.worktreeBranchDirty = true;
+        const override = applyBranchOverride(
+          String(newData.title),
+          String(action.value),
+        );
+        newData.worktreeBranch = override.worktreeBranch;
+        newData.worktreeBranchDirty = override.worktreeBranchDirty;
       }
       // Mark as dirty when user manually edits agent-step fields after a profile was chosen
       if (state.data.profile && ["yoloMode", "sandboxEnabled", "tool", "extraEnv"].includes(action.field)) {
@@ -195,7 +201,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       path: d.path, tool: d.tool,
       title: d.title || undefined, group: d.group || undefined,
       yolo_mode: d.yoloMode,
-      worktree_branch: d.worktreeBranch || "",
+      worktree_branch: getSubmittedBranch(d.title, d.worktreeBranch),
       create_new_branch: true,
       sandbox: d.sandboxEnabled,
       sandbox_image: d.sandboxEnabled ? d.sandboxImage : undefined,

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -10,6 +10,8 @@ import { ReviewStep } from "./steps/ReviewStep";
 export interface WizardData {
   path: string;
   title: string;
+  worktreeBranch: string;
+  worktreeBranchDirty: boolean;
   group: string;
   tool: string;
   profile: string;
@@ -50,7 +52,8 @@ type Action =
   | { type: "APPLY_PROFILE_DEFAULTS"; yoloMode: boolean; sandboxEnabled: boolean; tool: string; extraEnv: string[] };
 
 const initialData: WizardData = {
-  path: "", title: "", group: "", tool: "claude", profile: "",
+  path: "", title: "", worktreeBranch: "", worktreeBranchDirty: false,
+  group: "", tool: "claude", profile: "",
   yoloMode: false, sandboxEnabled: false, sandboxImage: "", extraEnv: [],
   advancedEnabled: false, profileDirty: false,
   customInstruction: "", extraArgs: "", commandOverride: "",
@@ -60,6 +63,12 @@ function reducer(state: WizardState, action: Action): WizardState {
   switch (action.type) {
     case "SET_FIELD": {
       const newData = { ...state.data, [action.field]: action.value };
+      if (action.field === "title" && !state.data.worktreeBranchDirty) {
+        newData.worktreeBranch = String(action.value);
+      }
+      if (action.field === "worktreeBranch") {
+        newData.worktreeBranchDirty = true;
+      }
       // Mark as dirty when user manually edits agent-step fields after a profile was chosen
       if (state.data.profile && ["yoloMode", "sandboxEnabled", "tool", "extraEnv"].includes(action.field)) {
         newData.profileDirty = true;
@@ -186,7 +195,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       path: d.path, tool: d.tool,
       title: d.title || undefined, group: d.group || undefined,
       yolo_mode: d.yoloMode,
-      worktree_branch: d.title || "",
+      worktree_branch: d.worktreeBranch || "",
       create_new_branch: true,
       sandbox: d.sandboxEnabled,
       sandbox_image: d.sandboxEnabled ? d.sandboxImage : undefined,

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyBranchOverride,
+  getReviewSummary,
+  getSubmittedBranch,
+} from "./sessionNames";
+
+describe("applyBranchOverride", () => {
+  it("marks a non-empty branch as a manual override", () => {
+    expect(applyBranchOverride("session-title", "feature/custom")).toEqual({
+      worktreeBranch: "feature/custom",
+      worktreeBranchDirty: true,
+    });
+  });
+
+  it("resets an empty branch back to the title-derived default", () => {
+    expect(applyBranchOverride("session-title", "")).toEqual({
+      worktreeBranch: "session-title",
+      worktreeBranchDirty: false,
+    });
+  });
+
+  it("keeps both fields empty when there is no title to fall back to", () => {
+    expect(applyBranchOverride("", "")).toEqual({
+      worktreeBranch: "",
+      worktreeBranchDirty: false,
+    });
+  });
+});
+
+describe("getSubmittedBranch", () => {
+  it("prefers the explicit branch override", () => {
+    expect(getSubmittedBranch("session-title", "feature/custom")).toBe(
+      "feature/custom",
+    );
+  });
+
+  it("falls back to the title when the branch field is cleared", () => {
+    expect(getSubmittedBranch("session-title", "")).toBe("session-title");
+  });
+
+  it("leaves the branch empty only when both fields are empty", () => {
+    expect(getSubmittedBranch("", "")).toBe("");
+  });
+});
+
+describe("getReviewSummary", () => {
+  it("shows the branch when the title is blank because the backend reuses it", () => {
+    expect(getReviewSummary("", "feature/custom")).toEqual({
+      title: "feature/custom",
+      branch: "feature/custom",
+    });
+  });
+
+  it("shows the title-derived branch when no explicit branch is set", () => {
+    expect(getReviewSummary("session-title", "")).toEqual({
+      title: "session-title",
+      branch: "session-title",
+    });
+  });
+});

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -1,0 +1,30 @@
+export function applyBranchOverride(title: string, worktreeBranch: string): {
+  worktreeBranch: string;
+  worktreeBranchDirty: boolean;
+} {
+  if (worktreeBranch === "") {
+    return {
+      worktreeBranch: title,
+      worktreeBranchDirty: false,
+    };
+  }
+
+  return {
+    worktreeBranch,
+    worktreeBranchDirty: true,
+  };
+}
+
+export function getSubmittedBranch(title: string, worktreeBranch: string): string {
+  return worktreeBranch || title || "";
+}
+
+export function getReviewSummary(title: string, worktreeBranch: string): {
+  title: string;
+  branch: string;
+} {
+  return {
+    title: title || worktreeBranch || "Auto-generated",
+    branch: worktreeBranch || title || "Auto-generated",
+  };
+}

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -5,6 +5,7 @@ import { getSettings } from "../../../lib/api";
 interface WizardData {
   tool: string;
   title: string;
+  worktreeBranch: string;
   profile: string;
   profileDirty: boolean;
   sandboxEnabled: boolean;
@@ -203,17 +204,29 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
 
       {showAdvanced && (
         <div className="mt-2 space-y-4 border-t border-surface-700/30 pt-4">
-          {/* Session name / branch */}
+          {/* Session title / branch */}
           <div>
-            <label className="block text-sm text-text-dim mb-1.5">Session name</label>
+            <label className="block text-sm text-text-dim mb-1.5">Session title</label>
             <input
               type="text"
               value={data.title}
               onChange={(e) => onChange("title", e.target.value)}
+              placeholder="Shown in Agent of Empires"
+              className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+            />
+            <p className="text-xs text-text-dim mt-1">Shown in the dashboard and session lists. Renaming it later does not rename the git branch.</p>
+          </div>
+
+          <div>
+            <label className="block text-sm text-text-dim mb-1.5">Branch name</label>
+            <input
+              type="text"
+              value={data.worktreeBranch}
+              onChange={(e) => onChange("worktreeBranch", e.target.value)}
               placeholder="Auto-generated if empty"
               className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
             />
-            <p className="text-xs text-text-dim mt-1">Used as the git branch name. Leave empty for auto-generated name.</p>
+            <p className="text-xs text-text-dim mt-1">Git branch and worktree name. Defaults to the session title until you edit it.</p>
           </div>
 
           {/* Container config (if sandbox enabled) */}

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -223,10 +223,10 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
               type="text"
               value={data.worktreeBranch}
               onChange={(e) => onChange("worktreeBranch", e.target.value)}
-              placeholder="Auto-generated if empty"
+              placeholder="Uses session title if empty"
               className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
             />
-            <p className="text-xs text-text-dim mt-1">Git branch and worktree name. Defaults to the session title until you edit it.</p>
+            <p className="text-xs text-text-dim mt-1">Git branch and worktree name. Clearing it switches back to the session title. Leave both title and branch empty to auto-generate.</p>
           </div>
 
           {/* Container config (if sandbox enabled) */}

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from "react";
 import type { StepDef, StepId } from "../StepIndicator";
+import { getReviewSummary } from "../sessionNames";
 
 interface WizardData { path: string; title: string; worktreeBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
 interface Props { data: WizardData; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
@@ -26,6 +27,7 @@ function Row({ label, value, stepId, onJumpTo, accent }: { label: string; value:
 export function ReviewStep({ data, isSubmitting, error, onSubmit, onJumpTo, steps }: Props) {
   const hasStep = (id: StepId) => steps.some((s) => s.id === id);
   const canSubmit = !isSubmitting && !!data.path && !!data.tool;
+  const summary = getReviewSummary(data.title, data.worktreeBranch);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -44,8 +46,8 @@ export function ReviewStep({ data, isSubmitting, error, onSubmit, onJumpTo, step
       <p className="text-sm text-text-muted mb-5">Here's what will be created. Make sure everything looks right.</p>
       <div className="bg-surface-900 border border-surface-700 rounded-lg p-4 mb-5">
         <Row label="Project" value={data.path || "(not set)"} stepId="project" onJumpTo={onJumpTo} />
-        <Row label="Title" value={data.title || "Auto-generated"} stepId="agent" onJumpTo={onJumpTo} />
-        <Row label="Branch" value={data.worktreeBranch || "Auto-generated"} stepId="agent" onJumpTo={onJumpTo} accent />
+        <Row label="Title" value={summary.title} stepId="agent" onJumpTo={onJumpTo} />
+        <Row label="Branch" value={summary.branch} stepId="agent" onJumpTo={onJumpTo} accent />
         <Row label="Agent" value={data.tool || "(not set)"} stepId="agent" onJumpTo={onJumpTo} />
         {data.profile && (
           <Row label="Profile" value={data.profileDirty ? `${data.profile} (Custom)` : data.profile} stepId="agent" onJumpTo={onJumpTo} accent />

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { StepDef, StepId } from "../StepIndicator";
 import { getReviewSummary } from "../sessionNames";
 
 interface WizardData { path: string; title: string; worktreeBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
-interface Props { data: WizardData; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
+interface Props { data: WizardData; onChange: (field: string, value: unknown) => void; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
@@ -24,7 +24,76 @@ function Row({ label, value, stepId, onJumpTo, accent }: { label: string; value:
   );
 }
 
-export function ReviewStep({ data, isSubmitting, error, onSubmit, onJumpTo, steps }: Props) {
+function EditableRow({ label, value, displayValue, placeholder, onChange, accent }: {
+  label: string;
+  value: string;
+  displayValue: string;
+  placeholder?: string;
+  onChange: (v: string) => void;
+  accent?: boolean;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) inputRef.current?.select();
+  }, [editing]);
+
+  const startEditing = () => {
+    setDraft(value);
+    setEditing(true);
+  };
+
+  const commit = () => {
+    setEditing(false);
+    if (draft !== value) onChange(draft);
+  };
+
+  const isPlaceholder = !value;
+
+  if (editing) {
+    return (
+      <div className="flex justify-between items-center w-full py-3 border-b border-surface-800 last:border-0 -mx-2 px-2 gap-3">
+        <span className="text-sm text-text-dim shrink-0">{label}</span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          placeholder={placeholder}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commit}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              // Stop the wizard's window-level Cmd+Enter submit handler
+              // from racing with our state update on commit.
+              e.preventDefault();
+              e.stopPropagation();
+              commit();
+            } else if (e.key === "Escape") {
+              e.preventDefault();
+              setEditing(false);
+            }
+          }}
+          className={`flex-1 min-w-0 text-sm font-mono bg-surface-800 border border-brand-600 rounded px-2 py-1 text-right placeholder:text-text-dim focus:outline-none ${accent ? "text-accent-600" : "text-text-primary"}`}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      className="flex justify-between items-center w-full py-3 border-b border-surface-800 last:border-0 text-left cursor-pointer hover:bg-surface-800/50 -mx-2 px-2 rounded-md"
+    >
+      <span className="text-sm text-text-dim">{label}</span>
+      <span className={`text-sm font-mono truncate ml-4 ${isPlaceholder ? "text-text-dim italic" : accent ? "text-accent-600" : "text-text-primary"}`}>{displayValue}</span>
+    </button>
+  );
+}
+
+export function ReviewStep({ data, onChange, isSubmitting, error, onSubmit, onJumpTo, steps }: Props) {
   const hasStep = (id: StepId) => steps.some((s) => s.id === id);
   const canSubmit = !isSubmitting && !!data.path && !!data.tool;
   const summary = getReviewSummary(data.title, data.worktreeBranch);
@@ -46,8 +115,21 @@ export function ReviewStep({ data, isSubmitting, error, onSubmit, onJumpTo, step
       <p className="text-sm text-text-muted mb-5">Here's what will be created. Make sure everything looks right.</p>
       <div className="bg-surface-900 border border-surface-700 rounded-lg p-4 mb-5">
         <Row label="Project" value={data.path || "(not set)"} stepId="project" onJumpTo={onJumpTo} />
-        <Row label="Title" value={summary.title} stepId="agent" onJumpTo={onJumpTo} />
-        <Row label="Branch" value={summary.branch} stepId="agent" onJumpTo={onJumpTo} accent />
+        <EditableRow
+          label="Title"
+          value={data.title}
+          displayValue={summary.title}
+          placeholder="Auto-generated"
+          onChange={(v) => onChange("title", v)}
+        />
+        <EditableRow
+          label="Branch"
+          value={data.worktreeBranch}
+          displayValue={summary.branch}
+          placeholder="Auto-generated"
+          onChange={(v) => onChange("worktreeBranch", v)}
+          accent
+        />
         <Row label="Agent" value={data.tool || "(not set)"} stepId="agent" onJumpTo={onJumpTo} />
         {data.profile && (
           <Row label="Profile" value={data.profileDirty ? `${data.profile} (Custom)` : data.profile} stepId="agent" onJumpTo={onJumpTo} accent />

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import type { StepDef, StepId } from "../StepIndicator";
 
-interface WizardData { path: string; title: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
+interface WizardData { path: string; title: string; worktreeBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
 interface Props { data: WizardData; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
@@ -44,9 +44,8 @@ export function ReviewStep({ data, isSubmitting, error, onSubmit, onJumpTo, step
       <p className="text-sm text-text-muted mb-5">Here's what will be created. Make sure everything looks right.</p>
       <div className="bg-surface-900 border border-surface-700 rounded-lg p-4 mb-5">
         <Row label="Project" value={data.path || "(not set)"} stepId="project" onJumpTo={onJumpTo} />
-        {data.title && (
-          <Row label="Branch" value={data.title} stepId="agent" onJumpTo={onJumpTo} accent />
-        )}
+        <Row label="Title" value={data.title || "Auto-generated"} stepId="agent" onJumpTo={onJumpTo} />
+        <Row label="Branch" value={data.worktreeBranch || "Auto-generated"} stepId="agent" onJumpTo={onJumpTo} accent />
         <Row label="Agent" value={data.tool || "(not set)"} stepId="agent" onJumpTo={onJumpTo} />
         {data.profile && (
           <Row label="Profile" value={data.profileDirty ? `${data.profile} (Custom)` : data.profile} stepId="agent" onJumpTo={onJumpTo} accent />

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -37,8 +37,11 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
       const projectPath = normalizePath(
         first.main_repo_path ?? first.project_path,
       );
-      const displayName =
-        branch ?? projectPath.split("/").pop() ?? projectPath;
+      const title = first.title.trim();
+      const projectName = projectPath.split("/").pop() ?? projectPath;
+      const displayName = groupSessions.length === 1
+        ? title || branch || projectName
+        : branch || projectName;
 
       workspaces.push({
         id,


### PR DESCRIPTION
## Description
- split the web session wizard into separate session title and branch fields instead of reusing one value for both
- keep branch creation tied to the branch field while making sidebar/breadcrumb labels show the session title for single-session workspaces
- stop the rename API from rewriting stored worktree branch metadata when only the session title changed
- closes #931

Verification:
- cd web && npm run build
- cargo check --features serve
- cargo test --features serve --lib "server::api::sessions::tests::rename_updates_title_without_changing_worktree_branch" -- --exact
- cargo test --features serve --lib "server::api::sessions::tests::session_response_branch_from_worktree" -- --exact

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the web title/branch split and rename metadata fix directly from issue triage for #931.

- [x] I am an AI Agent filling out this form (check box if true)
