### PR TITLE
fix(web): sync idle decay window from settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMatch, useNavigate } from "react-router-dom";
-import { isSessionActive } from "./lib/session";
+import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
@@ -9,7 +9,13 @@ import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useMobileKeyboard } from "./hooks/useMobileKeyboard";
-import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
+import {
+  loginStatus,
+  logout,
+  deleteSession,
+  fetchAbout,
+  fetchSettings,
+} from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
@@ -40,6 +46,7 @@ import {
 import { AboutModal } from "./components/AboutModal";
 import { CommandPalette } from "./components/command-palette/CommandPalette";
 import { DisconnectBanner } from "./components/DisconnectBanner";
+import { resolveIdleDecayWindowMs } from "./lib/idleDecay";
 
 export default function App() {
   const [loginRequired, setLoginRequired] = useState<boolean | null>(null);
@@ -110,6 +117,9 @@ export default function App() {
 }
 
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
+  const [idleDecayWindowMs, setIdleDecayWindowMs] = useState(
+    IDLE_DECAY_WINDOW_MS,
+  );
   const navigate = useNavigate();
   const sessionMatch = useMatch("/session/:sessionId");
   const settingsRootMatch = useMatch("/settings");
@@ -119,7 +129,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const settingsTab = settingsTabMatch?.params.tab ?? null;
 
   const { sessions, error, injectSession, setSessionStatus } = useSessions();
-  const workspaces = useWorkspaces(sessions);
+  const workspaces = useWorkspaces(sessions, idleDecayWindowMs);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
 
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
@@ -184,7 +194,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const handleSelectWorkspace = (workspaceId: string) => {
     const ws = workspaces.find((w) => w.id === workspaceId);
     if (ws) {
-      const running = ws.sessions.find((s) => isSessionActive(s));
+      const running = ws.sessions.find((s) =>
+        isSessionActive(s, idleDecayWindowMs),
+      );
       const picked = running?.id ?? ws.sessions[0]?.id ?? null;
       if (picked) {
         navigate(`/session/${encodeURIComponent(picked)}`);
@@ -216,6 +228,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
   const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
   const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchSettings().then((settings) => {
+      if (cancelled) return;
+      setIdleDecayWindowMs(resolveIdleDecayWindowMs(settings));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     fetchAbout().then((about) => {
@@ -444,6 +467,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       return (
         <Dashboard
           sessions={sessions}
+          idleDecayWindowMs={idleDecayWindowMs}
           onSelectSession={handleSelectSession}
           onNewSession={handleNewSession}
           onCloneFromUrl={handleCloneFromUrl}
@@ -537,6 +561,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           <WorkspaceSidebar
             groups={groups}
             activeId={activeWorkspace?.id ?? null}
+            idleDecayWindowMs={idleDecayWindowMs}
             open={sidebarOpen}
             onToggle={() => setSidebarOpen(false)}
             onSelect={handleSelectWorkspace}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -4,6 +4,7 @@ import { isSessionActive } from "../lib/session";
 
 interface Props {
   sessions: SessionResponse[];
+  idleDecayWindowMs: number;
   onSelectSession: (sessionId: string) => void;
   onNewSession: () => void;
   onCloneFromUrl: () => void;
@@ -13,6 +14,7 @@ interface Props {
 
 export function Dashboard({
   sessions,
+  idleDecayWindowMs,
   onNewSession,
   onCloneFromUrl,
   onToggleSidebar,
@@ -25,12 +27,12 @@ export function Dashboard({
     let errors = 0;
     for (const s of sessions) {
       projects.add(s.main_repo_path || s.project_path);
-      if (isSessionActive(s)) active++;
+      if (isSessionActive(s, idleDecayWindowMs)) active++;
       if (s.status === "Waiting") waiting++;
       if (s.status === "Error") errors++;
     }
     return { active, waiting, errors, projects: projects.size };
-  }, [sessions]);
+  }, [sessions, idleDecayWindowMs]);
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center bg-surface-950 px-4">

--- a/web/src/components/StatusGlyph.tsx
+++ b/web/src/components/StatusGlyph.tsx
@@ -52,13 +52,19 @@ export function StatusGlyph({
   status,
   createdAt,
   idleEnteredAt,
+  idleDecayWindowMs,
 }: {
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt?: string | null;
+  idleDecayWindowMs?: number;
 }) {
   const isFresh =
-    status === "Idle" && isFreshIdle({ status, idle_entered_at: idleEnteredAt ?? null });
+    status === "Idle" &&
+    isFreshIdle(
+      { status, idle_entered_at: idleEnteredAt ?? null },
+      idleDecayWindowMs,
+    );
   const rattleKey = STATUS_RATTLE[status];
   const rattle = isFresh
     ? FRESH_IDLE_RATTLE

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -30,6 +30,7 @@ function closeOtherContextMenus() {
 interface Props {
   groups: RepoGroup[];
   activeId: string | null;
+  idleDecayWindowMs: number;
   open: boolean;
   onToggle: () => void;
   onSelect: (workspaceId: string) => void;
@@ -43,12 +44,15 @@ interface Props {
 
 function bestSession(
   ws: Workspace,
+  idleDecayWindowMs: number,
 ): {
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt: string | null;
 } {
-  const running = ws.sessions.find((s) => isSessionActive(s));
+  const running = ws.sessions.find((s) =>
+    isSessionActive(s, idleDecayWindowMs)
+  );
   if (running)
     return {
       status: running.status,
@@ -117,6 +121,7 @@ const SessionRow = memo(function SessionRow({
   onDelete,
   readOnly,
   indented,
+  idleDecayWindowMs,
 }: {
   workspace: Workspace;
   isActive: boolean;
@@ -124,15 +129,24 @@ const SessionRow = memo(function SessionRow({
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   indented?: boolean;
+  idleDecayWindowMs: number;
 }) {
-  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(workspace);
-  const textClass = getStatusTextClass({
-    status: sessionStatus,
-    idle_entered_at: idleEnteredAt,
-  });
+  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(
+    workspace,
+    idleDecayWindowMs,
+  );
+  const textClass = getStatusTextClass(
+    {
+      status: sessionStatus,
+      idle_entered_at: idleEnteredAt,
+    },
+    idleDecayWindowMs,
+  );
   const label =
     workspace.branch ?? workspace.sessions[0]?.title ?? "default";
-  const runningSession = workspace.sessions.find((s) => isSessionActive(s));
+  const runningSession = workspace.sessions.find((s) =>
+    isSessionActive(s, idleDecayWindowMs)
+  );
   const firstSession = workspace.sessions[0];
   const sessionId = firstSession?.id;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
@@ -310,9 +324,10 @@ const SessionRow = memo(function SessionRow({
               status={sessionStatus}
               createdAt={createdAt}
               idleEnteredAt={idleEnteredAt}
+              idleDecayWindowMs={idleDecayWindowMs}
             />
           </span>
-          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
             {label}
           </span>
         </div>
@@ -457,6 +472,7 @@ function workspaceMatchesFilter(ws: Workspace, q: string): boolean {
 export function WorkspaceSidebar({
   groups,
   activeId,
+  idleDecayWindowMs,
   open,
   onToggle,
   onSelect,
@@ -645,6 +661,7 @@ export function WorkspaceSidebar({
                       onDelete={onDeleteSession}
                       readOnly={readOnly}
                       indented
+                      idleDecayWindowMs={idleDecayWindowMs}
                     />
                   ))}
               </div>

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -7,7 +7,10 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, "");
 }
 
-export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
+export function useWorkspaces(
+  sessions: SessionResponse[],
+  idleDecayWindowMs: number,
+): Workspace[] {
   return useMemo(() => {
     const groups = new Map<string, SessionResponse[]>();
 
@@ -29,7 +32,9 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
     for (const [id, groupSessions] of groups) {
       const first = groupSessions[0]!;
       const agents = [...new Set(groupSessions.map((s) => s.tool))];
-      const status = groupSessions.some((s) => isSessionActive(s))
+      const status = groupSessions.some((s) =>
+        isSessionActive(s, idleDecayWindowMs)
+      )
         ? "active"
         : "idle";
 
@@ -59,5 +64,5 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
     });
 
     return workspaces;
-  }, [sessions]);
+  }, [sessions, idleDecayWindowMs]);
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -101,6 +101,19 @@ export function getSessionFileDiff(
 
 // --- Settings ---
 
+export interface SettingsResponse {
+  theme?: {
+    idle_decay_minutes?: number | null;
+  } | null;
+}
+
+export function fetchSettings(
+  profile?: string,
+): Promise<SettingsResponse | null> {
+  const params = profile ? `?profile=${encodeURIComponent(profile)}` : "";
+  return fetchJson<SettingsResponse>(`/api/settings${params}`);
+}
+
 export function getSettings(profile?: string): Promise<Record<string, unknown> | null> {
   const params = profile ? `?profile=${encodeURIComponent(profile)}` : "";
   return fetchJson<Record<string, unknown>>(`/api/settings${params}`);

--- a/web/src/lib/idleDecay.test.ts
+++ b/web/src/lib/idleDecay.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { resolveIdleDecayWindowMs } from "./idleDecay";
+
+describe("resolveIdleDecayWindowMs", () => {
+  it("falls back to the dashboard default when the setting is missing", () => {
+    expect(resolveIdleDecayWindowMs(null)).toBe(0);
+    expect(resolveIdleDecayWindowMs({})).toBe(0);
+    expect(resolveIdleDecayWindowMs({ theme: {} })).toBe(0);
+  });
+
+  it("converts minutes to milliseconds", () => {
+    expect(resolveIdleDecayWindowMs({ theme: { idle_decay_minutes: 5 } })).toBe(
+      5 * 60 * 1000,
+    );
+  });
+
+  it("clamps negative values to zero", () => {
+    expect(resolveIdleDecayWindowMs({ theme: { idle_decay_minutes: -3 } })).toBe(0);
+  });
+});

--- a/web/src/lib/idleDecay.ts
+++ b/web/src/lib/idleDecay.ts
@@ -1,0 +1,12 @@
+import type { SettingsResponse } from "./api";
+import { IDLE_DECAY_WINDOW_MS } from "./session";
+
+export function resolveIdleDecayWindowMs(
+  settings: SettingsResponse | null | undefined,
+): number {
+  const minutes = settings?.theme?.idle_decay_minutes;
+  if (typeof minutes !== "number" || !Number.isFinite(minutes)) {
+    return IDLE_DECAY_WINDOW_MS;
+  }
+  return Math.max(0, minutes) * 60 * 1000;
+}


### PR DESCRIPTION
## Description
- fetch `/api/settings` on app boot and resolve `theme.idle_decay_minutes` into a shared web idle-decay window
- thread that window through dashboard/session activity helpers so fresh-idle indicators match the user's configured decay window
- add a small unit test for the settings-to-window conversion

Closes #874.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

OpenClaw issue-hunter (GPT-5.4)

**Any Additional AI Details you'd like to share:**

Verification run in the clean temp clone:
- `npm run test:unit` ✅
- `npm run build` ✅
- `npm run lint` ⚠️ fails on pre-existing `react-hooks/set-state-in-effect` / unused-var errors in unrelated existing files (`src/App.tsx`, `src/components/StatusGlyph.tsx`, `src/hooks/useFileDiff.ts`, several Playwright specs)

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)
