### PR TITLE
fix(cockpit): auto-spawn ACP workers for sessions added while serve runs

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -506,7 +506,30 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         }
     }
 
-    if args.launch {
+    #[cfg(feature = "serve")]
+    let is_cockpit = instance.cockpit_mode;
+    #[cfg(not(feature = "serve"))]
+    let is_cockpit = false;
+
+    if is_cockpit {
+        // Cockpit sessions aren't backed by tmux: their ACP worker is
+        // owned by `aoe serve`'s supervisor, which the
+        // status_poll_loop reconciler auto-spawns within ~2s of the
+        // session appearing on disk. `--launch` and the
+        // `aoe session start` next-step would both no-op (or now
+        // bail), so route the user to the dashboard instead.
+        println!();
+        println!("Next steps:");
+        println!("  aoe serve                   # Start the dashboard (worker auto-spawns)");
+        println!("  Open the printed URL and select '{}'.", final_title);
+        if args.launch {
+            println!();
+            println!(
+                "(--launch is a no-op for cockpit sessions; \
+                 lifecycle is managed by `aoe serve`.)"
+            );
+        }
+    } else if args.launch {
         let idx = instances
             .iter()
             .position(|i| i.id == instance.id)

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -349,6 +349,46 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         };
         instance.cockpit_agent = args.agent.clone();
         instance.cockpit_model = args.model.clone();
+
+        // Precondition: cockpit sessions are only usable if the resolved
+        // ACP adapter binary is on PATH. Persisting a session whose
+        // adapter is missing produces a silent failure mode where the
+        // dashboard shows the session, the supervisor's reconciler
+        // tries to spawn, AcpClient::spawn fails with "No such file
+        // or directory", and the user sees a 404 on their first
+        // prompt. Bail at add-time with the install hint instead.
+        // `--no-cockpit` and the implicit-default branch don't trip
+        // this — only sessions the user explicitly opted into cockpit
+        // for, where missing tooling is a hard error rather than a
+        // silent fallback to tmux.
+        if instance.cockpit_mode && user_picked_cockpit {
+            let registry = crate::cockpit::agent_registry::AgentRegistry::with_defaults();
+            let agent_name = pick_cockpit_agent_name(
+                &registry,
+                &instance.tool,
+                instance.cockpit_agent.as_deref(),
+            );
+            if let Some(spec) = registry.get(&agent_name) {
+                if !crate::cli::cockpit::command_present(&spec.command) {
+                    let hint = crate::cli::cockpit::install_hint_for(&spec.command)
+                        .unwrap_or("install via your package manager and re-run");
+                    bail!(
+                        "cockpit ACP adapter `{}` is not installed or not on $PATH.\n\
+                         Install: {}\n\
+                         Or run: aoe cockpit doctor --fix\n\
+                         Or use the bundled fallback: rerun with `--agent aoe-agent`\n\
+                         Or skip cockpit: rerun with `--no-cockpit` for a tmux-backed session.",
+                        spec.command,
+                        hint
+                    );
+                }
+            } else {
+                bail!(
+                    "cockpit agent `{agent_name}` is not in the registry.\n\
+                     Run `aoe cockpit doctor` to see configured agents."
+                );
+            }
+        }
     }
 
     // Handle sandbox setup
@@ -555,6 +595,31 @@ pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> 
         let existing_path = inst.project_path.trim_end_matches('/');
         existing_path == normalized_path && inst.title == title
     })
