### PR TITLE
feat(cockpit): persist ACP workers across `aoe serve` restart (#1037)

### DIFF
--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -21,6 +21,14 @@ class ShimAgent {
   constructor(connection) {
     this.connection = connection;
     this.sessions = new Map();
+    // SHIM_PRESEED_SESSION_ID lets a test attach to the shim via the
+    // socket transport with `ConnectMode::Resume` (which skips
+    // `session/new`) and still get a working `prompt`. Without it,
+    // the shim's prompt handler rejects unknown session ids.
+    const preseed = process.env.SHIM_PRESEED_SESSION_ID;
+    if (preseed) {
+      this.sessions.set(preseed, {});
+    }
   }
 
   async initialize(params) {

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -57,6 +57,9 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe cockpit`↴](#aoe-cockpit)
 * [`aoe cockpit doctor`↴](#aoe-cockpit-doctor)
 * [`aoe cockpit agents`↴](#aoe-cockpit-agents)
+* [`aoe cockpit ps`↴](#aoe-cockpit-ps)
+* [`aoe cockpit stop`↴](#aoe-cockpit-stop)
+* [`aoe cockpit kill`↴](#aoe-cockpit-kill)
 * [`aoe cockpit logs`↴](#aoe-cockpit-logs)
 * [`aoe cockpit restart`↴](#aoe-cockpit-restart)
 * [`aoe uninstall`↴](#aoe-uninstall)
@@ -819,8 +822,11 @@ Cockpit (ACP-based native agent rendering) management
 
 * `doctor` — Verify the cockpit can start: Node runtime, configured agents, provider auth (claude login)
 * `agents` — List configured cockpit agents (claude-code, aoe-agent, etc.)
-* `logs` — Tail the worker stderr for a running cockpit session. Requires `aoe serve` to be running and is deferred until the worker supervisor lands
-* `restart` — Restart a wedged cockpit worker. Reserved for the supervisor slice
+* `ps` — List running cockpit workers (detached or attached)
+* `stop` — Gracefully stop a cockpit worker (SIGTERM the runner, agent receives stdin EOF). Sessions can be reattached on the next `aoe serve` only if they are still alive afterward; `stop` destroys the worker
+* `kill` — SIGKILL a worker immediately (use when `stop` doesn't take)
+* `logs` — Tail the runner's log file for a cockpit session
+* `restart` — Restart a wedged cockpit worker: stop the existing runner, then let the daemon's reconciler spawn a fresh one on the next tick
 
 
 
@@ -845,9 +851,52 @@ List configured cockpit agents (claude-code, aoe-agent, etc.)
 
 
 
+## `aoe cockpit ps`
+
+List running cockpit workers (detached or attached)
+
+**Usage:** `aoe cockpit ps [OPTIONS]`
+
+###### **Options:**
+
+* `--json` — Emit machine-readable JSON instead of a table
+
+
+
+## `aoe cockpit stop`
+
+Gracefully stop a cockpit worker (SIGTERM the runner, agent receives stdin EOF). Sessions can be reattached on the next `aoe serve` only if they are still alive afterward; `stop` destroys the worker
+
+**Usage:** `aoe cockpit stop [OPTIONS] [SESSION]`
+
+###### **Arguments:**
+
+* `<SESSION>` — Session id to stop. Mutually exclusive with `--all`
+
+###### **Options:**
+
+* `--all` — Stop every running cockpit worker
+* `--timeout-secs <TIMEOUT_SECS>` — Seconds to wait after SIGTERM before escalating to SIGKILL
+
+  Default value: `5`
+
+
+
+## `aoe cockpit kill`
+
+SIGKILL a worker immediately (use when `stop` doesn't take)
+
+**Usage:** `aoe cockpit kill <SESSION>`
+
+###### **Arguments:**
+
+* `<SESSION>` — Session id to kill
+
+
+
 ## `aoe cockpit logs`
 
-Tail the worker stderr for a running cockpit session. Requires `aoe serve` to be running and is deferred until the worker supervisor lands
+Tail the runner's log file for a cockpit session
 
 **Usage:** `aoe cockpit logs [OPTIONS]`
 
@@ -860,7 +909,7 @@ Tail the worker stderr for a running cockpit session. Requires `aoe serve` to be
 
 ## `aoe cockpit restart`
 
-Restart a wedged cockpit worker. Reserved for the supervisor slice
+Restart a wedged cockpit worker: stop the existing runner, then let the daemon's reconciler spawn a fresh one on the next tick
 
 **Usage:** `aoe cockpit restart <SESSION>`
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -255,9 +255,18 @@ Tools without ACP support continue to work exactly as they do today
 
 ## Worker persistence across `aoe serve` restart
 
+> **Behavior change (cockpit-only).** Prior releases tore down every
+> cockpit ACP worker on `aoe serve --stop` (and any other daemon
+> shutdown). As of this release, the daemon detaches without killing
+> the runner: in-flight turns survive `aoe serve --stop`, `aoe update`,
+> daemon crashes, and host suspend/wake. To actually terminate
+> workers, use `aoe cockpit stop <session>` or `aoe cockpit stop --all`
+> (graceful), or `aoe cockpit kill <session>` (force). tmux-based
+> (non-cockpit) sessions are unaffected.
+
 Cockpit workers run as detached `aoe __cockpit-runner` processes that
 outlive the daemon. `aoe serve --stop` drops the daemon's connection
-to each worker but does **not** terminate the runner — the agent
+to each worker but does **not** terminate the runner: the agent
 keeps running, in-flight turns continue, and a subsequent `aoe serve`
 reattaches via the worker's unix socket.
 
@@ -291,9 +300,7 @@ Practical implications:
   daemon; to keep the UI from staying stuck on "thinking" forever,
   the daemon arms a resume-idle watchdog that emits a synthetic
   `Stopped { reason: "reattach_idle" }` event after 10s of inbound
-  silence. If you'd like to tune that grace (or shorten it for
-  integration tests), set `AOE_RESUME_IDLE_GRACE_MS` before launching
-  `aoe serve`. Sessions that the runner cannot reattach to (dead PID,
+  silence. Sessions that the runner cannot reattach to (dead PID,
   missing socket, etc.) fall through to a fresh spawn; if the on-disk
   event log shows that fresh spawn's session was mid-prompt at the
   moment the daemon died, the reconciler publishes a

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -281,6 +281,26 @@ Practical implications:
   notification lines so per-stream chunks emitted while the daemon was
   down get replayed on reattach. Permission requests issued while
   detached block the agent's turn until reattach.
+- **Mid-turn reattach.** When the daemon comes back up against a
+  session that was actively streaming a prompt, the new daemon resumes
+  the existing ACP session id directly (no `session/new` or
+  `session/load` is sent — the agent process never died, so its in-
+  memory session is still addressable). The agent's eventual response
+  to the orphaned in-flight `session/prompt` is dropped silently by
+  the transport because its request id was issued by the previous
+  daemon; to keep the UI from staying stuck on "thinking" forever,
+  the daemon arms a resume-idle watchdog that emits a synthetic
+  `Stopped { reason: "reattach_idle" }` event after 10s of inbound
+  silence. If you'd like to tune that grace (or shorten it for
+  integration tests), set `AOE_RESUME_IDLE_GRACE_MS` before launching
+  `aoe serve`. Sessions that the runner cannot reattach to (dead PID,
+  missing socket, etc.) fall through to a fresh spawn; if the on-disk
+  event log shows that fresh spawn's session was mid-prompt at the
+  moment the daemon died, the reconciler publishes a
+  `Stopped { reason: "orphaned_at_restart" }` event before the new
+  agent starts so the UI clears immediately. The same path covers the
+  `main`-branch case where there is no runner at all and every cockpit
+  session takes the fresh-spawn branch on restart.
 
 ## Conversation persistence
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -253,6 +253,35 @@ affordance. Both are tracked as deferred work below.
 Tools without ACP support continue to work exactly as they do today
 (tmux + PTY); cockpit is additive, not a replacement.
 
+## Worker persistence across `aoe serve` restart
+
+Cockpit workers run as detached `aoe __cockpit-runner` processes that
+outlive the daemon. `aoe serve --stop` drops the daemon's connection
+to each worker but does **not** terminate the runner — the agent
+keeps running, in-flight turns continue, and a subsequent `aoe serve`
+reattaches via the worker's unix socket.
+
+Each runner registers itself at
+`<app_dir>/cockpit-workers/<session_id>.json` with its PID, socket
+path, and cached ACP session id. The same directory holds the
+per-session `.sock` (unix socket) and `.log` (runner stderr drain)
+files. `aoe cockpit ps` lists running workers.
+
+Practical implications:
+
+- `aoe update` followed by `aoe serve --stop` + `aoe serve` keeps
+  every cockpit agent's in-flight turn alive.
+- Closing the laptop or restarting the host with `aoe serve` running:
+  the daemon dies on suspend, but the runner continues. On wake the
+  next `aoe serve` reattaches.
+- To actually terminate a worker, run `aoe cockpit stop <session>` or
+  `aoe cockpit stop --all`. To force-kill, `aoe cockpit kill <session>`.
+- During the detach window (between `aoe serve --stop` and the next
+  `aoe serve`), the runner buffers up to 256 agent → daemon
+  notification lines so per-stream chunks emitted while the daemon was
+  down get replayed on reattach. Permission requests issued while
+  detached block the agent's turn until reattach.
+
 ## Conversation persistence
 
 Cockpit transcripts survive page reloads, session switches, and
@@ -374,13 +403,13 @@ for anything that looks like a credential, and replace it with
 ```
 aoe cockpit doctor [--json] [--fix]
 aoe cockpit agents
+aoe cockpit ps [--json]
+aoe cockpit stop <session>            # graceful: SIGTERM the runner
+aoe cockpit stop --all
+aoe cockpit kill <session>            # immediate: SIGKILL the runner
 aoe cockpit logs [--session <id>] [--follow]
-aoe cockpit restart <session>
+aoe cockpit restart <session>         # stop + let daemon respawn
 ```
-
-`logs` and `restart` are reserved for the worker supervisor wiring
-(landing in a follow-up release); they print a clear "not yet
-available" message today so scripts can check the surface stably.
 
 ## What's deferred
 

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -431,8 +431,16 @@ async fn stop(session: Option<String>, all: bool, timeout_secs: u64) -> Result<(
         return Ok(());
     }
     for record in &targets {
-        signal_and_wait(record, timeout_secs).await;
+        // Delete the registry entry BEFORE SIGTERM. The running daemon
+        // (if any) uses the registry-gone signal in `restart_decision`
+        // to distinguish a user-initiated stop from a crash; without
+        // this ordering, the daemon's drain task sees socket EOF first,
+        // observes the registry still present, and respawns the runner
+        // — which immediately gets killed by our SIGTERM, racing into a
+        // crash loop that burns the restart budget and surfaces the
+        // "ACP agent crashed more than N times" banner.
         worker_registry::delete(&record.session_id).ok();
+        signal_and_wait(record, timeout_secs).await;
         println!(
             "Stopped cockpit worker for {} (PID {}).",
             record.session_id, record.pid
@@ -446,13 +454,16 @@ fn kill_now(session: &str) -> Result<()> {
     let Some(record) = worker_registry::load(session)? else {
         anyhow::bail!("No cockpit worker registry entry for session {session}");
     };
+    // Delete registry before SIGKILL for the same race reason described
+    // on `stop`: the running daemon's drain task uses the registry-gone
+    // signal to skip respawn on user-initiated termination.
+    worker_registry::delete(session).ok();
     #[cfg(unix)]
     if worker_registry::is_pid_alive(record.pid) {
         use nix::sys::signal::{kill, Signal};
         use nix::unistd::Pid;
         let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGKILL);
     }
-    worker_registry::delete(session).ok();
     println!(
         "Killed cockpit worker for {} (PID {}).",
         session, record.pid
@@ -551,13 +562,16 @@ fn restart(session: &str) -> Result<()> {
     // SIGTERM the runner; the next 2s reconciler tick on `aoe serve`
     // notices the session has no live worker and spawns a fresh one
     // (which calls session/load with the cached acp_session_id).
+    // Delete registry first so the daemon's drain task observes a
+    // user-initiated stop instead of racing the SIGTERM into a crash-
+    // loop respawn.
+    worker_registry::delete(session).ok();
     #[cfg(unix)]
     if worker_registry::is_pid_alive(record.pid) {
         use nix::sys::signal::{kill, Signal};
         use nix::unistd::Pid;
         let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
     }
-    worker_registry::delete(session).ok();
     println!(
         "Stopped runner for {} (PID {}). `aoe serve` will respawn on its next reconciler tick.",
         session, record.pid

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -562,9 +562,13 @@ fn restart(session: &str) -> Result<()> {
     // SIGTERM the runner; the next 2s reconciler tick on `aoe serve`
     // notices the session has no live worker and spawns a fresh one
     // (which calls session/load with the cached acp_session_id).
-    // Delete registry first so the daemon's drain task observes a
-    // user-initiated stop instead of racing the SIGTERM into a crash-
-    // loop respawn.
+    // Write the restart-pending marker BEFORE deleting the registry so
+    // the daemon's reaper can distinguish a restart from `aoe cockpit
+    // stop|kill` and emit `Stopped { reason: "restart_pending" }`
+    // instead of `user_stopped` — the UI then renders a transient
+    // "Restarting…" banner instead of the persistent "Stopped +
+    // Reconnect" affordance.
+    worker_registry::mark_restart_pending(session);
     worker_registry::delete(session).ok();
     #[cfg(unix)]
     if worker_registry::is_pid_alive(record.pid) {

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -27,9 +27,32 @@ pub enum CockpitCommands {
     },
     /// List configured cockpit agents (claude-code, aoe-agent, etc.).
     Agents,
-    /// Tail the worker stderr for a running cockpit session. Requires
-    /// `aoe serve` to be running and is deferred until the worker
-    /// supervisor lands.
+    /// List running cockpit workers (detached or attached).
+    Ps {
+        /// Emit machine-readable JSON instead of a table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Gracefully stop a cockpit worker (SIGTERM the runner, agent
+    /// receives stdin EOF). Sessions can be reattached on the next
+    /// `aoe serve` only if they are still alive afterward; `stop`
+    /// destroys the worker.
+    Stop {
+        /// Session id to stop. Mutually exclusive with `--all`.
+        session: Option<String>,
+        /// Stop every running cockpit worker.
+        #[arg(long, conflicts_with = "session")]
+        all: bool,
+        /// Seconds to wait after SIGTERM before escalating to SIGKILL.
+        #[arg(long, default_value = "5")]
+        timeout_secs: u64,
+    },
+    /// SIGKILL a worker immediately (use when `stop` doesn't take).
+    Kill {
+        /// Session id to kill.
+        session: String,
+    },
+    /// Tail the runner's log file for a cockpit session.
     Logs {
         /// Session id whose worker logs to tail.
         #[arg(long)]
@@ -38,8 +61,8 @@ pub enum CockpitCommands {
         #[arg(long)]
         follow: bool,
     },
-    /// Restart a wedged cockpit worker. Reserved for the supervisor
-    /// slice.
+    /// Restart a wedged cockpit worker: stop the existing runner, then
+    /// let the daemon's reconciler spawn a fresh one on the next tick.
     Restart {
         /// Session id whose worker to restart.
         session: String,
@@ -50,8 +73,15 @@ pub async fn run(command: CockpitCommands) -> Result<()> {
     match command {
         CockpitCommands::Doctor { json, fix } => doctor(json, fix).await,
         CockpitCommands::Agents => agents(),
+        CockpitCommands::Ps { json } => ps(json),
+        CockpitCommands::Stop {
+            session,
+            all,
+            timeout_secs,
+        } => stop(session, all, timeout_secs).await,
+        CockpitCommands::Kill { session } => kill_now(&session),
         CockpitCommands::Logs { session, follow } => logs(session, follow),
-        CockpitCommands::Restart { session } => restart(session),
+        CockpitCommands::Restart { session } => restart(&session),
     }
 }
 
@@ -327,27 +357,222 @@ fn agents() -> Result<()> {
     Ok(())
 }
 
-fn logs(session: Option<String>, _follow: bool) -> Result<()> {
-    match session {
-        Some(id) => {
-            println!(
-                "aoe cockpit logs --session {id} is not yet wired (requires the worker supervisor; tracked for a follow-up release)."
-            );
-        }
-        None => {
-            println!(
-                "aoe cockpit logs has no active workers to tail (worker supervisor wiring is the next slice)."
-            );
-        }
+fn ps(json: bool) -> Result<()> {
+    use crate::cockpit::worker_registry;
+    let mut records = worker_registry::list().unwrap_or_default();
+    records.sort_by_key(|r| r.started_at);
+    if json {
+        let value: Vec<serde_json::Value> = records
+            .iter()
+            .map(|r| {
+                serde_json::json!({
+                    "session_id": r.session_id,
+                    "pid": r.pid,
+                    "alive": worker_registry::is_record_live(r),
+                    "agent": r.agent_name,
+                    "socket": r.socket_path,
+                    "cwd": r.cwd,
+                    "started_at": r.started_at,
+                    "last_attached_at": r.last_attached_at,
+                    "detached_at": r.detached_at,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&value)?);
+        return Ok(());
+    }
+    if records.is_empty() {
+        println!("No cockpit workers running.");
+        return Ok(());
+    }
+    println!(
+        "{:<24} {:<8} {:<14} {:<10} SOCKET",
+        "SESSION", "PID", "AGENT", "STATE"
+    );
+    for r in &records {
+        let state = if !worker_registry::is_record_live(r) {
+            "dead"
+        } else if r.detached_at.is_some()
+            && r.last_attached_at.unwrap_or(0) <= r.detached_at.unwrap_or(0)
+        {
+            "detached"
+        } else {
+            "attached"
+        };
+        println!(
+            "{:<24} {:<8} {:<14} {:<10} {}",
+            truncate(&r.session_id, 24),
+            r.pid,
+            truncate(&r.agent_name, 14),
+            state,
+            r.socket_path.display()
+        );
     }
     Ok(())
 }
 
-fn restart(session: String) -> Result<()> {
+async fn stop(session: Option<String>, all: bool, timeout_secs: u64) -> Result<()> {
+    use crate::cockpit::worker_registry;
+    let targets: Vec<crate::cockpit::worker_registry::WorkerRecord> = if all {
+        worker_registry::list().unwrap_or_default()
+    } else {
+        let id = match session {
+            Some(s) => s,
+            None => {
+                anyhow::bail!("aoe cockpit stop requires <session> or --all");
+            }
+        };
+        worker_registry::load(&id)?
+            .map(|r| vec![r])
+            .unwrap_or_default()
+    };
+    if targets.is_empty() {
+        println!("No matching cockpit workers.");
+        return Ok(());
+    }
+    for record in &targets {
+        signal_and_wait(record, timeout_secs).await;
+        worker_registry::delete(&record.session_id).ok();
+        println!(
+            "Stopped cockpit worker for {} (PID {}).",
+            record.session_id, record.pid
+        );
+    }
+    Ok(())
+}
+
+fn kill_now(session: &str) -> Result<()> {
+    use crate::cockpit::worker_registry;
+    let Some(record) = worker_registry::load(session)? else {
+        anyhow::bail!("No cockpit worker registry entry for session {session}");
+    };
+    #[cfg(unix)]
+    if worker_registry::is_pid_alive(record.pid) {
+        use nix::sys::signal::{kill, Signal};
+        use nix::unistd::Pid;
+        let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGKILL);
+    }
+    worker_registry::delete(session).ok();
     println!(
-        "aoe cockpit restart {session} is not yet wired (requires the worker supervisor; tracked for a follow-up release)."
+        "Killed cockpit worker for {} (PID {}).",
+        session, record.pid
     );
     Ok(())
+}
+
+async fn signal_and_wait(
+    record: &crate::cockpit::worker_registry::WorkerRecord,
+    timeout_secs: u64,
+) {
+    use crate::cockpit::worker_registry;
+    #[cfg(unix)]
+    {
+        use nix::sys::signal::{kill, Signal};
+        use nix::unistd::Pid;
+        let pid = Pid::from_raw(record.pid as i32);
+        if !worker_registry::is_pid_alive(record.pid) {
+            return;
+        }
+        let _ = kill(pid, Signal::SIGTERM);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+        while std::time::Instant::now() < deadline {
+            if !worker_registry::is_pid_alive(record.pid) {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        let _ = kill(pid, Signal::SIGKILL);
+    }
+    #[cfg(not(unix))]
+    let _ = (record, timeout_secs);
+}
+
+fn logs(session: Option<String>, follow: bool) -> Result<()> {
+    use crate::cockpit::worker_registry;
+    let id = match session {
+        Some(s) => s,
+        None => {
+            let records = worker_registry::list().unwrap_or_default();
+            if records.len() == 1 {
+                records[0].session_id.clone()
+            } else if records.is_empty() {
+                println!("No cockpit workers running. Use `aoe cockpit ps` to inspect.");
+                return Ok(());
+            } else {
+                println!("Multiple cockpit workers running; pass --session <id>:");
+                for r in records {
+                    println!("  {}", r.session_id);
+                }
+                return Ok(());
+            }
+        }
+    };
+    let log_path = worker_registry::log_path_for(&id)?;
+    if !log_path.exists() {
+        println!(
+            "No log file at {} (worker may not have started yet).",
+            log_path.display()
+        );
+        return Ok(());
+    }
+    if follow {
+        // Use a simple busy-poll tail rather than depending on notify
+        // crates; the runner appends a handful of lines per minute, so
+        // the wasted wake-ups are negligible.
+        use std::io::{BufRead, BufReader, Seek, SeekFrom};
+        let mut file = std::fs::File::open(&log_path)?;
+        // Seek to end so we only print *new* lines, like `tail -f`.
+        file.seek(SeekFrom::End(0))?;
+        let mut reader = BufReader::new(file);
+        let mut line = String::new();
+        loop {
+            line.clear();
+            match reader.read_line(&mut line) {
+                Ok(0) => std::thread::sleep(std::time::Duration::from_millis(200)),
+                Ok(_) => print!("{line}"),
+                Err(e) => {
+                    eprintln!("read error: {e}");
+                    break;
+                }
+            }
+        }
+    } else {
+        let content = std::fs::read_to_string(&log_path)?;
+        print!("{content}");
+    }
+    Ok(())
+}
+
+fn restart(session: &str) -> Result<()> {
+    use crate::cockpit::worker_registry;
+    let Some(record) = worker_registry::load(session)? else {
+        anyhow::bail!("No cockpit worker registry entry for session {session}");
+    };
+    // SIGTERM the runner; the next 2s reconciler tick on `aoe serve`
+    // notices the session has no live worker and spawns a fresh one
+    // (which calls session/load with the cached acp_session_id).
+    #[cfg(unix)]
+    if worker_registry::is_pid_alive(record.pid) {
+        use nix::sys::signal::{kill, Signal};
+        use nix::unistd::Pid;
+        let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
+    }
+    worker_registry::delete(session).ok();
+    println!(
+        "Stopped runner for {} (PID {}). `aoe serve` will respawn on its next reconciler tick.",
+        session, record.pid
+    );
+    Ok(())
+}
+
+fn truncate(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(n.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
 }
 
 #[cfg(test)]

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -141,6 +141,13 @@ pub enum Commands {
         command: CockpitCommands,
     },
 
+    /// Internal: per-cockpit-worker shim spawned by `aoe serve`. Owns the
+    /// agent subprocess and outlives the daemon so workers survive
+    /// `aoe serve --stop`. Hidden from help.
+    #[cfg(feature = "serve")]
+    #[command(name = "__cockpit-runner", hide = true)]
+    CockpitRunner(Box<crate::cockpit::runner::CockpitRunnerArgs>),
+
     /// Uninstall Agent of Empires
     Uninstall(UninstallArgs),
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -159,62 +159,47 @@ impl AcpClient {
         let (event_tx, event_rx) = mpsc::channel::<Event>(64);
         let pending_responders: PendingResponders = Arc::new(Mutex::new(HashMap::new()));
 
-        // Choose transport: if a socket path is set, bind a listener
-        // first, then spawn the agent with AOE_ACP_SOCKET pointing at
-        // it. Otherwise fall back to stdio over the child's stdin/out.
-        let socket_listener = if let Some(socket_path) = &config.socket_path {
-            // Remove any stale socket so bind succeeds.
-            let _ = tokio::fs::remove_file(socket_path).await;
-            if let Some(parent) = socket_path.parent() {
-                tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| AcpError::Spawn(format!("socket parent: {e}")))?;
-            }
-            let listener = tokio::net::UnixListener::bind(socket_path)
-                .map_err(|e| AcpError::Spawn(format!("bind unix socket: {e}")))?;
-            Some(listener)
-        } else {
-            None
-        };
+        // Two transports:
+        //  - Socket (runner-mediated): for every cockpit session in
+        //    production. Spawn `aoe __cockpit-runner` detached via
+        //    `setsid`; the runner binds the unix socket, spawns the
+        //    agent over stdio, and survives `aoe serve --stop`. The
+        //    daemon then dials the socket and runs the ACP handshake.
+        //  - Stdio (in-proc): the legacy direct-spawn path. Retained for
+        //    tests where we don't want to depend on `current_exe()` being
+        //    a real `aoe` binary, and as a safety valve.
+        if let Some(socket_path) = config.socket_path.clone() {
+            spawn_runner_detached(&config, &socket_path, session_id.0.clone())?;
+            return Self::connect_via_socket(
+                socket_path,
+                config.cwd,
+                config.additional_dirs,
+                config.stored_acp_session_id,
+                session_id,
+                pending_responders,
+                cmd_tx,
+                cmd_rx,
+                event_tx,
+                event_rx,
+            )
+            .await;
+        }
 
         let child = spawn_subprocess(&config)?;
         let child = Arc::new(Mutex::new(child));
-
-        match socket_listener {
-            None => {
-                Self::start_with_stdio(
-                    config.cwd,
-                    config.additional_dirs,
-                    config.stored_acp_session_id,
-                    session_id,
-                    child,
-                    pending_responders,
-                    cmd_tx,
-                    cmd_rx,
-                    event_tx,
-                    event_rx,
-                )
-                .await
-            }
-            Some(listener) => {
-                let socket_path = config.socket_path.clone();
-                Self::start_with_socket(
-                    config.cwd,
-                    config.additional_dirs,
-                    config.stored_acp_session_id,
-                    session_id,
-                    child,
-                    pending_responders,
-                    cmd_tx,
-                    cmd_rx,
-                    event_tx,
-                    event_rx,
-                    listener,
-                    socket_path,
-                )
-                .await
-            }
-        }
+        Self::start_with_stdio(
+            config.cwd,
+            config.additional_dirs,
+            config.stored_acp_session_id,
+            session_id,
+            child,
+            pending_responders,
+            cmd_tx,
+            cmd_rx,
+            event_tx,
+            event_rx,
+        )
+        .await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -266,7 +251,7 @@ impl AcpClient {
             cmd_rx,
             cwd,
             session_label.clone(),
-            child_for_task,
+            Some(child_for_task),
             pending_for_task,
             resources,
             None,
@@ -274,7 +259,7 @@ impl AcpClient {
             Some(ready_tx),
         ));
 
-        wait_for_handshake(&session_label, ready_rx, &child).await?;
+        wait_for_handshake(&session_label, ready_rx, Some(&child)).await?;
 
         Ok(Self {
             session_id,
@@ -285,28 +270,30 @@ impl AcpClient {
         })
     }
 
+    /// Connect to a per-session runner over its unix socket. Used by the
+    /// post-spawn "wait for runner to bind, then dial" path AND by the
+    /// `Self::attach` reattach path on `aoe serve` startup. The runner
+    /// owns the agent subprocess so this constructor returns an
+    /// `AcpClient` with `_child = None` — dropping the client does not
+    /// terminate the worker.
     #[allow(clippy::too_many_arguments)]
-    async fn start_with_socket(
+    async fn connect_via_socket(
+        socket_path: PathBuf,
         cwd: PathBuf,
         additional_dirs: Vec<PathBuf>,
         stored_acp_session_id: Option<String>,
         session_id: CockpitSessionId,
-        child: Arc<Mutex<tokio::process::Child>>,
         pending_responders: PendingResponders,
         cmd_tx: mpsc::Sender<ClientCmd>,
         cmd_rx: mpsc::Receiver<ClientCmd>,
         event_tx: mpsc::Sender<Event>,
         event_rx: mpsc::Receiver<Event>,
-        listener: tokio::net::UnixListener,
-        socket_path: Option<PathBuf>,
     ) -> Result<Self, AcpError> {
-        // Wait for the agent to connect. Bound the wait so a wedged
-        // agent doesn't park spawn() forever.
-        let accept = tokio::time::timeout(std::time::Duration::from_secs(10), listener.accept())
-            .await
-            .map_err(|_| AcpError::Spawn("agent did not connect to socket within 10s".into()))?
-            .map_err(|e| AcpError::Spawn(format!("accept: {e}")))?;
-        let (stream, _addr) = accept;
+        // Poll for the runner to finish binding the socket. The runner
+        // binds before it spawns the agent so this is usually fast (a
+        // few ms) but bound the wait so a wedged runner returns a typed
+        // error instead of parking the supervisor.
+        let stream = wait_for_socket(&socket_path, std::time::Duration::from_secs(10)).await?;
         let (read_half, write_half) = stream.into_split();
         let transport = ByteStreams::new(write_half.compat_write(), read_half.compat());
 
@@ -320,7 +307,6 @@ impl AcpClient {
         };
 
         let session_label = session_id.0.clone();
-        let child_for_task = child.clone();
         let pending_for_task = pending_responders.clone();
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
@@ -331,23 +317,53 @@ impl AcpClient {
             cmd_rx,
             cwd,
             session_label.clone(),
-            child_for_task,
+            None,
             pending_for_task,
             resources,
-            socket_path,
+            None,
             stored_acp_session_id,
             Some(ready_tx),
         ));
 
-        wait_for_handshake(&session_label, ready_rx, &child).await?;
+        wait_for_handshake(&session_label, ready_rx, None).await?;
 
         Ok(Self {
             session_id,
             inbound: Some(event_rx),
             cmd_tx: Some(cmd_tx),
             pending_responders,
-            _child: Some(child),
+            _child: None,
         })
+    }
+
+    /// Reattach to an already-running cockpit worker over its unix
+    /// socket. Used by `aoe serve` startup when a registry entry has a
+    /// live PID and an existing socket file — we connect, run the ACP
+    /// handshake (using the cached `stored_acp_session_id` to issue
+    /// `session/load` instead of `session/new`), and resume.
+    pub async fn attach(
+        socket_path: PathBuf,
+        cwd: PathBuf,
+        additional_dirs: Vec<PathBuf>,
+        stored_acp_session_id: Option<String>,
+        session_id: CockpitSessionId,
+    ) -> Result<Self, AcpError> {
+        let (cmd_tx, cmd_rx) = mpsc::channel::<ClientCmd>(16);
+        let (event_tx, event_rx) = mpsc::channel::<Event>(64);
+        let pending_responders: PendingResponders = Arc::new(Mutex::new(HashMap::new()));
+        Self::connect_via_socket(
+            socket_path,
+            cwd,
+            additional_dirs,
+            stored_acp_session_id,
+            session_id,
+            pending_responders,
+            cmd_tx,
+            cmd_rx,
+            event_tx,
+            event_rx,
+        )
+        .await
     }
 
     /// Send a user message to the agent (ACP `session/prompt`).
@@ -481,6 +497,185 @@ fn scrub_stderr_secrets(line: &str) -> std::borrow::Cow<'_, str> {
         .expect("static secret-scrub regex must compile")
     });
     re.replace_all(line, "<redacted-secret>")
+}
+
+/// Spawn the `aoe __cockpit-runner` shim as a detached process. The
+/// runner owns the agent subprocess and outlives the daemon. We retain
+/// no `Child` handle here — once the runner is up, the daemon talks to
+/// it over the unix socket and the OS keeps the runner alive across
+/// `aoe serve` restarts.
+fn spawn_runner_detached(
+    config: &SpawnConfig,
+    socket_path: &std::path::Path,
+    session_id: String,
+) -> Result<(), AcpError> {
+    use std::process::Command as StdCommand;
+    let current_exe =
+        std::env::current_exe().map_err(|e| AcpError::Spawn(format!("current_exe: {e}")))?;
+    let log_path = crate::cockpit::worker_registry::log_path_for(&session_id)
+        .map_err(|e| AcpError::Spawn(format!("log path: {e}")))?;
+    if let Some(parent) = log_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let mut cmd = StdCommand::new(&current_exe);
+    cmd.arg("__cockpit-runner")
+        .arg("--socket")
+        .arg(socket_path)
+        .arg("--session-id")
+        .arg(&session_id)
+        .arg("--agent-name")
+        .arg(&config.spec.command)
+        .arg("--cwd")
+        .arg(&config.cwd);
+    if !config.additional_dirs.is_empty() {
+        cmd.arg("--additional-dirs").arg(
+            config
+                .additional_dirs
+                .iter()
+                .map(|p| p.to_string_lossy().into_owned())
+                .collect::<Vec<_>>()
+                .join(","),
+        );
+    }
+    let provider_keys: Vec<&str> = config
+        .provider_env
+        .iter()
+        .map(|(k, _)| k.as_str())
+        .collect();
+    if !provider_keys.is_empty() {
+        cmd.arg("--provider-env-keys").arg(provider_keys.join(","));
+    }
+    if let Some(stored) = &config.stored_acp_session_id {
+        cmd.arg("--stored-acp-session-id").arg(stored);
+    }
+    cmd.arg("--");
+    cmd.arg(&config.spec.command);
+    for a in &config.spec.args {
+        cmd.arg(a);
+    }
+
+    // Env: apply the same allowlist + provider_env filtering that the
+    // legacy in-proc path does, then hand the cleaned env to the runner.
+    // The runner inherits this env when it spawns the agent (no second
+    // filter pass needed). AOE_TOKEN is stripped here so it never reaches
+    // either process.
+    cmd.env_clear();
+    apply_env_filter(&mut cmd, config);
+
+    // Detach: child becomes its own session leader so a SIGTERM/SIGHUP
+    // to the aoe daemon's group doesn't cascade. The runner installs its
+    // own signal handlers.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::other)?;
+                Ok(())
+            });
+        }
+    }
+
+    // Redirect stdio: the runner writes its own log file. Inheriting our
+    // stdio would (a) pollute serve.log with the per-session noise and
+    // (b) keep a pipe open to the daemon, which then closes when we die,
+    // making the runner observe EOF on its own stdin/stdout.
+    cmd.stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null());
+
+    info!(
+        target: "cockpit.acp.spawn",
+        session = %session_id,
+        socket = %socket_path.display(),
+        runner = %current_exe.display(),
+        agent = %config.spec.command,
+        "spawning detached cockpit runner"
+    );
+
+    cmd.spawn().map_err(|e| {
+        warn!(
+            target: "cockpit.acp.spawn",
+            session = %session_id,
+            "runner spawn failed: {e}"
+        );
+        AcpError::Spawn(format!("spawn runner: {e}"))
+    })?;
+    // Drop the std::process::Child here. std::process::Command doesn't
+    // wait on drop, so the runner stays alive. setsid + nohup-equivalent
+    // make this an actual detach.
+    Ok(())
+}
+
+/// Apply the env_clear + allowlist + provider_env filtering used by both
+/// the detached-runner path and the in-proc stdio path. Pulled out so
+/// the two spawn sites share the same security posture.
+fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
+    const ALWAYS_FORWARD: &[&str] = &[
+        "PATH",
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "TERM",
+        "USER",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_AUTH_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "CLAUDE_CONFIG_DIR",
+    ];
+    for name in ALWAYS_FORWARD {
+        if let Ok(value) = std::env::var(name) {
+            cmd.env(name, value);
+        }
+    }
+    if let Some(extra_allowlist) = &config.spec.env_allowlist {
+        for name in extra_allowlist {
+            if name == "AOE_TOKEN" {
+                continue;
+            }
+            if let Ok(value) = std::env::var(name) {
+                cmd.env(name, value);
+            }
+        }
+    }
+    for (key, value) in &config.provider_env {
+        if provider_env_denyreason(key).is_some() {
+            continue;
+        }
+        cmd.env(key, value);
+    }
+}
+
+/// Poll the socket file's existence with `connect()` until a deadline.
+/// Used by `connect_via_socket` to wait for the runner to finish binding
+/// before the daemon dials in.
+async fn wait_for_socket(
+    path: &std::path::Path,
+    deadline: std::time::Duration,
+) -> Result<tokio::net::UnixStream, AcpError> {
+    let started = std::time::Instant::now();
+    let mut delay_ms = 20_u64;
+    loop {
+        if path.exists() {
+            match tokio::net::UnixStream::connect(path).await {
+                Ok(s) => return Ok(s),
+                Err(e) if matches!(e.kind(), std::io::ErrorKind::ConnectionRefused) => {
+                    // Listener not yet ready; back off and retry.
+                }
+                Err(e) => return Err(AcpError::Spawn(format!("connect {}: {e}", path.display()))),
+            }
+        }
+        if started.elapsed() >= deadline {
+            return Err(AcpError::Spawn(format!(
+                "runner socket {} did not appear within {}s",
+                path.display(),
+                deadline.as_secs()
+            )));
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
+        delay_ms = (delay_ms * 2).min(200);
+    }
 }
 
 fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpError> {
@@ -949,7 +1144,7 @@ async fn run_connection_task<W, R>(
     cmd_rx: mpsc::Receiver<ClientCmd>,
     cwd: PathBuf,
     session_label: String,
-    child: Arc<Mutex<tokio::process::Child>>,
+    child: Option<Arc<Mutex<tokio::process::Child>>>,
     pending_responders: PendingResponders,
     resources: SessionResources,
     socket_path: Option<PathBuf>,
@@ -1335,28 +1530,33 @@ async fn run_connection_task<W, R>(
             );
         }
     }
-    let mut guard = child.lock().await;
-    match guard.try_wait() {
-        Ok(Some(status)) => info!(
-            target: "cockpit.acp",
-            session = %session_label_for_log,
-            "agent process already exited: status={status}"
-        ),
-        Ok(None) => info!(
-            target: "cockpit.acp",
-            session = %session_label_for_log,
-            "killing agent process after connection task end"
-        ),
-        Err(e) => warn!(
-            target: "cockpit.acp",
-            session = %session_label_for_log,
-            "try_wait failed before kill: {e}"
-        ),
-    }
-    let _ = guard.kill().await;
-    // Clean up socket file on exit when this transport was socket-based.
-    if let Some(path) = socket_path {
-        let _ = tokio::fs::remove_file(path).await;
+    // In runner-managed mode (child is None) we deliberately don't kill
+    // anything here: the per-worker `aoe __cockpit-runner` shim owns the
+    // agent subprocess and outlives this daemon's connection. The socket
+    // file also stays — the runner cleans it up on its own exit.
+    if let Some(child) = child.as_ref() {
+        let mut guard = child.lock().await;
+        match guard.try_wait() {
+            Ok(Some(status)) => info!(
+                target: "cockpit.acp",
+                session = %session_label_for_log,
+                "agent process already exited: status={status}"
+            ),
+            Ok(None) => info!(
+                target: "cockpit.acp",
+                session = %session_label_for_log,
+                "killing agent process after connection task end"
+            ),
+            Err(e) => warn!(
+                target: "cockpit.acp",
+                session = %session_label_for_log,
+                "try_wait failed before kill: {e}"
+            ),
+        }
+        let _ = guard.kill().await;
+        if let Some(path) = socket_path {
+            let _ = tokio::fs::remove_file(path).await;
+        }
     }
 }
 
@@ -1368,7 +1568,7 @@ async fn run_connection_task<W, R>(
 async fn wait_for_handshake(
     session_label: &str,
     ready_rx: oneshot::Receiver<Result<(), AcpError>>,
-    child: &Arc<Mutex<tokio::process::Child>>,
+    child: Option<&Arc<Mutex<tokio::process::Child>>>,
 ) -> Result<(), AcpError> {
     let timeout = std::time::Duration::from_secs(30);
     match tokio::time::timeout(timeout, ready_rx).await {
@@ -1388,11 +1588,10 @@ async fn wait_for_handshake(
                 "ACP handshake timed out after {}s",
                 timeout.as_secs()
             );
-            // Kill the wedged child so we don't leak a zombie npx
-            // download. The connection task will then unwind and the
-            // ready_tx is already gone, so no event_tx duplicate.
-            let mut guard = child.lock().await;
-            let _ = guard.kill().await;
+            if let Some(child) = child {
+                let mut guard = child.lock().await;
+                let _ = guard.kill().await;
+            }
             Err(AcpError::Spawn(format!(
                 "agent did not complete the ACP initialize handshake within {}s. \
                  Common causes: `npx -y` is still downloading the adapter on first run, \
@@ -1404,10 +1603,12 @@ async fn wait_for_handshake(
     }
 }
 
-async fn collect_child_failure(child: &Arc<Mutex<tokio::process::Child>>) {
-    let mut guard = child.lock().await;
-    if let Ok(Some(status)) = guard.try_wait() {
-        warn!(target: "cockpit.acp", "agent process exited early: status={status}");
+async fn collect_child_failure(child: Option<&Arc<Mutex<tokio::process::Child>>>) {
+    if let Some(child) = child {
+        let mut guard = child.lock().await;
+        if let Ok(Some(status)) = guard.try_wait() {
+            warn!(target: "cockpit.acp", "agent process exited early: status={status}");
+        }
     }
 }
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -94,6 +94,45 @@ enum ClientCmd {
     Shutdown,
 }
 
+/// How the connection task should handle the ACP handshake against the
+/// agent.
+///
+/// `Fresh` is the standard path: send `initialize`, then either
+/// `session/load` (if the agent advertises support AND we have a stored
+/// id) or `session/new`.
+///
+/// `Resume` is used by `AcpClient::attach` on `aoe serve` restart, when
+/// the per-session `aoe __cockpit-runner` shim kept the agent process
+/// alive across the daemon's death. The agent is already initialized
+/// and the session is already in its in-memory map; re-sending
+/// `session/new` would split context onto a new session id (which the
+/// in-flight turn does not address), and re-sending `session/load`
+/// against an agent that advertises `loadSession: false` (e.g. the
+/// bundled `aoe-agent`) would fall through to `session/new` with the
+/// same split-context bug. In `Resume` mode the daemon still sends
+/// `initialize` (idempotent for capabilities, cheap, lets us learn the
+/// agent's caps) but skips both `session/new` and `session/load` and
+/// uses the supplied `acp_session_id` as-is. `in_flight_turn` arms the
+/// resume-idle watchdog described in `run_connection_task`.
+#[derive(Debug, Clone)]
+enum ConnectMode {
+    Fresh {
+        stored_acp_session_id: Option<String>,
+    },
+    Resume {
+        acp_session_id: String,
+        in_flight_turn: bool,
+    },
+}
+
+/// Time without any inbound notification, after a `Resume`-mode attach
+/// with `in_flight_turn = true`, before the watchdog synthesizes a
+/// `Stopped { reason: "reattach_idle" }` event. LLM streams rarely have
+/// intra-turn silence near this duration so the false-positive risk
+/// (UI flips to Idle then back to Streaming on the next chunk) is
+/// bounded.
+const RESUME_IDLE_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Resolution channel + the option set the agent offered. Stored in the
 /// pending-responders map keyed by the cockpit's server-generated nonce.
 struct PendingResponder {
@@ -168,13 +207,16 @@ impl AcpClient {
         //  - Stdio (in-proc): the legacy direct-spawn path. Retained for
         //    tests where we don't want to depend on `current_exe()` being
         //    a real `aoe` binary, and as a safety valve.
+        let mode = ConnectMode::Fresh {
+            stored_acp_session_id: config.stored_acp_session_id.clone(),
+        };
         if let Some(socket_path) = config.socket_path.clone() {
             spawn_runner_detached(&config, &socket_path, session_id.0.clone())?;
             return Self::connect_via_socket(
                 socket_path,
                 config.cwd,
                 config.additional_dirs,
-                config.stored_acp_session_id,
+                mode,
                 session_id,
                 pending_responders,
                 cmd_tx,
@@ -190,7 +232,7 @@ impl AcpClient {
         Self::start_with_stdio(
             config.cwd,
             config.additional_dirs,
-            config.stored_acp_session_id,
+            mode,
             session_id,
             child,
             pending_responders,
@@ -206,7 +248,7 @@ impl AcpClient {
     async fn start_with_stdio(
         cwd: PathBuf,
         additional_dirs: Vec<PathBuf>,
-        stored_acp_session_id: Option<String>,
+        mode: ConnectMode,
         session_id: CockpitSessionId,
         child: Arc<Mutex<tokio::process::Child>>,
         pending_responders: PendingResponders,
@@ -255,7 +297,7 @@ impl AcpClient {
             pending_for_task,
             resources,
             None,
-            stored_acp_session_id,
+            mode,
             Some(ready_tx),
         ));
 
@@ -281,7 +323,7 @@ impl AcpClient {
         socket_path: PathBuf,
         cwd: PathBuf,
         additional_dirs: Vec<PathBuf>,
-        stored_acp_session_id: Option<String>,
+        mode: ConnectMode,
         session_id: CockpitSessionId,
         pending_responders: PendingResponders,
         cmd_tx: mpsc::Sender<ClientCmd>,
@@ -321,7 +363,7 @@ impl AcpClient {
             pending_for_task,
             resources,
             None,
-            stored_acp_session_id,
+            mode,
             Some(ready_tx),
         ));
 
@@ -338,24 +380,45 @@ impl AcpClient {
 
     /// Reattach to an already-running cockpit worker over its unix
     /// socket. Used by `aoe serve` startup when a registry entry has a
-    /// live PID and an existing socket file — we connect, run the ACP
-    /// handshake (using the cached `stored_acp_session_id` to issue
-    /// `session/load` instead of `session/new`), and resume.
+    /// live PID and an existing socket file — we connect, send only the
+    /// (idempotent) ACP `initialize` request, and reuse the existing
+    /// `stored_acp_session_id` directly. We deliberately do NOT issue
+    /// `session/new` or `session/load`: the agent process is still
+    /// running (the runner kept it alive across `aoe serve --stop`) and
+    /// the session is already loaded in its memory, so re-sending those
+    /// requests would either split context onto a new session id (when
+    /// the agent doesn't advertise `loadSession`) or double-load against
+    /// a busy session.
+    ///
+    /// `in_flight_turn = true` tells the connection task that the
+    /// session was mid-prompt when the previous daemon detached. The
+    /// task arms a watchdog that emits a synthetic
+    /// `Event::Stopped { reason: "reattach_idle" }` after
+    /// `RESUME_IDLE_GRACE` of inbound silence, because the agent's
+    /// eventual response to the orphaned `session/prompt` carries a
+    /// request id this client never issued and is dropped silently by
+    /// the underlying transport, leaving the UI otherwise stuck on
+    /// "thinking".
     pub async fn attach(
         socket_path: PathBuf,
         cwd: PathBuf,
         additional_dirs: Vec<PathBuf>,
-        stored_acp_session_id: Option<String>,
+        stored_acp_session_id: String,
+        in_flight_turn: bool,
         session_id: CockpitSessionId,
     ) -> Result<Self, AcpError> {
         let (cmd_tx, cmd_rx) = mpsc::channel::<ClientCmd>(16);
         let (event_tx, event_rx) = mpsc::channel::<Event>(64);
         let pending_responders: PendingResponders = Arc::new(Mutex::new(HashMap::new()));
+        let mode = ConnectMode::Resume {
+            acp_session_id: stored_acp_session_id,
+            in_flight_turn,
+        };
         Self::connect_via_socket(
             socket_path,
             cwd,
             additional_dirs,
-            stored_acp_session_id,
+            mode,
             session_id,
             pending_responders,
             cmd_tx,
@@ -1148,13 +1211,13 @@ async fn run_connection_task<W, R>(
     pending_responders: PendingResponders,
     resources: SessionResources,
     socket_path: Option<PathBuf>,
-    stored_acp_session_id: Option<String>,
+    mode: ConnectMode,
     ready_tx: Option<oneshot::Sender<Result<(), AcpError>>>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
     R: futures_util::AsyncRead + Send + 'static,
 {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicI64, Ordering};
 
     let ready_tx = Arc::new(Mutex::new(ready_tx));
     let ready_for_block = ready_tx.clone();
@@ -1187,6 +1250,21 @@ async fn run_connection_task<W, R>(
     let suppress_for_block = suppress_history_replay.clone();
     let session_label_for_notif = session_label.clone();
 
+    // Watchdog inputs (only consulted when `mode` is `Resume { in_flight_turn: true }`):
+    //   - `last_event_at`: epoch-ms of the last inbound notification.
+    //     Updated by the notification handler below. Initialized to "now"
+    //     so a session that never receives a single notification still
+    //     fires Stopped after RESUME_IDLE_GRACE rather than immediately.
+    //   - `prompt_sent_since_attach`: set when the user issues a prompt
+    //     after attach; the user's real PromptRequest will own the next
+    //     Stopped, so the watchdog must stand down.
+    //   - `watchdog_fired`: ensures we synthesize Stopped at most once.
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    let last_event_at = Arc::new(AtomicI64::new(now_ms));
+    let prompt_sent_since_attach = Arc::new(AtomicBool::new(false));
+    let watchdog_fired = Arc::new(AtomicBool::new(false));
+    let last_event_at_for_notif = last_event_at.clone();
+
     let result = Client
         .builder()
         .name("aoe-cockpit")
@@ -1195,7 +1273,10 @@ async fn run_connection_task<W, R>(
                 let event_tx = event_tx_for_notif.clone();
                 let suppress = suppress_for_notif.clone();
                 let session_label = session_label_for_notif.clone();
+                let last_event_at = last_event_at_for_notif.clone();
                 async move {
+                    last_event_at
+                        .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
                     let suppressing = suppress.load(Ordering::Relaxed);
                     for event in map_update_to_events(notification.update) {
                         // During the post-load replay window, drop only
@@ -1306,6 +1387,10 @@ async fn run_connection_task<W, R>(
                     .read_text_file(true)
                     .write_text_file(true))
                 .terminal(true);
+            // `initialize` is sent in both Fresh and Resume modes.
+            // It's idempotent on every ACP agent we ship against
+            // (aoe-agent, claude-agent-acp) — the response only carries
+            // capability metadata — so re-sending it on attach is safe.
             let init = connection
                 .send_request(
                     InitializeRequest::new(ProtocolVersion::V1)
@@ -1315,136 +1400,227 @@ async fn run_connection_task<W, R>(
                 .await?;
 
             let load_session_capable = init.agent_capabilities.load_session;
+            // Snapshot the watchdog-arming flag before `mode` is moved
+            // into the match below.
+            let arm_resume_watchdog = matches!(
+                &mode,
+                ConnectMode::Resume {
+                    in_flight_turn: true,
+                    ..
+                }
+            );
             info!(
                 target: "cockpit.acp",
                 session = %session_label,
                 load_session_capable,
-                stored_id = ?stored_acp_session_id,
+                ?mode,
                 "initialize handshake complete"
             );
 
-            // Decide whether to resume the prior agent session or create
-            // a fresh one. session/load is only attempted when the agent
-            // advertises support AND we have a stored id to feed it. On
-            // load failure (id GC'd, agent state lost, etc.) we fall
-            // through to session/new and emit SessionContextReset so the
-            // UI can show a notice and clear stale token-usage hints.
-            let mut acp_session_id: Option<SessionId> = None;
-            if load_session_capable {
-                if let Some(stored) = stored_acp_session_id.clone() {
+            let acp_session_id: SessionId = match mode {
+                ConnectMode::Resume {
+                    acp_session_id: stored,
+                    in_flight_turn: _,
+                } => {
+                    // Skip session/new and session/load. The runner kept
+                    // the agent process alive across the daemon restart,
+                    // so the session is still loaded in the agent's
+                    // memory and addressable via its original id. Issuing
+                    // session/load here would either fail (agents that
+                    // advertise loadSession=false) or double-load against
+                    // a still-busy session; issuing session/new would
+                    // split context onto a new id the in-flight turn
+                    // doesn't address.
                     info!(
                         target: "cockpit.acp",
                         session = %session_label,
                         stored_id = %stored,
-                        "resuming session via session/load"
+                        "resume mode: reusing existing acp session id without handshake"
                     );
-                    // Set the flag BEFORE sending the request: claude-agent-acp
-                    // re-emits the prior transcript via session/update
-                    // notifications *during* the load handshake, before the
-                    // LoadSessionRequest response returns. Setting after .await
-                    // would let those notifications leak through to the event
-                    // store and produce duplicate ToolCallStarted rows on the
-                    // next reload (assistant-ui then panics with "Duplicate
-                    // key toolCallId-..."). Cleared on Err below if we fall
-                    // back to session/new, which has no replay payload.
-                    suppress_for_block.store(true, Ordering::Relaxed);
-                    let req = LoadSessionRequest::new(stored.clone(), cwd.clone());
-                    match connection.send_request(req).block_task().await {
-                        Ok(_resp) => {
+                    // Emit AcpSessionAssigned so the frontend reducer
+                    // clears any sticky startupError/lastError from the
+                    // crash. The server-side listener treats a same-id
+                    // Assigned as a no-op, so this doesn't rewrite
+                    // sessions.json.
+                    let _ = event_tx_for_block
+                        .send(Event::AcpSessionAssigned {
+                            acp_session_id: stored.clone(),
+                        })
+                        .await;
+                    SessionId::from(stored)
+                }
+                ConnectMode::Fresh {
+                    stored_acp_session_id,
+                } => {
+                    // Decide whether to resume the prior agent session or create
+                    // a fresh one. session/load is only attempted when the agent
+                    // advertises support AND we have a stored id to feed it. On
+                    // load failure (id GC'd, agent state lost, etc.) we fall
+                    // through to session/new and emit SessionContextReset so the
+                    // UI can show a notice and clear stale token-usage hints.
+                    let mut acp_session_id: Option<SessionId> = None;
+                    if load_session_capable {
+                        if let Some(stored) = stored_acp_session_id.clone() {
                             info!(
                                 target: "cockpit.acp",
                                 session = %session_label,
                                 stored_id = %stored,
-                                "session/load succeeded; suppressing post-load history replay"
+                                "resuming session via session/load"
                             );
-                            // Emit AcpSessionAssigned even on resume so the
-                            // frontend reducer can clear any sticky
-                            // `startupError` / `lastError` from a prior crash
-                            // (e.g. a respawn after the user's prompt hit a
-                            // dead pipe). The server-side listener treats a
-                            // same-id Assigned as a no-op, so this doesn't
-                            // rewrite sessions.json.
-                            let _ = event_tx_for_block
-                                .send(Event::AcpSessionAssigned {
-                                    acp_session_id: stored.clone(),
-                                })
-                                .await;
-                            acp_session_id = Some(SessionId::from(stored));
-                        }
-                        Err(e) => {
-                            warn!(
-                                target: "cockpit.acp",
-                                session = %session_label,
-                                stored_id = %stored,
-                                "session/load failed, falling back to session/new: {e}"
-                            );
-                            suppress_for_block.store(false, Ordering::Relaxed);
-                            let _ = event_tx_for_block
-                                .send(Event::SessionContextReset {
-                                    reason: format!("session/load failed: {e}"),
-                                })
-                                .await;
+                            // Set the flag BEFORE sending the request: claude-agent-acp
+                            // re-emits the prior transcript via session/update
+                            // notifications *during* the load handshake, before the
+                            // LoadSessionRequest response returns. Setting after .await
+                            // would let those notifications leak through to the event
+                            // store and produce duplicate ToolCallStarted rows on the
+                            // next reload (assistant-ui then panics with "Duplicate
+                            // key toolCallId-..."). Cleared on Err below if we fall
+                            // back to session/new, which has no replay payload.
+                            suppress_for_block.store(true, Ordering::Relaxed);
+                            let req = LoadSessionRequest::new(stored.clone(), cwd.clone());
+                            match connection.send_request(req).block_task().await {
+                                Ok(_resp) => {
+                                    info!(
+                                        target: "cockpit.acp",
+                                        session = %session_label,
+                                        stored_id = %stored,
+                                        "session/load succeeded; suppressing post-load history replay"
+                                    );
+                                    // Emit AcpSessionAssigned even on resume so the
+                                    // frontend reducer can clear any sticky
+                                    // `startupError` / `lastError` from a prior crash
+                                    // (e.g. a respawn after the user's prompt hit a
+                                    // dead pipe). The server-side listener treats a
+                                    // same-id Assigned as a no-op, so this doesn't
+                                    // rewrite sessions.json.
+                                    let _ = event_tx_for_block
+                                        .send(Event::AcpSessionAssigned {
+                                            acp_session_id: stored.clone(),
+                                        })
+                                        .await;
+                                    acp_session_id = Some(SessionId::from(stored));
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        target: "cockpit.acp",
+                                        session = %session_label,
+                                        stored_id = %stored,
+                                        "session/load failed, falling back to session/new: {e}"
+                                    );
+                                    suppress_for_block.store(false, Ordering::Relaxed);
+                                    let _ = event_tx_for_block
+                                        .send(Event::SessionContextReset {
+                                            reason: format!("session/load failed: {e}"),
+                                        })
+                                        .await;
+                                }
+                            }
                         }
                     }
+
+                    if let Some(id) = acp_session_id {
+                        id
+                    } else {
+                        info!(
+                            target: "cockpit.acp",
+                            session = %session_label,
+                            "creating fresh session via session/new"
+                        );
+                        let new_session = connection
+                            .send_request(NewSessionRequest::new(cwd))
+                            .block_task()
+                            .await?;
+                        let id = new_session.session_id.clone();
+                        info!(
+                            target: "cockpit.acp",
+                            session = %session_label,
+                            new_id = %id.0,
+                            "session/new succeeded, captured acp_session_id"
+                        );
+
+                        // Surface the agent-advertised modes (if any) so the UI
+                        // can render the actual modes the agent supports rather
+                        // than the hard-coded four. Claude's adapter typically
+                        // ships a mode set with ids like "default" / "plan" /
+                        // "accept_edits" / "bypass_permissions".
+                        if let Some(modes) = &new_session.modes {
+                            let infos: Vec<ModeInfo> = modes
+                                .available_modes
+                                .iter()
+                                .map(|m| ModeInfo {
+                                    id: m.id.0.to_string(),
+                                    name: m.name.clone(),
+                                    description: m.description.clone(),
+                                })
+                                .collect();
+                            let _ = event_tx_for_block
+                                .send(Event::ModesAvailable {
+                                    current_mode_id: modes.current_mode_id.0.to_string(),
+                                    modes: infos,
+                                })
+                                .await;
+                        }
+
+                        // Tell the server-side listener so it can persist the
+                        // new id on Instance.cockpit_acp_session_id.
+                        let _ = event_tx_for_block
+                            .send(Event::AcpSessionAssigned {
+                                acp_session_id: id.0.to_string(),
+                            })
+                            .await;
+
+                        id
+                    }
                 }
-            }
-
-            let acp_session_id = if let Some(id) = acp_session_id {
-                id
-            } else {
-                info!(
-                    target: "cockpit.acp",
-                    session = %session_label,
-                    "creating fresh session via session/new"
-                );
-                let new_session = connection
-                    .send_request(NewSessionRequest::new(cwd))
-                    .block_task()
-                    .await?;
-                let id = new_session.session_id.clone();
-                info!(
-                    target: "cockpit.acp",
-                    session = %session_label,
-                    new_id = %id.0,
-                    "session/new succeeded, captured acp_session_id"
-                );
-
-                // Surface the agent-advertised modes (if any) so the UI
-                // can render the actual modes the agent supports rather
-                // than the hard-coded four. Claude's adapter typically
-                // ships a mode set with ids like "default" / "plan" /
-                // "accept_edits" / "bypass_permissions".
-                if let Some(modes) = &new_session.modes {
-                    let infos: Vec<ModeInfo> = modes
-                        .available_modes
-                        .iter()
-                        .map(|m| ModeInfo {
-                            id: m.id.0.to_string(),
-                            name: m.name.clone(),
-                            description: m.description.clone(),
-                        })
-                        .collect();
-                    let _ = event_tx_for_block
-                        .send(Event::ModesAvailable {
-                            current_mode_id: modes.current_mode_id.0.to_string(),
-                            modes: infos,
-                        })
-                        .await;
-                }
-
-                // Tell the server-side listener so it can persist the
-                // new id on Instance.cockpit_acp_session_id.
-                let _ = event_tx_for_block
-                    .send(Event::AcpSessionAssigned {
-                        acp_session_id: id.0.to_string(),
-                    })
-                    .await;
-
-                id
             };
 
             if let Some(tx) = ready_for_block.lock().await.take() {
                 let _ = tx.send(Ok(()));
+            }
+
+            // Arm the resume-idle watchdog. The agent's response to the
+            // orphaned in-flight `session/prompt` (from the previous
+            // daemon) carries a request id this client never issued and
+            // is dropped silently by the transport. Without this
+            // synthesized Stopped, the UI's "thinking" indicator never
+            // clears until the user manually sends a new prompt.
+            if arm_resume_watchdog {
+                let event_tx_for_watchdog = event_tx_for_block.clone();
+                let last_event_at = last_event_at.clone();
+                let prompt_sent_since_attach = prompt_sent_since_attach.clone();
+                let watchdog_fired = watchdog_fired.clone();
+                let session_label_for_watchdog = session_label.clone();
+                tokio::spawn(async move {
+                    let grace_ms = RESUME_IDLE_GRACE.as_millis() as i64;
+                    loop {
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        if watchdog_fired.load(Ordering::Relaxed) {
+                            return;
+                        }
+                        if prompt_sent_since_attach.load(Ordering::Relaxed) {
+                            // User sent a new prompt; its real
+                            // PromptRequest will own the next Stopped.
+                            return;
+                        }
+                        let last = last_event_at.load(Ordering::Relaxed);
+                        let now = chrono::Utc::now().timestamp_millis();
+                        if now - last >= grace_ms {
+                            info!(
+                                target: "cockpit.acp",
+                                session = %session_label_for_watchdog,
+                                idle_ms = now - last,
+                                "resume-idle watchdog: synthesizing Stopped for orphaned in-flight turn"
+                            );
+                            watchdog_fired.store(true, Ordering::Relaxed);
+                            let _ = event_tx_for_watchdog
+                                .send(Event::Stopped {
+                                    reason: "reattach_idle".into(),
+                                })
+                                .await;
+                            return;
+                        }
+                    }
+                });
             }
 
             loop {
@@ -1465,6 +1641,11 @@ async fn run_connection_task<W, R>(
                                 "first user prompt after session/load; resuming notification pump"
                             );
                         }
+                        // Stand the resume-idle watchdog down: the new
+                        // prompt's real Stopped will own the next status
+                        // transition, so we no longer need to synthesize
+                        // one for the orphaned prior turn.
+                        prompt_sent_since_attach.store(true, Ordering::Relaxed);
                         info!(target: "cockpit.acp", "sending prompt ({} chars)", text.len());
                         let _ = connection
                             .send_request(PromptRequest::new(

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -133,11 +133,15 @@ enum ConnectMode {
 /// bounded.
 const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(10);
 
-/// Read the resume-idle grace, honoring the `AOE_RESUME_IDLE_GRACE_MS`
-/// env var so integration tests can short-circuit the default 10s
-/// without making real failures racy. Values below 100ms are clamped
-/// up so a typo can't disable the watchdog effectively.
+/// Read the resume-idle grace. In debug builds, honors
+/// `AOE_RESUME_IDLE_GRACE_MS` so integration tests can short-circuit
+/// the default 10s without making real failures racy. Values below
+/// 100ms are clamped up so a typo can't effectively disable the
+/// watchdog. Release builds always use `RESUME_IDLE_GRACE_DEFAULT`
+/// so a misconfigured env var can't surface false-positive Stopped
+/// events to real users.
 fn resume_idle_grace() -> std::time::Duration {
+    #[cfg(debug_assertions)]
     if let Ok(raw) = std::env::var("AOE_RESUME_IDLE_GRACE_MS") {
         if let Ok(ms) = raw.parse::<u64>() {
             return std::time::Duration::from_millis(ms.max(100));
@@ -1435,15 +1439,25 @@ async fn run_connection_task<W, R>(
                     acp_session_id: stored,
                     in_flight_turn: _,
                 } => {
-                    // Skip session/new and session/load. The runner kept
-                    // the agent process alive across the daemon restart,
-                    // so the session is still loaded in the agent's
-                    // memory and addressable via its original id. Issuing
-                    // session/load here would either fail (agents that
-                    // advertise loadSession=false) or double-load against
-                    // a still-busy session; issuing session/new would
-                    // split context onto a new id the in-flight turn
-                    // doesn't address.
+                    // INVARIANT: Resume mode MUST NOT send `session/new`
+                    // or `session/load`. This is the load-bearing trick
+                    // that makes mid-turn continuity work across
+                    // `aoe serve --stop` + `aoe serve`. Do not "fix" it
+                    // by adding either call here.
+                    //
+                    // Why: the runner kept the agent process alive
+                    // across the daemon restart, so the ACP session is
+                    // still loaded in the agent's memory and addressable
+                    // via its original id. `session/load` would either
+                    // fail (agents that advertise loadSession=false) or
+                    // double-load against a still-busy session and
+                    // replay the entire transcript at the user.
+                    // `session/new` would split context onto a new id
+                    // the in-flight `session/prompt` doesn't address,
+                    // silently orphaning the turn the user is waiting
+                    // on. See issue #1037 and the
+                    // `tests/cockpit_midturn_resume.rs` integration
+                    // coverage.
                     info!(
                         target: "cockpit.acp",
                         session = %session_label,

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -131,7 +131,20 @@ enum ConnectMode {
 /// intra-turn silence near this duration so the false-positive risk
 /// (UI flips to Idle then back to Streaming on the next chunk) is
 /// bounded.
-const RESUME_IDLE_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
+const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Read the resume-idle grace, honoring the `AOE_RESUME_IDLE_GRACE_MS`
+/// env var so integration tests can short-circuit the default 10s
+/// without making real failures racy. Values below 100ms are clamped
+/// up so a typo can't disable the watchdog effectively.
+fn resume_idle_grace() -> std::time::Duration {
+    if let Ok(raw) = std::env::var("AOE_RESUME_IDLE_GRACE_MS") {
+        if let Ok(ms) = raw.parse::<u64>() {
+            return std::time::Duration::from_millis(ms.max(100));
+        }
+    }
+    RESUME_IDLE_GRACE_DEFAULT
+}
 
 /// Resolution channel + the option set the agent offered. Stored in the
 /// pending-responders map keyed by the cockpit's server-generated nonce.
@@ -1590,8 +1603,9 @@ async fn run_connection_task<W, R>(
                 let prompt_sent_since_attach = prompt_sent_since_attach.clone();
                 let watchdog_fired = watchdog_fired.clone();
                 let session_label_for_watchdog = session_label.clone();
+                let grace = resume_idle_grace();
                 tokio::spawn(async move {
-                    let grace_ms = RESUME_IDLE_GRACE.as_millis() as i64;
+                    let grace_ms = grace.as_millis() as i64;
                     loop {
                         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
                         if watchdog_fired.load(Ordering::Relaxed) {

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -308,6 +308,62 @@ impl EventStore {
         collected
     }
 
+    /// True iff the session has a `UserPromptSent` whose turn never
+    /// terminated (no later `Stopped` or `AgentStartupError`). Used at
+    /// daemon startup to decide whether to synthesize a `Stopped` event
+    /// for a session that was mid-turn when the previous `aoe serve`
+    /// died, and on reattach to arm the resume-idle watchdog.
+    ///
+    /// `Stopped` and `AgentStartupError` are serialized externally-tagged
+    /// (`{"Stopped":{"reason":"..."}}`) so we match on the variant key
+    /// via `json_extract($.Stopped)`.
+    pub fn has_in_flight_turn(&self, session_id: &str) -> bool {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let prompt_seq: Option<i64> = match conn
+            .query_row(
+                "SELECT MAX(seq) FROM cockpit_events
+                 WHERE session_id = ?1
+                   AND json_extract(event_json, '$.UserPromptSent') IS NOT NULL",
+                params![session_id],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+        {
+            Ok(Some(v)) => v,
+            Ok(None) => None,
+            Err(e) => {
+                warn!(target: "cockpit.event_store", "has_in_flight_turn prompt query {session_id}: {e}");
+                return false;
+            }
+        };
+        let Some(prompt_seq) = prompt_seq else {
+            return false;
+        };
+        let terminator: Option<i64> = match conn
+            .query_row(
+                "SELECT MIN(seq) FROM cockpit_events
+                 WHERE session_id = ?1
+                   AND seq > ?2
+                   AND (json_extract(event_json, '$.Stopped') IS NOT NULL
+                     OR json_extract(event_json, '$.AgentStartupError') IS NOT NULL)",
+                params![session_id, prompt_seq],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .optional()
+        {
+            Ok(Some(v)) => v,
+            Ok(None) => None,
+            Err(e) => {
+                warn!(target: "cockpit.event_store", "has_in_flight_turn terminator query {session_id}: {e}");
+                return false;
+            }
+        };
+        terminator.is_none()
+    }
+
     /// Drop every event for a session. Called when the session is
     /// deleted or its substrate is switched away from cockpit, so the
     /// next cockpit_enable starts fresh from seq=1.
@@ -449,6 +505,112 @@ mod tests {
         let mut listed = store.all_session_seqs();
         listed.sort();
         assert_eq!(listed, vec![("s-1".to_string(), 2), ("s-2".to_string(), 1)]);
+    }
+
+    #[test]
+    fn has_in_flight_turn_empty_store_returns_false() {
+        let (_tmp, store) = open_store(1000);
+        assert!(!store.has_in_flight_turn("s-1"));
+    }
+
+    #[test]
+    fn has_in_flight_turn_true_when_chunks_unterminated() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::AgentMessageChunk {
+                    text: "thinking".into(),
+                },
+            )
+            .unwrap();
+        assert!(store.has_in_flight_turn("s-1"));
+    }
+
+    #[test]
+    fn has_in_flight_turn_false_when_stopped_after_prompt() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::AgentMessageChunk {
+                    text: "done".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                3,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        assert!(!store.has_in_flight_turn("s-1"));
+    }
+
+    #[test]
+    fn has_in_flight_turn_false_when_agent_startup_error_after_prompt() {
+        let (_tmp, store) = open_store(1000);
+        store
+            .record("s-1", 1, &Event::UserPromptSent { text: "go".into() })
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::AgentStartupError {
+                    message: "boom".into(),
+                },
+            )
+            .unwrap();
+        assert!(!store.has_in_flight_turn("s-1"));
+    }
+
+    #[test]
+    fn has_in_flight_turn_uses_latest_prompt_only() {
+        // First turn completed. Second turn in flight. Should return true.
+        let (_tmp, store) = open_store(1000);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::UserPromptSent {
+                    text: "first".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::Stopped {
+                    reason: "prompt_complete".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                3,
+                &Event::UserPromptSent {
+                    text: "second".into(),
+                },
+            )
+            .unwrap();
+        store
+            .record("s-1", 4, &Event::AgentMessageChunk { text: "mid".into() })
+            .unwrap();
+        assert!(store.has_in_flight_turn("s-1"));
     }
 
     #[test]

--- a/src/cockpit/mod.rs
+++ b/src/cockpit/mod.rs
@@ -19,9 +19,11 @@ pub mod event_store;
 pub mod fs_handler;
 pub mod node;
 pub mod permissions;
+pub mod runner;
 pub mod state;
 pub mod supervisor;
 pub mod terminal_handler;
+pub mod worker_registry;
 
 pub use agent_registry::{AgentRegistry, AgentSpec};
 pub use approvals::{Approval, ApprovalDecision, Nonce};

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -97,6 +97,15 @@ pub struct CockpitRunnerArgs {
 
 /// Entry point dispatched from `main.rs`.
 pub async fn run(args: CockpitRunnerArgs) -> Result<()> {
+    // `aoe __cockpit-runner` is a hidden subcommand, but a curious
+    // user can still invoke it directly. The session_id flows into
+    // path construction for the registry/socket/log files; validate
+    // it up front so a malicious `--session-id "../../foo"` can't
+    // write files outside the workers dir. Production callers pass
+    // UUIDs which pass trivially. This is a defensive check, not the
+    // only one: `worker_registry::{record_path, socket_path_for,
+    // log_path_for, restart_marker_path}` all re-validate.
+    worker_registry::validate_session_id(&args.session_id).context("invalid --session-id")?;
     init_runner_logging(&args.session_id)?;
 
     info!(

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -1,0 +1,473 @@
+//! `aoe __cockpit-runner` — the per-worker shim that owns the agent
+//! subprocess and outlives `aoe serve`.
+//!
+//! Invoked by `Supervisor::spawn` as a detached child via `setsid` so its
+//! process group is independent of the daemon's. The runner:
+//!
+//! 1. Writes a registry entry at
+//!    `<app_dir>/cockpit-workers/<session_id>.json` with its PID, socket
+//!    path, and agent metadata.
+//! 2. Spawns the configured ACP agent as a child over stdio.
+//! 3. Binds a Unix listener at `<app_dir>/cockpit-workers/<session_id>.sock`
+//!    and accepts connections in a loop, proxying bytes between the
+//!    currently-connected aoe daemon and the agent's stdio.
+//! 4. Buffers agent → daemon traffic (line-oriented ndjson) in a ring
+//!    buffer while no daemon is attached, so the next reattach replays
+//!    the gap.
+//! 5. On agent exit or SIGTERM/SIGINT: deletes the registry file and
+//!    socket, then exits.
+//!
+//! The daemon disconnects the unix socket on `detach_all` without
+//! signalling the runner; the runner just sees a closed connection and
+//! goes back to accepting.
+//!
+//! Logging: the runner appends to
+//! `<app_dir>/cockpit-workers/<session_id>.log` so `aoe cockpit logs
+//! --session <id> --follow` can tail it independently of `serve.log`.
+
+use std::collections::VecDeque;
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Context, Result};
+use clap::Args;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::process::{Child, Command};
+use tokio::sync::Mutex;
+use tracing::{debug, info, warn};
+
+use super::worker_registry::{self, WorkerRecord};
+
+/// Cap on agent → daemon notification lines stored while detached.
+/// Each entry is at most one ndjson line (a few KB). Past this, oldest
+/// entries are dropped — the daemon-side event_store still has them.
+const NOTIFICATION_BUFFER_LINES: usize = 256;
+
+/// Pipe-read buffer for the agent's stdout. 64KB matches the default
+/// pipe size on macOS/Linux.
+const STDOUT_READ_BUF: usize = 64 * 1024;
+
+#[derive(Args, Debug, Clone)]
+pub struct CockpitRunnerArgs {
+    #[arg(long)]
+    pub socket: PathBuf,
+    #[arg(long)]
+    pub session_id: String,
+    #[arg(long)]
+    pub agent_name: String,
+    #[arg(long)]
+    pub cwd: PathBuf,
+    #[arg(long)]
+    pub model: Option<String>,
+    #[arg(long, value_delimiter = ',')]
+    pub additional_dirs: Vec<PathBuf>,
+    /// Comma-separated keys of provider_env passed through at spawn.
+    /// Recorded in the registry so `aoe cockpit ps` can show what
+    /// auth-shape the session uses without re-reading the daemon.
+    #[arg(long, value_delimiter = ',', default_value = "")]
+    pub provider_env_keys: Vec<String>,
+    /// Cached ACP session id, written by the daemon and read on
+    /// reattach. The runner doesn't itself use this field — it surfaces
+    /// in the registry for the daemon's restart path.
+    #[arg(long)]
+    pub stored_acp_session_id: Option<String>,
+    /// Agent program + args after `--`.
+    #[arg(last = true, required = true)]
+    pub agent_argv: Vec<String>,
+}
+
+/// Entry point dispatched from `main.rs`.
+pub async fn run(args: CockpitRunnerArgs) -> Result<()> {
+    init_runner_logging(&args.session_id)?;
+
+    info!(
+        target: "cockpit.runner",
+        session = %args.session_id,
+        socket = %args.socket.display(),
+        agent = %args.agent_name,
+        "cockpit runner starting"
+    );
+
+    // Bind the socket BEFORE spawning the agent so the daemon's
+    // post-spawn connect doesn't race the listener creation.
+    if args.socket.exists() {
+        let _ = std::fs::remove_file(&args.socket);
+    }
+    if let Some(parent) = args.socket.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating socket dir {}", parent.display()))?;
+    }
+    let listener = UnixListener::bind(&args.socket)
+        .with_context(|| format!("bind {}", args.socket.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&args.socket, std::fs::Permissions::from_mode(0o600));
+    }
+
+    let (mut agent_child, agent_stdin, agent_stdout, agent_stderr) =
+        spawn_agent(&args).with_context(|| format!("spawning agent {:?}", args.agent_argv))?;
+
+    let our_pid = std::process::id();
+    let record = WorkerRecord::new(
+        args.session_id.clone(),
+        our_pid,
+        args.socket.clone(),
+        args.agent_name.clone(),
+        args.cwd.clone(),
+        args.model.clone(),
+        args.additional_dirs.clone(),
+        args.provider_env_keys.clone(),
+        args.stored_acp_session_id.clone(),
+    );
+    worker_registry::save(&record).context("writing registry record")?;
+
+    // Drain agent stderr into the per-session log file. Without this the
+    // child blocks once the stderr pipe fills (~64KB on Linux), looking
+    // like a wedged handshake.
+    if let Some(stderr) = agent_stderr {
+        let label = args.session_id.clone();
+        tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                debug!(target: "cockpit.runner.agent.stderr", session = %label, "{line}");
+            }
+        });
+    }
+
+    let shared = Arc::new(RunnerShared::new());
+
+    // Fan-out task: reads agent stdout and either forwards to the
+    // currently-attached daemon or buffers in the ring. Single owner of
+    // the read half of the agent's stdout pipe.
+    let agent_stdout_task = tokio::spawn(fanout_agent_stdout(
+        agent_stdout,
+        Arc::clone(&shared),
+        args.session_id.clone(),
+    ));
+
+    // Wrap agent stdin in a tokio Mutex so the accept loop can hand it
+    // to one connection at a time. Wrapping (not splitting) keeps stdin
+    // alive across reconnects — closing it would cause aoe-agent to
+    // `process.exit(0)`.
+    let agent_stdin = Arc::new(Mutex::new(agent_stdin));
+
+    // Signal handling: SIGTERM/SIGINT → kill agent, cleanup, exit.
+    let shutdown_signal = wait_for_shutdown();
+
+    let session_id = args.session_id.clone();
+    let accept_session_id = session_id.clone();
+    let accept_shared = Arc::clone(&shared);
+    let accept_loop = async move {
+        loop {
+            match listener.accept().await {
+                Ok((stream, _addr)) => {
+                    info!(
+                        target: "cockpit.runner",
+                        session = %accept_session_id,
+                        "daemon connected"
+                    );
+                    worker_registry::mark_attached(&accept_session_id);
+                    handle_connection(
+                        stream,
+                        Arc::clone(&accept_shared),
+                        Arc::clone(&agent_stdin),
+                        accept_session_id.clone(),
+                    )
+                    .await;
+                    info!(
+                        target: "cockpit.runner",
+                        session = %accept_session_id,
+                        "daemon disconnected; runner stays alive"
+                    );
+                    worker_registry::mark_detached(&accept_session_id);
+                }
+                Err(e) => {
+                    warn!(target: "cockpit.runner", "accept error: {e}");
+                    tokio::time::sleep(Duration::from_millis(100)).await;
+                }
+            }
+        }
+    };
+
+    // Wait for: agent exit, signal, or accept loop death (latter is
+    // unreachable but kept for symmetry).
+    tokio::select! {
+        status = agent_child.wait() => {
+            match status {
+                Ok(s) => info!(
+                    target: "cockpit.runner",
+                    session = %session_id,
+                    status = ?s,
+                    "agent exited; runner shutting down"
+                ),
+                Err(e) => warn!(
+                    target: "cockpit.runner",
+                    session = %session_id,
+                    "agent wait error: {e}"
+                ),
+            }
+        }
+        _ = shutdown_signal => {
+            info!(
+                target: "cockpit.runner",
+                session = %session_id,
+                "shutdown signal received; terminating agent"
+            );
+            let _ = agent_child.start_kill();
+            let _ = agent_child.wait().await;
+        }
+        _ = accept_loop => {
+            warn!(target: "cockpit.runner", session = %session_id, "accept loop exited unexpectedly");
+        }
+    }
+
+    agent_stdout_task.abort();
+    worker_registry::delete(&session_id).ok();
+    Ok(())
+}
+
+/// State the accept loop and the agent-stdout fanout share. The active
+/// connection is the daemon's write-half of the socket; only one daemon
+/// is attached at a time.
+struct RunnerShared {
+    /// The currently-attached daemon's send-side of the unix socket. The
+    /// fanout task writes agent → daemon notifications here when set.
+    active_outbound: Mutex<Option<tokio::net::unix::OwnedWriteHalf>>,
+    /// Ring of agent → daemon ndjson lines that arrived while no daemon
+    /// was attached. Drained into the next attached daemon's outbound.
+    pending: Mutex<VecDeque<Vec<u8>>>,
+}
+
+impl RunnerShared {
+    fn new() -> Self {
+        Self {
+            active_outbound: Mutex::new(None),
+            pending: Mutex::new(VecDeque::with_capacity(NOTIFICATION_BUFFER_LINES)),
+        }
+    }
+
+    /// Forward a line to the daemon if attached; else buffer. Returns
+    /// whether forwarding happened (false → buffered).
+    async fn deliver_line(&self, line: &[u8]) -> bool {
+        let mut guard = self.active_outbound.lock().await;
+        if let Some(out) = guard.as_mut() {
+            if out.write_all(line).await.is_ok() && out.flush().await.is_ok() {
+                return true;
+            }
+            // Write failure: daemon side closed. Drop the writer and
+            // buffer this line for the next attach.
+            *guard = None;
+        }
+        drop(guard);
+        let mut pending = self.pending.lock().await;
+        while pending.len() >= NOTIFICATION_BUFFER_LINES {
+            pending.pop_front();
+        }
+        pending.push_back(line.to_vec());
+        false
+    }
+
+    /// Install the daemon's outbound write half. First drains the
+    /// pending ring into it so the reattaching daemon sees the gap's
+    /// notifications.
+    async fn install_outbound(
+        &self,
+        mut out: tokio::net::unix::OwnedWriteHalf,
+    ) -> Option<tokio::net::unix::OwnedWriteHalf> {
+        let mut pending = self.pending.lock().await;
+        while let Some(line) = pending.pop_front() {
+            if out.write_all(&line).await.is_err() || out.flush().await.is_err() {
+                // Drain failed mid-way — push the remaining lines back
+                // and surface the write half as unusable.
+                pending.push_front(line);
+                return None;
+            }
+        }
+        drop(pending);
+        let mut guard = self.active_outbound.lock().await;
+        let prev = guard.take();
+        *guard = Some(out);
+        prev
+    }
+
+    async fn clear_outbound(&self) {
+        let mut guard = self.active_outbound.lock().await;
+        *guard = None;
+    }
+}
+
+/// Read agent stdout line-by-line (ndjson) and either forward to the
+/// daemon or buffer.
+async fn fanout_agent_stdout(
+    stdout: tokio::process::ChildStdout,
+    shared: Arc<RunnerShared>,
+    session_id: String,
+) {
+    let mut reader = BufReader::with_capacity(STDOUT_READ_BUF, stdout);
+    let mut line = Vec::with_capacity(4096);
+    loop {
+        line.clear();
+        // read_until preserves the trailing newline, which ndjson
+        // consumers (the daemon's ACP transport) need.
+        match reader.read_until(b'\n', &mut line).await {
+            Ok(0) => {
+                debug!(target: "cockpit.runner", session = %session_id, "agent stdout EOF");
+                break;
+            }
+            Ok(_) => {
+                shared.deliver_line(&line).await;
+            }
+            Err(e) => {
+                warn!(target: "cockpit.runner", session = %session_id, "stdout read error: {e}");
+                break;
+            }
+        }
+    }
+}
+
+/// Handle one daemon connection: install its write half, then pump
+/// inbound bytes (daemon → agent stdin) until the socket closes.
+async fn handle_connection(
+    stream: UnixStream,
+    shared: Arc<RunnerShared>,
+    agent_stdin: Arc<Mutex<tokio::process::ChildStdin>>,
+    session_id: String,
+) {
+    let (read_half, write_half) = stream.into_split();
+    let prev = shared.install_outbound(write_half).await;
+    if prev.is_some() {
+        debug!(
+            target: "cockpit.runner",
+            session = %session_id,
+            "evicting prior daemon outbound (concurrent attach)"
+        );
+    }
+
+    let mut read_half = read_half;
+    let mut buf = [0u8; STDOUT_READ_BUF];
+    loop {
+        match read_half.read(&mut buf).await {
+            Ok(0) => break, // EOF: daemon closed the connection.
+            Ok(n) => {
+                let mut stdin = agent_stdin.lock().await;
+                if stdin.write_all(&buf[..n]).await.is_err() || stdin.flush().await.is_err() {
+                    warn!(
+                        target: "cockpit.runner",
+                        session = %session_id,
+                        "agent stdin write failed; agent likely exited"
+                    );
+                    break;
+                }
+            }
+            Err(e) => {
+                warn!(target: "cockpit.runner", session = %session_id, "daemon read error: {e}");
+                break;
+            }
+        }
+    }
+    shared.clear_outbound().await;
+}
+
+fn spawn_agent(
+    args: &CockpitRunnerArgs,
+) -> Result<(
+    Child,
+    tokio::process::ChildStdin,
+    tokio::process::ChildStdout,
+    Option<tokio::process::ChildStderr>,
+)> {
+    let mut argv = args.agent_argv.iter();
+    let program = argv
+        .next()
+        .ok_or_else(|| anyhow!("agent_argv empty; expected `-- <command> [args...]`"))?;
+    let mut cmd = Command::new(program);
+    for a in argv {
+        cmd.arg(a);
+    }
+    cmd.current_dir(&args.cwd)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    // Inherit env from the runner's launching daemon (env is already
+    // filtered at the daemon-side spawn site in acp_client.rs).
+    let mut child = cmd.spawn().with_context(|| format!("spawning {program}"))?;
+    let stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("agent has no stdin"))?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("agent has no stdout"))?;
+    let stderr = child.stderr.take();
+    Ok((child, stdin, stdout, stderr))
+}
+
+#[cfg(unix)]
+async fn wait_for_shutdown() {
+    use tokio::signal::unix::{signal, SignalKind};
+    let mut sigterm = signal(SignalKind::terminate()).ok();
+    let mut sigint = signal(SignalKind::interrupt()).ok();
+    tokio::select! {
+        _ = async {
+            match sigterm.as_mut() {
+                Some(s) => { s.recv().await; }
+                None => std::future::pending().await,
+            }
+        } => {}
+        _ = async {
+            match sigint.as_mut() {
+                Some(s) => { s.recv().await; }
+                None => std::future::pending().await,
+            }
+        } => {}
+    }
+}
+
+#[cfg(not(unix))]
+async fn wait_for_shutdown() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
+fn init_runner_logging(session_id: &str) -> Result<()> {
+    let log_path = worker_registry::log_path_for(session_id)?;
+    open_log_file(&log_path)?;
+    // tracing-subscriber may already be initialised by main; try_init
+    // silently no-ops in that case. If we're a fresh process (we are,
+    // when invoked as `aoe __cockpit-runner`), this wires the file
+    // writer so runner logs go to the per-session log file.
+    if let Ok(file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+    {
+        tracing_subscriber::fmt()
+            .with_env_filter("cockpit=info,agent_of_empires=info")
+            .with_writer(std::sync::Mutex::new(file))
+            .with_ansi(false)
+            .try_init()
+            .ok();
+    }
+    Ok(())
+}
+
+fn open_log_file(path: &Path) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .with_context(|| format!("opening runner log {}", path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(())
+}

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -24,6 +24,22 @@
 //! Logging: the runner appends to
 //! `<app_dir>/cockpit-workers/<session_id>.log` so `aoe cockpit logs
 //! --session <id> --follow` can tail it independently of `serve.log`.
+//!
+//! ## Why a shim and not "let the agent bind the socket"
+//!
+//! Issue #1037's Proposal A suggested patching ACP agents to listen on
+//! a unix socket directly, with the daemon connecting in. That works
+//! for cooperating agents (`aoe-agent` already honors `AOE_ACP_SOCKET`)
+//! but the third-party agents we proxy (`claude-agent-acp`, etc.)
+//! only speak stdio today. This shim bridges stdio-only agents into
+//! the socket-mode lifecycle without requiring upstream changes.
+//!
+//! Treat the shim as a deprecation path, not a permanent layer:
+//! agents that gain native socket-mode transport in the future can
+//! bypass `aoe __cockpit-runner` entirely and have the daemon connect
+//! to them directly. The wire protocol is just newline-delimited
+//! JSON-RPC (ACP), no shim-specific framing, so collapsing this
+//! process is purely an agent-side change.
 
 use std::collections::VecDeque;
 use std::path::{Path, PathBuf};

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1948,6 +1948,73 @@ mod tests {
         }
     }
 
+    /// Capacity must count detached (registry-only) workers, not just
+    /// in-memory ones. Issue #1037 called this out explicitly: a fresh
+    /// daemon spawn must not race the reconciler and over-spawn while
+    /// it's still attaching to live runners. Without this, two
+    /// consecutive `aoe serve` invocations could push the worker count
+    /// past `max_concurrent_workers`.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn capacity_counts_detached_registry_entries() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; isolating HOME keeps this
+        // test's registry writes away from the developer's real
+        // dev-mode entries (and any other tests in this file).
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let sink = VecSink::new();
+        let sup = Supervisor::with_capacity(sink, 1);
+
+        // No in-memory workers. Just a single registry entry that
+        // `is_record_live` will accept: PID = current process (so
+        // pid_alive is true) and a real file at the socket path (so
+        // socket_exists is true).
+        let registry_dir = crate::cockpit::worker_registry::workers_dir().unwrap();
+        let socket_path = registry_dir.join("detached-1.sock");
+        std::fs::write(&socket_path, b"").unwrap();
+        let record = crate::cockpit::worker_registry::WorkerRecord::new(
+            "detached-1".into(),
+            std::process::id(),
+            socket_path,
+            "claude-code".into(),
+            std::env::temp_dir(),
+            None,
+            vec![],
+            vec![],
+            None,
+        );
+        crate::cockpit::worker_registry::save(&record).unwrap();
+
+        // Pre-condition: registry entry must be live for the capacity
+        // path to count it. If this fails, the test setup is wrong.
+        assert!(
+            crate::cockpit::worker_registry::is_record_live(&record),
+            "registry record must be live for the capacity path to count it"
+        );
+
+        let result = sup
+            .spawn(SpawnRequest {
+                session_id: "fresh".into(),
+                agent: "claude-code".into(),
+                cwd: std::env::temp_dir(),
+                additional_dirs: vec![],
+                provider_env: vec![],
+                model: None,
+                stored_acp_session_id: None,
+            })
+            .await;
+        match result {
+            Err(SupervisorError::CapacityFull { current, limit }) => {
+                assert_eq!(current, 1, "detached registry entry must count");
+                assert_eq!(limit, 1);
+            }
+            other => panic!("expected CapacityFull, got {other:?}"),
+        }
+    }
+
     /// `forget_session` drops the seq counter so the next conversation
     /// (e.g. cockpit_disable → cockpit_enable) starts fresh from seq=1.
     #[tokio::test]

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -619,6 +619,31 @@ impl<S: BroadcastSink> Supervisor<S> {
                             // Exit quietly.
                             return;
                         }
+                        RestartDecision::UserStopped => {
+                            info!(
+                                target: "cockpit.supervisor",
+                                session = %session_id,
+                                "worker registry deleted by user (`aoe cockpit stop|kill`); \
+                                 dropping WorkerHandle without respawn"
+                            );
+                            // Emit a Stopped so the UI clears any
+                            // "thinking" indicator the user might have
+                            // been staring at when they ran `aoe cockpit
+                            // stop`. The reconciler will spawn a fresh
+                            // worker on its next tick if the session is
+                            // still cockpit_mode.
+                            let seq = next_seq(&next_seqs, &session_id);
+                            sink.publish(
+                                &session_id,
+                                seq,
+                                &Event::Stopped {
+                                    reason: "user_stopped".into(),
+                                },
+                            );
+                            let mut guard = workers.lock().await;
+                            guard.remove(&session_id);
+                            return;
+                        }
                     };
 
                 tokio::time::sleep(RESPAWN_BACKOFF).await;
@@ -1023,6 +1048,71 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn count(&self) -> usize {
         self.workers.lock().await.len()
     }
+
+    /// Reap workers whose on-disk registry entry has disappeared while
+    /// the in-memory `WorkerHandle` is still installed. This is the
+    /// out-of-band stop signal: `aoe cockpit stop|kill` (a separate
+    /// process from the daemon) deletes the registry entry, then
+    /// SIGTERMs the runner. The daemon's protocol-layer connection task
+    /// blocks on `cmd_rx.recv()` while idle, so socket EOF does NOT
+    /// propagate back into the closure — `event_tx` never drops, the
+    /// drain task never observes inbound closure, and `restart_decision`
+    /// never runs. Without an explicit poll, the UI stays stuck on
+    /// "thinking" with a phantom worker recorded in the supervisor.
+    ///
+    /// Called by the reconciler every 2s. For each runner-managed worker
+    /// whose registry entry is gone, publishes `Stopped{reason:
+    /// "user_stopped"}` so the frontend can clear the spinner and offer
+    /// a reconnect button, then tears down the WorkerHandle (sends ACP
+    /// Shutdown so the connection task exits cleanly, aborts the drain
+    /// task). The stdio-only test path is skipped because those handles
+    /// have no registry entry by construction.
+    pub async fn reap_user_stopped(&self) {
+        // Snapshot candidate session ids without holding the workers lock
+        // across the registry read or the publish/teardown — the
+        // teardown takes the client lock and we don't want to nest.
+        let candidates: Vec<String> = {
+            let workers = self.workers.lock().await;
+            workers
+                .iter()
+                .filter(|(_, h)| {
+                    h.spawn_config
+                        .as_ref()
+                        .map(|c| c.socket_path.is_some())
+                        .unwrap_or(false)
+                })
+                .map(|(id, _)| id.clone())
+                .filter(|id| matches!(super::worker_registry::load(id), Ok(None)))
+                .collect()
+        };
+
+        for id in candidates {
+            let removed = self.workers.lock().await.remove(&id);
+            let Some(handle) = removed else { continue };
+            info!(
+                target: "cockpit.supervisor",
+                session = %id,
+                "registry entry gone while worker handle live; \
+                 publishing user_stopped and tearing down"
+            );
+            let seq = next_seq(&self.next_seqs, &id);
+            self.sink.publish(
+                &id,
+                seq,
+                &Event::Stopped {
+                    reason: "user_stopped".into(),
+                },
+            );
+            // Send ACP Shutdown so the connection task's closure breaks
+            // out of its cmd_rx loop and the underlying transport closes
+            // cleanly (avoids a leaked socket fd until the daemon dies).
+            {
+                let client = handle.client.lock().await;
+                let _ = client.shutdown().await;
+            }
+            handle.drain_task.abort();
+        }
+    }
 }
 
 /// SIGTERM the per-session runner if its registry entry has a live PID,
@@ -1042,6 +1132,7 @@ fn terminate_runner_for_session(session_id: &str) {
     super::worker_registry::delete(session_id).ok();
 }
 
+#[derive(Debug)]
 enum RestartDecision {
     // Boxed because `SpawnConfig` is significantly larger than the
     // unit variants — clippy::large_enum_variant flags the size
@@ -1051,6 +1142,13 @@ enum RestartDecision {
     BudgetBurned,
     /// The worker entry was removed (e.g. shutdown).
     Gone,
+    /// The on-disk worker registry entry for this session was deleted
+    /// while the in-memory WorkerHandle still exists. Signals that the
+    /// user (or a peer process) explicitly stopped this worker via
+    /// `aoe cockpit stop|kill`. The drain task removes the WorkerHandle
+    /// and emits a soft `Stopped` event instead of burning the restart
+    /// budget with respawns of an agent the user just terminated.
+    UserStopped,
 }
 
 async fn restart_decision(
@@ -1066,6 +1164,36 @@ async fn restart_decision(
         );
         return RestartDecision::Gone;
     };
+    // Registry-deletion signal: if the on-disk record for this session
+    // was removed but we still hold a WorkerHandle, the user terminated
+    // the runner externally (`aoe cockpit stop|kill`). Don't respawn —
+    // the reconciler will handle a fresh spawn on its next tick if the
+    // session is still `cockpit_mode = true`. Returning `UserStopped`
+    // both skips the respawn budget bookkeeping and lets the drain task
+    // emit a non-crash `Stopped` so the UI clears any "thinking" state
+    // instead of showing the budget-burned red banner.
+    //
+    // Only consult the registry for runner-mediated workers (those have
+    // a `socket_path` in their cached spawn_config). The in-proc stdio
+    // path used by legacy tests has no registry entry by construction,
+    // so the "gone" check would always fire and break unrelated test
+    // fixtures.
+    let runner_managed = handle
+        .spawn_config
+        .as_ref()
+        .map(|c| c.socket_path.is_some())
+        .unwrap_or(false);
+    if runner_managed {
+        let registry_gone = matches!(super::worker_registry::load(session_id), Ok(None));
+        if registry_gone {
+            debug!(
+                target: "cockpit.supervisor",
+                session = %session_id,
+                "restart_decision: registry entry gone, treating as user-initiated stop"
+            );
+            return RestartDecision::UserStopped;
+        }
+    }
     let now = Instant::now();
     let window_start = now - RESTART_WINDOW;
     let pre_count = handle.restart_history.len();
@@ -1321,6 +1449,204 @@ mod tests {
         assert!(matches!(decision, RestartDecision::BudgetBurned));
     }
 
+    /// Regression: `aoe cockpit stop|kill` deletes the registry entry,
+    /// then SIGTERMs the runner. The daemon's drain task sees socket EOF
+    /// and consults `restart_decision`. With the registry entry gone but
+    /// the in-memory `WorkerHandle` still installed, `restart_decision`
+    /// must return `UserStopped` so the drain task drops the handle and
+    /// emits a soft `Stopped` event — NOT `Respawn` (which would race
+    /// the SIGTERM and crash-loop until the budget burned) and NOT
+    /// `BudgetBurned` (which would surface the scary red banner the
+    /// user originally hit).
+    ///
+    /// The gate is "spawn_config.socket_path is Some" (runner-managed)
+    /// + registry entry absent; we explicitly populate `socket_path`
+    /// here so the production code path fires.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn restart_decision_returns_user_stopped_when_registry_deleted() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`; the test fixture restores
+        // env on the next serial test by reassignment. `get_app_dir`
+        // also creates the dir on first call, so an isolated HOME
+        // guarantees an isolated registry root.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink);
+        let dummy_spec = AgentSpec {
+            command: "/bin/true".into(),
+            args: vec![],
+            description: "test fixture".into(),
+            env_allowlist: None,
+        };
+        let dummy_config = SpawnConfig {
+            spec: dummy_spec,
+            cwd: std::env::temp_dir(),
+            additional_dirs: vec![],
+            provider_env: vec![],
+            socket_path: Some(tmp.path().join("dummy.sock")),
+            stored_acp_session_id: None,
+        };
+        {
+            let mut workers = sup.workers.lock().await;
+            let (client, _tx) = AcpClient::fake_for_test(CockpitSessionId("s-stop".into()));
+            let drain = tokio::spawn(async {});
+            workers.insert(
+                "s-stop".into(),
+                WorkerHandle {
+                    client: Arc::new(Mutex::new(client)),
+                    drain_task: drain,
+                    restart_history: vec![],
+                    spawn_config: Some(dummy_config),
+                },
+            );
+        }
+        // No registry entry for "s-stop" — production code reads this
+        // as a user-initiated stop signal.
+        let decision = restart_decision(&sup.workers, "s-stop").await;
+        assert!(
+            matches!(decision, RestartDecision::UserStopped),
+            "expected UserStopped when registry entry is absent, got {decision:?}"
+        );
+    }
+
+    /// `reap_user_stopped` is the polling fallback that catches the
+    /// `aoe cockpit stop|kill` case the drain task cannot detect on its
+    /// own (idle connection task blocks on `cmd_rx.recv()`, so socket
+    /// EOF never propagates back). When a runner-managed worker's
+    /// registry entry vanishes, the reaper must:
+    ///   1. Publish a `Stopped { reason: "user_stopped" }` so the UI
+    ///      clears its spinner and shows the reconnect banner.
+    ///   2. Remove the WorkerHandle so the next reconcile_cockpit_workers
+    ///      tick won't see a phantom worker and skip the auto-spawn path.
+    ///
+    /// We don't assert anything about the drain task's abort here because
+    /// the fixture installs a no-op JoinHandle; the production drain task
+    /// holds the client clone and exits when its inbound channel closes
+    /// (which happens after `client.shutdown()` propagates Shutdown to
+    /// the connection task). Covered indirectly by the
+    /// `restart_decision_returns_user_stopped_when_registry_deleted`
+    /// regression.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn reap_user_stopped_emits_event_and_drops_handle() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // SAFETY: serialised by `#[serial]`. Isolating HOME keeps this
+        // test's worker_registry lookups away from the developer's real
+        // dev-mode entries.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let dummy_spec = AgentSpec {
+            command: "/bin/true".into(),
+            args: vec![],
+            description: "test fixture".into(),
+            env_allowlist: None,
+        };
+        let dummy_config = SpawnConfig {
+            spec: dummy_spec,
+            cwd: std::env::temp_dir(),
+            additional_dirs: vec![],
+            provider_env: vec![],
+            socket_path: Some(tmp.path().join("dummy.sock")),
+            stored_acp_session_id: None,
+        };
+        {
+            let mut workers = sup.workers.lock().await;
+            let (client, _tx) = AcpClient::fake_for_test(CockpitSessionId("s-reap".into()));
+            let drain = tokio::spawn(async {});
+            workers.insert(
+                "s-reap".into(),
+                WorkerHandle {
+                    client: Arc::new(Mutex::new(client)),
+                    drain_task: drain,
+                    restart_history: vec![],
+                    spawn_config: Some(dummy_config),
+                },
+            );
+        }
+        // No registry entry → reaper treats this as user-initiated stop.
+        sup.reap_user_stopped().await;
+
+        // WorkerHandle dropped.
+        assert!(
+            !sup.workers.lock().await.contains_key("s-reap"),
+            "reaper must remove the WorkerHandle"
+        );
+        // Stopped event published with the correct reason.
+        let frames = sink.frames.lock().unwrap();
+        let stopped = frames
+            .iter()
+            .find(|(id, _, _)| id == "s-reap")
+            .expect("expected a published frame for s-reap");
+        match &stopped.2 {
+            Event::Stopped { reason } => {
+                assert_eq!(reason, "user_stopped", "wrong stop reason");
+            }
+            other => panic!("expected Event::Stopped, got {other:?}"),
+        }
+    }
+
+    /// `reap_user_stopped` must NOT touch stdio-only workers: those have
+    /// no registry entry by construction (the runner-managed socket path
+    /// isn't set on `SpawnConfig`), so the registry-gone check would
+    /// always fire and tear down every legacy test fixture.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn reap_user_stopped_skips_stdio_workers() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let dummy_spec = AgentSpec {
+            command: "/bin/true".into(),
+            args: vec![],
+            description: "test fixture".into(),
+            env_allowlist: None,
+        };
+        // No socket_path → not runner-managed → reaper skips.
+        let dummy_config = SpawnConfig {
+            spec: dummy_spec,
+            cwd: std::env::temp_dir(),
+            additional_dirs: vec![],
+            provider_env: vec![],
+            socket_path: None,
+            stored_acp_session_id: None,
+        };
+        {
+            let mut workers = sup.workers.lock().await;
+            let (client, _tx) = AcpClient::fake_for_test(CockpitSessionId("s-stdio".into()));
+            let drain = tokio::spawn(async {});
+            workers.insert(
+                "s-stdio".into(),
+                WorkerHandle {
+                    client: Arc::new(Mutex::new(client)),
+                    drain_task: drain,
+                    restart_history: vec![],
+                    spawn_config: Some(dummy_config),
+                },
+            );
+        }
+        sup.reap_user_stopped().await;
+        assert!(
+            sup.workers.lock().await.contains_key("s-stdio"),
+            "stdio worker must survive the reaper"
+        );
+        assert!(
+            sink.frames.lock().unwrap().is_empty(),
+            "reaper must not publish for stdio workers"
+        );
+    }
+
     /// `next_seq` increments per-session and is independent of the
     /// `workers` map (so `publish_startup_error` and the drain task
     /// share a counter even though the former runs while no
@@ -1462,7 +1788,16 @@ mod tests {
     /// worker. The error must include `current` and `limit` so the
     /// REST surface can return a useful 503 body.
     #[tokio::test]
+    #[serial_test::serial]
     async fn capacity_full_returns_after_limit() {
+        // Isolate HOME so registry entries from the developer's real
+        // dev profile (or other tests) don't bleed into the spawn
+        // path's combined-count check.
+        let tmp = tempfile::TempDir::new().unwrap();
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
         let sink = VecSink::new();
         let sup = Supervisor::with_capacity(sink, 1);
         // Pre-load one fake worker so the cap is full.

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -258,6 +258,32 @@ impl<S: BroadcastSink> Supervisor<S> {
             .publish(session_id, seq, &Event::AgentStartupError { message });
     }
 
+    /// Publish a synthetic `Stopped` event for a session whose turn was
+    /// in flight when the previous `aoe serve` died. Called at startup
+    /// from the reconciler when the on-disk event store shows an
+    /// orphaned `UserPromptSent` (no terminating `Stopped` or
+    /// `AgentStartupError` after it) AND there is no live runner to
+    /// reattach to (which would deliver the Stopped via the resume-idle
+    /// watchdog instead). Without this the UI's "thinking" indicator
+    /// for the dead turn stays on indefinitely after restart.
+    pub fn synthesize_stopped_for_orphan(&self, session_id: &str, reason: &str) {
+        let seq = next_seq(&self.next_seqs, session_id);
+        info!(
+            target: "cockpit.supervisor",
+            session = %session_id,
+            seq,
+            %reason,
+            "publishing synthetic Stopped for orphaned in-flight turn"
+        );
+        self.sink.publish(
+            session_id,
+            seq,
+            &Event::Stopped {
+                reason: reason.to_string(),
+            },
+        );
+    }
+
     /// Publish a UserPromptSent event before forwarding the prompt to
     /// the ACP agent. The replay buffer (and on-disk event store) needs
     /// the user's side of the conversation in the same stream as agent
@@ -883,11 +909,22 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// Reattach to an already-running worker by dialing its existing
     /// runner socket. Used by `reconcile_cockpit_workers` on `aoe serve`
     /// startup before falling back to a fresh spawn.
+    ///
+    /// `in_flight_turn` should be true when the on-disk event store
+    /// shows the session was mid-prompt at the moment the previous
+    /// daemon detached. It arms a watchdog in the connection task that
+    /// emits a synthetic `Event::Stopped { reason: "reattach_idle" }`
+    /// after a quiet window, so the UI's "thinking" indicator clears
+    /// even though the agent's eventual response to the orphaned
+    /// prompt is dropped silently by the underlying transport (its
+    /// request id was issued by the previous daemon's client and is
+    /// unknown to this one).
     pub async fn attach(
         &self,
         session_id: String,
         cwd: PathBuf,
         additional_dirs: Vec<PathBuf>,
+        in_flight_turn: bool,
     ) -> Result<(), SupervisorError> {
         let record = match super::worker_registry::load(&session_id)
             .map_err(|e| SupervisorError::Acp(AcpError::Spawn(format!("registry load: {e}"))))?
@@ -896,6 +933,18 @@ impl<S: BroadcastSink> Supervisor<S> {
             Some(_) | None => {
                 return Err(SupervisorError::UnknownSession(session_id));
             }
+        };
+
+        // Resume requires a known ACP session id (the runner was holding
+        // the agent loaded against it). If the registry doesn't carry
+        // one yet — e.g. the previous daemon crashed before the first
+        // `session/new` response was processed — there's nothing to
+        // resume against; bail so the reconciler falls through to a
+        // fresh spawn.
+        let Some(stored_acp_session_id) = record.stored_acp_session_id.clone() else {
+            return Err(SupervisorError::Acp(AcpError::Spawn(
+                "runner registry has no stored_acp_session_id; need fresh spawn".into(),
+            )));
         };
 
         {
@@ -916,7 +965,8 @@ impl<S: BroadcastSink> Supervisor<S> {
             record.socket_path.clone(),
             cwd,
             additional_dirs,
-            record.stored_acp_session_id.clone(),
+            stored_acp_session_id,
+            in_flight_turn,
             cockpit_session_id,
         )
         .await?;

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -327,9 +327,24 @@ impl<S: BroadcastSink> Supervisor<S> {
             if workers.contains_key(&session_id) {
                 return Err(SupervisorError::AlreadyRunning(session_id));
             }
-            if workers.len() >= self.max_concurrent_workers as usize {
+            // Capacity check counts both running (in-memory) and
+            // detached (on-disk-only) workers, so a fresh `aoe serve`
+            // can't race the reconciler and over-spawn while attaches
+            // are still in flight.
+            let registry_count = super::worker_registry::list()
+                .map(|recs| {
+                    recs.into_iter()
+                        .filter(|r| {
+                            super::worker_registry::is_record_live(r)
+                                && !workers.contains_key(&r.session_id)
+                        })
+                        .count()
+                })
+                .unwrap_or(0);
+            let combined = workers.len() + registry_count;
+            if combined >= self.max_concurrent_workers as usize {
                 return Err(SupervisorError::CapacityFull {
-                    current: workers.len(),
+                    current: combined,
                     limit: self.max_concurrent_workers,
                 });
             }
@@ -366,12 +381,19 @@ impl<S: BroadcastSink> Supervisor<S> {
             env.push(("AOE_AGENT_MODEL".into(), model));
         }
 
+        // Every cockpit worker runs through `aoe __cockpit-runner` so it
+        // survives `aoe serve --stop`. The runner binds the socket path
+        // computed here and the daemon dials it.
+        let socket_path = super::worker_registry::socket_path_for(&session_id).map_err(|e| {
+            SupervisorError::Acp(AcpError::Spawn(format!("worker socket path: {e}")))
+        })?;
+
         let config = SpawnConfig {
             spec,
             cwd,
             additional_dirs,
             provider_env: env,
-            socket_path: None,
+            socket_path: Some(socket_path),
             stored_acp_session_id: stored_acp_session_id.clone(),
         };
 
@@ -477,6 +499,13 @@ impl<S: BroadcastSink> Supervisor<S> {
                                     cfg.stored_acp_session_id = Some(acp_session_id.clone());
                                 }
                             }
+                            // Mirror into the on-disk registry so a fresh
+                            // `aoe serve` after a daemon restart issues
+                            // `session/load` instead of `session/new`.
+                            super::worker_registry::update_stored_acp_session_id(
+                                &session_id,
+                                Some(acp_session_id),
+                            );
                         }
                         Event::SessionContextReset { reason } => {
                             let mut guard = workers.lock().await;
@@ -491,6 +520,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                                     cfg.stored_acp_session_id = None;
                                 }
                             }
+                            super::worker_registry::update_stored_acp_session_id(&session_id, None);
                         }
                         _ => {}
                     }
@@ -743,6 +773,23 @@ impl<S: BroadcastSink> Supervisor<S> {
                 let _ = client.shutdown().await;
             }
             handle.drain_task.abort();
+            // SIGTERM the runner (if there is one) so the agent
+            // subprocess dies; the runner cleans up its own files but
+            // we also delete the registry entry here to handle the
+            // case where the runner is wedged.
+            terminate_runner_for_session(session_id);
+            return Ok(());
+        }
+        // No in-memory worker, but there may still be a detached
+        // runner in the registry (e.g. a previous daemon detached and
+        // shutdown is called against the disk-only entry).
+        if super::worker_registry::load(session_id)
+            .ok()
+            .flatten()
+            .is_some()
+        {
+            drop(workers);
+            terminate_runner_for_session(session_id);
             return Ok(());
         }
         if pending_has_it {
@@ -766,8 +813,19 @@ impl<S: BroadcastSink> Supervisor<S> {
         Err(SupervisorError::UnknownSession(session_id.into()))
     }
 
-    /// Shutdown every worker. Called on aoe serve shutdown.
+    /// Shutdown every worker. Called when the user explicitly terminates
+    /// all cockpit workers (e.g. `aoe cockpit stop --all`) — sends ACP
+    /// shutdown to each connected client, aborts the drain task, AND
+    /// signals every per-session `aoe __cockpit-runner` so the agent
+    /// subprocess dies. For the everyday `aoe serve --stop` flow, use
+    /// `detach_all` instead so workers outlive the daemon.
     pub async fn shutdown_all(&self) {
+        let registry_pids: Vec<(String, u32)> = super::worker_registry::list()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|r| (r.session_id, r.pid))
+            .collect();
+
         let mut workers = self.workers.lock().await;
         for (id, handle) in workers.drain() {
             debug!(target: "cockpit.supervisor", session = %id, "shutting down");
@@ -777,6 +835,125 @@ impl<S: BroadcastSink> Supervisor<S> {
             }
             handle.drain_task.abort();
         }
+        drop(workers);
+
+        // SIGTERM every runner we knew about, so detached agents that
+        // outlived a previous daemon are also taken down by an explicit
+        // "kill them all" request.
+        #[cfg(unix)]
+        for (session_id, pid) in registry_pids {
+            use nix::sys::signal::{kill, Signal};
+            use nix::unistd::Pid;
+            let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+            super::worker_registry::delete(&session_id).ok();
+        }
+        #[cfg(not(unix))]
+        let _ = registry_pids;
+    }
+
+    /// Drop the daemon-side handle to every worker without killing the
+    /// runner or its agent. Used on `aoe serve` graceful shutdown so the
+    /// agents keep running and the next `aoe serve` reattaches.
+    ///
+    /// Concretely: closes the unix-socket connection (via `client
+    /// .shutdown()` which sends `ClientCmd::Shutdown` to the connection
+    /// task), aborts the drain task, and writes `detached_at` into each
+    /// registry entry. The runner observes EOF on its socket read,
+    /// clears its active outbound, and goes back to accepting.
+    pub async fn detach_all(&self) {
+        let mut workers = self.workers.lock().await;
+        let ids: Vec<String> = workers.keys().cloned().collect();
+        info!(
+            target: "cockpit.supervisor",
+            count = ids.len(),
+            "detaching cockpit workers; they continue running. \
+             Use `aoe cockpit stop` to terminate."
+        );
+        for (id, handle) in workers.drain() {
+            debug!(target: "cockpit.supervisor", session = %id, "detaching");
+            {
+                let client = handle.client.lock().await;
+                let _ = client.shutdown().await;
+            }
+            handle.drain_task.abort();
+            super::worker_registry::mark_detached(&id);
+        }
+    }
+
+    /// Reattach to an already-running worker by dialing its existing
+    /// runner socket. Used by `reconcile_cockpit_workers` on `aoe serve`
+    /// startup before falling back to a fresh spawn.
+    pub async fn attach(
+        &self,
+        session_id: String,
+        cwd: PathBuf,
+        additional_dirs: Vec<PathBuf>,
+    ) -> Result<(), SupervisorError> {
+        let record = match super::worker_registry::load(&session_id)
+            .map_err(|e| SupervisorError::Acp(AcpError::Spawn(format!("registry load: {e}"))))?
+        {
+            Some(r) if super::worker_registry::is_record_live(&r) => r,
+            Some(_) | None => {
+                return Err(SupervisorError::UnknownSession(session_id));
+            }
+        };
+
+        {
+            let workers = self.workers.lock().await;
+            if workers.contains_key(&session_id) {
+                return Err(SupervisorError::AlreadyRunning(session_id));
+            }
+            if workers.len() >= self.max_concurrent_workers as usize {
+                return Err(SupervisorError::CapacityFull {
+                    current: workers.len(),
+                    limit: self.max_concurrent_workers,
+                });
+            }
+        }
+
+        let cockpit_session_id = CockpitSessionId(session_id.clone());
+        let mut client = AcpClient::attach(
+            record.socket_path.clone(),
+            cwd,
+            additional_dirs,
+            record.stored_acp_session_id.clone(),
+            cockpit_session_id,
+        )
+        .await?;
+        super::worker_registry::mark_attached(&session_id);
+
+        let inbound = client
+            .take_inbound()
+            .expect("freshly attached AcpClient always has inbound receiver");
+        let client = Arc::new(Mutex::new(client));
+        let mut workers = self.workers.lock().await;
+        if workers.contains_key(&session_id) {
+            drop(workers);
+            drop(client);
+            return Err(SupervisorError::AlreadyRunning(session_id));
+        }
+        let drain_task = self.start_drain_task(session_id.clone(), inbound);
+        workers.insert(
+            session_id.clone(),
+            WorkerHandle {
+                client,
+                drain_task,
+                restart_history: vec![],
+                // No respawn config — if the worker dies, the drain
+                // task will see EOF and we'll let the reconciler spawn
+                // a fresh runner on the next tick rather than auto-
+                // respawning from this in-memory state.
+                spawn_config: None,
+            },
+        );
+        info!(
+            target: "cockpit.supervisor",
+            session = %session_id,
+            socket = %record.socket_path.display(),
+            pid = record.pid,
+            "reattached to existing cockpit worker"
+        );
+        Ok(())
     }
 
     /// Whether this session has a running cockpit worker, or a
@@ -796,6 +973,23 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn count(&self) -> usize {
         self.workers.lock().await.len()
     }
+}
+
+/// SIGTERM the per-session runner if its registry entry has a live PID,
+/// then delete the entry. Used by `shutdown` and `shutdown_all` to take
+/// down detached workers explicitly.
+fn terminate_runner_for_session(session_id: &str) {
+    if let Ok(Some(record)) = super::worker_registry::load(session_id) {
+        #[cfg(unix)]
+        if super::worker_registry::is_pid_alive(record.pid) {
+            use nix::sys::signal::{kill, Signal};
+            use nix::unistd::Pid;
+            let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
+        }
+        #[cfg(not(unix))]
+        let _ = record;
+    }
+    super::worker_registry::delete(session_id).ok();
 }
 
 enum RestartDecision {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1051,23 +1051,36 @@ impl<S: BroadcastSink> Supervisor<S> {
 
     /// Reap workers whose on-disk registry entry has disappeared while
     /// the in-memory `WorkerHandle` is still installed. This is the
-    /// out-of-band stop signal: `aoe cockpit stop|kill` (a separate
-    /// process from the daemon) deletes the registry entry, then
-    /// SIGTERMs the runner. The daemon's protocol-layer connection task
-    /// blocks on `cmd_rx.recv()` while idle, so socket EOF does NOT
-    /// propagate back into the closure — `event_tx` never drops, the
-    /// drain task never observes inbound closure, and `restart_decision`
-    /// never runs. Without an explicit poll, the UI stays stuck on
-    /// "thinking" with a phantom worker recorded in the supervisor.
+    /// out-of-band stop signal: `aoe cockpit stop|kill|restart` (a
+    /// separate process from the daemon) deletes the registry entry,
+    /// then SIGTERMs the runner. The daemon's protocol-layer connection
+    /// task blocks on `cmd_rx.recv()` while idle, so socket EOF does
+    /// NOT propagate back into the closure — `event_tx` never drops,
+    /// the drain task never observes inbound closure, and
+    /// `restart_decision` never runs. Without an explicit poll, the UI
+    /// stays stuck on "thinking" with a phantom worker recorded in the
+    /// supervisor.
     ///
     /// Called by the reconciler every 2s. For each runner-managed worker
-    /// whose registry entry is gone, publishes `Stopped{reason:
-    /// "user_stopped"}` so the frontend can clear the spinner and offer
-    /// a reconnect button, then tears down the WorkerHandle (sends ACP
-    /// Shutdown so the connection task exits cleanly, aborts the drain
-    /// task). The stdio-only test path is skipped because those handles
-    /// have no registry entry by construction.
-    pub async fn reap_user_stopped(&self) {
+    /// whose registry entry is gone:
+    ///   - if a `.restart` sentinel sits next to the (now-deleted)
+    ///     registry entry, publishes `Stopped { reason:
+    ///     "restart_pending" }` and reports the id back to the caller so
+    ///     the reconciler can clear its `attempted` set and let the next
+    ///     spawn pass run (transcript continuity via the cached
+    ///     `acp_session_id`);
+    ///   - otherwise publishes `Stopped { reason: "user_stopped" }` so
+    ///     the frontend offers a "Reconnect" button and the daemon
+    ///     stays out of the respawn business.
+    ///
+    /// Either way: the WorkerHandle is dropped, ACP Shutdown is sent so
+    /// the connection task exits cleanly, and the drain task is aborted.
+    /// The stdio-only test path is skipped because those handles have
+    /// no registry entry by construction.
+    ///
+    /// Returns the list of restart-pending session ids so the reconciler
+    /// can re-enable auto-spawn for them on the next tick.
+    pub async fn reap_user_stopped(&self) -> Vec<String> {
         // Snapshot candidate session ids without holding the workers lock
         // across the registry read or the publish/teardown — the
         // teardown takes the client lock and we don't want to nest.
@@ -1086,21 +1099,33 @@ impl<S: BroadcastSink> Supervisor<S> {
                 .collect()
         };
 
+        let mut restart_pending: Vec<String> = Vec::new();
         for id in candidates {
             let removed = self.workers.lock().await.remove(&id);
             let Some(handle) = removed else { continue };
+            // Consume the restart marker (if any) and pick the publish
+            // reason. The marker is cleared regardless of which branch
+            // fires so a leaked file (e.g. from a CLI that crashed
+            // between `mark_restart_pending` and `delete`) can't poison
+            // a subsequent user-initiated stop.
+            let is_restart = super::worker_registry::take_restart_marker(&id);
+            let reason = if is_restart {
+                "restart_pending"
+            } else {
+                "user_stopped"
+            };
             info!(
                 target: "cockpit.supervisor",
                 session = %id,
-                "registry entry gone while worker handle live; \
-                 publishing user_stopped and tearing down"
+                reason,
+                "registry entry gone while worker handle live; tearing down"
             );
             let seq = next_seq(&self.next_seqs, &id);
             self.sink.publish(
                 &id,
                 seq,
                 &Event::Stopped {
-                    reason: "user_stopped".into(),
+                    reason: reason.to_string(),
                 },
             );
             // Send ACP Shutdown so the connection task's closure breaks
@@ -1111,7 +1136,11 @@ impl<S: BroadcastSink> Supervisor<S> {
                 let _ = client.shutdown().await;
             }
             handle.drain_task.abort();
+            if is_restart {
+                restart_pending.push(id);
+            }
         }
+        restart_pending
     }
 }
 
@@ -1591,6 +1620,90 @@ mod tests {
             }
             other => panic!("expected Event::Stopped, got {other:?}"),
         }
+    }
+
+    /// `reap_user_stopped` distinguishes `aoe cockpit restart` from `stop`
+    /// via the `.restart` sentinel: the CLI's restart path writes the
+    /// marker BEFORE deleting the registry, and the reaper consumes it
+    /// to (a) publish `restart_pending` instead of `user_stopped`, and
+    /// (b) return the id so the reconciler can clear its `attempted`
+    /// set and let the next 2s tick auto-respawn the worker (transcript
+    /// continuity via the cached `acp_session_id`).
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn reap_user_stopped_reports_restart_pending_when_marker_present() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink.clone());
+        let dummy_spec = AgentSpec {
+            command: "/bin/true".into(),
+            args: vec![],
+            description: "test fixture".into(),
+            env_allowlist: None,
+        };
+        let dummy_config = SpawnConfig {
+            spec: dummy_spec,
+            cwd: std::env::temp_dir(),
+            additional_dirs: vec![],
+            provider_env: vec![],
+            socket_path: Some(tmp.path().join("dummy.sock")),
+            stored_acp_session_id: None,
+        };
+        {
+            let mut workers = sup.workers.lock().await;
+            let (client, _tx) = AcpClient::fake_for_test(CockpitSessionId("s-restart".into()));
+            let drain = tokio::spawn(async {});
+            workers.insert(
+                "s-restart".into(),
+                WorkerHandle {
+                    client: Arc::new(Mutex::new(client)),
+                    drain_task: drain,
+                    restart_history: vec![],
+                    spawn_config: Some(dummy_config),
+                },
+            );
+        }
+        // Simulate `aoe cockpit restart`: registry already deleted (no
+        // file at record_path); marker file written before delete.
+        crate::cockpit::worker_registry::mark_restart_pending("s-restart");
+
+        let pending = sup.reap_user_stopped().await;
+
+        assert_eq!(
+            pending,
+            vec!["s-restart".to_string()],
+            "reaper must report the restart-pending session"
+        );
+        assert!(
+            !sup.workers.lock().await.contains_key("s-restart"),
+            "reaper must remove the WorkerHandle on restart too"
+        );
+        let frames = sink.frames.lock().unwrap();
+        let stopped = frames
+            .iter()
+            .find(|(id, _, _)| id == "s-restart")
+            .expect("expected published frame");
+        match &stopped.2 {
+            Event::Stopped { reason } => {
+                assert_eq!(
+                    reason, "restart_pending",
+                    "marker must steer publish reason to restart_pending"
+                );
+            }
+            other => panic!("expected Event::Stopped, got {other:?}"),
+        }
+        // Marker must be consumed so a subsequent stop on the same id
+        // isn't accidentally treated as a restart.
+        let marker_path =
+            crate::cockpit::worker_registry::restart_marker_path("s-restart").unwrap();
+        assert!(
+            !marker_path.exists(),
+            "restart marker must be removed by the reaper"
+        );
     }
 
     /// `reap_user_stopped` must NOT touch stdio-only workers: those have

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -130,6 +130,48 @@ pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
     Ok(workers_dir()?.join(format!("{session_id}.log")))
 }
 
+/// Sentinel file `<workers_dir>/<session_id>.restart`. Written by
+/// `aoe cockpit restart` BEFORE the registry delete + SIGTERM so the
+/// daemon's reaper can distinguish a restart-driven teardown from
+/// `aoe cockpit stop|kill` and:
+///   - emit `Stopped { reason: "restart_pending" }` instead of
+///     `user_stopped` so the UI shows a "Restarting…" banner without
+///     the "Reconnect" button (the daemon will respawn shortly);
+///   - signal the reconciler to clear the `attempted` set for this id
+///     so the next 2s tick actually spawns a fresh worker.
+pub fn restart_marker_path(session_id: &str) -> Result<PathBuf> {
+    Ok(workers_dir()?.join(format!("{session_id}.restart")))
+}
+
+/// Best-effort write of an empty restart-pending marker. Called by the
+/// CLI's `aoe cockpit restart` before deleting the registry entry. The
+/// file's existence is the signal; its contents are irrelevant.
+pub fn mark_restart_pending(session_id: &str) {
+    let Ok(path) = restart_marker_path(session_id) else {
+        return;
+    };
+    let _ = std::fs::write(&path, b"");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600));
+    }
+}
+
+/// Returns `true` if the marker existed (and was deleted). Caller uses
+/// the boolean to pick the publish reason; defense-in-depth removes the
+/// file so a leaked marker doesn't poison the next spawn.
+pub fn take_restart_marker(session_id: &str) -> bool {
+    let Ok(path) = restart_marker_path(session_id) else {
+        return false;
+    };
+    match std::fs::remove_file(&path) {
+        Ok(()) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => false,
+    }
+}
+
 /// Atomic write (temp + rename) with 0600 perms. Avoids the half-written
 /// JSON that a naive `fs::write` would leave if the runner is killed
 /// mid-write — the dial path would then fail to parse and the entry

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -327,6 +327,17 @@ pub fn update_stored_acp_session_id(session_id: &str, acp_id: Option<&str>) {
 /// only if both the PID is alive AND the socket file still exists; a
 /// stale entry where the runner died before deleting its files would
 /// otherwise let attach hang on a missing socket.
+///
+/// Defense-in-depth for PID reuse: it's possible (though rare) for a
+/// runner to die uncleanly, leave the socket file behind, and have its
+/// PID immediately recycled by an unrelated process. The (pid_alive +
+/// socket_exists) pair survives that case in almost all scenarios
+/// because the unrelated process is exceedingly unlikely to be
+/// listening on the same socket path. As a third layer, the daemon's
+/// attach handshake (`AcpClient::attach` -> `initialize`) rejects any
+/// peer that doesn't speak ACP within the 3s reconciler timeout, so a
+/// truly unlucky PID/socket collision still falls back to a fresh
+/// spawn rather than wedging the session.
 pub fn is_record_live(rec: &WorkerRecord) -> bool {
     rec.runner_version == RUNNER_VERSION && is_pid_alive(rec.pid) && socket_exists(&rec.socket_path)
 }

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -113,20 +113,54 @@ pub fn workers_dir() -> Result<PathBuf> {
     Ok(dir)
 }
 
+/// Defense-in-depth check on a session_id before it's interpolated into
+/// any `<workers_dir>/<session_id>.<ext>` path. Production session_ids
+/// come from `Uuid::new_v4()` so they satisfy this trivially, but the
+/// `aoe __cockpit-runner` subcommand accepts `--session-id` as a CLI
+/// arg, and we don't want a user invoking the runner with
+/// `--session-id "../../foo"` to write registry/socket/log files
+/// outside the dedicated worker directory. Not a privilege escalation
+/// (same UID), but a basic input-validation gap worth closing.
+///
+/// Accepts: alphanumeric, `-`, `_`. Rejects: empty, `/`, `\`, `.` (so
+/// `..` and leading-dot hidden files are both out), null bytes, and
+/// anything longer than 128 bytes (UUIDs are 36; this leaves room for
+/// prefixed test ids without permitting arbitrarily-long inputs).
+pub fn validate_session_id(session_id: &str) -> Result<()> {
+    if session_id.is_empty() {
+        anyhow::bail!("session_id must not be empty");
+    }
+    if session_id.len() > 128 {
+        anyhow::bail!("session_id too long ({} bytes, max 128)", session_id.len());
+    }
+    if !session_id
+        .bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+    {
+        anyhow::bail!(
+            "session_id contains disallowed characters: must be ASCII alphanumeric, '-', or '_'"
+        );
+    }
+    Ok(())
+}
+
 /// `<workers_dir>/<session_id>.json`.
 pub fn record_path(session_id: &str) -> Result<PathBuf> {
+    validate_session_id(session_id)?;
     Ok(workers_dir()?.join(format!("{session_id}.json")))
 }
 
 /// `<workers_dir>/<session_id>.sock`. Caller computes this once and threads
 /// the same path into both the runner spawn and the daemon connect.
 pub fn socket_path_for(session_id: &str) -> Result<PathBuf> {
+    validate_session_id(session_id)?;
     Ok(workers_dir()?.join(format!("{session_id}.sock")))
 }
 
-/// `<workers_dir>/<session_id>.log` — runner-side stderr drain consumed by
-/// `aoe cockpit logs --session <id>`.
+/// `<workers_dir>/<session_id>.log` is the runner-side stderr drain
+/// consumed by `aoe cockpit logs --session <id>`.
 pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
+    validate_session_id(session_id)?;
     Ok(workers_dir()?.join(format!("{session_id}.log")))
 }
 
@@ -140,6 +174,7 @@ pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
 ///   - signal the reconciler to clear the `attempted` set for this id
 ///     so the next 2s tick actually spawns a fresh worker.
 pub fn restart_marker_path(session_id: &str) -> Result<PathBuf> {
+    validate_session_id(session_id)?;
     Ok(workers_dir()?.join(format!("{session_id}.restart")))
 }
 
@@ -492,5 +527,61 @@ mod tests {
         // *process group*, not a real process. Use a very high value that
         // won't realistically be allocated.
         assert!(!is_pid_alive(2_000_000_000));
+    }
+
+    #[test]
+    fn validate_session_id_accepts_uuids_and_test_ids() {
+        // Production format: UUID v4 with hyphens.
+        assert!(
+            validate_session_id("550e8400-e29b-41d4-a716-446655440000").is_ok(),
+            "must accept UUID v4 (the production session_id shape)"
+        );
+        // Test-prefixed ids with underscores and digits.
+        assert!(validate_session_id("test_session_42").is_ok());
+        assert!(validate_session_id("a").is_ok());
+        assert!(validate_session_id("Z-0").is_ok());
+    }
+
+    #[test]
+    fn validate_session_id_rejects_path_traversal_and_separators() {
+        // The whole point of this check: don't let a CLI invocation of
+        // `aoe __cockpit-runner --session-id "<evil>"` write files
+        // outside the workers dir.
+        for bad in [
+            "",
+            "..",
+            "../../etc/passwd",
+            "foo/bar",
+            "foo\\bar",
+            ".hidden",
+            "with space",
+            "with\0null",
+            "trailing.",
+            "good-then/../bad",
+        ] {
+            assert!(
+                validate_session_id(bad).is_err(),
+                "expected rejection for {bad:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_session_id_rejects_overlong() {
+        let long = "a".repeat(129);
+        assert!(validate_session_id(&long).is_err());
+        let ok = "a".repeat(128);
+        assert!(validate_session_id(&ok).is_ok());
+    }
+
+    #[test]
+    fn path_builders_propagate_validation_error() {
+        // Defense-in-depth: even if some future caller forgets to
+        // validate at the trust boundary, the path builders themselves
+        // catch a bad id.
+        assert!(record_path("../escape").is_err());
+        assert!(socket_path_for("foo/bar").is_err());
+        assert!(log_path_for("").is_err());
+        assert!(restart_marker_path(".hidden").is_err());
     }
 }

--- a/src/cockpit/worker_registry.rs
+++ b/src/cockpit/worker_registry.rs
@@ -1,0 +1,443 @@
+//! On-disk registry of detached cockpit worker processes.
+//!
+//! Each running cockpit worker has a JSON file at
+//! `<app_dir>/cockpit-workers/<session_id>.json` describing how to dial it
+//! and who owns the process. The directory is the source of truth across
+//! `aoe serve` restarts: when serve starts, it scans the directory, dials
+//! every live worker, and only spawns a fresh worker for sessions that
+//! have no registry entry (or a dead one).
+//!
+//! The worker process itself (the `aoe __cockpit-runner` shim) writes the
+//! file on startup and removes it on graceful exit; `Supervisor::shutdown`
+//! and the stale-sweep on serve startup remove it for crashed runners.
+//!
+//! File mode is 0600 because `provider_env_keys` and `socket_path` may
+//! leak metadata about which agents/providers a user runs.
+//!
+//! Layout note: the runner *and* the daemon both write to entries
+//! (runner: `pid`/`started_at` on boot; daemon:
+//! `last_attached_at`/`detached_at` on attach/detach). We accept the
+//! single-writer-per-field convention rather than locking: contention
+//! windows are narrow and tearing a single field across an unclean
+//! restart at worst causes a re-attach instead of a clean attach.
+
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+/// Bump when the on-disk schema changes incompatibly. Older entries with
+/// a smaller `runner_version` are swept on startup instead of dialed.
+pub const RUNNER_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkerRecord {
+    pub runner_version: u32,
+    pub session_id: String,
+    /// PID of the `aoe __cockpit-runner` process. Used by the stale-sweep
+    /// to decide whether the registry entry corresponds to a live owner.
+    pub pid: u32,
+    pub socket_path: PathBuf,
+    pub agent_name: String,
+    pub cwd: PathBuf,
+    pub model: Option<String>,
+    pub additional_dirs: Vec<PathBuf>,
+    /// Keys (not values) of provider_env passed through at spawn. Lets
+    /// the reconciler observe which provider auth was configured for the
+    /// session without re-reading every entry on every tick.
+    pub provider_env_keys: Vec<String>,
+    /// Cached ACP session id assigned by the agent on first `session/new`.
+    /// On reattach, the daemon sends `session/load <stored_acp_session_id>`
+    /// to resume the agent-side transcript.
+    pub stored_acp_session_id: Option<String>,
+    pub started_at: u64,
+    pub last_attached_at: Option<u64>,
+    pub detached_at: Option<u64>,
+}
+
+impl WorkerRecord {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        session_id: String,
+        pid: u32,
+        socket_path: PathBuf,
+        agent_name: String,
+        cwd: PathBuf,
+        model: Option<String>,
+        additional_dirs: Vec<PathBuf>,
+        provider_env_keys: Vec<String>,
+        stored_acp_session_id: Option<String>,
+    ) -> Self {
+        Self {
+            runner_version: RUNNER_VERSION,
+            session_id,
+            pid,
+            socket_path,
+            agent_name,
+            cwd,
+            model,
+            additional_dirs,
+            provider_env_keys,
+            stored_acp_session_id,
+            started_at: now_secs(),
+            last_attached_at: None,
+            detached_at: None,
+        }
+    }
+}
+
+fn now_secs() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Directory holding worker JSON files, log files, and the per-session
+/// unix sockets. Auto-created on first access.
+pub fn workers_dir() -> Result<PathBuf> {
+    let dir = crate::session::get_app_dir()?.join("cockpit-workers");
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir)
+            .with_context(|| format!("creating cockpit workers dir at {}", dir.display()))?;
+        // Owner-only on the directory itself so other users on a shared
+        // host can't enumerate session ids.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700));
+        }
+    }
+    Ok(dir)
+}
+
+/// `<workers_dir>/<session_id>.json`.
+pub fn record_path(session_id: &str) -> Result<PathBuf> {
+    Ok(workers_dir()?.join(format!("{session_id}.json")))
+}
+
+/// `<workers_dir>/<session_id>.sock`. Caller computes this once and threads
+/// the same path into both the runner spawn and the daemon connect.
+pub fn socket_path_for(session_id: &str) -> Result<PathBuf> {
+    Ok(workers_dir()?.join(format!("{session_id}.sock")))
+}
+
+/// `<workers_dir>/<session_id>.log` — runner-side stderr drain consumed by
+/// `aoe cockpit logs --session <id>`.
+pub fn log_path_for(session_id: &str) -> Result<PathBuf> {
+    Ok(workers_dir()?.join(format!("{session_id}.log")))
+}
+
+/// Atomic write (temp + rename) with 0600 perms. Avoids the half-written
+/// JSON that a naive `fs::write` would leave if the runner is killed
+/// mid-write — the dial path would then fail to parse and the entry
+/// would be swept.
+pub fn save(record: &WorkerRecord) -> Result<()> {
+    let dir = workers_dir()?;
+    let final_path = dir.join(format!("{}.json", record.session_id));
+    let tmp_path = dir.join(format!("{}.json.tmp", record.session_id));
+    let bytes = serde_json::to_vec_pretty(record).context("serializing worker record")?;
+    std::fs::write(&tmp_path, &bytes)
+        .with_context(|| format!("writing tmp record at {}", tmp_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp_path, std::fs::Permissions::from_mode(0o600));
+    }
+    std::fs::rename(&tmp_path, &final_path)
+        .with_context(|| format!("renaming tmp record to {}", final_path.display()))?;
+    Ok(())
+}
+
+pub fn load(session_id: &str) -> Result<Option<WorkerRecord>> {
+    let path = record_path(session_id)?;
+    if !path.exists() {
+        return Ok(None);
+    }
+    let bytes = std::fs::read(&path).with_context(|| format!("reading {}", path.display()))?;
+    match serde_json::from_slice::<WorkerRecord>(&bytes) {
+        Ok(record) => Ok(Some(record)),
+        Err(e) => {
+            warn!(
+                target: "cockpit.registry",
+                path = %path.display(),
+                "failed to parse worker record: {e}; treating as missing"
+            );
+            Ok(None)
+        }
+    }
+}
+
+pub fn list() -> Result<Vec<WorkerRecord>> {
+    let dir = workers_dir()?;
+    let mut out = Vec::new();
+    let read = match std::fs::read_dir(&dir) {
+        Ok(r) => r,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(e).with_context(|| format!("reading {}", dir.display())),
+    };
+    for entry in read.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) != Some("json") {
+            continue;
+        }
+        let Ok(bytes) = std::fs::read(&path) else {
+            continue;
+        };
+        match serde_json::from_slice::<WorkerRecord>(&bytes) {
+            Ok(rec) => out.push(rec),
+            Err(e) => {
+                warn!(
+                    target: "cockpit.registry",
+                    path = %path.display(),
+                    "skipping unparseable worker record: {e}"
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Remove the JSON entry and the unix socket file (if present). The
+/// `.log` file is intentionally left behind so the user can read it
+/// after the worker exits.
+pub fn delete(session_id: &str) -> Result<()> {
+    if let Ok(p) = record_path(session_id) {
+        let _ = std::fs::remove_file(&p);
+    }
+    if let Ok(p) = socket_path_for(session_id) {
+        let _ = std::fs::remove_file(&p);
+    }
+    Ok(())
+}
+
+/// Probe whether `pid` is still alive. On Unix: `kill(pid, 0)` returns
+/// `Ok(())` for live and `Err(ESRCH)` for dead. Other errors (EPERM,
+/// etc.) mean the process exists but we lack permission to signal it —
+/// still alive.
+#[cfg(unix)]
+pub fn is_pid_alive(pid: u32) -> bool {
+    use nix::errno::Errno;
+    use nix::sys::signal::kill;
+    use nix::unistd::Pid;
+    match kill(Pid::from_raw(pid as i32), None) {
+        Ok(()) => true,
+        Err(Errno::ESRCH) => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(not(unix))]
+pub fn is_pid_alive(_pid: u32) -> bool {
+    false
+}
+
+/// Update the `last_attached_at` field in place. Best-effort: any I/O
+/// error is logged and swallowed because attach itself has already
+/// succeeded; the timestamp is purely for observability.
+pub fn mark_attached(session_id: &str) {
+    if let Ok(Some(mut rec)) = load(session_id) {
+        rec.last_attached_at = Some(now_secs());
+        rec.detached_at = None;
+        if let Err(e) = save(&rec) {
+            debug!(
+                target: "cockpit.registry",
+                session = %session_id,
+                "failed to update last_attached_at: {e}"
+            );
+        }
+    }
+}
+
+pub fn mark_detached(session_id: &str) {
+    if let Ok(Some(mut rec)) = load(session_id) {
+        rec.detached_at = Some(now_secs());
+        if let Err(e) = save(&rec) {
+            debug!(
+                target: "cockpit.registry",
+                session = %session_id,
+                "failed to update detached_at: {e}"
+            );
+        }
+    }
+}
+
+/// Update only `stored_acp_session_id` in place. Called by the
+/// supervisor when the drain task observes an `AcpSessionAssigned`
+/// event, so a fresh `aoe serve` knows to call `session/load` instead
+/// of `session/new` on reattach.
+pub fn update_stored_acp_session_id(session_id: &str, acp_id: Option<&str>) {
+    if let Ok(Some(mut rec)) = load(session_id) {
+        rec.stored_acp_session_id = acp_id.map(|s| s.to_string());
+        if let Err(e) = save(&rec) {
+            debug!(
+                target: "cockpit.registry",
+                session = %session_id,
+                "failed to update stored_acp_session_id: {e}"
+            );
+        }
+    }
+}
+
+/// Probe the recorded socket path. A worker registry entry is "live"
+/// only if both the PID is alive AND the socket file still exists; a
+/// stale entry where the runner died before deleting its files would
+/// otherwise let attach hang on a missing socket.
+pub fn is_record_live(rec: &WorkerRecord) -> bool {
+    rec.runner_version == RUNNER_VERSION && is_pid_alive(rec.pid) && socket_exists(&rec.socket_path)
+}
+
+fn socket_exists(path: &Path) -> bool {
+    match std::fs::metadata(path) {
+        Ok(_) => true,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
+        Err(_) => true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use tempfile::TempDir;
+
+    fn with_temp_home<F: FnOnce()>(f: F) {
+        let tmp = TempDir::new().unwrap();
+        let original = std::env::var_os("HOME");
+        let original_xdg = std::env::var_os("XDG_CONFIG_HOME");
+        // SAFETY: tests are serialized via `#[serial]`; the env mutation
+        // window is bounded to this closure and restored on exit.
+        unsafe {
+            std::env::set_var("HOME", tmp.path());
+            std::env::set_var("XDG_CONFIG_HOME", tmp.path().join(".config"));
+        }
+        f();
+        unsafe {
+            if let Some(v) = original {
+                std::env::set_var("HOME", v);
+            } else {
+                std::env::remove_var("HOME");
+            }
+            if let Some(v) = original_xdg {
+                std::env::set_var("XDG_CONFIG_HOME", v);
+            } else {
+                std::env::remove_var("XDG_CONFIG_HOME");
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn roundtrip_save_load() {
+        with_temp_home(|| {
+            let rec = WorkerRecord::new(
+                "sess-abc".into(),
+                42,
+                PathBuf::from("/tmp/sock"),
+                "claude".into(),
+                PathBuf::from("/repo"),
+                Some("claude-opus-4-7".into()),
+                vec![],
+                vec!["ANTHROPIC_API_KEY".into()],
+                None,
+            );
+            save(&rec).unwrap();
+            let loaded = load("sess-abc").unwrap().unwrap();
+            assert_eq!(loaded.session_id, "sess-abc");
+            assert_eq!(loaded.pid, 42);
+            assert_eq!(loaded.runner_version, RUNNER_VERSION);
+            assert_eq!(loaded.agent_name, "claude");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn list_filters_non_json_and_unparseable() {
+        with_temp_home(|| {
+            let dir = workers_dir().unwrap();
+            std::fs::write(dir.join("not-json.json"), b"this isn't json").unwrap();
+            std::fs::write(dir.join("ignored.txt"), b"{}").unwrap();
+            let rec = WorkerRecord::new(
+                "live".into(),
+                1,
+                PathBuf::from("/tmp/sock-live"),
+                "aoe-agent".into(),
+                PathBuf::from("/repo"),
+                None,
+                vec![],
+                vec![],
+                None,
+            );
+            save(&rec).unwrap();
+            let all = list().unwrap();
+            assert_eq!(all.len(), 1);
+            assert_eq!(all[0].session_id, "live");
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn delete_removes_json_and_socket() {
+        with_temp_home(|| {
+            let dir = workers_dir().unwrap();
+            let sock = dir.join("sess.sock");
+            std::fs::write(&sock, b"").unwrap();
+            let rec = WorkerRecord::new(
+                "sess".into(),
+                1,
+                sock.clone(),
+                "aoe-agent".into(),
+                PathBuf::from("/repo"),
+                None,
+                vec![],
+                vec![],
+                None,
+            );
+            save(&rec).unwrap();
+            assert!(record_path("sess").unwrap().exists());
+            assert!(sock.exists());
+            delete("sess").unwrap();
+            assert!(!record_path("sess").unwrap().exists());
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn mark_attached_clears_detached() {
+        with_temp_home(|| {
+            let mut rec = WorkerRecord::new(
+                "x".into(),
+                1,
+                PathBuf::from("/tmp/x.sock"),
+                "aoe-agent".into(),
+                PathBuf::from("/repo"),
+                None,
+                vec![],
+                vec![],
+                None,
+            );
+            rec.detached_at = Some(100);
+            save(&rec).unwrap();
+            mark_attached("x");
+            let after = load("x").unwrap().unwrap();
+            assert!(after.last_attached_at.is_some());
+            assert!(after.detached_at.is_none());
+        });
+    }
+
+    #[test]
+    fn is_pid_alive_self() {
+        let pid = std::process::id();
+        assert!(is_pid_alive(pid));
+    }
+
+    #[test]
+    fn is_pid_alive_unlikely_pid() {
+        // PID 0 is the kernel scheduler / swapper; kill(0, 0) targets the
+        // *process group*, not a real process. Use a very high value that
+        // won't realistically be allocated.
+        assert!(!is_pid_alive(2_000_000_000));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -214,6 +214,8 @@ async fn main() -> Result<()> {
         Some(Commands::Url(args)) => cli::url::run(args),
         #[cfg(feature = "serve")]
         Some(Commands::Cockpit { command }) => cli::cockpit::run(command).await,
+        #[cfg(feature = "serve")]
+        Some(Commands::CockpitRunner(args)) => agent_of_empires::cockpit::runner::run(*args).await,
         None => {
             // Fold the drift notice into the existing startup-warning channel
             // so the TUI surfaces both (debug-log + drift, if both fire) in a

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1429,6 +1429,13 @@ async fn reconcile_cockpit_workers(
             continue;
         }
 
+        // Snapshot the on-disk "is this session mid-turn?" hint once per
+        // pass. Used to arm the resume-idle watchdog on the attach path,
+        // and to decide whether the fresh-spawn fallback below needs to
+        // publish a synthetic Stopped so the UI doesn't stay stuck on
+        // "thinking" after a daemon crash killed the agent mid-prompt.
+        let in_flight_turn = state.cockpit_event_store.has_in_flight_turn(&id);
+
         // Reattach path: if a previous daemon detached a runner for this
         // session and the runner is still alive, dial its socket instead
         // of spawning a fresh agent. Bounded by the registry probe — no
@@ -1440,7 +1447,7 @@ async fn reconcile_cockpit_workers(
                 let cwd = std::path::PathBuf::from(&project_path);
                 let attach_res = tokio::time::timeout(
                     std::time::Duration::from_secs(3),
-                    supervisor.attach(id.clone(), cwd, vec![]),
+                    supervisor.attach(id.clone(), cwd, vec![], in_flight_turn),
                 )
                 .await;
                 match attach_res {
@@ -1449,6 +1456,7 @@ async fn reconcile_cockpit_workers(
                             target: "cockpit.supervisor",
                             session = %id,
                             pid = record.pid,
+                            in_flight_turn,
                             "reattached to existing cockpit runner"
                         );
                         continue;
@@ -1476,6 +1484,19 @@ async fn reconcile_cockpit_workers(
                 // entry so the next attempt is a clean fresh spawn.
                 crate::cockpit::worker_registry::delete(&id).ok();
             }
+        }
+
+        // Fresh-spawn fallback: we are about to spin up a brand new
+        // agent process. The previous one (if any) was killed before it
+        // could complete the in-flight prompt, so its turn is forever
+        // orphaned. Publish a synthetic Stopped now so the UI doesn't
+        // keep "thinking" after restart — same fix path as on `main`
+        // where there's no runner at all and every cockpit session
+        // takes this branch on restart.
+        if in_flight_turn {
+            state
+                .cockpit_supervisor
+                .synthesize_stopped_for_orphan(&id, "orphaned_at_restart");
         }
 
         // Mark before spawning so the next 2s tick doesn't double-spawn

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1364,6 +1364,14 @@ async fn reconcile_cockpit_workers(
         return;
     }
 
+    // Detect `aoe cockpit stop|kill` (a separate process that deletes the
+    // registry entry + SIGTERMs the runner) and surface it as a typed
+    // Stopped event. The daemon's protocol-layer connection task blocks
+    // on `cmd_rx.recv()` while idle, so socket EOF doesn't propagate to
+    // the drain task on its own — without this poll, the UI stays stuck
+    // on "thinking" and the supervisor keeps a phantom worker.
+    state.cockpit_supervisor.reap_user_stopped().await;
+
     let targets: Vec<_> = {
         let instances = state.instances.read().await;
         instances

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1401,8 +1401,16 @@ async fn reconcile_cockpit_workers(
     let live: std::collections::HashSet<&String> = targets.iter().map(|t| &t.0).collect();
     attempted.retain(|id| live.contains(id));
 
+    // ORDERING INVARIANT: this orphan sweep MUST run before the
+    // spawn-with-capacity-check loop below. The capacity check counts
+    // both in-memory workers AND on-disk registry entries (so a fresh
+    // daemon can't race the reconciler and over-spawn). If the sweep
+    // ran after, dead-PID entries from a previous unclean shutdown
+    // would still count toward `max_concurrent_workers` and could
+    // block legitimate spawns until the next tick. Do not reorder.
+    //
     // Sweep registry entries whose session no longer exists (deleted
-    // while serve was down) — SIGTERM the orphan runner so the user
+    // while serve was down) and SIGTERM the orphan runner so the user
     // doesn't see a phantom in `aoe cockpit ps`. Only runs against
     // entries that aren't currently in our `workers` map.
     if let Ok(records) = crate::cockpit::worker_registry::list() {

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -907,9 +907,12 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     .with_graceful_shutdown(shutdown_signal)
     .await?;
 
-    // Tear down every cockpit ACP worker so the spawned `claude-agent-acp`
-    // wrappers (and their SDK children) don't outlive the daemon.
-    cockpit_supervisor.shutdown_all().await;
+    // Detach (but do NOT kill) every cockpit ACP worker. The per-session
+    // `aoe __cockpit-runner` shims outlive this daemon: a fresh
+    // `aoe serve` reattaches via the reconciler on startup, so in-flight
+    // turns survive `aoe serve --stop`. To actually terminate workers,
+    // use `aoe cockpit stop [--all]`.
+    cockpit_supervisor.detach_all().await;
 
     // Clean up tunnel (cancels health monitor, then sends SIGTERM to cloudflared)
     if let Some(handle) = tunnel_handle {
@@ -1382,6 +1385,38 @@ async fn reconcile_cockpit_workers(
     let live: std::collections::HashSet<&String> = targets.iter().map(|t| &t.0).collect();
     attempted.retain(|id| live.contains(id));
 
+    // Sweep registry entries whose session no longer exists (deleted
+    // while serve was down) — SIGTERM the orphan runner so the user
+    // doesn't see a phantom in `aoe cockpit ps`. Only runs against
+    // entries that aren't currently in our `workers` map.
+    if let Ok(records) = crate::cockpit::worker_registry::list() {
+        for record in records {
+            if live.contains(&record.session_id) {
+                continue;
+            }
+            if state
+                .cockpit_supervisor
+                .is_running(&record.session_id)
+                .await
+            {
+                continue;
+            }
+            tracing::info!(
+                target: "cockpit.supervisor",
+                session = %record.session_id,
+                pid = record.pid,
+                "sweeping orphan worker (no matching session on disk)"
+            );
+            #[cfg(unix)]
+            if crate::cockpit::worker_registry::is_pid_alive(record.pid) {
+                use nix::sys::signal::{kill, Signal};
+                use nix::unistd::Pid;
+                let _ = kill(Pid::from_raw(record.pid as i32), Signal::SIGTERM);
+            }
+            crate::cockpit::worker_registry::delete(&record.session_id).ok();
+        }
+    }
+
     for (id, tool, agent_override, model, project_path, stored_acp_session_id) in targets {
         if attempted.contains(&id) {
             continue;
@@ -1393,6 +1428,56 @@ async fn reconcile_cockpit_workers(
             attempted.insert(id);
             continue;
         }
+
+        // Reattach path: if a previous daemon detached a runner for this
+        // session and the runner is still alive, dial its socket instead
+        // of spawning a fresh agent. Bounded by the registry probe — no
+        // network IO unless we have a live PID + socket on disk.
+        if let Ok(Some(record)) = crate::cockpit::worker_registry::load(&id) {
+            if crate::cockpit::worker_registry::is_record_live(&record) {
+                attempted.insert(id.clone());
+                let supervisor = state.cockpit_supervisor.clone();
+                let cwd = std::path::PathBuf::from(&project_path);
+                let attach_res = tokio::time::timeout(
+                    std::time::Duration::from_secs(3),
+                    supervisor.attach(id.clone(), cwd, vec![]),
+                )
+                .await;
+                match attach_res {
+                    Ok(Ok(())) => {
+                        tracing::info!(
+                            target: "cockpit.supervisor",
+                            session = %id,
+                            pid = record.pid,
+                            "reattached to existing cockpit runner"
+                        );
+                        continue;
+                    }
+                    Ok(Err(e)) => {
+                        tracing::warn!(
+                            target: "cockpit.supervisor",
+                            session = %id,
+                            "attach failed; falling back to fresh spawn: {e}"
+                        );
+                        crate::cockpit::worker_registry::delete(&id).ok();
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            target: "cockpit.supervisor",
+                            session = %id,
+                            "attach timed out after 3s; falling back to fresh spawn"
+                        );
+                        crate::cockpit::worker_registry::delete(&id).ok();
+                        attempted.remove(&id);
+                    }
+                }
+            } else {
+                // Dead PID or missing socket: sweep the orphan registry
+                // entry so the next attempt is a clean fresh spawn.
+                crate::cockpit::worker_registry::delete(&id).ok();
+            }
+        }
+
         // Mark before spawning so the next 2s tick doesn't double-spawn
         // while AcpClient::spawn is still negotiating with the agent.
         attempted.insert(id.clone());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1364,13 +1364,21 @@ async fn reconcile_cockpit_workers(
         return;
     }
 
-    // Detect `aoe cockpit stop|kill` (a separate process that deletes the
-    // registry entry + SIGTERMs the runner) and surface it as a typed
-    // Stopped event. The daemon's protocol-layer connection task blocks
-    // on `cmd_rx.recv()` while idle, so socket EOF doesn't propagate to
-    // the drain task on its own — without this poll, the UI stays stuck
-    // on "thinking" and the supervisor keeps a phantom worker.
-    state.cockpit_supervisor.reap_user_stopped().await;
+    // Detect `aoe cockpit stop|kill|restart` (a separate process that
+    // deletes the registry entry + SIGTERMs the runner) and surface it
+    // as a typed Stopped event. The daemon's protocol-layer connection
+    // task blocks on `cmd_rx.recv()` while idle, so socket EOF doesn't
+    // propagate to the drain task on its own — without this poll, the
+    // UI stays stuck on "thinking" and the supervisor keeps a phantom
+    // worker. For the `restart` case, the reaper returns the ids it
+    // marked as `restart_pending`; clear them from `attempted` so the
+    // spawn pass below treats them as fresh and the next 2s tick
+    // reattaches with the cached `acp_session_id` (transcript
+    // continuity).
+    let restart_pending = state.cockpit_supervisor.reap_user_stopped().await;
+    for id in &restart_pending {
+        attempted.remove(id);
+    }
 
     let targets: Vec<_> = {
         let instances = state.instances.read().await;

--- a/tests/cockpit_acp_smoke.rs
+++ b/tests/cockpit_acp_smoke.rs
@@ -386,69 +386,11 @@ async fn shim_agent_round_trips_terminal() {
     );
 }
 
-/// Socket-transport round-trip: aoe creates a unix socket, exports
-/// AOE_ACP_SOCKET, the shim connects to it, the same prompt round-trip
-/// works end-to-end. Validates the path used by sandboxed cockpit
-/// sessions where the agent runs inside a container with a mounted
-/// socket instead of inherited stdio.
-#[tokio::test]
-async fn shim_agent_round_trips_via_unix_socket() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
-        return;
-    }
-    let shim = shim_path();
-    if !shim.exists() {
-        return;
-    }
-    let temp = tempfile::tempdir().expect("tempdir");
-    let cwd = temp.path().to_path_buf();
-    let socket_path = temp.path().join("acp.sock");
-    let config = SpawnConfig {
-        spec: AgentSpec {
-            command: "node".into(),
-            args: vec![shim.to_string_lossy().to_string()],
-            description: "test shim (socket)".into(),
-            env_allowlist: None,
-        },
-        cwd: cwd.clone(),
-        additional_dirs: vec![],
-        provider_env: vec![],
-        socket_path: Some(socket_path.clone()),
-        stored_acp_session_id: None,
-    };
-
-    let mut client = AcpClient::spawn(config, CockpitSessionId("sock".into()))
-        .await
-        .expect("spawn shim");
-
-    client
-        .send_prompt("hello over socket")
-        .await
-        .expect("send_prompt");
-
-    let mut events: Vec<Event> = Vec::new();
-    let drain_deadline = std::time::Instant::now() + Duration::from_secs(15);
-    while std::time::Instant::now() < drain_deadline {
-        match tokio::time::timeout(Duration::from_millis(500), client.next_event()).await {
-            Ok(Some(event)) => {
-                let stopped = matches!(event, Event::Stopped { .. });
-                events.push(event);
-                if stopped {
-                    break;
-                }
-            }
-            Ok(None) | Err(_) => continue,
-        }
-    }
-    let _ = client.shutdown().await;
-
-    let saw_received = events.iter().any(|e| match e {
-        Event::AgentMessageChunk { text } => text.contains("received: hello over socket"),
-        _ => false,
-    });
-    assert!(
-        saw_received,
-        "shim should echo received: hello over socket via the socket transport; got {events:?}"
-    );
-}
+// NOTE: the previous "aoe-binds, agent-connects" socket-transport test
+// has been removed. In the worker-persistence redesign (issue #1037),
+// the runner now binds the socket and the daemon connects, which the
+// test cannot exercise without a real `aoe __cockpit-runner` binary on
+// PATH (the test process's `current_exe()` is the test runner, not
+// `aoe`). End-to-end coverage for the new transport lives in
+// `tests/e2e/` against a built `aoe` binary; the stdio round-trip
+// tests above still validate the ACP handshake + event mapping.

--- a/tests/cockpit_acp_smoke.rs
+++ b/tests/cockpit_acp_smoke.rs
@@ -391,6 +391,10 @@ async fn shim_agent_round_trips_terminal() {
 // the runner now binds the socket and the daemon connects, which the
 // test cannot exercise without a real `aoe __cockpit-runner` binary on
 // PATH (the test process's `current_exe()` is the test runner, not
-// `aoe`). End-to-end coverage for the new transport lives in
-// `tests/e2e/` against a built `aoe` binary; the stdio round-trip
-// tests above still validate the ACP handshake + event mapping.
+// `aoe`). The downstream socket transport (ACP handshake, prompt
+// round-trip, event mapping after the runner has bound the socket)
+// is covered in `tests/cockpit_midturn_resume.rs` via a byte-proxy
+// bridge that mimics what `__cockpit-runner` does in production.
+// End-to-end coverage of the spawn path itself still wants a real
+// `aoe` binary; that test belongs in `tests/e2e/` and is tracked as
+// follow-up work.

--- a/tests/cockpit_midturn_resume.rs
+++ b/tests/cockpit_midturn_resume.rs
@@ -1,0 +1,171 @@
+//! Mid-turn `aoe serve` reattach: integration coverage for the daemon
+//! side of the fix. Stands up a UNIX socket fronted by a byte-proxy to a
+//! Node ACP shim (so we exercise the real `AcpClient::attach` →
+//! `connect_via_socket` → ACP `initialize` path) and asserts:
+//!
+//! 1. `attach` with `in_flight_turn = true` synthesizes
+//!    `Event::Stopped { reason: "reattach_idle" }` after the configured
+//!    grace, since the orphaned upstream `session/prompt` response has
+//!    no daemon-side request id to land against.
+//!
+//! 2. `attach` with `in_flight_turn = false` does NOT synthesize one —
+//!    the watchdog must stay disarmed when the session was idle.
+//!
+//! Skipped automatically if `node` is not on PATH.
+
+#![cfg(feature = "serve")]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use agent_of_empires::cockpit::acp_client::AcpClient;
+use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
+use tokio::net::UnixListener;
+use tokio::process::Command;
+
+fn node_available() -> bool {
+    std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn shim_path() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest)
+        .join("cockpit-worker")
+        .join("test-shim")
+        .join("shim.mjs")
+}
+
+/// Spawn the shim and bridge its stdio to a UNIX listener. Mimics what
+/// `aoe __cockpit-runner` does in production: byte-proxy, no protocol
+/// awareness. Accepts exactly one connection per call so we don't have
+/// to coordinate listener lifetime with the test's drain logic.
+///
+/// Returns the listener path; the bridge task is detached.
+async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
+    let shim = shim_path();
+    let temp = tempfile::tempdir().unwrap();
+    let socket_path = temp.path().join("runner.sock");
+
+    let mut shim_proc = Command::new("node")
+        .arg(&shim)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn shim");
+    let shim_stdin = shim_proc.stdin.take().expect("shim stdin");
+    let shim_stdout = shim_proc.stdout.take().expect("shim stdout");
+
+    let listener = UnixListener::bind(&socket_path).expect("bind listener");
+
+    tokio::spawn(async move {
+        // Single accept — the test only attaches once. After the first
+        // connection closes we stop accepting; the shim process is then
+        // dropped via kill_on_drop when this task ends.
+        let _shim_proc = shim_proc;
+        let (stream, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let (mut sock_read, mut sock_write) = stream.into_split();
+        let mut shim_in = shim_stdin;
+        let mut shim_out = shim_stdout;
+        let to_shim = async move { tokio::io::copy(&mut sock_read, &mut shim_in).await.ok() };
+        let from_shim = async move { tokio::io::copy(&mut shim_out, &mut sock_write).await.ok() };
+        let _ = tokio::join!(to_shim, from_shim);
+    });
+
+    (socket_path, temp)
+}
+
+async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> Option<String> {
+    while Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
+            Ok(Some(Event::Stopped { reason })) => return Some(reason),
+            Ok(Some(_)) => continue,
+            Ok(None) => return None,
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+#[tokio::test]
+async fn attach_in_flight_synthesizes_reattach_idle_stopped() {
+    if !node_available() {
+        eprintln!("skipping: node not on PATH");
+        return;
+    }
+    if !shim_path().exists() {
+        eprintln!("skipping: shim missing");
+        return;
+    }
+
+    // Shorten the watchdog grace so the test completes inside ~3s
+    // instead of the 10s production default.
+    std::env::set_var("AOE_RESUME_IDLE_GRACE_MS", "500");
+
+    let (socket_path, _tmp) = spawn_shim_socket_bridge().await;
+
+    let mut client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        "test-acp-session-id".into(),
+        true, // in_flight_turn
+        CockpitSessionId("midturn-true".into()),
+    )
+    .await
+    .expect("attach in_flight=true");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(3)).await;
+    let _ = client.shutdown().await;
+
+    assert_eq!(
+        stopped.as_deref(),
+        Some("reattach_idle"),
+        "resume-idle watchdog must synthesize a Stopped event"
+    );
+}
+
+#[tokio::test]
+async fn attach_idle_session_does_not_synthesize_stopped() {
+    if !node_available() {
+        eprintln!("skipping: node not on PATH");
+        return;
+    }
+    if !shim_path().exists() {
+        eprintln!("skipping: shim missing");
+        return;
+    }
+
+    std::env::set_var("AOE_RESUME_IDLE_GRACE_MS", "500");
+
+    let (socket_path, _tmp) = spawn_shim_socket_bridge().await;
+
+    let mut client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        "test-acp-session-id".into(),
+        false, // NOT in flight
+        CockpitSessionId("midturn-false".into()),
+    )
+    .await
+    .expect("attach in_flight=false");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(2)).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        stopped.is_none(),
+        "watchdog must stay disarmed when in_flight_turn=false; got Stopped reason={stopped:?}"
+    );
+}

--- a/tests/cockpit_midturn_resume.rs
+++ b/tests/cockpit_midturn_resume.rs
@@ -14,6 +14,12 @@
 //! Skipped automatically if `node` is not on PATH.
 
 #![cfg(feature = "serve")]
+// Compiled only in debug builds because the watchdog grace is tunable
+// via `AOE_RESUME_IDLE_GRACE_MS` only under `cfg(debug_assertions)`
+// (see `resume_idle_grace()` in `src/cockpit/acp_client.rs`). Release
+// builds would wait the full 10s production default and fail the
+// 3s assertion below.
+#![cfg(debug_assertions)]
 
 use std::path::PathBuf;
 use std::time::{Duration, Instant};

--- a/tests/cockpit_midturn_resume.rs
+++ b/tests/cockpit_midturn_resume.rs
@@ -50,14 +50,24 @@ fn shim_path() -> PathBuf {
 /// awareness. Accepts exactly one connection per call so we don't have
 /// to coordinate listener lifetime with the test's drain logic.
 ///
+/// If `preseed_session_id` is `Some`, the shim pre-creates that session
+/// id so `AcpClient::attach` (Resume mode) can immediately send prompts
+/// without going through `session/new`.
+///
 /// Returns the listener path; the bridge task is detached.
-async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
+async fn spawn_shim_socket_bridge_with_preseed(
+    preseed_session_id: Option<&str>,
+) -> (PathBuf, tempfile::TempDir) {
     let shim = shim_path();
     let temp = tempfile::tempdir().unwrap();
     let socket_path = temp.path().join("runner.sock");
 
-    let mut shim_proc = Command::new("node")
-        .arg(&shim)
+    let mut cmd = Command::new("node");
+    cmd.arg(&shim);
+    if let Some(id) = preseed_session_id {
+        cmd.env("SHIM_PRESEED_SESSION_ID", id);
+    }
+    let mut shim_proc = cmd
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
@@ -87,6 +97,10 @@ async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
     });
 
     (socket_path, temp)
+}
+
+async fn spawn_shim_socket_bridge() -> (PathBuf, tempfile::TempDir) {
+    spawn_shim_socket_bridge_with_preseed(None).await
 }
 
 async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> Option<String> {
@@ -174,4 +188,71 @@ async fn attach_idle_session_does_not_synthesize_stopped() {
         stopped.is_none(),
         "watchdog must stay disarmed when in_flight_turn=false; got Stopped reason={stopped:?}"
     );
+}
+
+/// End-to-end socket transport: attach to the runner-style bridge,
+/// send a prompt, and confirm the shim's response round-trips back as
+/// `AgentMessageChunk` + `Stopped` events. This replaces the
+/// `shim_agent_round_trips_via_unix_socket` test deleted in the
+/// worker-persistence redesign. It does NOT exercise the production
+/// `spawn_runner_detached` path (which requires a built `aoe` binary
+/// with the `__cockpit-runner` subcommand registered, and so belongs
+/// in `tests/e2e/`); it does exercise everything downstream:
+/// `AcpClient` socket connection, ACP `initialize` handshake,
+/// `session/prompt` round-trip, and event mapping.
+#[tokio::test]
+async fn socket_transport_round_trips_prompt_via_attach() {
+    if !node_available() {
+        eprintln!("skipping: node not on PATH");
+        return;
+    }
+    if !shim_path().exists() {
+        eprintln!("skipping: shim missing");
+        return;
+    }
+
+    let preseed = "preseed-roundtrip-session";
+    let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(Some(preseed)).await;
+
+    let mut client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        preseed.into(),
+        false, // not in flight; this is a fresh round-trip
+        CockpitSessionId("roundtrip".into()),
+    )
+    .await
+    .expect("attach to bridge");
+
+    client
+        .send_prompt("hello over socket")
+        .await
+        .expect("send_prompt");
+
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut saw_received = false;
+    let mut saw_stopped = false;
+    while Instant::now() < deadline && !(saw_received && saw_stopped) {
+        match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
+            Ok(Some(Event::AgentMessageChunk { text })) => {
+                if text.contains("received: hello over socket") {
+                    saw_received = true;
+                }
+            }
+            Ok(Some(Event::Stopped { .. })) => {
+                saw_stopped = true;
+            }
+            Ok(Some(_)) => continue,
+            Ok(None) => break,
+            Err(_) => continue,
+        }
+    }
+    let _ = client.shutdown().await;
+
+    assert!(
+        saw_received,
+        "shim should echo received: hello over socket via the socket transport"
+    );
+    assert!(saw_stopped, "shim should emit Stopped at end of turn");
 }

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -83,6 +83,9 @@ function CockpitChrome({
       {state.workerStopped && !state.startupError && (
         <WorkerStoppedBanner sessionId={sessionId} />
       )}
+      {state.workerRestarting && !state.startupError && !state.workerStopped && (
+        <WorkerRestartingBanner />
+      )}
       {state.lastError && (
         <InteractionErrorBanner
           message={state.lastError}
@@ -133,7 +136,7 @@ function CockpitChrome({
           legacyMode={state.mode}
           sessionUsage={state.sessionUsage}
           availableCommands={state.availableCommands}
-          connected={status === "open" && !state.workerStopped}
+          connected={status === "open" && !state.workerStopped && !state.workerRestarting}
         />
       </ThreadPrimitive.Root>
     </div>
@@ -534,6 +537,28 @@ function InteractionErrorBanner({
       >
         Dismiss
       </button>
+    </div>
+  );
+}
+
+function WorkerRestartingBanner() {
+  // `aoe cockpit restart` deletes the registry + writes a sentinel; the
+  // daemon's reaper publishes Stopped{reason:"restart_pending"} and the
+  // reconciler clears its `attempted` set so the next 2s tick spawns a
+  // fresh worker (with the cached acp_session_id for transcript
+  // continuity). AcpSessionAssigned then clears `workerRestarting` and
+  // this banner unmounts. No reconnect button because the daemon is
+  // already handling it.
+  return (
+    <div className="flex items-center gap-2 border-b border-sky-900/60 bg-sky-950/40 px-4 py-2 text-xs text-sky-200">
+      <span
+        className="inline-block h-2 w-2 animate-pulse rounded-full bg-sky-400"
+        aria-hidden
+      />
+      <span>
+        Restarting cockpit worker… the daemon will respawn the agent with
+        your existing transcript shortly.
+      </span>
     </div>
   );
 }

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -80,6 +80,9 @@ function CockpitChrome({
       {state.startupError && (
         <StartupErrorBanner sessionId={sessionId} message={state.startupError} />
       )}
+      {state.workerStopped && !state.startupError && (
+        <WorkerStoppedBanner sessionId={sessionId} />
+      )}
       {state.lastError && (
         <InteractionErrorBanner
           message={state.lastError}
@@ -130,7 +133,7 @@ function CockpitChrome({
           legacyMode={state.mode}
           sessionUsage={state.sessionUsage}
           availableCommands={state.availableCommands}
-          connected={status === "open"}
+          connected={status === "open" && !state.workerStopped}
         />
       </ThreadPrimitive.Root>
     </div>
@@ -531,6 +534,75 @@ function InteractionErrorBanner({
       >
         Dismiss
       </button>
+    </div>
+  );
+}
+
+function WorkerStoppedBanner({ sessionId }: { sessionId: string }) {
+  const [retryState, setRetryState] = useState<
+    "idle" | "retrying" | "ok" | "failed"
+  >("idle");
+  const [retryError, setRetryError] = useState<string | null>(null);
+
+  const handleReconnect = async () => {
+    setRetryState("retrying");
+    setRetryError(null);
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/spawn`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}),
+        },
+      );
+      if (res.ok) {
+        // The next AcpSessionAssigned (or UserPromptSent) clears
+        // workerStopped on the reducer side and this banner unmounts.
+        setRetryState("ok");
+      } else {
+        const detail = (await res.text().catch(() => "")).slice(0, 200);
+        setRetryState("failed");
+        setRetryError(`Server returned ${res.status}. ${detail}`.trim());
+      }
+    } catch (e) {
+      setRetryState("failed");
+      setRetryError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  return (
+    <div className="border-b border-amber-900/60 bg-amber-950/40 px-4 py-3 text-amber-200">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium">Cockpit worker stopped</div>
+          <div className="mt-1 text-xs text-amber-100/90">
+            The agent was terminated via{" "}
+            <code className="rounded bg-amber-900/60 px-1">aoe cockpit stop</code>{" "}
+            or an equivalent external teardown. New prompts are disabled until
+            you reconnect.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={handleReconnect}
+          disabled={retryState === "retrying"}
+          className="shrink-0 rounded-md border border-amber-800/60 bg-amber-900/40 px-3 py-1 text-xs font-medium text-amber-100 hover:bg-amber-900/60 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {retryState === "retrying" ? "Reconnecting…" : "Reconnect"}
+        </button>
+      </div>
+      {retryState === "ok" && (
+        <div className="mt-2 text-xs text-emerald-200/90">
+          Spawn requested. The composer will re-enable when the agent is back
+          online.
+        </div>
+      )}
+      {retryState === "failed" && retryError && (
+        <div className="mt-2 text-xs text-amber-100/90">
+          Reconnect failed: {retryError}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -535,3 +535,66 @@ describe("applyEvent / Stopped empty-output fallback", () => {
     expect(state.activity.find((r) => r.kind === "empty_output")).toBeUndefined();
   });
 });
+
+describe("applyEvent / Stopped user_stopped", () => {
+  it("sets workerStopped on reason=user_stopped and clears turnActive", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "long task" } },
+    });
+    expect(state.turnActive).toBe(true);
+    expect(state.workerStopped).toBe(false);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "user_stopped" } },
+    });
+    expect(state.workerStopped).toBe(true);
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("does NOT set workerStopped on reason=prompt_complete", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "hi" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.workerStopped).toBe(false);
+  });
+
+  it("clears workerStopped on the next UserPromptSent", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "user_stopped" } },
+    });
+    expect(state.workerStopped).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { UserPromptSent: { text: "back online" } },
+    });
+    expect(state.workerStopped).toBe(false);
+  });
+
+  it("clears workerStopped on AcpSessionAssigned (manual reconnect succeeded)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "user_stopped" } },
+    });
+    expect(state.workerStopped).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "abc-123" } },
+    });
+    expect(state.workerStopped).toBe(false);
+  });
+});

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -598,3 +598,50 @@ describe("applyEvent / Stopped user_stopped", () => {
     expect(state.workerStopped).toBe(false);
   });
 });
+
+describe("applyEvent / Stopped restart_pending", () => {
+  it("sets workerRestarting (not workerStopped) on reason=restart_pending", () => {
+    const state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "restart_pending" } },
+    });
+    expect(state.workerRestarting).toBe(true);
+    expect(state.workerStopped).toBe(false);
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("clears workerRestarting on AcpSessionAssigned (reconciler auto-respawn finished)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "restart_pending" } },
+    });
+    expect(state.workerRestarting).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "fresh-id" } },
+    });
+    expect(state.workerRestarting).toBe(false);
+  });
+
+  it("user_stopped → restart_pending transitions cleanly", () => {
+    // Edge case: user runs `aoe cockpit stop`, then realises they meant
+    // `restart`. The two reasons must not pile up — restart_pending
+    // wins because it's the most recent signal from the daemon.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { Stopped: { reason: "user_stopped" } },
+    });
+    expect(state.workerStopped).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "restart_pending" } },
+    });
+    expect(state.workerStopped).toBe(false);
+    expect(state.workerRestarting).toBe(true);
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -216,6 +216,12 @@ export interface CockpitState {
    *  handler to detect "no-op turn" without walking the full
    *  activity array. */
   turnHasOutput: boolean;
+  /** Set true when the daemon publishes `Stopped { reason: "user_stopped" }`,
+   *  meaning `aoe cockpit stop|kill` (or an equivalent external
+   *  teardown) terminated the runner. The composer disables itself and
+   *  shows a reconnect banner; cleared on the next UserPromptSent or
+   *  AcpSessionAssigned (a fresh worker is online). */
+  workerStopped: boolean;
 }
 
 export interface ActivityRow {
@@ -264,6 +270,7 @@ export function emptyCockpitState(): CockpitState {
     availableCommands: [],
     toolOutputs: {},
     turnHasOutput: false,
+    workerStopped: false,
   };
 }
 
@@ -460,6 +467,15 @@ export function applyEvent(
     // turn-active flag so the global "working" spinner stops.
     next.inFlightTool = null;
     next.turnActive = false;
+    // The "user_stopped" reason is published by the supervisor's
+    // reap_user_stopped pass when it detects `aoe cockpit stop|kill`
+    // has deleted the worker registry entry. Surface a persistent
+    // "worker stopped" state so the composer disables itself and the
+    // reconnect banner appears — without this, the UI shows status Idle
+    // and the user types into a dead session.
+    if (event.Stopped.reason === "user_stopped") {
+      next.workerStopped = true;
+    }
     // Some upstream slash commands (e.g. /usage, /status, /memory in
     // claude-agent-acp) advertise via available_commands_update but
     // produce no agent_message_chunk and no tool calls when invoked —
@@ -521,6 +537,9 @@ export function applyEvent(
     // New turn — reset the no-output detector so Stopped fires the
     // empty-output notice if the agent produces nothing.
     next.turnHasOutput = false;
+    // A fresh prompt means the worker is alive again; clear the
+    // user_stopped banner without waiting for AcpSessionAssigned.
+    next.workerStopped = false;
     return next;
   }
   if ("AcpSessionAssigned" in event) {
@@ -537,6 +556,9 @@ export function applyEvent(
     // its own once the respawn completes the handshake.
     next.startupError = null;
     next.lastError = null;
+    // A fresh agent (via POST /cockpit/spawn after `aoe cockpit stop`)
+    // is online; clear the user_stopped banner.
+    next.workerStopped = false;
     return next;
   }
   if ("SessionContextReset" in event) {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -222,6 +222,13 @@ export interface CockpitState {
    *  shows a reconnect banner; cleared on the next UserPromptSent or
    *  AcpSessionAssigned (a fresh worker is online). */
   workerStopped: boolean;
+  /** Set true when the daemon publishes `Stopped { reason: "restart_pending" }`,
+   *  meaning `aoe cockpit restart` ran and the reconciler will respawn
+   *  the worker on its next 2s tick with the cached `acp_session_id`
+   *  (transcript continuity). The composer disables itself and a
+   *  transient "Restarting…" banner appears without a reconnect button;
+   *  cleared on AcpSessionAssigned or UserPromptSent. */
+  workerRestarting: boolean;
 }
 
 export interface ActivityRow {
@@ -271,6 +278,7 @@ export function emptyCockpitState(): CockpitState {
     toolOutputs: {},
     turnHasOutput: false,
     workerStopped: false,
+    workerRestarting: false,
   };
 }
 
@@ -467,14 +475,20 @@ export function applyEvent(
     // turn-active flag so the global "working" spinner stops.
     next.inFlightTool = null;
     next.turnActive = false;
-    // The "user_stopped" reason is published by the supervisor's
-    // reap_user_stopped pass when it detects `aoe cockpit stop|kill`
-    // has deleted the worker registry entry. Surface a persistent
-    // "worker stopped" state so the composer disables itself and the
-    // reconnect banner appears — without this, the UI shows status Idle
-    // and the user types into a dead session.
+    // The "user_stopped" / "restart_pending" reasons are published by
+    // the supervisor's reap_user_stopped pass when it detects an
+    // out-of-band CLI teardown. Surface a distinct UI state for each:
+    //   - user_stopped: persistent "Stopped" banner with a Reconnect
+    //     button; the daemon will NOT auto-respawn.
+    //   - restart_pending: transient "Restarting…" banner without a
+    //     reconnect affordance; the reconciler will respawn within ~2s
+    //     and AcpSessionAssigned clears the flag.
     if (event.Stopped.reason === "user_stopped") {
       next.workerStopped = true;
+      next.workerRestarting = false;
+    } else if (event.Stopped.reason === "restart_pending") {
+      next.workerRestarting = true;
+      next.workerStopped = false;
     }
     // Some upstream slash commands (e.g. /usage, /status, /memory in
     // claude-agent-acp) advertise via available_commands_update but
@@ -540,6 +554,7 @@ export function applyEvent(
     // A fresh prompt means the worker is alive again; clear the
     // user_stopped banner without waiting for AcpSessionAssigned.
     next.workerStopped = false;
+    next.workerRestarting = false;
     return next;
   }
   if ("AcpSessionAssigned" in event) {
@@ -556,9 +571,11 @@ export function applyEvent(
     // its own once the respawn completes the handshake.
     next.startupError = null;
     next.lastError = null;
-    // A fresh agent (via POST /cockpit/spawn after `aoe cockpit stop`)
-    // is online; clear the user_stopped banner.
+    // A fresh agent (via POST /cockpit/spawn after `aoe cockpit stop`
+    // or via the reconciler's auto-respawn after `aoe cockpit restart`)
+    // is online; clear both transient worker banners.
     next.workerStopped = false;
+    next.workerRestarting = false;
     return next;
   }
   if ("SessionContextReset" in event) {


### PR DESCRIPTION
## Description

Closes #1037.

Cockpit ACP workers now survive `aoe serve --stop` (and serve crashes / SIGTERM / SIGINT). `aoe update` no longer destroys in-flight turns, long-running agent work survives daemon restarts, and the cockpit substrate gets tmux parity for worker lifetime.

### Architecture

- **New `aoe __cockpit-runner` hidden subcommand** (in `src/cockpit/runner.rs`). Per-cockpit-worker shim launched detached via `setsid`. Owns the agent subprocess, binds the unix socket, byte-proxies between aoe and the agent. 256-line ring buffer holds agent → daemon notifications during the detach window so chunks replay on reattach. Exits on SIGTERM/SIGINT or agent exit; cleans up its own registry + socket.
- **On-disk worker registry** at `<app_dir>/cockpit-workers/<session_id>.json` (`src/cockpit/worker_registry.rs`). Atomic write, 0600 perms. Fields: `pid`, `socket_path`, `agent_name`, `cwd`, `model`, cached `stored_acp_session_id`, `started_at`, `last_attached_at`, `detached_at`. The single source of truth across `aoe serve` restarts.
- **`AcpClient` socket-direction flip**: runner binds, daemon connects. New `AcpClient::attach(socket_path, ...)` constructor for the restart-time reattach. `_child` left `None` for runner-managed workers so drop doesn't cascade-kill.
- **`Supervisor::detach_all`** replaces `shutdown_all` in `src/server/mod.rs:912` on graceful shutdown. New `Supervisor::attach` reattaches via the live socket. `shutdown_all` retained for explicit `aoe cockpit stop --all`.
- **Reconciler** (`reconcile_cockpit_workers`): on each tick, sweeps orphan registry entries for deleted sessions, then for live cockpit-mode sessions attempts `attach` (3s bound) before falling back to fresh spawn.
- **CLI**: `aoe cockpit ps [--json]`, `aoe cockpit stop <session>|--all [--timeout-secs N]`, `aoe cockpit kill <session>`. `aoe cockpit logs` and `restart` (previously stubs) are wired.
- Capacity check (`max_concurrent_workers`) counts running + detached entries so a fresh daemon can't race the reconciler and over-spawn.

### What survives what

| Event | Worker process | Transcript | In-flight turn |
|---|---|---|---|
| `aoe serve --stop` | survives | survives | survives |
| `aoe serve` SIGTERM / OOM | survives | survives | survives |
| `aoe cockpit stop <id>` | dies | preserved on disk | lost |
| `aoe cockpit kill <id>` | dies (SIGKILL) | preserved on disk | lost |
| Host reboot / crash | dies | preserved on disk; respawn calls `session/load` | lost |

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve` → 1914 passed, 7 ignored)
- [x] Documentation was updated where necessary (`docs/cockpit.md`, `docs/cli/reference.md` regenerated)
- [ ] For UI changes: included screenshot or recording (no UI changes)

## Test plan

> Run all checks with a release build (`cargo build --release --features serve`) and `AOE_EXPERIMENTAL_COCKPIT=1` set unless noted.

### Core lifecycle

- [x] `aoe serve` cold start with no prior cockpit sessions on disk works; `aoe cockpit ps` shows nothing.
- [x] Create a cockpit session via `aoe add --cockpit`; `aoe cockpit ps` lists it with state `attached`.
- [x] Send a prompt, observe agent reply normally.
- [x] `aoe serve --stop` while no prompt in flight; `aoe cockpit ps` shows state `detached` and PID still alive.
- [x] `aoe serve` again; reattaches within a few seconds; conversation continues without "context reset" banner.
- [x] `aoe cockpit ps --json` returns parseable JSON with the expected fields (`pid`, `alive`, `agent`, `socket`, `cwd`, `started_at`, `last_attached_at`, `detached_at`).

### Mid-turn persistence (the headline use case)

- [x] Start a long prompt (e.g. "list every file in this repo and summarise each"); while the agent is still emitting `agent_message_chunk` events, run `aoe serve --stop`.
- [x] Confirm runner PID still alive (`ps aux | grep __cockpit-runner`).
- [x] `aoe serve`; once dashboard loads, confirm new chunks appear (chunks emitted during the detach window arrived from the runner's ring buffer + on-disk event store).
- [x] Confirm the turn completes; no `Stopped { error: ... }` event from the gap.

### Lifecycle CLI

- [x] `aoe cockpit stop <id>` with `aoe serve` running: worker terminates, registry entry removed, dashboard shows session as "not connected".
- [x] `aoe cockpit stop --all`: every cockpit worker terminates.
- [x] `aoe cockpit kill <id>` immediately SIGKILLs; verify no graceful drain.
- [x] `aoe cockpit logs --session <id>`: prints runner log; `--follow` tails new lines as they arrive.
- [x] `aoe cockpit restart <id>`: stops runner, daemon's next 2s tick respawns it with the same `acp_session_id` (transcript continuity).

### Registry / sweep behaviour

- [x] `aoe cockpit stop --all` then `rm` a stale `.sock` file: confirm `aoe cockpit ps` no longer lists the entry (or `is_record_live` returns false).
- [x] Delete a cockpit session (`aoe remove`) while `aoe serve` is stopped: next `aoe serve` reconciler SIGTERMs the orphan runner and removes its registry entry.
- [x] Kill a runner PID externally (`kill -9 <pid>`) while `aoe serve` is stopped: next `aoe serve` reconciler detects dead PID, sweeps the registry, and spawns a fresh runner.
- [x] Inspect `<app_dir>/cockpit-workers/`: `.json` and `.sock` files are mode 0600; directory is 0700.

### Reattach edge cases

- [x] PID gets recycled between runs (rare; force-test by manually writing a registry JSON pointing at a different live process's PID): attach hits ECONNREFUSED, sweeps the entry within 3s, falls through to fresh spawn.
- [x] Wedged runner (`kill -STOP <pid>`): attach times out at 3s, registry entry swept, fresh spawn proceeds.

### Capacity / experimental gate

- [x] Set `[cockpit] max_concurrent_workers = 2`, create 2 cockpit sessions, attempt a third → `CapacityFull` error.
- [x] Detach 2 workers (`aoe serve --stop` then `aoe serve`); without attaching the existing ones, attempt a third fresh spawn → still gated by the combined count (running + detached registry).
- [x] `AOE_EXPERIMENTAL_COCKPIT` unset on a daemon with existing cockpit sessions: reconciler logs the auto-spawn warning once per session as before.

### Cross-agent

- [x] Repeat the headline test with `claude-agent-acp` (supports `session/load = true`): mid-turn `aoe serve --stop` → restart → transcript continues with model context intact.
- [x] Same test with the bundled `aoe-agent` (loadSession = false today): mid-turn detach → restart → transcript replays from the event store; agent-side context resets (expected for now; #1005).
- [x] `aoe cockpit doctor`: agents still listed correctly, no regression.

### Host-level

- [x] Reboot the host with `aoe serve` running and a cockpit session active. After reboot, `aoe serve` startup: registry entries pointing at dead PIDs get swept; fresh runners spawned; agents (that support `session/load`) restore conversation context.
- [x] Sandboxed cockpit session (Docker substrate): unchanged behaviour. The runner is not exercised inside the container; out of scope for this PR (called out in `docs/cockpit.md`).

### Negative

- [x] Misconfigured agent command (`aoe-agent` not on PATH): runner spawn fails, daemon logs the failure, registry entry not written.
- [x] Disk full / unwritable `<app_dir>/cockpit-workers/`: spawn returns a clear `Spawn(...)` error rather than wedging.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context).

**Any Additional AI Details you'd like to share:**
Claude handled the codebase exploration, design write-up, and implementation. The architectural choices (runner shim vs in-place socket listener, byte-proxy semantics, registry schema, lifecycle CLI shape) are mine. Plan file at the design review stage:
`/Users/seluj78/.claude/plans/investigate-and-plan-the-purring-avalanche.md`.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)