### PR TITLE
fix(serve): raise RLIMIT_NOFILE and clean up tmux child on PTY init failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ tokio-util = { version = "0.7", features = ["codec"] }
 cfg-if = "1.0"
 
 # Process handling
-nix = { version = "0.31", features = ["signal", "process", "net"] }
+nix = { version = "0.31", features = ["signal", "process", "net", "resource"] }
 
 # Unicode width
 unicode-width = "0.2"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -276,6 +276,43 @@ fn epoch_millis() -> i64 {
 
 // ── Server ──────────────────────────────────────────────────────────────────
 
+/// Raise the soft `RLIMIT_NOFILE` so the server can sustain many WS
+/// terminals at once. macOS's default soft cap of 256 is exhausted
+/// quickly: each WS terminal consumes ~3 file descriptors (PTY master +
+/// cloned reader + writer) plus tokio plumbing, so a handful of mobile
+/// reconnect bursts leaves `openpty` and the child-spawn `dup` calls
+/// failing with EMFILE.
+///
+/// Targets the smaller of 8192 and the hard limit. Setting soft = hard
+/// directly is unreliable on macOS where the hard limit reports as
+/// `RLIM_INFINITY` but the kernel caps allocation at
+/// `kern.maxfilesperproc`; clamping to a known-good value avoids the
+/// `setrlimit` rejection.
+#[cfg(unix)]
+fn raise_fd_limit() {
+    use nix::sys::resource::{getrlimit, setrlimit, Resource};
+    const TARGET: u64 = 8192;
+    match getrlimit(Resource::RLIMIT_NOFILE) {
+        Ok((soft, hard)) => {
+            let target = TARGET.min(hard).max(soft);
+            if target > soft {
+                if let Err(e) = setrlimit(Resource::RLIMIT_NOFILE, target, hard) {
+                    tracing::warn!("Failed to raise RLIMIT_NOFILE to {}: {}", target, e);
+                } else {
+                    info!(
+                        "Raised RLIMIT_NOFILE soft limit from {} to {}",
+                        soft, target
+                    );
+                }
+            }
+        }
+        Err(e) => tracing::warn!("Failed to read RLIMIT_NOFILE: {}", e),
+    }
+}
+
+#[cfg(not(unix))]
+fn raise_fd_limit() {}
+
 pub struct ServerConfig<'a> {
     pub profile: &'a str,
     pub host: &'a str,
@@ -304,6 +341,9 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         is_daemon,
         passphrase,
     } = config;
+
+    raise_fd_limit();
+
     let instances = load_all_instances()?;
 
     // Load or generate auth token

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -219,11 +219,15 @@ async fn handle_terminal_ws(
 
     let master = pair.master;
 
-    // Get reader and writer from the PTY master
+    // Get reader and writer from the PTY master. On failure we must kill
+    // and reap the child we just spawned, otherwise the tmux attach
+    // process and its slave PTY descriptor leak until exit.
     let mut reader = match master.try_clone_reader() {
         Ok(r) => r,
         Err(e) => {
             tracing::error!("Failed to clone PTY reader: {}", e);
+            let _ = child.kill();
+            let _ = child.wait();
             return;
         }
     };
@@ -232,6 +236,8 @@ async fn handle_terminal_ws(
         Ok(w) => w,
         Err(e) => {
             tracing::error!("Failed to take PTY writer: {}", e);
+            let _ = child.kill();
+            let _ = child.wait();
             return;
         }
     };


### PR DESCRIPTION
## Description

The web dashboard exhausts file descriptors under modest load (3 open session). Each WebSocket terminal session burns ~3 FDs (PTY master, cloned reader, writer) plus tokio plumbing, and macOS's default soft `RLIMIT_NOFILE` of 256 is hit quickly during reconnect bursts. The result is a flood of errors from `src/server/ws.rs`:

```
ERROR agent_of_empires::server::ws: Failed to spawn tmux attach: Too many open files (os error 24)
ERROR agent_of_empires::server::ws: Failed to open PTY: failed to openpty: Os { code: 24, kind: Uncategorized, message: "Too many open files" }
ERROR agent_of_empires::server::ws: Failed to spawn tmux attach: dup of fd 253 failed
ERROR agent_of_empires::server::api::sessions: Terminal creation failed: Too many open files (os error 24)
```

This PR:

1. **Raises `RLIMIT_NOFILE`** at `start_server` startup to `min(8192, hard)`. Clamping (rather than `soft = hard`) avoids macOS rejecting `setrlimit` when the hard limit is reported as `RLIM_INFINITY` but the kernel actually caps allocation at `kern.maxfilesperproc`.
2. **Fixes a latent child-process leak** in `handle_terminal_ws`: when `try_clone_reader` or `take_writer` fail after `spawn_command` succeeded, the function returned without `child.kill()`/`child.wait()`, orphaning the tmux attach process and its slave PTY FD. Now we kill and reap on those error paths.

Adds the `resource` feature to `nix` (already a dependency).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A — server-side fix)

Tested with `cargo build --features serve` and `cargo clippy --features serve --no-deps` (clean). The behavior was reproduced beforehand by running `aoe serve` against many parallel mobile terminal reconnects until the EMFILE flood appeared in `serve.log`; with the FD bump in place the flood disappears.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Diagnosis and fix drafted with Claude Code based on the EMFILE error trace. Reviewed and verified locally.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)