### PR TITLE
feat: isolate debug-build state from release (#985)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.
 - Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
 - Running from source needs `tmux` installed.
+- Debug builds use an isolated namespace so they don't collide with an installed release `aoe`: app data dir is `~/.agent-of-empires-dev` (macOS/Windows) or `~/.config/agent-of-empires-dev` (Linux), tmux session prefix is `aoe_dev_`, and `aoe serve` defaults to port `8081`. Release builds keep the original `agent-of-empires` paths, `aoe_` prefix, and port `8080`.
 
 ### Web Dashboard
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,6 +189,10 @@ strip = true
 inherits = "release"
 lto = false
 codegen-units = 16
+# Same "is this a dev build?" gate as the default dev profile, so the
+# isolated app dir / tmux prefix / serve port apply here too. Anything
+# that's not a true release build shares the dev namespace.
+debug-assertions = true
 
 [[bin]]
 name = "aoe"

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ cargo build --release  # Release build
 AGENT_OF_EMPIRES_DEBUG=1 cargo run
 ```
 
+Debug builds use a parallel namespace so they don't collide with an installed
+release `aoe`: app data lives in `~/.agent-of-empires-dev` (macOS/Windows) or
+`~/.config/agent-of-empires-dev` (Linux), tmux sessions are prefixed
+`aoe_dev_`, and `aoe serve` defaults to port `8081`. Release builds are
+unchanged.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=njbrake/agent-of-empires&type=date&legend=top-left)](https://www.star-history.com/#njbrake/agent-of-empires&type=date&legend=top-left)

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -756,9 +756,7 @@ Start a web dashboard for remote session access
 
 ###### **Options:**
 
-* `--port <PORT>` — Port to listen on
-
-  Default value: `8080`
+* `--port <PORT>` — Port to listen on (default: 8080; debug builds default to 8081 so a `cargo run` instance does not collide with an installed release `aoe`)
 * `--host <HOST>` — Host/IP to bind to (use 0.0.0.0 for LAN/VPN access)
 
   Default value: `127.0.0.1`

--- a/docs/development.md
+++ b/docs/development.md
@@ -19,6 +19,25 @@ AGENT_OF_EMPIRES_DEBUG=1 cargo run  # Debug logging (writes to debug.log in app 
 
 Requires `tmux` to be installed.
 
+### Dev namespace
+
+Debug builds use an isolated namespace so a local `cargo run` shares no
+state with an installed release `aoe`. Run them side-by-side without
+collisions on sessions, settings, the tmux server, or `aoe serve`.
+
+| | Release | Debug (`cargo run`) |
+| --- | --- | --- |
+| App dir (macOS / Windows) | `~/.agent-of-empires` | `~/.agent-of-empires-dev` |
+| App dir (Linux) | `~/.config/agent-of-empires` | `~/.config/agent-of-empires-dev` |
+| `tmux` session prefix | `aoe_` | `aoe_dev_` |
+| `aoe serve` default port | `8080` | `8081` |
+
+`debug.log` and `serve.log` live inside the app dir, so they are isolated
+automatically. Debug builds start with an empty namespace on first run, so
+nothing migrates from your real `~/.agent-of-empires`. Wipe dev state any
+time with `rm -rf ~/.agent-of-empires-dev` (or the Linux XDG equivalent);
+release data is untouched.
+
 ## Testing
 
 ```bash

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -8,7 +8,8 @@ use std::sync::Mutex;
 #[derive(Args)]
 pub struct ServeArgs {
     /// Port to listen on
-    #[arg(long, default_value = "8080")]
+    #[cfg_attr(debug_assertions, arg(long, default_value = "8081"))]
+    #[cfg_attr(not(debug_assertions), arg(long, default_value = "8080"))]
     pub port: u16,
 
     /// Host/IP to bind to (use 0.0.0.0 for LAN/VPN access)

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -7,10 +7,10 @@ use std::sync::Mutex;
 
 #[derive(Args)]
 pub struct ServeArgs {
-    /// Port to listen on
-    #[cfg_attr(debug_assertions, arg(long, default_value = "8081"))]
-    #[cfg_attr(not(debug_assertions), arg(long, default_value = "8080"))]
-    pub port: u16,
+    /// Port to listen on (default: 8080; debug builds default to 8081 so a
+    /// `cargo run` instance does not collide with an installed release `aoe`).
+    #[arg(long)]
+    pub port: Option<u16>,
 
     /// Host/IP to bind to (use 0.0.0.0 for LAN/VPN access)
     #[arg(long, default_value = "127.0.0.1")]
@@ -57,6 +57,17 @@ pub struct ServeArgs {
     /// Can also be set via AOE_SERVE_PASSPHRASE environment variable.
     #[arg(long, env = "AOE_SERVE_PASSPHRASE")]
     pub passphrase: Option<String>,
+}
+
+impl ServeArgs {
+    /// Resolve the port: explicit `--port` wins; otherwise 8081 in debug
+    /// builds, 8080 in release. The `-dev` suffix on the app dir keeps
+    /// state isolated, but two daemons cannot share a port, so the default
+    /// shifts as well.
+    pub fn resolved_port(&self) -> u16 {
+        self.port
+            .unwrap_or(if cfg!(debug_assertions) { 8081 } else { 8080 })
+    }
 }
 
 /// True when `aoe serve --remote` will route through Cloudflare and therefore
@@ -329,7 +340,7 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     let result = crate::server::start_server(crate::server::ServerConfig {
         profile,
         host: &host,
-        port: args.port,
+        port: args.resolved_port(),
         no_auth: args.no_auth,
         read_only: args.read_only,
         remote: args.remote,
@@ -380,7 +391,7 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     cmd.args([
         "serve",
         "--port",
-        &args.port.to_string(),
+        &args.resolved_port().to_string(),
         "--host",
         &args.host,
     ]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,12 @@ fn is_serve_command(_cli: &Cli) -> bool {
 async fn main() -> Result<()> {
     let cli = Cli::parse();
 
+    // Detect drift between release-build state and dev-build state BEFORE
+    // anything below calls `get_app_dir()` (which would auto-create the dev
+    // dir and silently flip the trigger condition for the rest of this
+    // process). Compiled away in release builds.
+    let debug_namespace_drift = agent_of_empires::session::debug_namespace_drift();
+
     let mut debug_log_warning: Option<String> = None;
     if std::env::var("AGENT_OF_EMPIRES_DEBUG").is_ok() {
         // Log to file to avoid corrupting the TUI on stderr.
@@ -57,6 +63,19 @@ async fn main() -> Result<()> {
             .with_ansi(false)
             .try_init()
             .ok();
+    }
+
+    // CLI invocations get the dev-namespace drift warning on stderr right
+    // away. TUI mode handles it via the existing startup-warning popup
+    // pipeline below — we don't print here for TUI because ratatui's
+    // alt-screen would clobber the message.
+    if cli.command.is_some() {
+        if let Some((release, dev)) = debug_namespace_drift.as_ref() {
+            eprintln!(
+                "\n{}\n",
+                agent_of_empires::session::format_debug_namespace_warning(release, dev),
+            );
+        }
     }
 
     // Handle commands that don't need app data or migrations.
@@ -118,7 +137,21 @@ async fn main() -> Result<()> {
         Some(Commands::Serve(args)) => cli::serve::run(&profile, args).await,
         #[cfg(feature = "serve")]
         Some(Commands::Cockpit { command }) => cli::cockpit::run(command).await,
-        None => tui::run(&profile, debug_log_warning).await,
+        None => {
+            // Fold the drift notice into the existing startup-warning channel
+            // so the TUI surfaces both (debug-log + drift, if both fire) in a
+            // single modal instead of stacking two dialogs.
+            let drift_msg = debug_namespace_drift.as_ref().map(|(release, dev)| {
+                agent_of_empires::session::format_debug_namespace_warning(release, dev)
+            });
+            let combined = match (debug_log_warning, drift_msg) {
+                (Some(a), Some(b)) => Some(format!("{a}\n\n{b}")),
+                (Some(a), None) => Some(a),
+                (None, Some(b)) => Some(b),
+                (None, None) => None,
+            };
+            tui::run(&profile, combined).await
+        }
         _ => unreachable!(),
     }
 }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -111,12 +111,12 @@ fn get_all_possible_dirs() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     if let Some(home) = dirs::home_dir() {
-        dirs.push(home.join(".agent-of-empires"));
+        dirs.push(home.join(crate::session::APP_DIR_NAME_OTHER));
     }
 
     #[cfg(target_os = "linux")]
     if let Some(config_dir) = dirs::config_dir() {
-        dirs.push(config_dir.join("agent-of-empires"));
+        dirs.push(config_dir.join(crate::session::APP_DIR_NAME_LINUX));
     }
 
     dirs

--- a/src/migrations/v001_xdg_linux.rs
+++ b/src/migrations/v001_xdg_linux.rs
@@ -13,6 +13,11 @@ use tracing::debug;
 use {std::fs, tracing::info};
 
 pub fn run() -> Result<()> {
+    if cfg!(debug_assertions) {
+        debug!("Skipping v001 XDG migration in debug build (dev namespace is isolated from release data)");
+        return Ok(());
+    }
+
     #[cfg(target_os = "linux")]
     {
         let home = dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -845,9 +845,12 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         #[cfg(target_os = "linux")]
-        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_LINUX);
         #[cfg(not(target_os = "linux"))]
-        let app_dir = temp_home.path().join(".agent-of-empires");
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         std::fs::create_dir_all(&app_dir).unwrap();
         std::fs::write(app_dir.join("config.toml"), r#"default_profile = "alpha""#).unwrap();
@@ -868,9 +871,12 @@ mod tests {
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         #[cfg(target_os = "linux")]
-        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_LINUX);
         #[cfg(not(target_os = "linux"))]
-        let app_dir = temp_home.path().join(".agent-of-empires");
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         std::fs::create_dir_all(&app_dir).unwrap();
         // Malformed: 'enabled_by_default' under [sandbox] expects a boolean.

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2387,9 +2387,12 @@ extra_volumes = ["/host/data:/container/data:ro"]
         std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
 
         #[cfg(target_os = "linux")]
-        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_LINUX);
         #[cfg(not(target_os = "linux"))]
-        let app_dir = temp_home.path().join(".agent-of-empires");
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         let profiles_dir = app_dir.join("profiles");
         fs::create_dir_all(profiles_dir.join("default")).unwrap();

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -457,9 +457,12 @@ mod tests {
 
         // Determine app dir layout (matches session::get_app_dir_path).
         #[cfg(target_os = "linux")]
-        let app_dir = temp_home.path().join(".config").join("agent-of-empires");
+        let app_dir = temp_home
+            .path()
+            .join(".config")
+            .join(crate::session::APP_DIR_NAME_LINUX);
         #[cfg(not(target_os = "linux"))]
-        let app_dir = temp_home.path().join(".agent-of-empires");
+        let app_dir = temp_home.path().join(crate::session::APP_DIR_NAME_OTHER);
 
         let profiles_dir = app_dir.join("profiles");
         std::fs::create_dir_all(profiles_dir.join("default")).unwrap();

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -48,7 +48,7 @@ pub use storage::Storage;
 
 use anyhow::Result;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 pub const DEFAULT_PROFILE: &str = "default";
@@ -90,6 +90,66 @@ fn get_app_dir_path() -> Result<PathBuf> {
         .join(APP_DIR_NAME_OTHER);
 
     Ok(dir)
+}
+
+/// Detect the first-launch case where a debug build is being run on a
+/// machine that has populated release-build state in `~/.agent-of-empires`
+/// but no dev-build state yet. Returns the (release_dir, dev_dir) pair so
+/// callers can surface the paths in a one-time warning.
+///
+/// Self-extinguishing by design: once `get_app_dir` creates the dev dir on
+/// any subsequent call, this returns `None` and the warning stops. No flag
+/// file, no config state, no dismissal logic — the directory topology IS
+/// the state.
+///
+/// Returns `None` on release builds (the dev/release split doesn't apply),
+/// when the release dir is absent or empty (user has no prior state to
+/// "lose visibility of"), or when the dev dir already exists.
+pub fn debug_namespace_drift() -> Option<(PathBuf, PathBuf)> {
+    if !cfg!(debug_assertions) {
+        return None;
+    }
+
+    #[cfg(target_os = "linux")]
+    let release_dir = dirs::config_dir()?.join("agent-of-empires");
+    #[cfg(not(target_os = "linux"))]
+    let release_dir = dirs::home_dir()?.join(".agent-of-empires");
+
+    #[cfg(target_os = "linux")]
+    let dev_dir = dirs::config_dir()?.join(APP_DIR_NAME_LINUX);
+    #[cfg(not(target_os = "linux"))]
+    let dev_dir = dirs::home_dir()?.join(APP_DIR_NAME_OTHER);
+
+    let release_populated = fs::read_dir(&release_dir)
+        .map(|mut entries| entries.next().is_some())
+        .unwrap_or(false);
+
+    if release_populated && !dev_dir.exists() {
+        Some((release_dir, dev_dir))
+    } else {
+        None
+    }
+}
+
+/// Format the user-facing warning shown when `debug_namespace_drift()`
+/// fires. Shared between the CLI stderr print and the TUI startup popup so
+/// both surfaces say exactly the same thing.
+pub fn format_debug_namespace_warning(release: &Path, dev: &Path) -> String {
+    format!(
+        "Debug builds now use an isolated app dir:\n  \
+         {}\n\n\
+         Your existing state in\n  \
+         {}\n\
+         is not visible to this build.\n\n\
+         To migrate it, run:\n  \
+         cp -r {} {}\n\n\
+         Otherwise, do nothing — this notice will not repeat once the dev dir exists.\n\
+         See docs/development.md for details.",
+        dev.display(),
+        release.display(),
+        release.display(),
+        dev.display(),
+    )
 }
 
 pub fn get_profile_dir(profile: &str) -> Result<PathBuf> {
@@ -348,5 +408,74 @@ mod tests {
 
         let warning = collect_startup_config_warnings("default").expect("expected a warning");
         assert!(warning.contains("Failed to load profile config 'default'"));
+    }
+
+    fn release_dir_in(temp: &tempfile::TempDir) -> PathBuf {
+        #[cfg(target_os = "linux")]
+        let d = temp.path().join(".config").join("agent-of-empires");
+        #[cfg(not(target_os = "linux"))]
+        let d = temp.path().join(".agent-of-empires");
+        d
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_drift_none_when_no_release_dir() {
+        let _temp = isolate_app_dir();
+        // Neither dir exists → no drift to flag.
+        assert!(debug_namespace_drift().is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_drift_none_when_release_empty() {
+        let temp = isolate_app_dir();
+        let release = release_dir_in(&temp);
+        fs::create_dir_all(&release).unwrap();
+        // Release dir exists but has no content — user has no prior state
+        // to lose visibility of, so don't nag them.
+        assert!(debug_namespace_drift().is_none());
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_drift_fires_when_release_populated_and_dev_absent() {
+        let temp = isolate_app_dir();
+        let release = release_dir_in(&temp);
+        fs::create_dir_all(release.join("profiles")).unwrap();
+
+        let drift = debug_namespace_drift();
+        // Only assert presence on debug builds — release builds compile this
+        // function to `None`.
+        if cfg!(debug_assertions) {
+            let (r, d) = drift.expect("expected drift on debug build");
+            assert_eq!(r, release);
+            assert!(d.to_string_lossy().contains("-dev"));
+        } else {
+            assert!(drift.is_none());
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_drift_silent_once_dev_dir_exists() {
+        let temp = isolate_app_dir();
+        let release = release_dir_in(&temp);
+        fs::create_dir_all(release.join("profiles")).unwrap();
+        // Simulate "user has already run aoe once after the namespace
+        // change" by creating the dev dir.
+        let _dev = app_dir(&temp);
+        assert!(debug_namespace_drift().is_none());
+    }
+
+    #[test]
+    fn test_format_warning_mentions_both_paths_and_migration_command() {
+        let release = PathBuf::from("/home/u/.config/agent-of-empires");
+        let dev = PathBuf::from("/home/u/.config/agent-of-empires-dev");
+        let msg = format_debug_namespace_warning(&release, &dev);
+        assert!(msg.contains("/home/u/.config/agent-of-empires"));
+        assert!(msg.contains("/home/u/.config/agent-of-empires-dev"));
+        assert!(msg.contains("cp -r"));
+        assert!(msg.contains("not repeat"));
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -53,6 +53,23 @@ use std::time::Duration;
 
 pub const DEFAULT_PROFILE: &str = "default";
 
+/// Linux app dir name (under `$XDG_CONFIG_HOME`). Debug builds use a `-dev`
+/// suffix so a `cargo run` instance shares no state with an installed
+/// release binary.
+pub const APP_DIR_NAME_LINUX: &str = if cfg!(debug_assertions) {
+    "agent-of-empires-dev"
+} else {
+    "agent-of-empires"
+};
+
+/// macOS/Windows app dir name (under `$HOME`). Debug builds use a `-dev`
+/// suffix; see `APP_DIR_NAME_LINUX`.
+pub const APP_DIR_NAME_OTHER: &str = if cfg!(debug_assertions) {
+    ".agent-of-empires-dev"
+} else {
+    ".agent-of-empires"
+};
+
 pub fn get_app_dir() -> Result<PathBuf> {
     let dir = get_app_dir_path()?;
     if !dir.exists() {
@@ -65,12 +82,12 @@ fn get_app_dir_path() -> Result<PathBuf> {
     #[cfg(target_os = "linux")]
     let dir = dirs::config_dir()
         .ok_or_else(|| anyhow::anyhow!("Cannot find config directory"))?
-        .join("agent-of-empires");
+        .join(APP_DIR_NAME_LINUX);
 
     #[cfg(not(target_os = "linux"))]
     let dir = dirs::home_dir()
         .ok_or_else(|| anyhow::anyhow!("Cannot find home directory"))?
-        .join(".agent-of-empires");
+        .join(APP_DIR_NAME_OTHER);
 
     Ok(dir)
 }
@@ -285,9 +302,9 @@ mod tests {
 
     fn app_dir(temp_home: &tempfile::TempDir) -> PathBuf {
         #[cfg(target_os = "linux")]
-        let dir = temp_home.path().join(".config").join("agent-of-empires");
+        let dir = temp_home.path().join(".config").join(APP_DIR_NAME_LINUX);
         #[cfg(not(target_os = "linux"))]
-        let dir = temp_home.path().join(".agent-of-empires");
+        let dir = temp_home.path().join(APP_DIR_NAME_OTHER);
         fs::create_dir_all(&dir).unwrap();
         dir
     }

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -27,9 +27,24 @@ use std::process::Command;
 use std::sync::RwLock;
 use std::time::{Duration, Instant};
 
-pub const SESSION_PREFIX: &str = "aoe_";
-pub const TERMINAL_PREFIX: &str = "aoe_term_";
-pub const CONTAINER_TERMINAL_PREFIX: &str = "aoe_cterm_";
+// Debug builds use `aoe_dev_*` prefixes so `cargo run` and an installed
+// release `aoe` can coexist on the same tmux server without seeing each
+// other's sessions.
+pub const SESSION_PREFIX: &str = if cfg!(debug_assertions) {
+    "aoe_dev_"
+} else {
+    "aoe_"
+};
+pub const TERMINAL_PREFIX: &str = if cfg!(debug_assertions) {
+    "aoe_dev_term_"
+} else {
+    "aoe_term_"
+};
+pub const CONTAINER_TERMINAL_PREFIX: &str = if cfg!(debug_assertions) {
+    "aoe_dev_cterm_"
+} else {
+    "aoe_cterm_"
+};
 
 /// Pre-fetched pane metadata from a single `tmux list-panes -a` call.
 #[derive(Debug, Clone)]
@@ -271,55 +286,54 @@ impl AvailableTools {
 mod tests {
     use super::*;
 
+    // Session names embed `SESSION_PREFIX`, which differs between release
+    // (`aoe_`) and debug (`aoe_dev_`) builds. Use the constant so the same
+    // test bodies cover both.
+    const P: &str = SESSION_PREFIX;
+
     #[test]
     fn test_parse_pane_metadata_basic() {
-        let output = "aoe_my_proj_abc12345|0|0|claude\n";
-        let map = parse_pane_metadata(output);
+        let output = format!("{P}my_proj_abc12345|0|0|claude\n");
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
-        let meta = map.get("aoe_my_proj_abc12345").unwrap();
+        let meta = map.get(&format!("{P}my_proj_abc12345")).unwrap();
         assert!(!meta.pane_dead);
         assert_eq!(meta.pane_current_command.as_deref(), Some("claude"));
     }
 
     #[test]
     fn test_parse_pane_metadata_dead_pane() {
-        let output = "aoe_proj_abc12345|0|1|bash\n";
-        let map = parse_pane_metadata(output);
-        let meta = map.get("aoe_proj_abc12345").unwrap();
+        let output = format!("{P}proj_abc12345|0|1|bash\n");
+        let map = parse_pane_metadata(&output);
+        let meta = map.get(&format!("{P}proj_abc12345")).unwrap();
         assert!(meta.pane_dead);
     }
 
     #[test]
     fn test_parse_pane_metadata_filters_non_aoe_sessions() {
-        let output = "\
-user_session|0|0|bash\n\
-aoe_proj_abc12345|0|0|claude\n\
-my_tmux|0|0|vim\n";
-        let map = parse_pane_metadata(output);
+        let output =
+            format!("user_session|0|0|bash\n{P}proj_abc12345|0|0|claude\nmy_tmux|0|0|vim\n");
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
-        assert!(map.contains_key("aoe_proj_abc12345"));
+        assert!(map.contains_key(&format!("{P}proj_abc12345")));
     }
 
     #[test]
     fn test_parse_pane_metadata_filters_non_zero_panes() {
-        let output = "\
-aoe_proj_abc12345|0|0|claude\n\
-aoe_proj_abc12345|1|0|bash\n";
-        let map = parse_pane_metadata(output);
+        let output = format!("{P}proj_abc12345|0|0|claude\n{P}proj_abc12345|1|0|bash\n");
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
-        let meta = map.get("aoe_proj_abc12345").unwrap();
+        let meta = map.get(&format!("{P}proj_abc12345")).unwrap();
         assert_eq!(meta.pane_current_command.as_deref(), Some("claude"));
     }
 
     #[test]
     fn test_parse_pane_metadata_first_window_wins() {
         // Two windows both have pane 0, first window's data should be kept
-        let output = "\
-aoe_proj_abc12345|0|0|claude\n\
-aoe_proj_abc12345|0|1|bash\n";
-        let map = parse_pane_metadata(output);
+        let output = format!("{P}proj_abc12345|0|0|claude\n{P}proj_abc12345|0|1|bash\n");
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
-        let meta = map.get("aoe_proj_abc12345").unwrap();
+        let meta = map.get(&format!("{P}proj_abc12345")).unwrap();
         assert!(!meta.pane_dead);
         assert_eq!(meta.pane_current_command.as_deref(), Some("claude"));
     }
@@ -331,45 +345,41 @@ aoe_proj_abc12345|0|1|bash\n";
 
     #[test]
     fn test_parse_pane_metadata_malformed_lines() {
-        let output = "\
-too|few|fields\n\
-aoe_proj_abc12345|0|0|claude\n\
-\n";
-        let map = parse_pane_metadata(output);
+        let output = format!("too|few|fields\n{P}proj_abc12345|0|0|claude\n\n");
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 1);
     }
 
     #[test]
     fn test_parse_pane_metadata_empty_command() {
-        let output = "aoe_proj_abc12345|0|0|\n";
-        let map = parse_pane_metadata(output);
-        let meta = map.get("aoe_proj_abc12345").unwrap();
+        let output = format!("{P}proj_abc12345|0|0|\n");
+        let map = parse_pane_metadata(&output);
+        let meta = map.get(&format!("{P}proj_abc12345")).unwrap();
         assert!(meta.pane_current_command.is_none());
     }
 
     #[test]
     fn test_parse_pane_metadata_multiple_sessions() {
-        let output = "\
-aoe_proj_a_abc12345|0|0|claude\n\
-aoe_proj_b_def67890|0|0|opencode\n\
-aoe_proj_c_ghi11111|0|1|bash\n";
-        let map = parse_pane_metadata(output);
+        let output = format!(
+            "{P}proj_a_abc12345|0|0|claude\n{P}proj_b_def67890|0|0|opencode\n{P}proj_c_ghi11111|0|1|bash\n"
+        );
+        let map = parse_pane_metadata(&output);
         assert_eq!(map.len(), 3);
         assert_eq!(
-            map.get("aoe_proj_a_abc12345")
+            map.get(&format!("{P}proj_a_abc12345"))
                 .unwrap()
                 .pane_current_command
                 .as_deref(),
             Some("claude")
         );
         assert_eq!(
-            map.get("aoe_proj_b_def67890")
+            map.get(&format!("{P}proj_b_def67890"))
                 .unwrap()
                 .pane_current_command
                 .as_deref(),
             Some("opencode")
         );
-        assert!(map.get("aoe_proj_c_ghi11111").unwrap().pane_dead);
+        assert!(map.get(&format!("{P}proj_c_ghi11111")).unwrap().pane_dead);
     }
 
     fn tmux_available() -> bool {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -230,7 +230,14 @@ impl App {
         // is `width - 4` columns wide (borders + 1-cell margin on each side),
         // so each \n-separated line wraps to ceil(len / inner_width) visual
         // rows. Borders + margin + the OK button take 6 rows.
-        const WIDTH: u16 = 80;
+        //
+        // 96, not 80: at the typical ~35-col sidebar width, a centered
+        // 80-wide dialog on a 150-col terminal lands its left border exactly
+        // at the sidebar's right border, which makes the modal visually
+        // blend into the layout. 96 shifts the coincidence point off the
+        // common laptop-fullscreen width and gives long path lines (e.g.
+        // `~/.config/agent-of-empires-dev`) more breathing room.
+        const WIDTH: u16 = 96;
         let inner_width = WIDTH.saturating_sub(4) as usize;
         let visual_lines: usize = message
             .lines()

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -6,13 +6,8 @@ use crate::harness::{require_tmux, TuiTestHarness};
 
 /// Helper to read a session field from the sessions.json in the harness's isolated home.
 fn read_sessions_json(h: &TuiTestHarness) -> serde_json::Value {
-    let sessions_path = if cfg!(target_os = "linux") {
-        h.home_path()
-            .join(".config/agent-of-empires/profiles/default/sessions.json")
-    } else {
-        h.home_path()
-            .join(".agent-of-empires/profiles/default/sessions.json")
-    };
+    let sessions_path =
+        crate::harness::app_dir_in(h.home_path()).join("profiles/default/sessions.json");
     let content = std::fs::read_to_string(&sessions_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {}", sessions_path.display(), e));
     serde_json::from_str(&content).expect("invalid sessions JSON")
@@ -108,11 +103,7 @@ fn test_cli_add_respects_config_extra_args() {
     let project = h.project_path();
 
     // Write config with agent_extra_args for claude
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -152,11 +143,7 @@ fn test_cli_add_respects_config_command_override() {
     let project = h.project_path();
 
     // Write config with agent_command_override for claude
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -196,11 +183,7 @@ fn test_cli_add_cli_flags_override_config() {
     let project = h.project_path();
 
     // Write config with agent_extra_args for claude
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -255,11 +238,7 @@ fn test_cli_add_respects_default_tool() {
     let h = TuiTestHarness::new("cli_add_default_tool");
     let project = h.project_path();
 
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -302,11 +281,7 @@ fn test_cli_add_cmd_overrides_default_tool() {
     let h = TuiTestHarness::new("cli_add_cmd_overrides");
     let project = h.project_path();
 
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -351,11 +326,7 @@ fn test_cli_add_respects_yolo_mode_default() {
     let h = TuiTestHarness::new("cli_add_yolo_default");
     let project = h.project_path();
 
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false
@@ -517,7 +488,11 @@ fn test_cli_rename_preserves_tmux_session() {
     let truncated_id = &session_id[..8.min(session_id.len())];
 
     // 3. Compute the tmux session name that aoe would use
-    let old_tmux_name = format!("aoe_OldName_{}", truncated_id);
+    let old_tmux_name = format!(
+        "{}OldName_{}",
+        agent_of_empires::tmux::SESSION_PREFIX,
+        truncated_id
+    );
 
     // Create a real tmux session with that name (simulates a running session)
     let create = Command::new("tmux")
@@ -562,7 +537,11 @@ fn test_cli_rename_preserves_tmux_session() {
     );
 
     // 6. The new tmux session name should exist
-    let new_tmux_name = format!("aoe_NewName_{}", truncated_id);
+    let new_tmux_name = format!(
+        "{}NewName_{}",
+        agent_of_empires::tmux::SESSION_PREFIX,
+        truncated_id
+    );
     let new_exists = Command::new("tmux")
         .args(["has-session", "-t", &new_tmux_name])
         .output()
@@ -669,11 +648,7 @@ fn test_cli_add_workspace_global_hook_fallback() {
 
     // Set up global hooks (no repo config).
     let hook_marker = h.home_path().join("global-hook-ran.marker");
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config/agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[updates]
 check_enabled = false

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -18,6 +18,22 @@ use std::time::{Duration, Instant};
 use tempfile::TempDir;
 
 // ---------------------------------------------------------------------------
+// App dir name (mirrors `agent_of_empires::session::APP_DIR_NAME_*`).
+// Debug builds use the `-dev` suffix; tests run in debug, so this resolves
+// to `agent-of-empires-dev` for the binary under test.
+// ---------------------------------------------------------------------------
+
+/// Return the app dir under the given test home, matching `get_app_dir_path`.
+pub fn app_dir_in(home: &Path) -> PathBuf {
+    if cfg!(target_os = "linux") {
+        home.join(".config")
+            .join(agent_of_empires::session::APP_DIR_NAME_LINUX)
+    } else {
+        home.join(agent_of_empires::session::APP_DIR_NAME_OTHER)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // tmux availability guard
 // ---------------------------------------------------------------------------
 
@@ -142,13 +158,10 @@ impl TuiTestHarness {
         }
 
         // Pre-seed config.toml to skip the welcome dialog and update checks.
-        // On Linux the app uses $XDG_CONFIG_HOME/agent-of-empires/ (set below),
-        // on macOS it uses $HOME/.agent-of-empires/.
-        let config_dir = if cfg!(target_os = "linux") {
-            home_dir.path().join(".config").join("agent-of-empires")
-        } else {
-            home_dir.path().join(".agent-of-empires")
-        };
+        // On Linux the app uses $XDG_CONFIG_HOME/agent-of-empires[-dev]/ (set
+        // below), on macOS it uses $HOME/.agent-of-empires[-dev]/. The `-dev`
+        // suffix kicks in on debug builds, which is what `cargo test` produces.
+        let config_dir = app_dir_in(home_dir.path());
         std::fs::create_dir_all(&config_dir).expect("create config dir");
         let config_content = format!(
             r#"[updates]

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -47,11 +47,7 @@ fn submit_new_session_dialog(h: &TuiTestHarness) {
 /// Write a global config with on_create hooks so session creation goes through
 /// the background CreationPoller and shows a Creating stub in the session list.
 fn write_config_with_hooks(h: &TuiTestHarness, hook_cmd: &str) {
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config").join("agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let config_content = format!(
         r#"[hooks]
 on_create = ["{hook_cmd}"]

--- a/tests/e2e/profile_picker.rs
+++ b/tests/e2e/profile_picker.rs
@@ -5,11 +5,7 @@ use crate::harness::{require_tmux, TuiTestHarness};
 
 /// Helper: create extra profile directories in the harness's isolated home.
 fn create_profile(h: &TuiTestHarness, name: &str) {
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config").join("agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     std::fs::create_dir_all(config_dir.join("profiles").join(name)).expect("create profile dir");
 }
 

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -21,12 +21,7 @@ use crate::harness::{require_tmux, TuiTestHarness};
 /// Resolve the daemon's PID file inside the harness's isolated home.
 /// Mirrors `crate::session::get_app_dir`'s platform split.
 fn daemon_pid_path(h: &TuiTestHarness) -> PathBuf {
-    let dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config").join("agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
-    dir.join("serve.pid")
+    crate::harness::app_dir_in(h.home_path()).join("serve.pid")
 }
 
 /// Bind a TCP listener to an ephemeral port, drop it, and return the port.

--- a/tests/e2e/unified_view.rs
+++ b/tests/e2e/unified_view.rs
@@ -5,11 +5,7 @@ use crate::harness::{require_tmux, TuiTestHarness};
 
 /// Helper: create a profile with a session in the harness's isolated home.
 fn create_profile_with_session(h: &TuiTestHarness, profile: &str, title: &str) {
-    let config_dir = if cfg!(target_os = "linux") {
-        h.home_path().join(".config").join("agent-of-empires")
-    } else {
-        h.home_path().join(".agent-of-empires")
-    };
+    let config_dir = crate::harness::app_dir_in(h.home_path());
     let profile_dir = config_dir.join("profiles").join(profile);
     std::fs::create_dir_all(&profile_dir).expect("create profile dir");
 

--- a/tests/e2e/update_command.rs
+++ b/tests/e2e/update_command.rs
@@ -36,7 +36,11 @@ fn update_calls_brew_when_method_is_homebrew() {
     // Create an isolated config dir with a fake update cache so check_for_update
     // thinks there's a newer version available (without hitting GitHub).
     let config_home = tempfile::tempdir().unwrap();
-    let app_dir = config_home.path().join("agent-of-empires");
+    // The binary under test is built in debug mode, so it resolves the app
+    // dir to the `-dev` namespace.
+    let app_dir = config_home
+        .path()
+        .join(agent_of_empires::session::APP_DIR_NAME_LINUX);
     fs::create_dir_all(&app_dir).unwrap();
 
     let cache = serde_json::json!({


### PR DESCRIPTION
## Description

Closes #985.

`cargo run` (debug build) and an installed release `aoe` currently share the same app data dir, tmux session prefix, default `aoe serve` port, and log files, so any local development risks corrupting the user's real sessions and overwrites logs needed for post-mortems on the release build.

This PR gates those four things on `cfg!(debug_assertions)` so debug and release run in fully isolated namespaces:

| | Release | Debug (`cargo run`) |
| --- | --- | --- |
| App dir (mac/win) | `~/.agent-of-empires` | `~/.agent-of-empires-dev` |
| App dir (Linux) | `~/.config/agent-of-empires` | `~/.config/agent-of-empires-dev` |
| tmux session prefix | `aoe_` | `aoe_dev_` |
| `aoe serve` default port | 8080 | 8081 |
| `debug.log` / `serve.log` | release app dir | dev app dir |

`debug.log` and `serve.log` live inside the app dir, so they isolate automatically.

### Migrations

`src/migrations/get_all_possible_dirs()` now uses the namespaced constants, so the dev dir's `.schema_version` is correctly tracked. `v001_xdg_linux::run` is a no-op in debug builds so it cannot move the release user's `~/.agent-of-empires` into `~/.config/agent-of-empires` from a `cargo run`.

### Tests

Test fixtures that hardcoded `agent-of-empires` literally were updated to use the new `APP_DIR_NAME_LINUX` / `APP_DIR_NAME_OTHER` constants (or, in e2e, a small `harness::app_dir_in()` helper). The in-module `parse_pane_metadata` tests are parametrized via `SESSION_PREFIX` so the same bodies cover both prefixes. `tests/e2e/cli.rs::test_cli_rename_preserves_tmux_session` computes its expected tmux name from `agent_of_empires::tmux::SESSION_PREFIX`.

### Out of scope (matches the issue)

- Multi-instance support for release builds (e.g. `AOE_INSTANCE=<name>`).
- Data migration into the dev namespace (it starts fresh on first run).
- Per-repo `.agent-of-empires/config.toml` (already isolated per project).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (README dev section + AGENTS.md)
- [ ] For UI changes: included screenshot or recording (n/a — no UI changes)

### How I tested

- `cargo build` and `cargo build --release`: both green.
- `cargo clippy --all-targets`: no issues.
- `cargo fmt --check`: clean.
- `cargo test --lib`: 1470 pass, 2 unrelated `containers::runtime::*` failures from a missing local Docker daemon.
- `cargo test --test e2e`: 47 pass, 2 ignored (Docker-gated).
- All other integration test files (`config_merge`, `repo_config`, `migration_pipeline`, `update_command`, etc.) green.
- Manually verified release path unchanged (release binary still uses `~/.agent-of-empires`, port 8080, `aoe_` prefix) and dev path isolated (`cargo run -- ...` writes to `~/.agent-of-empires-dev`, port 8081, `aoe_dev_` sessions). Both can coexist on the same tmux server with both `serve` daemons up.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** The investigation, the per-file plan, and the implementation were drafted by Claude under my direction. The framing, the scope cut (e.g. dropping multi-instance generalization, choosing to run migrations against the dev dir rather than skipping them entirely), the migration-safety call to short-circuit v001 in debug builds, and the decision to ship were mine.

- [x] I am an AI Agent filling out this form (check box if true)