### PR TITLE
fix(web): sync idle decay from settings

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMatch, useNavigate } from "react-router-dom";
-import { isSessionActive } from "./lib/session";
+import {
+  IDLE_DECAY_WINDOW_MS,
+  isSessionActive,
+  resolveIdleDecayWindowMs,
+} from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
@@ -9,7 +13,13 @@ import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useMobileKeyboard } from "./hooks/useMobileKeyboard";
-import { loginStatus, logout, deleteSession, fetchAbout } from "./lib/api";
+import {
+  loginStatus,
+  logout,
+  deleteSession,
+  fetchAbout,
+  getSettings,
+} from "./lib/api";
 import type { DeleteSessionOptions, ServerAbout } from "./lib/api";
 import { toastBus } from "./lib/toastBus";
 import { OPEN_SESSION_EVENT } from "./lib/sessionRoute";
@@ -119,7 +129,9 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const settingsTab = settingsTabMatch?.params.tab ?? null;
 
   const { sessions, error, injectSession, setSessionStatus } = useSessions();
-  const workspaces = useWorkspaces(sessions);
+  const [idleDecayWindowMs, setIdleDecayWindowMs] =
+    useState(IDLE_DECAY_WINDOW_MS);
+  const workspaces = useWorkspaces(sessions, idleDecayWindowMs);
   const { groups, toggleRepoCollapsed } = useRepoGroups(workspaces);
 
   const [selectedFilePath, setSelectedFilePath] = useState<string | null>(null);
@@ -179,12 +191,14 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       focusKeyboardProxy();
       if (window.innerWidth < 768) setSidebarOpen(false);
     }
