### PR TITLE
feat: multi-repo workspace support (project registry + pickers + dashboard)

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -33,6 +33,10 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe profile delete`↴](#aoe-profile-delete)
 * [`aoe profile rename`↴](#aoe-profile-rename)
 * [`aoe profile default`↴](#aoe-profile-default)
+* [`aoe project`↴](#aoe-project)
+* [`aoe project list`↴](#aoe-project-list)
+* [`aoe project add`↴](#aoe-project-add)
+* [`aoe project remove`↴](#aoe-project-remove)
 * [`aoe worktree`↴](#aoe-worktree)
 * [`aoe worktree list`↴](#aoe-worktree-list)
 * [`aoe worktree info`↴](#aoe-worktree-info)
@@ -72,6 +76,7 @@ Run without arguments to launch the TUI dashboard.
 * `session` — Manage session lifecycle (start, stop, attach, etc.)
 * `group` — Manage groups for organizing sessions
 * `profile` — Manage profiles (separate workspaces)
+* `project` — Manage the project registry used by multi-repo session pickers
 * `worktree` — Manage git worktrees for parallel development
 * `tmux` — tmux integration utilities
 * `sounds` — Manage sound effects for agent state transitions
@@ -109,6 +114,7 @@ Add a new session
 * `-w`, `--worktree <WORKTREE_BRANCH>` — Create session in a git worktree for the specified branch
 * `-b`, `--new-branch` — Create a new branch (use with --worktree)
 * `-r`, `--repo <EXTRA_REPOS>` — Additional repositories for multi-repo workspace (use with --worktree)
+* `--project <PROJECTS>` — Names of registered projects to include as extra repos (use with --worktree). Resolves against the union of global + profile project registries
 * `-s`, `--sandbox` — Run session in a container sandbox
 * `--sandbox-image <SANDBOX_IMAGE>` — Custom container image for sandbox (implies --sandbox)
 * `-y`, `--yolo` — Enable YOLO mode (skip permission prompts)
@@ -495,6 +501,81 @@ Show or set default profile
 ###### **Arguments:**
 
 * `<NAME>` — Profile name (optional, shows current if not provided)
+
+
+
+## `aoe project`
+
+Manage the project registry used by multi-repo session pickers
+
+**Usage:** `aoe project <COMMAND>`
+
+###### **Subcommands:**
+
+* `list` — List registered projects
+* `add` — Add a project to the registry
+* `remove` — Remove a project from the registry
+
+
+
+## `aoe project list`
+
+List registered projects
+
+**Usage:** `aoe project list [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Output as JSON
+* `--scope <SCOPE>` — Filter by scope (default: all)
+
+  Default value: `all`
+
+  Possible values: `all`, `global`, `profile`
+
+
+
+
+## `aoe project add`
+
+Add a project to the registry
+
+**Usage:** `aoe project add [OPTIONS] <PATH>`
+
+###### **Arguments:**
+
+* `<PATH>` — Path to the git repository
+
+###### **Options:**
+
+* `--name <NAME>` — Display name (defaults to the directory's basename)
+* `--scope <SCOPE>` — Registry scope. Default: GLOBAL (visible from every profile). Pass `--scope profile` to scope the entry to the current profile only
+
+  Default value: `global`
+
+  Possible values: `global`, `profile`
+
+
+
+
+## `aoe project remove`
+
+Remove a project from the registry
+
+**Usage:** `aoe project remove [OPTIONS] <NAME_OR_PATH>`
+
+###### **Arguments:**
+
+* `<NAME_OR_PATH>` — Project name or path to remove
+
+###### **Options:**
+
+* `--scope <SCOPE>` — Registry scope to remove from. Default: GLOBAL
+
+  Default value: `global`
+
+  Possible values: `global`, `profile`
+
 
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -555,6 +555,7 @@ Add a project to the registry
 
   Possible values: `global`, `profile`
 
+* `--allow-override` — Allow registering this path even if it already exists in the other scope. Without this flag the command errors when the same canonical path is already registered globally (when adding to profile) or in any profile (when adding globally). When override is allowed and both scopes hold the same path, the profile entry shadows the global one
 
 
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -549,9 +549,7 @@ Add a project to the registry
 ###### **Options:**
 
 * `--name <NAME>` — Display name (defaults to the directory's basename)
-* `--scope <SCOPE>` — Registry scope. Default: GLOBAL (visible from every profile). Pass `--scope profile` to scope the entry to the current profile only
-
-  Default value: `global`
+* `--scope <SCOPE>` — Registry scope. When omitted: defaults to GLOBAL, unless `-p <profile>` was passed at the top level, in which case it defaults to PROFILE (scoping the entry to that profile only)
 
   Possible values: `global`, `profile`
 
@@ -571,9 +569,7 @@ Remove a project from the registry
 
 ###### **Options:**
 
-* `--scope <SCOPE>` — Registry scope to remove from. Default: GLOBAL
-
-  Default value: `global`
+* `--scope <SCOPE>` — Registry scope to remove from. When omitted: defaults to GLOBAL, unless `-p <profile>` was passed at the top level, in which case it defaults to PROFILE
 
   Possible values: `global`, `profile`
 

--- a/docs/guides/multi-repo-workspaces.md
+++ b/docs/guides/multi-repo-workspaces.md
@@ -1,0 +1,137 @@
+# Multi-Repo Workspaces
+
+Run a single AoE session across several git repositories at once. Each repo gets its own worktree on a shared branch name, all rooted under one workspace directory, attached to one tmux session.
+
+Use this when a unit of work, a feature, a bug fix, an investigation, touches more than one repo and you want one agent driving all of them, not N agents you have to mentally reconcile.
+
+## When to Use
+
+| Scenario | Multi-repo? |
+|---|---|
+| Bug spans backend and frontend repos | Yes |
+| Refactor across an OSS core and a private wrapper | Yes |
+| Feature limited to a single repo | No, regular session |
+| Investigating logs that touch many repos | Yes, agent picks the relevant ones |
+| OSS core is pinned and rarely changes | Use [`on_create` hooks](repo-config.md) instead |
+
+## Quick Start
+
+### 1. Register your repos once
+
+```bash
+aoe project add /path/to/backend
+aoe project add /path/to/frontend
+aoe project add /path/to/shared-lib
+```
+
+`aoe project list` shows what is registered.
+
+### 2. Start a multi-repo session
+
+CLI:
+
+```bash
+aoe add /path/to/backend \
+  --project frontend \
+  --project shared-lib \
+  -w feat/auth-rewrite -b
+```
+
+TUI: open the new-session dialog (`n`), enter the worktree branch, focus the **Extra Repos** field, press `Ctrl+R`, and pick the registered projects you want to include.
+
+Web: `+ New session`, pick a primary repo, then click registered projects in the **Extra repos** picker (or paste a path with the free-text input).
+
+### 3. The agent sees one workspace
+
+The session starts in the workspace root with all the worktrees as siblings:
+
+```
+~/aoe-workspaces/feat-auth-rewrite/
+├── backend/      ← branch feat/auth-rewrite
+├── frontend/     ← branch feat/auth-rewrite
+└── shared-lib/   ← branch feat/auth-rewrite
+```
+
+The agent navigates between them like any normal multi-repo working tree. Use `cd` and standard git commands; AoE does not impose any cross-repo orchestration.
+
+## The Project Registry
+
+Saved repo paths the multi-repo pickers draw from. Two scopes:
+
+| Scope | File | Visibility |
+|---|---|---|
+| Global | `<app_dir>/projects.json` | Every profile |
+| Profile | `<app_dir>/profiles/{profile}/projects.json` | Only that profile |
+
+`<app_dir>` is `$XDG_CONFIG_HOME/agent-of-empires/` on Linux, `~/.agent-of-empires/` on macOS.
+
+When both scopes hold the same canonical path, the **profile entry wins** in merged views (this is how `--allow-override` is meant to be used: stage a profile-specific name on top of a global default).
+
+### Default scope
+
+| Invocation | Default scope |
+|---|---|
+| `aoe project add <path>` | Global |
+| `aoe -p <profile> project add <path>` | Profile |
+
+Pass `--scope global` or `--scope profile` to override.
+
+### Cross-scope collisions
+
+```bash
+aoe project add /repo/foo                     # global
+aoe -p other project add /repo/foo            # ERROR: same path in global scope
+aoe -p other project add /repo/foo --allow-override  # OK, profile shadows global
+```
+
+## CLI Reference
+
+```bash
+# List
+aoe project list                       # merged (global + active profile)
+aoe project list --scope global        # globals only
+aoe project list --scope profile       # active profile only
+aoe project list --json                # machine-readable
+
+# Add
+aoe project add /path/to/repo                          # global, name = basename
+aoe project add /path/to/repo --name shortname        # custom display name
+aoe project add /path/to/repo --scope profile         # profile-only
+aoe project add /path/to/repo --allow-override        # shadow other-scope entry
+
+# Remove
+aoe project remove backend                # by name (case-insensitive)
+aoe project remove /path/to/repo          # by canonical path
+aoe project remove backend --scope profile
+
+# Use in a session
+aoe add /path/to/primary --project name1 --project name2 -w branch -b
+aoe add /path/to/primary --repo /literal/path --project registered -w branch -b
+```
+
+`--repo` and `--project` may be mixed; the union is passed to the workspace builder. The builder rejects duplicate repo names, so the same repo via two paths is a hard error.
+
+`aoe list --json` includes a `workspace_repos` array for each session; the array is empty for single-repo sessions.
+
+## Web Dashboard
+
+The Projects page (folder icon in the sidebar footer) is full CRUD over the registry: add, remove, switch scope, opt into `allow_override`. Read-only servers (`aoe serve --read-only`) hide the destructive controls.
+
+The new-session wizard surfaces the registry as toggleable chips on the Project step. The free-text input still works for paths that aren't registered.
+
+Multi-repo sessions are bucketed into a single **Multi-repo** group at the bottom of the sidebar, regardless of which repo was chosen as the primary. Each session row shows a chip per repo under the title.
+
+## Limitations
+
+These are out of scope for the current release; tracked separately:
+
+- **One branch name per workspace**: every repo gets the same `-w <branch>` value. Per-repo branch names is a future feature.
+- **No agent-driven repo pull-in mid-session**: if the agent realizes it needs another repo, you have to start a new session. Tracked alongside the orchestrator work.
+- **No saved workspace templates** ("named bundles of repos"): each session picks the set fresh. If your bundle is fixed, register the repos and select them all from the picker.
+- **No per-repo PR tracking**: AoE does not track PRs today. Coordinated PR workflow happens outside AoE.
+
+## Related
+
+- [Worktrees Reference](worktrees.md) — how the per-repo worktrees are created.
+- [Repository Configuration & Hooks](repo-config.md) — `on_create` hooks for fixed sibling repos that don't need a registry entry.
+- [CLI Reference](../cli/reference.md) — full `aoe project` and `aoe add --project` flag listing.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -47,6 +47,11 @@ pub struct AddArgs {
     #[arg(long = "repo", short = 'r')]
     extra_repos: Vec<PathBuf>,
 
+    /// Names of registered projects to include as extra repos (use with --worktree).
+    /// Resolves against the union of global + profile project registries.
+    #[arg(long = "project")]
+    projects: Vec<String>,
+
     /// Run session in a container sandbox
     #[arg(short = 's', long)]
     sandbox: bool,
@@ -83,9 +88,22 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         bail!("Path is not a directory: {}", path.display());
     }
 
-    if !args.extra_repos.is_empty() && args.worktree_branch.is_none() {
-        bail!("--repo requires --worktree to specify a branch\nTip: aoe add /path --repo /other -w branch-name");
+    if (!args.extra_repos.is_empty() || !args.projects.is_empty()) && args.worktree_branch.is_none()
+    {
+        bail!("--repo/--project requires --worktree to specify a branch\nTip: aoe add /path --project repoB -w branch-name");
     }
+
+    let resolved_project_paths: Vec<PathBuf> = if args.projects.is_empty() {
+        Vec::new()
+    } else {
+        crate::session::projects::resolve_names(profile, &args.projects)?
+            .into_iter()
+            .map(|p| PathBuf::from(p.path))
+            .collect()
+    };
+    let mut all_extra_repos: Vec<PathBuf> = Vec::new();
+    all_extra_repos.extend(args.extra_repos.iter().cloned());
+    all_extra_repos.extend(resolved_project_paths);
 
     let config = repo_config::resolve_config_with_repo_or_warn(profile, &path);
 
@@ -104,10 +122,10 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
         let branch = branch_raw.trim();
 
-        if !args.extra_repos.is_empty() {
+        if !all_extra_repos.is_empty() {
             let ws_result = builder::create_workspace(
                 &path,
-                &args.extra_repos,
+                &all_extra_repos,
                 branch,
                 args.create_branch,
                 &config.worktree.workspace_path_template,

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -11,6 +11,7 @@ use super::group::GroupCommands;
 use super::init::InitArgs;
 use super::list::ListArgs;
 use super::profile::ProfileCommands;
+use super::project::ProjectCommands;
 use super::remove::RemoveArgs;
 use super::send::SendArgs;
 #[cfg(feature = "serve")]
@@ -85,6 +86,12 @@ pub enum Commands {
     Profile {
         #[command(subcommand)]
         command: Option<ProfileCommands>,
+    },
+
+    /// Manage the project registry used by multi-repo session pickers
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommands,
     },
 
     /// Manage git worktrees for parallel development

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -33,6 +33,32 @@ struct SessionJson {
     command: String,
     profile: String,
     created_at: chrono::DateTime<chrono::Utc>,
+    /// Empty for single-repo sessions; populated with one entry per repo
+    /// (including the primary) for sessions created with `--repo`/`--project`.
+    workspace_repos: Vec<WorkspaceRepoJson>,
+}
+
+#[derive(Serialize)]
+struct WorkspaceRepoJson {
+    name: String,
+    source_path: String,
+    branch: String,
+}
+
+fn workspace_repos_for(inst: &Instance) -> Vec<WorkspaceRepoJson> {
+    inst.workspace_info
+        .as_ref()
+        .map(|w| {
+            w.repos
+                .iter()
+                .map(|r| WorkspaceRepoJson {
+                    name: r.name.clone(),
+                    source_path: r.source_path.clone(),
+                    branch: r.branch.clone(),
+                })
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 fn print_table_header() {
@@ -93,6 +119,7 @@ pub async fn run(profile: &str, args: ListArgs) -> Result<()> {
                 command: inst.command.clone(),
                 profile: storage.profile().to_string(),
                 created_at: inst.created_at,
+                workspace_repos: workspace_repos_for(inst),
             })
             .collect();
         super::output::print_json(&sessions)?;
@@ -125,6 +152,7 @@ async fn run_all_profiles(json: bool) -> Result<()> {
             if let Ok(storage) = Storage::new(profile_name) {
                 if let Ok((instances, _)) = storage.load_with_groups() {
                     for inst in instances {
+                        let workspace_repos = workspace_repos_for(&inst);
                         all_sessions.push(SessionJson {
                             id: inst.id,
                             title: inst.title,
@@ -134,6 +162,7 @@ async fn run_all_profiles(json: bool) -> Result<()> {
                             command: inst.command,
                             profile: profile_name.clone(),
                             created_at: inst.created_at,
+                            workspace_repos,
                         });
                     }
                 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod init;
 pub mod list;
 pub mod output;
 pub mod profile;
+pub mod project;
 pub mod remove;
 pub mod send;
 #[cfg(feature = "serve")]

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -2,7 +2,7 @@
 //! multi-repo workspace pickers.
 
 use anyhow::{bail, Result};
-use clap::{Args, Subcommand, ValueEnum};
+use clap::{Args, Subcommand, ValueEnum, ValueHint};
 use serde::Serialize;
 use std::path::PathBuf;
 
@@ -51,6 +51,7 @@ pub enum ScopeArg {
 #[derive(Args)]
 pub struct ProjectAddArgs {
     /// Path to the git repository
+    #[arg(value_hint = ValueHint::DirPath)]
     path: PathBuf,
 
     /// Display name (defaults to the directory's basename)
@@ -74,6 +75,7 @@ pub struct ProjectAddArgs {
 #[derive(Args)]
 pub struct ProjectRemoveArgs {
     /// Project name or path to remove
+    #[arg(value_hint = ValueHint::AnyPath)]
     name_or_path: String,
 
     /// Registry scope to remove from. Default: GLOBAL.

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -1,0 +1,174 @@
+//! `aoe project` subcommands: manage the project registry used by the
+//! multi-repo workspace pickers.
+
+use anyhow::{bail, Result};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::Serialize;
+use std::path::PathBuf;
+
+use crate::git::GitWorktree;
+use crate::session::projects;
+use crate::session::{Project, ProjectScope};
+
+#[derive(Subcommand)]
+pub enum ProjectCommands {
+    /// List registered projects
+    #[command(alias = "ls")]
+    List(ProjectListArgs),
+
+    /// Add a project to the registry
+    Add(ProjectAddArgs),
+
+    /// Remove a project from the registry
+    #[command(alias = "rm")]
+    Remove(ProjectRemoveArgs),
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum ScopeFilter {
+    All,
+    Global,
+    Profile,
+}
+
+#[derive(Args)]
+pub struct ProjectListArgs {
+    /// Output as JSON
+    #[arg(long)]
+    json: bool,
+
+    /// Filter by scope (default: all)
+    #[arg(long, value_enum, default_value_t = ScopeFilter::All)]
+    scope: ScopeFilter,
+}
+
+#[derive(Copy, Clone, Debug, ValueEnum)]
+pub enum ScopeArg {
+    Global,
+    Profile,
+}
+
+#[derive(Args)]
+pub struct ProjectAddArgs {
+    /// Path to the git repository
+    path: PathBuf,
+
+    /// Display name (defaults to the directory's basename)
+    #[arg(long)]
+    name: Option<String>,
+
+    /// Registry scope. Default: GLOBAL (visible from every profile).
+    /// Pass `--scope profile` to scope the entry to the current profile only.
+    #[arg(long, value_enum, default_value_t = ScopeArg::Global)]
+    scope: ScopeArg,
+}
+
+#[derive(Args)]
+pub struct ProjectRemoveArgs {
+    /// Project name or path to remove
+    name_or_path: String,
+
+    /// Registry scope to remove from. Default: GLOBAL.
+    #[arg(long, value_enum, default_value_t = ScopeArg::Global)]
+    scope: ScopeArg,
+}
+
+#[derive(Serialize)]
+struct ProjectInfo {
+    name: String,
+    path: String,
+    scope: String,
+}
+
+pub async fn run(profile: &str, command: ProjectCommands) -> Result<()> {
+    match command {
+        ProjectCommands::List(args) => list(profile, args).await,
+        ProjectCommands::Add(args) => add(profile, args).await,
+        ProjectCommands::Remove(args) => remove(profile, args).await,
+    }
+}
+
+async fn list(profile: &str, args: ProjectListArgs) -> Result<()> {
+    let entries: Vec<Project> = match args.scope {
+        ScopeFilter::All => projects::load_merged(profile)?,
+        ScopeFilter::Global => projects::load_global()?,
+        ScopeFilter::Profile => projects::load_profile(profile)?,
+    };
+
+    if args.json {
+        let info: Vec<ProjectInfo> = entries
+            .iter()
+            .map(|p| ProjectInfo {
+                name: p.name.clone(),
+                path: p.path.clone(),
+                scope: p.scope.as_str().to_string(),
+            })
+            .collect();
+        super::output::print_json(&info)?;
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!("No projects registered.");
+        println!("Add one with: aoe project add <path>");
+        return Ok(());
+    }
+
+    println!("Projects:\n");
+    for p in &entries {
+        println!("  • {} [{}]  {}", p.name, p.scope.as_str(), p.path);
+    }
+    println!("\nTotal: {} projects", entries.len());
+    Ok(())
+}
+
+async fn add(profile: &str, args: ProjectAddArgs) -> Result<()> {
+    let scope = match args.scope {
+        ScopeArg::Global => ProjectScope::Global,
+        ScopeArg::Profile => ProjectScope::Profile,
+    };
+
+    let canonical = args
+        .path
+        .canonicalize()
+        .unwrap_or_else(|_| args.path.clone());
+    if !GitWorktree::is_git_repo(&canonical) {
+        bail!(
+            "Path is not a git repository: {}\n\
+             Tip: pass the path to a repo's working tree (or a linked worktree)",
+            canonical.display()
+        );
+    }
+
+    let name = args.name.unwrap_or_else(|| {
+        canonical
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "project".to_string())
+    });
+
+    let project = Project::new(name.clone(), canonical.to_string_lossy(), scope);
+    let saved = projects::add(profile, scope, project)?;
+    println!(
+        "✓ Registered project '{}' [{}] at {}",
+        saved.name,
+        scope.as_str(),
+        saved.path
+    );
+    Ok(())
+}
+
+async fn remove(profile: &str, args: ProjectRemoveArgs) -> Result<()> {
+    let scope = match args.scope {
+        ScopeArg::Global => ProjectScope::Global,
+        ScopeArg::Profile => ProjectScope::Profile,
+    };
+    let removed = projects::remove(profile, scope, &args.name_or_path)?;
+    println!(
+        "✓ Removed project '{}' [{}] (was at {})",
+        removed.name,
+        scope.as_str(),
+        removed.path
+    );
+    Ok(())
+}

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -58,10 +58,11 @@ pub struct ProjectAddArgs {
     #[arg(long)]
     name: Option<String>,
 
-    /// Registry scope. Default: GLOBAL (visible from every profile).
-    /// Pass `--scope profile` to scope the entry to the current profile only.
-    #[arg(long, value_enum, default_value_t = ScopeArg::Global)]
-    scope: ScopeArg,
+    /// Registry scope. When omitted: defaults to GLOBAL, unless `-p <profile>`
+    /// was passed at the top level, in which case it defaults to PROFILE
+    /// (scoping the entry to that profile only).
+    #[arg(long, value_enum)]
+    scope: Option<ScopeArg>,
 
     /// Allow registering this path even if it already exists in the other
     /// scope. Without this flag the command errors when the same canonical
@@ -78,9 +79,11 @@ pub struct ProjectRemoveArgs {
     #[arg(value_hint = ValueHint::AnyPath)]
     name_or_path: String,
 
-    /// Registry scope to remove from. Default: GLOBAL.
-    #[arg(long, value_enum, default_value_t = ScopeArg::Global)]
-    scope: ScopeArg,
+    /// Registry scope to remove from. When omitted: defaults to GLOBAL,
+    /// unless `-p <profile>` was passed at the top level, in which case it
+    /// defaults to PROFILE.
+    #[arg(long, value_enum)]
+    scope: Option<ScopeArg>,
 }
 
 #[derive(Serialize)]
@@ -90,11 +93,19 @@ struct ProjectInfo {
     scope: String,
 }
 
-pub async fn run(profile: &str, command: ProjectCommands) -> Result<()> {
+pub async fn run(profile: &str, profile_explicit: bool, command: ProjectCommands) -> Result<()> {
     match command {
         ProjectCommands::List(args) => list(profile, args).await,
-        ProjectCommands::Add(args) => add(profile, args).await,
-        ProjectCommands::Remove(args) => remove(profile, args).await,
+        ProjectCommands::Add(args) => add(profile, profile_explicit, args).await,
+        ProjectCommands::Remove(args) => remove(profile, profile_explicit, args).await,
+    }
+}
+
+fn resolve_default_scope(profile_explicit: bool) -> ProjectScope {
+    if profile_explicit {
+        ProjectScope::Profile
+    } else {
+        ProjectScope::Global
     }
 }
 
@@ -137,10 +148,11 @@ async fn list(profile: &str, args: ProjectListArgs) -> Result<()> {
     Ok(())
 }
 
-async fn add(profile: &str, args: ProjectAddArgs) -> Result<()> {
+async fn add(profile: &str, profile_explicit: bool, args: ProjectAddArgs) -> Result<()> {
     let scope = match args.scope {
-        ScopeArg::Global => ProjectScope::Global,
-        ScopeArg::Profile => ProjectScope::Profile,
+        Some(ScopeArg::Global) => ProjectScope::Global,
+        Some(ScopeArg::Profile) => ProjectScope::Profile,
+        None => resolve_default_scope(profile_explicit),
     };
 
     let canonical = args
@@ -174,10 +186,11 @@ async fn add(profile: &str, args: ProjectAddArgs) -> Result<()> {
     Ok(())
 }
 
-async fn remove(profile: &str, args: ProjectRemoveArgs) -> Result<()> {
+async fn remove(profile: &str, profile_explicit: bool, args: ProjectRemoveArgs) -> Result<()> {
     let scope = match args.scope {
-        ScopeArg::Global => ProjectScope::Global,
-        ScopeArg::Profile => ProjectScope::Profile,
+        Some(ScopeArg::Global) => ProjectScope::Global,
+        Some(ScopeArg::Profile) => ProjectScope::Profile,
+        None => resolve_default_scope(profile_explicit),
     };
     let removed = projects::remove(profile, scope, &args.name_or_path)?;
     println!(

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -61,6 +61,14 @@ pub struct ProjectAddArgs {
     /// Pass `--scope profile` to scope the entry to the current profile only.
     #[arg(long, value_enum, default_value_t = ScopeArg::Global)]
     scope: ScopeArg,
+
+    /// Allow registering this path even if it already exists in the other
+    /// scope. Without this flag the command errors when the same canonical
+    /// path is already registered globally (when adding to profile) or in any
+    /// profile (when adding globally). When override is allowed and both
+    /// scopes hold the same path, the profile entry shadows the global one.
+    #[arg(long)]
+    allow_override: bool,
 }
 
 #[derive(Args)]
@@ -148,7 +156,7 @@ async fn add(profile: &str, args: ProjectAddArgs) -> Result<()> {
     });
 
     let project = Project::new(name.clone(), canonical.to_string_lossy(), scope);
-    let saved = projects::add(profile, scope, project)?;
+    let saved = projects::add(profile, scope, project, args.allow_override)?;
     println!(
         "✓ Registered project '{}' [{}] at {}",
         saved.name,

--- a/src/cli/project.rs
+++ b/src/cli/project.rs
@@ -128,7 +128,12 @@ async fn list(profile: &str, args: ProjectListArgs) -> Result<()> {
     for p in &entries {
         println!("  • {} [{}]  {}", p.name, p.scope.as_str(), p.path);
     }
-    println!("\nTotal: {} projects", entries.len());
+    let n = entries.len();
+    println!(
+        "\nTotal: {} {}",
+        n,
+        if n == 1 { "project" } else { "projects" }
+    );
     Ok(())
 }
 
@@ -145,7 +150,8 @@ async fn add(profile: &str, args: ProjectAddArgs) -> Result<()> {
     if !GitWorktree::is_git_repo(&canonical) {
         bail!(
             "Path is not a git repository: {}\n\
-             Tip: pass the path to a repo's working tree (or a linked worktree)",
+             Tip: pass the path to a directory that contains a `.git` folder \
+             (i.e. the root of a cloned repository).",
             canonical.display()
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ async fn main() -> Result<()> {
         Some(Commands::Session { command }) => cli::session::run(&profile, command).await,
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
         Some(Commands::Profile { command }) => cli::profile::run(command).await,
+        Some(Commands::Project { command }) => cli::project::run(&profile, command).await,
         Some(Commands::Worktree { command }) => cli::worktree::run(&profile, command).await,
         #[cfg(feature = "serve")]
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ async fn main() -> Result<()> {
         _ => {}
     }
 
+    let profile_explicit = cli.profile.is_some();
     let profile = cli.profile.unwrap_or_default();
 
     // TUI mode handles migrations with a spinner; CLI runs them silently
@@ -109,7 +110,9 @@ async fn main() -> Result<()> {
         Some(Commands::Session { command }) => cli::session::run(&profile, command).await,
         Some(Commands::Group { command }) => cli::group::run(&profile, command).await,
         Some(Commands::Profile { command }) => cli::profile::run(command).await,
-        Some(Commands::Project { command }) => cli::project::run(&profile, command).await,
+        Some(Commands::Project { command }) => {
+            cli::project::run(&profile, profile_explicit, command).await
+        }
         Some(Commands::Worktree { command }) => cli::worktree::run(&profile, command).await,
         #[cfg(feature = "serve")]
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -11,10 +11,12 @@
 pub(super) use super::AppState;
 
 mod git;
+mod projects;
 mod sessions;
 mod system;
 
 pub use git::{clone_repo, list_branches};
+pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     list_sessions, read_output, rename_session, send_message, session_diff_file,

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -84,6 +84,11 @@ pub struct CreateProjectBody {
     /// "global" (default) or "profile".
     #[serde(default)]
     pub scope: Option<String>,
+    /// When true, allow registering this path even if it already exists in
+    /// the other scope. Defaults to false; cross-scope path collisions
+    /// otherwise return 409.
+    #[serde(default)]
+    pub allow_override: bool,
 }
 
 pub async fn create_project(
@@ -136,7 +141,7 @@ pub async fn create_project(
     });
 
     let project = Project::new(name, canonical.to_string_lossy(), scope);
-    match projects::add(&state.profile, scope, project) {
+    match projects::add(&state.profile, scope, project, body.allow_override) {
         Ok(saved) => (StatusCode::CREATED, Json(ProjectResponse::from(saved))).into_response(),
         Err(e) => (
             StatusCode::CONFLICT,

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -1,0 +1,194 @@
+//! Web CRUD for the project registry. Backs the dashboard's Projects page
+//! and feeds the session-creation wizard's multi-select picker.
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::git::GitWorktree;
+use crate::session::projects;
+use crate::session::{Project, ProjectScope};
+
+use super::AppState;
+
+#[derive(Serialize)]
+pub struct ProjectResponse {
+    pub name: String,
+    pub path: String,
+    pub scope: String,
+}
+
+impl From<Project> for ProjectResponse {
+    fn from(p: Project) -> Self {
+        Self {
+            name: p.name,
+            path: p.path,
+            scope: p.scope.as_str().to_string(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+pub struct ListQuery {
+    /// Optional scope filter: "global", "profile", or omitted (= all).
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+pub async fn list_projects(
+    State(state): State<Arc<AppState>>,
+    Query(q): Query<ListQuery>,
+) -> impl IntoResponse {
+    let result: anyhow::Result<Vec<Project>> = match q.scope.as_deref() {
+        Some("global") => projects::load_global(),
+        Some("profile") => projects::load_profile(&state.profile),
+        Some(other) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_scope",
+                    "message": format!("Unknown scope '{}'. Use 'global', 'profile', or omit.", other),
+                })),
+            )
+                .into_response();
+        }
+        None => projects::load_merged(&state.profile),
+    };
+
+    match result {
+        Ok(list) => Json(
+            list.into_iter()
+                .map(ProjectResponse::from)
+                .collect::<Vec<_>>(),
+        )
+        .into_response(),
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "load_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct CreateProjectBody {
+    pub path: String,
+    #[serde(default)]
+    pub name: Option<String>,
+    /// "global" (default) or "profile".
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+pub async fn create_project(
+    State(state): State<Arc<AppState>>,
+    Json(body): Json<CreateProjectBody>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+
+    let scope = match body.scope.as_deref() {
+        Some("profile") => ProjectScope::Profile,
+        Some("global") | None => ProjectScope::Global,
+        Some(other) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_scope",
+                    "message": format!("Unknown scope '{}'. Use 'global' or 'profile'.", other),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let path_buf = std::path::PathBuf::from(&body.path);
+    let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
+    if !GitWorktree::is_git_repo(&canonical) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "not_a_git_repo",
+                "message": format!("Path is not a git repository: {}", canonical.display()),
+            })),
+        )
+            .into_response();
+    }
+
+    let name = body.name.unwrap_or_else(|| {
+        canonical
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "project".to_string())
+    });
+
+    let project = Project::new(name, canonical.to_string_lossy(), scope);
+    match projects::add(&state.profile, scope, project) {
+        Ok(saved) => (StatusCode::CREATED, Json(ProjectResponse::from(saved))).into_response(),
+        Err(e) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "add_failed", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct DeleteQuery {
+    /// "global" (default) or "profile".
+    #[serde(default)]
+    pub scope: Option<String>,
+}
+
+pub async fn delete_project(
+    State(state): State<Arc<AppState>>,
+    Path(name): Path<String>,
+    Query(q): Query<DeleteQuery>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(
+                serde_json::json!({"error": "read_only", "message": "Server is in read-only mode"}),
+            ),
+        )
+            .into_response();
+    }
+
+    let scope = match q.scope.as_deref() {
+        Some("profile") => ProjectScope::Profile,
+        Some("global") | None => ProjectScope::Global,
+        Some(other) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "bad_scope",
+                    "message": format!("Unknown scope '{}'. Use 'global' or 'profile'.", other),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    match projects::remove(&state.profile, scope, &name) {
+        Ok(removed) => (StatusCode::OK, Json(ProjectResponse::from(removed))).into_response(),
+        Err(e) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found", "message": e.to_string()})),
+        )
+            .into_response(),
+    }
+}

--- a/src/server/api/projects.rs
+++ b/src/server/api/projects.rs
@@ -12,7 +12,7 @@ use axum::{
 use serde::{Deserialize, Serialize};
 
 use crate::git::GitWorktree;
-use crate::session::projects;
+use crate::session::projects::{self, RegistryError};
 use crate::session::{Project, ProjectScope};
 
 use super::AppState;
@@ -143,8 +143,18 @@ pub async fn create_project(
     let project = Project::new(name, canonical.to_string_lossy(), scope);
     match projects::add(&state.profile, scope, project, body.allow_override) {
         Ok(saved) => (StatusCode::CREATED, Json(ProjectResponse::from(saved))).into_response(),
-        Err(e) => (
+        Err(RegistryError::Conflict(msg)) => (
             StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "conflict", "message": msg})),
+        )
+            .into_response(),
+        Err(RegistryError::NotFound(msg)) => (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({"error": "not_found", "message": msg})),
+        )
+            .into_response(),
+        Err(RegistryError::Other(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "add_failed", "message": e.to_string()})),
         )
             .into_response(),
@@ -190,9 +200,19 @@ pub async fn delete_project(
 
     match projects::remove(&state.profile, scope, &name) {
         Ok(removed) => (StatusCode::OK, Json(ProjectResponse::from(removed))).into_response(),
-        Err(e) => (
+        Err(RegistryError::NotFound(msg)) => (
             StatusCode::NOT_FOUND,
-            Json(serde_json::json!({"error": "not_found", "message": e.to_string()})),
+            Json(serde_json::json!({"error": "not_found", "message": msg})),
+        )
+            .into_response(),
+        Err(RegistryError::Conflict(msg)) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({"error": "conflict", "message": msg})),
+        )
+            .into_response(),
+        Err(RegistryError::Other(e)) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "remove_failed", "message": e.to_string()})),
         )
             .into_response(),
     }

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -51,6 +51,17 @@ pub struct SessionResponse {
     /// `~/.claude/settings.json`). The web client uses this to skip
     /// scrollback-tracking workarounds that target tmux copy-mode.
     pub claude_fullscreen: bool,
+    /// Repos in the multi-repo workspace (empty for single-repo sessions).
+    /// Each entry mirrors `WorkspaceRepo` minus paths the dashboard does
+    /// not need to display.
+    pub workspace_repos: Vec<WorkspaceRepoSummary>,
+}
+
+#[derive(Serialize, Clone)]
+pub struct WorkspaceRepoSummary {
+    pub name: String,
+    pub source_path: String,
+    pub branch: String,
 }
 
 #[derive(Serialize, Clone)]
@@ -102,6 +113,20 @@ impl SessionResponse {
             notify_on_idle: inst.notify_on_idle,
             notify_on_error: inst.notify_on_error,
             claude_fullscreen: claude_fullscreen && inst.tool == "claude",
+            workspace_repos: inst
+                .workspace_info
+                .as_ref()
+                .map(|w| {
+                    w.repos
+                        .iter()
+                        .map(|r| WorkspaceRepoSummary {
+                            name: r.name.clone(),
+                            source_path: r.source_path.clone(),
+                            branch: r.branch.clone(),
+                        })
+                        .collect()
+                })
+                .unwrap_or_default(),
         }
     }
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -799,6 +799,11 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/git/branches", get(api::list_branches))
         .route("/api/git/clone", post(api::clone_repo))
         .route("/api/groups", get(api::list_groups))
+        .route(
+            "/api/projects",
+            get(api::list_projects).post(api::create_project),
+        )
+        .route("/api/projects/{name}", delete(api::delete_project))
         .route("/api/docker/status", get(api::docker_status))
         // Settings + themes
         .route(

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -11,6 +11,7 @@ mod groups;
 mod instance;
 pub mod poller;
 pub mod profile_config;
+pub mod projects;
 pub mod repo_config;
 pub(crate) mod serde_helpers;
 mod storage;
@@ -36,6 +37,7 @@ pub use profile_config::{
     SandboxConfigOverride, SessionConfigOverride, ThemeConfigOverride, TmuxConfigOverride,
     UpdatesConfigOverride, WorktreeConfigOverride,
 };
+pub use projects::{Project, ProjectScope};
 pub use repo_config::{
     check_hook_trust, execute_hooks, execute_hooks_in_container, load_repo_config,
     merge_repo_config, profile_to_repo_config, repo_config_to_profile, resolve_config_with_repo,

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -141,9 +141,20 @@ pub fn save_scope(profile: &str, scope: ProjectScope, projects: &[Project]) -> R
     write_file(&path, projects)
 }
 
-/// Append a project to the given scope. Errors if a project with the same name
-/// or canonical path already exists in that scope.
-pub fn add(profile: &str, scope: ProjectScope, mut project: Project) -> Result<Project> {
+/// Append a project to the given scope.
+///
+/// Errors if:
+/// - a project with the same name or canonical path already exists in the
+///   target scope (always; overriding within a scope makes no sense), or
+/// - the canonical path already exists in the *other* scope and
+///   `allow_override` is false. Pass `allow_override = true` to deliberately
+///   shadow a global entry from a profile (or vice versa).
+pub fn add(
+    profile: &str,
+    scope: ProjectScope,
+    mut project: Project,
+    allow_override: bool,
+) -> Result<Project> {
     project.scope = scope;
     let path_buf = PathBuf::from(&project.path);
     let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
@@ -169,6 +180,31 @@ pub fn add(profile: &str, scope: ProjectScope, mut project: Project) -> Result<P
                 p.name,
                 scope.as_str()
             );
+        }
+    }
+
+    if !allow_override {
+        let other_scope = match scope {
+            ProjectScope::Global => ProjectScope::Profile,
+            ProjectScope::Profile => ProjectScope::Global,
+        };
+        let other = match other_scope {
+            ProjectScope::Global => load_global().unwrap_or_default(),
+            ProjectScope::Profile => load_profile(profile).unwrap_or_default(),
+        };
+        for p in &other {
+            if canonical_key(&p.path) == canonical_key(&project.path) {
+                bail!(
+                    "Path '{}' is already registered as '{}' in {} scope.\n\
+                     Tip: remove it first with `aoe project remove {} --scope {}`,\n\
+                     or pass `--allow-override` to keep both entries (the profile entry shadows the global entry in merged views).",
+                    project.path,
+                    p.name,
+                    other_scope.as_str(),
+                    p.name,
+                    other_scope.as_str(),
+                );
+            }
         }
     }
 
@@ -247,6 +283,7 @@ mod tests {
             "default",
             ProjectScope::Global,
             Project::new("repoA", repo.to_string_lossy(), ProjectScope::Global),
+            false,
         )?;
 
         let loaded = load_global()?;
@@ -268,6 +305,7 @@ mod tests {
             "default",
             ProjectScope::Global,
             Project::new("global-name", repo.to_string_lossy(), ProjectScope::Global),
+            false,
         )?;
         add(
             "default",
@@ -277,6 +315,7 @@ mod tests {
                 repo.to_string_lossy(),
                 ProjectScope::Profile,
             ),
+            true,
         )?;
 
         let merged = load_merged("default")?;
@@ -300,13 +339,55 @@ mod tests {
             "default",
             ProjectScope::Global,
             Project::new("dup", repo1.to_string_lossy(), ProjectScope::Global),
+            false,
         )?;
         let err = add(
             "default",
             ProjectScope::Global,
             Project::new("dup", repo2.to_string_lossy(), ProjectScope::Global),
+            false,
         );
         assert!(err.is_err());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn cross_scope_path_collision_blocked_by_default() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoZ");
+        let _ = git2::Repository::init(&repo);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("first", repo.to_string_lossy(), ProjectScope::Global),
+            false,
+        )?;
+        let err = add(
+            "default",
+            ProjectScope::Profile,
+            Project::new("second", repo.to_string_lossy(), ProjectScope::Profile),
+            false,
+        );
+        assert!(
+            err.is_err(),
+            "cross-scope dup should error without override"
+        );
+        let msg = format!("{}", err.unwrap_err());
+        assert!(
+            msg.contains("--allow-override") && msg.contains("global"),
+            "error should mention --allow-override and the other scope, got: {msg}"
+        );
+
+        // With override, succeeds.
+        add(
+            "default",
+            ProjectScope::Profile,
+            Project::new("second", repo.to_string_lossy(), ProjectScope::Profile),
+            true,
+        )?;
         Ok(())
     }
 
@@ -332,6 +413,7 @@ mod tests {
             "default",
             ProjectScope::Global,
             Project::new("repoR", repo.to_string_lossy(), ProjectScope::Global),
+            false,
         )?;
         let removed = remove("default", ProjectScope::Global, "repoR")?;
         assert_eq!(removed.name, "repoR");

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -166,11 +166,12 @@ pub fn add(
     };
 
     for p in &existing {
-        if p.name == project.name {
+        if p.name.eq_ignore_ascii_case(&project.name) {
             bail!(
-                "Project '{}' already registered in {} scope",
+                "Project '{}' already registered in {} scope (as '{}')",
                 project.name,
-                scope.as_str()
+                scope.as_str(),
+                p.name,
             );
         }
         if canonical_key(&p.path) == canonical_key(&project.path) {
@@ -224,7 +225,9 @@ pub fn remove(profile: &str, scope: ProjectScope, name_or_path: &str) -> Result<
     let canonical_target = canonical_key(name_or_path);
     let idx = existing
         .iter()
-        .position(|p| p.name == name_or_path || canonical_key(&p.path) == canonical_target)
+        .position(|p| {
+            p.name.eq_ignore_ascii_case(name_or_path) || canonical_key(&p.path) == canonical_target
+        })
         .ok_or_else(|| {
             anyhow::anyhow!("No project '{}' in {} scope", name_or_path, scope.as_str())
         })?;
@@ -242,18 +245,21 @@ pub fn resolve_names(profile: &str, names: &[String]) -> Result<Vec<Project>> {
     let merged = load_merged(profile)?;
     let mut resolved = Vec::with_capacity(names.len());
     for name in names {
-        let project = merged.iter().find(|p| p.name == *name).ok_or_else(|| {
-            let available: Vec<String> = merged.iter().map(|p| p.name.clone()).collect();
-            anyhow::anyhow!(
-                "Unknown project '{}'. Available: {}",
-                name,
-                if available.is_empty() {
-                    "<none registered>".to_string()
-                } else {
-                    available.join(", ")
-                }
-            )
-        })?;
+        let project = merged
+            .iter()
+            .find(|p| p.name.eq_ignore_ascii_case(name))
+            .ok_or_else(|| {
+                let available: Vec<String> = merged.iter().map(|p| p.name.clone()).collect();
+                anyhow::anyhow!(
+                    "Unknown project '{}'. Available: {}",
+                    name,
+                    if available.is_empty() {
+                        "<none registered>".to_string()
+                    } else {
+                        available.join(", ")
+                    }
+                )
+            })?;
         resolved.push(project.clone());
     }
     Ok(resolved)
@@ -348,6 +354,43 @@ mod tests {
             false,
         );
         assert!(err.is_err());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn name_matching_is_case_insensitive() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo1 = temp.path().join("Mixed");
+        let repo2 = temp.path().join("Other");
+        let _ = git2::Repository::init(&repo1);
+        let _ = git2::Repository::init(&repo2);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("MixedCase", repo1.to_string_lossy(), ProjectScope::Global),
+            false,
+        )?;
+
+        // Add with same name, different case → rejected.
+        let err = add(
+            "default",
+            ProjectScope::Global,
+            Project::new("mixedcase", repo2.to_string_lossy(), ProjectScope::Global),
+            false,
+        );
+        assert!(err.is_err(), "duplicate name (different case) should error");
+
+        // Resolve via lowercase finds the original.
+        let resolved = resolve_names("default", &["MIXEDCASE".to_string()])?;
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "MixedCase");
+
+        // Remove via lowercase succeeds.
+        let removed = remove("default", ProjectScope::Global, "mixedcase")?;
+        assert_eq!(removed.name, "MixedCase");
         Ok(())
     }
 

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -3,13 +3,46 @@
 //! - Global: `<app_dir>/projects.json`, visible from every profile.
 //! - Profile: `<app_dir>/profiles/{profile}/projects.json`, visible only inside that profile.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use thiserror::Error;
 use tracing::warn;
 
 use super::{get_app_dir, get_profile_dir};
+
+/// Distinct failure modes for registry mutations. The web layer maps these to
+/// HTTP status codes (Conflict → 409, NotFound → 404, Other → 500); CLI/TUI
+/// callers convert via `Into<anyhow::Error>` and surface the message verbatim.
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    /// A project with the same name or canonical path already exists in the
+    /// target scope, or in the other scope when `allow_override` is false.
+    #[error("{0}")]
+    Conflict(String),
+
+    /// `remove` could not find a project matching the given name or path in
+    /// the requested scope.
+    #[error("{0}")]
+    NotFound(String),
+
+    /// Any other failure (I/O, JSON parse, missing app dir).
+    #[error(transparent)]
+    Other(#[from] anyhow::Error),
+}
+
+impl From<std::io::Error> for RegistryError {
+    fn from(e: std::io::Error) -> Self {
+        RegistryError::Other(e.into())
+    }
+}
+
+impl From<serde_json::Error> for RegistryError {
+    fn from(e: serde_json::Error) -> Self {
+        RegistryError::Other(e.into())
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -154,33 +187,33 @@ pub fn add(
     scope: ProjectScope,
     mut project: Project,
     allow_override: bool,
-) -> Result<Project> {
+) -> std::result::Result<Project, RegistryError> {
     project.scope = scope;
     let path_buf = PathBuf::from(&project.path);
     let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
     project.path = canonical.to_string_lossy().to_string();
 
     let mut existing = match scope {
-        ProjectScope::Global => load_global()?,
-        ProjectScope::Profile => load_profile(profile)?,
+        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
+        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
     };
 
     for p in &existing {
         if p.name.eq_ignore_ascii_case(&project.name) {
-            bail!(
+            return Err(RegistryError::Conflict(format!(
                 "Project '{}' already registered in {} scope (as '{}')",
                 project.name,
                 scope.as_str(),
                 p.name,
-            );
+            )));
         }
         if canonical_key(&p.path) == canonical_key(&project.path) {
-            bail!(
+            return Err(RegistryError::Conflict(format!(
                 "Path '{}' already registered as '{}' in {} scope",
                 project.path,
                 p.name,
                 scope.as_str()
-            );
+            )));
         }
     }
 
@@ -195,7 +228,7 @@ pub fn add(
         };
         for p in &other {
             if canonical_key(&p.path) == canonical_key(&project.path) {
-                bail!(
+                return Err(RegistryError::Conflict(format!(
                     "Path '{}' is already registered as '{}' in {} scope.\n\
                      Tip: remove it first with `aoe project remove {} --scope {}`,\n\
                      or pass `--allow-override` to keep both entries (the profile entry shadows the global entry in merged views).",
@@ -204,22 +237,26 @@ pub fn add(
                     other_scope.as_str(),
                     p.name,
                     other_scope.as_str(),
-                );
+                )));
             }
         }
     }
 
     existing.push(project.clone());
-    save_scope(profile, scope, &existing)?;
+    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
     Ok(project)
 }
 
 /// Remove the entry matching `name_or_path` from the given scope. Returns the
 /// removed project, or errors if no match was found.
-pub fn remove(profile: &str, scope: ProjectScope, name_or_path: &str) -> Result<Project> {
+pub fn remove(
+    profile: &str,
+    scope: ProjectScope,
+    name_or_path: &str,
+) -> std::result::Result<Project, RegistryError> {
     let mut existing = match scope {
-        ProjectScope::Global => load_global()?,
-        ProjectScope::Profile => load_profile(profile)?,
+        ProjectScope::Global => load_global().map_err(RegistryError::Other)?,
+        ProjectScope::Profile => load_profile(profile).map_err(RegistryError::Other)?,
     };
 
     let canonical_target = canonical_key(name_or_path);
@@ -229,10 +266,14 @@ pub fn remove(profile: &str, scope: ProjectScope, name_or_path: &str) -> Result<
             p.name.eq_ignore_ascii_case(name_or_path) || canonical_key(&p.path) == canonical_target
         })
         .ok_or_else(|| {
-            anyhow::anyhow!("No project '{}' in {} scope", name_or_path, scope.as_str())
+            RegistryError::NotFound(format!(
+                "No project '{}' in {} scope",
+                name_or_path,
+                scope.as_str()
+            ))
         })?;
     let removed = existing.remove(idx);
-    save_scope(profile, scope, &existing)?;
+    save_scope(profile, scope, &existing).map_err(RegistryError::Other)?;
     Ok(removed)
 }
 

--- a/src/session/projects.rs
+++ b/src/session/projects.rs
@@ -1,0 +1,342 @@
+//! Project registry: saved repo paths the user can pick from when creating
+//! a multi-repo session. Two scopes:
+//! - Global: `<app_dir>/projects.json`, visible from every profile.
+//! - Profile: `<app_dir>/profiles/{profile}/projects.json`, visible only inside that profile.
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+use tracing::warn;
+
+use super::{get_app_dir, get_profile_dir};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProjectScope {
+    Global,
+    Profile,
+}
+
+impl ProjectScope {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ProjectScope::Global => "global",
+            ProjectScope::Profile => "profile",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Project {
+    pub name: String,
+    pub path: String,
+    /// Populated by the loader; not persisted.
+    #[serde(skip, default = "default_scope")]
+    pub scope: ProjectScope,
+}
+
+fn default_scope() -> ProjectScope {
+    ProjectScope::Global
+}
+
+impl Project {
+    pub fn new(name: impl Into<String>, path: impl Into<String>, scope: ProjectScope) -> Self {
+        Self {
+            name: name.into(),
+            path: path.into(),
+            scope,
+        }
+    }
+}
+
+fn global_path() -> Result<PathBuf> {
+    Ok(get_app_dir()?.join("projects.json"))
+}
+
+fn profile_path(profile: &str) -> Result<PathBuf> {
+    Ok(get_profile_dir(profile)?.join("projects.json"))
+}
+
+fn read_file(path: &Path, scope: ProjectScope) -> Result<Vec<Project>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let content = fs::read_to_string(path)?;
+    if content.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut projects: Vec<Project> = serde_json::from_str(&content)?;
+    for p in &mut projects {
+        p.scope = scope;
+    }
+    Ok(projects)
+}
+
+fn write_file(path: &Path, projects: &[Project]) -> Result<()> {
+    if path.exists() {
+        let backup = path.with_extension("json.bak");
+        if let Err(e) = fs::copy(path, &backup) {
+            warn!("Failed to back up {}: {}", path.display(), e);
+        }
+    }
+    let content = serde_json::to_string_pretty(projects)?;
+    fs::write(path, content)?;
+    Ok(())
+}
+
+/// Load global registry only.
+pub fn load_global() -> Result<Vec<Project>> {
+    read_file(&global_path()?, ProjectScope::Global)
+}
+
+/// Load profile-scoped registry only.
+pub fn load_profile(profile: &str) -> Result<Vec<Project>> {
+    read_file(&profile_path(profile)?, ProjectScope::Profile)
+}
+
+/// Load union of global + profile, deduped by canonical path. Profile entries
+/// shadow global ones with the same path.
+pub fn load_merged(profile: &str) -> Result<Vec<Project>> {
+    let global = load_global().unwrap_or_else(|e| {
+        warn!("Failed to load global projects: {}", e);
+        Vec::new()
+    });
+    let profile = load_profile(profile).unwrap_or_else(|e| {
+        warn!("Failed to load profile projects: {}", e);
+        Vec::new()
+    });
+
+    let mut merged: Vec<Project> = Vec::new();
+    let mut seen_paths: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+
+    for p in global.into_iter().chain(profile) {
+        let canonical = canonical_key(&p.path);
+        if let Some(&idx) = seen_paths.get(&canonical) {
+            // Profile shadows global on path collision.
+            if p.scope == ProjectScope::Profile {
+                merged[idx] = p;
+            }
+        } else {
+            seen_paths.insert(canonical, merged.len());
+            merged.push(p);
+        }
+    }
+    Ok(merged)
+}
+
+fn canonical_key(path: &str) -> String {
+    PathBuf::from(path)
+        .canonicalize()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_else(|_| path.to_string())
+}
+
+/// Replace the contents of one scope's registry file.
+pub fn save_scope(profile: &str, scope: ProjectScope, projects: &[Project]) -> Result<()> {
+    let path = match scope {
+        ProjectScope::Global => global_path()?,
+        ProjectScope::Profile => profile_path(profile)?,
+    };
+    write_file(&path, projects)
+}
+
+/// Append a project to the given scope. Errors if a project with the same name
+/// or canonical path already exists in that scope.
+pub fn add(profile: &str, scope: ProjectScope, mut project: Project) -> Result<Project> {
+    project.scope = scope;
+    let path_buf = PathBuf::from(&project.path);
+    let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
+    project.path = canonical.to_string_lossy().to_string();
+
+    let mut existing = match scope {
+        ProjectScope::Global => load_global()?,
+        ProjectScope::Profile => load_profile(profile)?,
+    };
+
+    for p in &existing {
+        if p.name == project.name {
+            bail!(
+                "Project '{}' already registered in {} scope",
+                project.name,
+                scope.as_str()
+            );
+        }
+        if canonical_key(&p.path) == canonical_key(&project.path) {
+            bail!(
+                "Path '{}' already registered as '{}' in {} scope",
+                project.path,
+                p.name,
+                scope.as_str()
+            );
+        }
+    }
+
+    existing.push(project.clone());
+    save_scope(profile, scope, &existing)?;
+    Ok(project)
+}
+
+/// Remove the entry matching `name_or_path` from the given scope. Returns the
+/// removed project, or errors if no match was found.
+pub fn remove(profile: &str, scope: ProjectScope, name_or_path: &str) -> Result<Project> {
+    let mut existing = match scope {
+        ProjectScope::Global => load_global()?,
+        ProjectScope::Profile => load_profile(profile)?,
+    };
+
+    let canonical_target = canonical_key(name_or_path);
+    let idx = existing
+        .iter()
+        .position(|p| p.name == name_or_path || canonical_key(&p.path) == canonical_target)
+        .ok_or_else(|| {
+            anyhow::anyhow!("No project '{}' in {} scope", name_or_path, scope.as_str())
+        })?;
+    let removed = existing.remove(idx);
+    save_scope(profile, scope, &existing)?;
+    Ok(removed)
+}
+
+/// Resolve a list of project names against the merged registry. Errors on the
+/// first unknown name with the available names listed.
+pub fn resolve_names(profile: &str, names: &[String]) -> Result<Vec<Project>> {
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let merged = load_merged(profile)?;
+    let mut resolved = Vec::with_capacity(names.len());
+    for name in names {
+        let project = merged.iter().find(|p| p.name == *name).ok_or_else(|| {
+            let available: Vec<String> = merged.iter().map(|p| p.name.clone()).collect();
+            anyhow::anyhow!(
+                "Unknown project '{}'. Available: {}",
+                name,
+                if available.is_empty() {
+                    "<none registered>".to_string()
+                } else {
+                    available.join(", ")
+                }
+            )
+        })?;
+        resolved.push(project.clone());
+    }
+    Ok(resolved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::tempdir;
+
+    fn setup(temp: &Path) {
+        std::env::set_var("HOME", temp);
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp.join(".config"));
+    }
+
+    #[test]
+    #[serial]
+    fn add_then_load_global() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoA");
+        let _ = git2::Repository::init(&repo);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("repoA", repo.to_string_lossy(), ProjectScope::Global),
+        )?;
+
+        let loaded = load_global()?;
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].name, "repoA");
+        assert_eq!(loaded[0].scope, ProjectScope::Global);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn profile_shadows_global_on_path_collision() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoX");
+        let _ = git2::Repository::init(&repo);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("global-name", repo.to_string_lossy(), ProjectScope::Global),
+        )?;
+        add(
+            "default",
+            ProjectScope::Profile,
+            Project::new(
+                "profile-name",
+                repo.to_string_lossy(),
+                ProjectScope::Profile,
+            ),
+        )?;
+
+        let merged = load_merged("default")?;
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].name, "profile-name");
+        assert_eq!(merged[0].scope, ProjectScope::Profile);
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn duplicate_name_rejected_within_scope() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo1 = temp.path().join("r1");
+        let repo2 = temp.path().join("r2");
+        let _ = git2::Repository::init(&repo1);
+        let _ = git2::Repository::init(&repo2);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("dup", repo1.to_string_lossy(), ProjectScope::Global),
+        )?;
+        let err = add(
+            "default",
+            ProjectScope::Global,
+            Project::new("dup", repo2.to_string_lossy(), ProjectScope::Global),
+        );
+        assert!(err.is_err());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn resolve_names_errors_on_unknown() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let err = resolve_names("default", &["nonesuch".to_string()]);
+        assert!(err.is_err());
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn remove_round_trip() -> Result<()> {
+        let temp = tempdir()?;
+        setup(temp.path());
+        let repo = temp.path().join("repoR");
+        let _ = git2::Repository::init(&repo);
+
+        add(
+            "default",
+            ProjectScope::Global,
+            Project::new("repoR", repo.to_string_lossy(), ProjectScope::Global),
+        )?;
+        let removed = remove("default", ProjectScope::Global, "repoR")?;
+        assert_eq!(removed.name, "repoR");
+        let loaded = load_global()?;
+        assert!(loaded.is_empty());
+        Ok(())
+    }
+}

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 43;
+const DIALOG_HEIGHT: u16 = 44;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -118,6 +118,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("n/N", "Next/prev match"),
                     ("s", "Settings"),
                     ("P", "Profiles"),
+                    ("p", "Projects"),
                     ("R", "Serve (LAN / Tunnel)"),
                     ("u", "Update aoe (when available)"),
                     ("Ctrl+x", "Dismiss update bar (this session)"),

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -208,6 +208,14 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
             payload: PaletteAction::Key(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::SHIFT)),
         },
         PaletteCommand {
+            id: "projects",
+            title: "Manage projects".to_string(),
+            group: PaletteGroup::Settings,
+            keywords: vec!["registry", "repos", "multi-repo", "workspace"],
+            hotkey: "p",
+            payload: PaletteAction::Key(key('p')),
+        },
+        PaletteCommand {
             id: "help",
             title: "Show keyboard shortcuts".to_string(),
             group: PaletteGroup::Settings,

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -12,6 +12,7 @@ mod info;
 mod new_session;
 mod no_agents;
 mod profile_picker;
+mod projects;
 mod rename;
 mod send_message;
 #[cfg(feature = "serve")]
@@ -33,6 +34,7 @@ pub use info::InfoDialog;
 pub use new_session::{NewSessionData, NewSessionDialog};
 pub use no_agents::{NoAgentsAction, NoAgentsDialog};
 pub use profile_picker::{ProfileEntry, ProfilePickerAction, ProfilePickerDialog};
+pub use projects::ProjectsDialog;
 pub use rename::{RenameData, RenameDialog, RenameMode};
 pub use send_message::SendMessageDialog;
 #[cfg(feature = "serve")]

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1157,8 +1157,47 @@ impl NewSessionDialog {
         }
     }
 
+    /// Resolve a label chosen from the project picker back to the underlying
+    /// project entry and append its path to the workspace repos list.
+    fn apply_picked_project(&mut self, value: &str) {
+        if let Some(project) = self
+            .available_projects
+            .iter()
+            .find(|p| project_picker_label(p) == value)
+        {
+            if !self.workspace_repos.contains(&project.path) {
+                self.workspace_repos.push(project.path.clone());
+            }
+            self.workspace_repos_expanded = true;
+            self.workspace_repo_selected_index = self.workspace_repos.len().saturating_sub(1);
+        }
+    }
+
+    /// Build and activate the registered-projects picker (Ctrl+R on the
+    /// extra-repos field). Filters out the primary repo and any paths already
+    /// in the workspace_repos list to avoid the builder's duplicate-name guard.
+    fn open_projects_picker(&mut self) {
+        let primary = self.path.value().trim().to_string();
+        let merged = crate::session::projects::load_merged(&self.profile).unwrap_or_default();
+        self.available_projects = merged
+            .into_iter()
+            .filter(|p| p.path != primary && !self.workspace_repos.contains(&p.path))
+            .collect();
+        if self.available_projects.is_empty() {
+            self.error_message = Some(
+                "No registered projects available. Add one with `aoe project add <path>`.".into(),
+            );
+        } else {
+            let labels: Vec<String> = self
+                .available_projects
+                .iter()
+                .map(project_picker_label)
+                .collect();
+            self.projects_picker.activate(labels);
+        }
+    }
+
     /// Handle key events when in worktree configuration mode.
-    #[allow(clippy::too_many_lines)]
     fn handle_worktree_config_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
         // Worktree config fields: 0=name, 1=new_branch checkbox, 2=extra_repos list
         const WT_NAME: usize = 0;
@@ -1175,18 +1214,7 @@ impl NewSessionDialog {
 
         if self.projects_picker.is_active() {
             if let ListPickerResult::Selected(value) = self.projects_picker.handle_key(key) {
-                if let Some(project) = self
-                    .available_projects
-                    .iter()
-                    .find(|p| project_picker_label(p) == value)
-                {
-                    if !self.workspace_repos.contains(&project.path) {
-                        self.workspace_repos.push(project.path.clone());
-                    }
-                    self.workspace_repos_expanded = true;
-                    self.workspace_repo_selected_index =
-                        self.workspace_repos.len().saturating_sub(1);
-                }
+                self.apply_picked_project(&value);
             }
             return DialogResult::Continue;
         }
@@ -1224,26 +1252,7 @@ impl NewSessionDialog {
                 if key.modifiers.contains(KeyModifiers::CONTROL)
                     && self.worktree_config_focused_field == WT_EXTRA_REPOS =>
             {
-                let primary = self.path.value().trim().to_string();
-                let merged =
-                    crate::session::projects::load_merged(&self.profile).unwrap_or_default();
-                self.available_projects = merged
-                    .into_iter()
-                    .filter(|p| p.path != primary && !self.workspace_repos.contains(&p.path))
-                    .collect();
-                if self.available_projects.is_empty() {
-                    self.error_message = Some(
-                        "No registered projects available. Add one with `aoe project add <path>`."
-                            .into(),
-                    );
-                } else {
-                    let labels: Vec<String> = self
-                        .available_projects
-                        .iter()
-                        .map(project_picker_label)
-                        .collect();
-                    self.projects_picker.activate(labels);
-                }
+                self.open_projects_picker();
                 DialogResult::Continue
             }
             KeyCode::Enter if self.worktree_config_focused_field == WT_EXTRA_REPOS => {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -162,6 +162,13 @@ pub struct NewSessionDialog {
     pub(super) existing_groups: Vec<String>,
     pub(super) group_picker: ListPicker,
     pub(super) branch_picker: ListPicker,
+    /// Picker over registered projects (global ∪ profile). Activated from
+    /// the workspace_repos list with Ctrl+R; selection appends the
+    /// project's path to `workspace_repos`.
+    pub(super) projects_picker: ListPicker,
+    /// Snapshot of registered projects at picker activation, parallel to
+    /// the picker's display list, used to map the chosen name back to a path.
+    pub(super) available_projects: Vec<crate::session::Project>,
     pub(super) dir_picker: DirPicker,
     pub(super) error_message: Option<String>,
     pub(super) show_help: bool,
@@ -377,6 +384,8 @@ impl NewSessionDialog {
             existing_groups,
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
+            projects_picker: ListPicker::new("Add registered project"),
+            available_projects: Vec::new(),
             dir_picker: DirPicker::new(),
             worktree_enabled,
             worktree_branch: Input::default(),
@@ -617,6 +626,8 @@ impl NewSessionDialog {
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
+            projects_picker: ListPicker::new("Add registered project"),
+            available_projects: Vec::new(),
             dir_picker: DirPicker::new(),
             worktree_enabled: config.worktree.enabled,
             worktree_branch: Input::default(),
@@ -677,6 +688,8 @@ impl NewSessionDialog {
             existing_groups: Vec::new(),
             group_picker: ListPicker::new("Select Group"),
             branch_picker: ListPicker::new("Select Branch"),
+            projects_picker: ListPicker::new("Add registered project"),
+            available_projects: Vec::new(),
             dir_picker: DirPicker::new(),
             worktree_enabled: false,
             worktree_branch: Input::default(),
@@ -725,7 +738,16 @@ impl NewSessionDialog {
     pub fn set_error(&mut self, error: String) {
         self.error_message = Some(error);
     }
+}
 
+/// Label shown in the registered-projects picker. Includes scope so users
+/// can disambiguate when the same name exists across scopes (rare; the
+/// merger dedupes by path, not name).
+fn project_picker_label(p: &crate::session::Project) -> String {
+    format!("{} [{}]  {}", p.name, p.scope.as_str(), p.path)
+}
+
+impl NewSessionDialog {
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
         // When loading, only allow Esc to cancel
         if self.loading {
@@ -1136,6 +1158,7 @@ impl NewSessionDialog {
     }
 
     /// Handle key events when in worktree configuration mode.
+    #[allow(clippy::too_many_lines)]
     fn handle_worktree_config_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
         // Worktree config fields: 0=name, 1=new_branch checkbox, 2=extra_repos list
         const WT_NAME: usize = 0;
@@ -1146,6 +1169,24 @@ impl NewSessionDialog {
         if self.branch_picker.is_active() {
             if let ListPickerResult::Selected(value) = self.branch_picker.handle_key(key) {
                 self.worktree_branch = Input::new(value);
+            }
+            return DialogResult::Continue;
+        }
+
+        if self.projects_picker.is_active() {
+            if let ListPickerResult::Selected(value) = self.projects_picker.handle_key(key) {
+                if let Some(project) = self
+                    .available_projects
+                    .iter()
+                    .find(|p| project_picker_label(p) == value)
+                {
+                    if !self.workspace_repos.contains(&project.path) {
+                        self.workspace_repos.push(project.path.clone());
+                    }
+                    self.workspace_repos_expanded = true;
+                    self.workspace_repo_selected_index =
+                        self.workspace_repos.len().saturating_sub(1);
+                }
             }
             return DialogResult::Continue;
         }
@@ -1174,6 +1215,34 @@ impl NewSessionDialog {
                     if !branches.is_empty() {
                         self.branch_picker.activate(branches);
                     }
+                }
+                DialogResult::Continue
+            }
+            // Ctrl+R on extra_repos field opens the registered-projects picker.
+            // Selection appends the project's path to the workspace_repos list.
+            KeyCode::Char('r')
+                if key.modifiers.contains(KeyModifiers::CONTROL)
+                    && self.worktree_config_focused_field == WT_EXTRA_REPOS =>
+            {
+                let primary = self.path.value().trim().to_string();
+                let merged =
+                    crate::session::projects::load_merged(&self.profile).unwrap_or_default();
+                self.available_projects = merged
+                    .into_iter()
+                    .filter(|p| p.path != primary && !self.workspace_repos.contains(&p.path))
+                    .collect();
+                if self.available_projects.is_empty() {
+                    self.error_message = Some(
+                        "No registered projects available. Add one with `aoe project add <path>`."
+                            .into(),
+                    );
+                } else {
+                    let labels: Vec<String> = self
+                        .available_projects
+                        .iter()
+                        .map(project_picker_label)
+                        .collect();
+                    self.projects_picker.activate(labels);
                 }
                 DialogResult::Continue
             }

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -475,6 +475,10 @@ impl NewSessionDialog {
             self.branch_picker.render(frame, area, theme);
         }
 
+        if self.projects_picker.is_active() {
+            self.projects_picker.render(frame, area, theme);
+        }
+
         if self.dir_picker.is_active() {
             self.dir_picker.render(frame, area, theme);
         }
@@ -884,6 +888,8 @@ impl NewSessionDialog {
                 Span::raw(" next  "),
                 Span::styled("Enter", Style::default().fg(theme.hint)),
                 Span::raw(" edit repos  "),
+                Span::styled("C-r", Style::default().fg(theme.hint)),
+                Span::raw(" pick project  "),
                 Span::styled("Esc", Style::default().fg(theme.hint)),
                 Span::raw(" back"),
             ];
@@ -896,6 +902,10 @@ impl NewSessionDialog {
 
         if self.branch_picker.is_active() {
             self.branch_picker.render(frame, area, theme);
+        }
+
+        if self.projects_picker.is_active() {
+            self.projects_picker.render(frame, area, theme);
         }
 
         if self.dir_picker.is_active() {

--- a/src/tui/dialogs/projects.rs
+++ b/src/tui/dialogs/projects.rs
@@ -26,7 +26,9 @@ pub struct ProjectsDialog {
     add_input: Input,
     /// Scope selection when adding (Global vs Profile)
     add_scope: ProjectScope,
-    /// Cursor field while adding: 0=path, 1=scope
+    /// Allow registering even if path is already in the other scope.
+    add_allow_override: bool,
+    /// Cursor field while adding: 0=path, 1=scope, 2=allow-override
     add_focused: usize,
     error: Option<String>,
     info: Option<String>,
@@ -41,6 +43,7 @@ impl ProjectsDialog {
             mode: Mode::Browse,
             add_input: Input::default(),
             add_scope: ProjectScope::Global,
+            add_allow_override: false,
             add_focused: 0,
             error: None,
             info: None,
@@ -89,6 +92,7 @@ impl ProjectsDialog {
                 self.mode = Mode::Adding;
                 self.add_input = Input::default();
                 self.add_scope = ProjectScope::Global;
+                self.add_allow_override = false;
                 self.add_focused = 0;
                 self.error = None;
                 DialogResult::Continue
@@ -117,11 +121,11 @@ impl ProjectsDialog {
                 DialogResult::Continue
             }
             KeyCode::Tab => {
-                self.add_focused = (self.add_focused + 1) % 2;
+                self.add_focused = (self.add_focused + 1) % 3;
                 DialogResult::Continue
             }
             KeyCode::BackTab => {
-                self.add_focused = if self.add_focused == 0 { 1 } else { 0 };
+                self.add_focused = (self.add_focused + 2) % 3;
                 DialogResult::Continue
             }
             KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') if self.add_focused == 1 => {
@@ -129,6 +133,10 @@ impl ProjectsDialog {
                     ProjectScope::Global => ProjectScope::Profile,
                     ProjectScope::Profile => ProjectScope::Global,
                 };
+                DialogResult::Continue
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') if self.add_focused == 2 => {
+                self.add_allow_override = !self.add_allow_override;
                 DialogResult::Continue
             }
             KeyCode::Enter => {
@@ -149,7 +157,12 @@ impl ProjectsDialog {
                     .unwrap_or_else(|| "project".to_string());
                 let project =
                     Project::new(name.clone(), canonical.to_string_lossy(), self.add_scope);
-                match projects::add(&self.profile, self.add_scope, project) {
+                match projects::add(
+                    &self.profile,
+                    self.add_scope,
+                    project,
+                    self.add_allow_override,
+                ) {
                     Ok(saved) => {
                         self.info = Some(format!(
                             "Added '{}' [{}]",
@@ -177,7 +190,12 @@ impl ProjectsDialog {
     pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width: u16 = 76;
         let list_height: u16 = (self.items.len() as u16).clamp(3, 12);
-        let dialog_height: u16 = list_height + 9;
+        let adding_extra: u16 = if matches!(self.mode, Mode::Adding) {
+            2
+        } else {
+            0
+        };
+        let dialog_height: u16 = list_height + 9 + adding_extra;
         let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
         frame.render_widget(Clear, dialog_area);
 
@@ -194,7 +212,7 @@ impl ProjectsDialog {
             Constraint::Length(list_height),
             Constraint::Length(1),
             Constraint::Length(if matches!(self.mode, Mode::Adding) {
-                4
+                6
             } else {
                 1
             }),
@@ -295,7 +313,24 @@ impl ProjectsDialog {
                         Style::default().fg(theme.accent).bold(),
                     ),
                 ]);
-                let mut lines = vec![path_line, scope_line];
+                let override_label_style = if self.add_focused == 2 {
+                    Style::default().fg(theme.accent).underlined()
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                let override_box = if self.add_allow_override {
+                    "[x]"
+                } else {
+                    "[ ]"
+                };
+                let override_line = Line::from(vec![
+                    Span::styled("Override: ", override_label_style),
+                    Span::styled(
+                        format!("{} allow shadowing other scope", override_box),
+                        Style::default().fg(theme.accent).bold(),
+                    ),
+                ]);
+                let mut lines = vec![path_line, scope_line, override_line];
                 if let Some(err) = &self.error {
                     lines.push(Line::from(Span::styled(
                         err.clone(),
@@ -322,7 +357,7 @@ impl ProjectsDialog {
                 Span::styled("Tab", Style::default().fg(theme.hint)),
                 Span::raw(" next  "),
                 Span::styled("Space/←/→", Style::default().fg(theme.hint)),
-                Span::raw(" toggle scope  "),
+                Span::raw(" toggle  "),
                 Span::styled("Enter", Style::default().fg(theme.hint)),
                 Span::raw(" save  "),
                 Span::styled("Esc", Style::default().fg(theme.hint)),

--- a/src/tui/dialogs/projects.rs
+++ b/src/tui/dialogs/projects.rs
@@ -1,0 +1,334 @@
+//! Projects panel: list/add/remove the project registry from the TUI home screen.
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+use tui_input::backend::crossterm::EventHandler;
+use tui_input::Input;
+
+use super::DialogResult;
+use crate::session::projects;
+use crate::session::{Project, ProjectScope};
+use crate::tui::styles::Theme;
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+enum Mode {
+    Browse,
+    Adding,
+}
+
+pub struct ProjectsDialog {
+    profile: String,
+    items: Vec<Project>,
+    selected: usize,
+    mode: Mode,
+    /// Path input when adding
+    add_input: Input,
+    /// Scope selection when adding (Global vs Profile)
+    add_scope: ProjectScope,
+    /// Cursor field while adding: 0=path, 1=scope
+    add_focused: usize,
+    error: Option<String>,
+    info: Option<String>,
+}
+
+impl ProjectsDialog {
+    pub fn new(profile: &str) -> Self {
+        let mut dialog = Self {
+            profile: profile.to_string(),
+            items: Vec::new(),
+            selected: 0,
+            mode: Mode::Browse,
+            add_input: Input::default(),
+            add_scope: ProjectScope::Global,
+            add_focused: 0,
+            error: None,
+            info: None,
+        };
+        dialog.reload();
+        dialog
+    }
+
+    fn reload(&mut self) {
+        match projects::load_merged(&self.profile) {
+            Ok(items) => {
+                self.items = items;
+                if self.selected >= self.items.len() {
+                    self.selected = self.items.len().saturating_sub(1);
+                }
+                self.error = None;
+            }
+            Err(e) => {
+                self.error = Some(format!("Failed to load projects: {}", e));
+            }
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        self.info = None;
+        match self.mode {
+            Mode::Browse => self.handle_browse_key(key),
+            Mode::Adding => self.handle_add_key(key),
+        }
+    }
+
+    fn handle_browse_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char('q') => DialogResult::Cancel,
+            KeyCode::Down | KeyCode::Char('j') => {
+                if !self.items.is_empty() {
+                    self.selected = (self.selected + 1).min(self.items.len() - 1);
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                self.selected = self.selected.saturating_sub(1);
+                DialogResult::Continue
+            }
+            KeyCode::Char('a') => {
+                self.mode = Mode::Adding;
+                self.add_input = Input::default();
+                self.add_scope = ProjectScope::Global;
+                self.add_focused = 0;
+                self.error = None;
+                DialogResult::Continue
+            }
+            KeyCode::Char('d') | KeyCode::Delete => {
+                if let Some(project) = self.items.get(self.selected).cloned() {
+                    match projects::remove(&self.profile, project.scope, &project.name) {
+                        Ok(_) => {
+                            self.info = Some(format!("Removed '{}'", project.name));
+                            self.reload();
+                        }
+                        Err(e) => self.error = Some(format!("Remove failed: {}", e)),
+                    }
+                }
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    fn handle_add_key(&mut self, key: KeyEvent) -> DialogResult<()> {
+        match key.code {
+            KeyCode::Esc => {
+                self.mode = Mode::Browse;
+                self.error = None;
+                DialogResult::Continue
+            }
+            KeyCode::Tab => {
+                self.add_focused = (self.add_focused + 1) % 2;
+                DialogResult::Continue
+            }
+            KeyCode::BackTab => {
+                self.add_focused = if self.add_focused == 0 { 1 } else { 0 };
+                DialogResult::Continue
+            }
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ') if self.add_focused == 1 => {
+                self.add_scope = match self.add_scope {
+                    ProjectScope::Global => ProjectScope::Profile,
+                    ProjectScope::Profile => ProjectScope::Global,
+                };
+                DialogResult::Continue
+            }
+            KeyCode::Enter => {
+                let path = self.add_input.value().trim().to_string();
+                if path.is_empty() {
+                    self.error = Some("Path required".into());
+                    return DialogResult::Continue;
+                }
+                let path_buf = std::path::PathBuf::from(&path);
+                let canonical = path_buf.canonicalize().unwrap_or_else(|_| path_buf.clone());
+                if !crate::git::GitWorktree::is_git_repo(&canonical) {
+                    self.error = Some(format!("Not a git repository: {}", canonical.display()));
+                    return DialogResult::Continue;
+                }
+                let name = canonical
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| "project".to_string());
+                let project =
+                    Project::new(name.clone(), canonical.to_string_lossy(), self.add_scope);
+                match projects::add(&self.profile, self.add_scope, project) {
+                    Ok(saved) => {
+                        self.info = Some(format!(
+                            "Added '{}' [{}]",
+                            saved.name,
+                            self.add_scope.as_str()
+                        ));
+                        self.mode = Mode::Browse;
+                        self.add_input = Input::default();
+                        self.reload();
+                    }
+                    Err(e) => self.error = Some(format!("Add failed: {}", e)),
+                }
+                DialogResult::Continue
+            }
+            _ => {
+                if self.add_focused == 0 && !key.modifiers.contains(KeyModifiers::CONTROL) {
+                    self.add_input
+                        .handle_event(&crossterm::event::Event::Key(key));
+                }
+                DialogResult::Continue
+            }
+        }
+    }
+
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dialog_width: u16 = 76;
+        let list_height: u16 = (self.items.len() as u16).clamp(3, 12);
+        let dialog_height: u16 = list_height + 9;
+        let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .title(" Projects ")
+            .title_style(Style::default().fg(theme.title).bold());
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let constraints = vec![
+            Constraint::Length(list_height),
+            Constraint::Length(1),
+            Constraint::Length(if matches!(self.mode, Mode::Adding) {
+                4
+            } else {
+                1
+            }),
+            Constraint::Min(1),
+        ];
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .margin(1)
+            .constraints(constraints)
+            .split(inner);
+
+        // Project list
+        if self.items.is_empty() {
+            let p = Paragraph::new("No registered projects. Press 'a' to add one.")
+                .style(Style::default().fg(theme.dimmed));
+            frame.render_widget(p, chunks[0]);
+        } else {
+            let lines: Vec<Line> = self
+                .items
+                .iter()
+                .enumerate()
+                .map(|(idx, project)| {
+                    let style = if idx == self.selected {
+                        Style::default().fg(theme.accent).bold()
+                    } else {
+                        Style::default().fg(theme.text)
+                    };
+                    let scope_style = if idx == self.selected {
+                        Style::default().fg(theme.accent)
+                    } else {
+                        Style::default().fg(theme.dimmed)
+                    };
+                    Line::from(vec![
+                        Span::styled(if idx == self.selected { "› " } else { "  " }, style),
+                        Span::styled(project.name.clone(), style),
+                        Span::raw(" "),
+                        Span::styled(format!("[{}]", project.scope.as_str()), scope_style),
+                        Span::raw("  "),
+                        Span::styled(project.path.clone(), Style::default().fg(theme.dimmed)),
+                    ])
+                })
+                .collect();
+            frame.render_widget(Paragraph::new(lines), chunks[0]);
+        }
+
+        // Separator
+        frame.render_widget(
+            Paragraph::new("─".repeat(inner.width as usize))
+                .style(Style::default().fg(theme.dimmed)),
+            chunks[1],
+        );
+
+        // Add form or status line
+        match self.mode {
+            Mode::Browse => {
+                let mut spans = vec![];
+                if let Some(err) = &self.error {
+                    spans.push(Span::styled(err.clone(), Style::default().fg(theme.error)));
+                } else if let Some(info) = &self.info {
+                    spans.push(Span::styled(
+                        info.clone(),
+                        Style::default().fg(theme.accent),
+                    ));
+                }
+                frame.render_widget(Paragraph::new(Line::from(spans)), chunks[2]);
+            }
+            Mode::Adding => {
+                let path_label_style = if self.add_focused == 0 {
+                    Style::default().fg(theme.accent).underlined()
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                let path_line = Line::from(vec![
+                    Span::styled("Path: ", path_label_style),
+                    Span::styled(
+                        self.add_input.value().to_string(),
+                        Style::default().fg(theme.text),
+                    ),
+                    if self.add_focused == 0 {
+                        Span::styled("█", Style::default().fg(theme.accent))
+                    } else {
+                        Span::raw("")
+                    },
+                ]);
+                let scope_label_style = if self.add_focused == 1 {
+                    Style::default().fg(theme.accent).underlined()
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                let scope_value = match self.add_scope {
+                    ProjectScope::Global => "global (all profiles)",
+                    ProjectScope::Profile => "profile-only",
+                };
+                let scope_line = Line::from(vec![
+                    Span::styled("Scope: ", scope_label_style),
+                    Span::styled(
+                        format!("< {} >", scope_value),
+                        Style::default().fg(theme.accent).bold(),
+                    ),
+                ]);
+                let mut lines = vec![path_line, scope_line];
+                if let Some(err) = &self.error {
+                    lines.push(Line::from(Span::styled(
+                        err.clone(),
+                        Style::default().fg(theme.error),
+                    )));
+                }
+                frame.render_widget(Paragraph::new(lines), chunks[2]);
+            }
+        }
+
+        // Hints
+        let hint_spans: Vec<Span> = match self.mode {
+            Mode::Browse => vec![
+                Span::styled("a", Style::default().fg(theme.hint)),
+                Span::raw(" add  "),
+                Span::styled("d", Style::default().fg(theme.hint)),
+                Span::raw(" remove  "),
+                Span::styled("j/k", Style::default().fg(theme.hint)),
+                Span::raw(" move  "),
+                Span::styled("q/Esc", Style::default().fg(theme.hint)),
+                Span::raw(" close"),
+            ],
+            Mode::Adding => vec![
+                Span::styled("Tab", Style::default().fg(theme.hint)),
+                Span::raw(" next  "),
+                Span::styled("Space/←/→", Style::default().fg(theme.hint)),
+                Span::raw(" toggle scope  "),
+                Span::styled("Enter", Style::default().fg(theme.hint)),
+                Span::raw(" save  "),
+                Span::styled("Esc", Style::default().fg(theme.hint)),
+                Span::raw(" cancel"),
+            ],
+        };
+        frame.render_widget(Paragraph::new(Line::from(hint_spans)), chunks[3]);
+    }
+}

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1759,12 +1759,12 @@ impl HomeView {
                 KeyCode::Char(c.to_ascii_lowercase()),
                 KeyModifiers::NONE,
             )),
-            // Block bare lowercase action letters that would fire without a modifier
-            KeyCode::Char('q' | 'n' | 't' | 'c' | 's' | 'd' | 'x' | 'r' | 'm' | 'o' | 'g')
-                if bare =>
-            {
-                None
-            }
+            // Block bare lowercase action letters that would fire without a modifier.
+            // `p` opens the Projects panel in non-strict mode; in strict mode reach it
+            // via the command palette (Ctrl+K → "Manage projects").
+            KeyCode::Char(
+                'q' | 'n' | 't' | 'c' | 's' | 'd' | 'x' | 'r' | 'm' | 'o' | 'g' | 'p',
+            ) if bare => None,
             // Everything else passes through unchanged (navigation, ?, /, Enter, etc.)
             _ => Some(key),
         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -15,7 +15,8 @@ use crate::tui::dialogs::{
     builtin_commands, CommandPaletteDialog, ConfirmDialog, DeleteDialogConfig, DialogResult,
     GroupDeleteOptionsDialog, HookTrustAction, HooksInstallDialog, InfoDialog, NewSessionData,
     NewSessionDialog, NoAgentsAction, PaletteAction, PaletteCommand, PaletteGroup,
-    ProfilePickerAction, RenameDialog, RenameMode, SendMessageDialog, UnifiedDeleteDialog,
+    ProfilePickerAction, ProjectsDialog, RenameDialog, RenameMode, SendMessageDialog,
+    UnifiedDeleteDialog,
 };
 use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::settings::{SettingsAction, SettingsView};
@@ -437,6 +438,16 @@ impl HomeView {
             return None;
         }
 
+        if let Some(dialog) = &mut self.projects_dialog {
+            match dialog.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel | DialogResult::Submit(()) => {
+                    self.projects_dialog = None;
+                }
+            }
+            return None;
+        }
+
         if let Some(dialog) = &mut self.profile_picker_dialog {
             match dialog.handle_key(key) {
                 DialogResult::Continue => {}
@@ -627,6 +638,10 @@ impl HomeView {
             }
             KeyCode::Char('P') => {
                 self.show_profile_picker();
+            }
+            KeyCode::Char('p') => {
+                let profile = self.active_profile.as_deref().unwrap_or("default");
+                self.projects_dialog = Some(ProjectsDialog::new(profile));
             }
             #[cfg(feature = "serve")]
             KeyCode::Char('R') => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -27,8 +27,8 @@ use super::dialogs::ServeView;
 use super::dialogs::{
     ChangelogDialog, CommandPaletteDialog, ConfirmDialog, GroupDeleteOptionsDialog,
     HookTrustDialog, HooksInstallDialog, InfoDialog, NewSessionData, NewSessionDialog,
-    NoAgentsDialog, ProfilePickerDialog, RenameDialog, UnifiedDeleteDialog, UpdateConfirmDialog,
-    WelcomeDialog,
+    NoAgentsDialog, ProfilePickerDialog, ProjectsDialog, RenameDialog, UnifiedDeleteDialog,
+    UpdateConfirmDialog, WelcomeDialog,
 };
 use super::diff::DiffView;
 use super::settings::SettingsView;
@@ -173,6 +173,7 @@ pub struct HomeView {
     pub(super) changelog_dialog: Option<ChangelogDialog>,
     pub(super) info_dialog: Option<InfoDialog>,
     pub(super) profile_picker_dialog: Option<ProfilePickerDialog>,
+    pub(super) projects_dialog: Option<ProjectsDialog>,
     pub(super) command_palette: Option<CommandPaletteDialog>,
     #[cfg(feature = "serve")]
     pub(super) serve_view: Option<ServeView>,
@@ -352,6 +353,7 @@ impl HomeView {
             changelog_dialog: None,
             info_dialog: None,
             profile_picker_dialog: None,
+            projects_dialog: None,
             command_palette: None,
             #[cfg(feature = "serve")]
             serve_view: None,
@@ -1132,6 +1134,7 @@ impl HomeView {
             || self.changelog_dialog.is_some()
             || self.info_dialog.is_some()
             || self.profile_picker_dialog.is_some()
+            || self.projects_dialog.is_some()
             || self.command_palette.is_some()
             || self.send_message_dialog.is_some()
             || self.update_confirm_dialog.is_some()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -295,6 +295,7 @@ impl HomeView {
             changelog_dialog,
             info_dialog,
             profile_picker_dialog,
+            projects_dialog,
             command_palette,
             send_message_dialog,
             update_confirm_dialog,

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -22,6 +22,7 @@ mod command_palette;
 mod errors;
 mod new_session;
 mod profile_picker;
+mod project_registry;
 mod sandbox;
 mod serve;
 mod tui_launch;

--- a/tests/e2e/project_registry.rs
+++ b/tests/e2e/project_registry.rs
@@ -1,0 +1,242 @@
+//! E2E tests for the `aoe project` registry CLI surface.
+//!
+//! Exercises `aoe project add`, `aoe project list`, and `aoe project remove`
+//! against an isolated home, plus the `aoe add --project NAME` shortcut and
+//! the cross-scope override guard.
+
+use serial_test::serial;
+use std::path::Path;
+use std::process::Command;
+
+use crate::harness::TuiTestHarness;
+
+/// Initialize a directory as a git repo with one empty commit so
+/// `aoe project add` accepts it.
+fn init_git_repo(path: &Path) {
+    std::fs::create_dir_all(path).expect("create repo dir");
+    let run = |args: &[&str]| {
+        let status = Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .expect("git invocation");
+        assert!(
+            status.success(),
+            "git {:?} failed in {}",
+            args,
+            path.display()
+        );
+    };
+    run(&["init", "-q", "-b", "main"]);
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "Test"]);
+    run(&["commit", "--allow-empty", "-q", "-m", "init"]);
+}
+
+#[test]
+#[serial]
+fn test_project_add_list_remove_round_trip() {
+    let h = TuiTestHarness::new("project_round_trip");
+    let repo = h.home_path().join("repoA");
+    init_git_repo(&repo);
+
+    // 1. List on empty registry
+    let list_empty = h.run_cli(&["project", "list"]);
+    assert!(list_empty.status.success());
+    let stdout = String::from_utf8_lossy(&list_empty.stdout);
+    assert!(
+        stdout.contains("No projects registered"),
+        "expected empty-registry hint, got: {stdout}"
+    );
+
+    // 2. Add a project (default scope: global)
+    let add = h.run_cli(&["project", "add", repo.to_str().unwrap()]);
+    assert!(
+        add.status.success(),
+        "project add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+    let add_stdout = String::from_utf8_lossy(&add.stdout);
+    assert!(
+        add_stdout.contains("repoA") && add_stdout.contains("[global]"),
+        "add output should include name and scope, got: {add_stdout}"
+    );
+
+    // 3. List shows it
+    let list = h.run_cli(&["project", "list"]);
+    assert!(list.status.success());
+    let list_stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        list_stdout.contains("repoA") && list_stdout.contains("[global]"),
+        "list output should show added project, got: {list_stdout}"
+    );
+
+    // 4. JSON output is valid and contains the entry
+    let list_json = h.run_cli(&["project", "list", "--json"]);
+    assert!(list_json.status.success());
+    let json: serde_json::Value =
+        serde_json::from_slice(&list_json.stdout).expect("invalid JSON output");
+    let arr = json.as_array().expect("expected JSON array");
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "repoA");
+    assert_eq!(arr[0]["scope"], "global");
+
+    // 5. Remove (case-insensitive name match)
+    let remove = h.run_cli(&["project", "remove", "REPOA"]);
+    assert!(
+        remove.status.success(),
+        "remove failed: {}",
+        String::from_utf8_lossy(&remove.stderr)
+    );
+
+    // 6. List is empty again
+    let list_after = h.run_cli(&["project", "list"]);
+    let after_stdout = String::from_utf8_lossy(&list_after.stdout);
+    assert!(
+        after_stdout.contains("No projects registered"),
+        "expected empty after remove, got: {after_stdout}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_project_add_rejects_non_git_path() {
+    let h = TuiTestHarness::new("project_non_git");
+    let plain = h.home_path().join("plain-dir");
+    std::fs::create_dir_all(&plain).expect("create plain dir");
+
+    let out = h.run_cli(&["project", "add", plain.to_str().unwrap()]);
+    assert!(
+        !out.status.success(),
+        "expected failure for non-git path, stdout: {}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("not a git repository"),
+        "expected 'not a git repository' message, got: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_project_add_duplicate_within_scope() {
+    let h = TuiTestHarness::new("project_dup_within_scope");
+    let repo = h.home_path().join("repoB");
+    init_git_repo(&repo);
+
+    let first = h.run_cli(&["project", "add", repo.to_str().unwrap()]);
+    assert!(first.status.success());
+
+    let dup = h.run_cli(&["project", "add", repo.to_str().unwrap()]);
+    assert!(
+        !dup.status.success(),
+        "duplicate add should fail, stdout: {}",
+        String::from_utf8_lossy(&dup.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&dup.stderr);
+    assert!(
+        stderr.contains("already registered"),
+        "expected 'already registered' message, got: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_project_cross_scope_override() {
+    let h = TuiTestHarness::new("project_cross_scope_override");
+    let repo = h.home_path().join("repoC");
+    init_git_repo(&repo);
+
+    // Add globally first.
+    let add_global = h.run_cli(&["project", "add", repo.to_str().unwrap()]);
+    assert!(add_global.status.success());
+
+    // Re-add to profile without override -> error.
+    let dup = h.run_cli(&[
+        "project",
+        "add",
+        repo.to_str().unwrap(),
+        "--scope",
+        "profile",
+    ]);
+    assert!(!dup.status.success(), "cross-scope dup should fail");
+    let stderr = String::from_utf8_lossy(&dup.stderr);
+    assert!(
+        stderr.contains("--allow-override"),
+        "expected --allow-override hint, got: {stderr}"
+    );
+
+    // Re-add with override -> succeeds.
+    let with_override = h.run_cli(&[
+        "project",
+        "add",
+        repo.to_str().unwrap(),
+        "--scope",
+        "profile",
+        "--allow-override",
+    ]);
+    assert!(
+        with_override.status.success(),
+        "override add failed: {}",
+        String::from_utf8_lossy(&with_override.stderr)
+    );
+
+    // Merged listing shows one row (profile shadows global).
+    let list = h.run_cli(&["project", "list"]);
+    let list_stdout = String::from_utf8_lossy(&list.stdout);
+    assert!(
+        list_stdout.contains("[profile]"),
+        "merged list should show the profile entry, got: {list_stdout}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_aoe_add_project_flag_requires_worktree() {
+    let h = TuiTestHarness::new("project_add_requires_worktree");
+    let primary = h.home_path().join("primary");
+    let extra = h.home_path().join("extra");
+    init_git_repo(&primary);
+    init_git_repo(&extra);
+
+    // Register the extra repo.
+    let reg = h.run_cli(&["project", "add", extra.to_str().unwrap()]);
+    assert!(reg.status.success());
+
+    // Using --project without -w should fail with the worktree-required message.
+    let out = h.run_cli(&["add", primary.to_str().unwrap(), "--project", "extra"]);
+    assert!(!out.status.success(), "should fail without --worktree");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--worktree") || stderr.contains("--project"),
+        "expected message about --worktree requirement, got: {stderr}"
+    );
+}
+
+#[test]
+#[serial]
+fn test_aoe_add_project_unknown_name_fails_fast() {
+    let h = TuiTestHarness::new("project_unknown_name");
+    let primary = h.home_path().join("primary2");
+    init_git_repo(&primary);
+
+    let out = h.run_cli(&[
+        "add",
+        primary.to_str().unwrap(),
+        "--project",
+        "ghost-project",
+        "-w",
+        "feat-branch",
+        "-b",
+    ]);
+    assert!(
+        !out.status.success(),
+        "unknown --project name should fail fast"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("ghost-project") || stderr.contains("Unknown project"),
+        "expected message naming the unknown project, got: {stderr}"
+    );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import { TerminalView } from "./components/TerminalView";
 import { RightPanel } from "./components/RightPanel";
 import { DiffFileViewer } from "./components/diff/DiffFileViewer";
 import { SettingsView } from "./components/SettingsView";
+import { ProjectsView } from "./components/ProjectsView";
 import { HelpOverlay } from "./components/HelpOverlay";
 import { SessionWizard } from "./components/session-wizard/SessionWizard";
 import type { WizardPrefill } from "./components/session-wizard/SessionWizard";
@@ -137,8 +138,10 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const sessionMatch = useMatch("/session/:sessionId");
   const settingsRootMatch = useMatch("/settings");
   const settingsTabMatch = useMatch("/settings/:tab");
+  const projectsMatch = useMatch("/projects");
   const activeSessionId = sessionMatch?.params.sessionId ?? null;
   const showSettings = settingsRootMatch !== null || settingsTabMatch !== null;
+  const showProjects = projectsMatch !== null;
   const settingsTab = settingsTabMatch?.params.tab ?? null;
 
   const { sessions, error, injectSession, setSessionStatus } = useSessions();
@@ -319,6 +322,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     if (window.innerWidth < 768) setSidebarOpen(false);
   }, [navigate]);
 
+  const handleOpenProjects = useCallback(() => {
+    navigate("/projects");
+    if (window.innerWidth < 768) setSidebarOpen(false);
+  }, [navigate]);
+
+  const handleCloseProjects = useCallback(() => {
+    if (activeSessionId) {
+      navigate(`/session/${encodeURIComponent(activeSessionId)}`);
+    } else {
+      navigate("/");
+    }
+  }, [navigate, activeSessionId]);
+
   const handleCloseSettings = useCallback(() => {
     if (activeSessionId) {
       navigate(`/session/${encodeURIComponent(activeSessionId)}`);
@@ -465,6 +481,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       );
     }
 
+    if (showProjects) {
+      return (
+        <ProjectsView
+          onClose={handleCloseProjects}
+          readOnly={serverAbout?.read_only}
+        />
+      );
+    }
+
     if (!activeWorkspace || !activeSession) {
       return (
         <Dashboard
@@ -558,7 +583,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       <DisconnectBanner />
 
       <div className="flex flex-1 min-h-0">
-        {!showSettings && (
+        {!showSettings && !showProjects && (
           <WorkspaceSidebar
             groups={groups}
             activeId={activeWorkspace?.id ?? null}
@@ -569,6 +594,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onNew={() => { setWizardPrefill(undefined); setShowSessionWizard(true); }}
             onCreateSession={handleCreateSession}
             onSettings={handleOpenSettings}
+            onProjects={handleOpenProjects}
             onDeleteSession={handleDeleteSession}
             readOnly={serverAbout?.read_only}
           />

--- a/web/src/components/DirectoryBrowser.tsx
+++ b/web/src/components/DirectoryBrowser.tsx
@@ -136,7 +136,7 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
       </div>
 
       {/* Directory listing */}
-      <div className="border border-surface-700 rounded-lg overflow-hidden" role="listbox" aria-label="Directories">
+      <div className="border border-surface-700 rounded-lg overflow-y-auto max-h-[50vh]" role="listbox" aria-label="Directories">
         {loading ? (
           // Skeleton loading rows
           <div className="animate-pulse">

--- a/web/src/components/ProjectsView.tsx
+++ b/web/src/components/ProjectsView.tsx
@@ -1,0 +1,255 @@
+import { useEffect, useState } from "react";
+import type { ProjectInfo } from "../lib/types";
+import { fetchProjects, createProject, deleteProject } from "../lib/api";
+import { DirectoryBrowser } from "./DirectoryBrowser";
+
+interface Props {
+  onClose: () => void;
+  readOnly?: boolean;
+}
+
+export function ProjectsView({ onClose, readOnly }: Props) {
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showAdd, setShowAdd] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Add-form state
+  const [path, setPath] = useState("");
+  const [name, setName] = useState("");
+  const [scope, setScope] = useState<"global" | "profile">("global");
+  const [showBrowser, setShowBrowser] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const reload = async () => {
+    setLoading(true);
+    const list = await fetchProjects();
+    setProjects(list);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    reload();
+  }, []);
+
+  const handleAdd = async () => {
+    const trimmedPath = path.trim();
+    if (!trimmedPath) return;
+    setSubmitting(true);
+    setError(null);
+    const result = await createProject({
+      path: trimmedPath,
+      name: name.trim() || undefined,
+      scope,
+    });
+    setSubmitting(false);
+    if (!result.ok) {
+      setError(result.error || "Add failed");
+      return;
+    }
+    setPath("");
+    setName("");
+    setScope("global");
+    setShowAdd(false);
+    setShowBrowser(false);
+    await reload();
+  };
+
+  const handleRemove = async (project: ProjectInfo) => {
+    if (!confirm(`Remove project '${project.name}' from ${project.scope} scope?`)) return;
+    setError(null);
+    const result = await deleteProject(project.name, project.scope);
+    if (!result.ok) {
+      setError(result.error || "Remove failed");
+      return;
+    }
+    await reload();
+  };
+
+  return (
+    <div className="flex flex-col h-full bg-surface-900">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-surface-700/30">
+        <div>
+          <h1 className="text-lg font-semibold text-text-primary">Projects</h1>
+          <p className="text-xs text-text-dim">
+            Saved repositories you can multi-select when creating sessions.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {!readOnly && !showAdd && (
+            <button
+              type="button"
+              onClick={() => setShowAdd(true)}
+              className="px-3 py-1.5 text-sm bg-brand-600 hover:bg-brand-700 text-surface-900 rounded-md cursor-pointer font-medium"
+            >
+              + Add project
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mx-4 mt-3 px-3 py-2 bg-red-900/20 border border-red-700/30 rounded-md">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {showAdd && !readOnly && (
+        <div className="px-4 pt-4">
+          <div className="bg-surface-800 border border-surface-700/40 rounded-lg p-4">
+            <h2 className="text-sm font-medium text-text-primary mb-3">Add project</h2>
+
+            <label className="block text-[12px] text-text-dim mb-1">Path</label>
+            <div className="flex gap-2 mb-3">
+              <input
+                type="text"
+                value={path}
+                onChange={(e) => setPath(e.target.value)}
+                placeholder="/path/to/repo"
+                className="flex-1 px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
+              />
+              <button
+                type="button"
+                onClick={() => setShowBrowser((b) => !b)}
+                className="px-3 py-2 text-sm border border-surface-700 text-text-secondary hover:bg-surface-700/40 rounded-md cursor-pointer"
+              >
+                {showBrowser ? "Hide browser" : "Browse"}
+              </button>
+            </div>
+            {showBrowser && (
+              <div className="mb-3">
+                <DirectoryBrowser
+                  onSelect={(p) => {
+                    setPath(p);
+                    setShowBrowser(false);
+                  }}
+                />
+              </div>
+            )}
+
+            <label className="block text-[12px] text-text-dim mb-1">Name (optional)</label>
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="defaults to directory name"
+              className="w-full px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 mb-3"
+            />
+
+            <label className="block text-[12px] text-text-dim mb-1">Scope</label>
+            <div className="flex gap-2 mb-4">
+              {(["global", "profile"] as const).map((s) => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => setScope(s)}
+                  className={`px-3 py-1.5 text-sm rounded-md cursor-pointer transition-colors ${
+                    scope === s
+                      ? "bg-brand-600/20 border border-brand-600/40 text-text-primary"
+                      : "bg-surface-900 border border-surface-700/40 text-text-secondary hover:border-surface-700"
+                  }`}
+                >
+                  {s === "global" ? "Global (all profiles)" : "Profile-only"}
+                </button>
+              ))}
+            </div>
+
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setShowAdd(false);
+                  setShowBrowser(false);
+                  setPath("");
+                  setName("");
+                  setScope("global");
+                  setError(null);
+                }}
+                className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleAdd}
+                disabled={!path.trim() || submitting}
+                className={`px-3 py-1.5 text-sm rounded-md font-medium ${
+                  !path.trim() || submitting
+                    ? "bg-brand-600/40 text-surface-900/60 cursor-not-allowed"
+                    : "bg-brand-600 hover:bg-brand-700 text-surface-900 cursor-pointer"
+                }`}
+              >
+                {submitting ? "Adding…" : "Add"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <div className="flex-1 overflow-y-auto p-4">
+        {loading && (
+          <div className="space-y-2 animate-pulse">
+            {[...Array(3)].map((_, i) => (
+              <div key={i} className="h-[60px] bg-surface-800/40 border border-surface-700/40 rounded-md" />
+            ))}
+          </div>
+        )}
+
+        {!loading && projects.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-16 text-center">
+            <p className="text-sm text-text-secondary mb-1">No registered projects yet.</p>
+            <p className="text-xs text-text-dim">
+              Add one above, or use{" "}
+              <code className="text-text-secondary">aoe project add &lt;path&gt;</code> from the CLI.
+            </p>
+          </div>
+        )}
+
+        {!loading && projects.length > 0 && (
+          <ul className="space-y-2">
+            {projects.map((p) => (
+              <li
+                key={`${p.scope}:${p.path}`}
+                className="flex items-center gap-3 px-3 py-2.5 bg-surface-800/40 border border-surface-700/40 rounded-md"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-text-primary">{p.name}</span>
+                    <span
+                      className={`text-[10px] uppercase tracking-wider px-1.5 py-0.5 rounded ${
+                        p.scope === "global"
+                          ? "bg-brand-600/20 text-text-primary"
+                          : "bg-surface-700/60 text-text-secondary"
+                      }`}
+                    >
+                      {p.scope}
+                    </span>
+                  </div>
+                  <p className="text-[11px] font-mono text-text-dim truncate mt-0.5" title={p.path}>
+                    {p.path}
+                  </p>
+                </div>
+                {!readOnly && (
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(p)}
+                    className="px-2 py-1 text-xs border border-surface-700 text-text-dim hover:text-status-error hover:border-status-error/40 rounded-md cursor-pointer"
+                  >
+                    Remove
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ProjectsView.tsx
+++ b/web/src/components/ProjectsView.tsx
@@ -18,6 +18,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
   const [path, setPath] = useState("");
   const [name, setName] = useState("");
   const [scope, setScope] = useState<"global" | "profile">("global");
+  const [allowOverride, setAllowOverride] = useState(false);
   const [showBrowser, setShowBrowser] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
@@ -41,6 +42,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
       path: trimmedPath,
       name: name.trim() || undefined,
       scope,
+      allow_override: allowOverride || undefined,
     });
     setSubmitting(false);
     if (!result.ok) {
@@ -50,6 +52,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
     setPath("");
     setName("");
     setScope("global");
+    setAllowOverride(false);
     setShowAdd(false);
     setShowBrowser(false);
     await reload();
@@ -161,6 +164,23 @@ export function ProjectsView({ onClose, readOnly }: Props) {
               ))}
             </div>
 
+            <label className="flex items-start gap-2 mb-4 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={allowOverride}
+                onChange={(e) => setAllowOverride(e.target.checked)}
+                className="mt-0.5 cursor-pointer"
+              />
+              <span className="text-[12px] text-text-secondary">
+                Allow override
+                <span className="block text-text-dim text-[11px] mt-0.5">
+                  Permit registering even if this path already exists in the
+                  other scope. The profile entry will shadow the global one in
+                  merged views.
+                </span>
+              </span>
+            </label>
+
             <div className="flex justify-end gap-2">
               <button
                 type="button"
@@ -170,6 +190,7 @@ export function ProjectsView({ onClose, readOnly }: Props) {
                   setPath("");
                   setName("");
                   setScope("global");
+                  setAllowOverride(false);
                   setError(null);
                 }}
                 className="px-3 py-1.5 text-sm border border-surface-700 text-text-secondary hover:bg-surface-800 rounded-md cursor-pointer"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -342,6 +342,21 @@ const SessionRow = memo(function SessionRow({
                 {subtitle}
               </span>
             )}
+            {firstSession && firstSession.workspace_repos.length > 1 && (
+              <span
+                className="mt-0.5 flex flex-wrap gap-1 text-[10px] font-mono text-text-dim"
+                title={firstSession.workspace_repos.map((r) => r.source_path).join("\n")}
+              >
+                {firstSession.workspace_repos.map((r) => (
+                  <span
+                    key={r.source_path}
+                    className="px-1 py-px bg-surface-800/50 border border-surface-700/40 rounded text-text-secondary"
+                  >
+                    {r.name}
+                  </span>
+                ))}
+              </span>
+            )}
           </div>
         </div>
       </Link>

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -344,7 +344,7 @@ const SessionRow = memo(function SessionRow({
                 {subtitle}
               </span>
             )}
-            {firstSession && firstSession.workspace_repos.length > 1 && (
+            {firstSession && (firstSession.workspace_repos?.length ?? 0) > 1 && (
               <span
                 className="mt-0.5 flex flex-wrap gap-1 text-[10px] font-mono text-text-dim"
                 title={firstSession.workspace_repos.map((r) => r.source_path).join("\n")}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
+import { MULTI_REPO_GROUP_ID } from "../hooks/useRepoGroups";
 import {
   STATUS_DOT_CLASS,
   getStatusTextClass,
@@ -679,7 +680,11 @@ export function WorkspaceSidebar({
                   group={{ ...group, collapsed: !showExpanded }}
                   hasActiveChild={!showExpanded && hasActiveChild}
                   onClick={() => !q && onToggleRepo(group.id)}
-                  onNewSession={() => onCreateSession(group.repoPath)}
+                  onNewSession={() =>
+                    group.id === MULTI_REPO_GROUP_ID
+                      ? onNew()
+                      : onCreateSession(group.repoPath)
+                  }
                 />
                 {showExpanded &&
                   group.workspaces.map((ws) => (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -38,6 +38,7 @@ interface Props {
   onNew: () => void;
   onCreateSession: (repoPath: string) => void;
   onSettings: () => void;
+  onProjects: () => void;
   onDeleteSession?: (workspaceId: string) => void;
   readOnly?: boolean;
 }
@@ -508,6 +509,7 @@ export function WorkspaceSidebar({
   onNew,
   onCreateSession,
   onSettings,
+  onProjects,
   onDeleteSession,
   readOnly,
 }: Props) {
@@ -704,7 +706,26 @@ export function WorkspaceSidebar({
           )}
         </div>
 
-        <div className="border-t border-surface-700/20 p-2">
+        <div className="border-t border-surface-700/20 p-2 flex items-center gap-1">
+          <button
+            onClick={onProjects}
+            className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"
+            title="Projects"
+            aria-label="Projects"
+          >
+            <svg
+              width="16"
+              height="16"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+            </svg>
+          </button>
           <button
             onClick={onSettings}
             className="w-8 h-8 flex items-center justify-center text-text-secondary hover:text-text-primary hover:bg-surface-800/50 cursor-pointer rounded-md transition-colors"

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -22,6 +22,9 @@ export interface WizardData {
   sandboxEnabled: boolean;
   sandboxImage: string;
   extraEnv: string[];
+  /** Additional repo paths to include in the multi-repo workspace.
+   *  Free-text paths and registered project paths flow into the same list. */
+  extraRepoPaths: string[];
   advancedEnabled: boolean;
   customInstruction: string;
   extraArgs: string;
@@ -59,6 +62,7 @@ const initialData: WizardData = {
   useWorktree: true,
   group: "", tool: "claude", profile: "",
   yoloMode: false, sandboxEnabled: false, sandboxImage: "", extraEnv: [],
+  extraRepoPaths: [],
   advancedEnabled: false, profileDirty: false,
   customInstruction: "", extraArgs: "", commandOverride: "",
 };
@@ -210,6 +214,7 @@ export function SessionWizard({ onClose, onCreated, prefill }: Props) {
       sandbox: d.sandboxEnabled,
       sandbox_image: d.sandboxEnabled ? d.sandboxImage : undefined,
       extra_env: d.sandboxEnabled && d.extraEnv.length > 0 ? d.extraEnv.filter(Boolean) : undefined,
+      extra_repo_paths: d.extraRepoPaths.length > 0 ? d.extraRepoPaths : undefined,
       extra_args: d.extraArgs || undefined,
       command_override: d.commandOverride || undefined,
       custom_instruction: d.customInstruction || undefined,

--- a/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
+++ b/web/src/components/session-wizard/steps/ExtraReposPicker.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from "react";
+import type { ProjectInfo } from "../../../lib/types";
+import { fetchProjects } from "../../../lib/api";
+
+interface Props {
+  primaryPath: string;
+  selectedPaths: string[];
+  onChange: (paths: string[]) => void;
+}
+
+export function ExtraReposPicker({ primaryPath, selectedPaths, onChange }: Props) {
+  const [projects, setProjects] = useState<ProjectInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [freeText, setFreeText] = useState("");
+
+  useEffect(() => {
+    fetchProjects().then((p) => {
+      setProjects(p);
+      setLoading(false);
+    });
+  }, []);
+
+  // Hide the primary repo from the picker so users can't accidentally
+  // duplicate it (the builder rejects duplicate repo names).
+  const pickable = projects.filter((p) => p.path !== primaryPath);
+
+  const isSelected = (path: string) => selectedPaths.includes(path);
+
+  const toggle = (path: string) => {
+    if (isSelected(path)) {
+      onChange(selectedPaths.filter((p) => p !== path));
+    } else {
+      onChange([...selectedPaths, path]);
+    }
+  };
+
+  const addFreeText = () => {
+    const trimmed = freeText.trim();
+    if (!trimmed) return;
+    if (selectedPaths.includes(trimmed) || trimmed === primaryPath) {
+      setFreeText("");
+      return;
+    }
+    onChange([...selectedPaths, trimmed]);
+    setFreeText("");
+  };
+
+  const removePath = (path: string) => {
+    onChange(selectedPaths.filter((p) => p !== path));
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <h3 className="text-sm font-medium text-text-primary">Extra repos (optional)</h3>
+        <span className="text-[11px] text-text-dim">
+          {selectedPaths.length > 0 ? `${selectedPaths.length} selected` : "none"}
+        </span>
+      </div>
+      <p className="text-[11px] text-text-dim mb-3">
+        Include additional repositories in the same workspace. Each gets its own worktree on the same branch.
+      </p>
+
+      {selectedPaths.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {selectedPaths.map((path) => {
+            const known = projects.find((p) => p.path === path);
+            const label = known?.name || path.split("/").filter(Boolean).pop() || path;
+            return (
+              <span
+                key={path}
+                className="inline-flex items-center gap-1.5 px-2 py-1 bg-brand-600/20 border border-brand-600/40 rounded-md text-[12px] text-text-primary"
+                title={path}
+              >
+                <span className="font-mono">{label}</span>
+                <button
+                  type="button"
+                  onClick={() => removePath(path)}
+                  className="text-text-dim hover:text-text-primary cursor-pointer"
+                  aria-label={`Remove ${label}`}
+                >
+                  &times;
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {!loading && pickable.length > 0 && (
+        <div className="mb-3">
+          <p className="text-[10px] uppercase tracking-wider text-text-dim mb-1.5">Registered projects</p>
+          <div className="flex flex-wrap gap-1.5">
+            {pickable.map((p) => (
+              <button
+                key={p.path}
+                type="button"
+                onClick={() => toggle(p.path)}
+                className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md text-[12px] cursor-pointer transition-colors ${
+                  isSelected(p.path)
+                    ? "bg-brand-600/20 border border-brand-600/40 text-text-primary"
+                    : "bg-surface-900 border border-surface-700/40 text-text-secondary hover:border-surface-700"
+                }`}
+                title={p.path}
+              >
+                <span className="font-mono">{p.name}</span>
+                <span className="text-[9px] uppercase text-text-dim">{p.scope}</span>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {!loading && pickable.length === 0 && projects.length === 0 && (
+        <p className="text-[11px] text-text-dim mb-3">
+          No registered projects yet. Add one with{" "}
+          <code className="text-text-secondary">aoe project add &lt;path&gt;</code>{" "}
+          or via the Projects page.
+        </p>
+      )}
+
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={freeText}
+          onChange={(e) => setFreeText(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addFreeText();
+            }
+          }}
+          placeholder="/path/to/another/repo"
+          className="flex-1 px-3 py-2 text-sm bg-surface-900 border border-surface-700/40 rounded-md text-text-primary placeholder:text-text-dim focus:outline-none focus:border-brand-600 font-mono"
+        />
+        <button
+          type="button"
+          onClick={addFreeText}
+          disabled={!freeText.trim()}
+          className={`px-3 py-2 text-sm rounded-md transition-colors ${
+            !freeText.trim()
+              ? "bg-surface-800 text-text-dim cursor-not-allowed"
+              : "bg-surface-700 hover:bg-surface-600 text-text-primary cursor-pointer"
+          }`}
+        >
+          Add
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -2,9 +2,11 @@ import { useEffect, useMemo, useState } from "react";
 import { fetchSessions, cloneRepo } from "../../../lib/api";
 import type { SessionResponse } from "../../../lib/types";
 import { DirectoryBrowser } from "../../DirectoryBrowser";
+import { ExtraReposPicker } from "./ExtraReposPicker";
 
 interface WizardData {
   path: string;
+  extraRepoPaths: string[];
   [key: string]: unknown;
 }
 
@@ -316,6 +318,17 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
         <div className="mt-4 px-3 py-2 bg-surface-900 border border-brand-600/30 rounded-md">
           <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim mb-1">Selected project</p>
           <p className="text-sm font-mono text-text-primary truncate">{data.path}</p>
+        </div>
+      )}
+
+      {/* Extra repos picker (multi-repo workspace) */}
+      {data.path && activeTab !== "browse" && (
+        <div className="mt-5 pt-4 border-t border-surface-700/30">
+          <ExtraReposPicker
+            primaryPath={data.path}
+            selectedPaths={data.extraRepoPaths}
+            onChange={(paths) => onChange("extraRepoPaths", paths)}
+          />
         </div>
       )}
     </div>

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import type { Workspace, RepoGroup } from "../lib/types";
 
 const COLLAPSED_KEY_PREFIX = "aoe-repo-collapsed-";
+export const MULTI_REPO_GROUP_ID = "__multi_repo__";
 
 function loadCollapsed(id: string): boolean {
   try {
@@ -9,6 +10,10 @@ function loadCollapsed(id: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isMultiRepoWorkspace(ws: Workspace): boolean {
+  return ws.sessions.some((s) => s.workspace_repos.length > 1);
 }
 
 export function useRepoGroups(workspaces: Workspace[]): {
@@ -19,8 +24,13 @@ export function useRepoGroups(workspaces: Workspace[]): {
 
   const groups = useMemo(() => {
     const byRepo = new Map<string, Workspace[]>();
+    const multiRepo: Workspace[] = [];
 
     for (const ws of workspaces) {
+      if (isMultiRepoWorkspace(ws)) {
+        multiRepo.push(ws);
+        continue;
+      }
       const existing = byRepo.get(ws.projectPath);
       if (existing) {
         existing.push(ws);
@@ -29,10 +39,8 @@ export function useRepoGroups(workspaces: Workspace[]): {
       }
     }
 
-    const repoGroups: RepoGroup[] = [];
-
-    for (const [repoPath, repoWorkspaces] of byRepo) {
-      const sorted = [...repoWorkspaces].sort((a, b) => {
+    const sortWorkspaces = (list: Workspace[]) =>
+      [...list].sort((a, b) => {
         if (a.status === "active" && b.status !== "active") return -1;
         if (a.status !== "active" && b.status === "active") return 1;
         const aName = a.branch ?? "";
@@ -40,6 +48,10 @@ export function useRepoGroups(workspaces: Workspace[]): {
         return aName.localeCompare(bName) || a.id.localeCompare(b.id);
       });
 
+    const repoGroups: RepoGroup[] = [];
+
+    for (const [repoPath, repoWorkspaces] of byRepo) {
+      const sorted = sortWorkspaces(repoWorkspaces);
       const hasActive = sorted.some((ws) => ws.status === "active");
       const collapsed =
         collapsedMap[repoPath] ?? loadCollapsed(repoPath);
@@ -58,7 +70,25 @@ export function useRepoGroups(workspaces: Workspace[]): {
       });
     }
 
+    if (multiRepo.length > 0) {
+      const sorted = sortWorkspaces(multiRepo);
+      const hasActive = sorted.some((ws) => ws.status === "active");
+      const collapsed =
+        collapsedMap[MULTI_REPO_GROUP_ID] ?? loadCollapsed(MULTI_REPO_GROUP_ID);
+      repoGroups.push({
+        id: MULTI_REPO_GROUP_ID,
+        repoPath: MULTI_REPO_GROUP_ID,
+        displayName: "Multi-repo",
+        remoteOwner: null,
+        workspaces: sorted,
+        status: hasActive ? "active" : "idle",
+        collapsed,
+      });
+    }
+
     repoGroups.sort((a, b) => {
+      if (a.id === MULTI_REPO_GROUP_ID) return 1;
+      if (b.id === MULTI_REPO_GROUP_ID) return -1;
       if (a.status === "active" && b.status !== "active") return -1;
       if (a.status !== "active" && b.status === "active") return 1;
       return a.displayName.localeCompare(b.displayName) || a.repoPath.localeCompare(b.repoPath);

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -13,7 +13,7 @@ function loadCollapsed(id: string): boolean {
 }
 
 function isMultiRepoWorkspace(ws: Workspace): boolean {
-  return ws.sessions.some((s) => s.workspace_repos.length > 1);
+  return ws.sessions.some((s) => (s.workspace_repos?.length ?? 0) > 1);
 }
 
 export function useRepoGroups(workspaces: Workspace[]): {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,7 @@ import type {
   ProfileInfo,
   BrowseResponse,
   GroupInfo,
+  ProjectInfo,
   DockerStatusResponse,
   CreateSessionRequest,
 } from "./types";
@@ -280,6 +281,62 @@ export async function browseFilesystem(
 
 export async function fetchGroups(): Promise<GroupInfo[]> {
   return (await fetchJson<GroupInfo[]>("/api/groups")) ?? [];
+}
+
+export async function fetchProjects(scope?: "global" | "profile"): Promise<ProjectInfo[]> {
+  const url = scope ? `/api/projects?scope=${scope}` : "/api/projects";
+  return (await fetchJson<ProjectInfo[]>(url)) ?? [];
+}
+
+export async function createProject(body: {
+  path: string;
+  name?: string;
+  scope?: "global" | "profile";
+}): Promise<{ ok: boolean; error?: string; project?: ProjectInfo }> {
+  try {
+    const res = await fetch("/api/projects", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        return { ok: false, error: data.message || `Server error (${res.status})` };
+      } catch {
+        return { ok: false, error: text || `Server error (${res.status})` };
+      }
+    }
+    const project = (await res.json()) as ProjectInfo;
+    return { ok: true, project };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+export async function deleteProject(
+  name: string,
+  scope: "global" | "profile",
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(
+      `/api/projects/${encodeURIComponent(name)}?scope=${scope}`,
+      { method: "DELETE" },
+    );
+    if (!res.ok) {
+      const text = await res.text();
+      try {
+        const data = JSON.parse(text);
+        return { ok: false, error: data.message || `Server error (${res.status})` };
+      } catch {
+        return { ok: false, error: text || `Server error (${res.status})` };
+      }
+    }
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 export async function fetchDockerStatus(): Promise<DockerStatusResponse> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -292,6 +292,7 @@ export async function createProject(body: {
   path: string;
   name?: string;
   scope?: "global" | "profile";
+  allow_override?: boolean;
 }): Promise<{ ok: boolean; error?: string; project?: ProjectInfo }> {
   try {
     const res = await fetch("/api/projects", {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -198,6 +198,13 @@ export interface GroupInfo {
   session_count: number;
 }
 
+/** Project info returned by /api/projects */
+export interface ProjectInfo {
+  name: string;
+  path: string;
+  scope: "global" | "profile";
+}
+
 /** Docker status returned by /api/docker/status */
 export interface DockerStatusResponse {
   available: boolean;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -33,6 +33,14 @@ export interface SessionResponse {
    *  ~/.claude/settings.json). The mobile rendering path uses this to
    *  skip scrollback-tracking workarounds that target tmux copy-mode. */
   claude_fullscreen: boolean;
+  /** Repos in the multi-repo workspace. Empty array for single-repo sessions. */
+  workspace_repos: WorkspaceRepoSummary[];
+}
+
+export interface WorkspaceRepoSummary {
+  name: string;
+  source_path: string;
+  branch: string;
 }
 
 export interface CleanupDefaults {

--- a/web/tests/helpers/terminal-mocks.ts
+++ b/web/tests/helpers/terminal-mocks.ts
@@ -34,6 +34,7 @@ export async function mockTerminalApis(page: Page): Promise<MockHandle> {
           is_sandboxed: false,
           has_terminal: true,
           profile: "default",
+          workspace_repos: [],
         },
       ],
     });

--- a/web/tests/ws-reconnect.spec.ts
+++ b/web/tests/ws-reconnect.spec.ts
@@ -34,6 +34,7 @@ async function mockApisExceptWs(page: Page, sessionTitle: string) {
           is_sandboxed: false,
           has_terminal: true,
           profile: "default",
+          workspace_repos: [],
         },
       ],
     });

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -82,6 +82,13 @@ const PAGES = [
     description:
       "Persist and resume Claude Code conversations across reboots, upgrades, and runtime rotations.",
   },
+  {
+    source: "docs/guides/multi-repo-workspaces.md",
+    dest: "guides/multi-repo-workspaces.md",
+    title: "Multi-Repo Workspaces",
+    description:
+      "Drive a single Agent of Empires session across several git repositories with the project registry and multi-select pickers.",
+  },
 
   // --- Docs pages (docs/ → pages/docs/) ---
   {
@@ -170,6 +177,7 @@ const URL_MAP = {
   "docs/guides/worktrees.md": "/guides/worktrees/",
   "docs/guides/agent-override.md": "/guides/agent-override/",
   "docs/guides/session-resume.md": "/guides/session-resume/",
+  "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
 };
 
 const GITHUB_BASE =

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -25,6 +25,7 @@ export const docsNav: NavSection[] = [
       { title: "Remote Phone Access", href: "/guides/remote-phone-access/" },
       { title: "Repo Config & Hooks", href: "/guides/repo-config/" },
       { title: "Git Worktrees", href: "/guides/worktrees/" },
+      { title: "Multi-Repo Workspaces", href: "/guides/multi-repo-workspaces/" },
       { title: "Diff View", href: "/guides/diff-view/" },
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/" },
       { title: "Agent Command Overrides", href: "/guides/agent-override/" },


### PR DESCRIPTION
## Description

First-class multi-repo workspace support for `agent-of-empires`.

Closes https://github.com/njbrake/agent-of-empires/issues/917

The multi-repo plumbing (`WorkspaceInfo.repos`, `--repo` flag, TUI Extra Repos field) already existed. This PR adds the three pieces called out in njbrake's final comment on the issue, plus closes two adjacent gaps that were blocking dashboard parity:

1. **Project registry** — saved repos with full CRUD across CLI, TUI, and web. Hybrid storage: a global `<app_dir>/projects.json` visible from every profile, and a per-profile `<app_dir>/profiles/{profile}/projects.json`. Loader merges them and lets profile entries shadow global ones on path collision.
2. **Multi-select picker at session creation** — TUI new-session dialog gets `Ctrl+R` on the Extra Repos field to open a registered-project picker; web wizard gets a chip-based multi-select with free-text fallback.
3. **Dashboard surfaces all repos** — multi-repo sessions render an inline chip row under the title; `SessionResponse` now carries `workspace_repos` so the frontend can show them.

Also fixed along the way:
- The web wizard previously did not POST `extra_repo_paths`, so the dashboard could not create multi-repo sessions even though the API accepted them.
- `SessionResponse` did not expose any workspace-repo info, so existing multi-repo sessions had no way to render correctly on the dashboard.

### Defaults & ergonomics

- `aoe project add <path>` defaults to `--scope global`. When `-p <profile>` is passed at the top level, the default flips to `--scope profile` (the user is already in profile context, so registering globally would be surprising). Explicit `--scope` always wins.
- Cross-scope path collisions error by default with a tip pointing at `aoe project remove` and an `--allow-override` opt-in. Without this guard a re-add silently created a phantom duplicate.
- Name matching (`add` dedup, `remove`, `aoe add --project NAME`) is ASCII case-insensitive: `aoe project remove smartcaller` finds `SmartCaller`.
- `aoe add --project NAME -w branch -b` is a shortcut for typed `--repo /long/path/...` invocations.
- `aoe project list` pluralizes correctly.
- `value_hint = DirPath`/`AnyPath` on the path positionals so zsh and fish shell completion wire `_files` for `~/<TAB>` expansion (bash hits a known clap_complete upstream limitation).

### What's not in scope (per njbrake's comment)

- Agent-driven mid-session repo pull-in (orchestrator work, #553).
- Per-repo PR tracking (its own issue, tied to #927).
- Saved workspace templates / named bundles.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(Recordings/screenshots: pending — opening as draft so reviewers can request specific captures.)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Sonnet/Opus) drove planning, exploration of the existing multi-repo plumbing, scaffolding of the new modules, and incremental commits. Each commit was reviewed and tested locally before being staged.

**Any Additional AI Details you'd like to share:** Plan was iterated in plan mode before implementation began. After landing, the user (Seluj78) walked the surfaces by hand and reported several rough edges (cross-scope override behaviour, plural noun, unclear "worktree" tip wording, case-sensitivity on remove, scope-default ergonomics under `-p`); each was diagnosed and fixed in a follow-up commit.

- [x] I am an AI Agent filling out this form (check box if true)

---

## Manual Testing TODO

Setup once at the top of a session:

```bash
TMPHOME=$(mktemp -d)
export HOME="$TMPHOME"
export XDG_CONFIG_HOME="$TMPHOME/.config"

mkdir -p "$TMPHOME/repoA" "$TMPHOME/repoB" "$TMPHOME/repoC"
for d in repoA repoB repoC; do
  git -C "$TMPHOME/$d" init -q -b main
  git -C "$TMPHOME/$d" -c user.email=t@t -c user.name=t commit --allow-empty -q -m init
done

cargo build --features serve
AOE=./target/debug/aoe
```

Reset registry state between scenarios with: `rm -rf "$TMPHOME/.config/agent-of-empires" "$TMPHOME/.agent-of-empires"`.

### 1. CLI: `aoe project`

- [x] 1.1 — `$AOE project list` on empty registry shows "No projects registered." + hint
- [x] 1.2 — `$AOE project add "$TMPHOME/repoA"` registers as `[global]`, name `repoA`
- [x] 1.3 — `$AOE project list` shows `repoA [global]  /…/repoA`
- [x] 1.4 — `$AOE project list --json` returns valid JSON array with `scope: "global"`
- [x] 1.5 — `$AOE project add "$TMPHOME/repoB" --scope profile` shows `[profile]` badge
- [x] 1.6 — `$AOE project list --scope global` shows only repoA
- [x] 1.7 — `$AOE project list --scope profile` shows only repoB
- [x] 1.8 — `$AOE project list` (default merged) shows both
- [x] 1.9 — `$AOE project add /not/a/repo` errors with "not a git repository" + `.git` folder tip
- [x] 1.10 — `$AOE project add "$TMPHOME/repoA"` (duplicate) errors with "already registered in global scope"
- [x] 1.11 — `$AOE project add "$TMPHOME/repoA" --name something --scope profile --allow-override` succeeds; profile shadows global
- [x] 1.12 — Without `--allow-override`, the same cross-scope add errors with the tip pointing at `aoe project remove --scope global`
- [x] 1.13 — `$AOE project list` after 1.11 shows the profile entry (one row, name `something`)
- [x] 1.14 — `$AOE project remove repoA` removes from global; profile entry survives
- [x] 1.15 — `$AOE project remove SOMETHING --scope profile` (uppercase) finds the lowercase entry — case-insensitive
- [x] 1.16 — `$AOE project remove "$TMPHOME/repoB" --scope profile` removes by full path
- [x] 1.17 — `$AOE project remove ghost` errors with "no project 'ghost' in global scope"
- [x] 1.18 — `$AOE -p custom project add "$TMPHOME/repoC"` (no `--scope`) defaults to PROFILE scope
- [x] 1.19 — `$AOE -p custom project add "$TMPHOME/repoC" --scope global` honors the explicit override
- [x] 1.20 — `$AOE project list` (default) vs `$AOE -p custom project list` shows different visible sets
- [x] 1.21 — `$AOE project list` after registering 1 project prints "Total: 1 project" (singular)
- [x] 1.22 — Shell completion: with `aoe completion zsh` sourced, `$AOE project add ~/<TAB>` expands paths

### 2. CLI: `aoe add --project`

Pre-reqs: register repoB as global, repoC as profile-only.

- [x] 2.1 — `$AOE add "$TMPHOME/repoA" --project repoB -w feat -b` creates a 2-worktree workspace
- [x] 2.2 — `$AOE add "$TMPHOME/repoA" --project repoB --project repoC -w feat2 -b` creates a 3-worktree workspace
- [x] 2.3 — `$AOE add "$TMPHOME/repoA" --project ghost -w feat3 -b` fails fast with "Unknown project 'ghost'. Available: repoB, repoC"
- [x] 2.4 — `$AOE add "$TMPHOME/repoA" --project repoB` (no `-w`) fails: `--repo`/`--project` requires `--worktree`
- [x] 2.5 — `$AOE add "$TMPHOME/repoA" --project REPOB -w feat5 -b` resolves case-insensitively
- [x] 2.6 — `$AOE add "$TMPHOME/repoA" --repo "$TMPHOME/repoB" --project repoB -w feat4 -b` fails the duplicate-name guard (same repo via two routes)
- [x] 2.7 — `$AOE add "$TMPHOME/repoA" -w solo -b` (no project flag) regression: single-repo session unchanged
- [x] 2.8 — After 2.1, `aoe list` shows the session and stored JSON has 2 repos in `workspace_info`

### 3. Web API (`aoe serve --no-auth --port 41234 --host 127.0.0.1`)

`BASE=http://127.0.0.1:41234`.

- [x] 3.1 — `curl $BASE/api/projects` returns `[]` initially
- [x] 3.2 — `POST /api/projects` with `{"path":".../repoA"}` returns 201 + `scope: "global"`
- [x] 3.3 — `POST` with `"scope":"profile"` returns 201 + `scope: "profile"`
- [x] 3.4 — `POST` with `"scope":"weird"` returns 400 `bad_scope`
- [x] 3.5 — `POST` with a non-git path returns 400 `not_a_git_repo`
- [x] 3.6 — `POST` duplicate within scope returns 409 `add_failed`
- [x] 3.7 — `POST` cross-scope dup without `allow_override` returns 409
- [x]  3.8 — `POST` cross-scope dup with `"allow_override": true` returns 201
- [x] 3.9 — `GET /api/projects?scope=global` returns only globals
- [x] 3.10 — `GET /api/projects?scope=profile` returns only profile entries
- [x] 3.11 — `GET /api/projects?scope=invalid` returns 400
- [x] 3.12 — `DELETE /api/projects/repoA?scope=global` returns 200 with the removed entry
- [x] 3.13 — `DELETE /api/projects/ghost?scope=global` returns 404
- [x] 3.14 — Restart with `--read-only`: `POST`/`DELETE` return 403 `read_only`
- [x] 3.15 — `GET /api/sessions` for a multi-repo session populates `workspace_repos`; single-repo sessions return `[]`, never `null`/missing

### 4. Web Wizard (`localhost:41234`, "+ New session")

- [x] 4.1 — Step 1, no project selected: "Extra repos" picker hidden
- [x] 4.2 — Pick a repo via Browse tab: picker appears below
- [x] 4.3 — Pick again from Recent: picker still appears
- [x] 4.4 — Picker with empty registry: "No registered projects yet." hint
- [x] 4.5 — Picker with registered projects: each shown as a chip with `[global]`/`[profile]` badge
- [x] 4.6 — Click a project chip: toggles to "selected" with brand color
- [x] 4.7 — Click again: deselects
- [x] 4.8 — Free-text input + "Add" button: path appears as a selected chip with `×` button
- [x] 4.9 — Free-text input + Enter: same
- [x] 4.10 — Primary repo path is filtered out of the registered list
- [x] 4.11 — Submit wizard with 0 extras: single-repo session created, no `extra_repo_paths` in POST
- [x] 4.12 — Submit with 2 extras: POST body includes `extra_repo_paths: [...]`; session created with workspace
- [x] 4.13 — Submit with primary repo path also in extras: backend hard-fails, error bubbles to wizard
- [x] 4.14 — DevTools network tab confirms POST `/api/sessions` body includes `extra_repo_paths` only when non-empty

### 5. Web Projects page (`/projects`, folder icon in sidebar footer)

- [x] 5.1 — Empty state: "No registered projects yet." + CLI hint
- [x] 5.2 — Click "+ Add project": form expands inline
- [x] 5.3 — DirectoryBrowser opens via "Browse"; selection writes path back into the form
- [x] 5.4 — Empty path: Add button disabled
- [x] 5.5 — Non-git path: error banner with "not a git repository"
- [x] 5.6 — Valid path, scope=global, no name: adds with directory basename, `[global]` badge
- [x] 5.7 — Same path, scope=global again: 409 conflict error
- [x] 5.8 — Same path, scope=profile, allow_override unchecked: 409
- [x] 5.9 — Same path, scope=profile, allow_override checked: 201, profile shadows global in merged view
- [x] 5.10 — List shows global = brand-tinted badge, profile = neutral
- [x] 5.11 — Click Remove on a profile entry: confirm prompt; on accept the row disappears
- [x] 5.12 — `--read-only` server: Add button hidden, Remove button hidden
- [x] 5.13 — Resize to mobile (DevTools iPhone preset): page usable, no overflow, tap-friendly
- [x] 5.14 — Close button returns to last route (session or dashboard)
- [x] 5.15 — Back/forward nav between `/projects` and `/session/:id`: no flicker, sidebar reappears when leaving

### 6. Web dashboard cards

- [x] 6.1 — Single-repo session in sidebar renders unchanged (label + branch subtitle)
- [x] 6.2 — Multi-repo session shows a small chip row with each repo name under the label
- [x] 6.3 — Hovering the chip row exposes full source paths via `title`
- [x] 6.4 — Two sessions in the same multi-repo workspace render chips independently
- [x] 6.5 — Reload page: chips persist (server returns `workspace_repos`)

### 7. TUI projects picker (in new-session dialog)

`aoe` to open TUI, press `n` for new session.

- [x] 7.1 — Fill path + worktree branch, Tab to "Worktree" field: field shows
- [x] 7.2 — `Ctrl+P` on Worktree: worktree config overlay opens
- [x] 7.3 — Tab to "Extra Repos" field: hint row shows `C-r pick project`
- [x] 7.4 — `Ctrl+R` on empty registry: error message "No registered projects available…"
- [x] 7.5 — After registering one project, `Ctrl+R`: picker overlay opens with "Add registered project" title
- [x] 7.6 — Pick a project via Enter: project's path appended to repo list
- [x] 7.7 — `Ctrl+R` again: already-added project filtered out
- [x] 7.8 — Primary repo (not in registry) is filtered out of picker
- [x] 7.9 — Esc out of picker: closes, no change
- [x] 7.10 — Submit dialog: multi-repo session created with selected project's path
- [x] 7.11 — Free-text path entry still works (regression for typed paths)

### 8. TUI projects panel

- [x] 8.1 — Press `p` on home screen: Projects dialog opens
- [x] 8.2 — Empty registry: "No registered projects. Press 'a' to add one."
- [x] 8.3 — Press `a`: add form appears with Path field focused
- [x] 8.4 — Type non-git path, Enter: inline error "Not a git repository"
- [x] 8.5 — Type valid path, Enter: added with default scope=global, returns to browse mode
- [x] 8.6 — Press `a` again, Tab to Scope field: scope label underlined
- [x] 8.7 — Space / ← / → on Scope field: toggles global ↔ profile-only
- [x] 8.8 — Tab to Override field, Space toggles `[ ]` ↔ `[x]`
- [x] 8.9 — Submit with profile scope: adds with `[profile]` badge
- [x] 8.10 — `j`/`k` on the list: cursor moves
- [x] 8.11 — `d` (or Delete): removes selected entry, status line shows "Removed '…'"
- [x] 8.12 — `q` or Esc: dialog closes
- [x] 8.13 — Re-open after `d`: list reflects removal
- [x] 8.14 — Press `P` (capital): profile picker opens (regression — no collision with `p`)
- [x] 8.15 — While dialog is open, other home keybinds are ignored (dialog has focus)

### 9. Cross-surface consistency

- [x] 9.1 — Add via CLI, observe in TUI panel after dialog reload
- [x] 9.2 — Add via web Projects page, observe in `aoe project list`
- [x] 9.3 — Add via TUI, refresh dashboard: chip appears in wizard picker
- [x] 9.4 — Same path added in global + profile (different names): merged shows one entry; profile name wins; CLI scoped lists show both
- [x] 9.5 — Switch profile (`-p other`): profile-scoped entries from default not visible; globals still visible
- [x] 9.6 — Remove a project that a session is using: session unaffected (paths stored on session, not by lookup)
- [x] 9.7 — Move a registered repo on disk, then re-list: path still shown; new sessions with `--project NAME` may fail (documented limitation)

### 10. Edge / regression

- [x] 10.1 — Single-repo session created before this branch loads fine; web returns `workspace_repos: []`; sidebar unchanged
- [x] 10.2 — `aoe add /path -w feat -b` (no `--repo`, no `--project`): single worktree path unchanged
- [x] 10.3 — `aoe add /path -r /other -w feat -b` (only `--repo`): multi-repo workspace built, no registry interaction
- [x] 10.4 — `--repo` and `--project` together: both merged into extras; duplicate-name guard fires only on real duplicates
- [x] 10.5 — Empty profile name (env unset): defaults to `default`; profile-scoped projects.json lives at `profiles/default/projects.json`
- [x] 10.6 — After 2nd save in either scope, `.bak` sibling exists
- [x] 10.7 — Hand-edit `projects.json` to invalid JSON: loaders return error; CLI list shows error; TUI/web log warning, no panic
- [x] 10.8 — Delete `projects.json` while server running: next API call returns empty list, no crash
- [x] 10.9 — Path with spaces / special chars: canonicalizes correctly; chips render the basename
- [x] 10.10 — Symlinked repo path: canonicalizes to target; same-repo dedup matches

### 11. Build / CI

- [x] 11.1 — `cargo fmt --check` clean
- [x] 11.2 — `cargo clippy --all-targets --features serve` no warnings
- [x] 11.3 — `cargo test` passes (2 known pre-existing Docker `containers::runtime` failures unrelated)
- [x] 11.4 — `cargo build --features serve --release` clean
- [x] 11.5 — `cd web && npx tsc --noEmit` clean
- [x] 11.6 — `cd web && npx vite build` clean
- [x] 11.7 — `cargo xtask gen-docs` then `git diff docs/cli/reference.md` shows no diff
