### PR TITLE
fix(serve): WebSocket heartbeat and idle reaper for terminal connections

### DIFF
--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -7,6 +7,7 @@
 
 use std::io::{Read, Write};
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     extract::{
@@ -122,6 +123,21 @@ pub async fn terminal_ws(
 
 /// Unique client ID counter for primary-client tracking.
 static CLIENT_COUNTER: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Server-originated Ping cadence. Each Ping elicits a Pong from the
+/// browser, which the recv loop's idle timeout treats as proof of life.
+/// Also keeps NAT mappings warm on mobile carriers that otherwise drop
+/// idle TCP flows.
+const PING_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Drop a WebSocket that has been completely silent for this long. With
+/// PING_INTERVAL of 30s the client should respond with a Pong every 30s,
+/// so 90s tolerates two missed round-trips before tearing down. Without
+/// this, an idle tmux session whose client has gone dark (mobile app
+/// backgrounded, WiFi blip, abrupt close without Close frame) holds its
+/// tmux child + PTY pair until tmux next produces output, which can be
+/// hours. That leak is what exhausts RLIMIT_NOFILE under modest load.
+const IDLE_TIMEOUT: Duration = Duration::from_secs(90);
 
 /// Per-tmux-session map tracking which WebSocket client "owns" resizing.
 ///
@@ -266,6 +282,12 @@ async fn handle_terminal_ws(
 
     // Task 2: PTY output + control messages -> WebSocket sender
     let send_handle = tokio::spawn(async move {
+        let mut ping_interval = tokio::time::interval(PING_INTERVAL);
+        ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Tokio fires the first interval tick immediately; consume it so
+        // we don't ping at connection time (the browser hasn't even
+        // attached its onmessage handler yet on first connect).
+        ping_interval.tick().await;
         loop {
             tokio::select! {
                 data = output_rx.recv() => {
@@ -286,6 +308,15 @@ async fn handle_terminal_ws(
                             }
                         }
                         None => break,
+                    }
+                }
+                _ = ping_interval.tick() => {
+                    // Empty payload: we only care that the client echoes a
+                    // Pong, not what's in it. axum's WebSocket forwards
+                    // client Pongs to the recv loop, which resets its
+                    // idle timer.
+                    if ws_sender.send(Message::Ping(Vec::new().into())).await.is_err() {
+                        break;
                     }
                 }
             }
@@ -311,7 +342,19 @@ async fn handle_terminal_ws(
         // when this client becomes primary.
         let mut pending_size: Option<(u16, u16)> = None;
 
-        while let Some(Ok(msg)) = ws_receiver.next().await {
+        loop {
+            // Wrap each receive in IDLE_TIMEOUT so a silent socket
+            // (mobile backgrounded, WiFi vanished without TCP RST) is
+            // detected and the cleanup path below can kill the tmux
+            // child + free its PTY pair. Server-originated Pings in the
+            // send task elicit Pongs that arrive here and reset the
+            // timer, so live-but-idle sessions stay open indefinitely.
+            let msg = match tokio::time::timeout(IDLE_TIMEOUT, ws_receiver.next()).await {
+                Err(_) => break,
+                Ok(None) => break,
+                Ok(Some(Err(_))) => break,
+                Ok(Some(Ok(msg))) => msg,
+            };
             match msg {
                 Message::Binary(data) => {
                     // Raw bytes from xterm.js -> PTY stdin (blocked in read-only mode)


### PR DESCRIPTION
## Description

Each `aoe serve` WebSocket terminal owns a `tmux attach` child plus its PTY pair (master + cloned reader + writer = ~3 FDs, plus the child's own descriptors). When a client goes silent without sending a Close frame, those resources stay pinned until tmux next emits output, which on an idle session can be hours. The most common ways this happens today:

1. Mobile app gets backgrounded; iOS/Android suspend the WebSocket without closing it cleanly.
2. WiFi vanishes mid-session (subway, elevator) without TCP RST propagating.
3. Browser tab is force-closed.

The accumulated leaked FDs are exactly the pressure that motivated the `RLIMIT_NOFILE` bump in #971. That PR raised the ceiling; this PR removes the leak that fills it.

### What this changes

In `src/server/ws.rs` `handle_terminal_ws`:

1. Send task now also drives a `tokio::time::interval(30s)` and emits `Message::Ping` on each tick. The first immediate tick is consumed before entering the select so we don't ping at connection time. `MissedTickBehavior::Skip` keeps backpressure from producing a burst of pings.
2. Recv task wraps `ws_receiver.next()` in a `tokio::time::timeout(90s)`. On idle timeout it breaks out of the loop, which releases the recv handle and lets the existing cleanup path run (`release_primary`, `pause_exit`, `child.kill()`, `child.wait()`).

axum's `WebSocket` forwards client Pongs back to the recv loop, so live-but-idle sessions stay open indefinitely: each server Ping prompts a client Pong, the Pong arrives in recv, the timeout resets. 90s tolerates two missed round-trips before tear-down.

### Why these constants

- `PING_INTERVAL = 30s`: long enough to be cheap (one tiny frame per direction every 30s); short enough to keep mobile-carrier NAT mappings warm (typical UDP/TCP NAT timeouts on cellular start around 60s).
- `IDLE_TIMEOUT = 90s`: 3 × `PING_INTERVAL`, so a single dropped packet doesn't kill the connection but a genuinely dead client is reaped within ~90s.

### What this doesn't change

- `Message::Ping` payloads are empty; we don't track RTTs or sequence numbers.
- No write-side timeout. A backgrounded mobile client whose TCP receive window has filled will still cause server sends to block; trying to tear that down on a short timeout would punish slow-but-live clients. The recv-side idle timeout is the load-bearing safeguard for FD reclaim.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (N/A, internal behavior)
- [ ] For UI changes: included screenshot or recording (N/A, server-side fix)

Verified locally with:

- `cargo build --features serve` (clean)
- `cargo clippy --features serve --no-deps -- -D warnings` (clean)
- `cargo test --features serve --lib server::ws` (10 ws tests pass)
- Manual: ran `aoe serve --no-auth`, attached a browser, put the tab to sleep without sending Close, watched the connection get reaped after ~90s with the tmux attach child correctly killed.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Drafted with Claude Code after a discussion about the deeper design issue behind #971. Reviewed and verified locally before posting.

- [x] I am an AI Agent filling out this form (check box if true)