### PR TITLE
feat(worktree): add init_submodules config to skip recursive submodule init

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -123,6 +123,7 @@ Add a new session
 * `-b`, `--new-branch` — Create a new branch (use with --worktree)
 * `-r`, `--repo <EXTRA_REPOS>` — Additional repositories for multi-repo workspace (use with --worktree)
 * `--project <PROJECTS>` — Names of registered projects to include as extra repos (use with --worktree). Resolves against the union of global + profile project registries
+* `--no-submodules` — Skip `git submodule update --init --recursive` after creating the worktree, overriding the `worktree.init_submodules` config (default true). Useful for repos with large or deeply nested submodule trees that you don't need inside the agent session
 * `-s`, `--sandbox` — Run session in a container sandbox
 * `--sandbox-image <SANDBOX_IMAGE>` — Custom container image for sandbox (implies --sandbox)
 * `-y`, `--yolo` — Enable YOLO mode (skip permission prompts)

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -108,6 +108,7 @@ bare_repo_path_template = "./{branch}"
 auto_cleanup = true
 show_branch_in_tui = true
 delete_branch_on_cleanup = false
+init_submodules = true
 ```
 
 | Option | Default | Description |
@@ -118,6 +119,7 @@ delete_branch_on_cleanup = false
 | `auto_cleanup` | `true` | Prompt to remove worktree when deleting a session |
 | `show_branch_in_tui` | `true` | Display branch name in the TUI session list |
 | `delete_branch_on_cleanup` | `false` | Also delete the git branch when removing a worktree |
+| `init_submodules` | `true` | Run `git submodule update --init --recursive` after creating a worktree; set to `false` (or pass `--no-submodules` to `aoe add`) to skip submodule init for repos with large or deeply-nested submodule trees |
 
 **Template variables:**
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -59,7 +59,12 @@ bare_repo_path_template = "./{branch}"
 auto_cleanup = true
 show_branch_in_tui = true
 delete_branch_on_cleanup = false
+init_submodules = true
 ```
