### PR TITLE
fix(serve): web terminal logging + auto-respawn dead pane (#1009)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -15,6 +15,9 @@ The release binary is at `target/release/aoe`.
 ```bash
 cargo run --release            # Run from source
 AGENT_OF_EMPIRES_DEBUG=1 cargo run  # Debug logging (writes to debug.log in app data dir)
+AOE_LOG_LEVEL=trace cargo run        # Pick the log level explicitly
+AOE_ACP_TRACE=1 cargo run            # Plus raw ACP JSON-RPC firehose
+AOE_TERMINAL_TRACE=1 cargo run       # Plus per-message bytes for the web terminal WS (spammy)
 ```
 
 Requires `tmux` to be installed.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -35,7 +35,10 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 | Variable | Description |
 |----------|-------------|
 | `AGENT_OF_EMPIRES_PROFILE` | Default profile to use |
-| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging to `debug.log` in app data dir (`1` to enable) |
+| `AGENT_OF_EMPIRES_DEBUG` | Enable debug logging to `debug.log` in app data dir (`1` to enable). Legacy alias for `AOE_LOG_LEVEL=debug`. |
+| `AOE_LOG_LEVEL` | File log level: `trace`, `debug`, `info`, `warn`, `error`. Applies to `agent_of_empires`, `cockpit`, and `terminal` targets. |
+| `AOE_ACP_TRACE` | Add the ACP framework's raw JSON-RPC firehose to `debug.log` (`1` to enable). Very chatty; useful for chasing schema mismatches. |
+| `AOE_TERMINAL_TRACE` | Add per-message byte tracing for the web terminal WebSocket relay to `debug.log` (`1` to enable). Bumps the `terminal` target to `trace`, surfacing every PTY read/write and every WS send/recv. Spammy under load (a busy claude session emits thousands of frames/min); use only when chasing terminal disconnect bugs. |
 
 ## Theme
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -126,8 +126,14 @@ async fn main() -> Result<()> {
         // stare at "(waiting for daemon output...)" for 30-60s during
         // cert provisioning. Foreground `aoe serve` just prints to
         // the user's terminal; that's fine and matches other CLIs.
+        //
+        // `terminal=info` mirrors the file logger's target list so a
+        // default serve (no AOE_LOG_LEVEL set) still captures
+        // `terminal.ws` warn/error lines in serve.log. Without this,
+        // dead-pane warnings, idle-reaper firings, and ws send/recv
+        // errors would be silently dropped in production.
         tracing_subscriber::fmt()
-            .with_env_filter("agent_of_empires=info,cockpit=info")
+            .with_env_filter("agent_of_empires=info,cockpit=info,terminal=info")
             .with_ansi(false)
             .try_init()
             .ok();

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,16 +80,28 @@ async fn main() -> Result<()> {
         if let Some(file) = log_file {
             // Cockpit code uses custom log targets like `cockpit.acp`,
             // `cockpit.supervisor`, `cockpit.acp.stderr`, etc., which
-            // don't match the `agent_of_empires` crate prefix. List
-            // them explicitly so debug.log captures the full picture
-            // when chasing a crashed agent. Add new top-level targets
-            // here when introducing them.
-            let mut filter = format!("agent_of_empires={level},cockpit={level}");
+            // don't match the `agent_of_empires` crate prefix. The web
+            // terminal WS handler uses `terminal.ws` and the per-byte
+            // firehose uses `terminal.ws.bytes`. List them explicitly so
+            // debug.log captures the full picture when chasing a crashed
+            // agent. Add new top-level targets here when introducing them.
+            let mut filter = format!("agent_of_empires={level},cockpit={level},terminal={level}");
             if std::env::var("AOE_ACP_TRACE").is_ok() {
                 filter.push_str(
                     ",agent_client_protocol=debug,\
                      agent_client_protocol::jsonrpc::transport_actor=trace",
                 );
+            }
+            // Per-WS-message byte firehose for the terminal relay, hidden
+            // behind its own opt-in. The bytes target (`terminal.ws.bytes`)
+            // logs at trace, so we only need to bump the `terminal` target
+            // up to trace when the user explicitly wants the firehose;
+            // a busy claude session emits thousands of frames/min and
+            // would drown the lifecycle signal otherwise. The duplicate
+            // directive overrides the baseline `terminal={level}` above
+            // (EnvFilter is last-wins per target).
+            if std::env::var("AOE_TERMINAL_TRACE").is_ok() {
+                filter.push_str(",terminal=trace");
             }
             tracing_subscriber::fmt()
                 .with_env_filter(filter)

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1077,22 +1077,49 @@ pub async fn ensure_terminal(
     let _guard = inst_lock.lock().await;
 
     // Re-check after acquiring the lock; the first caller may have created it.
+    // `has_terminal()` only checks the in-memory `terminal_info.created` flag.
+    // The pane shell can exit (Ctrl+D, `exit`, SIGHUP from a destroyed tmux
+    // client, etc.) while the flag stays true and the session keeps existing
+    // (because we set tmux's `remain-on-exit on`). When that happens the web
+    // UI would attach to a dead pane that swallows every keystroke, so do
+    // the same kill+recreate dance the TUI runs in src/tui/app.rs around the
+    // attach path.
     {
         let instances = state.instances.read().await;
         if let Some(i) = instances.iter().find(|i| i.id == id) {
             if i.has_terminal() {
-                return (
-                    StatusCode::OK,
-                    Json(serde_json::json!({"status": "exists"})),
-                )
-                    .into_response();
+                let pane_dead = i
+                    .terminal_tmux_session()
+                    .ok()
+                    .map(|s| s.exists() && s.is_pane_dead())
+                    .unwrap_or(false);
+                if !pane_dead {
+                    return (
+                        StatusCode::OK,
+                        Json(serde_json::json!({"status": "exists"})),
+                    )
+                        .into_response();
+                }
+                tracing::warn!(
+                    target: "terminal.ws",
+                    session = %id,
+                    "paired terminal pane is dead, respawning"
+                );
             }
         }
     }
 
     let mut inst_clone = inst;
 
-    let result = tokio::task::spawn_blocking(move || inst_clone.start_terminal()).await;
+    let result = tokio::task::spawn_blocking(move || {
+        if let Ok(session) = inst_clone.terminal_tmux_session() {
+            if session.exists() && session.is_pane_dead() {
+                let _ = session.kill();
+            }
+        }
+        inst_clone.start_terminal()
+    })
+    .await;
 
     match result {
         Ok(Ok(())) => {
@@ -1146,24 +1173,45 @@ pub async fn ensure_container_terminal(
     let inst_lock = state.instance_lock(&id).await;
     let _guard = inst_lock.lock().await;
 
+    // Same dead-pane rescue as `ensure_terminal`: an existing-but-dead
+    // pane would otherwise silently swallow every keystroke from the
+    // browser. See the longer comment in `ensure_terminal`.
     {
         let instances = state.instances.read().await;
         if let Some(i) = instances.iter().find(|i| i.id == id) {
             if i.has_container_terminal() {
-                return (
-                    StatusCode::OK,
-                    Json(serde_json::json!({"status": "exists"})),
-                )
-                    .into_response();
+                let pane_dead = i
+                    .container_terminal_tmux_session()
+                    .ok()
+                    .map(|s| s.exists() && s.is_pane_dead())
+                    .unwrap_or(false);
+                if !pane_dead {
+                    return (
+                        StatusCode::OK,
+                        Json(serde_json::json!({"status": "exists"})),
+                    )
+                        .into_response();
+                }
+                tracing::warn!(
+                    target: "terminal.ws",
+                    session = %id,
+                    "container terminal pane is dead, respawning"
+                );
             }
         }
     }
 
     let mut inst_clone = inst;
 
-    let result =
-        tokio::task::spawn_blocking(move || inst_clone.start_container_terminal_with_size(None))
-            .await;
+    let result = tokio::task::spawn_blocking(move || {
+        if let Ok(session) = inst_clone.container_terminal_tmux_session() {
+            if session.exists() && session.is_pane_dead() {
+                let _ = session.kill();
+            }
+        }
+        inst_clone.start_container_terminal_with_size(None)
+    })
+    .await;
 
     match result {
         Ok(Ok(())) => (

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1112,11 +1112,7 @@ pub async fn ensure_terminal(
     let mut inst_clone = inst;
 
     let result = tokio::task::spawn_blocking(move || {
-        if let Ok(session) = inst_clone.terminal_tmux_session() {
-            if session.exists() && session.is_pane_dead() {
-                let _ = session.kill();
-            }
-        }
+        let _ = inst_clone.kill_terminal_if_dead();
         inst_clone.start_terminal()
     })
     .await;
@@ -1204,11 +1200,7 @@ pub async fn ensure_container_terminal(
     let mut inst_clone = inst;
 
     let result = tokio::task::spawn_blocking(move || {
-        if let Ok(session) = inst_clone.container_terminal_tmux_session() {
-            if session.exists() && session.is_pane_dead() {
-                let _ = session.kill();
-            }
-        }
+        let _ = inst_clone.kill_container_terminal_if_dead();
         inst_clone.start_container_terminal_with_size(None)
     })
     .await;

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -47,7 +47,7 @@ pub async fn paired_terminal_ws(
     let primaries = Arc::clone(&state.session_primaries);
     let pause_counts = Arc::clone(&state.session_pause_counts);
 
-    let Some(mut inst) = inst else {
+    let Some(inst) = inst else {
         warn!(target: "terminal.ws", session = %id, kind = "paired", "session not found, returning 404");
         return (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response();
     };
@@ -58,7 +58,7 @@ pub async fn paired_terminal_ws(
     // (most commonly across an `aoe serve` restart) would attach to a
     // tombstone that swallows every keystroke. Match the kill+recreate
     // dance in `ensure_terminal` and the TUI attach path.
-    let tmux_name = match respawn_paired_if_dead(&state, &id, &mut inst).await {
+    let tmux_name = match respawn_paired_if_dead(&state, &id, &inst).await {
         Ok(name) => name,
         Err(e) => {
             warn!(
@@ -94,7 +94,7 @@ pub async fn paired_terminal_ws(
 async fn respawn_paired_if_dead(
     state: &Arc<AppState>,
     id: &str,
-    inst: &mut crate::session::Instance,
+    inst: &crate::session::Instance,
 ) -> anyhow::Result<String> {
     let tmux_name = crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title);
 
@@ -147,13 +147,13 @@ pub async fn container_terminal_ws(
     let primaries = Arc::clone(&state.session_primaries);
     let pause_counts = Arc::clone(&state.session_pause_counts);
 
-    let Some(mut inst) = inst else {
+    let Some(inst) = inst else {
         warn!(target: "terminal.ws", session = %id, kind = "container", "session not found, returning 404");
         return (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response();
     };
 
     // See `paired_terminal_ws` for the dead-pane rescue rationale.
-    let tmux_name = match respawn_container_if_dead(&state, &id, &mut inst).await {
+    let tmux_name = match respawn_container_if_dead(&state, &id, &inst).await {
         Ok(name) => name,
         Err(e) => {
             warn!(
@@ -186,7 +186,7 @@ pub async fn container_terminal_ws(
 async fn respawn_container_if_dead(
     state: &Arc<AppState>,
     id: &str,
-    inst: &mut crate::session::Instance,
+    inst: &crate::session::Instance,
 ) -> anyhow::Result<String> {
     let tmux_name = crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title);
 
@@ -195,6 +195,9 @@ async fn respawn_container_if_dead(
 
     let mut inst_for_blocking = inst.clone();
     let tmux_name_clone = tmux_name.clone();
+    // No in-memory cache to update for container terminal: `has_container_terminal()`
+    // queries tmux directly, so unlike the paired variant we don't need to write
+    // back a `terminal_info` flag after a successful respawn.
     let _respawned = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
         let session = inst_for_blocking.container_terminal_tmux_session()?;
         if !session.exists() || !session.is_pane_dead() {

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -106,8 +106,7 @@ async fn respawn_paired_if_dead(
     let mut inst_for_blocking = inst.clone();
     let tmux_name_clone = tmux_name.clone();
     let respawned = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-        let session = inst_for_blocking.terminal_tmux_session()?;
-        if !session.exists() || !session.is_pane_dead() {
+        if !inst_for_blocking.kill_terminal_if_dead()? {
             return Ok(false);
         }
         tracing::warn!(
@@ -115,7 +114,6 @@ async fn respawn_paired_if_dead(
             tmux = %tmux_name_clone,
             "paired terminal pane dead at WS upgrade, killing and respawning"
         );
-        let _ = session.kill();
         inst_for_blocking.start_terminal()?;
         Ok(true)
     })
@@ -199,8 +197,7 @@ async fn respawn_container_if_dead(
     // queries tmux directly, so unlike the paired variant we don't need to write
     // back a `terminal_info` flag after a successful respawn.
     let _respawned = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
-        let session = inst_for_blocking.container_terminal_tmux_session()?;
-        if !session.exists() || !session.is_pane_dead() {
+        if !inst_for_blocking.kill_container_terminal_if_dead()? {
             return Ok(false);
         }
         tracing::warn!(
@@ -208,7 +205,6 @@ async fn respawn_container_if_dead(
             tmux = %tmux_name_clone,
             "container terminal pane dead at WS upgrade, killing and respawning"
         );
-        let _ = session.kill();
         inst_for_blocking.start_container_terminal_with_size(None)?;
         Ok(true)
     })

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -7,7 +7,7 @@
 
 use std::io::{Read, Write};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use axum::{
     extract::{
@@ -18,6 +18,17 @@ use axum::{
 };
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use tokio::sync::RwLock;
+use tracing::{debug, error, info, trace, warn};
+
+/// Per-message byte tracing is hidden behind `AOE_TERMINAL_TRACE=1` so the
+/// default `AOE_LOG_LEVEL=debug` run captures lifecycle without drowning
+/// the log in PTY-byte chatter (a busy claude session emits thousands of
+/// frames/min). Read once at connect time so the gate is a single atomic
+/// load per message instead of an env lookup.
+fn terminal_trace_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var("AOE_TERMINAL_TRACE").is_ok())
+}
 
 use super::AppState;
 
@@ -27,6 +38,7 @@ pub async fn paired_terminal_ws(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    debug!(target: "terminal.ws", session = %id, kind = "paired", "ws route entered");
     let instances = state.instances.read().await;
     let session_info = instances
         .iter()
@@ -50,7 +62,10 @@ pub async fn paired_terminal_ws(
                 handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
             })
             .into_response(),
-        None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
+        None => {
+            warn!(target: "terminal.ws", session = %id, kind = "paired", "session not found, returning 404");
+            (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response()
+        }
     }
 }
 
@@ -60,6 +75,7 @@ pub async fn container_terminal_ws(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    debug!(target: "terminal.ws", session = %id, kind = "container", "ws route entered");
     let instances = state.instances.read().await;
     let session_info = instances
         .iter()
@@ -83,7 +99,10 @@ pub async fn container_terminal_ws(
                 handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
             })
             .into_response(),
-        None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
+        None => {
+            warn!(target: "terminal.ws", session = %id, kind = "container", "session not found, returning 404");
+            (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response()
+        }
     }
 }
 
@@ -93,6 +112,7 @@ pub async fn terminal_ws(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
+    debug!(target: "terminal.ws", session = %id, kind = "agent", "ws route entered");
     // Verify session exists before upgrading
     let instances = state.instances.read().await;
     let session_info = instances
@@ -117,7 +137,10 @@ pub async fn terminal_ws(
                 handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
             })
             .into_response(),
-        None => (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response(),
+        None => {
+            warn!(target: "terminal.ws", session = %id, kind = "agent", "session not found, returning 404");
+            (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response()
+        }
     }
 }
 
@@ -171,6 +194,16 @@ async fn handle_terminal_ws(
         "ws-{}",
         CLIENT_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
     );
+    let started_at = Instant::now();
+    let trace_bytes = terminal_trace_enabled();
+    info!(
+        target: "terminal.ws",
+        client = %client_id,
+        tmux = %tmux_name,
+        read_only,
+        trace_bytes,
+        "ws upgrade complete, starting PTY relay"
+    );
 
     // Spawn tmux attach inside a PTY
     let pty_system = NativePtySystem::default();
@@ -182,7 +215,12 @@ async fn handle_terminal_ws(
     }) {
         Ok(pair) => pair,
         Err(e) => {
-            tracing::error!("Failed to open PTY: {}", e);
+            error!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                "openpty failed, aborting ws: {}", e
+            );
             return;
         }
     };
@@ -225,10 +263,21 @@ async fn handle_terminal_ws(
     let mut child = match pair.slave.spawn_command(cmd) {
         Ok(child) => child,
         Err(e) => {
-            tracing::error!("Failed to spawn tmux attach: {}", e);
+            error!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                "spawn tmux attach-session failed: {}", e
+            );
             return;
         }
     };
+    debug!(
+        target: "terminal.ws",
+        client = %client_id,
+        tmux = %tmux_name,
+        "tmux attach-session spawned"
+    );
 
     // We're done with the slave side
     drop(pair.slave);
@@ -241,7 +290,12 @@ async fn handle_terminal_ws(
     let mut reader = match master.try_clone_reader() {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!("Failed to clone PTY reader: {}", e);
+            error!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                "clone PTY reader failed, killing tmux child: {}", e
+            );
             let _ = child.kill();
             let _ = child.wait();
             return;
@@ -251,7 +305,12 @@ async fn handle_terminal_ws(
     let writer = match master.take_writer() {
         Ok(w) => w,
         Err(e) => {
-            tracing::error!("Failed to take PTY writer: {}", e);
+            error!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                "take PTY writer failed, killing tmux child: {}", e
+            );
             let _ = child.kill();
             let _ = child.wait();
             return;
@@ -271,22 +330,60 @@ async fn handle_terminal_ws(
     let (ctrl_tx, mut ctrl_rx) = tokio::sync::mpsc::channel::<String>(8);
 
     // Task 1: PTY stdout -> channel (blocking read in dedicated thread)
+    let reader_client = client_id.clone();
+    let reader_tmux = tmux_name.clone();
     tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 4096];
+        let mut total_bytes: u64 = 0;
+        let exit_reason: &'static str;
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => break,
+                Ok(0) => {
+                    exit_reason = "pty_eof";
+                    break;
+                }
                 Ok(n) => {
+                    total_bytes += n as u64;
+                    if trace_bytes {
+                        trace!(
+                            target: "terminal.ws.bytes",
+                            client = %reader_client,
+                            tmux = %reader_tmux,
+                            dir = "pty->ws",
+                            bytes = n,
+                            "pty read"
+                        );
+                    }
                     if output_tx.blocking_send(buf[..n].to_vec()).is_err() {
+                        exit_reason = "ws_closed";
                         break; // receiver dropped (WebSocket closed)
                     }
                 }
-                Err(_) => break,
+                Err(e) => {
+                    warn!(
+                        target: "terminal.ws",
+                        client = %reader_client,
+                        tmux = %reader_tmux,
+                        "pty read error after {} bytes: {}", total_bytes, e
+                    );
+                    exit_reason = "pty_read_error";
+                    break;
+                }
             }
         }
+        debug!(
+            target: "terminal.ws",
+            client = %reader_client,
+            tmux = %reader_tmux,
+            reason = exit_reason,
+            bytes = total_bytes,
+            "pty reader task exiting"
+        );
     });
 
     // Task 2: PTY output + control messages -> WebSocket sender
+    let send_client = client_id.clone();
+    let send_tmux = tmux_name.clone();
     let send_handle = tokio::spawn(async move {
         let mut ping_interval = tokio::time::interval(PING_INTERVAL);
         ping_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -294,26 +391,70 @@ async fn handle_terminal_ws(
         // we don't ping at connection time (the browser hasn't even
         // attached its onmessage handler yet on first connect).
         ping_interval.tick().await;
+        let exit_reason: &'static str;
         loop {
             tokio::select! {
                 data = output_rx.recv() => {
                     match data {
                         Some(data) => {
+                            let n = data.len();
                             if ws_sender.send(Message::Binary(data.into())).await.is_err() {
+                                warn!(
+                                    target: "terminal.ws",
+                                    client = %send_client,
+                                    tmux = %send_tmux,
+                                    "ws send (binary) failed, peer gone"
+                                );
+                                exit_reason = "ws_send_error_binary";
                                 break;
                             }
+                            if trace_bytes {
+                                trace!(
+                                    target: "terminal.ws.bytes",
+                                    client = %send_client,
+                                    tmux = %send_tmux,
+                                    dir = "ws->client",
+                                    bytes = n,
+                                    "ws send binary"
+                                );
+                            }
                         }
-                        None => break,
+                        None => {
+                            debug!(
+                                target: "terminal.ws",
+                                client = %send_client,
+                                tmux = %send_tmux,
+                                "pty output channel closed (reader task exited)"
+                            );
+                            exit_reason = "pty_output_channel_closed";
+                            break;
+                        }
                     }
                 }
                 msg = ctrl_rx.recv() => {
                     match msg {
                         Some(text) => {
                             if ws_sender.send(Message::Text(text.into())).await.is_err() {
+                                warn!(
+                                    target: "terminal.ws",
+                                    client = %send_client,
+                                    tmux = %send_tmux,
+                                    "ws send (control text) failed, peer gone"
+                                );
+                                exit_reason = "ws_send_error_ctrl";
                                 break;
                             }
                         }
-                        None => break,
+                        None => {
+                            debug!(
+                                target: "terminal.ws",
+                                client = %send_client,
+                                tmux = %send_tmux,
+                                "control channel closed (recv task dropped sender)"
+                            );
+                            exit_reason = "ctrl_channel_closed";
+                            break;
+                        }
                     }
                 }
                 _ = ping_interval.tick() => {
@@ -322,11 +463,31 @@ async fn handle_terminal_ws(
                     // client Pongs to the recv loop, which resets its
                     // idle timer.
                     if ws_sender.send(Message::Ping(Vec::new().into())).await.is_err() {
+                        warn!(
+                            target: "terminal.ws",
+                            client = %send_client,
+                            tmux = %send_tmux,
+                            "ws send Ping failed, peer gone"
+                        );
+                        exit_reason = "ws_ping_error";
                         break;
                     }
+                    trace!(
+                        target: "terminal.ws",
+                        client = %send_client,
+                        tmux = %send_tmux,
+                        "sent keepalive Ping"
+                    );
                 }
             }
         }
+        debug!(
+            target: "terminal.ws",
+            client = %send_client,
+            tmux = %send_tmux,
+            reason = exit_reason,
+            "send task exiting, sending Close frame"
+        );
         let _ = ws_sender.send(Message::Close(None)).await;
     });
 
@@ -343,10 +504,13 @@ async fn handle_terminal_ws(
     let this_ws_paused = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let this_ws_paused_for_recv = this_ws_paused.clone();
 
+    let recv_client = client_id.clone();
+    let recv_tmux = tmux_name.clone();
     let recv_handle = tokio::spawn(async move {
         // Track the last resize the browser requested so we can apply it
         // when this client becomes primary.
         let mut pending_size: Option<(u16, u16)> = None;
+        let exit_reason: &'static str;
 
         loop {
             // Wrap each receive in IDLE_TIMEOUT so a silent socket
@@ -356,16 +520,64 @@ async fn handle_terminal_ws(
             // send task elicit Pongs that arrive here and reset the
             // timer, so live-but-idle sessions stay open indefinitely.
             let msg = match tokio::time::timeout(IDLE_TIMEOUT, ws_receiver.next()).await {
-                Err(_) => break,
-                Ok(None) => break,
-                Ok(Some(Err(_))) => break,
+                Err(_) => {
+                    warn!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        idle_timeout_secs = IDLE_TIMEOUT.as_secs(),
+                        "ws idle reaper fired (no client traffic, including Pongs)"
+                    );
+                    exit_reason = "idle_reaper";
+                    break;
+                }
+                Ok(None) => {
+                    debug!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        "ws stream returned None (peer closed cleanly)"
+                    );
+                    exit_reason = "ws_stream_end";
+                    break;
+                }
+                Ok(Some(Err(e))) => {
+                    warn!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        "ws recv error: {}", e
+                    );
+                    exit_reason = "ws_recv_error";
+                    break;
+                }
                 Ok(Some(Ok(msg))) => msg,
             };
             match msg {
                 Message::Binary(data) => {
                     // Raw bytes from xterm.js -> PTY stdin (blocked in read-only mode)
                     if read_only {
+                        if trace_bytes {
+                            trace!(
+                                target: "terminal.ws.bytes",
+                                client = %recv_client,
+                                tmux = %recv_tmux,
+                                bytes = data.len(),
+                                "dropped client binary (read_only)"
+                            );
+                        }
                         continue;
+                    }
+
+                    if trace_bytes {
+                        trace!(
+                            target: "terminal.ws.bytes",
+                            client = %recv_client,
+                            tmux = %recv_tmux,
+                            dir = "client->pty",
+                            bytes = data.len(),
+                            "client binary"
+                        );
                     }
 
                     // Claim primary on input. If we just became primary,
@@ -377,6 +589,12 @@ async fn handle_terminal_ws(
                     )
                     .await;
                     if became_primary {
+                        debug!(
+                            target: "terminal.ws",
+                            client = %recv_client,
+                            tmux = %recv_tmux,
+                            "claimed primary on binary input"
+                        );
                         if let Some((cols, rows)) = pending_size {
                             resize_pty(&master_for_resize, cols, rows).await;
                         }
@@ -399,6 +617,14 @@ async fn handle_terminal_ws(
                     if let Ok(control) = serde_json::from_str::<ControlMessage>(&text) {
                         match control {
                             ControlMessage::Resize { cols, rows } if cols > 0 && rows > 0 => {
+                                debug!(
+                                    target: "terminal.ws",
+                                    client = %recv_client,
+                                    tmux = %recv_tmux,
+                                    cols,
+                                    rows,
+                                    "control: resize"
+                                );
                                 pending_size = Some((cols, rows));
 
                                 let dominated = is_primary_or_vacant(
@@ -419,8 +645,23 @@ async fn handle_terminal_ws(
                                 }
                             }
                             // Ignore zero-dimension resize (buggy client)
-                            ControlMessage::Resize { .. } => {}
+                            ControlMessage::Resize { cols, rows } => {
+                                warn!(
+                                    target: "terminal.ws",
+                                    client = %recv_client,
+                                    tmux = %recv_tmux,
+                                    cols,
+                                    rows,
+                                    "control: ignoring zero-dimension resize"
+                                );
+                            }
                             ControlMessage::Activate => {
+                                debug!(
+                                    target: "terminal.ws",
+                                    client = %recv_client,
+                                    tmux = %recv_tmux,
+                                    "control: activate"
+                                );
                                 // In read-only mode, don't claim primary. All
                                 // viewers get independent resize (vacant state).
                                 if read_only {
@@ -454,6 +695,12 @@ async fn handle_terminal_ws(
                                 // from the same ws are idempotent so a client
                                 // that sends two pause_outputs doesn't
                                 // over-contribute to the count.
+                                debug!(
+                                    target: "terminal.ws",
+                                    client = %recv_client,
+                                    tmux = %recv_tmux,
+                                    "control: pause_output"
+                                );
                                 if read_only {
                                     continue;
                                 }
@@ -468,6 +715,12 @@ async fn handle_terminal_ws(
                                 // Decrement this ws's contribution; only
                                 // SIGCONT when the refcount reaches 0. Safe
                                 // to call even if this ws wasn't paused.
+                                debug!(
+                                    target: "terminal.ws",
+                                    client = %recv_client,
+                                    tmux = %recv_tmux,
+                                    "control: resume_output"
+                                );
                                 pause_exit(
                                     &pause_counts_for_recv,
                                     &tmux_name_for_recv,
@@ -477,6 +730,16 @@ async fn handle_terminal_ws(
                             }
                         }
                     } else if !read_only {
+                        if trace_bytes {
+                            trace!(
+                                target: "terminal.ws.bytes",
+                                client = %recv_client,
+                                tmux = %recv_tmux,
+                                dir = "client->pty",
+                                bytes = text.len(),
+                                "client text (non-control)"
+                            );
+                        }
                         // Plain text input -> PTY stdin (blocked in read-only mode).
                         // Also claims primary, same as binary input.
                         let became_primary = claim_primary(
@@ -505,17 +768,64 @@ async fn handle_terminal_ws(
                         .await;
                     }
                 }
-                Message::Close(_) => break,
-                _ => {}
+                Message::Close(frame) => {
+                    let (code, reason) = match frame {
+                        Some(cf) => (Some(cf.code), cf.reason.to_string()),
+                        None => (None, String::new()),
+                    };
+                    debug!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        code = ?code,
+                        reason = %reason,
+                        "client sent Close frame"
+                    );
+                    exit_reason = "client_close";
+                    break;
+                }
+                Message::Ping(_) => {
+                    trace!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        "received Ping (axum auto-replies with Pong)"
+                    );
+                }
+                Message::Pong(_) => {
+                    trace!(
+                        target: "terminal.ws",
+                        client = %recv_client,
+                        tmux = %recv_tmux,
+                        "received Pong (resets idle timer)"
+                    );
+                }
             }
         }
+        debug!(
+            target: "terminal.ws",
+            client = %recv_client,
+            tmux = %recv_tmux,
+            reason = exit_reason,
+            "recv task exiting"
+        );
     });
 
     // Wait for either direction to finish
-    tokio::select! {
-        _ = send_handle => {},
-        _ = recv_handle => {},
-    }
+    let exit_side = tokio::select! {
+        _ = send_handle => "send",
+        _ = recv_handle => "recv",
+    };
+    let elapsed = started_at.elapsed();
+    info!(
+        target: "terminal.ws",
+        client = %client_id,
+        tmux = %tmux_name,
+        exit_side,
+        elapsed_secs = elapsed.as_secs(),
+        elapsed_ms = elapsed.as_millis() as u64,
+        "ws session ended, cleaning up"
+    );
 
     // Release primary if this client held it, so the next client can take over.
     release_primary(&primaries, &tmux_name, &client_id).await;
@@ -529,6 +839,12 @@ async fn handle_terminal_ws(
     // Clean up: kill the tmux attach process
     let _ = child.kill();
     let _ = child.wait();
+    debug!(
+        target: "terminal.ws",
+        client = %client_id,
+        tmux = %tmux_name,
+        "tmux attach child reaped, ws handler done"
+    );
 }
 
 /// Claim primary for this client. Returns `true` if the client was NOT

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -40,33 +40,96 @@ pub async fn paired_terminal_ws(
 ) -> impl IntoResponse {
     debug!(target: "terminal.ws", session = %id, kind = "paired", "ws route entered");
     let instances = state.instances.read().await;
-    let session_info = instances
-        .iter()
-        .find(|i| i.id == id)
-        .map(|inst| crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title));
+    let inst = instances.iter().find(|i| i.id == id).cloned();
     drop(instances);
 
     let read_only = state.read_only;
     let primaries = Arc::clone(&state.session_primaries);
     let pause_counts = Arc::clone(&state.session_pause_counts);
 
-    match session_info {
-        // Accept the "aoe-auth" subprotocol so the browser's handshake
-        // completes. The client offers `["aoe-auth", <token>]`; the auth
-        // middleware validates the token from the same header, and the
-        // server echoes back "aoe-auth" to satisfy the WS spec. The token
-        // itself is not echoed, only the marker.
-        Some(tmux_name) => ws
-            .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| {
-                handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
-            })
-            .into_response(),
-        None => {
-            warn!(target: "terminal.ws", session = %id, kind = "paired", "session not found, returning 404");
-            (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response()
+    let Some(mut inst) = inst else {
+        warn!(target: "terminal.ws", session = %id, kind = "paired", "session not found, returning 404");
+        return (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response();
+    };
+
+    // Auto-respawn a dead pane before upgrading. The browser's WS reconnect
+    // path goes straight to this route without re-running ensure_terminal,
+    // so without this check a pane that died while the page stayed open
+    // (most commonly across an `aoe serve` restart) would attach to a
+    // tombstone that swallows every keystroke. Match the kill+recreate
+    // dance in `ensure_terminal` and the TUI attach path.
+    let tmux_name = match respawn_paired_if_dead(&state, &id, &mut inst).await {
+        Ok(name) => name,
+        Err(e) => {
+            warn!(
+                target: "terminal.ws",
+                session = %id,
+                kind = "paired",
+                "failed to respawn dead pane: {}", e
+            );
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to revive terminal",
+            )
+                .into_response();
+        }
+    };
+
+    // Accept the "aoe-auth" subprotocol so the browser's handshake
+    // completes. The client offers `["aoe-auth", <token>]`; the auth
+    // middleware validates the token from the same header, and the
+    // server echoes back "aoe-auth" to satisfy the WS spec. The token
+    // itself is not echoed, only the marker.
+    ws.protocols(["aoe-auth"])
+        .on_upgrade(move |socket| {
+            handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
+        })
+        .into_response()
+}
+
+/// Returns the tmux session name to attach to. If the existing pane is
+/// dead, kills and recreates the tmux session in a blocking task before
+/// returning. The instance's `terminal_info.created` flag is updated in
+/// the in-memory store on successful recreate.
+async fn respawn_paired_if_dead(
+    state: &Arc<AppState>,
+    id: &str,
+    inst: &mut crate::session::Instance,
+) -> anyhow::Result<String> {
+    let tmux_name = crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title);
+
+    // Serialize concurrent reconnects for the same session so two
+    // simultaneous WS attaches don't both try to recreate the pane.
+    let lock = state.instance_lock(id).await;
+    let _guard = lock.lock().await;
+
+    let mut inst_for_blocking = inst.clone();
+    let tmux_name_clone = tmux_name.clone();
+    let respawned = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+        let session = inst_for_blocking.terminal_tmux_session()?;
+        if !session.exists() || !session.is_pane_dead() {
+            return Ok(false);
+        }
+        tracing::warn!(
+            target: "terminal.ws",
+            tmux = %tmux_name_clone,
+            "paired terminal pane dead at WS upgrade, killing and respawning"
+        );
+        let _ = session.kill();
+        inst_for_blocking.start_terminal()?;
+        Ok(true)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("respawn task panicked: {e}"))??;
+
+    if respawned {
+        let mut instances = state.instances.write().await;
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
+            stored.terminal_info = Some(crate::session::TerminalInfo { created: true });
         }
     }
+
+    Ok(tmux_name)
 }
 
 /// WebSocket for the paired container terminal (ContainerTerminalSession tmux session)
@@ -77,33 +140,79 @@ pub async fn container_terminal_ws(
 ) -> impl IntoResponse {
     debug!(target: "terminal.ws", session = %id, kind = "container", "ws route entered");
     let instances = state.instances.read().await;
-    let session_info = instances
-        .iter()
-        .find(|i| i.id == id)
-        .map(|inst| crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title));
+    let inst = instances.iter().find(|i| i.id == id).cloned();
     drop(instances);
 
     let read_only = state.read_only;
     let primaries = Arc::clone(&state.session_primaries);
     let pause_counts = Arc::clone(&state.session_pause_counts);
 
-    match session_info {
-        // Accept the "aoe-auth" subprotocol so the browser's handshake
-        // completes. The client offers `["aoe-auth", <token>]`; the auth
-        // middleware validates the token from the same header, and the
-        // server echoes back "aoe-auth" to satisfy the WS spec. The token
-        // itself is not echoed, only the marker.
-        Some(tmux_name) => ws
-            .protocols(["aoe-auth"])
-            .on_upgrade(move |socket| {
-                handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
-            })
-            .into_response(),
-        None => {
-            warn!(target: "terminal.ws", session = %id, kind = "container", "session not found, returning 404");
-            (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response()
+    let Some(mut inst) = inst else {
+        warn!(target: "terminal.ws", session = %id, kind = "container", "session not found, returning 404");
+        return (axum::http::StatusCode::NOT_FOUND, "Session not found").into_response();
+    };
+
+    // See `paired_terminal_ws` for the dead-pane rescue rationale.
+    let tmux_name = match respawn_container_if_dead(&state, &id, &mut inst).await {
+        Ok(name) => name,
+        Err(e) => {
+            warn!(
+                target: "terminal.ws",
+                session = %id,
+                kind = "container",
+                "failed to respawn dead pane: {}", e
+            );
+            return (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to revive terminal",
+            )
+                .into_response();
         }
-    }
+    };
+
+    // Accept the "aoe-auth" subprotocol so the browser's handshake
+    // completes. The client offers `["aoe-auth", <token>]`; the auth
+    // middleware validates the token from the same header, and the
+    // server echoes back "aoe-auth" to satisfy the WS spec. The token
+    // itself is not echoed, only the marker.
+    ws.protocols(["aoe-auth"])
+        .on_upgrade(move |socket| {
+            handle_terminal_ws(socket, tmux_name, read_only, primaries, pause_counts)
+        })
+        .into_response()
+}
+
+/// Container-terminal counterpart of [`respawn_paired_if_dead`].
+async fn respawn_container_if_dead(
+    state: &Arc<AppState>,
+    id: &str,
+    inst: &mut crate::session::Instance,
+) -> anyhow::Result<String> {
+    let tmux_name = crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title);
+
+    let lock = state.instance_lock(id).await;
+    let _guard = lock.lock().await;
+
+    let mut inst_for_blocking = inst.clone();
+    let tmux_name_clone = tmux_name.clone();
+    let _respawned = tokio::task::spawn_blocking(move || -> anyhow::Result<bool> {
+        let session = inst_for_blocking.container_terminal_tmux_session()?;
+        if !session.exists() || !session.is_pane_dead() {
+            return Ok(false);
+        }
+        tracing::warn!(
+            target: "terminal.ws",
+            tmux = %tmux_name_clone,
+            "container terminal pane dead at WS upgrade, killing and respawning"
+        );
+        let _ = session.kill();
+        inst_for_blocking.start_container_terminal_with_size(None)?;
+        Ok(true)
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("respawn task panicked: {e}"))??;
+
+    Ok(tmux_name)
 }
 
 /// WebSocket for the agent's main tmux session

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -706,6 +706,19 @@ impl Instance {
         Ok(())
     }
 
+    /// Kill the paired terminal tmux session if its pane is dead (shell
+    /// exited while `remain-on-exit on` kept the session as a tombstone).
+    /// Returns true if a kill happened so the caller knows to re-spawn.
+    /// A missing session or a live pane both return Ok(false).
+    pub fn kill_terminal_if_dead(&self) -> Result<bool> {
+        let session = self.terminal_tmux_session()?;
+        if session.exists() && session.is_pane_dead() {
+            let _ = session.kill();
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
     pub fn container_terminal_tmux_session(&self) -> Result<tmux::ContainerTerminalSession> {
         tmux::ContainerTerminalSession::new(&self.id, &self.title)
     }
@@ -772,6 +785,16 @@ impl Instance {
             session.kill()?;
         }
         Ok(())
+    }
+
+    /// Container counterpart of [`Self::kill_terminal_if_dead`].
+    pub fn kill_container_terminal_if_dead(&self) -> Result<bool> {
+        let session = self.container_terminal_tmux_session()?;
+        if session.exists() && session.is_pane_dead() {
+            let _ = session.kill();
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     fn sandbox_display(&self) -> Option<crate::tmux::status_bar::SandboxDisplay> {
@@ -2741,5 +2764,134 @@ mod tests {
 
         // Longer names like "opencode" should still match.
         assert!(pane_has_agent_content("OpenCode v1.0", "opencode"));
+    }
+
+    mod kill_terminal_if_dead {
+        use super::*;
+        use std::process::Command;
+
+        fn tmux_available() -> bool {
+            Command::new("tmux")
+                .arg("-V")
+                .output()
+                .map(|o| o.status.success())
+                .unwrap_or(false)
+        }
+
+        /// Manually create a tmux session under `name` with `remain-on-exit on`
+        /// so the session survives the inner command's exit. Used to simulate
+        /// the dead-pane state without going through `start_terminal`, which
+        /// would also apply unrelated tmux options.
+        fn spawn_remain_on_exit(name: &str, cmd: &str) {
+            let output = Command::new("tmux")
+                .args([
+                    "new-session",
+                    "-d",
+                    "-s",
+                    name,
+                    "-x",
+                    "80",
+                    "-y",
+                    "24",
+                    cmd,
+                    ";",
+                    "set-option",
+                    "-p",
+                    "-t",
+                    name,
+                    "remain-on-exit",
+                    "on",
+                ])
+                .output()
+                .expect("tmux new-session");
+            assert!(
+                output.status.success(),
+                "tmux new-session failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            crate::tmux::refresh_session_cache();
+        }
+
+        fn cleanup(name: &str) {
+            let _ = Command::new("tmux")
+                .args(["kill-session", "-t", name])
+                .output();
+            crate::tmux::refresh_session_cache();
+        }
+
+        #[test]
+        #[serial_test::serial]
+        fn returns_false_when_no_session() {
+            if !tmux_available() {
+                eprintln!("Skipping: tmux not available");
+                return;
+            }
+            let inst = Instance::new("ktid_missing", "/tmp");
+            crate::tmux::refresh_session_cache();
+            assert!(!inst.kill_terminal_if_dead().unwrap());
+        }
+
+        #[test]
+        #[serial_test::serial]
+        fn returns_false_when_pane_alive() {
+            if !tmux_available() {
+                eprintln!("Skipping: tmux not available");
+                return;
+            }
+            let inst = Instance::new("ktid_alive", "/tmp");
+            let name = crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title);
+            spawn_remain_on_exit(&name, "sleep 30");
+            // Give tmux a moment to register the pane.
+            std::thread::sleep(std::time::Duration::from_millis(200));
+
+            let result = inst.kill_terminal_if_dead();
+            cleanup(&name);
+
+            assert!(!result.unwrap(), "live pane should not trigger a kill");
+        }
+
+        #[test]
+        #[serial_test::serial]
+        fn kills_dead_pane_session() {
+            if !tmux_available() {
+                eprintln!("Skipping: tmux not available");
+                return;
+            }
+            let inst = Instance::new("ktid_dead", "/tmp");
+            let name = crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title);
+            // `true` exits immediately; remain-on-exit keeps the session alive
+            // with a dead pane (matches the production failure mode: shell
+            // exited via Ctrl+D / `exit` / SIGHUP, session still listed).
+            spawn_remain_on_exit(&name, "true");
+            // Allow the pane to transition to dead.
+            std::thread::sleep(std::time::Duration::from_millis(300));
+
+            let session = inst.terminal_tmux_session().unwrap();
+            assert!(
+                session.exists(),
+                "session should still exist via remain-on-exit"
+            );
+            assert!(
+                session.is_pane_dead(),
+                "pane should be dead after `true` exits"
+            );
+
+            let killed = inst.kill_terminal_if_dead().unwrap();
+            assert!(
+                killed,
+                "kill_terminal_if_dead should return true for dead pane"
+            );
+
+            let session = inst.terminal_tmux_session().unwrap();
+            assert!(!session.exists(), "session should be gone after kill");
+
+            // Idempotent: second call on now-missing session returns false.
+            assert!(
+                !inst.kill_terminal_if_dead().unwrap(),
+                "second call on missing session should return false"
+            );
+
+            cleanup(&name);
+        }
     }
 }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -10,6 +10,39 @@ import type {
 import { getToken } from "../lib/token";
 import { useWebSettings } from "./useWebSettings";
 
+// Client-side terminal WS debug logging is gated behind a runtime flag
+// so production users don't get a console full of lifecycle chatter.
+// Two opt-ins, both checked once and cached: `localStorage.aoeDebug = '1'`
+// (sticky across reloads) or `?debug=1` URL param (per-tab). Mirrors the
+// server's AOE_LOG_LEVEL/AOE_TERMINAL_TRACE pair so a full triage trace
+// can be captured by setting both.
+const TERMINAL_DEBUG_ENABLED = (() => {
+  if (typeof window === "undefined") return false;
+  try {
+    if (window.localStorage?.getItem("aoeDebug") === "1") return true;
+  } catch {
+    // localStorage can throw (Safari private mode, sandboxed iframes).
+    // Fall through to URL param.
+  }
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get("debug") === "1") return true;
+  } catch {
+    // location.search can throw in pathological embeds; treat as off.
+  }
+  return false;
+})();
+const tdbg = (...args: unknown[]) => {
+  if (!TERMINAL_DEBUG_ENABLED) return;
+  console.debug("[terminal.ws]", ...args);
+};
+const twarn = (...args: unknown[]) => {
+  // Warnings are always emitted (cheap, low-volume, useful in the wild
+  // even without the debug toggle). Use console.warn so DevTools filters
+  // can surface terminal-specific issues quickly.
+  console.warn("[terminal.ws]", ...args);
+};
+
 // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s (cap). Seven attempts
 // cover typical tunnel restarts and transient WiFi drops without flooding
 // the server or burning the user's battery on a truly dead backend.
@@ -432,6 +465,13 @@ export function useTerminal(
       // Tailscale, any reverse proxy); subprotocol headers don't.
       const token = getToken();
       const url = `${proto}//${location.host}/sessions/${sessionId}/${wsPath}`;
+      tdbg("connect()", {
+        sessionId,
+        wsPath,
+        url,
+        tokenPresent: !!token,
+        attempt: retryCountRef.current,
+      });
       const ws = token
         ? new WebSocket(url, ["aoe-auth", token])
         : new WebSocket(url);
@@ -439,6 +479,11 @@ export function useTerminal(
       wsRef.current = ws;
 
       ws.onopen = () => {
+        tdbg("ws.onopen", {
+          sessionId,
+          readyState: ws.readyState,
+          protocol: ws.protocol,
+        });
         retryCountRef.current = 0;
         // Reset the dedup baseline so the first resize on a fresh
         // connection always reaches the server, even if it matches
@@ -509,13 +554,26 @@ export function useTerminal(
         }
       };
 
-      ws.onclose = () => {
+      ws.onclose = (event: CloseEvent) => {
+        const closeInfo = {
+          sessionId,
+          code: event.code,
+          reason: event.reason,
+          wasClean: event.wasClean,
+          attempt: retryCountRef.current,
+        };
         setState((prev) => ({ ...prev, connected: false }));
         if (retryCountRef.current < MAX_RETRIES) {
           retryCountRef.current += 1;
           const count = retryCountRef.current;
           const delayMs = retryDelayMs(count);
           let countdown = Math.ceil(delayMs / 1000);
+
+          tdbg("ws.onclose -> scheduling retry", {
+            ...closeInfo,
+            nextAttempt: count,
+            delayMs,
+          });
 
           setState((prev) => ({
             ...prev,
@@ -526,7 +584,7 @@ export function useTerminal(
           }));
 
           term.write(
-            `\r\n\x1b[33m[Disconnected, reconnecting in ${countdown}s... (${count}/${MAX_RETRIES})]\x1b[0m\r\n`,
+            `\r\n\x1b[33m[Disconnected (code=${event.code}${event.reason ? ` ${event.reason}` : ""}), reconnecting in ${countdown}s... (${count}/${MAX_RETRIES})]\x1b[0m\r\n`,
           );
 
           countdownRef.current = setInterval(() => {
@@ -538,11 +596,13 @@ export function useTerminal(
 
           retryTimerRef.current = setTimeout(() => {
             if (countdownRef.current) clearInterval(countdownRef.current);
+            tdbg("retry timer fired, calling connect()", { attempt: count });
             connect();
           }, delayMs);
         } else {
+          twarn("ws.onclose -> retries exhausted", closeInfo);
           term.write(
-            "\r\n\x1b[31m[Connection lost. Click retry or press Enter to reconnect.]\x1b[0m\r\n",
+            `\r\n\x1b[31m[Connection lost (code=${event.code}${event.reason ? ` ${event.reason}` : ""}). Click retry or press Enter to reconnect.]\x1b[0m\r\n`,
           );
           setState((prev) => ({
             ...prev,
@@ -554,8 +614,15 @@ export function useTerminal(
         }
       };
 
-      ws.onerror = () => {
-        // onclose will fire after onerror
+      ws.onerror = (event: Event) => {
+        // onclose will fire after onerror; log here so debug.log captures
+        // both sides of the failure (the close path only sees code/reason,
+        // not the underlying transport error type).
+        twarn("ws.onerror", {
+          sessionId,
+          readyState: ws.readyState,
+          type: event.type,
+        });
       };
 
       // Relay keystrokes as binary. When the virtual Ctrl button is armed,
@@ -1004,16 +1071,24 @@ export function useTerminal(
       }
     };
     const onVisibilityChange = () => {
+      tdbg("visibilitychange", {
+        state: document.visibilityState,
+        readyState: wsRef.current?.readyState,
+      });
       if (document.visibilityState === "visible") sendActivate();
     };
+    const onWindowFocus = () => {
+      tdbg("window.focus", { readyState: wsRef.current?.readyState });
+      sendActivate();
+    };
     document.addEventListener("visibilitychange", onVisibilityChange);
-    window.addEventListener("focus", sendActivate);
+    window.addEventListener("focus", onWindowFocus);
 
     return () => {
       connectOnReady = false;
       cancelMomentum();
       document.removeEventListener("visibilitychange", onVisibilityChange);
-      window.removeEventListener("focus", sendActivate);
+      window.removeEventListener("focus", onWindowFocus);
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
@@ -1062,6 +1137,11 @@ export function useTerminal(
   }, [state.isInScrollback]);
 
   const manualReconnect = () => {
+    const ws = wsRef.current;
+    tdbg("manualReconnect()", {
+      readyState: ws?.readyState,
+      previousAttempt: retryCountRef.current,
+    });
     retryCountRef.current = 0;
     setState((prev) => ({
       ...prev,
@@ -1070,7 +1150,7 @@ export function useTerminal(
       retryCount: 0,
       retryCountdown: 0,
     }));
-    wsRef.current?.close();
+    ws?.close();
   };
 
   const sendData = useCallback((data: string) => {


### PR DESCRIPTION
> ⚠️ **Stacked on #1008 — merge that one first.**
> This branch is rebased on `fix-acp-webui` (the head of #1008). Until #1008 merges, the diff here will show its commits too. Once #1008 lands on `main`, this PR's diff will collapse to just the changes below. CI may also depend on pieces from #1008.

## Description

Tackles the first half of #1009: triage instrumentation for the web terminal WebSocket, plus an auto-revive for dead tmux panes that the web UI was previously rendering as un-typeable tombstones.

**Server (`src/server/ws.rs`)**
- `tracing` on every close path so `debug.log` distinguishes idle reaper vs PTY EOF vs ws send/recv error vs client Close. Each task (reader / sender / recv) logs its exit reason, byte totals where useful, and the outer `select!` arm logs which side ended plus the session's elapsed duration.
- Per-message bytes go to a new `terminal.ws.bytes` target at `trace`, gated behind `AOE_TERMINAL_TRACE=1` so the firehose is opt-in (a busy claude session emits thousands of frames/min and would otherwise drown the lifecycle signal).
- `paired_terminal_ws` and `container_terminal_ws` now check `is_pane_dead()` immediately before `on_upgrade` and run a kill+recreate dance if the pane has died (matches the TUI behavior at `src/tui/app.rs`). Without this, the browser's WS reconnect path was attaching to dead panes whose only response to keystrokes was nothing. Serialized via the per-instance lock so concurrent reconnects don't race the recreate. Doesn't touch `terminal_ws` (the agent's main session) since killing that would terminate claude.

**Client (`web/src/hooks/useTerminal.ts`)**
- `console.debug` at every WS state transition (`connect()`, `onopen`, `onclose` with `event.code` / `reason` / `wasClean`, `onerror`, retry-attempt-N with computed backoff, `manualReconnect` with current `readyState`, `visibilitychange`, `focus`). Gated behind `localStorage.aoeDebug='1'` or `?debug=1`.
- `console.warn` at `onerror` and retries-exhausted always fire so even a user without the toggle has signal in DevTools.
- The terminal banner now embeds the close code/reason so a screenshot of the disconnect message is enough for triage.

**API (`src/server/api/sessions.rs`)**
- `ensure_terminal` and `ensure_container_terminal` likewise rescue dead panes (covers the page-reload path; the WS-route check covers the in-place reconnect path).

**Plumbing**
- `terminal=` added to the file-logging EnvFilter in `src/main.rs`. `AOE_TERMINAL_TRACE` documented in `docs/guides/configuration.md` and `docs/development.md`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib` → 1699 passed; `cargo clippy --features serve -- -D warnings` clean; `cd web && npx tsc --noEmit` clean; `cd web && npx eslint src/hooks/useTerminal.ts` clean)
- [x] Documentation was updated where necessary (`docs/guides/configuration.md`, `docs/development.md`)
- [x] For UI changes: included screenshot or recording — manually reproduced the dead-pane bug locally, confirmed the warn line `paired terminal pane dead at WS upgrade, killing and respawning` fires and the pane revives without a page reload

## Test plan

- [x] `aoe serve` with `AOE_LOG_LEVEL=debug AOE_TERMINAL_TRACE=1`, attach a session, confirm `terminal.ws` lifecycle lines and `terminal.ws.bytes` per-frame trace land in `debug.log`.
- [x] Open a session terminal in the web UI, type `ls`, kill `aoe serve`, restart it, observe pane reviving on next reconnect (no page reload) — debug.log shows the respawn warn.
- [x] Same scenario with a full page reload — the `ensure_terminal` path also rescues.
- [ ] Mobile / iOS PWA reconnect smoke test — not done locally, would benefit from a follow-up.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Claude handled code edits, log instrumentation, and test runs via back-and-forth. The bug investigation, dead-pane root-cause analysis, repro, and decisions on which paths to fix were mine.

- [x] I am an AI Agent filling out this form (check box if true)