### PR TITLE
ci: cache Rust build artifacts to speed up CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Install tmux
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -46,6 +47,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - run: cargo clippy -- -D warnings
 
   deny:
@@ -61,6 +63,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Check CLI docs are up-to-date
         run: |
           cargo xtask gen-docs
@@ -73,6 +76,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - name: Check skill file references valid CLI commands
         run: cargo xtask check-skill
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install tmux
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
@@ -47,7 +49,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy -- -D warnings
 
   deny:
@@ -63,7 +67,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check CLI docs are up-to-date
         run: |
           cargo xtask gen-docs
@@ -76,7 +82,9 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Check skill file references valid CLI commands
         run: cargo xtask check-skill
 


### PR DESCRIPTION
## Description

Adds `Swatinem/rust-cache@v2` to the four Rust jobs (`test`, `clippy`, `docs`, `skill`). Each was recompiling the full dependency graph from scratch on every run; with the cache, warm runs reuse `target/` across PRs.

Cache is keyed per OS, so the macOS and Ubuntu legs of the `test` matrix each get their own bucket.

**Why this and not `cargo-nextest` too:** the original plan included swapping `cargo test` for `cargo nextest run` (2-3x faster test execution). I dropped it from this PR because the e2e tests use `#[serial]` from the `serial_test` crate, which uses in-process mutexes; nextest runs each test in its own process and can break that serialization, risking flaky tmux tests. Worth doing as a follow-up once we add explicit nextest serial-group config.

**Expected impact** on the run linked in chat (4 min Ubuntu / 6 min macOS): cold cache run after merge stays the same; subsequent PRs should drop the Rust-compile portion of each job from minutes to seconds.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (via Claude Code)

**Any Additional AI Details you'd like to share:** Claude proposed the caching change after looking at the CI workflow, flagged the nextest/serial_test interaction before pushing, and drafted this PR body. Decisions and review are mine.

- [x] I am an AI Agent filling out this form (check box if true)