### PR TITLE
feat(cli): add `aoe logs` to view debug/serve logs with a pretty viewer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ dependencies = [
  "unicode-width",
  "uuid",
  "webbrowser",
+ "which",
  "xz2",
 ]
 
@@ -1026,6 +1027,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "equivalent"
@@ -4861,6 +4868,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5120,6 +5139,12 @@ checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,9 @@ futures-util = "0.3"
 # Temporary files and directories
 tempfile = "3.14"
 
+# PATH lookup for external viewers (lnav, bat, less) used by `aoe logs`.
+which = "7.0"
+
 # Local SQLite reader for opencode's session store. Bundled to avoid a
 # system libsqlite3 dependency. Used to read session state without spawning
 # `opencode session list`, which leaks a 4.5MB /tmp/.<hash>.so per invocation

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ cargo build --release  # Release build
 
 # Debug logging (writes to debug.log in app data dir)
 AGENT_OF_EMPIRES_DEBUG=1 cargo run
+
+# View the resulting log with the best viewer available
+# (lnav > bat > less > stdout). Add --serve for the daemon log,
+# --all to merge both, --follow to live-tail, --path to print the
+# resolved file path, --no-pager to dump plain text.
+aoe logs
 ```
 
 Debug builds use a parallel namespace so they don't collide with an installed

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -9,6 +9,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe agents`↴](#aoe-agents)
 * [`aoe init`↴](#aoe-init)
 * [`aoe list`↴](#aoe-list)
+* [`aoe logs`↴](#aoe-logs)
 * [`aoe remove`↴](#aoe-remove)
 * [`aoe send`↴](#aoe-send)
 * [`aoe status`↴](#aoe-status)
@@ -76,6 +77,7 @@ Run without arguments to launch the TUI dashboard.
 * `agents` — List supported agents and their install status
 * `init` — Initialize .agent-of-empires/config.toml in a repository
 * `list` — List all sessions
+* `logs` — View AoE log files (debug.log, serve.log) with a pretty viewer
 * `remove` — Remove a session
 * `send` — Send a message to a running agent session
 * `status` — Show session status summary
@@ -168,6 +170,24 @@ List all sessions
 
 * `--json` — Output as JSON
 * `--all` — List sessions from all profiles
+
+
+
+## `aoe logs`
+
+View AoE log files (debug.log, serve.log) with a pretty viewer
+
+**Usage:** `aoe logs [OPTIONS]`
+
+###### **Options:**
+
+* `--debug` — View debug.log (default)
+* `--serve` — View serve.log (daemon stdout/stderr)
+* `--all` — View both debug.log and serve.log, merged by timestamp
+* `-f`, `--follow` — Live-tail the log
+* `-n`, `--lines <N>` — Show only the last N lines (fallback viewers; lnav handles its own)
+* `--no-pager` — Skip viewer detection; write plain log to stdout
+* `--path` — Print the resolved log file path(s) and exit (no viewing)
 
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -18,6 +18,10 @@ AGENT_OF_EMPIRES_DEBUG=1 cargo run  # Debug logging (writes to debug.log in app 
 AOE_LOG_LEVEL=trace cargo run        # Pick the log level explicitly
 AOE_ACP_TRACE=1 cargo run            # Plus raw ACP JSON-RPC firehose
 AOE_TERMINAL_TRACE=1 cargo run       # Plus per-message bytes for the web terminal WS (spammy)
+aoe logs                       # View debug.log via lnav/bat/less (auto-detects)
+aoe logs --serve               # View serve.log (daemon stdout/stderr)
+aoe logs --all --no-pager      # Merge both logs, plain stdout
+aoe logs --path                # Print the resolved log file path
 ```
 
 Requires `tmux` to be installed.

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -160,7 +160,7 @@ sudo pacman -S alsa-utils pulseaudio
 - Check that sound files exist in `~/.config/agent-of-empires/sounds/`
 - Verify sounds are enabled in Settings
 - Test audio with: `aplay ~/.config/agent-of-empires/sounds/start.wav` (Linux)
-- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe` (writes to `debug.log` in app data dir)
+- Check logs: `AGENT_OF_EMPIRES_DEBUG=1 aoe` then `aoe logs` to view the resulting `debug.log`
 
 **Want Age of Empires II sounds?**
 If you own AoE II, manually copy the taunt files to your sounds directory.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -12,6 +12,7 @@ use super::cockpit::CockpitCommands;
 use super::group::GroupCommands;
 use super::init::InitArgs;
 use super::list::ListArgs;
+use super::logs::LogsArgs;
 use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
 use super::remove::RemoveArgs;
@@ -63,6 +64,9 @@ pub enum Commands {
     /// List all sessions
     #[command(alias = "ls")]
     List(ListArgs),
+
+    /// View AoE log files (debug.log, serve.log) with a pretty viewer
+    Logs(LogsArgs),
 
     /// Remove a session
     #[command(alias = "rm")]

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -120,9 +120,18 @@ pub async fn run(args: LogsArgs) -> Result<()> {
     }
 
     // For --all, materialize a merged stream into a temp file and view that.
-    // _guard keeps the tempfile alive for the duration of the viewer.
+    // _guard keeps the tempfile alive for the duration of the viewer. If no
+    // source file exists, print does-not-exist hints rather than opening an
+    // empty viewer, matching the --debug/--serve behavior below.
     let (target_path, _guard) = match mode {
         Mode::All => {
+            if paths.iter().all(|p| !p.exists()) {
+                for p in &paths {
+                    eprintln!("{} does not exist (yet).", p.display());
+                }
+                eprintln!("Tip: run with AGENT_OF_EMPIRES_DEBUG=1 to generate debug.log.");
+                return Ok(());
+            }
             let merged = merged_temp_file(&paths)?;
             (merged.path().to_path_buf(), Some(merged))
         }
@@ -138,10 +147,10 @@ pub async fn run(args: LogsArgs) -> Result<()> {
     }
 
     let viewer = detect_viewer(args.no_pager);
-    if !args.no_pager && viewer != Viewer::Lnav {
+    if !args.no_pager && viewer != Viewer::Lnav && std::env::var_os("AOE_NO_LNAV_TIP").is_none() {
         eprintln!(
             "Tip: install `lnav` for color, level filters, and search (https://lnav.org). \
-             Falling back to {}.",
+             Set AOE_NO_LNAV_TIP=1 to silence. Falling back to {}.",
             viewer_name(viewer)
         );
     }
@@ -206,6 +215,12 @@ fn run_viewer(viewer: Viewer, path: &Path, args: &LogsArgs) -> Result<()> {
         }
         Viewer::Less => {
             if args.follow {
+                // `less +F` on a file can't seek to "last N"; route through
+                // tail when --lines is set so the user only sees the recent
+                // window plus live appends.
+                if let Some(n) = args.lines {
+                    return tail_pipe_into(path, n, Command::new("less").args(["-R", "+F"]));
+                }
                 Command::new("less")
                     .arg("-R")
                     .arg("+F")
@@ -218,7 +233,11 @@ fn run_viewer(viewer: Viewer, path: &Path, args: &LogsArgs) -> Result<()> {
         }
         Viewer::PlainStdout => {
             if args.follow {
-                Command::new("tail").arg("-F").arg(path).status()?;
+                let mut cmd = Command::new("tail");
+                if let Some(n) = args.lines {
+                    cmd.args(["-n", &n.to_string()]);
+                }
+                cmd.arg("-F").arg(path).status()?;
                 return Ok(());
             }
             let content = read_content(path, args.lines)?;
@@ -257,6 +276,24 @@ fn pipe_through(cmd: &mut Command, content: &str) -> Result<()> {
         let _ = stdin.write_all(content.as_bytes());
     }
     let _ = child.wait()?;
+    Ok(())
+}
+
+/// Spawn `tail -n N -F path` and feed its stdout into `viewer`'s stdin so the
+/// viewer keeps following live appends while only showing the last N lines.
+/// Kills tail when the viewer exits so we don't leak a background tail.
+fn tail_pipe_into(path: &Path, lines: usize, viewer: &mut Command) -> Result<()> {
+    use std::process::Stdio;
+    let mut tail = Command::new("tail")
+        .args(["-n", &lines.to_string(), "-F"])
+        .arg(path)
+        .stdout(Stdio::piped())
+        .spawn()?;
+    let tail_out = tail.stdout.take().expect("piped stdout");
+    let status = viewer.stdin(Stdio::from(tail_out)).status();
+    let _ = tail.kill();
+    let _ = tail.wait();
+    status?;
     Ok(())
 }
 

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -1,0 +1,458 @@
+//! `aoe logs` - view AoE log files (debug.log, serve.log) with a pretty viewer.
+//!
+//! Resolves the right path under the app data dir, picks the best available
+//! viewer (lnav > bat > less > plain stdout), and prints a one-line tip when
+//! `lnav` is missing so users know there's a better experience available.
+
+use anyhow::{bail, Result};
+use clap::Args;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+#[derive(Args)]
+pub struct LogsArgs {
+    /// View debug.log (default).
+    #[arg(long, conflicts_with_all = ["serve", "all"])]
+    pub debug: bool,
+
+    /// View serve.log (daemon stdout/stderr).
+    #[arg(long, conflicts_with_all = ["debug", "all"])]
+    pub serve: bool,
+
+    /// View both debug.log and serve.log, merged by timestamp.
+    #[arg(long, conflicts_with_all = ["debug", "serve"])]
+    pub all: bool,
+
+    /// Live-tail the log.
+    #[arg(short = 'f', long)]
+    pub follow: bool,
+
+    /// Show only the last N lines (fallback viewers; lnav handles its own).
+    #[arg(short = 'n', long, value_name = "N")]
+    pub lines: Option<usize>,
+
+    /// Skip viewer detection; write plain log to stdout.
+    #[arg(long)]
+    pub no_pager: bool,
+
+    /// Print the resolved log file path(s) and exit (no viewing).
+    #[arg(long)]
+    pub path: bool,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum Viewer {
+    Lnav,
+    Bat,
+    Less,
+    PlainStdout,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Mode {
+    Debug,
+    Serve,
+    All,
+}
+
+fn debug_log_path() -> Result<PathBuf> {
+    Ok(crate::session::get_app_dir()?.join("debug.log"))
+}
+
+#[cfg(feature = "serve")]
+fn serve_log_path() -> Result<PathBuf> {
+    crate::cli::serve::daemon_log_path()
+}
+
+pub fn detect_viewer(no_pager: bool) -> Viewer {
+    if no_pager {
+        return Viewer::PlainStdout;
+    }
+    if which::which("lnav").is_ok() {
+        return Viewer::Lnav;
+    }
+    if which::which("bat").is_ok() {
+        return Viewer::Bat;
+    }
+    if which::which("less").is_ok() {
+        return Viewer::Less;
+    }
+    Viewer::PlainStdout
+}
+
+fn viewer_name(v: Viewer) -> &'static str {
+    match v {
+        Viewer::Lnav => "lnav",
+        Viewer::Bat => "bat",
+        Viewer::Less => "less",
+        Viewer::PlainStdout => "plain stdout",
+    }
+}
+
+pub async fn run(args: LogsArgs) -> Result<()> {
+    let mode = if args.serve {
+        Mode::Serve
+    } else if args.all {
+        Mode::All
+    } else {
+        Mode::Debug
+    };
+
+    #[cfg(not(feature = "serve"))]
+    if matches!(mode, Mode::Serve | Mode::All) {
+        bail!(
+            "--serve and --all need a build with the `serve` feature; \
+             this binary was built without it. Use `--debug` (default) for debug.log."
+        );
+    }
+
+    let paths = resolve_paths(mode)?;
+
+    if args.path {
+        for p in &paths {
+            println!("{}", p.display());
+        }
+        return Ok(());
+    }
+
+    if args.follow && mode == Mode::All {
+        bail!("--follow is not supported with --all; pick --debug or --serve.");
+    }
+
+    // For --all, materialize a merged stream into a temp file and view that.
+    // _guard keeps the tempfile alive for the duration of the viewer.
+    let (target_path, _guard) = match mode {
+        Mode::All => {
+            let merged = merged_temp_file(&paths)?;
+            (merged.path().to_path_buf(), Some(merged))
+        }
+        _ => (paths[0].clone(), None),
+    };
+
+    if !target_path.exists() {
+        eprintln!("{} does not exist (yet).", target_path.display());
+        if mode == Mode::Debug {
+            eprintln!("Tip: run with AGENT_OF_EMPIRES_DEBUG=1 to generate debug.log.");
+        }
+        return Ok(());
+    }
+
+    let viewer = detect_viewer(args.no_pager);
+    if !args.no_pager && viewer != Viewer::Lnav {
+        eprintln!(
+            "Tip: install `lnav` for color, level filters, and search (https://lnav.org). \
+             Falling back to {}.",
+            viewer_name(viewer)
+        );
+    }
+
+    run_viewer(viewer, &target_path, &args)
+}
+
+fn resolve_paths(mode: Mode) -> Result<Vec<PathBuf>> {
+    match mode {
+        Mode::Debug => Ok(vec![debug_log_path()?]),
+        #[cfg(feature = "serve")]
+        Mode::Serve => Ok(vec![serve_log_path()?]),
+        #[cfg(feature = "serve")]
+        Mode::All => Ok(vec![debug_log_path()?, serve_log_path()?]),
+        #[cfg(not(feature = "serve"))]
+        Mode::Serve | Mode::All => unreachable!("bailed earlier when serve feature is off"),
+    }
+}
+
+#[cfg(feature = "serve")]
+fn merged_temp_file(paths: &[PathBuf]) -> Result<tempfile::NamedTempFile> {
+    use std::io::Write;
+    let debug_text = std::fs::read_to_string(&paths[0]).unwrap_or_default();
+    let serve_text = std::fs::read_to_string(&paths[1]).unwrap_or_default();
+    let merged = merge_by_timestamp(&debug_text, &serve_text);
+    let mut tmp = tempfile::Builder::new()
+        .prefix("aoe-logs-merged-")
+        .suffix(".log")
+        .tempfile()?;
+    tmp.write_all(merged.as_bytes())?;
+    tmp.flush()?;
+    Ok(tmp)
+}
+
+#[cfg(not(feature = "serve"))]
+fn merged_temp_file(_paths: &[PathBuf]) -> Result<tempfile::NamedTempFile> {
+    unreachable!("--all requires the serve feature; bailed earlier")
+}
+
+fn run_viewer(viewer: Viewer, path: &Path, args: &LogsArgs) -> Result<()> {
+    match viewer {
+        Viewer::Lnav => {
+            // lnav handles --follow natively and ignores --lines.
+            Command::new("lnav").arg(path).status()?;
+            Ok(())
+        }
+        Viewer::Bat => {
+            // bat has no follow mode; downgrade to less +F or plain tail.
+            if args.follow {
+                let fallback = if which::which("less").is_ok() {
+                    Viewer::Less
+                } else {
+                    Viewer::PlainStdout
+                };
+                return run_viewer(fallback, path, args);
+            }
+            let content = read_content(path, args.lines)?;
+            pipe_through(
+                Command::new("bat").args(["--paging=always", "-l", "log"]),
+                &content,
+            )
+        }
+        Viewer::Less => {
+            if args.follow {
+                Command::new("less")
+                    .arg("-R")
+                    .arg("+F")
+                    .arg(path)
+                    .status()?;
+                return Ok(());
+            }
+            let content = read_content(path, args.lines)?;
+            pipe_through(Command::new("less").arg("-R"), &content)
+        }
+        Viewer::PlainStdout => {
+            if args.follow {
+                Command::new("tail").arg("-F").arg(path).status()?;
+                return Ok(());
+            }
+            let content = read_content(path, args.lines)?;
+            print!("{}", content);
+            Ok(())
+        }
+    }
+}
+
+fn read_content(path: &Path, lines: Option<usize>) -> Result<String> {
+    let raw = std::fs::read_to_string(path)?;
+    Ok(match lines {
+        Some(n) => last_n_lines(&raw, n),
+        None => raw,
+    })
+}
+
+pub fn last_n_lines(text: &str, n: usize) -> String {
+    if n == 0 {
+        return String::new();
+    }
+    let lines: Vec<&str> = text.lines().collect();
+    let start = lines.len().saturating_sub(n);
+    let mut out = lines[start..].join("\n");
+    if text.ends_with('\n') && !out.is_empty() {
+        out.push('\n');
+    }
+    out
+}
+
+fn pipe_through(cmd: &mut Command, content: &str) -> Result<()> {
+    use std::io::Write;
+    use std::process::Stdio;
+    let mut child = cmd.stdin(Stdio::piped()).spawn()?;
+    if let Some(stdin) = child.stdin.as_mut() {
+        let _ = stdin.write_all(content.as_bytes());
+    }
+    let _ = child.wait()?;
+    Ok(())
+}
+
+/// Merge two tracing-formatted log streams by leading ISO-8601 timestamp.
+/// Each emitted line is prefixed with `[debug]` / `[serve]` so the source
+/// is unambiguous after merging. Continuation lines (no leading timestamp,
+/// e.g. multi-line tracing payloads) ride along with their preceding head.
+pub fn merge_by_timestamp(debug: &str, serve: &str) -> String {
+    let mut entries: Vec<(Option<String>, String, &'static str)> = Vec::new();
+    for (ts, body) in group_entries(debug) {
+        entries.push((ts, body, "debug"));
+    }
+    for (ts, body) in group_entries(serve) {
+        entries.push((ts, body, "serve"));
+    }
+    // Stable sort: timestamps strict-ordered; entries without a timestamp
+    // (e.g. orphan continuation at file start) sink to the end.
+    entries.sort_by(|a, b| match (&a.0, &b.0) {
+        (Some(x), Some(y)) => x.cmp(y),
+        (Some(_), None) => std::cmp::Ordering::Less,
+        (None, Some(_)) => std::cmp::Ordering::Greater,
+        (None, None) => std::cmp::Ordering::Equal,
+    });
+
+    let mut out = String::new();
+    for (_ts, body, tag) in entries {
+        for line in body.lines() {
+            out.push('[');
+            out.push_str(tag);
+            out.push_str("] ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    out
+}
+
+fn group_entries(text: &str) -> Vec<(Option<String>, String)> {
+    let mut out: Vec<(Option<String>, String)> = Vec::new();
+    for line in text.lines() {
+        if let Some(ts) = leading_timestamp(line) {
+            out.push((Some(ts), line.to_string()));
+        } else if let Some(last) = out.last_mut() {
+            last.1.push('\n');
+            last.1.push_str(line);
+        } else {
+            out.push((None, line.to_string()));
+        }
+    }
+    out
+}
+
+/// `tracing-subscriber`'s default formatter prefixes each event with an
+/// ISO-8601 timestamp like `2024-09-12T18:42:11.305812Z`. Detect that
+/// prefix conservatively: if the first 19 chars match the date-time
+/// skeleton, return the full token up to the first whitespace. Otherwise
+/// return None (continuation line, blank line, or non-tracing format).
+fn leading_timestamp(line: &str) -> Option<String> {
+    let bytes = line.as_bytes();
+    if bytes.len() < 19 {
+        return None;
+    }
+    let shape_ok = bytes[0].is_ascii_digit()
+        && bytes[1].is_ascii_digit()
+        && bytes[2].is_ascii_digit()
+        && bytes[3].is_ascii_digit()
+        && bytes[4] == b'-'
+        && bytes[5].is_ascii_digit()
+        && bytes[6].is_ascii_digit()
+        && bytes[7] == b'-'
+        && bytes[8].is_ascii_digit()
+        && bytes[9].is_ascii_digit()
+        && bytes[10] == b'T'
+        && bytes[11].is_ascii_digit()
+        && bytes[12].is_ascii_digit()
+        && bytes[13] == b':'
+        && bytes[14].is_ascii_digit()
+        && bytes[15].is_ascii_digit()
+        && bytes[16] == b':'
+        && bytes[17].is_ascii_digit()
+        && bytes[18].is_ascii_digit();
+    if !shape_ok {
+        return None;
+    }
+    let end = line[19..]
+        .char_indices()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, _)| 19 + i)
+        .unwrap_or(line.len());
+    Some(line[..end].to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detect_viewer_no_pager_returns_plain_stdout() {
+        assert_eq!(detect_viewer(true), Viewer::PlainStdout);
+    }
+
+    #[test]
+    fn last_n_lines_returns_tail_and_preserves_trailing_newline() {
+        let input = "a\nb\nc\nd\ne\n";
+        assert_eq!(last_n_lines(input, 2), "d\ne\n");
+    }
+
+    #[test]
+    fn last_n_lines_no_trailing_newline_in_input() {
+        let input = "a\nb\nc";
+        assert_eq!(last_n_lines(input, 2), "b\nc");
+    }
+
+    #[test]
+    fn last_n_lines_zero_returns_empty() {
+        assert_eq!(last_n_lines("a\nb\n", 0), "");
+    }
+
+    #[test]
+    fn last_n_lines_n_larger_than_input_returns_full_input() {
+        let input = "a\nb\n";
+        assert_eq!(last_n_lines(input, 100), "a\nb\n");
+    }
+
+    #[test]
+    fn last_n_lines_empty_input() {
+        assert_eq!(last_n_lines("", 5), "");
+    }
+
+    #[test]
+    fn leading_timestamp_extracts_iso8601_with_microseconds() {
+        let ts = leading_timestamp("2024-09-12T18:42:11.305812Z  INFO foo: bar");
+        assert_eq!(ts.as_deref(), Some("2024-09-12T18:42:11.305812Z"));
+    }
+
+    #[test]
+    fn leading_timestamp_extracts_iso8601_no_fraction() {
+        let ts = leading_timestamp("2024-09-12T18:42:11Z  INFO foo");
+        assert_eq!(ts.as_deref(), Some("2024-09-12T18:42:11Z"));
+    }
+
+    #[test]
+    fn leading_timestamp_rejects_non_timestamp_lines() {
+        assert_eq!(leading_timestamp("    at src/foo.rs:42"), None);
+        assert_eq!(leading_timestamp(""), None);
+        assert_eq!(leading_timestamp("    panicked at..."), None);
+    }
+
+    #[test]
+    fn merge_by_timestamp_interleaves_two_streams_in_order() {
+        let dbg = "2024-01-01T00:00:01Z  INFO d1\n\
+                   2024-01-01T00:00:03Z  INFO d2\n";
+        let srv = "2024-01-01T00:00:02Z  INFO s1\n\
+                   2024-01-01T00:00:04Z  INFO s2\n";
+        let merged = merge_by_timestamp(dbg, srv);
+        let lines: Vec<&str> = merged.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "[debug] 2024-01-01T00:00:01Z  INFO d1",
+                "[serve] 2024-01-01T00:00:02Z  INFO s1",
+                "[debug] 2024-01-01T00:00:03Z  INFO d2",
+                "[serve] 2024-01-01T00:00:04Z  INFO s2",
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_by_timestamp_preserves_continuation_lines_with_their_head() {
+        // Continuation lines have no leading timestamp; they should attach
+        // to the previous head and travel together when the heads are
+        // re-sorted. Use explicit `\n` to keep the indentation intact (a
+        // `\`-continued raw string would strip the indent).
+        let dbg = "2024-01-01T00:00:01Z  ERROR boom\n    at src/foo.rs:42\n    at src/bar.rs:7\n2024-01-01T00:00:03Z  INFO recover\n";
+        let srv = "2024-01-01T00:00:02Z  INFO between\n";
+        let merged = merge_by_timestamp(dbg, srv);
+        let lines: Vec<&str> = merged.lines().collect();
+        assert_eq!(
+            lines,
+            vec![
+                "[debug] 2024-01-01T00:00:01Z  ERROR boom",
+                "[debug]     at src/foo.rs:42",
+                "[debug]     at src/bar.rs:7",
+                "[serve] 2024-01-01T00:00:02Z  INFO between",
+                "[debug] 2024-01-01T00:00:03Z  INFO recover",
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_by_timestamp_handles_empty_inputs() {
+        assert_eq!(merge_by_timestamp("", ""), "");
+        let only_dbg = "2024-01-01T00:00:01Z  INFO hi\n";
+        assert_eq!(
+            merge_by_timestamp(only_dbg, ""),
+            "[debug] 2024-01-01T00:00:01Z  INFO hi\n"
+        );
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod definition;
 pub mod group;
 pub mod init;
 pub mod list;
+pub mod logs;
 pub mod output;
 pub mod profile;
 pub mod project;

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,7 @@ async fn main() -> Result<()> {
             };
         }
         Some(Commands::Agents) => return cli::agents::run(),
+        Some(Commands::Logs(args)) => return cli::logs::run(args).await,
         Some(Commands::Sounds { command }) => return cli::sounds::run(command).await,
         Some(Commands::Theme { command }) => {
             use cli::theme::ThemeCommands;

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -401,12 +401,19 @@ last_seen_version = "{}"
 
     /// Run `aoe <args>` as a subprocess (not in tmux) with the same env
     /// isolation. Returns the `Output` (stdout, stderr, status).
+    ///
+    /// Clears `AGENT_OF_EMPIRES_DEBUG` and `AOE_LOG_LEVEL` from the inherited
+    /// env so tests run with a deterministic logging configuration: when
+    /// either is set, `aoe` truncates `debug.log` on startup, which would
+    /// silently destroy any fixture that an `aoe logs` test seeded.
     pub fn run_cli(&self, args: &[&str]) -> Output {
         Command::new(&self.binary_path)
             .args(args)
             .env("HOME", self.home_dir.path())
             .env("XDG_CONFIG_HOME", self.home_dir.path().join(".config"))
             .env("PATH", self.env_path())
+            .env_remove("AGENT_OF_EMPIRES_DEBUG")
+            .env_remove("AOE_LOG_LEVEL")
             .output()
             .expect("failed to run aoe CLI")
     }

--- a/tests/e2e/logs.rs
+++ b/tests/e2e/logs.rs
@@ -175,3 +175,30 @@ fn logs_missing_debug_log_exits_zero_with_hint() {
         "stderr should explain missing file: {stderr}"
     );
 }
+
+#[test]
+#[serial]
+fn logs_all_missing_both_files_exits_zero_with_hints() {
+    if !cfg!(feature = "serve") {
+        eprintln!("Skipping: built without `serve` feature");
+        return;
+    }
+
+    let h = TuiTestHarness::new("logs_all_missing");
+    // Don't seed either log file.
+    let out = h.run_cli(&["logs", "--all", "--no-pager"]);
+    assert!(
+        out.status.success(),
+        "should exit 0 when both files missing; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.matches("does not exist").count() >= 2,
+        "stderr should list both missing paths: {stderr}"
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).is_empty(),
+        "stdout should be empty when no viewer runs"
+    );
+}

--- a/tests/e2e/logs.rs
+++ b/tests/e2e/logs.rs
@@ -1,0 +1,177 @@
+//! E2E coverage for `aoe logs`.
+//!
+//! Drives the binary via `run_cli` against a fixture log seeded inside the
+//! harness's isolated `$HOME` so the real user's logs are never read or
+//! touched. We use `--no-pager` everywhere to keep the test deterministic
+//! (no interactive viewer launch).
+
+use serial_test::serial;
+
+use crate::harness::{app_dir_in, TuiTestHarness};
+
+/// Write a fake debug.log under the harness's isolated app dir.
+fn seed_debug_log(h: &TuiTestHarness, content: &str) -> std::path::PathBuf {
+    let app_dir = app_dir_in(h.home_path());
+    std::fs::create_dir_all(&app_dir).expect("create app dir");
+    let path = app_dir.join("debug.log");
+    std::fs::write(&path, content).expect("write debug.log");
+    path
+}
+
+/// Write a fake serve.log under the harness's isolated app dir.
+fn seed_serve_log(h: &TuiTestHarness, content: &str) -> std::path::PathBuf {
+    let app_dir = app_dir_in(h.home_path());
+    std::fs::create_dir_all(&app_dir).expect("create app dir");
+    let path = app_dir.join("serve.log");
+    std::fs::write(&path, content).expect("write serve.log");
+    path
+}
+
+#[test]
+#[serial]
+fn logs_no_pager_prints_debug_log_to_stdout() {
+    let h = TuiTestHarness::new("logs_no_pager");
+    seed_debug_log(
+        &h,
+        "2024-01-01T00:00:01Z  INFO line one\n\
+         2024-01-01T00:00:02Z  INFO line two\n",
+    );
+
+    let out = h.run_cli(&["logs", "--no-pager"]);
+    assert!(
+        out.status.success(),
+        "aoe logs --no-pager failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("line one"),
+        "stdout missing 'line one': {stdout}"
+    );
+    assert!(
+        stdout.contains("line two"),
+        "stdout missing 'line two': {stdout}"
+    );
+}
+
+#[test]
+#[serial]
+fn logs_lines_returns_only_tail() {
+    let h = TuiTestHarness::new("logs_lines");
+    seed_debug_log(&h, "a\nb\nc\nd\ne\n");
+
+    let out = h.run_cli(&["logs", "--no-pager", "--lines", "2"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout, "d\ne\n");
+}
+
+#[test]
+#[serial]
+fn logs_path_prints_debug_log_path() {
+    let h = TuiTestHarness::new("logs_path");
+    let path = seed_debug_log(&h, "");
+
+    let out = h.run_cli(&["logs", "--path"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout.trim(), path.to_string_lossy());
+}
+
+#[test]
+#[serial]
+fn logs_path_all_prints_both_paths() {
+    // --all is gated on the `serve` feature; this test runs only when the
+    // binary was built with it. `cargo test --features serve` covers it;
+    // plain `cargo test` builds without the feature, so skip in that case.
+    if !cfg!(feature = "serve") {
+        eprintln!("Skipping: built without `serve` feature");
+        return;
+    }
+
+    let h = TuiTestHarness::new("logs_path_all");
+    let dbg = seed_debug_log(&h, "");
+    let srv = seed_serve_log(&h, "");
+
+    let out = h.run_cli(&["logs", "--all", "--path"]);
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(lines.len(), 2, "expected 2 paths, got: {stdout}");
+    assert_eq!(lines[0], dbg.to_string_lossy());
+    assert_eq!(lines[1], srv.to_string_lossy());
+}
+
+#[test]
+#[serial]
+fn logs_serve_no_pager_prints_serve_log() {
+    if !cfg!(feature = "serve") {
+        eprintln!("Skipping: built without `serve` feature");
+        return;
+    }
+
+    let h = TuiTestHarness::new("logs_serve");
+    seed_serve_log(&h, "serve daemon line\n");
+
+    let out = h.run_cli(&["logs", "--serve", "--no-pager"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("serve daemon line"));
+}
+
+#[test]
+#[serial]
+fn logs_all_no_pager_merges_streams_with_tags() {
+    if !cfg!(feature = "serve") {
+        eprintln!("Skipping: built without `serve` feature");
+        return;
+    }
+
+    let h = TuiTestHarness::new("logs_all_merge");
+    seed_debug_log(
+        &h,
+        "2024-01-01T00:00:01Z  INFO debug-a\n\
+         2024-01-01T00:00:03Z  INFO debug-b\n",
+    );
+    seed_serve_log(
+        &h,
+        "2024-01-01T00:00:02Z  INFO serve-a\n\
+         2024-01-01T00:00:04Z  INFO serve-b\n",
+    );
+
+    let out = h.run_cli(&["logs", "--all", "--no-pager"]);
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let lines: Vec<&str> = stdout.lines().collect();
+    assert_eq!(
+        lines,
+        vec![
+            "[debug] 2024-01-01T00:00:01Z  INFO debug-a",
+            "[serve] 2024-01-01T00:00:02Z  INFO serve-a",
+            "[debug] 2024-01-01T00:00:03Z  INFO debug-b",
+            "[serve] 2024-01-01T00:00:04Z  INFO serve-b",
+        ]
+    );
+}
+
+#[test]
+#[serial]
+fn logs_missing_debug_log_exits_zero_with_hint() {
+    let h = TuiTestHarness::new("logs_missing");
+    // Don't seed: app dir + debug.log absent.
+    let out = h.run_cli(&["logs", "--no-pager"]);
+    assert!(out.status.success(), "should exit 0 when missing");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("does not exist"),
+        "stderr should explain missing file: {stderr}"
+    );
+}

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -20,6 +20,7 @@ mod harness;
 mod cli;
 mod command_palette;
 mod errors;
+mod logs;
 mod new_session;
 mod profile_picker;
 mod project_registry;


### PR DESCRIPTION
*AI disclosure: investigation, scaffolding, code, tests, docs, and this PR body written by Claude (Opus 4.7). Prompts, scope decisions, and final review are mine.*

> ⚠️ **Depends on #1008 (`fix-acp-webui`).** This branch was rebased onto `fix-acp-webui`, so the diff against `main` includes the 5 cockpit commits from #1008. Please merge #1008 first, then rebase/merge this PR on top to get a clean diff. If #1008 lands and this branch is rebased, the diff here will reduce to just the `aoe logs` work.

## Description

Resolves #1003. Adds a top-level `aoe logs` subcommand so users can view AoE log files without remembering platform-specific paths or piping through `cat`/`tail`/`less -R` by hand.

The command resolves the right path (`debug.log` via `get_app_dir()`; `serve.log` via `daemon_log_path()`) and dispatches to the best viewer found on `$PATH`:

```
lnav > bat > less > plain stdout
```

When the chosen viewer falls below `lnav`, a one-line tip prints on stderr so users discover the better experience. Suppressed under `--no-pager`.

### Flags

| Flag | Effect |
|------|--------|
| `--debug` | View `debug.log` (default) |
| `--serve` | View `serve.log` (daemon stdout/stderr) |
| `--all` | Merge both by ISO-8601 timestamp; lines prefixed `[debug]`/`[serve]` |
| `-f`, `--follow` | Live-tail (`lnav` natively; `less +F`; otherwise `tail -F`) |
| `-n`, `--lines N` | Tail the last N lines (fallback viewers only; `lnav` ignores) |
| `--no-pager` | Bypass viewer detection; dump plain text to stdout |
| `--path` | Print resolved path(s) and exit |

`--serve` / `--all` require the `serve` feature; on TUI-only builds they bail with a helpful message instead of pretending `serve.log` exists. `--follow` is rejected with `--all` (timestamp merge needs the full files).

### Merge logic for `--all`

Both tracing-formatted streams are grouped into entries (a "head" line that starts with an ISO-8601 timestamp plus any continuation lines that follow it). Entries are stable-sorted by timestamp, each emitted line is prefixed with its source tag, and the merged buffer is written to a temp file the viewer reads. Multi-line tracing payloads stay glued to their head through the sort.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A, CLI only)

### Tests

- 12 unit tests in `src/cli/logs.rs` cover viewer selection, last-N-lines, ISO-8601 timestamp extraction, and merge ordering (interleaving, continuation lines, empty inputs).
- 7 e2e tests in `tests/e2e/logs.rs` drive the binary via `run_cli` with seeded fixture logs in an isolated `$HOME`. Covers `--no-pager`, `--lines`, `--path`, `--serve`, `--all` merge output, and missing-file handling.
- Harness fix: `run_cli` now strips `AGENT_OF_EMPIRES_DEBUG` and `AOE_LOG_LEVEL` from the inherited env. Either var triggers `tracing-subscriber` to truncate `debug.log` on startup, which would silently destroy any fixture an `aoe logs` test seeded.

How tested:

```
cargo fmt
cargo clippy --all-targets --features serve -- -D warnings   # clean
cargo test --features serve --test e2e                       # 57 passed, 2 ignored
cargo test --lib cli::logs                                   # 12 passed
cargo xtask gen-docs                                         # idempotent
cargo xtask check-skill                                      # passed
```

Manual: `AGENT_OF_EMPIRES_DEBUG=1 cargo run -- list` to seed `debug.log`, then `cargo run -- logs --no-pager`, `cargo run -- logs --path`, `cargo run -- logs --all --no-pager` (with serve feature). Verified the lnav-recommended tip surfaces when only `bat`/`less` are installed.

### Docs

- `README.md`, `docs/development.md`, `docs/sounds.md` mention `aoe logs` next to the existing `AGENT_OF_EMPIRES_DEBUG=1` hint.
- `docs/cli/reference.md` regenerated via `cargo xtask gen-docs` (CI-enforced).

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Plan was written and approved before any code changes; the agent then implemented, tested, fixed a harness env-bleed bug found during e2e, and wrote this PR body. The human reviewed each step.

- [x] I am an AI Agent filling out this form (check box if true)