### PR TITLE
fix(deletion): tear down tmux + container before host worktree

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -134,12 +134,17 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
 
                 match GitWorktree::new(main_repo.clone()) {
                     Ok(git_wt) => {
+                        // --keep-container means the sandbox fallback
+                        // must not surprise-tear-down the container to
+                        // free a permission-bound worktree.
+                        let allow_container_removal = !args.keep_container;
                         match remove_managed_worktree(
                             &git_wt,
                             &worktree_path,
                             &main_repo,
                             &inst,
                             args.force,
+                            allow_container_removal,
                         ) {
                             Ok(()) => {
                                 worktree_removed = true;

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -281,6 +281,16 @@ pub fn cleanup_sandbox_worktree(instance: &Instance) -> bool {
 /// - `.git` file present: uses `git worktree remove`, falls back to
 ///   container cleanup for sandboxed sessions with permission errors
 ///
+/// `allow_container_removal` controls whether the sandbox fallback is
+/// permitted to force-remove the container as part of its recovery.
+/// Set to `true` when the caller has already requested container
+/// deletion (or is about to), and `false` when the caller wants to
+/// preserve the container (e.g. `aoe remove --keep-container` or
+/// `delete_worktree=true, delete_sandbox=false`). When `false` and
+/// the fallback is the only way to make progress, the worktree
+/// removal fails with the original permission error instead of
+/// quietly tearing down the container behind the user's back.
+///
 /// Returns `Ok(())` if the worktree was successfully removed, or
 /// `Err(errors)` with error messages on failure.
 pub fn remove_managed_worktree(
@@ -289,6 +299,7 @@ pub fn remove_managed_worktree(
     main_repo: &Path,
     instance: &Instance,
     force: bool,
+    allow_container_removal: bool,
 ) -> Result<(), Vec<String>> {
     let mut errors = Vec::new();
     let has_dot_git = worktree_path.join(".git").exists();
@@ -298,6 +309,7 @@ pub fn remove_managed_worktree(
         has_dot_git,
         is_sandboxed = instance.is_sandboxed(),
         force,
+        allow_container_removal,
         "worktree cleanup starting"
     );
 
@@ -313,7 +325,12 @@ pub fn remove_managed_worktree(
             Err(e) => {
                 tracing::debug!(error = %e, kind = ?e.kind(), "remove_worktree_dir failed (no .git)");
                 if is_permission_error(&e.to_string())
-                    && try_sandbox_dir_cleanup(worktree_path, main_repo, instance)
+                    && try_sandbox_dir_cleanup(
+                        worktree_path,
+                        main_repo,
+                        instance,
+                        allow_container_removal,
+                    )
                 {
                     worktree_removed = true;
                 } else {
@@ -340,7 +357,12 @@ pub fn remove_managed_worktree(
                 // git worktree remove won't work afterward. Fall back to
                 // removing the directory and pruning stale references.
                 if is_permission_error(&err_str)
-                    && try_sandbox_dir_cleanup(worktree_path, main_repo, instance)
+                    && try_sandbox_dir_cleanup(
+                        worktree_path,
+                        main_repo,
+                        instance,
+                        allow_container_removal,
+                    )
                 {
                     worktree_removed = true;
                     if let Err(e2) = git_wt.prune_worktrees() {
@@ -378,8 +400,23 @@ pub fn remove_managed_worktree(
 /// 1. Runs `find . -mindepth 1 -delete` inside the container
 /// 2. Force-removes the container to release the bind mount
 /// 3. Retries directory removal (with VirtioFS delay handling)
-fn try_sandbox_dir_cleanup(worktree_path: &Path, main_repo: &Path, instance: &Instance) -> bool {
+///
+/// Step 2 is gated on `allow_container_removal`: when the caller
+/// opted out of container deletion, we refuse to nuke the container
+/// just to free a permission-bound worktree. In that case the caller
+/// sees the original Worktree permission error and can decide what
+/// to do.
+fn try_sandbox_dir_cleanup(
+    worktree_path: &Path,
+    main_repo: &Path,
+    instance: &Instance,
+    allow_container_removal: bool,
+) -> bool {
     if !instance.is_sandboxed() {
+        return false;
+    }
+    if !allow_container_removal {
+        tracing::debug!("sandbox fallback skipped: caller forbade container removal");
         return false;
     }
 
@@ -429,6 +466,58 @@ mod tests {
         let result = remove_worktree_dir(&wt, &main, false);
         assert!(result.is_ok());
         assert!(!wt.exists());
+    }
+
+    /// `try_sandbox_dir_cleanup` must respect `allow_container_removal=false`
+    /// by returning early without touching the container, even when the
+    /// instance is sandboxed and the worktree would otherwise be a
+    /// fallback candidate. We can't easily test the docker-side branch
+    /// without a real container runtime, but we CAN guarantee the
+    /// early-return: a non-sandboxed instance should also return false,
+    /// and a sandboxed instance with `allow_container_removal=false`
+    /// should not even attempt to invoke `cleanup_sandbox_worktree`.
+    /// This regression test is checked via a side effect: we point the
+    /// instance at a non-existent worktree path, so the only way the
+    /// function could reach the post-cleanup `remove_worktree_dir` call
+    /// is if it bypassed the early-return. If the flag is honored,
+    /// the function returns false immediately.
+    #[test]
+    fn test_try_sandbox_dir_cleanup_respects_allow_container_removal_false() {
+        use crate::session::{Instance, SandboxInfo};
+        let mut instance = Instance::new("Test", "/tmp/aoe-cleanup-test-nonexistent");
+        instance.sandbox_info = Some(SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "alpine".to_string(),
+            container_name: "aoe-sandbox-doesnotexist".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        });
+
+        let worktree = std::path::PathBuf::from("/tmp/aoe-cleanup-test-nonexistent");
+        let main_repo = std::path::PathBuf::from("/tmp/aoe-cleanup-test-main-nonexistent");
+
+        // With allow_container_removal=false, must return false without
+        // touching anything.
+        let result = try_sandbox_dir_cleanup(&worktree, &main_repo, &instance, false);
+        assert!(
+            !result,
+            "sandbox fallback must bail when allow_container_removal=false"
+        );
+    }
+
+    #[test]
+    fn test_try_sandbox_dir_cleanup_returns_false_for_non_sandboxed() {
+        use crate::session::Instance;
+        let instance = Instance::new("Test", "/tmp/aoe-cleanup-test-nonexistent");
+        // No sandbox_info set.
+        let worktree = std::path::PathBuf::from("/tmp/aoe-cleanup-test-nonexistent");
+        let main_repo = std::path::PathBuf::from("/tmp/aoe-cleanup-test-main-nonexistent");
+
+        // Even with allow_container_removal=true, a non-sandboxed
+        // instance must early-return.
+        let result = try_sandbox_dir_cleanup(&worktree, &main_repo, &instance, true);
+        assert!(!result);
     }
 
     #[test]

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -83,16 +83,12 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // Stage 3: container removal. Releases the bind mount on the
     // worktree so the host can finish cleanup without racing in-
     // container processes.
-    if request.delete_sandbox {
+    if request.delete_sandbox && is_sandboxed {
         tracing::debug!(session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
-        if let Some(sandbox) = &request.instance.sandbox_info {
-            if sandbox.enabled {
-                let container = DockerContainer::from_session_id(&request.instance.id);
-                if container.exists().unwrap_or(false) {
-                    if let Err(e) = container.remove(true) {
-                        errors.push(format!("Container: {}", e));
-                    }
-                }
+        let container = DockerContainer::from_session_id(&request.instance.id);
+        if container.exists().unwrap_or(false) {
+            if let Err(e) = container.remove(true) {
+                errors.push(format!("Container: {}", e));
             }
         }
     }
@@ -130,6 +126,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                             &main_repo,
                             &request.instance,
                             request.force_delete,
+                            request.delete_sandbox,
                         ) {
                             errors.extend(errs);
                         }
@@ -159,6 +156,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                     &main_repo,
                                     &request.instance,
                                     request.force_delete,
+                                    request.delete_sandbox,
                                 ) {
                                     errors.extend(
                                         errs.into_iter()

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -41,11 +41,67 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         "perform_deletion: starting"
     );
 
-    // Execute on_destroy hooks before any cleanup so resources (containers,
-    // worktrees) are still available for teardown commands.
+    // Stage 1: on_destroy hooks. The container and worktree are still
+    // alive here so teardown commands have full access.
+    tracing::debug!(session_id = %request.session_id, stage = "on_destroy_hooks", "perform_deletion: stage");
     run_on_destroy_hooks(&request.instance);
 
-    // Track branch info for potential deletion after worktree removal
+    // Stage 2: sever the live agent BEFORE we touch the working tree it
+    // may be writing to. Killing the tmux session terminates the user's
+    // `docker exec`; for sandboxed sessions we also wipe root-owned
+    // worktree contents from INSIDE the container so the host's
+    // `git worktree remove` below doesn't fight permissions or a still-
+    // running bind mount. Previously the order was reversed (worktree
+    // first, container second, tmux last), which raced the in-container
+    // agent and produced flaky deletions on Docker + worktree sessions.
+    tracing::debug!(session_id = %request.session_id, stage = "tmux_kill", "perform_deletion: stage");
+    let _ = request.instance.kill();
+    let _ = request.instance.kill_terminal();
+
+    let is_sandboxed = request
+        .instance
+        .sandbox_info
+        .as_ref()
+        .is_some_and(|s| s.enabled);
+
+    if request.delete_worktree && is_sandboxed {
+        tracing::debug!(session_id = %request.session_id, stage = "sandbox_worktree_preclean", "perform_deletion: stage");
+        // Best-effort. The container's workdir is the session's main
+        // worktree (or, for workspace sessions, the workspace root that
+        // contains every per-repo worktree). `find . -delete` from
+        // there recursively wipes everything we care about under the
+        // bind mount. If this fails, the host-side removal below will
+        // surface a permission error and exit cleanly. We do NOT walk
+        // workspace_info.repos here: their container mount paths are
+        // computed relative to the common ancestor of all repos
+        // (see compute_workspace_volume_paths) and don't necessarily
+        // match `/workspace/{repo.name}`, and the workspace-root walk
+        // already covers their contents.
+        let _ = crate::git::cleanup::cleanup_sandbox_worktree(&request.instance);
+    }
+
+    // Stage 3: container removal. Releases the bind mount on the
+    // worktree so the host can finish cleanup without racing in-
+    // container processes.
+    if request.delete_sandbox {
+        tracing::debug!(session_id = %request.session_id, stage = "container_remove", "perform_deletion: stage");
+        if let Some(sandbox) = &request.instance.sandbox_info {
+            if sandbox.enabled {
+                let container = DockerContainer::from_session_id(&request.instance.id);
+                if container.exists().unwrap_or(false) {
+                    if let Err(e) = container.remove(true) {
+                        errors.push(format!("Container: {}", e));
+                    }
+                }
+            }
+        }
+    }
+
+    // Stage 4: worktree cleanup. Container is gone, agent is gone, no
+    // bind mount holds the directory open, and (for sandboxed sessions)
+    // the preclean above wiped any root-owned files. Must happen
+    // before branch deletion since the worktree is using the branch.
+    tracing::debug!(session_id = %request.session_id, stage = "worktree_remove", "perform_deletion: stage");
     let branch_to_delete = if request.delete_branch {
         request
             .instance
@@ -60,8 +116,6 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         tracing::debug!(branch = %b, main_repo = %r.display(), "perform_deletion: branch_to_delete resolved");
     }
 
-    // Worktree cleanup (if user opted to delete it)
-    // Must happen before branch deletion since the worktree is using the branch
     if request.delete_worktree {
         if let Some(wt_info) = &request.instance.worktree_info {
             if wt_info.managed_by_aoe {
@@ -129,7 +183,9 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         }
     }
 
-    // Branch cleanup (if user opted to delete it and worktree was successfully removed)
+    // Stage 5: branch cleanup (if user opted to delete it and worktree
+    // was successfully removed).
+    tracing::debug!(session_id = %request.session_id, stage = "branch_delete", "perform_deletion: stage");
     if let Some((branch, main_repo)) = branch_to_delete {
         let worktree_ok =
             !request.delete_worktree || !errors.iter().any(|e| e.starts_with("Worktree:"));
@@ -174,27 +230,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         }
     }
 
-    // Container cleanup (if user opted to delete it)
-    if request.delete_sandbox {
-        if let Some(sandbox) = &request.instance.sandbox_info {
-            if sandbox.enabled {
-                let container = DockerContainer::from_session_id(&request.instance.id);
-                if container.exists().unwrap_or(false) {
-                    if let Err(e) = container.remove(true) {
-                        errors.push(format!("Container: {}", e));
-                    }
-                }
-            }
-        }
-    }
-
-    // Tmux kill - non-fatal if session already gone
-    let _ = request.instance.kill();
-
-    // Kill paired terminal session if it exists
-    let _ = request.instance.kill_terminal();
-
-    // Clean up hook status files
+    // Stage 6: hook status cleanup
+    tracing::debug!(session_id = %request.session_id, stage = "hook_status_cleanup", "perform_deletion: stage");
     crate::hooks::cleanup_hook_status_dir(&request.instance.id);
 
     if !errors.is_empty() {
@@ -350,5 +387,367 @@ mod tests {
 
         let result = perform_deletion(&request);
         assert_eq!(result.session_id, custom_id);
+    }
+
+    mod ordering {
+        use super::*;
+        use crate::session::SandboxInfo;
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+        use tracing::subscriber::with_default;
+        use tracing::Subscriber;
+        use tracing_subscriber::layer::{Context, SubscriberExt};
+        use tracing_subscriber::registry::LookupSpan;
+        use tracing_subscriber::Layer;
+
+        /// tracing Layer that captures the `stage` field value of every
+        /// `perform_deletion: stage` event in order of emission.
+        struct StageRecorder {
+            stages: Arc<Mutex<Vec<String>>>,
+        }
+
+        impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for StageRecorder {
+            fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+                struct V {
+                    msg: Option<String>,
+                    stage: Option<String>,
+                }
+                impl Visit for V {
+                    fn record_str(&mut self, field: &Field, value: &str) {
+                        match field.name() {
+                            "stage" => self.stage = Some(value.to_string()),
+                            "message" => self.msg = Some(value.to_string()),
+                            _ => {}
+                        }
+                    }
+                    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+                        let rendered = format!("{:?}", value);
+                        let unquoted = rendered.trim_matches('"').to_string();
+                        match field.name() {
+                            "stage" => self.stage = Some(unquoted),
+                            "message" => self.msg = Some(unquoted),
+                            _ => {}
+                        }
+                    }
+                }
+                let mut v = V {
+                    msg: None,
+                    stage: None,
+                };
+                event.record(&mut v);
+                if v.msg.as_deref() == Some("perform_deletion: stage") {
+                    if let Some(stage) = v.stage {
+                        self.stages.lock().unwrap().push(stage);
+                    }
+                }
+            }
+        }
+
+        fn run_with_capture<F: FnOnce()>(f: F) -> Vec<String> {
+            let stages = Arc::new(Mutex::new(Vec::new()));
+            let layer = StageRecorder {
+                stages: Arc::clone(&stages),
+            };
+            let subscriber = tracing_subscriber::registry().with(layer);
+            with_default(subscriber, f);
+            let g = stages.lock().unwrap();
+            g.clone()
+        }
+
+        /// Index of the first occurrence of `needle` in `stages`. Panics
+        /// with a descriptive message if absent so test failures point
+        /// at the missing stage instead of an inscrutable `unwrap`.
+        fn idx(stages: &[String], needle: &str) -> usize {
+            stages
+                .iter()
+                .position(|s| s == needle)
+                .unwrap_or_else(|| panic!("stage {:?} missing from {:?}", needle, stages))
+        }
+
+        /// Regression: sandboxed + worktree deletion must drop the
+        /// container BEFORE touching the worktree directory. The old
+        /// order (worktree first) raced the still-running in-container
+        /// agent and produced flaky permission errors and dirty-tree
+        /// failures.
+        #[test]
+        fn sandboxed_with_worktree_kills_tmux_and_container_before_worktree() {
+            // Synthesize an instance with both worktree_info and an
+            // (enabled) sandbox_info pointing at a non-existent
+            // container. The container ops will no-op (container does
+            // not exist), but the *order* of stage events is still
+            // emitted, and that's what we're testing.
+            let mut instance = Instance::new("Test", "/tmp/aoe-deletion-test-nonexistent");
+            instance.sandbox_info = Some(SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "alpine".to_string(),
+                container_name: "aoe-sandbox-doesnotexist".to_string(),
+                extra_env: None,
+                custom_instruction: None,
+            });
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: true,
+                delete_branch: false,
+                delete_sandbox: true,
+                force_delete: false,
+            };
+
+            let stages = run_with_capture(|| {
+                let _ = perform_deletion(&request);
+            });
+
+            // tmux_kill must precede container_remove must precede
+            // worktree_remove must precede branch_delete.
+            let i_tmux = idx(&stages, "tmux_kill");
+            let i_container = idx(&stages, "container_remove");
+            let i_worktree = idx(&stages, "worktree_remove");
+            let i_branch = idx(&stages, "branch_delete");
+
+            assert!(
+                i_tmux < i_container,
+                "tmux must be killed before container removal: stages={:?}",
+                stages
+            );
+            assert!(
+                i_container < i_worktree,
+                "container must be removed before worktree cleanup: stages={:?}",
+                stages
+            );
+            assert!(
+                i_worktree < i_branch,
+                "worktree must be cleaned before branch delete: stages={:?}",
+                stages
+            );
+
+            // Sandboxed + delete_worktree: we should also see the
+            // in-container preclean stage between tmux_kill and
+            // container_remove.
+            let i_preclean = idx(&stages, "sandbox_worktree_preclean");
+            assert!(
+                i_tmux < i_preclean && i_preclean < i_container,
+                "preclean must run after tmux kill and before container remove: stages={:?}",
+                stages
+            );
+        }
+
+        /// End-to-end-on-disk: build a real git repo + worktree on the
+        /// filesystem (no docker, no tmux session), call
+        /// `perform_deletion(delete_worktree=true)`, and verify the
+        /// worktree directory and `.git/worktrees/<name>` admin entry
+        /// are gone afterwards. This is the closest we can get to an
+        /// e2e test for the worktree-delete path without a real
+        /// container runtime.
+        #[test]
+        fn e2e_real_worktree_is_removed_on_disk() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let main_repo = tmp.path().join("main");
+            let worktree_path = tmp.path().join("worktree");
+            std::fs::create_dir(&main_repo).unwrap();
+
+            // init main repo with one commit so branches can be created
+            let repo = git2::Repository::init(&main_repo).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree_id = {
+                let mut index = repo.index().unwrap();
+                index.write_tree().unwrap()
+            };
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+
+            // create the worktree on a new branch via real `git` so the
+            // admin files match what aoe creates in production
+            let status = std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    "feature/delete-me",
+                    worktree_path.to_str().unwrap(),
+                ])
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+            assert!(
+                status.status.success(),
+                "git worktree add failed: {}",
+                String::from_utf8_lossy(&status.stderr)
+            );
+            assert!(worktree_path.exists());
+            assert!(
+                main_repo.join(".git/worktrees/worktree").exists(),
+                "worktree admin dir should exist before deletion"
+            );
+
+            // construct an Instance matching what builder would produce
+            let mut instance = Instance::new("Test", worktree_path.to_str().unwrap());
+            instance.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: "feature/delete-me".to_string(),
+                main_repo_path: main_repo.to_string_lossy().to_string(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+            });
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: true,
+                delete_branch: true,
+                delete_sandbox: false,
+                force_delete: false,
+            };
+
+            let result = perform_deletion(&request);
+            assert!(
+                result.success,
+                "perform_deletion failed: {:?}",
+                result.error
+            );
+
+            // worktree directory and its admin entry must be gone
+            assert!(
+                !worktree_path.exists(),
+                "worktree dir should be removed after delete"
+            );
+            assert!(
+                !main_repo.join(".git/worktrees/worktree").exists(),
+                "worktree admin dir should be pruned after delete"
+            );
+
+            // branch should be deleted
+            let branches_out = std::process::Command::new("git")
+                .args(["branch", "--list", "feature/delete-me"])
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+            assert!(
+                String::from_utf8_lossy(&branches_out.stdout)
+                    .trim()
+                    .is_empty(),
+                "branch should be deleted: stdout={}",
+                String::from_utf8_lossy(&branches_out.stdout)
+            );
+        }
+
+        /// Race-condition repro: the agent left untracked files in the
+        /// worktree (this is what triggered the original
+        /// "fatal: '<path>' contains modified or untracked files"
+        /// failures). With `force_delete=true` the worktree must be
+        /// removed cleanly even with untracked content, which is the
+        /// fallback path the TUI takes when the user picks "force
+        /// delete" after a normal delete failed.
+        #[test]
+        fn e2e_real_worktree_with_untracked_files_force_removed() {
+            let tmp = tempfile::TempDir::new().unwrap();
+            let main_repo = tmp.path().join("main");
+            let worktree_path = tmp.path().join("worktree");
+            std::fs::create_dir(&main_repo).unwrap();
+
+            let repo = git2::Repository::init(&main_repo).unwrap();
+            let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+            let tree_id = repo.index().unwrap().write_tree().unwrap();
+            let tree = repo.find_tree(tree_id).unwrap();
+            repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+                .unwrap();
+
+            let status = std::process::Command::new("git")
+                .args([
+                    "worktree",
+                    "add",
+                    "-b",
+                    "feature/race-repro",
+                    worktree_path.to_str().unwrap(),
+                ])
+                .current_dir(&main_repo)
+                .output()
+                .unwrap();
+            assert!(status.status.success());
+
+            // simulate what the in-container agent leaves behind: an
+            // untracked log file, plus a modified-but-not-committed
+            // file. Without force_delete, `git worktree remove` refuses
+            // to delete a dirty tree.
+            std::fs::write(worktree_path.join("agent.log"), "scratch").unwrap();
+            std::fs::write(worktree_path.join("debug.json"), "{\"k\":1}").unwrap();
+
+            let mut instance = Instance::new("Test", worktree_path.to_str().unwrap());
+            instance.worktree_info = Some(crate::session::WorktreeInfo {
+                branch: "feature/race-repro".to_string(),
+                main_repo_path: main_repo.to_string_lossy().to_string(),
+                managed_by_aoe: true,
+                created_at: chrono::Utc::now(),
+            });
+
+            // First: without force, deletion must fail and leave the
+            // worktree intact so the user can decide.
+            let req_no_force = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance: instance.clone(),
+                delete_worktree: true,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+            };
+            let result = perform_deletion(&req_no_force);
+            assert!(
+                !result.success,
+                "dirty worktree must NOT be deleted without --force"
+            );
+            assert!(
+                worktree_path.exists(),
+                "dirty worktree must still exist after failed delete"
+            );
+
+            // Now retry with force: must succeed and clean everything.
+            let req_force = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: true,
+                delete_branch: true,
+                delete_sandbox: false,
+                force_delete: true,
+            };
+            let result = perform_deletion(&req_force);
+            assert!(
+                result.success,
+                "force delete should succeed: {:?}",
+                result.error
+            );
+            assert!(!worktree_path.exists());
+            assert!(!main_repo.join(".git/worktrees/worktree").exists());
+        }
+
+        /// Non-sandboxed deletion: no preclean stage is emitted, but
+        /// tmux still gets killed before worktree work.
+        #[test]
+        fn unsandboxed_kills_tmux_before_worktree() {
+            let instance = Instance::new("Test", "/tmp/aoe-deletion-test-nonexistent");
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: true,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+            };
+
+            let stages = run_with_capture(|| {
+                let _ = perform_deletion(&request);
+            });
+
+            assert!(
+                idx(&stages, "tmux_kill") < idx(&stages, "worktree_remove"),
+                "tmux must be killed before worktree cleanup: stages={:?}",
+                stages
+            );
+            assert!(
+                !stages.iter().any(|s| s == "sandbox_worktree_preclean"),
+                "unsandboxed deletion must not emit sandbox preclean stage: stages={:?}",
+                stages
+            );
+        }
     }
 }

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -407,6 +407,21 @@ mod tests {
         }
 
         impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for StageRecorder {
+            fn register_callsite(
+                &self,
+                _meta: &'static tracing::Metadata<'static>,
+            ) -> tracing::subscriber::Interest {
+                tracing::subscriber::Interest::always()
+            }
+
+            fn enabled(&self, _meta: &tracing::Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+                true
+            }
+
+            fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+                Some(tracing::level_filters::LevelFilter::TRACE)
+            }
+
             fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
                 struct V {
                     msg: Option<String>,
@@ -449,7 +464,17 @@ mod tests {
                 stages: Arc::clone(&stages),
             };
             let subscriber = tracing_subscriber::registry().with(layer);
-            with_default(subscriber, f);
+            with_default(subscriber, || {
+                // Tracing caches callsite interest globally on first hit.
+                // If a parallel test in this binary executed
+                // `perform_deletion` before us with no subscriber (e.g.
+                // the on-disk e2e tests below), the `stage` callsites
+                // got cached as never-interesting and our subscriber
+                // would never see them. Force a re-evaluation while
+                // our subscriber is the active default.
+                tracing::callsite::rebuild_interest_cache();
+                f();
+            });
             let g = stages.lock().unwrap();
             g.clone()
         }


### PR DESCRIPTION
## Description

For sandboxed sessions with a worktree, the deletion pipeline tore resources down in the wrong order, racing the live in-container agent.

**Old order:** `git worktree remove` (host) → `docker rm -f` → tmux kill.
The container was still alive (with the worktree bind-mounted) and the agent was still writing during the host-side worktree probe. Same user action produced different outcomes depending on what the agent happened to be doing at that microsecond. Symptoms users reported:

- `fatal: validation failed, cannot remove working tree: '<path>/.git' does not exist`
- `error: cannot delete branch 'feat' used by worktree at '<path>'`
- `fatal: '<path>' contains modified or untracked files`

The `try_sandbox_dir_cleanup` recovery path added in #471 catches EPERM for root-owned files, but only after a failed host probe, by which point the worktree's admin state could already be inconsistent.

**New order** (matches what `Instance::stop` at `src/session/instance.rs:1413-1426` already does for the non-delete path):

1. `on_destroy` hooks (container + worktree still live, unchanged)
2. tmux kill (severs the user's `docker exec`, so the agent's shell stops)
3. **sandbox worktree preclean** (only if sandboxed + deleting worktree): `find . -mindepth 1 -delete` from inside the container wipes root-owned files *while the bind mount is still attached*. This is the same primitive the old recovery fallback used, just promoted to a deterministic step.
4. `docker rm -f` (releases the bind mount)
5. host-side `git worktree remove` (now: empty dir, no agent, no mount, no permission fight)
6. branch delete
7. hook status cleanup

Each stage emits a `tracing::debug!(stage = …)` event for observability.

## Intentional behavior changes

- `delete_worktree=true, delete_sandbox=false` no longer surprise-removes the container. The pre-fix recovery fallback would force-remove the container even when the user explicitly opted out of container deletion. This is now honored end-to-end: `remove_managed_worktree` and `try_sandbox_dir_cleanup` take an `allow_container_removal` flag; the TUI/web pass `request.delete_sandbox`, and `aoe remove` passes `!args.keep_container`. When the flag is `false`, the fallback bails out with a clear log line and the worktree removal surfaces the original permission error instead of nuking the container behind the user's back.
- Sandboxed + `delete_worktree=true` always runs the in-container preclean (one extra `docker exec` per deletion, sub-second). Previously this only ran as recovery after a failed host probe.

## History considered

I traced the design through the relevant commits before changing it:

- #73 (Jan 2026) introduced the original `DeletionPoller` with order: worktree → container → tmux. This pre-dated awareness of root-owned sandbox files.
- #405 (Mar 2026) added "clean files from inside the container first" specifically because sandbox containers create root-owned files that host can't unlink (especially on macOS Docker Desktop VirtioFS).
- #471 (Mar 2026) introduced `try_sandbox_dir_cleanup` as a *fallback* when the host probe hits EPERM. Container-first was the right idea, but it was wired up as recovery rather than the primary path.
- #707 (Apr 2026) extracted the logic into `src/session/deletion.rs` for sharing between TUI and web. Preserved the existing order.

So the worktree-first order was a holdover from before sandbox concerns existed, and successive PRs band-aided the fallout instead of revisiting it. This PR moves to container-first as the primary path.

## Known limitations

- **Residual race window**: between `tmux_kill` and `container.remove(true)`, the agent process inside the container is reparented to PID 1 rather than killed (tmux's SIGHUP usually terminates well-behaved agents, but not guaranteed). If the agent writes a new file during the in-container preclean, `find` can miss it, and the leaked root-owned file would then fail the host-side worktree removal. The window is much smaller than the original race, and the user can recover by re-running with force. Closing this fully would require `pkill`-style process cleanup inside the container before `find` — left as a follow-up.
- **`try_sandbox_dir_cleanup` is now reachable in narrow conditions only.** With the new ordering it fires only when `delete_sandbox=false` AND preclean failed AND the host probe hit EPERM. Could be deleted in a follow-up release once the new order has shipped.

## Tests

Added to `src/session/deletion.rs`:

- `ordering::sandboxed_with_worktree_kills_tmux_and_container_before_worktree` — captures stage events via a custom `tracing` Layer; asserts `tmux_kill < preclean < container_remove < worktree_remove < branch_delete`. Verified it catches the regression by commenting out the tmux_kill stage; both ordering tests fail as expected.
- `ordering::unsandboxed_kills_tmux_before_worktree` — non-sandbox path: no preclean emitted, tmux still precedes worktree.
- `ordering::e2e_real_worktree_is_removed_on_disk` — builds a real `git init` + `git worktree add` on disk, runs `perform_deletion`, asserts the worktree dir, `.git/worktrees/<name>/` admin entry, and branch are all gone.
- `ordering::e2e_real_worktree_with_untracked_files_force_removed` — reproduces the dirty-tree path: simulates agent-leftover files, asserts non-force delete fails cleanly without nuking the dir, then force delete succeeds end-to-end.

Added to `src/git/cleanup.rs`:

- `test_try_sandbox_dir_cleanup_respects_allow_container_removal_false` — regression test for the new flag: sandboxed instance + `allow_container_removal=false` must return false without touching the container.
- `test_try_sandbox_dir_cleanup_returns_false_for_non_sandboxed` — guard for the existing early-return.

## Test plan

- [x] `cargo test --lib` — 1509 passed
- [x] `cargo test --tests` — full integration suite green (includes the 55 e2e tests; the 2 docker-only ones remain `#[ignore]`)
- [x] `cargo clippy --lib --tests` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified the new ordering tests catch a deliberately reintroduced bug
- [x] 5 consecutive parallel runs of the lib suite — green every time
- [ ] Manual: delete a sandboxed session with worktree on macOS Docker Desktop and confirm no "branch / worktree doesn't exist" errors. **I couldn't run this; the dev sandbox here has no docker. Reviewer to validate on a real session.**

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary — no user-facing docs affected
- [ ] For UI changes: not a UI change

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 (1M context)

**Any Additional AI Details you'd like to share:** The race condition diagnosis, ordering rewrite, and tests were done in a single Claude Code session. I reviewed every change, walked the historical commits (#73, #405, #471, #707) to understand the design intent, and gated the merge on the new ordering tests. The deliberate-bug-injection check confirmed the tests catch the regression they're meant to. Follow-up commits addressed reviewer feedback: tightened the `delete_sandbox=false` semantics so the fallback honors the flag, added regression tests for the new plumbing, and used the cached `is_sandboxed` bool consistently.

- [x] I am an AI Agent filling out this form (check box if true)