### PR TITLE
tui: compact tool selector with bidirectional cycle navigation

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -781,7 +781,8 @@ impl Instance {
         let profile = self.effective_profile();
         let on_launch_hooks = self.resolve_on_launch_hooks(skip_on_launch, &profile);
 
-        let agent = crate::agents::get_agent(&self.tool);
+        let agent = crate::agents::get_agent(&self.tool)
+            .or_else(|| crate::agents::get_agent(&self.detect_as));
         self.install_agent_status_hooks(agent);
 
         let cmd = if self.is_sandboxed() {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -944,7 +944,25 @@ impl NewSessionDialog {
                 }
                 DialogResult::Continue
             }
-            KeyCode::Left | KeyCode::Right if self.focused_field == tool_field => {
+            KeyCode::Left if self.focused_field == tool_field => {
+                self.tool_index = if self.tool_index == 0 {
+                    self.available_tools.len() - 1
+                } else {
+                    self.tool_index - 1
+                };
+                if self.selected_tool_always_yolo() {
+                    self.yolo_mode = true;
+                } else {
+                    self.yolo_mode = self.yolo_mode_default;
+                }
+                if self.selected_tool_host_only() {
+                    self.sandbox_enabled = false;
+                    self.worktree_branch.reset();
+                }
+                self.reload_tool_config();
+                DialogResult::Continue
+            }
+            KeyCode::Right if self.focused_field == tool_field => {
                 self.tool_index = (self.tool_index + 1) % self.available_tools.len();
                 if self.selected_tool_always_yolo() {
                     self.yolo_mode = true;

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -944,40 +944,18 @@ impl NewSessionDialog {
                 }
                 DialogResult::Continue
             }
-            KeyCode::Left if self.focused_field == tool_field => {
-                self.tool_index = if self.tool_index == 0 {
-                    self.available_tools.len() - 1
+            KeyCode::Left | KeyCode::Right | KeyCode::Char(' ')
+                if self.focused_field == tool_field =>
+            {
+                if key.code == KeyCode::Left {
+                    self.tool_index = if self.tool_index == 0 {
+                        self.available_tools.len() - 1
+                    } else {
+                        self.tool_index - 1
+                    };
                 } else {
-                    self.tool_index - 1
-                };
-                if self.selected_tool_always_yolo() {
-                    self.yolo_mode = true;
-                } else {
-                    self.yolo_mode = self.yolo_mode_default;
+                    self.tool_index = (self.tool_index + 1) % self.available_tools.len();
                 }
-                if self.selected_tool_host_only() {
-                    self.sandbox_enabled = false;
-                    self.worktree_branch.reset();
-                }
-                self.reload_tool_config();
-                DialogResult::Continue
-            }
-            KeyCode::Right if self.focused_field == tool_field => {
-                self.tool_index = (self.tool_index + 1) % self.available_tools.len();
-                if self.selected_tool_always_yolo() {
-                    self.yolo_mode = true;
-                } else {
-                    self.yolo_mode = self.yolo_mode_default;
-                }
-                if self.selected_tool_host_only() {
-                    self.sandbox_enabled = false;
-                    self.worktree_branch.reset();
-                }
-                self.reload_tool_config();
-                DialogResult::Continue
-            }
-            KeyCode::Char(' ') if self.focused_field == tool_field => {
-                self.tool_index = (self.tool_index + 1) % self.available_tools.len();
                 if self.selected_tool_always_yolo() {
                     self.yolo_mode = true;
                 } else {

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -176,20 +176,18 @@ impl NewSessionDialog {
 
             let mut tool_spans = vec![Span::styled("Tool:", label_style), Span::raw(" ")];
 
-            for (idx, tool_name) in self.available_tools.iter().enumerate() {
-                let is_selected = idx == self.tool_index;
-                let style = if is_selected {
-                    Style::default().fg(theme.accent).bold()
-                } else {
-                    Style::default().fg(theme.dimmed)
-                };
+            let selected_name = &self.available_tools[self.tool_index];
+            let total = self.available_tools.len();
+            let dimmed = Style::default().fg(theme.dimmed);
+            let accent = Style::default().fg(theme.accent).bold();
 
-                if idx > 0 {
-                    tool_spans.push(Span::raw("  "));
-                }
-                tool_spans.push(Span::styled(if is_selected { "● " } else { "○ " }, style));
-                tool_spans.push(Span::styled(tool_name.as_str(), style));
-            }
+            tool_spans.push(Span::styled("← ", dimmed));
+            tool_spans.push(Span::styled("● ", accent));
+            tool_spans.push(Span::styled(selected_name.as_str(), accent));
+            tool_spans.push(Span::styled(
+                format!("  [{}/{}]  →", self.tool_index + 1, total),
+                dimmed,
+            ));
 
             // Show Ctrl+P hint and summary of tool config
             let has_config =

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -181,13 +181,18 @@ impl NewSessionDialog {
             let dimmed = Style::default().fg(theme.dimmed);
             let accent = Style::default().fg(theme.accent).bold();
 
-            tool_spans.push(Span::styled("← ", dimmed));
+            if is_tool_focused {
+                tool_spans.push(Span::styled("← ", dimmed));
+            }
             tool_spans.push(Span::styled("● ", accent));
             tool_spans.push(Span::styled(selected_name.as_str(), accent));
             tool_spans.push(Span::styled(
-                format!("  [{}/{}]  →", self.tool_index + 1, total),
+                format!("  [{}/{}]", self.tool_index + 1, total),
                 dimmed,
             ));
+            if is_tool_focused {
+                tool_spans.push(Span::styled("  →", dimmed));
+            }
 
             // Show Ctrl+P hint and summary of tool config
             let has_config =

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -453,6 +453,30 @@ fn test_tool_selection_left_right() {
 }
 
 #[test]
+fn test_tool_selection_left_right_three_tools() {
+    let mut dialog = NewSessionDialog::new_with_tools(
+        vec!["claude", "opencode", "codex"],
+        TEST_PATH.to_string(),
+    );
+    dialog.focused_field = 2; // tool field
+    assert_eq!(dialog.tool_index, 0);
+
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.tool_index, 1);
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.tool_index, 2);
+    dialog.handle_key(key(KeyCode::Right));
+    assert_eq!(dialog.tool_index, 0, "right wraps from last to first");
+
+    dialog.handle_key(key(KeyCode::Left));
+    assert_eq!(dialog.tool_index, 2, "left wraps from first to last");
+    dialog.handle_key(key(KeyCode::Left));
+    assert_eq!(dialog.tool_index, 1);
+    dialog.handle_key(key(KeyCode::Left));
+    assert_eq!(dialog.tool_index, 0);
+}
+
+#[test]
 fn test_tool_selection_space() {
     let mut dialog = multi_tool_dialog();
     dialog.focused_field = 2; // tool field


### PR DESCRIPTION
## Description

This PR fixes three issues affecting custom agents (defined via `config.session.custom_agents`) in the New Session dialog.

---

### Fix 1: Tool selector overflow (render.rs)

The dialog renders all tools in a single horizontal line. With 5+ built-ins plus custom agents, the line overflows — custom agents become invisible and unreachable.

**Before:**
```
Tool: ● claude  ○ opencode  ○ codex  ○ gemini  ○ copilot  ○ cl-|
                                                            (truncated, unreachable)
```

**After:**
```
Tool: ← ● claude-gemma  [6/10]  →
```

---

### Fix 2: Bidirectional navigation broken (mod.rs)

Both `←` and `→` performed the same action (forward increment). `←` was effectively broken.

Split into two separate handlers: `→` increments, `←` decrements with wrap-around.

---

### Fix 3: YOLO mode ignored for custom agents (instance.rs)

Custom agents are not in the built-in `AGENTS` list, so `get_agent(&self.tool)` returns `None` for them. This caused the YOLO flag to be silently skipped regardless of the YOLO toggle in the dialog — `apply_yolo_mode` was never called.

**Fix:** fall back to `self.detect_as` (already stored on the instance from `agent_detect_as` config) when the primary lookup returns `None`:

```rust
// Before:
let agent = crate::agents::get_agent(&self.tool);

// After:
let agent = crate::agents::get_agent(&self.tool)
    .or_else(|| crate::agents::get_agent(&self.detect_as));
```

This lets custom agents inherit the correct `YoloMode` from their declared `agent_detect_as` agent (e.g. `--dangerously-skip-permissions` for `claude`).

---

## Changes

- `src/tui/dialogs/new_session/render.rs` — compact selector display with counter
- `src/tui/dialogs/new_session/mod.rs` — split Left/Right handler, fix `←` direction
- `src/session/instance.rs` — YOLO mode fallback via `detect_as` for custom agents

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Sonnet 4.6 via Claude Code CLI

**Any Additional AI Details you'd like to share:** All three bugs were discovered while using custom Ollama cloud model aliases with AOE. Fixes were implemented, built locally, and tested before submitting.

- [ ] I am an AI Agent filling out this form (check box if true)