+}
+
+/// Sync mirror of `Supervisor::pick_agent_for_tool` so add-time
+/// precondition checks can resolve the agent without spinning up the
+/// async supervisor. Precedence: explicit override → tool-keyed
+/// registry entry → legacy (`claude` → `claude`, else `aoe-agent`).
+#[cfg(feature = "serve")]
+fn pick_cockpit_agent_name(
+    registry: &crate::cockpit::agent_registry::AgentRegistry,
+    tool: &str,
+    explicit_override: Option<&str>,
+) -> String {
+    if let Some(name) = explicit_override {
+        if !name.is_empty() {
+            return name.to_string();
+        }
+    }
+    if registry.get(tool).is_some() {
+        return tool.to_string();
+    }
+    if tool == "claude" {
+        "claude".into()
+    } else {
+        "aoe-agent".into()
+    }
 }
 
 fn detect_tool(cmd: &str) -> Result<String> {

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -89,7 +89,7 @@ const NPM_INSTALLABLE_ACP: &[(&str, &str)] = &[
 /// Native CLIs whose ACP server is shipped as part of the agent
 /// itself, not as a separate npm adapter. These get a one-line
 /// install hint in the doctor output instead of an `npm i -g`.
-fn install_hint_for(binary: &str) -> Option<&'static str> {
+pub(crate) fn install_hint_for(binary: &str) -> Option<&'static str> {
     Some(match binary {
         "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp",
         "codex-acp" => "npm install -g @zed-industries/codex-acp",
@@ -283,14 +283,17 @@ fn find_in_path(binary: &str) -> Option<String> {
     None
 }
 
-fn command_present(command: &str) -> bool {
-    if command.contains('/') || command.contains('\\') {
-        std::path::Path::new(command).exists()
-    } else if command.contains("${") {
-        // Path placeholders like ${aoe_data_dir}/cockpit-worker/...
-        // resolve at runtime; treat as "configured but not yet
-        // verified."
+pub(crate) fn command_present(command: &str) -> bool {
+    // Placeholders like `${aoe_data_dir}/cockpit-worker/...` resolve at
+    // runtime against the app data dir, so the literal string contains
+    // both `${` and `/`. Check the placeholder branch FIRST — otherwise
+    // the `/`-branch tries to stat a literal path containing `${...}`
+    // and reports "missing" for every placeholder-based agent
+    // (notably `aoe-agent`, our bundled multi-provider fallback).
+    if command.contains("${") {
         true
+    } else if command.contains('/') || command.contains('\\') {
+        std::path::Path::new(command).exists()
     } else {
         find_in_path(command).is_some()
     }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -177,6 +177,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides.
     instances[idx].source_profile = profile.to_string();
+    bail_if_cockpit(&instances[idx], "start")?;
     instances[idx].start_with_size(crate::terminal::get_size())?;
     let title = instances[idx].title.clone();
 
@@ -187,11 +188,40 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     Ok(())
 }
 
+/// Cockpit-mode sessions are not backed by tmux; their ACP worker is owned
+/// by `aoe serve`'s supervisor (auto-spawned by the reconciler within ~2s
+/// of the session appearing on disk). Calling `start`/`stop`/`restart`
+/// from the CLI silently no-ops, which previously misled users into
+/// thinking the session was up. Bail loudly with the actual remediation.
+///
+/// `cockpit_mode` is gated behind the `serve` feature; without it the
+/// field doesn't exist on `Instance` and no session can be in cockpit
+/// mode, so this is a no-op shim.
+#[cfg(feature = "serve")]
+fn bail_if_cockpit(inst: &crate::session::Instance, verb: &str) -> Result<()> {
+    if inst.cockpit_mode {
+        bail!(
+            "cockpit sessions are managed by `aoe serve`; \
+             cannot `aoe session {verb}` from the CLI.\n\
+             The ACP worker is auto-spawned within ~2s of `aoe add --cockpit` \
+             while serve is running, or on next `aoe serve` startup.\n\
+             To control a cockpit session, use the web dashboard or the REST API."
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(feature = "serve"))]
+fn bail_if_cockpit(_inst: &crate::session::Instance, _verb: &str) -> Result<()> {
+    Ok(())
+}
+
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
     let (mut instances, groups) = storage.load_with_groups()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
+    bail_if_cockpit(inst, "stop")?;
     let session_id = inst.id.clone();
     let title = inst.title.clone();
     let tmux_session = crate::tmux::Session::new(&inst.id, &inst.title)?;
@@ -330,13 +360,27 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 }
 
 /// Sessions in `Deleting` or `Creating` are mid-transition; restarting them
-/// would race the deletion/boot path. Everything else is fair game; agents
-/// have their own resume-or-restart logic on the next start.
+/// would race the deletion/boot path. Cockpit-mode sessions are skipped
+/// because their lifecycle is owned by `aoe serve`'s supervisor, not
+/// tmux: a CLI-side restart would no-op silently and (with the explicit
+/// bail in `restart_session`) flood `--all` with per-session errors.
+/// Everything else is fair game; agents have their own resume-or-restart
+/// logic on the next start.
 fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<String> {
     use crate::session::Status;
     instances
         .iter()
         .filter(|i| !matches!(i.status, Status::Deleting | Status::Creating))
+        .filter(|_i| {
+            #[cfg(feature = "serve")]
+            {
+                !_i.cockpit_mode
+            }
+            #[cfg(not(feature = "serve"))]
+            {
+                true
+            }
+        })
         .map(|i| i.id.clone())
         .collect()
 }
@@ -358,6 +402,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // instances always come back blank; rehydrate it from the storage profile
     // so restart-time config resolution honors the right profile's overrides.
     instances[idx].source_profile = profile.to_string();
+    bail_if_cockpit(&instances[idx], "restart")?;
     instances[idx].restart_with_size(crate::terminal::get_size())?;
     let title = instances[idx].title.clone();
 
@@ -373,6 +418,7 @@ async fn attach_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let (instances, _) = storage.load_with_groups()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
+    bail_if_cockpit(inst, "attach")?;
     let tmux_session = crate::tmux::Session::new(&inst.id, &inst.title)?;
 
     if !tmux_session.exists() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -462,53 +462,11 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
 
     let app = build_router(state.clone());
 
-    // Auto-spawn cockpit workers for persisted sessions that have
-    // cockpit_mode enabled. Best-effort: failures (e.g. missing Node)
-    // are logged and the session still appears in the list, just
-    // without a running worker until the user retries via REST or
-    // restarts serve. Each spawn runs on its own task so a slow agent
-    // doesn't delay startup.
-    #[cfg(feature = "serve")]
-    {
-        let cockpit_targets: Vec<_> = {
-            let instances = state.instances.read().await;
-            instances
-                .iter()
-                .filter(|i| i.cockpit_mode)
-                .map(|i| {
-                    (
-                        i.id.clone(),
-                        i.tool.clone(),
-                        i.cockpit_agent.clone(),
-                        i.cockpit_model.clone(),
-                        i.project_path.clone(),
-                    )
-                })
-                .collect()
-        };
-        for (id, tool, agent_override, model, project_path) in cockpit_targets {
-            let supervisor = state.cockpit_supervisor.clone();
-            let agent = supervisor
-                .pick_agent_for_tool(&tool, agent_override.as_deref())
-                .await;
-            let cwd = std::path::PathBuf::from(project_path);
-            tokio::spawn(async move {
-                if let Err(e) = supervisor
-                    .spawn(id.clone(), &agent, cwd, vec![], vec![], model)
-                    .await
-                {
-                    let message = format!("Failed to start cockpit agent {agent:?}: {e}");
-                    tracing::warn!(
-                        target: "cockpit.supervisor",
-                        session = %id,
-                        agent = %agent,
-                        "auto-spawn at serve startup failed: {message}"
-                    );
-                    supervisor.publish_startup_error(&id, message);
-                }
-            });
-        }
-    }
+    // Cockpit workers for persisted sessions get auto-spawned by the
+    // reconciler in `status_poll_loop`. The poll interval's first tick
+    // fires immediately, so on cold startup this is equivalent to the
+    // old in-place loop here, while also covering sessions added via
+    // `aoe add --cockpit` while serve is already running.
 
     let addr = format!("{}:{}", host, port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
@@ -1209,6 +1167,80 @@ fn load_all_instances() -> anyhow::Result<Vec<Instance>> {
     Ok(all)
 }
 
+/// Reconcile cockpit workers against the on-disk session list. Spawns a
+/// worker for every cockpit-mode session that doesn't already have one,
+/// recording the attempt in `attempted` so a permanently-failing spawn
+/// (e.g. `claude-agent-acp` not installed) doesn't retry every 2s tick.
+/// Pruning `attempted` to live ids first lets a delete + recreate of
+/// the same id spawn again.
+///
+/// Covers three entry points to "cockpit session exists, no worker
+/// running": cold serve startup (first tick fires immediately), `aoe
+/// add --cockpit` while serve is running (next tick after the disk
+/// write), and any race where serve starts before a session file is
+/// fully written.
+#[cfg(feature = "serve")]
+async fn reconcile_cockpit_workers(
+    state: &Arc<AppState>,
+    attempted: &mut std::collections::HashSet<String>,
+) {
+    let targets: Vec<_> = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .filter(|i| i.cockpit_mode)
+            .map(|i| {
+                (
+                    i.id.clone(),
+                    i.tool.clone(),
+                    i.cockpit_agent.clone(),
+                    i.cockpit_model.clone(),
+                    i.project_path.clone(),
+                )
+            })
+            .collect()
+    };
+
+    let live: std::collections::HashSet<&String> = targets.iter().map(|t| &t.0).collect();
+    attempted.retain(|id| live.contains(id));
+
+    for (id, tool, agent_override, model, project_path) in targets {
+        if attempted.contains(&id) {
+            continue;
+        }
+        if state.cockpit_supervisor.is_running(&id).await {
+            // A REST-triggered spawn (POST /api/sessions or
+            // /api/cockpit/sessions/:id/enable) already owns the worker;
+            // record the id so we don't poll is_running every tick.
+            attempted.insert(id);
+            continue;
+        }
+        // Mark before spawning so the next 2s tick doesn't double-spawn
+        // while AcpClient::spawn is still negotiating with the agent.
+        attempted.insert(id.clone());
+        let supervisor = state.cockpit_supervisor.clone();
+        let agent = supervisor
+            .pick_agent_for_tool(&tool, agent_override.as_deref())
+            .await;
+        let cwd = std::path::PathBuf::from(project_path);
+        tokio::spawn(async move {
+            if let Err(e) = supervisor
+                .spawn(id.clone(), &agent, cwd, vec![], vec![], model)
+                .await
+            {
+                let message = format!("Failed to start cockpit agent {agent:?}: {e}");
+                tracing::warn!(
+                    target: "cockpit.supervisor",
+                    session = %id,
+                    agent = %agent,
+                    "auto-spawn reconciler failed: {message}"
+                );
+                supervisor.publish_startup_error(&id, message);
+            }
+        });
+    }
+}
+
 /// Background task that periodically refreshes session statuses. On each
 /// tick, diffs pre- and post-refresh statuses and emits a `StatusChange`
 /// on `state.status_tx` for every transition. Keeping the diff here,
@@ -1217,6 +1249,9 @@ fn load_all_instances() -> anyhow::Result<Vec<Instance>> {
 /// and keeps TUI/CLI callers unchanged.
 async fn status_poll_loop(state: Arc<AppState>) {
     let mut interval = tokio::time::interval(std::time::Duration::from_secs(2));
+    #[cfg(feature = "serve")]
+    let mut attempted_cockpit_spawns: std::collections::HashSet<String> =
+        std::collections::HashSet::new();
     loop {
         interval.tick().await;
 
@@ -1265,6 +1300,9 @@ async fn status_poll_loop(state: Arc<AppState>) {
                 }
             }
             *state.instances.write().await = instances;
+
+            #[cfg(feature = "serve")]
+            reconcile_cockpit_workers(&state, &mut attempted_cockpit_spawns).await;
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -459,6 +459,21 @@ impl Instance {
         self.yolo_mode
     }
 
+    /// True when this session runs through the ACP cockpit (managed by
+    /// `aoe serve`'s supervisor) rather than a tmux pane. Always false
+    /// when the `serve` feature is disabled, since the field doesn't
+    /// exist and no session can be in cockpit mode.
+    pub fn is_cockpit_mode(&self) -> bool {
+        #[cfg(feature = "serve")]
+        {
+            self.cockpit_mode
+        }
+        #[cfg(not(feature = "serve"))]
+        {
+            false
+        }
+    }
+
     /// Whether this agent uses a session ID poller for live tracking.
     pub fn supports_session_poller(&self) -> bool {
         crate::agents::get_agent(&self.tool).is_some_and(|a| {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1107,6 +1107,12 @@ impl HomeView {
                         if matches!(inst.status, Status::Deleting | Status::Creating) {
                             return None;
                         }
+                        if inst.is_cockpit_mode() {
+                            return Some(Action::SetTransientStatus(
+                                "Cockpit session: open the web dashboard (aoe serve) to attach"
+                                    .to_string(),
+                            ));
+                        }
                     }
                     return match self.view_mode {
                         ViewMode::Agent => Some(Action::AttachSession(id.clone())),

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -631,15 +631,16 @@ impl HomeView {
                 // how long it's actually been since the agent stopped.
                 // Color tracks the fresh/decayed binary used by the icon so
                 // the readout fades in step.
-                let badge_text: Option<&'static str> =
-                    if self.view_mode == ViewMode::Terminal && inst.is_sandboxed() {
-                        Some(match self.get_terminal_mode(id) {
-                            TerminalMode::Container => " [container]",
-                            TerminalMode::Host => " [host]",
-                        })
-                    } else {
-                        None
-                    };
+                let badge_text: Option<&'static str> = if inst.is_cockpit_mode() {
+                    Some(" [cockpit]")
+                } else if self.view_mode == ViewMode::Terminal && inst.is_sandboxed() {
+                    Some(match self.get_terminal_mode(id) {
+                        TerminalMode::Container => " [container]",
+                        TerminalMode::Host => " [host]",
+                    })
+                } else {
+                    None
+                };
                 let badge_width = badge_text.map_or(0, |s| s.len());
 
                 let used_width: usize = line_spans.iter().map(|s| s.width()).sum();

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -355,6 +355,45 @@ fn test_enter_on_session_returns_attach_action() {
     assert!(matches!(action, Some(Action::AttachSession(_))));
 }
 
+#[cfg(feature = "serve")]
+#[test]
+#[serial]
+fn test_enter_on_cockpit_session_returns_toast() {
+    use crate::session::config::GroupByMode;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+    let mut instances = vec![
+        Instance::new("plain", "/tmp/0"),
+        Instance::new("cockpit", "/tmp/1"),
+        Instance::new("plain2", "/tmp/2"),
+    ];
+    instances[1].cockpit_mode = true;
+    storage.save(&instances).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.group_by = GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.cursor = 1;
+    view.update_selected();
+
+    let action = view.handle_key(key(KeyCode::Enter), None);
+    match action {
+        Some(Action::SetTransientStatus(msg)) => {
+            assert!(
+                msg.to_lowercase().contains("cockpit"),
+                "toast should mention cockpit, got: {msg}"
+            );
+            assert!(
+                msg.to_lowercase().contains("dashboard") || msg.contains("aoe serve"),
+                "toast should point at the dashboard, got: {msg}"
+            );
+        }
+        other => panic!("expected SetTransientStatus toast for cockpit session, got {other:?}"),
+    }
+}
+
 #[test]
 #[serial]
 fn test_slash_enters_search_mode() {


### PR DESCRIPTION
## Description

Stacks on top of #868 (the `native` branch). Fixes the "session started but nothing in the webui" report from #868's review thread, plus the surrounding silent-failure UX cliffs that surface from the same root cause.

### 1. Daemon-side reconciler — `d8c21bf`

**Bug.** Cockpit-mode sessions added via `aoe add . --cmd <tool> --cockpit` while `aoe serve` was already running never got an ACP worker. The dashboard showed the session (the 2s status poller picks it up from disk) but the agent stayed silent because no code path called `cockpit_supervisor.spawn(...)` for it. `aoe session start <name>` looked like it worked but is a no-op for cockpit sessions: `Instance::start_with_size_opts` returns early on `cockpit_mode == true`.

Worker spawning previously fired only at three entry points:
- serve-startup auto-scan (`src/server/mod.rs`)
- `POST /api/sessions` (web wizard create)
- `POST /api/cockpit/sessions/:id/enable` (substrate switch)

Nothing watched for cockpit sessions appearing in the on-disk list after startup.

**Fix.** Move auto-spawn out of the one-shot startup block and into the existing `status_poll_loop`. Each tick reconciles cockpit-mode sessions on disk against the supervisor's worker map and spawns any that are missing.

- `attempted_cockpit_spawns: HashSet<String>` guards against retry storms when a spawn permanently fails (e.g. `claude-agent-acp` not installed).
- The set is pruned to the live id set each tick so a delete + recreate of the same id can spawn again.
- Cold-startup latency is unchanged: `tokio::time::interval`'s first tick fires immediately, so the reconciler runs at the same point the old startup loop did.

### 2. CLI bail for cockpit lifecycle commands — `ca4c112`

`aoe session start <name>` (and `stop`/`restart`/`attach`) on a cockpit-mode session previously printed `✓ Started session: ...` while doing nothing, because `Instance::start_with_size_opts` early-returns on `cockpit_mode`. The CLI now refuses these commands with a message pointing at `aoe serve` + the dashboard. `aoe session restart --all` skips cockpit sessions instead of erroring on each one. `cockpit_mode` is gated on the `serve` feature, so TUI-only builds compile to a no-op shim.

### 3. `aoe add --cockpit` next-steps redirect — `ed0c90f`

The post-add summary printed the same `aoe session start <name>` / `aoe` (TUI attach) hint regardless of substrate, sending cockpit users straight into the lifecycle commands that now bail. The cockpit branch now points at `aoe serve` + the dashboard. For `--launch`, surface that the flag is a no-op so the user understands why the run didn't open a terminal.

### 4. `aoe add --cockpit` precondition check — `1bf3eb6`

Persisting a `--cockpit` session whose ACP adapter binary isn't on `$PATH` used to fail silently end-to-end: `aoe add` returned 0, the dashboard listed the session, the supervisor's reconciler tried to spawn the worker, `AcpClient::spawn` errored with "No such file or directory", and the user only learned something was wrong when the first prompt POST returned 404 ("session has no running cockpit").

Verify the resolved adapter binary is on `$PATH` at add-time and bail loudly with the install hint, the bundled-fallback (`--agent aoe-agent`) suggestion, and the tmux-passthrough escape hatch (`--no-cockpit`). Only sessions the user explicitly opted into cockpit for hit this check; the implicit default-for-claude branch keeps falling back to tmux, so users without cockpit tooling on `$PATH` aren't suddenly blocked.

Drive-by fix in `command_present` (`src/cli/cockpit.rs`): the placeholder branch was shadowed by the `/`-branch, so any agent whose command embeds a `${aoe_data_dir}/...` placeholder (notably `aoe-agent`, our bundled fallback) was reported as missing in `aoe cockpit doctor` and would have failed this new precondition. Reorder the checks so placeholders resolve at runtime as documented.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
  - `cargo test --features serve --lib server::tests` 16/16
  - `cargo test --features serve --lib cockpit` 39/39
  - `cargo build --features serve --profile dev-release`, `cargo build`
  - `cargo clippy --features serve -- -D warnings`, `cargo clippy -- -D warnings`
  - `cargo fmt --check`
- [x] Documentation was updated where necessary (no user-facing surface changes; `aoe cockpit doctor` output is now correct for placeholder-based agents)
- [ ] For UI changes: included screenshot or recording (n/a — CLI + daemon-internal)

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**
The original investigation comment on #868 was authored by me with Claude's help; this PR implements option #1 from that comment (commit 1) and option #3 from the same comment, expanded to cover the surrounding silent-failure UX cliffs (commits 2-4). I read every change and verified the build/clippy/fmt/unit-tests locally.

- [ ] I am an AI Agent filling out this form (check box if true)

## Test plan

- [ ] `cargo build --features serve --profile dev-release`
- [ ] Two-terminal repro from the investigation comment (validates commit 1):
  ```
  Term A: aoe serve
  Term B: aoe add . --cmd claude --cockpit  # adapter installed
  ```
  Confirm the cockpit conversation comes online within ~2s without an `aoe serve` restart.
- [ ] Without `claude-agent-acp` on `$PATH` (validates commit 4):
  ```
  aoe add . --cmd claude --cockpit
  ```
  Confirm it fails fast with the install hint instead of persisting a broken session.
- [ ] On a cockpit session, run `aoe session start <name>` and `aoe session restart <name>` (validates commit 2). Confirm both bail with the "managed by `aoe serve`" message.
- [ ] `aoe session restart --all` in a profile mixing cockpit and tmux sessions (validates commit 2). Confirm the cockpit ones are skipped silently and tmux ones restart.
- [ ] `aoe add . --cmd claude --cockpit` (validates commit 3). Confirm the next-steps block points at `aoe serve` + the dashboard, not `aoe session start`.
- [ ] `aoe cockpit doctor` (validates the drive-by). Confirm `aoe-agent` is reported as `[OK]`.

## Out of scope

A separate (pre-existing) sidebar bug surfaced while testing this PR: when multiple sessions share the same `(project_path, branch)` key, `useWorkspaces` collapses them into one workspace and the sidebar renders only `workspace.sessions[0]`. Reproduces with tmux-only sessions too. I'll open a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)