### PR TITLE
fix: reframe web project flow as session creation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -126,7 +126,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [diffCollapsed, setDiffCollapsed] = useState(
     () => window.innerWidth < 768,
   );
-  const [showAddProject, setShowAddProject] = useState(false);
+  const [showSessionWizard, setShowSessionWizard] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
   const [showPalette, setShowPalette] = useState(false);
   const [showAbout, setShowAbout] = useState(false);
@@ -271,7 +271,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       group: latest?.group_path || undefined,
       skipToReview: true,
     });
-    setShowAddProject(true);
+    setShowSessionWizard(true);
   }, [sessions]);
 
   const toggleDiff = useCallback(() => setDiffCollapsed((c) => !c), []);
@@ -330,12 +330,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
 
   const handleNewSession = useCallback(() => {
     setWizardPrefill(undefined);
-    setShowAddProject(true);
+    setShowSessionWizard(true);
   }, []);
 
   const handleCloneFromUrl = useCallback(() => {
     setWizardPrefill({ initialTab: "clone" });
-    setShowAddProject(true);
+    setShowSessionWizard(true);
   }, []);
 
   const handleToggleTerminalFocus = useCallback(() => {
@@ -385,7 +385,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   useKeyboardShortcuts(
     useCallback(
       () => ({
-        onNew: () => setShowAddProject(true),
+        onNew: () => setShowSessionWizard(true),
         onDiff: () => toggleDiff(),
         onEscape: () => {
           if (deletingWorkspaceId) {
@@ -396,7 +396,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             setShowPalette(false);
             return;
           }
-          setShowAddProject(false);
+          setShowSessionWizard(false);
           setShowHelp(false);
           if (showSettings) handleCloseSettings();
           setShowAbout(false);
@@ -541,7 +541,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onToggle={() => setSidebarOpen(false)}
             onSelect={handleSelectWorkspace}
             onToggleRepo={toggleRepoCollapsed}
-            onNew={() => { setWizardPrefill(undefined); setShowAddProject(true); }}
+            onNew={() => { setWizardPrefill(undefined); setShowSessionWizard(true); }}
             onCreateSession={handleCreateSession}
             onSettings={handleOpenSettings}
             onDeleteSession={handleDeleteSession}
@@ -554,16 +554,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         </div>
       </div>
 
-      {showAddProject && (
+      {showSessionWizard && (
         <SessionWizard
-          onClose={() => { setShowAddProject(false); setWizardPrefill(undefined); }}
+          onClose={() => { setShowSessionWizard(false); setWizardPrefill(undefined); }}
           onCreated={(session?: SessionResponse) => {
             if (session) {
               injectSession(session);
               navigate(`/session/${encodeURIComponent(session.id)}`);
               if (window.innerWidth < 768) setSidebarOpen(false);
             }
-            setShowAddProject(false);
+            setShowSessionWizard(false);
             setWizardPrefill(undefined);
           }}
           prefill={wizardPrefill}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -146,8 +146,8 @@ export function Dashboard({
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 max-w-2xl w-full">
           <ActionPane
-            title="Open project"
-            subtitle="Browse, pick recent, or start a new session"
+            title="New session"
+            subtitle="Pick a project, then launch a new session"
             onClick={onNewSession}
             icon="folder"
             featured

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -548,11 +548,11 @@ export function WorkspaceSidebar({
               </svg>
             </button>
           </Tooltip>
-          <Tooltip text="Add project">
+          <Tooltip text="New session">
             <button
               onClick={onNew}
               className="w-8 h-8 flex items-center justify-center text-text-muted hover:text-text-secondary hover:bg-surface-800 cursor-pointer rounded-md transition-colors"
-              aria-label="Add project"
+              aria-label="New session"
             >
               <svg
                 width="16"

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -152,6 +152,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
   const currentStepDef = steps[state.currentStep];
   const isFirst = state.currentStep === 0;
   const isLast = currentStepDef?.id === "review";
+  const modalTitle = prefill?.skipToReview ? "New session" : "Add project";
 
   useEffect(() => {
     fetchAgents().then((a) => dispatch({ type: "SET_AGENTS", agents: a }));
@@ -234,7 +235,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div className="relative w-full max-w-lg bg-surface-800 border border-surface-700/30 rounded-xl flex flex-col max-h-[min(720px,90vh)]">
         <div className="flex items-center justify-between px-5 py-4 border-b border-surface-700/20">
-          <h1 className="text-sm font-medium text-text-secondary">Add project</h1>
+          <h1 className="text-sm font-medium text-text-secondary">{modalTitle}</h1>
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center text-text-dim hover:text-text-secondary cursor-pointer rounded-md hover:bg-surface-700/50 transition-colors" aria-label="Close">&times;</button>
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-5">

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -152,7 +152,6 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
   const currentStepDef = steps[state.currentStep];
   const isFirst = state.currentStep === 0;
   const isLast = currentStepDef?.id === "review";
-  const modalTitle = prefill?.skipToReview ? "New session" : "Add project";
 
   useEffect(() => {
     fetchAgents().then((a) => dispatch({ type: "SET_AGENTS", agents: a }));
@@ -235,7 +234,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       <div className="absolute inset-0 bg-black/60" onClick={onClose} />
       <div className="relative w-full max-w-lg bg-surface-800 border border-surface-700/30 rounded-xl flex flex-col max-h-[min(720px,90vh)]">
         <div className="flex items-center justify-between px-5 py-4 border-b border-surface-700/20">
-          <h1 className="text-sm font-medium text-text-secondary">{modalTitle}</h1>
+          <h1 className="text-sm font-medium text-text-secondary">New session</h1>
           <button onClick={onClose} className="w-8 h-8 flex items-center justify-center text-text-dim hover:text-text-secondary cursor-pointer rounded-md hover:bg-surface-700/50 transition-colors" aria-label="Close">&times;</button>
         </div>
         <div className="flex-1 overflow-y-auto px-5 py-5">

--- a/web/tests/command-palette.spec.ts
+++ b/web/tests/command-palette.spec.ts
@@ -83,14 +83,14 @@ test.describe("Command palette", () => {
     await page.getByPlaceholder("Search actions, sessions, settings…").fill("new session");
     await page.keyboard.press("ArrowDown");
     await page.keyboard.press("Enter");
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
   });
 
   test("opens from within a focused input", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await page.getByLabel("Add project").first().click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByLabel("New session").first().click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     await page.getByPlaceholder("Type to filter...").click();
     await page.keyboard.press("ControlOrMeta+k");
     await expect(page.getByPlaceholder("Search actions, sessions, settings…")).toBeVisible();

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from "@playwright/test";
 
+const NEW_SESSION_PANE_NAME = /New session Pick a project, then launch a new session/i;
+
 test.describe("Dashboard layout", () => {
   test("loads and shows header", async ({ page }) => {
     await page.goto("/");
@@ -14,7 +16,7 @@ test.describe("Dashboard layout", () => {
   test("shows branded home screen with action panes", async ({ page }) => {
     await page.goto("/");
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
-    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
     await expect(page.getByText("Clone URL")).toBeVisible();
     await expect(page.getByText("Docs")).toBeVisible();
   });
@@ -29,7 +31,7 @@ test.describe("Sidebar", () => {
   test("sidebar visible on desktop by default", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    await expect(page.getByLabel("Add project")).toBeVisible();
+    await expect(page.getByLabel("New session")).toBeVisible();
   });
 
   test("sidebar toggle button exists", async ({ page }) => {
@@ -40,7 +42,7 @@ test.describe("Sidebar", () => {
   test("sidebar can be toggled closed and open on desktop", async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
-    const addBtn = page.getByLabel("Add project");
+    const addBtn = page.getByLabel("New session");
     await expect(addBtn).toBeVisible();
 
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
@@ -52,16 +54,16 @@ test.describe("Sidebar", () => {
 });
 
 test.describe("Create session from home screen", () => {
-  test("'Open project' pane opens session wizard", async ({ page }) => {
+  test("'New session' pane opens session wizard", async ({ page }) => {
     await page.goto("/");
-    await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
   });
 
   test("'Clone URL' pane opens wizard on Clone tab", async ({ page }) => {
     await page.goto("/");
     await page.getByText("Clone URL").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     // Should be on the Clone tab, showing the URL input
     await expect(page.getByPlaceholder("https://github.com/user/repo.git")).toBeVisible();
   });
@@ -71,32 +73,32 @@ test.describe("Create session from home screen", () => {
     await page.goto("/");
     await page.locator("body").click();
     await page.keyboard.press("n");
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
   });
 
   test("wizard closes on cancel", async ({ page }) => {
     await page.goto("/");
-    await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     await page.getByRole("button", { name: "Cancel" }).click();
-    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).not.toBeVisible();
   });
 
   test("wizard closes on escape", async ({ page }) => {
     await page.goto("/");
-    await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).not.toBeVisible();
   });
 
   test("wizard closes on backdrop click", async ({ page }) => {
     await page.goto("/");
-    await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
     // Click the backdrop (top-left corner, outside the modal)
     await page.mouse.click(10, 10);
-    await expect(page.getByRole("heading", { name: "Add project" })).not.toBeVisible();
+    await expect(page.getByRole("heading", { name: "New session" })).not.toBeVisible();
   });
 });
 
@@ -159,7 +161,7 @@ test.describe("Mobile responsive", () => {
     await page.goto("/");
     // Sidebar is translated off-screen on mobile (not display:none), so
     // use toBeInViewport rather than toBeVisible.
-    await expect(page.getByLabel("Add project")).not.toBeInViewport();
+    await expect(page.getByLabel("New session")).not.toBeInViewport();
     // Home screen content visible
     await expect(page.getByText("empires", { exact: false })).toBeVisible();
   });
@@ -168,24 +170,24 @@ test.describe("Mobile responsive", () => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await expect(page.getByText("Show sessions")).toBeVisible();
-    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
   });
 
   test("hamburger opens sidebar overlay on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("Add project")).toBeInViewport();
+    await expect(page.getByLabel("New session")).toBeInViewport();
   });
 
   test("sidebar closes via toggle on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("Add project")).toBeInViewport();
+    await expect(page.getByLabel("New session")).toBeInViewport();
     // Toggle the sidebar closed again
     await page.getByRole("button", { name: "Toggle sidebar" }).click();
-    await expect(page.getByLabel("Add project")).not.toBeInViewport();
+    await expect(page.getByLabel("New session")).not.toBeInViewport();
   });
 
   test("settings gear accessible on mobile", async ({ page }) => {
@@ -197,8 +199,8 @@ test.describe("Mobile responsive", () => {
   test("create modal works on mobile", async ({ page }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await page.goto("/");
-    await page.getByText("Open project").click();
-    await expect(page.getByRole("heading", { name: "Add project" })).toBeVisible();
+    await page.getByRole("button", { name: NEW_SESSION_PANE_NAME }).click();
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
   });
 });
 

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -1,11 +1,13 @@
 import { test, expect } from "@playwright/test";
 
+const NEW_SESSION_PANE_NAME = /New session Pick a project, then launch a new session/i;
+
 // Verifies URL-based routing: deep links land on the right view, refresh
 // preserves location, and back/forward replays history.
 test.describe("URL routing", () => {
   test("'/' renders the dashboard home screen", async ({ page }) => {
     await page.goto("/");
-    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
     await expect(page).toHaveURL("/");
   });
 
@@ -34,7 +36,7 @@ test.describe("URL routing", () => {
     // the resolver finds no session and the dashboard renders. Importantly
     // the URL stays put so a real backend can later resolve it.
     await page.goto("/session/does-not-exist");
-    await expect(page.getByText("Open project")).toBeVisible();
+    await expect(page.getByRole("button", { name: NEW_SESSION_PANE_NAME })).toBeVisible();
     await expect(page).toHaveURL("/session/does-not-exist");
   });
 


### PR DESCRIPTION
## Description
- reframe the web wizard and global entry points as session creation instead of project creation
- rename the remaining user-facing "Add project"/"Open project" copy to "New session"
- build on top of #936, which handles the narrower existing-project title case
- closes #920

Verification:
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you would like to share:**
Implemented the broader wording cleanup directly from issue triage for #920, stacked on #936.

- [x] I am an AI Agent filling out this form (check box if true)
