### PR TITLE
fix: webui debug log noise + idempotent session branch deletion

### DIFF
--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -509,6 +509,11 @@ impl GitWorktree {
     /// Delete a local git branch.
     /// Returns an error if the branch doesn't exist or is currently checked out.
     pub fn delete_branch(&self, branch: &str) -> Result<()> {
+        tracing::debug!(
+            branch,
+            repo = %self.repo_path.display(),
+            "delete_branch: invoking `git branch -d`"
+        );
         let output = std::process::Command::new("git")
             .args(["branch", "-d", branch])
             .current_dir(&self.repo_path)
@@ -516,6 +521,14 @@ impl GitWorktree {
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            tracing::debug!(
+                branch,
+                exit = ?output.status.code(),
+                stderr = %stderr,
+                stdout = %stdout,
+                "delete_branch: `git branch -d` failed"
+            );
             // If the branch has unmerged changes, try force delete
             if stderr.contains("not fully merged") {
                 let force_output = std::process::Command::new("git")
@@ -524,10 +537,25 @@ impl GitWorktree {
                     .output()?;
 
                 if !force_output.status.success() {
-                    return Err(GitError::BranchNotFound(branch.to_string()));
+                    let force_stderr = String::from_utf8_lossy(&force_output.stderr);
+                    tracing::debug!(
+                        branch,
+                        exit = ?force_output.status.code(),
+                        stderr = %force_stderr,
+                        "delete_branch: `git branch -D` (force) also failed"
+                    );
+                    return Err(GitError::WorktreeCommandFailed(format!(
+                        "git branch -D {}: {}",
+                        branch,
+                        force_stderr.trim()
+                    )));
                 }
             } else {
-                return Err(GitError::BranchNotFound(branch.to_string()));
+                return Err(GitError::WorktreeCommandFailed(format!(
+                    "git branch -d {}: {}",
+                    branch,
+                    stderr.trim()
+                )));
             }
         }
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -507,7 +507,13 @@ impl GitWorktree {
     }
 
     /// Delete a local git branch.
-    /// Returns an error if the branch doesn't exist or is currently checked out.
+    ///
+    /// Idempotent: if the branch does not exist, returns Ok(()) — the caller
+    /// asked for the branch to be gone, and it is. This matters for session
+    /// deletion where the branch may never have been created (e.g. session
+    /// metadata stamped with a stale value, or worktree creation aborted
+    /// mid-flight). Returns an error only when git rejects the operation
+    /// for a reason other than "not found".
     pub fn delete_branch(&self, branch: &str) -> Result<()> {
         tracing::debug!(
             branch,
@@ -529,6 +535,15 @@ impl GitWorktree {
                 stdout = %stdout,
                 "delete_branch: `git branch -d` failed"
             );
+            // Branch already gone: treat as success. Git emits
+            // "error: branch '<name>' not found" in this case.
+            if stderr.contains("not found") {
+                tracing::debug!(
+                    branch,
+                    "delete_branch: branch already absent, treating as success"
+                );
+                return Ok(());
+            }
             // If the branch has unmerged changes, try force delete
             if stderr.contains("not fully merged") {
                 let force_output = std::process::Command::new("git")
@@ -1111,14 +1126,66 @@ mod tests {
     }
 
     #[test]
-    fn test_delete_branch_fails_for_nonexistent_branch() {
+    fn test_delete_branch_is_idempotent_for_nonexistent_branch() {
+        // Sessions whose metadata stamps a branch that was never actually
+        // created (e.g. stale or corrupted session record) should still
+        // delete cleanly. The caller asked for the branch to be gone, and
+        // it is — that's the intended end state.
         let (_dir, repo) = setup_test_repo();
         let repo_path = repo.path().parent().unwrap();
 
         let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
         let result = git_wt.delete_branch("nonexistent");
 
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "delete_branch should succeed when branch is absent, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_delete_branch_idempotent_for_branch_with_spaces_in_name() {
+        // Regression for sessions whose branch field was populated with a
+        // free-form string ("too many open files"). Git rejects such a name
+        // with "branch '<name>' not found"; treat as success.
+        let (_dir, repo) = setup_test_repo();
+        let repo_path = repo.path().parent().unwrap();
+
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        let result = git_wt.delete_branch("too many open files");
+
+        assert!(
+            result.is_ok(),
+            "delete_branch should be idempotent for never-created branch names, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn test_delete_branch_returns_error_for_other_failures() {
+        // Trying to delete the currently checked-out branch should still
+        // fail — that's a real error, not a "branch doesn't exist" case.
+        let (_dir, repo) = setup_test_repo();
+        let repo_path = repo.path().parent().unwrap();
+
+        // The setup_test_repo helper checks out a branch named "main" or
+        // "master" depending on git defaults. Either way, it's the active
+        // branch and cannot be deleted.
+        let head_branch = repo
+            .head()
+            .ok()
+            .and_then(|h| h.shorthand().map(String::from))
+            .expect("HEAD should be a branch");
+
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        let result = git_wt.delete_branch(&head_branch);
+
+        assert!(
+            result.is_err(),
+            "delete_branch should fail for the checked-out branch, got {:?}",
+            result
+        );
     }
 
     #[test]

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -418,6 +418,10 @@ pub fn spawn_consumer(state: std::sync::Arc<super::AppState>) {
         let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(SEND_CONCURRENCY));
         let mut rx = state.status_tx.subscribe();
         let mut dwell: HashMap<String, DwellState> = HashMap::new();
+        // Tracks the last suppression reason so we only log on transitions
+        // (active → suppressed, suppressed → active, or reason flip),
+        // instead of every 500ms tick while the dashboard is open.
+        let mut last_suppress_reason: Option<&'static str> = None;
 
         // Interleave receiving status changes with polling the dwell
         // map for sessions whose dwell window has elapsed. A simple
@@ -441,7 +445,7 @@ pub fn spawn_consumer(state: std::sync::Arc<super::AppState>) {
                     }
                 }
                 _ = tick.tick() => {
-                    fire_due_pushes(state.clone(), &client, &semaphore, &mut dwell).await;
+                    fire_due_pushes(state.clone(), &client, &semaphore, &mut dwell, &mut last_suppress_reason).await;
                 }
             }
         }
@@ -499,6 +503,7 @@ async fn fire_due_pushes(
     client: &reqwest::Client,
     semaphore: &std::sync::Arc<tokio::sync::Semaphore>,
     dwell: &mut HashMap<String, DwellState>,
+    last_suppress_reason: &mut Option<&'static str>,
 ) {
     let Some(push) = app_state.push.as_ref() else {
         return; // feature disabled, nothing to do
@@ -518,8 +523,20 @@ async fn fire_due_pushes(
     } else {
         None
     };
-    if let Some(reason) = suppress_reason {
-        tracing::debug!("push: suppressed, {}", reason);
+    // Only log on transitions: entering a new suppression reason or
+    // resuming after suppression ends. Otherwise this fires every 500ms.
+    if suppress_reason != *last_suppress_reason {
+        match (*last_suppress_reason, suppress_reason) {
+            (None, Some(reason)) => tracing::debug!("push: suppressed, {}", reason),
+            (Some(_), Some(reason)) => {
+                tracing::debug!("push: suppression reason changed to {}", reason)
+            }
+            (Some(prev), None) => tracing::debug!("push: resumed (was suppressed: {})", prev),
+            (None, None) => {}
+        }
+        *last_suppress_reason = suppress_reason;
+    }
+    if suppress_reason.is_some() {
         return;
     }
 

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -27,6 +27,20 @@ pub struct DeletionResult {
 pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     let mut errors = Vec::new();
 
+    tracing::debug!(
+        session_id = %request.session_id,
+        title = %request.instance.title,
+        delete_worktree = request.delete_worktree,
+        delete_branch = request.delete_branch,
+        delete_sandbox = request.delete_sandbox,
+        force_delete = request.force_delete,
+        worktree_branch = request.instance.worktree_info.as_ref().map(|w| w.branch.as_str()).unwrap_or("<none>"),
+        worktree_managed = request.instance.worktree_info.as_ref().map(|w| w.managed_by_aoe).unwrap_or(false),
+        worktree_main_repo = request.instance.worktree_info.as_ref().map(|w| w.main_repo_path.as_str()).unwrap_or("<none>"),
+        workspace_repos = request.instance.workspace_info.as_ref().map(|w| w.repos.len()).unwrap_or(0),
+        "perform_deletion: starting"
+    );
+
     // Execute on_destroy hooks before any cleanup so resources (containers,
     // worktrees) are still available for teardown commands.
     run_on_destroy_hooks(&request.instance);
@@ -42,6 +56,9 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     } else {
         None
     };
+    if let Some((b, r)) = branch_to_delete.as_ref() {
+        tracing::debug!(branch = %b, main_repo = %r.display(), "perform_deletion: branch_to_delete resolved");
+    }
 
     // Worktree cleanup (if user opted to delete it)
     // Must happen before branch deletion since the worktree is using the branch
@@ -116,17 +133,24 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     if let Some((branch, main_repo)) = branch_to_delete {
         let worktree_ok =
             !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Worktree:"));
+        tracing::debug!(branch = %branch, main_repo = %main_repo.display(), worktree_ok, "perform_deletion: attempting branch deletion");
         if worktree_ok {
-            match GitWorktree::new(main_repo) {
+            match GitWorktree::new(main_repo.clone()) {
                 Ok(git_wt) => {
                     if let Err(e) = git_wt.delete_branch(&branch) {
+                        tracing::debug!(branch = %branch, error = %e, "perform_deletion: delete_branch returned error");
                         errors.push(format!("Branch: {}", e));
                     }
                 }
                 Err(e) => {
+                    tracing::debug!(main_repo = %main_repo.display(), error = %e, "perform_deletion: GitWorktree::new failed");
                     errors.push(format!("Branch: {}", e));
                 }
             }
+        } else {
+            tracing::debug!(
+                "perform_deletion: skipping branch deletion (worktree removal had errors)"
+            );
         }
     }
 
@@ -172,6 +196,17 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
 
     // Clean up hook status files
     crate::hooks::cleanup_hook_status_dir(&request.instance.id);
+
+    if !errors.is_empty() {
+        tracing::debug!(
+            session_id = %request.session_id,
+            error_count = errors.len(),
+            errors = ?errors,
+            "perform_deletion: completed with errors"
+        );
+    } else {
+        tracing::debug!(session_id = %request.session_id, "perform_deletion: completed successfully");
+    }
 
     DeletionResult {
         session_id: request.session_id.clone(),

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -40,20 +40,9 @@ pub fn detect_status_from_content(content: &str, tool: &str) -> Status {
     // called with -e (to preserve colors for the TUI preview), but color codes
     // interspersed in text like "esc interrupt" break plain substring matches.
     let clean = strip_ansi(content);
-    let status = crate::agents::get_agent(tool)
+    crate::agents::get_agent(tool)
         .map(|a| (a.detect_status)(&clean))
-        .unwrap_or(Status::Idle);
-
-    if status == Status::Idle {
-        let last_lines: Vec<&str> = clean.lines().rev().take(5).collect();
-        tracing::debug!(
-            "status detection returned Idle for tool '{}', last 5 lines: {:?}",
-            tool,
-            last_lines
-        );
-    }
-
-    status
+        .unwrap_or(Status::Idle)
 }
 
 /// Spinner frame characters Claude Code rotates through next to its active


### PR DESCRIPTION
## Description

Three small fixes that surfaced while debugging `aoe serve`:

1. **`debug.log` noise reduction.** Two log sites accounted for ~99% of `AGENT_OF_EMPIRES_DEBUG=1` log volume:
   - `server::push` was logging `push: suppressed, web dashboard is active` every 500ms tick. Now logs only on transitions (suppressed → active, active → suppressed, reason flip).
   - `tmux::status_detection` was logging `status detection returned Idle for tool '...', last 5 lines: ...` on every poll per session. The downstream `instance.rs` already traces the detected status, so this was redundant; removed.

2. **Better diagnostics around session deletion.** `perform_deletion` now logs the session id, title, deletion flags, worktree branch/main_repo, and the per-step outcome. `git::worktree::delete_branch` now logs the actual git stdout/stderr/exit code on failure instead of swallowing every error under a fake `BranchNotFound`. The user-visible error became `WorktreeCommandFailed` carrying the real stderr so it stops lying.

3. **`delete_branch` is now idempotent for absent branches.** Sessions whose stored branch name was never actually created as a git branch (e.g. corrupt or stale metadata) used to fail deletion with `Branch '<name>' not found`. The caller asked for the branch to be gone, and it is — that's the desired end state, not a failure. Real errors (deleting the checked-out branch, etc.) still surface with the actual git stderr.

Hit while a session whose branch field had been stamped with the literal string `too many open files` could not be deleted via the web UI (`DELETE /api/sessions/{id}` → 500 `deletion_failed: Branch: Branch 'too many open files' not found`). Symptom is now fixed; the deletion logs make the upstream stamping bug easy to chase next.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Tested with `cargo build --features serve`, `cargo clippy --features serve --lib --tests` (no warnings), `cargo test --lib git::` (85 passed). New unit tests cover the idempotent absent-branch case, the spaces-in-branch-name regression, and the still-errors-for-checked-out-branch case. Manually verified the spammy log lines disappear by re-running `AGENT_OF_EMPIRES_DEBUG=1 ./target/debug/aoe serve` and inspecting `~/.agent-of-empires/debug.log`.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Investigation, log instrumentation, fix, and tests drafted by Claude. Framing, scope cut, and the call to keep the debug-logs commit separate from the symptom fix are mine.

- [x] I am an AI Agent filling out this form (check box if true)