### PR TITLE
Cockpit polishing: 9 small fixes across wizard, cockpit, and logs

### DIFF
--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1311,13 +1311,37 @@ async fn run_connection_task<W, R>(
                                                 target: "cockpit.acp",
                                                 "sending session/set_mode mode={mode_id} during in-flight prompt"
                                             );
-                                            let _ = connection
+                                            match connection
                                                 .send_request(SetSessionModeRequest::new(
                                                     acp_session_id.clone(),
-                                                    mode_id,
+                                                    mode_id.clone(),
                                                 ))
                                                 .block_task()
-                                                .await?;
+                                                .await
+                                            {
+                                                Ok(_) => {
+                                                    // Mirror the success into the event
+                                                    // stream so the UI flips even when the
+                                                    // adapter (e.g. claude-agent-acp)
+                                                    // treats the request response as
+                                                    // authoritative and skips the follow-up
+                                                    // current_mode_update notification.
+                                                    // Adapters that DO emit the notification
+                                                    // just push the same id again, which the
+                                                    // reducer applies idempotently.
+                                                    let _ = event_tx_for_block
+                                                        .send(Event::CurrentModeChanged {
+                                                            current_mode_id: mode_id,
+                                                        })
+                                                        .await;
+                                                }
+                                                Err(e) => {
+                                                    warn!(
+                                                        target: "cockpit.acp",
+                                                        "session/set_mode failed mid-turn: {e}"
+                                                    );
+                                                }
+                                            }
                                         }
                                         Some(ClientCmd::Prompt(_)) => {
                                             // Client-side prompt queueing is
@@ -1355,13 +1379,25 @@ async fn run_connection_task<W, R>(
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
                         info!(target: "cockpit.acp", "sending session/set_mode mode={mode_id}");
-                        let _ = connection
+                        match connection
                             .send_request(SetSessionModeRequest::new(
                                 acp_session_id.clone(),
-                                mode_id,
+                                mode_id.clone(),
                             ))
                             .block_task()
-                            .await?;
+                            .await
+                        {
+                            Ok(_) => {
+                                let _ = event_tx_for_block
+                                    .send(Event::CurrentModeChanged {
+                                        current_mode_id: mode_id,
+                                    })
+                                    .await;
+                            }
+                            Err(e) => {
+                                warn!(target: "cockpit.acp", "session/set_mode failed: {e}");
+                            }
+                        }
                     }
                     Some(ClientCmd::Shutdown) | None => {
                         info!(target: "cockpit.acp", "shutdown received, exiting connection loop");

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1715,37 +1715,46 @@ async fn run_connection_task<W, R>(
                                                 target: "cockpit.acp",
                                                 "sending session/set_mode mode={mode_id} during in-flight prompt"
                                             );
-                                            match connection
-                                                .send_request(SetSessionModeRequest::new(
+                                            // Fire the request and hand the
+                                            // response handling to a detached
+                                            // task. Awaiting it here would
+                                            // freeze this select loop for the
+                                            // duration of the round-trip,
+                                            // defeating the point of polling
+                                            // cmd_rx concurrently — a Cancel
+                                            // arriving while set_mode is in
+                                            // flight would queue. The detached
+                                            // task mirrors the success into the
+                                            // event stream so the UI flips even
+                                            // when the adapter (e.g.
+                                            // claude-agent-acp) treats the
+                                            // response as authoritative and
+                                            // skips the follow-up
+                                            // current_mode_update notification.
+                                            let sent = connection.send_request(
+                                                SetSessionModeRequest::new(
                                                     acp_session_id.clone(),
                                                     mode_id.clone(),
-                                                ))
-                                                .block_task()
-                                                .await
-                                            {
-                                                Ok(_) => {
-                                                    // Mirror the success into the event
-                                                    // stream so the UI flips even when the
-                                                    // adapter (e.g. claude-agent-acp)
-                                                    // treats the request response as
-                                                    // authoritative and skips the follow-up
-                                                    // current_mode_update notification.
-                                                    // Adapters that DO emit the notification
-                                                    // just push the same id again, which the
-                                                    // reducer applies idempotently.
-                                                    let _ = event_tx_for_block
-                                                        .send(Event::CurrentModeChanged {
-                                                            current_mode_id: mode_id,
-                                                        })
-                                                        .await;
+                                                ),
+                                            );
+                                            let tx = event_tx_for_block.clone();
+                                            tokio::spawn(async move {
+                                                match sent.block_task().await {
+                                                    Ok(_) => {
+                                                        let _ = tx
+                                                            .send(Event::CurrentModeChanged {
+                                                                current_mode_id: mode_id,
+                                                            })
+                                                            .await;
+                                                    }
+                                                    Err(e) => {
+                                                        warn!(
+                                                            target: "cockpit.acp",
+                                                            "session/set_mode failed mid-turn: {e}"
+                                                        );
+                                                    }
                                                 }
-                                                Err(e) => {
-                                                    warn!(
-                                                        target: "cockpit.acp",
-                                                        "session/set_mode failed mid-turn: {e}"
-                                                    );
-                                                }
-                                            }
+                                            });
                                         }
                                         Some(ClientCmd::Prompt(_)) => {
                                             // Client-side prompt queueing is
@@ -1767,14 +1776,24 @@ async fn run_connection_task<W, R>(
                                 }
                             }
                         }
+                        // Always emit a terminal Stopped for this turn before
+                        // leaving the Prompt arm, including the shutdown path.
+                        // Consumers (reducer, persisted status) need a single
+                        // turn-end event per turn or they sit on a stale
+                        // "in flight" state forever.
+                        let reason = if shutdown {
+                            "shutdown"
+                        } else {
+                            "prompt_complete"
+                        };
+                        let _ = event_tx_for_block
+                            .send(Event::Stopped {
+                                reason: reason.into(),
+                            })
+                            .await;
                         if shutdown {
                             break;
                         }
-                        let _ = event_tx_for_block
-                            .send(Event::Stopped {
-                                reason: "prompt_complete".into(),
-                            })
-                            .await;
                     }
                     Some(ClientCmd::Cancel) => {
                         info!(target: "cockpit.acp", "sending session/cancel (no prompt in flight)");
@@ -1783,25 +1802,27 @@ async fn run_connection_task<W, R>(
                     }
                     Some(ClientCmd::SetMode(mode_id)) => {
                         info!(target: "cockpit.acp", "sending session/set_mode mode={mode_id}");
-                        match connection
-                            .send_request(SetSessionModeRequest::new(
-                                acp_session_id.clone(),
-                                mode_id.clone(),
-                            ))
-                            .block_task()
-                            .await
-                        {
-                            Ok(_) => {
-                                let _ = event_tx_for_block
-                                    .send(Event::CurrentModeChanged {
-                                        current_mode_id: mode_id,
-                                    })
-                                    .await;
+                        // Detached, same shape as the mid-turn path: don't
+                        // freeze the cmd_rx loop on the round-trip.
+                        let sent = connection.send_request(SetSessionModeRequest::new(
+                            acp_session_id.clone(),
+                            mode_id.clone(),
+                        ));
+                        let tx = event_tx_for_block.clone();
+                        tokio::spawn(async move {
+                            match sent.block_task().await {
+                                Ok(_) => {
+                                    let _ = tx
+                                        .send(Event::CurrentModeChanged {
+                                            current_mode_id: mode_id,
+                                        })
+                                        .await;
+                                }
+                                Err(e) => {
+                                    warn!(target: "cockpit.acp", "session/set_mode failed: {e}");
+                                }
                             }
-                            Err(e) => {
-                                warn!(target: "cockpit.acp", "session/set_mode failed: {e}");
-                            }
-                        }
+                        });
                     }
                     Some(ClientCmd::Shutdown) | None => {
                         info!(target: "cockpit.acp", "shutdown received, exiting connection loop");

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -967,7 +967,7 @@ async fn run_connection_task<W, R>(
     let event_tx_for_perm = event_tx.clone();
     let event_tx_for_block = event_tx.clone();
     let pending_for_perm = pending_responders.clone();
-    let cmd_rx = Arc::new(Mutex::new(cmd_rx));
+    let mut cmd_rx = cmd_rx;
     let session_label_for_log = session_label.clone();
     let res_read = resources.clone();
     let res_write = resources.clone();
@@ -1253,10 +1253,7 @@ async fn run_connection_task<W, R>(
             }
 
             loop {
-                let cmd = {
-                    let mut rx = cmd_rx.lock().await;
-                    rx.recv().await
-                };
+                let cmd = cmd_rx.recv().await;
                 match cmd {
                     Some(ClientCmd::Prompt(text)) => {
                         // First user prompt after session/load: stop
@@ -1271,13 +1268,80 @@ async fn run_connection_task<W, R>(
                             );
                         }
                         info!(target: "cockpit.acp", "sending prompt ({} chars)", text.len());
-                        let _ = connection
+                        // Drive the prompt request concurrently with the
+                        // command channel so out-of-band notifications
+                        // (Cancel, SetMode) can be delivered to the agent
+                        // mid-turn. Per the ACP spec, session/cancel is a
+                        // notification specifically designed to be sent
+                        // while a session/prompt request is in flight; if
+                        // we serialise the loop on the prompt's await, the
+                        // cancel sits idle in the channel and only goes
+                        // out after the turn already finished.
+                        let prompt_fut = connection
                             .send_request(PromptRequest::new(
                                 acp_session_id.clone(),
                                 vec![ContentBlock::Text(TextContent::new(text))],
                             ))
-                            .block_task()
-                            .await?;
+                            .block_task();
+                        tokio::pin!(prompt_fut);
+
+                        let mut shutdown = false;
+                        loop {
+                            tokio::select! {
+                                res = &mut prompt_fut => {
+                                    let _ = res?;
+                                    break;
+                                }
+                                cmd = cmd_rx.recv() => {
+                                    match cmd {
+                                        Some(ClientCmd::Cancel) => {
+                                            info!(
+                                                target: "cockpit.acp",
+                                                "sending session/cancel during in-flight prompt"
+                                            );
+                                            connection.send_notification(
+                                                CancelNotification::new(acp_session_id.clone()),
+                                            )?;
+                                            // Keep awaiting the prompt; the
+                                            // agent should resolve it with
+                                            // StopReason::Cancelled.
+                                        }
+                                        Some(ClientCmd::SetMode(mode_id)) => {
+                                            info!(
+                                                target: "cockpit.acp",
+                                                "sending session/set_mode mode={mode_id} during in-flight prompt"
+                                            );
+                                            let _ = connection
+                                                .send_request(SetSessionModeRequest::new(
+                                                    acp_session_id.clone(),
+                                                    mode_id,
+                                                ))
+                                                .block_task()
+                                                .await?;
+                                        }
+                                        Some(ClientCmd::Prompt(_)) => {
+                                            // Client-side prompt queueing is
+                                            // tracked separately in #1031.
+                                            warn!(
+                                                target: "cockpit.acp",
+                                                "received Prompt while one is in flight; dropping (queueing tracked in #1031)"
+                                            );
+                                        }
+                                        Some(ClientCmd::Shutdown) | None => {
+                                            info!(
+                                                target: "cockpit.acp",
+                                                "shutdown received during in-flight prompt; aborting turn"
+                                            );
+                                            shutdown = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        if shutdown {
+                            break;
+                        }
                         let _ = event_tx_for_block
                             .send(Event::Stopped {
                                 reason: "prompt_complete".into(),
@@ -1285,7 +1349,7 @@ async fn run_connection_task<W, R>(
                             .await;
                     }
                     Some(ClientCmd::Cancel) => {
-                        info!(target: "cockpit.acp", "sending session/cancel");
+                        info!(target: "cockpit.acp", "sending session/cancel (no prompt in flight)");
                         connection
                             .send_notification(CancelNotification::new(acp_session_id.clone()))?;
                     }

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -51,7 +51,7 @@ use std::sync::Mutex;
 
 use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
-use tracing::{debug, warn};
+use tracing::{debug, trace, warn};
 
 use super::state::Event;
 
@@ -133,10 +133,12 @@ impl EventStore {
             .with_context(|| format!("insert {session_id}@{seq}"))?;
         if inserted == 0 {
             // Primary-key collision: same (session_id, seq) seen before.
-            // Logged at debug because the cause is usually a benign retry
+            // Logged at trace because the cause is usually a benign retry
             // (publish_user_prompt + replay drain re-publishing) rather
-            // than a bug, but we still want a breadcrumb.
-            debug!(
+            // than a bug, but we still want a breadcrumb. Per-event lines
+            // are too noisy to live at debug — they bury the lifecycle
+            // signal in debug.log during an active turn.
+            trace!(
                 target: "cockpit.event_store",
                 session = %session_id,
                 seq,
@@ -144,7 +146,7 @@ impl EventStore {
                 "skipped duplicate event (already on disk)"
             );
         } else {
-            debug!(
+            trace!(
                 target: "cockpit.event_store",
                 session = %session_id,
                 seq,
@@ -171,7 +173,7 @@ impl EventStore {
             ) {
                 Ok(0) => {}
                 Ok(pruned) => {
-                    debug!(
+                    trace!(
                         target: "cockpit.event_store",
                         session = %session_id,
                         pruned,
@@ -233,7 +235,7 @@ impl EventStore {
                 Err(e) => warn!(target: "cockpit.event_store", "row error: {e}"),
             }
         }
-        debug!(
+        trace!(
             target: "cockpit.event_store",
             session = %session_id,
             since,
@@ -262,7 +264,7 @@ impl EventStore {
             Ok(Some(Some(max))) => max as u64,
             _ => 0,
         };
-        debug!(
+        trace!(
             target: "cockpit.event_store",
             session = %session_id,
             highest_seq = max,

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -607,10 +607,57 @@ fn resolve_worktree_branch(
     }
     Some(
         match worktree_branch.map(str::trim).filter(|b| !b.is_empty()) {
-            Some(b) => BranchSource::Explicit(b.to_string()),
+            // Defense-in-depth: even if the frontend slug missed a forbidden
+            // char (or the caller is a CLI/API user typing a title-shaped
+            // string into the branch field), sanitise here so libgit2 never
+            // sees a value it'll reject with InvalidSpec. `/` is preserved
+            // since it's the legal namespace separator in git refs.
+            Some(b) => BranchSource::Explicit(git_sanitize_branch_name(b)),
             None => BranchSource::Derived(branch_name_from_title(final_title)),
         },
     )
+}
+
+/// Replace characters that git ref names cannot contain (per
+/// `git-check-ref-format(1)`) with '-'. Unlike `branch_name_from_title`
+/// this keeps the user's casing and preserves '/' so `feat/auth`-style
+/// branches survive when the user types them explicitly.
+fn git_sanitize_branch_name(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_was_dash = false;
+    for ch in s.trim().chars() {
+        let forbidden = ch.is_whitespace()
+            || ch.is_control()
+            || matches!(ch, '~' | '^' | ':' | '?' | '*' | '[' | '\\');
+        let push_ch = if forbidden { '-' } else { ch };
+        if push_ch == '-' {
+            if out.is_empty() || last_was_dash {
+                continue;
+            }
+            last_was_dash = true;
+        } else {
+            last_was_dash = false;
+        }
+        out.push(push_ch);
+    }
+    // Disallowed multi-char sequences: ".." and "@{".
+    let mut out = out.replace("..", "-").replace("@{", "-");
+    // Trim trailing chars git rejects (".lock" suffix, lone '/', '.', '-').
+    if let Some(stripped) = out.strip_suffix(".lock") {
+        out = stripped.to_string();
+    }
+    while matches!(out.chars().last(), Some('-' | '.' | '/')) {
+        out.pop();
+    }
+    // Trim leading chars git rejects ('.', '-', '/').
+    while matches!(out.chars().next(), Some('-' | '.' | '/')) {
+        out.remove(0);
+    }
+    if out.is_empty() {
+        "session".to_string()
+    } else {
+        out
+    }
 }
 
 /// Find the next branch name not present in `taken`.
@@ -739,8 +786,52 @@ mod tests {
 
     #[test]
     fn test_worktree_branch_preserves_explicit_name() {
+        // The git-safe sanitiser leaves valid refs alone: '/' is a legal
+        // namespace separator, so `feat/auth` survives unchanged.
         let branch = resolve_worktree_branch(true, Some("feat/auth"), "Fix Login Flow").unwrap();
         assert!(matches!(branch, BranchSource::Explicit(ref s) if s == "feat/auth"));
+    }
+
+    #[test]
+    fn test_worktree_branch_sanitizes_explicit_with_spaces() {
+        // Without this, the value reaches libgit2 and surfaces as the opaque
+        // 'reference name … is not valid' InvalidSpec error in the dashboard.
+        let branch =
+            resolve_worktree_branch(true, Some("Exploration and issues v2"), "Fix Login Flow")
+                .unwrap();
+        assert!(
+            matches!(branch, BranchSource::Explicit(ref s) if s == "Exploration-and-issues-v2")
+        );
+    }
+
+    #[test]
+    fn test_git_sanitize_branch_name_passes_through_valid_refs() {
+        assert_eq!(git_sanitize_branch_name("feat/auth"), "feat/auth");
+        assert_eq!(git_sanitize_branch_name("release-1.2.3"), "release-1.2.3");
+        assert_eq!(
+            git_sanitize_branch_name("user_name/topic"),
+            "user_name/topic"
+        );
+    }
+
+    #[test]
+    fn test_git_sanitize_branch_name_replaces_forbidden_chars() {
+        assert_eq!(git_sanitize_branch_name("has spaces"), "has-spaces");
+        assert_eq!(git_sanitize_branch_name("a:b?c*d"), "a-b-c-d");
+        assert_eq!(git_sanitize_branch_name("ref^name"), "ref-name");
+        assert_eq!(git_sanitize_branch_name("a..b"), "a-b");
+        assert_eq!(git_sanitize_branch_name("a@{b"), "a-b");
+    }
+
+    #[test]
+    fn test_git_sanitize_branch_name_trims_edges() {
+        assert_eq!(git_sanitize_branch_name("  hello  "), "hello");
+        assert_eq!(git_sanitize_branch_name("-leading"), "leading");
+        assert_eq!(git_sanitize_branch_name(".hidden"), "hidden");
+        assert_eq!(git_sanitize_branch_name("/foo"), "foo");
+        assert_eq!(git_sanitize_branch_name("foo/"), "foo");
+        assert_eq!(git_sanitize_branch_name("foo.lock"), "foo");
+        assert_eq!(git_sanitize_branch_name(""), "session");
     }
 
     #[test]

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -642,18 +642,23 @@ fn git_sanitize_branch_name(s: &str) -> String {
     }
     // Disallowed multi-char sequences: ".." and "@{".
     let mut out = out.replace("..", "-").replace("@{", "-");
-    // Trim trailing chars git rejects (".lock" suffix, lone '/', '.', '-').
-    if let Some(stripped) = out.strip_suffix(".lock") {
-        out = stripped.to_string();
-    }
+    // Strip the ".lock" suffix from every slash-separated component, not
+    // just the last one — git-check-ref-format(1) rejects any component
+    // ending in ".lock" (e.g. `foo.lock/bar` is just as invalid as
+    // `foo.lock`).
+    out = out
+        .split('/')
+        .map(|seg| seg.strip_suffix(".lock").unwrap_or(seg))
+        .collect::<Vec<_>>()
+        .join("/");
     while matches!(out.chars().last(), Some('-' | '.' | '/')) {
         out.pop();
     }
-    // Trim leading chars git rejects ('.', '-', '/').
     while matches!(out.chars().next(), Some('-' | '.' | '/')) {
         out.remove(0);
     }
-    if out.is_empty() {
+    // A lone '@' is also rejected by git as a complete ref name.
+    if out.is_empty() || out == "@" {
         "session".to_string()
     } else {
         out
@@ -832,6 +837,25 @@ mod tests {
         assert_eq!(git_sanitize_branch_name("foo/"), "foo");
         assert_eq!(git_sanitize_branch_name("foo.lock"), "foo");
         assert_eq!(git_sanitize_branch_name(""), "session");
+    }
+
+    #[test]
+    fn test_git_sanitize_branch_name_strips_interior_lock_suffix() {
+        // git-check-ref-format rejects ANY slash-separated component ending
+        // in ".lock", not just the trailing one.
+        assert_eq!(git_sanitize_branch_name("foo.lock/bar"), "foo/bar");
+        assert_eq!(
+            git_sanitize_branch_name("feat/release.lock/v2"),
+            "feat/release/v2"
+        );
+    }
+
+    #[test]
+    fn test_git_sanitize_branch_name_rejects_bare_at_sign() {
+        // git-check-ref-format also rejects the single character "@" as a
+        // complete ref name — fall back to "session" rather than producing
+        // a name libgit2 will refuse.
+        assert_eq!(git_sanitize_branch_name("@"), "session");
     }
 
     #[test]

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -1,6 +1,7 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
+import { Pencil } from "lucide-react";
 import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
 import { MULTI_REPO_GROUP_ID } from "../hooks/useRepoGroups";
 import {
@@ -11,6 +12,7 @@ import {
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { renameSession, setSessionNotifications } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
+import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 
@@ -166,6 +168,15 @@ const SessionRow = memo(function SessionRow({
     firstSession?.notify_on_idle,
     firstSession?.notify_on_error,
   );
+  // Surface an unsent cockpit-composer draft on this workspace's row.
+  // Drafts live in localStorage under `cockpit:draft:<session_id>`; we
+  // check every session id in the workspace so multi-session rows
+  // (rare today) still light up if any of them has pending text.
+  const sessionIds = useMemo(
+    () => workspace.sessions.map((s) => s.id),
+    [workspace.sessions],
+  );
+  const hasDraft = useHasDraftForSessions(sessionIds);
 
   const setNotifyPreset = async (preset: NotifyPreset) => {
     setContextMenu(null);
@@ -337,8 +348,17 @@ const SessionRow = memo(function SessionRow({
             />
           </span>
           <div className="min-w-0 flex-1">
-            <span className={`block text-[13px] md:text-[14px] truncate ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`} title={label}>
-              {label}
+            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`}>
+              <span className="truncate" title={label}>{label}</span>
+              {hasDraft && (
+                <span
+                  title="Unsent draft"
+                  aria-label="Unsent draft"
+                  className="inline-flex shrink-0"
+                >
+                  <Pencil className="h-3 w-3 text-amber-400/90" />
+                </span>
+              )}
             </span>
             {subtitle && (
               <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitle}>

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -543,6 +543,7 @@ function StartupErrorBanner({
   message: string;
 }) {
   const isAuth = /authentic|login|api[_ -]?key/i.test(message);
+  const isCapacity = /capacity full|max_concurrent_workers/i.test(message);
   const [retryState, setRetryState] = useState<
     "idle" | "retrying" | "ok" | "failed"
   >("idle");
@@ -614,6 +615,16 @@ function StartupErrorBanner({
             in a terminal to write credentials to{" "}
             <code className="rounded bg-rose-900/60 px-1">~/.claude</code>,
             then restart aoe.
+          </>
+        ) : isCapacity ? (
+          <>
+            All cockpit worker slots are in use. Either raise{" "}
+            <code className="rounded bg-rose-900/60 px-1">[cockpit] max_concurrent_workers</code>{" "}
+            in <code className="rounded bg-rose-900/60 px-1">config.toml</code>{" "}
+            and restart <code className="rounded bg-rose-900/60 px-1">aoe serve</code>,
+            or free a slot by deleting an existing cockpit session
+            or switching one to the tmux substrate. Reinstalling the adapter
+            won't help — the adapter is fine, the cap is the limit.
           </>
         ) : (
           <>

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -119,6 +119,61 @@ export function Composer({
     el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
   };
 
+  // Per-session draft persistence: keep an unsent prompt across
+  // sidebar navigation / route changes by mirroring composer text into
+  // localStorage. The CockpitView unmounts when the user switches to
+  // another session, so without this the draft is gone on return.
+  // Keyed by sessionId; cleared when the text goes empty (user deleted
+  // it, or the runtime cleared after a successful send).
+  useEffect(() => {
+    const key = `cockpit:draft:${sessionId}`;
+    try {
+      const saved = localStorage.getItem(key);
+      if (saved && composerRuntime.getState().text === "") {
+        composerRuntime.setText(saved);
+        // setText doesn't fire the textarea's onInput, so the auto-grow
+        // never runs for the restored value. Resize manually once the DOM
+        // has the seeded text.
+        requestAnimationFrame(() => {
+          const el = taRef.current;
+          if (el) {
+            el.style.height = "auto";
+            el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+          }
+        });
+      }
+    } catch {
+      // localStorage may throw in private-mode / over-quota scenarios.
+      // Draft persistence is best-effort, never block the composer.
+    }
+
+    let writeTimer: number | null = null;
+    const flush = () => {
+      writeTimer = null;
+      try {
+        const text = composerRuntime.getState().text;
+        if (text.length === 0) {
+          localStorage.removeItem(key);
+        } else {
+          localStorage.setItem(key, text);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    const unsub = composerRuntime.subscribe(() => {
+      if (writeTimer !== null) window.clearTimeout(writeTimer);
+      writeTimer = window.setTimeout(flush, 250);
+    });
+    return () => {
+      unsub();
+      if (writeTimer !== null) {
+        window.clearTimeout(writeTimer);
+        flush();
+      }
+    };
+  }, [composerRuntime, sessionId]);
+
   // wterm's async init() in the right pane focuses its hidden textarea
   // ~200-500ms after mount and steals focus from us. Re-claim a couple
   // of times so the agent input wins; only when focus is on body or

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -29,6 +29,7 @@ import {
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
 import type { CockpitState } from "../../lib/cockpitTypes";
+import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 
 interface Props {
   sessionId: string;
@@ -126,40 +127,25 @@ export function Composer({
   // Keyed by sessionId; cleared when the text goes empty (user deleted
   // it, or the runtime cleared after a successful send).
   useEffect(() => {
-    const key = `cockpit:draft:${sessionId}`;
-    try {
-      const saved = localStorage.getItem(key);
-      if (saved && composerRuntime.getState().text === "") {
-        composerRuntime.setText(saved);
-        // setText doesn't fire the textarea's onInput, so the auto-grow
-        // never runs for the restored value. Resize manually once the DOM
-        // has the seeded text.
-        requestAnimationFrame(() => {
-          const el = taRef.current;
-          if (el) {
-            el.style.height = "auto";
-            el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
-          }
-        });
-      }
-    } catch {
-      // localStorage may throw in private-mode / over-quota scenarios.
-      // Draft persistence is best-effort, never block the composer.
+    const saved = getDraft(sessionId);
+    if (saved && composerRuntime.getState().text === "") {
+      composerRuntime.setText(saved);
+      // setText doesn't fire the textarea's onInput, so the auto-grow
+      // never runs for the restored value. Resize manually once the DOM
+      // has the seeded text.
+      requestAnimationFrame(() => {
+        const el = taRef.current;
+        if (el) {
+          el.style.height = "auto";
+          el.style.height = `${Math.min(el.scrollHeight, 200)}px`;
+        }
+      });
     }
 
     let writeTimer: number | null = null;
     const flush = () => {
       writeTimer = null;
-      try {
-        const text = composerRuntime.getState().text;
-        if (text.length === 0) {
-          localStorage.removeItem(key);
-        } else {
-          localStorage.setItem(key, text);
-        }
-      } catch {
-        /* ignore */
-      }
+      setDraft(sessionId, composerRuntime.getState().text);
     };
     const unsub = composerRuntime.subscribe(() => {
       if (writeTimer !== null) window.clearTimeout(writeTimer);

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -25,6 +25,7 @@ import { getHighlighter, langKeyForExt, loadLanguage } from "../../lib/highlight
 import { hasAnsi, parseAnsi, type AnsiStyle } from "../../lib/ansi";
 import { parseJsonObject, pickFirst, pickStr } from "../../lib/cockpitArgs";
 import type { ActivityRow, ToolCall } from "../../lib/cockpitTypes";
+import { reclassifyBash } from "../../lib/toolReclassify";
 
 interface Props {
   tool: ToolCall;
@@ -32,7 +33,8 @@ interface Props {
 }
 
 export function ToolCard({ tool, result }: Props) {
-  switch (tool.kind) {
+  const { kind, provenance } = reclassifyBash(tool);
+  switch (kind) {
     case "execute":
       return <ExecuteToolCard tool={tool} result={result} />;
     case "read":
@@ -42,7 +44,9 @@ export function ToolCard({ tool, result }: Props) {
     case "delete":
       return <DeleteToolCard tool={tool} result={result} />;
     case "search":
-      return <SearchToolCard tool={tool} result={result} />;
+      return (
+        <SearchToolCard tool={tool} result={result} provenance={provenance} />
+      );
     case "fetch":
       return <FetchToolCard tool={tool} result={result} />;
     case "think":
@@ -531,12 +535,21 @@ function DeleteToolCard({ tool, result }: Props) {
 
 /* ── search ─────────────────────────────────────────────────────── */
 
-function SearchToolCard({ tool, result }: Props) {
+interface SearchProps extends Props {
+  /** Set to "bash" when the call was a grep/find/rg shell-out that the
+   *  dispatcher reclassified into this card. Surfaced in the label so
+   *  the swap stays transparent ("search · bash"). */
+  provenance?: "bash" | null;
+}
+
+function SearchToolCard({ tool, result, provenance }: SearchProps) {
   const status = statusFor(result);
   const args = parseJsonObject(tool.args_preview);
   const argQuery = pickStr(args, "query", "pattern", "q", "search");
+  const argCommand = pickStr(args, "command");
   const title = pickStr(args, "_aoe_title");
-  const query = pickFirst(argQuery, title, tool.name) ?? "(no query)";
+  const query =
+    pickFirst(argQuery, title, argCommand, tool.name) ?? "(no query)";
   const path = pickStr(args, "path", "directory", "scope");
   const output = result?.text ?? "";
   const lines = output ? output.split("\n").filter(Boolean) : [];
@@ -546,7 +559,7 @@ function SearchToolCard({ tool, result }: Props) {
     <CardChrome
       status={status}
       icon={<Search className="h-3.5 w-3.5" />}
-      label="search"
+      label={provenance === "bash" ? "search · bash" : "search"}
       primary={query}
       meta={
         <>

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -9,7 +9,7 @@ import { ProjectStep } from "./steps/ProjectStep";
 import { SessionStep } from "./steps/SessionStep";
 import { AgentStep } from "./steps/AgentStep";
 import { ReviewStep } from "./steps/ReviewStep";
-import { applyBranchOverride, getSubmittedBranch } from "./sessionNames";
+import { applyBranchOverride, getSubmittedBranch, slugifyBranch } from "./sessionNames";
 
 export interface WizardData {
   path: string;
@@ -74,7 +74,7 @@ function reducer(state: WizardState, action: Action): WizardState {
     case "SET_FIELD": {
       const newData = { ...state.data, [action.field]: action.value };
       if (action.field === "title" && !state.data.worktreeBranchDirty) {
-        newData.worktreeBranch = String(action.value);
+        newData.worktreeBranch = slugifyBranch(String(action.value));
       }
       if (action.field === "worktreeBranch") {
         const override = applyBranchOverride(

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -3,6 +3,7 @@ import {
   applyBranchOverride,
   getReviewSummary,
   getSubmittedBranch,
+  slugifyBranch,
 } from "./sessionNames";
 
 describe("applyBranchOverride", () => {
@@ -41,6 +42,40 @@ describe("getSubmittedBranch", () => {
 
   it("leaves the branch empty only when both fields are empty", () => {
     expect(getSubmittedBranch("", "")).toBe("");
+  });
+});
+
+describe("slugifyBranch", () => {
+  it("kebab-cases titles with spaces", () => {
+    expect(slugifyBranch("Exploration and issues v2")).toBe(
+      "exploration-and-issues-v2",
+    );
+  });
+
+  it("collapses runs of punctuation into a single dash", () => {
+    expect(slugifyBranch("Fix: login @ mobile #42")).toBe(
+      "fix-login-mobile-42",
+    );
+  });
+
+  it("replaces forward slashes — git allows them but the slug stays kebab", () => {
+    expect(slugifyBranch("feat/auth.refactor")).toBe("feat-auth-refactor");
+  });
+
+  it("folds Latin diacritics and ligatures", () => {
+    expect(slugifyBranch("café fix")).toBe("cafe-fix");
+    expect(slugifyBranch("Straße")).toBe("strasse");
+    expect(slugifyBranch("œuvre")).toBe("oeuvre");
+  });
+
+  it("strips leading and trailing punctuation", () => {
+    expect(slugifyBranch("  hello world!  ")).toBe("hello-world");
+  });
+
+  it("falls back to 'session' when nothing survives", () => {
+    expect(slugifyBranch("")).toBe("session");
+    expect(slugifyBranch("---")).toBe("session");
+    expect(slugifyBranch("🚀")).toBe("session");
   });
 });
 

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -13,17 +13,17 @@ describe("applyBranchOverride", () => {
     });
   });
 
-  it("resets an empty branch back to the title-derived default", () => {
+  it("honors an explicit clear and marks the field dirty so the title mirror stops", () => {
     expect(applyBranchOverride("session-title", "")).toEqual({
-      worktreeBranch: "session-title",
-      worktreeBranchDirty: false,
+      worktreeBranch: "",
+      worktreeBranchDirty: true,
     });
   });
 
   it("keeps both fields empty when there is no title to fall back to", () => {
     expect(applyBranchOverride("", "")).toEqual({
       worktreeBranch: "",
-      worktreeBranchDirty: false,
+      worktreeBranchDirty: true,
     });
   });
 });

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -1,3 +1,43 @@
+// Mirror of `branch_name_from_title` in src/session/builder.rs: titles
+// flow through this when the wizard auto-fills the branch field so the
+// user sees the kebab-case slug git will accept rather than the raw
+// title (which often contains spaces and would otherwise be rejected
+// by libgit2 with an opaque InvalidSpec error).
+const LIGATURES: Record<string, string> = {
+  "ß": "ss", "æ": "ae", "Æ": "AE", "œ": "oe", "Œ": "OE",
+  "ø": "o", "Ø": "O", "ł": "l", "Ł": "L", "đ": "d", "Đ": "D",
+  "þ": "th", "Þ": "Th",
+};
+
+export function slugifyBranch(title: string): string {
+  let expanded = "";
+  for (const ch of title) {
+    expanded += LIGATURES[ch] ?? ch;
+  }
+  const stripped = expanded
+    .normalize("NFKD")
+    .replace(/\p{M}/gu, "")
+    .toLowerCase();
+  let out = "";
+  let lastDash = false;
+  for (const ch of stripped) {
+    const code = ch.charCodeAt(0);
+    const isAlnum =
+      (code >= 0x30 && code <= 0x39) ||
+      (code >= 0x61 && code <= 0x7a);
+    if (isAlnum || ch === "-" || ch === "_") {
+      out += ch;
+      lastDash = false;
+    } else if (/\s/.test(ch) || /[!-/:-@[-`{-~]/.test(ch)) {
+      if (out.length === 0 || lastDash) continue;
+      out += "-";
+      lastDash = true;
+    }
+  }
+  while (out.endsWith("-")) out = out.slice(0, -1);
+  return out.length === 0 ? "session" : out;
+}
+
 export function applyBranchOverride(_title: string, worktreeBranch: string): {
   worktreeBranch: string;
   worktreeBranchDirty: boolean;

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -1,14 +1,11 @@
-export function applyBranchOverride(title: string, worktreeBranch: string): {
+export function applyBranchOverride(_title: string, worktreeBranch: string): {
   worktreeBranch: string;
   worktreeBranchDirty: boolean;
 } {
-  if (worktreeBranch === "") {
-    return {
-      worktreeBranch: title,
-      worktreeBranchDirty: false,
-    };
-  }
-
+  // Any direct edit on the branch field — including clearing it — marks it
+  // dirty so the title→branch mirror stops overwriting the user's input on
+  // the next keystroke. Empty is a valid UI state; the submit path falls
+  // back to the title via getSubmittedBranch.
   return {
     worktreeBranch,
     worktreeBranchDirty: true,

--- a/web/src/lib/cockpitDrafts.ts
+++ b/web/src/lib/cockpitDrafts.ts
@@ -1,0 +1,86 @@
+// Cockpit composer drafts live in localStorage under one key per session
+// (`cockpit:draft:<session_id>`). This module centralises the storage
+// shape and exposes a tiny pub/sub so non-composer UI (e.g. the sidebar
+// "unsent draft" dot) can react to writes from any tab.
+
+import { useSyncExternalStore } from "react";
+
+const DRAFT_KEY_PREFIX = "cockpit:draft:";
+
+function draftKey(sessionId: string): string {
+  return `${DRAFT_KEY_PREFIX}${sessionId}`;
+}
+
+type Listener = () => void;
+
+const localListeners = new Set<Listener>();
+
+function emitLocal() {
+  for (const cb of localListeners) cb();
+}
+
+export function getDraft(sessionId: string): string {
+  try {
+    return localStorage.getItem(draftKey(sessionId)) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+export function setDraft(sessionId: string, text: string): void {
+  try {
+    if (text.length === 0) {
+      localStorage.removeItem(draftKey(sessionId));
+    } else {
+      localStorage.setItem(draftKey(sessionId), text);
+    }
+  } catch {
+    /* localStorage blocked / quota; persistence is best-effort */
+  }
+  emitLocal();
+}
+
+export function hasDraft(sessionId: string): boolean {
+  try {
+    const v = localStorage.getItem(draftKey(sessionId));
+    return v !== null && v.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+// Subscribe to draft changes. Fires for writes in the current tab
+// (manually emitted) and for writes in other tabs (storage event).
+// Returns an unsubscribe function.
+export function subscribeDrafts(cb: Listener): () => void {
+  localListeners.add(cb);
+  const onStorage = (e: StorageEvent) => {
+    // e.key is null when localStorage.clear() is called from another
+    // tab; treat that as "everything changed" and re-read.
+    if (e.key === null || e.key.startsWith(DRAFT_KEY_PREFIX)) cb();
+  };
+  window.addEventListener("storage", onStorage);
+  return () => {
+    localListeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+// Returns true when ANY of the given session ids has a non-empty draft.
+// Re-renders the calling component whenever drafts change.
+export function useHasDraftForSessions(sessionIds: readonly string[]): boolean {
+  // Pre-join the ids into a stable key so getSnapshot returns the same
+  // primitive across renders unless drafts actually change. Otherwise
+  // useSyncExternalStore would tear under React 18's strict checks.
+  const ids = sessionIds.join("|");
+  return useSyncExternalStore(
+    subscribeDrafts,
+    () => {
+      for (const id of ids ? ids.split("|") : []) {
+        if (id && hasDraft(id)) return true;
+      }
+      return false;
+    },
+    () => false,
+  );
+}

--- a/web/src/lib/cockpitDrafts.ts
+++ b/web/src/lib/cockpitDrafts.ts
@@ -3,7 +3,7 @@
 // shape and exposes a tiny pub/sub so non-composer UI (e.g. the sidebar
 // "unsent draft" dot) can react to writes from any tab.
 
-import { useSyncExternalStore } from "react";
+import { useMemo, useSyncExternalStore } from "react";
 
 const DRAFT_KEY_PREFIX = "cockpit:draft:";
 
@@ -11,12 +11,23 @@ function draftKey(sessionId: string): string {
   return `${DRAFT_KEY_PREFIX}${sessionId}`;
 }
 
+function sessionIdFromKey(key: string): string | null {
+  if (!key.startsWith(DRAFT_KEY_PREFIX)) return null;
+  return key.slice(DRAFT_KEY_PREFIX.length);
+}
+
 type Listener = () => void;
 
-const localListeners = new Set<Listener>();
+// Each listener may register an optional id filter. When present, the
+// listener only fires for changes to a draft whose session id is in the
+// set; null means "fire for any draft change" (and for cross-tab
+// `localStorage.clear()`, where we don't know which keys went away).
+const localListeners = new Map<Listener, ReadonlySet<string> | null>();
 
-function emitLocal() {
-  for (const cb of localListeners) cb();
+function notify(sessionId: string | null) {
+  for (const [cb, filter] of localListeners) {
+    if (filter === null || sessionId === null || filter.has(sessionId)) cb();
+  }
 }
 
 export function getDraft(sessionId: string): string {
@@ -37,7 +48,7 @@ export function setDraft(sessionId: string, text: string): void {
   } catch {
     /* localStorage blocked / quota; persistence is best-effort */
   }
-  emitLocal();
+  notify(sessionId);
 }
 
 export function hasDraft(sessionId: string): boolean {
@@ -49,15 +60,25 @@ export function hasDraft(sessionId: string): boolean {
   }
 }
 
-// Subscribe to draft changes. Fires for writes in the current tab
-// (manually emitted) and for writes in other tabs (storage event).
-// Returns an unsubscribe function.
-export function subscribeDrafts(cb: Listener): () => void {
-  localListeners.add(cb);
+// Subscribe to draft changes. `filter` scopes the listener to a specific
+// set of session ids; pass null/undefined to receive every draft change.
+// Fires for writes in the current tab (manually emitted) and for writes
+// in other tabs (storage event). Returns an unsubscribe function.
+export function subscribeDrafts(
+  cb: Listener,
+  filter: ReadonlySet<string> | null = null,
+): () => void {
+  localListeners.set(cb, filter);
   const onStorage = (e: StorageEvent) => {
     // e.key is null when localStorage.clear() is called from another
-    // tab; treat that as "everything changed" and re-read.
-    if (e.key === null || e.key.startsWith(DRAFT_KEY_PREFIX)) cb();
+    // tab; treat that as "everything changed" and unconditionally fire.
+    if (e.key === null) {
+      cb();
+      return;
+    }
+    const sid = sessionIdFromKey(e.key);
+    if (sid === null) return;
+    if (filter === null || filter.has(sid)) cb();
   };
   window.addEventListener("storage", onStorage);
   return () => {
@@ -67,14 +88,19 @@ export function subscribeDrafts(cb: Listener): () => void {
 }
 
 // Returns true when ANY of the given session ids has a non-empty draft.
-// Re-renders the calling component whenever drafts change.
+// Re-renders the calling component only when one of THESE ids changes,
+// not on every cockpit draft write anywhere in the app.
 export function useHasDraftForSessions(sessionIds: readonly string[]): boolean {
-  // Pre-join the ids into a stable key so getSnapshot returns the same
-  // primitive across renders unless drafts actually change. Otherwise
+  // Stable join key so getSnapshot returns the same primitive across
+  // renders unless the relevant drafts actually change — otherwise
   // useSyncExternalStore would tear under React 18's strict checks.
   const ids = sessionIds.join("|");
+  const subscribe = useMemo(() => {
+    const filter = new Set(ids ? ids.split("|").filter(Boolean) : []);
+    return (cb: Listener) => subscribeDrafts(cb, filter);
+  }, [ids]);
   return useSyncExternalStore(
-    subscribeDrafts,
+    subscribe,
     () => {
       for (const id of ids ? ids.split("|") : []) {
         if (id && hasDraft(id)) return true;

--- a/web/src/lib/toolReclassify.test.ts
+++ b/web/src/lib/toolReclassify.test.ts
@@ -18,6 +18,7 @@ describe("reclassifyBash", () => {
     expect(reclassifyBash(bash("rg --hidden pattern src/")).kind).toBe("search");
     expect(reclassifyBash(bash("find . -name '*.tsx'")).kind).toBe("search");
     expect(reclassifyBash(bash("fd '\\.rs$' src")).kind).toBe("search");
+    expect(reclassifyBash(bash("ripgrep pattern src/")).kind).toBe("search");
   });
 
   it("tags reclassified calls with the bash provenance", () => {

--- a/web/src/lib/toolReclassify.test.ts
+++ b/web/src/lib/toolReclassify.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { reclassifyBash } from "./toolReclassify";
+import type { ToolCall } from "./cockpitTypes";
+
+function bash(command: string, kind = "execute"): ToolCall {
+  return {
+    id: "tc-1",
+    name: "Bash",
+    kind,
+    args_preview: JSON.stringify({ command }),
+    started_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("reclassifyBash", () => {
+  it("reclassifies plain grep/rg/find/fd shellouts as search", () => {
+    expect(reclassifyBash(bash("grep -rn foo .")).kind).toBe("search");
+    expect(reclassifyBash(bash("rg --hidden pattern src/")).kind).toBe("search");
+    expect(reclassifyBash(bash("find . -name '*.tsx'")).kind).toBe("search");
+    expect(reclassifyBash(bash("fd '\\.rs$' src")).kind).toBe("search");
+  });
+
+  it("tags reclassified calls with the bash provenance", () => {
+    expect(reclassifyBash(bash("grep foo")).provenance).toBe("bash");
+  });
+
+  it("leaves the command alone when it isn't a known search binary", () => {
+    expect(reclassifyBash(bash("npm install")).kind).toBe("execute");
+    expect(reclassifyBash(bash("cargo build")).kind).toBe("execute");
+    expect(reclassifyBash(bash("./run.sh")).kind).toBe("execute");
+  });
+
+  it("rejects pipes and command chaining as not-search", () => {
+    expect(reclassifyBash(bash("grep foo | wc -l")).kind).toBe("execute");
+    expect(reclassifyBash(bash("grep foo; echo done")).kind).toBe("execute");
+    expect(reclassifyBash(bash("grep foo && rm bar")).kind).toBe("execute");
+  });
+
+  it("rejects redirects that turn a search into a write", () => {
+    expect(reclassifyBash(bash("grep foo > out.txt")).kind).toBe("execute");
+    expect(reclassifyBash(bash("grep foo >> log")).kind).toBe("execute");
+  });
+
+  it("rejects destructive find flags", () => {
+    expect(reclassifyBash(bash("find . -name '*.tmp' -delete")).kind).toBe(
+      "execute",
+    );
+    expect(reclassifyBash(bash("find . -exec rm {} +")).kind).toBe("execute");
+  });
+
+  it("passes through non-execute kinds unchanged", () => {
+    const t: ToolCall = {
+      id: "t",
+      name: "Read",
+      kind: "read",
+      args_preview: "{}",
+      started_at: "2026-01-01T00:00:00Z",
+    };
+    expect(reclassifyBash(t).kind).toBe("read");
+    expect(reclassifyBash(t).provenance).toBeNull();
+  });
+
+  it("is a no-op when the args don't carry a command string", () => {
+    const t: ToolCall = {
+      id: "t",
+      name: "Bash",
+      kind: "execute",
+      args_preview: "{}",
+      started_at: "2026-01-01T00:00:00Z",
+    };
+    expect(reclassifyBash(t).kind).toBe("execute");
+  });
+});

--- a/web/src/lib/toolReclassify.ts
+++ b/web/src/lib/toolReclassify.ts
@@ -7,8 +7,9 @@
 import type { ToolCall } from "./cockpitTypes";
 import { parseJsonObject, pickStr } from "./cockpitArgs";
 
-// Command starts with a known read-only search binary.
-const SEARCH_BIN = /^\s*(?:rg|grep|egrep|fgrep|ack|ag|find|fd)\b/;
+// Command starts with a known read-only search binary. `ripgrep` covers
+// the long form that some users still type out of habit.
+const SEARCH_BIN = /^\s*(?:ripgrep|rg|grep|egrep|fgrep|ack|ag|find|fd)\b/;
 
 // Anything that turns the call into something other than a pure read:
 // pipes, command chaining, file redirects, or destructive find flags.

--- a/web/src/lib/toolReclassify.ts
+++ b/web/src/lib/toolReclassify.ts
@@ -1,0 +1,39 @@
+// Tool-card presentation heuristic: reclassify ACP "execute" (Bash) tool
+// calls that are actually pure search shellouts (grep, rg, find, fd, …)
+// so the cockpit renders them in the search card instead of the heavier
+// bash card. The Rust `kind` stays faithful to ACP; this is purely a
+// frontend rendering concern.
+
+import type { ToolCall } from "./cockpitTypes";
+import { parseJsonObject, pickStr } from "./cockpitArgs";
+
+// Command starts with a known read-only search binary.
+const SEARCH_BIN = /^\s*(?:rg|grep|egrep|fgrep|ack|ag|find|fd)\b/;
+
+// Anything that turns the call into something other than a pure read:
+// pipes, command chaining, file redirects, or destructive find flags.
+// `<=` is excluded so `grep` doesn't trip on comparison-like fragments
+// inside a pattern argument that the user genuinely typed.
+const MUTATING = /[|;&]|>{1,2}|<(?!=)|-delete\b|-exec\b|--exec\b/;
+
+export interface Reclassified {
+  /** Effective tool kind to dispatch to (may differ from tool.kind). */
+  kind: string;
+  /** Origin of the call when reclassified — used to surface "search · bash"
+   *  on the card so the swap stays transparent. Null when not reclassified. */
+  provenance: "bash" | null;
+}
+
+export function reclassifyBash(tool: ToolCall): Reclassified {
+  if (tool.kind !== "execute") {
+    return { kind: tool.kind, provenance: null };
+  }
+  const command = pickStr(parseJsonObject(tool.args_preview), "command")?.trim();
+  if (!command) {
+    return { kind: tool.kind, provenance: null };
+  }
+  if (SEARCH_BIN.test(command) && !MUTATING.test(command)) {
+    return { kind: "search", provenance: "bash" };
+  }
+  return { kind: tool.kind, provenance: null };
+}


### PR DESCRIPTION
## Description

Batch of small, independent cockpit + wizard improvements. Each commit closes (or addresses part of) one issue and can be reverted on its own.

- Closes #1035 — Wizard: clearing the worktree branch field now sticks; the title→branch mirror stops once the field is touched. (`83d342d`)
- Closes #1039 — Cockpit: `session/cancel` now reaches the agent mid-turn. Drives the in-flight prompt future inside `tokio::select!` alongside the command channel, so the Stop button actually stops. (`5828bc9`)
- Closes #1034 — Wizard: title→branch mirror slugifies (`Exploration and issues v2` → `exploration-and-issues-v2`). Backend `resolve_worktree_branch` defensively sanitizes the Explicit arm too while preserving `/` for valid `feat/auth`-style refs. (`2972acb`)
- Closes #1033 — Cockpit: composer drafts persist per-session in `localStorage`, restored on mount. Follow-up commit `812e2bd` adds a small amber pencil icon on sidebar rows whose session has a non-empty draft, sharing draft storage via a new `cockpitDrafts.ts` pub/sub. (`5b83bee`, `812e2bd`)
- Closes #1032 — Cockpit: bash search-shaped calls (`grep`/`rg`/`find`/`fd` with no pipes / destructive flags) render via `SearchToolCard` with a `search · bash` label. Pure presentation; the ACP `kind` stays faithful. (`4ed09a1`)
- Closes #1030 — Logs: per-event `cockpit.event_store` lines (`recorded event`, `replayed events`, `highest_seq query`, etc.) demoted from `debug` to `trace` so `debug.log` stays skimmable during active turns. (`21d1597`)
- Addresses #1027 (part A only) — Cockpit: capacity-full startup banner now shows the actual remedy (raise the cap or free a slot) instead of the catch-all "reinstall the adapter" hint. Parts B (don't auto-spawn into a doomed slot) and C (`/api/cockpit/workers` endpoint + slot-visibility UI) are deliberately follow-ups. (`456e63f`)
- Closes #1028 — Cockpit: emit `Event::CurrentModeChanged` after a successful `session/set_mode`. `claude-agent-acp` doesn't push a follow-up `current_mode_update`, so the picker chip was a no-op. Also stops using `let _ = …await?` on the request, which would tear down the connection on a transient failure. (`aa6369a`)

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Mix of bug fixes and small UX features. "Bug fix" is the better single fit.)

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Tests:
- Rust: `cargo test --features serve --lib cockpit::` (64 pass), `builder::` (18 pass), full `cargo clippy --features serve` clean.
- Web: `vitest run` (98 pass across 9 files, 22 new across `sessionNames.test.ts` + `toolReclassify.test.ts`), `tsc --noEmit` clean.
- No docs changed: searched `docs/` for each behavior touched; nothing mentions wizard mirror, branch sanitization, draft persistence, mode picker mid-turn, or the per-event log lines.
- UI changes: tested manually against `aoe serve --no-auth`. No screenshot attached here — happy to record one for any specific surface on request (full per-commit manual repro steps are in the chat history of the session that produced this branch).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context) — multi-turn back-and-forth: issue triage, codebase research, implementation, tests, commit messages, this PR description. Idea, scoping, decisions, and review remain @Seluj78's.

**Any Additional AI Details you'd like to share:** Each commit was produced by walking through one issue at a time, reading the relevant code paths, asking clarifying questions before non-trivial work (e.g. scope for #1034 sanitization aggressiveness; declined work for #1038 and #1027 parts B/C), and verifying with the existing test suite before committing.

- [x] I am an AI Agent filling out this form (check box if true)