### PR TITLE
feature(container): Add claude vertex auth forwarding with GCP credential support

### DIFF
--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -167,6 +167,15 @@ If the referenced host env var is not set, the entry is silently skipped.
 
 To use a literal value starting with `$`, double it: `$$LITERAL` is injected as `$LITERAL`.
 
+### Claude on Vertex AI
+
+If `CLAUDE_CODE_USE_VERTEX` is set on the host (and non-empty), AOE wires up Claude+Vertex sessions automatically:
+
+- The Vertex env vars `CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, `ANTHROPIC_VERTEX_REGION`, and `CLOUD_ML_REGION` are forwarded into the container when set.
+- GCP Application Default Credentials are bind-mounted read-only at the well-known container path `/root/.config/gcloud/application_default_credentials.json`. AOE uses `$GOOGLE_APPLICATION_CREDENTIALS` if set, otherwise falls back to `~/.config/gcloud/application_default_credentials.json`. `GOOGLE_APPLICATION_CREDENTIALS` itself is not forwarded; client libraries discover the well-known path automatically.
+
+This only triggers when the active agent is `claude`; other agents (opencode, codex, etc.) get neither the vars nor the cred mount even if the host flag is set. `ANTHROPIC_API_KEY` is not auto-forwarded; if you also want it inside the container, list it in `sandbox.environment` explicitly.
+
 ### GitHub authentication with `GH_TOKEN`
 
 Forwarding `GH_TOKEN` (e.g. `"GH_TOKEN=$GH_TOKEN"` in `sandbox.environment`) enables both `gh` and plain `git push` to authenticate against `github.com` inside the container. AOE seeds a scoped credential helper in the sandbox gitconfig that reads the token at push time; no credential is ever written to disk.

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -552,7 +552,6 @@ fn default_sandbox_image() -> String {
 fn default_sandbox_environment() -> Vec<String> {
     crate::session::environment::DEFAULT_TERMINAL_ENV_VARS
         .iter()
-        .chain(crate::session::environment::AUTO_FORWARD_API_ENV_VARS.iter())
         .map(|s| s.to_string())
         .collect()
 }
@@ -989,7 +988,6 @@ mod tests {
         assert!(sb.extra_volumes.is_empty());
         assert!(sb.environment.contains(&"TERM".to_string()));
         assert!(sb.environment.contains(&"COLORTERM".to_string()));
-        assert!(sb.environment.contains(&"ANTHROPIC_API_KEY".to_string()));
         assert!(sb.cpu_limit.is_none());
         assert!(sb.memory_limit.is_none());
         assert!(sb.volume_ignores.is_empty());

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -552,6 +552,7 @@ fn default_sandbox_image() -> String {
 fn default_sandbox_environment() -> Vec<String> {
     crate::session::environment::DEFAULT_TERMINAL_ENV_VARS
         .iter()
+        .chain(crate::session::environment::AUTO_FORWARD_API_ENV_VARS.iter())
         .map(|s| s.to_string())
         .collect()
 }
@@ -988,6 +989,7 @@ mod tests {
         assert!(sb.extra_volumes.is_empty());
         assert!(sb.environment.contains(&"TERM".to_string()));
         assert!(sb.environment.contains(&"COLORTERM".to_string()));
+        assert!(sb.environment.contains(&"ANTHROPIC_API_KEY".to_string()));
         assert!(sb.cpu_limit.is_none());
         assert!(sb.memory_limit.is_none());
         assert!(sb.volume_ignores.is_empty());

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -875,6 +875,40 @@ pub(crate) fn build_container_config(
         }
     }
 
+    // Mount GCP credentials into the well-known ADC path when Vertex AI is configured.
+    // GOOGLE_APPLICATION_CREDENTIALS is not forwarded as an env var; client libraries
+    // discover the well-known path automatically.
+    if std::env::var("CLAUDE_CODE_USE_VERTEX").is_ok() {
+        let container_cred_path = format!(
+            "{}/.config/gcloud/application_default_credentials.json",
+            CONTAINER_HOME
+        );
+        if let Ok(cred_path) = std::env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+            let cred_file = std::path::Path::new(&cred_path);
+            if cred_file.exists() {
+                volumes.push(VolumeMount {
+                    host_path: cred_path.clone(),
+                    container_path: container_cred_path,
+                    read_only: true,
+                });
+            } else {
+                tracing::warn!(
+                    "GOOGLE_APPLICATION_CREDENTIALS points to non-existent file: {}",
+                    cred_path
+                );
+            }
+        } else {
+            let adc_path = home.join(".config/gcloud/application_default_credentials.json");
+            if adc_path.exists() {
+                volumes.push(VolumeMount {
+                    host_path: adc_path.to_string_lossy().to_string(),
+                    container_path: container_cred_path,
+                    read_only: true,
+                });
+            }
+        }
+    }
+
     // Sync host agent config into a shared sandbox directory per agent and
     // bind-mount it read-write. Only mount the config for the active tool.
     // Agent definitions are in AGENT_CONFIG_MOUNTS -- add new agents there, not here.

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -875,10 +875,13 @@ pub(crate) fn build_container_config(
         }
     }
 
-    // Mount GCP credentials into the well-known ADC path when Vertex AI is configured.
-    // GOOGLE_APPLICATION_CREDENTIALS is not forwarded as an env var; client libraries
+    // Mount GCP credentials into the well-known ADC path for Claude+Vertex sessions.
+    // Gated on `tool == "claude"` because `CLAUDE_CODE_USE_VERTEX` is Claude-specific;
+    // there's no reason to expose GCP creds to other agents (opencode, codex, etc.)
+    // just because the user has the flag exported globally.
+    // `GOOGLE_APPLICATION_CREDENTIALS` is not forwarded as an env var; client libraries
     // discover the well-known path automatically.
-    if std::env::var("CLAUDE_CODE_USE_VERTEX").is_ok() {
+    if tool == "claude" && super::environment::host_vertex_enabled() {
         let container_cred_path = format!(
             "{}/.config/gcloud/application_default_credentials.json",
             CONTAINER_HOME
@@ -2787,5 +2790,191 @@ volume_ignores = ["target"]
 
         // Should not panic or error when files don't exist
         prepare_sandbox_dir(&mount, home.path()).unwrap();
+    }
+
+    // --- GCP credential mount tests ---
+    //
+    // These exercise the Vertex AI cred mount inside `build_container_config`.
+    // They use `serial_test::serial` because they mutate process-wide env vars,
+    // and isolate `HOME`/`XDG_CONFIG_HOME` so global config doesn't bleed in.
+
+    fn build_minimal_sandbox_info() -> super::super::instance::SandboxInfo {
+        super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        }
+    }
+
+    fn write_adc_at(home: &std::path::Path) -> std::path::PathBuf {
+        let adc_dir = home.join(".config").join("gcloud");
+        fs::create_dir_all(&adc_dir).unwrap();
+        let adc_path = adc_dir.join("application_default_credentials.json");
+        fs::write(&adc_path, r#"{"type":"authorized_user"}"#).unwrap();
+        adc_path
+    }
+
+    fn run_build_for_vertex_test(tool: &str, project_dir: &std::path::Path) -> ContainerConfig {
+        git2::Repository::init(project_dir).unwrap();
+        let info = build_minimal_sandbox_info();
+        build_container_config(
+            project_dir.to_str().unwrap(),
+            &info,
+            tool,
+            false,
+            "test-instance-id",
+            None,
+            "",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_mounts_default_adc_when_flag_set_and_tool_is_claude() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        let adc_path = write_adc_at(temp_home.path());
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("claude", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        let mount = config
+            .volumes
+            .iter()
+            .find(|v| v.container_path == target)
+            .expect("expected ADC mount when Vertex flag is set");
+        assert_eq!(mount.host_path, adc_path.to_string_lossy());
+        assert!(mount.read_only);
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_mounts_custom_path_from_google_application_credentials() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+
+        let cred_dir = TempDir::new().unwrap();
+        let custom_cred = cred_dir.path().join("custom-key.json");
+        fs::write(&custom_cred, r#"{"type":"service_account"}"#).unwrap();
+        std::env::set_var("GOOGLE_APPLICATION_CREDENTIALS", &custom_cred);
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("claude", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        let mount = config
+            .volumes
+            .iter()
+            .find(|v| v.container_path == target)
+            .expect("expected mount at well-known ADC path");
+        assert_eq!(mount.host_path, custom_cred.to_string_lossy());
+        assert!(mount.read_only);
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_skips_mount_when_flag_unset() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        let _ = write_adc_at(temp_home.path());
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("claude", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        assert!(
+            !config.volumes.iter().any(|v| v.container_path == target),
+            "ADC must not be mounted when Vertex flag is unset",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_skips_mount_when_tool_is_not_claude() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        let _ = write_adc_at(temp_home.path());
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("opencode", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        assert!(
+            !config.volumes.iter().any(|v| v.container_path == target),
+            "ADC must not be mounted for non-claude tools even when Vertex flag is set",
+        );
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_skips_mount_when_flag_is_empty_string() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        let _ = write_adc_at(temp_home.path());
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("claude", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        assert!(
+            !config.volumes.iter().any(|v| v.container_path == target),
+            "Empty CLAUDE_CODE_USE_VERTEX must be treated as unset",
+        );
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_vertex_skips_mount_when_adc_file_missing() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::remove_var("GOOGLE_APPLICATION_CREDENTIALS");
+        // Note: no ADC file written
+
+        let project_dir = TempDir::new().unwrap();
+        let config = run_build_for_vertex_test("claude", project_dir.path());
+
+        let target = "/root/.config/gcloud/application_default_credentials.json";
+        assert!(
+            !config.volumes.iter().any(|v| v.container_path == target),
+            "ADC must not be mounted when the host file does not exist",
+        );
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
     }
 }

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -113,6 +113,15 @@ fn redact_export_statements(cmd: &str) -> String {
 pub(crate) const DEFAULT_TERMINAL_ENV_VARS: &[&str] =
     &["TERM", "COLORTERM", "FORCE_COLOR", "NO_COLOR"];
 
+/// API/provider env vars forwarded into sandbox containers when set on the host.
+pub(crate) const AUTO_FORWARD_API_ENV_VARS: &[&str] = &[
+    "ANTHROPIC_API_KEY",
+    "ANTHROPIC_VERTEX_PROJECT_ID",
+    "ANTHROPIC_VERTEX_REGION",
+    "CLAUDE_CODE_USE_VERTEX",
+    "CLOUD_ML_REGION",
+];
+
 /// Returns the user's preferred shell from `$SHELL`, falling back to `bash`.
 ///
 /// Used for host-side command wrappers (agent launch, local hook execution)
@@ -253,6 +262,18 @@ pub(crate) fn collect_environment(
 
     // Always ensure the terminal defaults are present (pass-through from host)
     for &key in DEFAULT_TERMINAL_ENV_VARS {
+        if seen_keys.insert(key.to_string()) {
+            if let Ok(val) = std::env::var(key) {
+                result.push(EnvEntry::Inherit {
+                    key: key.to_string(),
+                    value: val,
+                });
+            }
+        }
+    }
+
+    // Auto-forward API provider credentials when set on the host.
+    for &key in AUTO_FORWARD_API_ENV_VARS {
         if seen_keys.insert(key.to_string()) {
             if let Ok(val) = std::env::var(key) {
                 result.push(EnvEntry::Inherit {
@@ -1034,5 +1055,95 @@ environment = ["GH_TOKEN=write_token"]
             Some(v) => std::env::set_var("SHELL", v),
             None => std::env::remove_var("SHELL"),
         }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_environment_auto_forwards_api_vars() {
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-test-key");
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::set_var("CLOUD_ML_REGION", "us-east5");
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        let api_key =
+            find_entry(&result, "ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not found");
+        assert_eq!(api_key.value(), "sk-test-key");
+        assert!(matches!(api_key, EnvEntry::Inherit { .. }));
+
+        let vertex_flag = find_entry(&result, "CLAUDE_CODE_USE_VERTEX")
+            .expect("CLAUDE_CODE_USE_VERTEX not found");
+        assert_eq!(vertex_flag.value(), "1");
+        assert!(matches!(vertex_flag, EnvEntry::Inherit { .. }));
+
+        let region = find_entry(&result, "CLOUD_ML_REGION").expect("CLOUD_ML_REGION not found");
+        assert_eq!(region.value(), "us-east5");
+        assert!(matches!(region, EnvEntry::Inherit { .. }));
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("CLOUD_ML_REGION");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_environment_skips_unset_api_vars() {
+        std::env::remove_var("CLOUD_ML_REGION");
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        assert!(
+            find_entry(&result, "CLOUD_ML_REGION").is_none(),
+            "CLOUD_ML_REGION should not appear when unset on host",
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_environment_api_vars_not_duplicated() {
+        std::env::set_var("ANTHROPIC_API_KEY", "sk-host-key");
+        let config = SandboxConfig {
+            environment: vec!["ANTHROPIC_API_KEY".to_string()],
+            ..Default::default()
+        };
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        let matches: Vec<_> = result
+            .iter()
+            .filter(|e| e.key() == "ANTHROPIC_API_KEY")
+            .collect();
+        assert_eq!(
+            matches.len(),
+            1,
+            "ANTHROPIC_API_KEY should appear exactly once, got {}",
+            matches.len(),
+        );
+        assert_eq!(matches[0].value(), "sk-host-key");
+
+        std::env::remove_var("ANTHROPIC_API_KEY");
     }
 }

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -113,14 +113,30 @@ fn redact_export_statements(cmd: &str) -> String {
 pub(crate) const DEFAULT_TERMINAL_ENV_VARS: &[&str] =
     &["TERM", "COLORTERM", "FORCE_COLOR", "NO_COLOR"];
 
-/// API/provider env vars forwarded into sandbox containers when set on the host.
-pub(crate) const AUTO_FORWARD_API_ENV_VARS: &[&str] = &[
-    "ANTHROPIC_API_KEY",
+/// Vertex provider env vars auto-forwarded into sandbox containers when
+/// `CLAUDE_CODE_USE_VERTEX` is set on the host. The flag itself is included
+/// so the container sees a consistent state.
+///
+/// `ANTHROPIC_API_KEY` is intentionally not in this list: Vertex auth uses
+/// GCP credentials, and force-forwarding the Anthropic API key would change
+/// behavior for users who happen to have it on their shell for unrelated
+/// reasons. Users who want it forwarded can add it to `sandbox.environment`
+/// explicitly.
+pub(crate) const AUTO_FORWARD_VERTEX_ENV_VARS: &[&str] = &[
     "ANTHROPIC_VERTEX_PROJECT_ID",
     "ANTHROPIC_VERTEX_REGION",
     "CLAUDE_CODE_USE_VERTEX",
     "CLOUD_ML_REGION",
 ];
+
+/// Returns true when `CLAUDE_CODE_USE_VERTEX` is set on the host to a
+/// non-empty value. An empty string is treated as unset to match how the
+/// flag is conventionally interpreted.
+pub(crate) fn host_vertex_enabled() -> bool {
+    std::env::var("CLAUDE_CODE_USE_VERTEX")
+        .ok()
+        .is_some_and(|v| !v.is_empty())
+}
 
 /// Returns the user's preferred shell from `$SHELL`, falling back to `bash`.
 ///
@@ -272,14 +288,17 @@ pub(crate) fn collect_environment(
         }
     }
 
-    // Auto-forward API provider credentials when set on the host.
-    for &key in AUTO_FORWARD_API_ENV_VARS {
-        if seen_keys.insert(key.to_string()) {
-            if let Ok(val) = std::env::var(key) {
-                result.push(EnvEntry::Inherit {
-                    key: key.to_string(),
-                    value: val,
-                });
+    // Auto-forward Vertex provider env vars when Vertex is enabled on the host.
+    // Gating on the host flag keeps non-Vertex users' sandboxes unchanged.
+    if host_vertex_enabled() {
+        for &key in AUTO_FORWARD_VERTEX_ENV_VARS {
+            if seen_keys.insert(key.to_string()) {
+                if let Ok(val) = std::env::var(key) {
+                    result.push(EnvEntry::Inherit {
+                        key: key.to_string(),
+                        value: val,
+                    });
+                }
             }
         }
     }
@@ -1059,9 +1078,9 @@ environment = ["GH_TOKEN=write_token"]
 
     #[test]
     #[serial_test::serial]
-    fn test_collect_environment_auto_forwards_api_vars() {
-        std::env::set_var("ANTHROPIC_API_KEY", "sk-test-key");
+    fn test_collect_environment_auto_forwards_vertex_vars_when_enabled() {
         std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj");
         std::env::set_var("CLOUD_ML_REGION", "us-east5");
         let config = SandboxConfig::default();
         let info = SandboxInfo {
@@ -1074,29 +1093,30 @@ environment = ["GH_TOKEN=write_token"]
         };
 
         let result = collect_environment(&config, &info);
-        let api_key =
-            find_entry(&result, "ANTHROPIC_API_KEY").expect("ANTHROPIC_API_KEY not found");
-        assert_eq!(api_key.value(), "sk-test-key");
-        assert!(matches!(api_key, EnvEntry::Inherit { .. }));
 
         let vertex_flag = find_entry(&result, "CLAUDE_CODE_USE_VERTEX")
             .expect("CLAUDE_CODE_USE_VERTEX not found");
         assert_eq!(vertex_flag.value(), "1");
         assert!(matches!(vertex_flag, EnvEntry::Inherit { .. }));
 
+        let project = find_entry(&result, "ANTHROPIC_VERTEX_PROJECT_ID")
+            .expect("ANTHROPIC_VERTEX_PROJECT_ID not found");
+        assert_eq!(project.value(), "my-proj");
+
         let region = find_entry(&result, "CLOUD_ML_REGION").expect("CLOUD_ML_REGION not found");
         assert_eq!(region.value(), "us-east5");
-        assert!(matches!(region, EnvEntry::Inherit { .. }));
 
-        std::env::remove_var("ANTHROPIC_API_KEY");
         std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
         std::env::remove_var("CLOUD_ML_REGION");
     }
 
     #[test]
     #[serial_test::serial]
-    fn test_collect_environment_skips_unset_api_vars() {
-        std::env::remove_var("CLOUD_ML_REGION");
+    fn test_collect_environment_skips_vertex_vars_when_flag_unset() {
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj");
+        std::env::set_var("CLOUD_ML_REGION", "us-east5");
         let config = SandboxConfig::default();
         let info = SandboxInfo {
             enabled: true,
@@ -1109,17 +1129,72 @@ environment = ["GH_TOKEN=write_token"]
 
         let result = collect_environment(&config, &info);
         assert!(
-            find_entry(&result, "CLOUD_ML_REGION").is_none(),
-            "CLOUD_ML_REGION should not appear when unset on host",
+            find_entry(&result, "ANTHROPIC_VERTEX_PROJECT_ID").is_none(),
+            "Vertex vars should not auto-forward when CLAUDE_CODE_USE_VERTEX is unset",
         );
+        assert!(find_entry(&result, "CLOUD_ML_REGION").is_none());
+
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
+        std::env::remove_var("CLOUD_ML_REGION");
     }
 
     #[test]
     #[serial_test::serial]
-    fn test_collect_environment_api_vars_not_duplicated() {
+    fn test_collect_environment_skips_vertex_vars_when_flag_empty() {
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "");
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj");
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        assert!(
+            find_entry(&result, "ANTHROPIC_VERTEX_PROJECT_ID").is_none(),
+            "Empty CLAUDE_CODE_USE_VERTEX must be treated as unset",
+        );
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_environment_does_not_auto_forward_anthropic_api_key() {
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
         std::env::set_var("ANTHROPIC_API_KEY", "sk-host-key");
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        assert!(
+            find_entry(&result, "ANTHROPIC_API_KEY").is_none(),
+            "ANTHROPIC_API_KEY must not be auto-forwarded; users opt in via sandbox.environment",
+        );
+
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("ANTHROPIC_API_KEY");
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_collect_environment_vertex_vars_not_duplicated() {
+        std::env::set_var("CLAUDE_CODE_USE_VERTEX", "1");
+        std::env::set_var("ANTHROPIC_VERTEX_PROJECT_ID", "my-proj");
         let config = SandboxConfig {
-            environment: vec!["ANTHROPIC_API_KEY".to_string()],
+            environment: vec!["ANTHROPIC_VERTEX_PROJECT_ID".to_string()],
             ..Default::default()
         };
         let info = SandboxInfo {
@@ -1134,16 +1209,12 @@ environment = ["GH_TOKEN=write_token"]
         let result = collect_environment(&config, &info);
         let matches: Vec<_> = result
             .iter()
-            .filter(|e| e.key() == "ANTHROPIC_API_KEY")
+            .filter(|e| e.key() == "ANTHROPIC_VERTEX_PROJECT_ID")
             .collect();
-        assert_eq!(
-            matches.len(),
-            1,
-            "ANTHROPIC_API_KEY should appear exactly once, got {}",
-            matches.len(),
-        );
-        assert_eq!(matches[0].value(), "sk-host-key");
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].value(), "my-proj");
 
-        std::env::remove_var("ANTHROPIC_API_KEY");
+        std::env::remove_var("CLAUDE_CODE_USE_VERTEX");
+        std::env::remove_var("ANTHROPIC_VERTEX_PROJECT_ID");
     }
 }


### PR DESCRIPTION
## Description

Auto-forward Vertex AI and API provider environment variables into sandboxed containers, and auto-mount GCP Application Default Credentials when Vertex is enabled.

Closes #952

### What changed

1. **`src/session/environment.rs`**: New `AUTO_FORWARD_API_ENV_VARS` constant that auto-forwards `ANTHROPIC_API_KEY`, `ANTHROPIC_VERTEX_PROJECT_ID`, `ANTHROPIC_VERTEX_REGION`, `CLAUDE_CODE_USE_VERTEX`, and `CLOUD_ML_REGION` when set on the host. Uses `EnvEntry::Inherit` (key-only in argv) to keep secrets out of process listings and logs.

2. **`src/session/container_config.rs`**: When `CLAUDE_CODE_USE_VERTEX` is set, mounts GCP credentials into the container at the well-known ADC path (`/root/.config/gcloud/application_default_credentials.json`). Supports both `GOOGLE_APPLICATION_CREDENTIALS` (custom path) and the default ADC location.

3. **`src/session/config.rs`**: Updated `default_sandbox_environment()` to include the new API vars so they appear in the TUI new-session env list.

### How I tested

- Built with `cargo build --release`, created a sandboxed session
- Verified env vars appear inside the container (`env | grep ANTHROPIC`)
- Verified ADC file is mounted at the expected path
- `cargo test` passes (3 pre-existing container runtime failures unrelated to this change)
- `cargo fmt --check` and `cargo clippy` clean

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code

**Any Additional AI Details you'd like to share:**
Used Claude for codebase discovery, identifying the right env var names from official docs, edge case review, and code review of the changes. The feature idea, testing, and final decisions are mine.

- [ ] I am an AI Agent filling out this form (check box if true)