-  }, [navigate, workspaces]);
+  }, [idleDecayWindowMs, navigate, workspaces]);
 
   const handleSelectWorkspace = (workspaceId: string) => {
     const ws = workspaces.find((w) => w.id === workspaceId);
     if (ws) {
-      const running = ws.sessions.find((s) => isSessionActive(s));
+      const running = ws.sessions.find((s) =>
+        isSessionActive(s, idleDecayWindowMs),
+      );
       const picked = running?.id ?? ws.sessions[0]?.id ?? null;
       if (picked) {
         navigate(`/session/${encodeURIComponent(picked)}`);
@@ -216,6 +230,17 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [wizardPrefill, setWizardPrefill] = useState<WizardPrefill | undefined>(undefined);
   const [deletingWorkspaceId, setDeletingWorkspaceId] = useState<string | null>(null);
   const [serverAbout, setServerAbout] = useState<ServerAbout | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    getSettings().then((settings) => {
+      if (cancelled) return;
+      setIdleDecayWindowMs(resolveIdleDecayWindowMs(settings));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   useEffect(() => {
     fetchAbout().then((about) => {
@@ -448,6 +473,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           onNewSession={handleNewSession}
           onCloneFromUrl={handleCloneFromUrl}
           onToggleSidebar={handleToggleSidebar}
+          idleDecayWindowMs={idleDecayWindowMs}
           readOnly={serverAbout?.read_only}
         />
       );
@@ -545,6 +571,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onCreateSession={handleCreateSession}
             onSettings={handleOpenSettings}
             onDeleteSession={handleDeleteSession}
+            idleDecayWindowMs={idleDecayWindowMs}
             readOnly={serverAbout?.read_only}
           />
         )}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ interface Props {
   onNewSession: () => void;
   onCloneFromUrl: () => void;
   onToggleSidebar: () => void;
+  idleDecayWindowMs: number;
   readOnly?: boolean;
 }
 
@@ -16,6 +17,7 @@ export function Dashboard({
   onNewSession,
   onCloneFromUrl,
   onToggleSidebar,
+  idleDecayWindowMs,
   readOnly,
 }: Props) {
   const stats = useMemo(() => {
@@ -25,12 +27,12 @@ export function Dashboard({
     let errors = 0;
     for (const s of sessions) {
       projects.add(s.main_repo_path || s.project_path);
-      if (isSessionActive(s)) active++;
+      if (isSessionActive(s, idleDecayWindowMs)) active++;
       if (s.status === "Waiting") waiting++;
       if (s.status === "Error") errors++;
     }
     return { active, waiting, errors, projects: projects.size };
-  }, [sessions]);
+  }, [sessions, idleDecayWindowMs]);
 
   return (
     <div className="flex-1 flex flex-col items-center justify-center bg-surface-950 px-4">

--- a/web/src/components/StatusGlyph.tsx
+++ b/web/src/components/StatusGlyph.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import type { SessionStatus } from "../lib/types";
-import { isFreshIdle } from "../lib/session";
+import { IDLE_DECAY_WINDOW_MS, isFreshIdle } from "../lib/session";
 
 /** Animated spinner frames from rattles (https://github.com/vyfor/rattles) */
 const RATTLES: Record<string, { frames: string[]; interval: number }> = {
@@ -52,13 +52,19 @@ export function StatusGlyph({
   status,
   createdAt,
   idleEnteredAt,
+  idleDecayWindowMs = IDLE_DECAY_WINDOW_MS,
 }: {
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt?: string | null;
+  idleDecayWindowMs?: number;
 }) {
   const isFresh =
-    status === "Idle" && isFreshIdle({ status, idle_entered_at: idleEnteredAt ?? null });
+    status === "Idle" &&
+    isFreshIdle(
+      { status, idle_entered_at: idleEnteredAt ?? null },
+      idleDecayWindowMs,
+    );
   const rattleKey = STATUS_RATTLE[status];
   const rattle = isFresh
     ? FRESH_IDLE_RATTLE

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -38,17 +38,19 @@ interface Props {
   onCreateSession: (repoPath: string) => void;
   onSettings: () => void;
   onDeleteSession?: (workspaceId: string) => void;
+  idleDecayWindowMs: number;
   readOnly?: boolean;
 }
 
 function bestSession(
   ws: Workspace,
+  idleDecayWindowMs: number,
 ): {
   status: SessionStatus;
   createdAt: string | null;
   idleEnteredAt: string | null;
 } {
-  const running = ws.sessions.find((s) => isSessionActive(s));
+  const running = ws.sessions.find((s) => isSessionActive(s, idleDecayWindowMs));
   if (running)
     return {
       status: running.status,
@@ -117,6 +119,7 @@ const SessionRow = memo(function SessionRow({
   onDelete,
   readOnly,
   indented,
+  idleDecayWindowMs,
 }: {
   workspace: Workspace;
   isActive: boolean;
@@ -124,15 +127,24 @@ const SessionRow = memo(function SessionRow({
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
   indented?: boolean;
+  idleDecayWindowMs: number;
 }) {
-  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(workspace);
-  const textClass = getStatusTextClass({
-    status: sessionStatus,
-    idle_entered_at: idleEnteredAt,
-  });
+  const { status: sessionStatus, createdAt, idleEnteredAt } = bestSession(
+    workspace,
+    idleDecayWindowMs,
+  );
+  const textClass = getStatusTextClass(
+    {
+      status: sessionStatus,
+      idle_entered_at: idleEnteredAt,
+    },
+    idleDecayWindowMs,
+  );
   const label =
     workspace.branch ?? workspace.sessions[0]?.title ?? "default";
-  const runningSession = workspace.sessions.find((s) => isSessionActive(s));
+  const runningSession = workspace.sessions.find((s) =>
+    isSessionActive(s, idleDecayWindowMs),
+  );
   const firstSession = workspace.sessions[0];
   const sessionId = firstSession?.id;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
@@ -310,9 +322,10 @@ const SessionRow = memo(function SessionRow({
               status={sessionStatus}
               createdAt={createdAt}
               idleEnteredAt={idleEnteredAt}
+              idleDecayWindowMs={idleDecayWindowMs}
             />
           </span>
-          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
+          <span className={`text-[13px] md:text-[14px] truncate flex-1 ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
             {label}
           </span>
         </div>
@@ -465,6 +478,7 @@ export function WorkspaceSidebar({
   onCreateSession,
   onSettings,
   onDeleteSession,
+  idleDecayWindowMs,
   readOnly,
 }: Props) {
   const [width, setWidth] = useState(loadSavedWidth);
@@ -645,6 +659,7 @@ export function WorkspaceSidebar({
                       onDelete={onDeleteSession}
                       readOnly={readOnly}
                       indented
+                      idleDecayWindowMs={idleDecayWindowMs}
                     />
                   ))}
               </div>

--- a/web/src/hooks/useWorkspaces.ts
+++ b/web/src/hooks/useWorkspaces.ts
@@ -7,7 +7,10 @@ function normalizePath(p: string): string {
   return p.replace(/\/+$/, "");
 }
 
-export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
+export function useWorkspaces(
+  sessions: SessionResponse[],
+  idleDecayWindowMs: number,
+): Workspace[] {
   return useMemo(() => {
     const groups = new Map<string, SessionResponse[]>();
 
@@ -29,7 +32,7 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
     for (const [id, groupSessions] of groups) {
       const first = groupSessions[0]!;
       const agents = [...new Set(groupSessions.map((s) => s.tool))];
-      const status = groupSessions.some((s) => isSessionActive(s))
+      const status = groupSessions.some((s) => isSessionActive(s, idleDecayWindowMs))
         ? "active"
         : "idle";
 
@@ -59,5 +62,5 @@ export function useWorkspaces(sessions: SessionResponse[]): Workspace[] {
     });
 
     return workspaces;
-  }, [sessions]);
+  }, [sessions, idleDecayWindowMs]);
 }

--- a/web/src/lib/session.test.ts
+++ b/web/src/lib/session.test.ts
@@ -6,6 +6,7 @@ import {
   idleAgeMs,
   isFreshIdle,
   isSessionActive,
+  resolveIdleDecayWindowMs,
 } from "./session";
 import type { SessionResponse, SessionStatus } from "./types";
 
@@ -29,6 +30,31 @@ function session(
 ): Pick<SessionResponse, "status" | "idle_entered_at"> {
   return { status, idle_entered_at: idleEnteredAt };
 }
+
+describe("resolveIdleDecayWindowMs", () => {
+  it("falls back to the module default when settings are missing", () => {
+    expect(resolveIdleDecayWindowMs(null)).toBe(IDLE_DECAY_WINDOW_MS);
+    expect(resolveIdleDecayWindowMs({})).toBe(IDLE_DECAY_WINDOW_MS);
+  });
+
+  it("converts theme.idle_decay_minutes to milliseconds", () => {
+    expect(
+      resolveIdleDecayWindowMs({ theme: { idle_decay_minutes: 5 } }),
+    ).toBe(5 * 60 * 1000);
+  });
+
+  it("clamps negative values back to zero", () => {
+    expect(
+      resolveIdleDecayWindowMs({ theme: { idle_decay_minutes: -3 } }),
+    ).toBe(0);
+  });
+
+  it("ignores non-numeric theme values", () => {
+    expect(
+      resolveIdleDecayWindowMs({ theme: { idle_decay_minutes: "5" } }),
+    ).toBe(IDLE_DECAY_WINDOW_MS);
+  });
+});
 
 describe("IDLE_DECAY_WINDOW_MS default", () => {
   it("is 0 (off) by default — opt-in feature", () => {

--- a/web/src/lib/session.ts
+++ b/web/src/lib/session.ts
@@ -10,6 +10,18 @@ import type { SessionResponse, SessionStatus } from "./types";
  *  without changing the call sites. Pass a positive number to enable. */
 export const IDLE_DECAY_WINDOW_MS = 0;
 
+export function resolveIdleDecayWindowMs(
+  settings: Record<string, unknown> | null | undefined,
+): number {
+  const theme = settings?.theme;
+  if (!theme || typeof theme !== "object") return IDLE_DECAY_WINDOW_MS;
+  const value = (theme as Record<string, unknown>).idle_decay_minutes;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return IDLE_DECAY_WINDOW_MS;
+  }
+  return Math.max(0, value) * 60 * 1000;
+}
+
 /** Tailwind class for status dot background color by session status */
 export const STATUS_DOT_CLASS: Record<SessionStatus, string> = {
   Running: "bg-status-running",


### PR DESCRIPTION
## Description
- fetch `/api/settings` once on app boot and derive the web idle-decay window from `theme.idle_decay_minutes`
- thread that resolved window through workspace grouping, dashboard stats, and status glyph/class helpers so fresh-idle matches the configured server value instead of a hard-coded mirror
- add unit coverage for the settings parsing helper and keep the existing freshness helpers covered with the explicit window path
- closes #874

Verification:
- cd web && npm run test:unit -- src/lib/session.test.ts
- cd web && npm run build

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Codex (GPT-5)

**Any Additional AI Details you'd like to share:**
Implemented the `/api/settings` wiring for the web idle-decay signal directly from issue triage for #874.

- [x] I am an AI Agent filling out this form (check box if true)