+
+### Skipping submodule init
+
+`init_submodules = false` skips the `git submodule update --init --recursive` step that runs after `git worktree add` when the checkout contains a `.gitmodules` file. Useful for repos that vendor deep submodule trees (e.g. OpenROAD-flow-scripts, llvm-project, chromium) where every new session would otherwise sit in `Creating…` for minutes while submodules clone. Per-invocation override on the CLI: `aoe add --worktree <branch> --no-submodules`.
 
 ### Template Variables
 

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -52,6 +52,13 @@ pub struct AddArgs {
     #[arg(long = "project")]
     projects: Vec<String>,
 
+    /// Skip `git submodule update --init --recursive` after creating the
+    /// worktree, overriding the `worktree.init_submodules` config (default
+    /// true). Useful for repos with large or deeply nested submodule trees
+    /// that you don't need inside the agent session.
+    #[arg(long = "no-submodules")]
+    no_submodules: bool,
+
     /// Run session in a container sandbox
     #[arg(short = 's', long)]
     sandbox: bool,
@@ -150,6 +157,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         use chrono::Utc;
 
         let branch = branch_raw.trim();
+        let init_submodules = config.worktree.init_submodules && !args.no_submodules;
 
         if !all_extra_repos.is_empty() {
             let ws_result = builder::create_workspace(
@@ -158,6 +166,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 branch,
                 args.create_branch,
                 &config.worktree.workspace_path_template,
+                init_submodules,
             )?;
 
             for repo in &ws_result.workspace_info.repos {
@@ -182,7 +191,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             }
 
             let main_repo_path = GitWorktree::find_main_repo(&path)?;
-            let git_wt = GitWorktree::new(main_repo_path.clone())?;
+            let git_wt =
+                GitWorktree::new(main_repo_path.clone())?.with_init_submodules(init_submodules);
 
             let session_id = uuid::Uuid::new_v4().to_string();
             let session_id_short = &session_id[..8];

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -2078,8 +2078,18 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_create_worktree_initializes_submodules() {
+    /// Build a main repo with a single submodule served by a `git daemon`
+    /// fixture, then create a `test-feature` branch on its current HEAD.
+    /// Returns the `TempDir` containers, the daemon guard (must stay alive
+    /// for `git submodule update` to reach the URL), and the repo path.
+    ///
+    /// The submodule is added at `.claude/` and contains a `skill.md` file,
+    /// so tests can assert on `wt_path.join(".claude").join("skill.md")` to
+    /// distinguish "submodule initialized" from "only .gitmodules checked
+    /// out".
+    fn build_repo_with_submodule_and_branch(
+        branch: &str,
+    ) -> (TempDir, TempDir, GitDaemonGuard, TempDir) {
         let submodule_src_dir = TempDir::new().unwrap();
         let submodule_repo = git2::Repository::init(submodule_src_dir.path()).unwrap();
         let sig = git2::Signature::now("Test", "test@example.com").unwrap();
@@ -2116,7 +2126,7 @@ mod tests {
                 "submodule.git",
             ],
         );
-        let (_daemon, submodule_url) = spawn_git_daemon(daemon_root.path(), "submodule.git");
+        let (daemon, submodule_url) = spawn_git_daemon(daemon_root.path(), "submodule.git");
 
         let repo_dir = TempDir::new().unwrap();
         let repo = git2::Repository::init(repo_dir.path()).unwrap();
@@ -2146,12 +2156,19 @@ mod tests {
             repo_dir.path(),
             &["submodule", "add", &submodule_url, ".claude"],
         );
-
         run_git(repo_dir.path(), &["commit", "-am", "Add submodule"]);
 
         let repo = git2::Repository::open(repo_dir.path()).unwrap();
         let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
-        repo.branch("test-feature", &head_commit, false).unwrap();
+        repo.branch(branch, &head_commit, false).unwrap();
+
+        (submodule_src_dir, daemon_root, daemon, repo_dir)
+    }
+
+    #[test]
+    fn test_create_worktree_initializes_submodules() {
+        let (_submodule_src, _daemon_root, _daemon, repo_dir) =
+            build_repo_with_submodule_and_branch("test-feature");
 
         let git_wt = GitWorktree::new(repo_dir.path().to_path_buf()).unwrap();
         let worktree_parent = TempDir::new().unwrap();
@@ -2168,80 +2185,10 @@ mod tests {
 
     #[test]
     fn test_create_worktree_skips_submodules_when_disabled() {
-        // Same fixture as test_create_worktree_initializes_submodules, but
         // with_init_submodules(false) must skip the `git submodule update`
         // step entirely so the worktree shows up before submodules clone.
-        let submodule_src_dir = TempDir::new().unwrap();
-        let submodule_repo = git2::Repository::init(submodule_src_dir.path()).unwrap();
-        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
-
-        std::fs::write(
-            submodule_src_dir.path().join("skill.md"),
-            "hello from submodule\n",
-        )
-        .unwrap();
-        let submodule_tree_id = {
-            let mut index = submodule_repo.index().unwrap();
-            index.add_path(Path::new("skill.md")).unwrap();
-            index.write_tree().unwrap()
-        };
-        let submodule_tree = submodule_repo.find_tree(submodule_tree_id).unwrap();
-        submodule_repo
-            .commit(
-                Some("HEAD"),
-                &sig,
-                &sig,
-                "Initial submodule commit",
-                &submodule_tree,
-                &[],
-            )
-            .unwrap();
-
-        let daemon_root = TempDir::new().unwrap();
-        run_git(
-            daemon_root.path(),
-            &[
-                "clone",
-                "--bare",
-                submodule_src_dir.path().to_str().unwrap(),
-                "submodule.git",
-            ],
-        );
-        let (_daemon, submodule_url) = spawn_git_daemon(daemon_root.path(), "submodule.git");
-
-        let repo_dir = TempDir::new().unwrap();
-        let repo = git2::Repository::init(repo_dir.path()).unwrap();
-        std::fs::write(repo_dir.path().join("README.md"), "main repo\n").unwrap();
-        let initial_tree_id = {
-            let mut index = repo.index().unwrap();
-            index.add_path(Path::new("README.md")).unwrap();
-            index.write_tree().unwrap()
-        };
-        let initial_tree = repo.find_tree(initial_tree_id).unwrap();
-        repo.commit(
-            Some("HEAD"),
-            &sig,
-            &sig,
-            "Initial commit",
-            &initial_tree,
-            &[],
-        )
-        .unwrap();
-
-        run_git(repo_dir.path(), &["config", "user.name", "Test"]);
-        run_git(
-            repo_dir.path(),
-            &["config", "user.email", "test@example.com"],
-        );
-        run_git(
-            repo_dir.path(),
-            &["submodule", "add", &submodule_url, ".claude"],
-        );
-        run_git(repo_dir.path(), &["commit", "-am", "Add submodule"]);
-
-        let repo = git2::Repository::open(repo_dir.path()).unwrap();
-        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
-        repo.branch("test-feature", &head_commit, false).unwrap();
+        let (_submodule_src, _daemon_root, _daemon, repo_dir) =
+            build_repo_with_submodule_and_branch("test-feature");
 
         let git_wt = GitWorktree::new(repo_dir.path().to_path_buf())
             .unwrap()

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -22,6 +22,12 @@ pub struct WorktreeEntry {
 
 pub struct GitWorktree {
     pub repo_path: PathBuf,
+    /// Whether `create_worktree` should run `git submodule update --init
+    /// --recursive` when the new checkout contains a `.gitmodules` file.
+    /// Defaults to true to preserve the behavior introduced in #942; callers
+    /// that respect a user-facing setting (see `WorktreeConfig::init_submodules`)
+    /// should call `with_init_submodules` to override it per session.
+    init_submodules: bool,
 }
 
 impl GitWorktree {
@@ -29,7 +35,17 @@ impl GitWorktree {
         if !Self::is_git_repo(&repo_path) {
             return Err(GitError::NotAGitRepo);
         }
-        Ok(Self { repo_path })
+        Ok(Self {
+            repo_path,
+            init_submodules: true,
+        })
+    }
+
+    /// Configure whether `create_worktree` recursively initializes submodules
+    /// for the new checkout. Defaults to true.
+    pub fn with_init_submodules(mut self, init_submodules: bool) -> Self {
+        self.init_submodules = init_submodules;
+        self
     }
 
     pub fn is_git_repo(path: &Path) -> bool {
@@ -400,7 +416,11 @@ impl GitWorktree {
         );
 
         let t = std::time::Instant::now();
-        let submodule_status = Self::initialize_submodules(path)?;
+        let submodule_status = if self.init_submodules {
+            Self::initialize_submodules(path)?
+        } else {
+            "disabled-by-config".to_string()
+        };
         tracing::info!(
             "worktree create: submodules ({}) done in {:?}",
             submodule_status,
@@ -2143,6 +2163,106 @@ mod tests {
         assert!(
             wt_path.join(".claude").join("skill.md").is_file(),
             "submodule contents should be initialized in the new worktree"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_skips_submodules_when_disabled() {
+        // Same fixture as test_create_worktree_initializes_submodules, but
+        // with_init_submodules(false) must skip the `git submodule update`
+        // step entirely so the worktree shows up before submodules clone.
+        let submodule_src_dir = TempDir::new().unwrap();
+        let submodule_repo = git2::Repository::init(submodule_src_dir.path()).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+
+        std::fs::write(
+            submodule_src_dir.path().join("skill.md"),
+            "hello from submodule\n",
+        )
+        .unwrap();
+        let submodule_tree_id = {
+            let mut index = submodule_repo.index().unwrap();
+            index.add_path(Path::new("skill.md")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let submodule_tree = submodule_repo.find_tree(submodule_tree_id).unwrap();
+        submodule_repo
+            .commit(
+                Some("HEAD"),
+                &sig,
+                &sig,
+                "Initial submodule commit",
+                &submodule_tree,
+                &[],
+            )
+            .unwrap();
+
+        let daemon_root = TempDir::new().unwrap();
+        run_git(
+            daemon_root.path(),
+            &[
+                "clone",
+                "--bare",
+                submodule_src_dir.path().to_str().unwrap(),
+                "submodule.git",
+            ],
+        );
+        let (_daemon, submodule_url) = spawn_git_daemon(daemon_root.path(), "submodule.git");
+
+        let repo_dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(repo_dir.path()).unwrap();
+        std::fs::write(repo_dir.path().join("README.md"), "main repo\n").unwrap();
+        let initial_tree_id = {
+            let mut index = repo.index().unwrap();
+            index.add_path(Path::new("README.md")).unwrap();
+            index.write_tree().unwrap()
+        };
+        let initial_tree = repo.find_tree(initial_tree_id).unwrap();
+        repo.commit(
+            Some("HEAD"),
+            &sig,
+            &sig,
+            "Initial commit",
+            &initial_tree,
+            &[],
+        )
+        .unwrap();
+
+        run_git(repo_dir.path(), &["config", "user.name", "Test"]);
+        run_git(
+            repo_dir.path(),
+            &["config", "user.email", "test@example.com"],
+        );
+        run_git(
+            repo_dir.path(),
+            &["submodule", "add", &submodule_url, ".claude"],
+        );
+        run_git(repo_dir.path(), &["commit", "-am", "Add submodule"]);
+
+        let repo = git2::Repository::open(repo_dir.path()).unwrap();
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        repo.branch("test-feature", &head_commit, false).unwrap();
+
+        let git_wt = GitWorktree::new(repo_dir.path().to_path_buf())
+            .unwrap()
+            .with_init_submodules(false);
+        let worktree_parent = TempDir::new().unwrap();
+        let wt_path = worktree_parent.path().join("submodule-worktree");
+        git_wt
+            .create_worktree("test-feature", &wt_path, false)
+            .unwrap();
+
+        assert!(
+            wt_path.join(".git").exists(),
+            "worktree itself should still be created"
+        );
+        assert!(
+            wt_path.join(".gitmodules").is_file(),
+            ".gitmodules should be checked out from the parent commit"
+        );
+        assert!(
+            !wt_path.join(".claude").join("skill.md").is_file(),
+            "submodule contents must NOT be initialized when init_submodules=false"
         );
     }
 

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -78,6 +78,7 @@ pub fn create_workspace(
     branch: &str,
     create_new_branch: bool,
     workspace_template: &str,
+    init_submodules: bool,
 ) -> Result<WorkspaceResult> {
     let primary_main_repo = GitWorktree::find_main_repo(primary_path)?;
     let primary_git_wt = GitWorktree::new(primary_main_repo)?;
@@ -182,7 +183,8 @@ pub fn create_workspace(
                         let repo_start = std::time::Instant::now();
                         let result = (|| -> std::result::Result<Vec<String>, String> {
                             let git_wt = GitWorktree::new(main_repo_path)
-                                .map_err(|e| format!("{}: {}", repo_name, e))?;
+                                .map_err(|e| format!("{}: {}", repo_name, e))?
+                                .with_init_submodules(init_submodules);
                             git_wt
                                 .create_worktree(&branch, &worktree_subdir, create_new_branch)
                                 .map_err(|e| format!("{}: {}", repo_name, e))
@@ -359,6 +361,7 @@ pub fn build_instance(
                 branch,
                 params.create_new_branch,
                 &config.worktree.workspace_path_template,
+                config.worktree.init_submodules,
             )?;
 
             final_path = ws_result.workspace_path.to_string_lossy().to_string();
@@ -375,7 +378,8 @@ pub fn build_instance(
             let main_repo_path = main_repo_path_raw
                 .canonicalize()
                 .unwrap_or(main_repo_path_raw);
-            let git_wt = GitWorktree::new(main_repo_path.clone())?;
+            let git_wt = GitWorktree::new(main_repo_path.clone())?
+                .with_init_submodules(config.worktree.init_submodules);
 
             // Choose appropriate template based on repo type (bare vs regular)
             // Use main_repo_path (not path) to correctly detect bare repos when running from a worktree
@@ -836,7 +840,14 @@ mod tests {
             .to_string_lossy()
             .into_owned();
 
-        let result = create_workspace(&repo_a, &[repo_b], "nonexistent-branch", false, &template);
+        let result = create_workspace(
+            &repo_a,
+            &[repo_b],
+            "nonexistent-branch",
+            false,
+            &template,
+            true,
+        );
 
         let err = match result {
             Ok(_) => panic!("workspace creation should fail when no repo has the branch"),
@@ -871,7 +882,7 @@ mod tests {
             .to_string_lossy()
             .into_owned();
 
-        let result = create_workspace(&repo_a, &[], "nonexistent-branch", false, &template);
+        let result = create_workspace(&repo_a, &[], "nonexistent-branch", false, &template, true);
 
         let err = match result {
             Ok(_) => panic!("single-repo failure should still surface"),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -497,6 +497,15 @@ pub struct WorktreeConfig {
     /// Supports {branch} and {session-id} placeholders.
     #[serde(default = "default_workspace_template")]
     pub workspace_path_template: String,
+
+    /// Run `git submodule update --init --recursive` after creating a worktree
+    /// when the checkout contains a `.gitmodules` file. Defaults to true to
+    /// preserve the behavior introduced in #942. Disable for repos with large
+    /// or deeply-nested submodule trees that you don't need inside agent
+    /// sessions; new sessions then finish creating instead of stalling in
+    /// `Creating…` while submodules clone.
+    #[serde(default = "default_true")]
+    pub init_submodules: bool,
 }
 
 impl Default for WorktreeConfig {
@@ -509,6 +518,7 @@ impl Default for WorktreeConfig {
             show_branch_in_tui: true,
             delete_branch_on_cleanup: false,
             workspace_path_template: default_workspace_template(),
+            init_submodules: true,
         }
     }
 }
@@ -1032,6 +1042,10 @@ mod tests {
         assert_eq!(wt.path_template, "../{repo-name}-worktrees/{branch}");
         assert!(wt.auto_cleanup);
         assert!(wt.show_branch_in_tui);
+        assert!(
+            wt.init_submodules,
+            "init_submodules must default to true to preserve #942 behavior"
+        );
     }
 
     #[test]
@@ -1041,12 +1055,25 @@ mod tests {
             path_template = "/custom/{branch}"
             auto_cleanup = false
             show_branch_in_tui = false
+            init_submodules = false
         "#;
         let wt: WorktreeConfig = toml::from_str(toml).unwrap();
         assert!(wt.enabled);
         assert_eq!(wt.path_template, "/custom/{branch}");
         assert!(!wt.auto_cleanup);
         assert!(!wt.show_branch_in_tui);
+        assert!(!wt.init_submodules);
+    }
+
+    #[test]
+    fn test_worktree_config_init_submodules_defaults_when_absent() {
+        // Configs predating this option must continue to recursively init
+        // submodules (preserve #942 behavior) when upgrading.
+        let toml = r#"
+            enabled = true
+        "#;
+        let wt: WorktreeConfig = toml::from_str(toml).unwrap();
+        assert!(wt.init_submodules);
     }
 
     // Tests for SandboxConfig

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -119,6 +119,9 @@ pub struct WorktreeConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workspace_path_template: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub init_submodules: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -375,6 +378,9 @@ pub fn apply_worktree_overrides(
     }
     if let Some(ref workspace_path_template) = source.workspace_path_template {
         target.workspace_path_template = workspace_path_template.clone();
+    }
+    if let Some(init_submodules) = source.init_submodules {
+        target.init_submodules = init_submodules;
     }
 }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -61,6 +61,7 @@ pub enum FieldKey {
     WorktreeAutoCleanup,
     DeleteBranchOnCleanup,
     WorkspacePathTemplate,
+    InitSubmodules,
     // Sandbox
     SandboxEnabledByDefault,
     YoloModeDefault,
@@ -621,6 +622,11 @@ fn build_worktree_fields(
         global.worktree.workspace_path_template.clone(),
         wt.and_then(|w| w.workspace_path_template.clone()),
     );
+    let (init_submodules, o6) = resolve_value(
+        scope,
+        global.worktree.init_submodules,
+        wt.and_then(|w| w.init_submodules),
+    );
 
     vec![
         SettingField {
@@ -688,6 +694,15 @@ fn build_worktree_fields(
                 o5,
                 FieldValue::Text(global.worktree.workspace_path_template.clone()),
             ),
+        },
+        SettingField {
+            key: FieldKey::InitSubmodules,
+            label: "Init Submodules",
+            description: "Run `git submodule update --init --recursive` after creating a worktree",
+            value: FieldValue::Bool(init_submodules),
+            category: SettingsCategory::Worktree,
+            has_override: o6,
+            inherited_display: inherited_if(o6, FieldValue::Bool(global.worktree.init_submodules)),
         },
     ]
 }
@@ -1604,6 +1619,7 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::WorkspacePathTemplate, FieldValue::Text(v)) => {
             config.worktree.workspace_path_template = v.clone()
         }
+        (FieldKey::InitSubmodules, FieldValue::Bool(v)) => config.worktree.init_submodules = *v,
         // Sandbox
         (FieldKey::SandboxEnabledByDefault, FieldValue::Bool(v)) => {
             config.sandbox.enabled_by_default = *v
@@ -1816,6 +1832,9 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             set_profile_override(v.clone(), &mut config.worktree, |s, val| {
                 s.workspace_path_template = val
             });
+        }
+        (FieldKey::InitSubmodules, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.worktree, |s, val| s.init_submodules = val);
         }
         // Sandbox
         (FieldKey::SandboxEnabledByDefault, FieldValue::Bool(v)) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -593,6 +593,11 @@ impl SettingsView {
                     w.workspace_path_template = None;
                 }
             }
+            FieldKey::InitSubmodules => {
+                if let Some(ref mut w) = config.worktree {
+                    w.init_submodules = None;
+                }
+            }
             // Sandbox
             FieldKey::DefaultImage => {
                 if let Some(ref mut s) = config.sandbox {

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -384,6 +384,12 @@ export function SettingsView({
               checked={(worktree.delete_branch_on_cleanup as boolean) ?? false}
               onChange={(v) => saveField("worktree", worktree, "delete_branch_on_cleanup", v)}
             />
+            <ToggleField
+              label="Init submodules"
+              description="Run `git submodule update --init --recursive` after creating a worktree"
+              checked={(worktree.init_submodules as boolean) ?? true}
+              onChange={(v) => saveField("worktree", worktree, "init_submodules", v)}
+            />
           </div>
         );
 


### PR DESCRIPTION
## Description

Closes #1020.

`#942` made `create_worktree` unconditionally run `git submodule update --init --recursive` whenever the new checkout contains a `.gitmodules` file. For repos that vendor large or deeply-nested submodule trees (OpenROAD-flow-scripts, llvm-project, chromium, etc.) every new session sits in `Creating…` for many minutes while submodules clone, with no progress visible in the TUI. From the user's perspective the session looks hung.

This PR adds a `worktree.init_submodules` setting (default `true`, so the #942 behavior is preserved for everyone else) that gates the recursive submodule init step. The CLI also gains `aoe add --no-submodules` for a per-invocation override.

```toml
[worktree]
init_submodules = true   # default; set to false to skip recursive submodule init
```

The flag is wired through the full settings surface per `CLAUDE.md`:

- `WorktreeConfig` + `WorktreeConfigOverride` + `apply_worktree_overrides` (with a `default_true` serde default so configs predating this option keep the current behavior).
- TUI settings: `FieldKey::InitSubmodules`, `build_worktree_fields`, `apply_field_to_global`, `apply_field_to_profile`, and `clear_profile_override`.
- Web `SettingsView` `ToggleField`.
- `GitWorktree` gets a `with_init_submodules(bool)` builder so call sites in `builder.rs` and `cli/add.rs` can plumb the config through without changing `create_worktree`'s signature for the many existing test call sites.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

`docs/guides/worktrees.md` and `docs/guides/configuration.md` cover the new option; `docs/cli/reference.md` is regenerated by `cargo xtask gen-docs`.

The web `SettingsView` gains one `ToggleField` ("Init submodules") under the Worktree section, mirroring the existing "Auto cleanup" / "Delete branch on cleanup" toggles. No new visual layout, so no screenshot.

## Testing

- `cargo test --profile dev-release --lib worktree_config` — 4 passed.
- `cargo test --profile dev-release --lib test_create_worktree_initializes_submodules` — pre-existing test for the #942 behavior still passes (default remains `true`).
- `cargo test --profile dev-release --lib test_create_worktree_skips_submodules_when_disabled` — new test verifies that with `with_init_submodules(false)` the worktree is created and `.gitmodules` is checked out, but submodule contents are NOT populated.
- `cargo test --profile dev-release --lib` and `cargo test --profile dev-release --tests` pass (the only failing test on my machine, `containers::runtime::tests::test_image_exists_locally_with_common_image`, is unrelated: a Docker Hub auth issue pulling `hello-world`).
- `cargo fmt --check` clean; `cargo clippy --profile dev-release --all-targets` adds no new warnings (the one pre-existing `repeat_once` warning in `src/tui/home/render.rs` is unrelated).
- `cargo build --features serve --profile dev-release` builds clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Used to scaffold the config/TUI/CLI plumbing and write the new regression test against the same `spawn_git_daemon` fixture used by `test_create_worktree_initializes_submodules`. Implementation choices, plumbing into `WorktreeConfigOverride`/settings TUI, and the `with_init_submodules` builder design were reviewed and authored interactively.

- [x] I am an AI Agent filling out this form (check box if true)
