### PR TITLE
fix(cli): cleaner error when add path does not exist

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,6 +1,6 @@
 //! `agent-of-empires add` command implementation
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use std::path::PathBuf;
 
@@ -105,7 +105,12 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     let mut path = if args.path.as_os_str() == "." {
         std::env::current_dir()?
     } else {
-        args.path.canonicalize()?
+        if !args.path.exists() {
+            bail!("Path does not exist: {}", args.path.display());
+        }
+        args.path
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve path: {}", args.path.display()))?
     };
 
     if !path.is_dir() {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,6 +1,6 @@
 //! `agent-of-empires init` command implementation
 
-use anyhow::{bail, Result};
+use anyhow::{bail, Context, Result};
 use clap::Args;
 use std::fs;
 use std::path::PathBuf;
@@ -18,7 +18,12 @@ pub async fn run(args: InitArgs) -> Result<()> {
     let path = if args.path.as_os_str() == "." {
         std::env::current_dir()?
     } else {
-        args.path.canonicalize()?
+        if !args.path.exists() {
+            bail!("Path does not exist: {}", args.path.display());
+        }
+        args.path
+            .canonicalize()
+            .with_context(|| format!("Failed to resolve path: {}", args.path.display()))?
     };
 
     let config_dir = path.join(".agent-of-empires");


### PR DESCRIPTION
## Description

When running `aoe add <path>` with a non-existent path, the user got the raw IO error:

```
Error: No such file or directory (os error 2)
```

This now reports the missing path explicitly:

```
Error: Path does not exist: /path/to/big/repo
```

Implementation in `src/cli/add.rs`: check `args.path.exists()` before `canonicalize()`, and wrap any remaining `canonicalize()` failure with `anyhow::Context` so it names the path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Used Claude Code to locate the offending `canonicalize()?` call and apply the context wrapper. Reviewed and tested the change manually.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)