### PR TITLE
fix(web): make sidebar session row a block link

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -317,7 +317,7 @@ const SessionRow = memo(function SessionRow({
         onTouchEnd={handleTouchEnd}
         onTouchMove={clearLongPress}
         onTouchCancel={clearLongPress}
-        className={`w-full text-left py-2 cursor-pointer select-none transition-colors duration-75 ${
+        className={`block w-full text-left py-2 cursor-pointer select-none transition-colors duration-75 ${
           indented ? "pl-6 pr-3" : "px-3"
         } ${
           isActive


### PR DESCRIPTION
## Description

The cockpit sidebar session row used `<Link>` rendered as an inline `<a>`, so `border-l-2 border-brand-600` and `hover:bg-surface-700/40` only painted around inline boxes — the active marker landed between rows instead of full-height on the left edge, and hover never filled the row. Adding `block` resolves both.

Single-line change in `web/src/components/WorkspaceSidebar.tsx`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No screenshot attached here — diff is one Tailwind class; visual is the active border now fills row height and hover fills the full row width.)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Claude diagnosed the inline-vs-block layout cause and drafted the one-line fix. Framing and decision are mine.

- [x] I am an AI Agent filling out this form (check box if true)