### PR TITLE
Cockpit polishing 2: More cockpit / worktree / sidebar fixes !

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -162,7 +162,7 @@ default_agent = "aoe-agent"
 approval_timeout_secs = 300
 destructive_require_double_confirm = true
 max_concurrent_workers = 5
-replay_events = 500
+replay_events = 0  # 0 = unlimited history; set a positive value to cap per-session rows
 replay_bytes = 5_242_880
 node_path = ""
 ```
@@ -172,7 +172,10 @@ even if a session has `--cockpit`. `default_for_claude = true` makes
 new Claude sessions cockpit-mode by default on mobile clients.
 
 Migration v005 seeds these defaults on upgrade so the section already
-exists if you came from 1.4.x.
+exists if you came from 1.4.x. Migration v006 then flips the v005-seeded
+`replay_events = 500` to `0` so upgraders pick up the new unlimited
+default; any user who has explicitly chosen a different cap is left
+alone.
 
 ## Disabling / escape hatches
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -21,7 +21,7 @@
 > for any session.
 >
 > The data model (`cockpit_mode: bool` per session) is stable; the
-> UI and reliability story are still evolving — see "What's deferred".
+> UI and reliability story are still evolving; see "What's deferred".
 
 Cockpit is aoe's native rendering surface for AI coding agents. Instead
 of viewing the agent through a terminal pane (PTY bytes piped through
@@ -49,7 +49,7 @@ The wizard greys out the cockpit option for tools not in this set.
 | `vibe`     | `vibe-acp` (native, Mistral)                               | Mistral API key; set up via `vibe` first |
 | `pi`       | `pi-acp` (adapter, requires `@mariozechner/pi-coding-agent`) | `pi-acp --terminal-login` for OAuth, or env vars per provider |
 | `aoe-agent`| Bundled multi-provider agent (Vercel AI SDK 6)             | Whatever provider env vars Vercel AI SDK expects |
-| *aider, cursor, copilot, droid, settl, hermes* | not yet wired into the cockpit registry — fall back to terminal mode |
+| *aider, cursor, copilot, droid, settl, hermes* | not yet wired into the cockpit registry; fall back to terminal mode |
 
 The four env vars cockpit always forwards to the agent process are
 `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `CLAUDE_CODE_OAUTH_TOKEN`,
@@ -114,13 +114,13 @@ Configured agents:
 [OK] claude-code  (Alias for `claude` (legacy name))
 [!! ] codex  (OpenAI Codex CLI via Zed adapter …)
     install: npm install -g @zed-industries/codex-acp
-[!! ] gemini  (Google Gemini CLI — native ACP via `gemini --acp`)
+[!! ] gemini  (Google Gemini CLI; native ACP via `gemini --acp`)
     install: npm install -g @google/gemini-cli  (then `gemini --acp`)
-[!! ] opencode  (OpenCode (SST) — native ACP via `opencode acp`)
+[!! ] opencode  (OpenCode (SST); native ACP via `opencode acp`)
     install: curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)
 [!! ] pi  (Hermes coding agent (`pi`) via the pi-acp adapter …)
     install: npm install -g pi-acp  (also requires `npm i -g @mariozechner/pi-coding-agent`)
-[!! ] vibe  (Mistral Vibe — native ACP via the bundled `vibe-acp` binary)
+[!! ] vibe  (Mistral Vibe; native ACP via the bundled `vibe-acp` binary)
     install: follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)
 
 Overall: partial
@@ -183,7 +183,7 @@ alone.
 - `--no-cockpit` per session (CLI).
 - `cockpit.enabled = false` in `config.toml` (persistent master). The
   reconciler short-circuits, REST endpoints return 503, and the CLI
-  refuses `--cockpit`. The web settings panel toggles this live —
+  refuses `--cockpit`. The web settings panel toggles this live;
   flipping the switch shuts down running workers within a couple of
   seconds and respawns them when re-enabled, no `aoe serve --stop`
   required.
@@ -297,7 +297,7 @@ Practical implications:
 - **Mid-turn reattach.** When the daemon comes back up against a
   session that was actively streaming a prompt, the new daemon resumes
   the existing ACP session id directly (no `session/new` or
-  `session/load` is sent — the agent process never died, so its in-
+  `session/load` is sent; the agent process never died, so its in-
   memory session is still addressable). The agent's eventual response
   to the orphaned in-flight `session/prompt` is dropped silently by
   the transport because its request id was issued by the previous
@@ -318,7 +318,7 @@ Practical implications:
 Cockpit transcripts survive page reloads, session switches, and
 `aoe serve --stop`/restart cycles. For agents that support session
 restoration (Claude today), the model itself also retains conversation
-context across restarts — so a follow-up like "what did we just
+context across restarts; so a follow-up like "what did we just
 decide?" still works after a daemon restart.
 
 If context restoration fails (e.g., the agent's stored session is no
@@ -430,7 +430,7 @@ context where approvals legitimately take longer.
 agent stderr verbatim to `debug.log` under the app data dir. We scrub
 common API-key prefixes (Anthropic `sk-...`, GitHub `ghp_...`, AWS
 `AKIA...`, `Bearer <token>`, etc.) before they hit disk, but the scrub
-is best-effort — a hand-rolled secret with no recognisable shape will
+is best-effort; a hand-rolled secret with no recognisable shape will
 pass through. Before attaching `debug.log` to a bug report, skim it
 for anything that looks like a credential, and replace it with
 `<redacted>` if needed.

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -392,6 +392,12 @@ npm install -g @agentclientprotocol/claude-agent-acp
 
 Then run `claude login` if you haven't already.
 
+### "Failed to start cockpit agent" while the adapter is installed
+
+`aoe serve` captures the launching shell's PATH at startup and keeps it for the daemon's lifetime. If the adapter is installed under a node-version-manager dir (`~/.nvm/versions/node/v<ver>/bin`, `~/.fnm/node-versions/.../installation/bin`, mise/asdf equivalents) and the active node version on the daemon's PATH doesn't match, the spawn fails with `agent spawn failed: No such file or directory`.
+
+The spawn path scans common node-manager bin dirs (nvm, fnm, mise, asdf, Volta, `~/.npm-global/bin`, `~/.local/bin`, `/usr/local/bin`, `/opt/homebrew/bin`) per spawn, so a `nvm use <other-version>` after the daemon started is picked up on the next worker respawn without a daemon restart. If the binary lives somewhere else, either restart `aoe serve` from a shell where `which claude-agent-acp` resolves, or symlink it into one of those dirs.
+
 ### Cockpit feels "stuck" with no events
 
 - Check `aoe cockpit logs --follow` (when the worker supervisor lands)

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -165,6 +165,7 @@ max_concurrent_workers = 5
 replay_events = 0  # 0 = unlimited history; set a positive value to cap per-session rows
 replay_bytes = 5_242_880
 node_path = ""
+show_tool_durations = true  # per-tool elapsed-time label in the web UI
 ```
 
 `enabled = false` is a master kill switch; cockpit refuses to spawn

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -66,6 +66,8 @@ init_submodules = true
 
 `init_submodules = false` skips the `git submodule update --init --recursive` step that runs after `git worktree add` when the checkout contains a `.gitmodules` file. Useful for repos that vendor deep submodule trees (e.g. OpenROAD-flow-scripts, llvm-project, chromium) where every new session would otherwise sit in `Creating…` for minutes while submodules clone. Per-invocation override on the CLI: `aoe add --worktree <branch> --no-submodules`.
 
+On the delete side, aoe runs `git submodule deinit -f --all` before `git worktree remove` for any worktree with `.gitmodules`, so the panic-button `Force` checkbox is not required just because the worktree has submodules. If git still refuses (e.g. a partially-broken submodule), aoe falls back to clearing `<main>/.git/worktrees/<name>/modules/` and pruning the stale entry manually.
+
 ### Template Variables
 
 | Variable | Description |

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1354,6 +1354,7 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
                     tool_call_id: id,
                     is_error,
                     content: content_text,
+                    completed_at: chrono::Utc::now(),
                 });
             } else if !content_text.is_empty() {
                 events.push(Event::ToolCallContent {
@@ -2682,6 +2683,7 @@ mod tests {
                 tool_call_id,
                 is_error,
                 content,
+                completed_at: _,
             } => {
                 assert_eq!(tool_call_id, "tc-1");
                 assert!(!*is_error);

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1141,13 +1141,60 @@ fn transcript_event_kind(event: &Event) -> &'static str {
     }
 }
 
+/// Heuristic detector for the end of a `/compact` cycle. The Claude ACP
+/// adapter emits "Compacting..." while the compaction runs and
+/// "Compacting completed." once the model's context window has been
+/// replaced by a summary — both as plain `agent_message_chunk`s with no
+/// `_meta` flag (see #1050 for the upstream gap). String-matching on
+/// the completion message is fragile to localisation but the wrong-firing
+/// failure mode (an extra "context reset" divider) is harmless — it can
+/// never destroy transcript data.
+fn is_compact_completion(text: &str) -> bool {
+    text.contains("Compacting completed.")
+}
+
 /// Map an ACP `SessionUpdate` to the cockpit's typed `Event`. Variants we
 /// don't yet handle pass through as `RawAgentUpdate` so UI clients can at
 /// least see them; we'll narrow these as the schema stabilises.
 fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
     match update {
         SessionUpdate::AgentMessageChunk(chunk) => match chunk.content {
-            ContentBlock::Text(text) => vec![Event::AgentMessageChunk { text: text.text }],
+            ContentBlock::Text(text) => {
+                // /compact emits a plain text chunk ("Compacting completed.")
+                // and a usage_update with used=0 — no typed signal. Detect
+                // the literal string the adapter uses and append a typed
+                // SessionContextReset event so the cockpit can render a
+                // divider, otherwise the silent context replacement leaves
+                // the chat looking unchanged while the model's view has
+                // been swapped out underneath the user. See #1050.
+                let mut events = vec![Event::AgentMessageChunk {
+                    text: text.text.clone(),
+                }];
+                if is_compact_completion(&text.text) {
+                    events.push(Event::SessionContextReset {
+                        reason: "Conversation compacted — earlier turns above \
+                                 are summarised in the model's context."
+                            .into(),
+                    });
+                    // /compact wipes the model's tool-state alongside the
+                    // chat history, so any TodoWrite plan it was tracking
+                    // is gone from its perspective. The cockpit plan strip
+                    // (PlanStrip + sidebar PlanProgressMini) lives in our
+                    // own event log though, so without this clear it keeps
+                    // showing a plan Claude no longer remembers — the user
+                    // then asks "resolve the first task" and Claude
+                    // responds "no task list." Emit an empty PlanUpdated
+                    // so the UI matches the model's actual context.
+                    events.push(Event::PlanUpdated {
+                        plan: Plan {
+                            plan_id: format!("plan-{}", chrono::Utc::now().timestamp_millis()),
+                            version: 1,
+                            steps: Vec::new(),
+                        },
+                    });
+                }
+                events
+            }
             other => vec![raw_event(&other)],
         },
         SessionUpdate::AgentThoughtChunk(_) => vec![Event::ThinkingStarted],
@@ -2339,6 +2386,15 @@ mod tests {
         };
         let result = AcpClient::spawn(config, CockpitSessionId("s-1".into())).await;
         assert!(matches!(result, Err(AcpError::Spawn(_))));
+    }
+
+    #[test]
+    fn is_compact_completion_matches_adapter_string() {
+        assert!(is_compact_completion("Compacting completed."));
+        assert!(is_compact_completion("\n\nCompacting completed.\n"));
+        assert!(!is_compact_completion("Compacting..."));
+        assert!(!is_compact_completion("compact done"));
+        assert!(!is_compact_completion(""));
     }
 
     #[test]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1367,22 +1367,68 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
             events
         }
         SessionUpdate::Plan(p) => {
-            let plan = Plan {
-                plan_id: format!("plan-{}", chrono::Utc::now().timestamp_millis()),
-                version: 1,
-                steps: p
-                    .entries
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, e)| PlanStep {
-                        id: format!("step-{i}"),
-                        title: e.content,
-                        detail: None,
-                        status: map_plan_status(e.status),
+            // Build the structured plan + a synthetic TodoWrite tool call
+            // from the same entries. claude-agent-acp routes Claude's
+            // TodoWrite through the structured `SessionUpdate::Plan`
+            // channel (not the tool channel), so without this synthesis
+            // the cockpit's PlanStrip + sidebar light up but no tool
+            // card ever renders — the user sees a plan appear "from
+            // nowhere" and has no per-update record of which calls
+            // produced which states. Emit a ToolCallStarted /
+            // ToolCallCompleted pair shaped to match what the
+            // TodoUpdateCard classifier in ToolCards.tsx expects
+            // (`name = "TodoWrite"`, `args.todos = [...]`), one per
+            // adapter update.
+            let ts_ms = chrono::Utc::now().timestamp_millis();
+            let plan_id = format!("plan-{ts_ms}");
+            let tool_id = format!("todo-{ts_ms}");
+            let todos_json: Vec<serde_json::Value> = p
+                .entries
+                .iter()
+                .map(|e| {
+                    serde_json::json!({
+                        "content": e.content,
+                        "status": plan_status_to_str(&e.status),
                     })
-                    .collect(),
-            };
-            vec![Event::PlanUpdated { plan }]
+                })
+                .collect();
+            let args_preview = serde_json::json!({ "todos": todos_json }).to_string();
+            let steps: Vec<PlanStep> = p
+                .entries
+                .into_iter()
+                .enumerate()
+                .map(|(i, e)| PlanStep {
+                    id: format!("step-{i}"),
+                    title: e.content,
+                    detail: None,
+                    status: map_plan_status(e.status),
+                })
+                .collect();
+            let now = chrono::Utc::now();
+            vec![
+                Event::ToolCallStarted {
+                    tool_call: ToolCall {
+                        id: tool_id.clone(),
+                        name: "TodoWrite".to_string(),
+                        kind: "think".to_string(),
+                        args_preview,
+                        started_at: now,
+                    },
+                },
+                Event::PlanUpdated {
+                    plan: Plan {
+                        plan_id,
+                        version: 1,
+                        steps,
+                    },
+                },
+                Event::ToolCallCompleted {
+                    tool_call_id: tool_id,
+                    is_error: false,
+                    content: String::new(),
+                    completed_at: now,
+                },
+            ]
         }
         SessionUpdate::CurrentModeUpdate(mode_update) => {
             let id = mode_update.current_mode_id.0.to_string();
@@ -1447,6 +1493,20 @@ fn map_plan_status(status: agent_client_protocol::schema::PlanEntryStatus) -> Pl
         PlanEntryStatus::Completed => PlanStepStatus::Done,
         // The schema is non-exhaustive; treat unknown variants as Pending.
         _ => PlanStepStatus::Pending,
+    }
+}
+
+/// Lowercase string form of a PlanEntryStatus for the synthetic
+/// TodoWrite args payload. Matches the values
+/// `web/src/components/cockpit/ToolCards.tsx::normaliseTodoStatus`
+/// accepts so the TodoUpdateCard renders the right glyph.
+fn plan_status_to_str(status: &agent_client_protocol::schema::PlanEntryStatus) -> &'static str {
+    use agent_client_protocol::schema::PlanEntryStatus;
+    match status {
+        PlanEntryStatus::Pending => "pending",
+        PlanEntryStatus::InProgress => "in_progress",
+        PlanEntryStatus::Completed => "completed",
+        _ => "pending",
     }
 }
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1317,6 +1317,17 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
                 Some(agent_client_protocol::schema::ToolCallStatus::Completed)
                     | Some(agent_client_protocol::schema::ToolCallStatus::Failed)
             );
+            // claude-agent-acp emits the initial `tool_call` frame
+            // eagerly, often well before the underlying bash / read /
+            // edit actually starts running. Use `status: InProgress` as
+            // the canonical "running now" signal and re-stamp the
+            // tool's `started_at` so the duration label measures real
+            // tool runtime rather than adapter scheduling overhead.
+            // See #1060.
+            let in_progress = matches!(
+                update.fields.status,
+                Some(agent_client_protocol::schema::ToolCallStatus::InProgress)
+            );
             let content_text = update
                 .fields
                 .content
@@ -1326,11 +1337,16 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
             let new_args_preview = update.fields.raw_input.as_ref().map(preview_args);
             let new_title = update.fields.title.clone();
             let mut events: Vec<Event> = Vec::new();
-            if new_title.is_some() || new_args_preview.is_some() {
+            if new_title.is_some() || new_args_preview.is_some() || in_progress {
                 events.push(Event::ToolCallUpdated {
                     tool_call_id: id.clone(),
                     title: new_title,
                     args_preview: new_args_preview,
+                    started_at: if in_progress {
+                        Some(chrono::Utc::now())
+                    } else {
+                        None
+                    },
                 });
             }
             if completed {
@@ -2687,8 +2703,21 @@ mod tests {
             ))]);
         let update = ToolCallUpdate::new("tc-2", fields);
         let events = map_update_to_events(SessionUpdate::ToolCallUpdate(update));
-        assert_eq!(events.len(), 1);
+        // InProgress now emits a ToolCallUpdated re-stamping started_at
+        // (#1060 follow-up) plus the streaming ToolCallContent.
+        assert_eq!(events.len(), 2);
         match &events[0] {
+            Event::ToolCallUpdated {
+                tool_call_id,
+                started_at,
+                ..
+            } => {
+                assert_eq!(tool_call_id, "tc-2");
+                assert!(started_at.is_some());
+            }
+            other => panic!("expected ToolCallUpdated, got {other:?}"),
+        }
+        match &events[1] {
             Event::ToolCallContent {
                 tool_call_id,
                 content,
@@ -2697,6 +2726,32 @@ mod tests {
                 assert_eq!(content, "partial output");
             }
             other => panic!("expected ToolCallContent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_tool_call_update_in_progress_restamps_started_at() {
+        use agent_client_protocol::schema::{ToolCallStatus, ToolCallUpdate, ToolCallUpdateFields};
+        let fields = ToolCallUpdateFields::new().status(ToolCallStatus::InProgress);
+        let update = ToolCallUpdate::new("tc-3", fields);
+        let events = map_update_to_events(SessionUpdate::ToolCallUpdate(update));
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::ToolCallUpdated {
+                tool_call_id,
+                started_at,
+                title,
+                args_preview,
+            } => {
+                assert_eq!(tool_call_id, "tc-3");
+                assert!(
+                    started_at.is_some(),
+                    "InProgress must carry a re-stamped started_at"
+                );
+                assert!(title.is_none());
+                assert!(args_preview.is_none());
+            }
+            other => panic!("expected ToolCallUpdated, got {other:?}"),
         }
     }
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -579,9 +579,98 @@ fn scrub_stderr_secrets(line: &str) -> std::borrow::Cow<'_, str> {
     re.replace_all(line, "<redacted-secret>")
 }
 
+/// Resolve a bare agent command name to an absolute path, scanning common
+/// node-version-manager bin dirs (nvm, fnm, mise, asdf, Volta) plus the
+/// usual system locations. Returns the absolute binary path and the bin
+/// dir we found it in; the caller prepends that dir to the agent's PATH
+/// so the adapter's own subprocesses (`node`, `npx`) can still resolve.
+///
+/// Re-runs per spawn (no cache) so an `nvm use <other-version>` after the
+/// daemon started picks up immediately without a daemon restart. Returns
+/// None when the command is already a path, contains a `${placeholder}`,
+/// or isn't found anywhere we know to look.
+pub fn resolve_agent_command(command: &str) -> Option<(std::path::PathBuf, std::path::PathBuf)> {
+    if command.contains('/') || command.contains('\\') || command.contains("${") {
+        return None;
+    }
+
+    if let Some(path) = find_in_path_env(command) {
+        let parent = path
+            .parent()
+            .map(|p| p.to_path_buf())
+            .unwrap_or_else(std::path::PathBuf::new);
+        return Some((path, parent));
+    }
+
+    for dir in node_search_dirs() {
+        let candidate = dir.join(command);
+        if candidate.is_file() {
+            return Some((candidate, dir));
+        }
+    }
+    None
+}
+
+fn find_in_path_env(binary: &str) -> Option<std::path::PathBuf> {
+    let path_var = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path_var) {
+        let candidate = dir.join(binary);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// Best-effort enumeration of node bin dirs the user is likely to have
+/// the adapter installed into. Order matters only for tie-breaking; the
+/// first hit wins, but in practice each binary only lives in one place.
+fn node_search_dirs() -> Vec<std::path::PathBuf> {
+    let mut out = Vec::new();
+    if let Some(home) = dirs::home_dir() {
+        // nvm: `~/.nvm/versions/node/v<ver>/bin/<binary>`
+        push_subdirs(&mut out, &home.join(".nvm/versions/node"), "bin");
+        // fnm: `~/.fnm/node-versions/v<ver>/installation/bin/<binary>`
+        push_subdirs(
+            &mut out,
+            &home.join(".fnm/node-versions"),
+            "installation/bin",
+        );
+        // mise: `~/.local/share/mise/installs/node/<ver>/bin/<binary>`
+        push_subdirs(
+            &mut out,
+            &home.join(".local/share/mise/installs/node"),
+            "bin",
+        );
+        // asdf: `~/.asdf/installs/nodejs/<ver>/bin/<binary>`
+        push_subdirs(&mut out, &home.join(".asdf/installs/nodejs"), "bin");
+        // Volta + user-scoped npm prefixes
+        out.push(home.join(".volta/bin"));
+        out.push(home.join(".npm-global/bin"));
+        out.push(home.join(".local/bin"));
+        out.push(home.join("bin"));
+    }
+    out.push(std::path::PathBuf::from("/usr/local/bin"));
+    out.push(std::path::PathBuf::from("/opt/homebrew/bin"));
+    out.push(std::path::PathBuf::from("/usr/bin"));
+    out
+}
+
+fn push_subdirs(out: &mut Vec<std::path::PathBuf>, root: &std::path::Path, leaf: &str) {
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let bin = entry.path().join(leaf);
+        if bin.is_dir() {
+            out.push(bin);
+        }
+    }
+}
+
 /// Spawn the `aoe __cockpit-runner` shim as a detached process. The
 /// runner owns the agent subprocess and outlives the daemon. We retain
-/// no `Child` handle here — once the runner is up, the daemon talks to
+/// no `Child` handle here; once the runner is up, the daemon talks to
 /// it over the unix socket and the OS keeps the runner alive across
 /// `aoe serve` restarts.
 fn spawn_runner_detached(
@@ -597,6 +686,17 @@ fn spawn_runner_detached(
     if let Some(parent) = log_path.parent() {
         let _ = std::fs::create_dir_all(parent);
     }
+
+    // Resolve the agent binary against PATH + known node-manager dirs so
+    // the runner spawns the right binary even when the daemon's frozen
+    // PATH doesn't contain it. See #1048. The resolved bin dir is also
+    // prepended to PATH below so the adapter's own `node`/`npx`
+    // subprocesses land in the same install.
+    let resolved = resolve_agent_command(&config.spec.command);
+    let (spawn_command, extra_path_dir) = match &resolved {
+        Some((abs, dir)) => (abs.to_string_lossy().into_owned(), Some(dir.clone())),
+        None => (config.spec.command.clone(), None),
+    };
 
     let mut cmd = StdCommand::new(&current_exe);
     cmd.arg("__cockpit-runner")
@@ -630,7 +730,10 @@ fn spawn_runner_detached(
         cmd.arg("--stored-acp-session-id").arg(stored);
     }
     cmd.arg("--");
-    cmd.arg(&config.spec.command);
+    // Pass the resolved absolute path (or fall back to the bare command).
+    // The runner spawns whatever it receives, so an absolute path bypasses
+    // any PATH lookup inside the runner.
+    cmd.arg(&spawn_command);
     for a in &config.spec.args {
         cmd.arg(a);
     }
@@ -642,6 +745,17 @@ fn spawn_runner_detached(
     // either process.
     cmd.env_clear();
     apply_env_filter(&mut cmd, config);
+    if let Some(extra) = &extra_path_dir {
+        // Prepend the resolved bin dir to the PATH we just forwarded so
+        // the adapter's own `node`/`npx` lookups land in the same install
+        // as the adapter itself, not whatever node happens to be on the
+        // daemon's frozen PATH.
+        let current = std::env::var("PATH").unwrap_or_default();
+        let extra_s = extra.to_string_lossy();
+        if !std::env::split_paths(&current).any(|p| p == *extra) {
+            cmd.env("PATH", format!("{}:{}", extra_s, current));
+        }
+    }
 
     // Detach: child becomes its own session leader so a SIGTERM/SIGHUP
     // to the aoe daemon's group doesn't cascade. The runner installs its
@@ -671,6 +785,7 @@ fn spawn_runner_detached(
         socket = %socket_path.display(),
         runner = %current_exe.display(),
         agent = %config.spec.command,
+        resolved = %spawn_command,
         "spawning detached cockpit runner"
     );
 
@@ -759,7 +874,17 @@ async fn wait_for_socket(
 }
 
 fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpError> {
-    let mut cmd = tokio::process::Command::new(&config.spec.command);
+    // Resolve bare command names against PATH + known node-manager dirs.
+    // `aoe serve` captures PATH at daemon-launch time and freezes it for
+    // its lifetime; without this, a `nvm use` after launch leaves the
+    // adapter installed but unreachable. See #1048.
+    let resolved = resolve_agent_command(&config.spec.command);
+    let (spawn_command, extra_path_dir) = match &resolved {
+        Some((abs, dir)) => (abs.to_string_lossy().into_owned(), Some(dir.clone())),
+        None => (config.spec.command.clone(), None),
+    };
+
+    let mut cmd = tokio::process::Command::new(&spawn_command);
     cmd.args(&config.spec.args)
         .current_dir(&config.cwd)
         .stdin(Stdio::piped())
@@ -787,7 +912,19 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
     ];
     let mut forwarded_keys: Vec<&str> = Vec::new();
     for name in always_forward {
-        if let Ok(value) = std::env::var(name) {
+        if let Ok(mut value) = std::env::var(name) {
+            // Prepend the resolved bin dir to PATH so the adapter's own
+            // `node`/`npx` lookups land in the same node install as the
+            // adapter itself, not whatever node happens to be on the
+            // daemon's frozen PATH.
+            if name == "PATH" {
+                if let Some(extra) = &extra_path_dir {
+                    let extra_s = extra.to_string_lossy();
+                    if !std::env::split_paths(&value).any(|p| p == *extra) {
+                        value = format!("{}:{}", extra_s, value);
+                    }
+                }
+            }
             cmd.env(name, value);
             forwarded_keys.push(name);
         }
@@ -829,6 +966,7 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
     info!(
         target: "cockpit.acp.spawn",
         command = %config.spec.command,
+        resolved = %spawn_command,
         args = ?config.spec.args,
         cwd = %config.cwd.display(),
         transport = if config.socket_path.is_some() { "socket" } else { "stdio" },
@@ -842,9 +980,24 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
         warn!(
             target: "cockpit.acp.spawn",
             command = %config.spec.command,
+            resolved = %spawn_command,
             "spawn failed: {e}"
         );
-        AcpError::Spawn(e.to_string())
+        // ENOENT on a bare command means we couldn't find the binary on
+        // PATH or in any known node-manager dir. Bubble up a hint instead
+        // of the bare libc message — the daemon's frozen PATH is the
+        // most common cause and the generic message doesn't say so.
+        if e.kind() == std::io::ErrorKind::NotFound && resolved.is_none() {
+            AcpError::Spawn(format!(
+                "{} (binary `{}` not found on the daemon's PATH or in any \
+                 known node-manager bin dir; install it where the daemon \
+                 can see it, or restart `aoe serve` from a shell where \
+                 `which {}` resolves)",
+                e, config.spec.command, config.spec.command
+            ))
+        } else {
+            AcpError::Spawn(e.to_string())
+        }
     })?;
 
     let pid = child.id();
@@ -2186,6 +2339,53 @@ mod tests {
         };
         let result = AcpClient::spawn(config, CockpitSessionId("s-1".into())).await;
         assert!(matches!(result, Err(AcpError::Spawn(_))));
+    }
+
+    #[test]
+    fn resolve_agent_command_returns_none_for_absolute_path() {
+        assert!(resolve_agent_command("/usr/local/bin/claude-agent-acp").is_none());
+        assert!(resolve_agent_command("./relative/path").is_none());
+    }
+
+    #[test]
+    fn resolve_agent_command_returns_none_for_placeholder() {
+        assert!(resolve_agent_command("${aoe_data_dir}/cockpit-worker/dist/aoe-agent").is_none());
+    }
+
+    #[test]
+    fn resolve_agent_command_finds_binary_in_path_env() {
+        // Build a temp dir with a fake binary, point PATH at it.
+        let dir = tempfile::TempDir::new().unwrap();
+        let bin = dir.path().join("aoe-test-resolver-fake");
+        std::fs::write(&bin, "#!/bin/sh\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let prev = std::env::var_os("PATH");
+        let new_path = format!(
+            "{}:{}",
+            dir.path().display(),
+            prev.as_ref()
+                .map(|p| p.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        );
+        // SAFETY: this test mutates the process-wide PATH. Other tests in
+        // this module don't depend on PATH; tagging the test single-thread
+        // would be heavier than the current race surface.
+        unsafe {
+            std::env::set_var("PATH", &new_path);
+        }
+        let resolved = resolve_agent_command("aoe-test-resolver-fake");
+        if let Some(prev) = prev {
+            unsafe {
+                std::env::set_var("PATH", prev);
+            }
+        }
+        let (path, parent) = resolved.expect("binary should resolve from PATH");
+        assert_eq!(path, bin);
+        assert_eq!(parent, dir.path());
     }
 
     #[test]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1141,6 +1141,83 @@ fn transcript_event_kind(event: &Event) -> &'static str {
     }
 }
 
+/// Parse Claude's ExitPlanMode tool input into a structured `Plan`.
+/// Claude ships the plan markdown in `raw_input.plan`; we extract its
+/// bullet- or number-prefixed lines as `PlanStep`s with status=Pending,
+/// matching the ACP `SessionUpdate::Plan` shape so the existing
+/// PlanStrip renderer can consume it.
+///
+/// Returns `None` when the input has no `plan` key, the value isn't a
+/// string, or the string has no recognisable list items — in which case
+/// the generic tool card is still rendered so the user sees the raw
+/// plan text. See #1059 for the upstream gap this works around.
+fn extract_plan_from_switch_mode(raw_input: &serde_json::Value) -> Option<Plan> {
+    let plan_text = raw_input.get("plan")?.as_str()?;
+    let steps = parse_plan_steps(plan_text);
+    if steps.is_empty() {
+        return None;
+    }
+    Some(Plan {
+        plan_id: format!("plan-{}", chrono::Utc::now().timestamp_millis()),
+        version: 1,
+        steps,
+    })
+}
+
+/// Flatten plan markdown into `PlanStep`s. v1 heuristic: every line
+/// starting with `-`, `*`, or `<digit>.` becomes one step. Sub-bullets
+/// flatten into the parent list (PlanEntry has no nesting field in the
+/// ACP spec). Strips bold/italic markers from the step title so the
+/// PlanStrip doesn't render literal `**foo**`.
+fn parse_plan_steps(text: &str) -> Vec<PlanStep> {
+    use std::sync::OnceLock;
+    static BULLET: OnceLock<regex::Regex> = OnceLock::new();
+    let bullet = BULLET.get_or_init(|| {
+        regex::Regex::new(r"^\s*(?:[-*]|\d+\.)\s+(.+?)\s*$")
+            .expect("static plan-step regex must compile")
+    });
+
+    let mut steps = Vec::new();
+    for line in text.lines() {
+        if let Some(caps) = bullet.captures(line) {
+            let raw_title = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+            let title = strip_markdown_emphasis(raw_title);
+            if title.is_empty() {
+                continue;
+            }
+            steps.push(PlanStep {
+                id: format!("step-{}", steps.len()),
+                title,
+                detail: None,
+                status: PlanStepStatus::Pending,
+            });
+        }
+    }
+    steps
+}
+
+fn strip_markdown_emphasis(s: &str) -> String {
+    // Replace **bold**, __bold__, *italic*, _italic_ markers with their
+    // inner text. Keep it permissive — the source is Claude's planning
+    // markdown, which is usually well-formed but occasionally drops a
+    // closing marker.
+    use std::sync::OnceLock;
+    static RE: OnceLock<regex::Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        regex::Regex::new(r"\*\*(.+?)\*\*|__(.+?)__|\*([^*]+?)\*|_([^_]+?)_")
+            .expect("static emphasis-strip regex must compile")
+    });
+    re.replace_all(s.trim(), |caps: &regex::Captures<'_>| {
+        for i in 1..=4 {
+            if let Some(m) = caps.get(i) {
+                return m.as_str().to_string();
+            }
+        }
+        String::new()
+    })
+    .into_owned()
+}
+
 /// Heuristic detector for the end of a `/compact` cycle. The Claude ACP
 /// adapter emits "Compacting..." while the compaction runs and
 /// "Compacting completed." once the model's context window has been
@@ -1215,6 +1292,17 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
             // If the same payload carries diff content, surface it.
             if let Some(diff) = extract_diff_from_locations(&tc.locations) {
                 events.push(Event::DiffEmitted { diff });
+            }
+            // claude-agent-acp routes Claude's built-in ExitPlanMode through
+            // the tool channel (kind=switch_mode, plan markdown in
+            // raw_input.plan) instead of the structured SessionUpdate::Plan
+            // channel. Synthesise a PlanUpdated event so the cockpit's
+            // PlanStrip and the rest of the plan-aware UI light up. See
+            // #1059.
+            if matches!(tc.kind, agent_client_protocol::schema::ToolKind::SwitchMode) {
+                if let Some(plan) = extract_plan_from_switch_mode(&raw_args) {
+                    events.push(Event::PlanUpdated { plan });
+                }
             }
             events
         }
@@ -2386,6 +2474,62 @@ mod tests {
         };
         let result = AcpClient::spawn(config, CockpitSessionId("s-1".into())).await;
         assert!(matches!(result, Err(AcpError::Spawn(_))));
+    }
+
+    #[test]
+    fn parse_plan_steps_extracts_dash_and_numbered_bullets() {
+        let md = "Here's the plan:\n\n- First, **read** the file\n- Then patch it\n1. Run tests\n2. Commit\n\nOther prose.";
+        let steps = parse_plan_steps(md);
+        let titles: Vec<&str> = steps.iter().map(|s| s.title.as_str()).collect();
+        assert_eq!(
+            titles,
+            vec![
+                "First, read the file",
+                "Then patch it",
+                "Run tests",
+                "Commit"
+            ]
+        );
+        for s in &steps {
+            assert!(matches!(s.status, PlanStepStatus::Pending));
+        }
+    }
+
+    #[test]
+    fn parse_plan_steps_returns_empty_when_no_bullets() {
+        assert!(parse_plan_steps("Just a paragraph with no list.").is_empty());
+        assert!(parse_plan_steps("").is_empty());
+    }
+
+    #[test]
+    fn extract_plan_from_switch_mode_handles_missing_plan_field() {
+        let v = serde_json::json!({});
+        assert!(extract_plan_from_switch_mode(&v).is_none());
+        let v = serde_json::json!({ "plan": 42 });
+        assert!(extract_plan_from_switch_mode(&v).is_none());
+    }
+
+    #[test]
+    fn extract_plan_from_switch_mode_builds_plan_when_input_has_bullets() {
+        let v = serde_json::json!({
+            "plan": "- Step one\n- Step two\n- Step three"
+        });
+        let plan = extract_plan_from_switch_mode(&v).expect("plan should parse");
+        assert_eq!(plan.steps.len(), 3);
+        assert_eq!(plan.steps[0].title, "Step one");
+    }
+
+    #[test]
+    fn strip_markdown_emphasis_unwraps_bold_and_italic() {
+        assert_eq!(strip_markdown_emphasis("**bold**"), "bold");
+        assert_eq!(strip_markdown_emphasis("__bold__"), "bold");
+        assert_eq!(strip_markdown_emphasis("*italic*"), "italic");
+        assert_eq!(strip_markdown_emphasis("_italic_"), "italic");
+        assert_eq!(
+            strip_markdown_emphasis("mix of **bold** and *italic*"),
+            "mix of bold and italic"
+        );
+        assert_eq!(strip_markdown_emphasis("plain"), "plain");
     }
 
     #[test]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -133,6 +133,11 @@ enum ConnectMode {
 /// bounded.
 const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Monotonic counter appended to synthetic tool-call IDs so two events
+/// minted within the same millisecond don't collide on the
+/// `(session_id, tool_id)` keys used by the cockpit event store.
+static SYNTHETIC_TOOL_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
 /// Read the resume-idle grace. In debug builds, honors
 /// `AOE_RESUME_IDLE_GRACE_MS` so integration tests can short-circuit
 /// the default 10s without making real failures racy. Values below
@@ -333,7 +338,7 @@ impl AcpClient {
     /// post-spawn "wait for runner to bind, then dial" path AND by the
     /// `Self::attach` reattach path on `aoe serve` startup. The runner
     /// owns the agent subprocess so this constructor returns an
-    /// `AcpClient` with `_child = None` — dropping the client does not
+    /// `AcpClient` with `_child = None`; dropping the client does not
     /// terminate the worker.
     #[allow(clippy::too_many_arguments)]
     async fn connect_via_socket(
@@ -397,7 +402,7 @@ impl AcpClient {
 
     /// Reattach to an already-running cockpit worker over its unix
     /// socket. Used by `aoe serve` startup when a registry entry has a
-    /// live PID and an existing socket file — we connect, send only the
+    /// live PID and an existing socket file; we connect, send only the
     /// (idempotent) ACP `initialize` request, and reuse the existing
     /// `stored_acp_session_id` directly. We deliberately do NOT issue
     /// `session/new` or `session/load`: the agent process is still
@@ -527,7 +532,7 @@ impl AcpClient {
 }
 
 /// Reject `provider_env` request entries whose key would either escape
-/// the agent sandbox (PATH, HOME, etc. — `always_forward` already wires
+/// the agent sandbox (PATH, HOME, etc.; `always_forward` already wires
 /// those from the operator's environment) or hijack the dynamic linker
 /// (LD_PRELOAD, DYLD_INSERT_LIBRARIES, etc.) to run arbitrary code in
 /// the child. Provider auth keys (`ANTHROPIC_API_KEY`, etc.) are
@@ -561,12 +566,12 @@ fn provider_env_denyreason(key: &str) -> Option<&'static str> {
 }
 
 /// Scrub well-known secret patterns from agent stderr before it lands in
-/// `debug.log`. Conservative — only redacts strings that unambiguously
+/// `debug.log`. Conservative; only redacts strings that unambiguously
 /// signal a secret via prefix (Anthropic `sk-`, GitHub `ghp_`,
 /// `Bearer <token>`, etc.). Catches the common case where an adapter
 /// prints "auth failed: api_key=sk-ant-..."; will not catch a hand-rolled
 /// secret with no recognisable shape. Users sharing logs in bug reports
-/// should still scan them — see docs/cockpit.md#sharing-debug-logs.
+/// should still scan them; see docs/cockpit.md#sharing-debug-logs.
 fn scrub_stderr_secrets(line: &str) -> std::borrow::Cow<'_, str> {
     use std::sync::OnceLock;
     static RE: OnceLock<regex::Regex> = OnceLock::new();
@@ -985,7 +990,7 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
         );
         // ENOENT on a bare command means we couldn't find the binary on
         // PATH or in any known node-manager dir. Bubble up a hint instead
-        // of the bare libc message — the daemon's frozen PATH is the
+        // of the bare libc message; the daemon's frozen PATH is the
         // most common cause and the generic message doesn't say so.
         if e.kind() == std::io::ErrorKind::NotFound && resolved.is_none() {
             AcpError::Spawn(format!(
@@ -1148,7 +1153,7 @@ fn transcript_event_kind(event: &Event) -> &'static str {
 /// PlanStrip renderer can consume it.
 ///
 /// Returns `None` when the input has no `plan` key, the value isn't a
-/// string, or the string has no recognisable list items — in which case
+/// string, or the string has no recognisable list items; in which case
 /// the generic tool card is still rendered so the user sees the raw
 /// plan text. See #1059 for the upstream gap this works around.
 fn extract_plan_from_switch_mode(raw_input: &serde_json::Value) -> Option<Plan> {
@@ -1198,7 +1203,7 @@ fn parse_plan_steps(text: &str) -> Vec<PlanStep> {
 
 fn strip_markdown_emphasis(s: &str) -> String {
     // Replace **bold**, __bold__, *italic*, _italic_ markers with their
-    // inner text. Keep it permissive — the source is Claude's planning
+    // inner text. Keep it permissive; the source is Claude's planning
     // markdown, which is usually well-formed but occasionally drops a
     // closing marker.
     use std::sync::OnceLock;
@@ -1221,10 +1226,10 @@ fn strip_markdown_emphasis(s: &str) -> String {
 /// Heuristic detector for the end of a `/compact` cycle. The Claude ACP
 /// adapter emits "Compacting..." while the compaction runs and
 /// "Compacting completed." once the model's context window has been
-/// replaced by a summary — both as plain `agent_message_chunk`s with no
+/// replaced by a summary; both as plain `agent_message_chunk`s with no
 /// `_meta` flag (see #1050 for the upstream gap). String-matching on
 /// the completion message is fragile to localisation but the wrong-firing
-/// failure mode (an extra "context reset" divider) is harmless — it can
+/// failure mode (an extra "context reset" divider) is harmless; it can
 /// never destroy transcript data.
 fn is_compact_completion(text: &str) -> bool {
     text.contains("Compacting completed.")
@@ -1238,7 +1243,7 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
         SessionUpdate::AgentMessageChunk(chunk) => match chunk.content {
             ContentBlock::Text(text) => {
                 // /compact emits a plain text chunk ("Compacting completed.")
-                // and a usage_update with used=0 — no typed signal. Detect
+                // and a usage_update with used=0; no typed signal. Detect
                 // the literal string the adapter uses and append a typed
                 // SessionContextReset event so the cockpit can render a
                 // divider, otherwise the silent context replacement leaves
@@ -1249,7 +1254,7 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
                 }];
                 if is_compact_completion(&text.text) {
                     events.push(Event::SessionContextReset {
-                        reason: "Conversation compacted — earlier turns above \
+                        reason: "Conversation compacted; earlier turns above \
                                  are summarised in the model's context."
                             .into(),
                     });
@@ -1258,7 +1263,7 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
                     // is gone from its perspective. The cockpit plan strip
                     // (PlanStrip + sidebar PlanProgressMini) lives in our
                     // own event log though, so without this clear it keeps
-                    // showing a plan Claude no longer remembers — the user
+                    // showing a plan Claude no longer remembers; the user
                     // then asks "resolve the first task" and Claude
                     // responds "no task list." Emit an empty PlanUpdated
                     // so the UI matches the model's actual context.
@@ -1372,16 +1377,21 @@ fn map_update_to_events(update: SessionUpdate) -> Vec<Event> {
             // TodoWrite through the structured `SessionUpdate::Plan`
             // channel (not the tool channel), so without this synthesis
             // the cockpit's PlanStrip + sidebar light up but no tool
-            // card ever renders — the user sees a plan appear "from
+            // card ever renders; the user sees a plan appear "from
             // nowhere" and has no per-update record of which calls
             // produced which states. Emit a ToolCallStarted /
             // ToolCallCompleted pair shaped to match what the
             // TodoUpdateCard classifier in ToolCards.tsx expects
             // (`name = "TodoWrite"`, `args.todos = [...]`), one per
             // adapter update.
+            // Append a session-local monotonic counter so two plan updates
+            // arriving in the same millisecond don't share a synthetic ID
+            // (which would collide in the cockpit_events row keys and
+            // render as a single card instead of two).
             let ts_ms = chrono::Utc::now().timestamp_millis();
-            let plan_id = format!("plan-{ts_ms}");
-            let tool_id = format!("todo-{ts_ms}");
+            let seq = SYNTHETIC_TOOL_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            let plan_id = format!("plan-{ts_ms}-{seq}");
+            let tool_id = format!("todo-{ts_ms}-{seq}");
             let todos_json: Vec<serde_json::Value> = p
                 .entries
                 .iter()
@@ -1553,7 +1563,7 @@ fn preview_args(raw: &serde_json::Value) -> String {
 }
 
 /// Concat the textual portion of a tool call's `content` array. Drops
-/// non-text content blocks (images, resources, embedded terminals) — the
+/// non-text content blocks (images, resources, embedded terminals); the
 /// per-tool renderer fall-back path only knows how to display text. Diffs
 /// are surfaced separately via `extract_diff_from_locations` (and could
 /// later be picked up here too via `ToolCallContent::Diff`).
@@ -1622,7 +1632,7 @@ async fn run_connection_task<W, R>(
     // historical assistant turn replayed as agent_message_chunk
     // events). Our SQLite event store already has those events from
     // the original run, so passing them through would double the
-    // transcript on the next reload — every prior assistant bubble
+    // transcript on the next reload; every prior assistant bubble
     // appears once from disk replay, then again from the agent's
     // history dump. Suppress agent-side notifications during the
     // window between session/load success and the first user prompt;
@@ -1666,7 +1676,7 @@ async fn run_connection_task<W, R>(
                         // visible transcript (assistant chunks, tool
                         // calls, plans, etc.). Ambient state events
                         // (mode/usage/available_commands) and lifecycle
-                        // events (stopped, errors) must pass through —
+                        // events (stopped, errors) must pass through;
                         // otherwise the composer footer and pickers
                         // stay stale until the user types something.
                         if suppressing && is_transcript_event(&event) {
@@ -1771,8 +1781,8 @@ async fn run_connection_task<W, R>(
                 .terminal(true);
             // `initialize` is sent in both Fresh and Resume modes.
             // It's idempotent on every ACP agent we ship against
-            // (aoe-agent, claude-agent-acp) — the response only carries
-            // capability metadata — so re-sending it on attach is safe.
+            // (aoe-agent, claude-agent-acp); the response only carries
+            // capability metadata; so re-sending it on attach is safe.
             let init = connection
                 .send_request(
                     InitializeRequest::new(ProtocolVersion::V1)
@@ -2086,7 +2096,7 @@ async fn run_connection_task<W, R>(
                                             // freeze this select loop for the
                                             // duration of the round-trip,
                                             // defeating the point of polling
-                                            // cmd_rx concurrently — a Cancel
+                                            // cmd_rx concurrently; a Cancel
                                             // arriving while set_mode is in
                                             // flight would queue. The detached
                                             // task mirrors the success into the
@@ -2228,7 +2238,7 @@ async fn run_connection_task<W, R>(
     // In runner-managed mode (child is None) we deliberately don't kill
     // anything here: the per-worker `aoe __cockpit-runner` shim owns the
     // agent subprocess and outlives this daemon's connection. The socket
-    // file also stays — the runner cleans it up on its own exit.
+    // file also stays; the runner cleans it up on its own exit.
     if let Some(child) = child.as_ref() {
         let mut guard = child.lock().await;
         match guard.try_wait() {
@@ -2630,8 +2640,12 @@ mod tests {
     }
 
     #[test]
+    #[serial_test::serial]
     fn resolve_agent_command_finds_binary_in_path_env() {
         // Build a temp dir with a fake binary, point PATH at it.
+        // Tagged `#[serial]` because the test mutates the process-wide
+        // PATH; any concurrent test that reads PATH (e.g. resolves a
+        // real binary) would race.
         let dir = tempfile::TempDir::new().unwrap();
         let bin = dir.path().join("aoe-test-resolver-fake");
         std::fs::write(&bin, "#!/bin/sh\n").unwrap();
@@ -2648,9 +2662,9 @@ mod tests {
                 .map(|p| p.to_string_lossy().into_owned())
                 .unwrap_or_default()
         );
-        // SAFETY: this test mutates the process-wide PATH. Other tests in
-        // this module don't depend on PATH; tagging the test single-thread
-        // would be heavier than the current race surface.
+        // SAFETY: this test mutates the process-wide PATH. Other PATH
+        // readers in the same test binary would race; `#[serial]` keeps
+        // them apart.
         unsafe {
             std::env::set_var("PATH", &new_path);
         }

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -53,7 +53,7 @@ use anyhow::{Context, Result};
 use rusqlite::{params, Connection, OptionalExtension};
 use tracing::{debug, trace, warn};
 
-use super::state::Event;
+use super::state::{Event, Plan};
 
 /// SQLite-backed cockpit event log. One row per (session_id, seq).
 pub struct EventStore {
@@ -255,6 +255,36 @@ impl EventStore {
             "replayed events"
         );
         out
+    }
+
+    /// Return the latest `Event::PlanUpdated` stored for `session_id`,
+    /// if any. Used by the REST sessions endpoint to surface
+    /// plan-progress chrome (current step / completed / total) on the
+    /// sidebar without subscribing to the cockpit WS for every session.
+    /// See #1061.
+    pub fn latest_plan(&self, session_id: &str) -> Option<Plan> {
+        let conn = match self.conn.lock() {
+            Ok(g) => g,
+            Err(p) => p.into_inner(),
+        };
+        let json: String = conn
+            .query_row(
+                "SELECT event_json FROM cockpit_events
+                 WHERE session_id = ?1
+                   AND event_json LIKE '{\"PlanUpdated\":%'
+                 ORDER BY seq DESC LIMIT 1",
+                params![session_id],
+                |row| row.get(0),
+            )
+            .optional()
+            .ok()
+            .flatten()?;
+        let event: Event = serde_json::from_str(&json).ok()?;
+        if let Event::PlanUpdated { plan } = event {
+            Some(plan)
+        } else {
+            None
+        }
     }
 
     /// Return the highest seq stored for `session_id`, or 0 if none.
@@ -486,6 +516,60 @@ mod tests {
         } else {
             panic!("expected UserPromptSent");
         }
+    }
+
+    #[test]
+    fn latest_plan_returns_most_recent_plan_event() {
+        use super::super::state::{Plan, PlanStep, PlanStepStatus};
+        let (_tmp, store) = open_store(1000);
+        let plan_v1 = Plan {
+            plan_id: "p-1".into(),
+            version: 1,
+            steps: vec![PlanStep {
+                id: "s-1".into(),
+                title: "Step one".into(),
+                detail: None,
+                status: PlanStepStatus::Pending,
+            }],
+        };
+        let plan_v2 = Plan {
+            plan_id: "p-2".into(),
+            version: 2,
+            steps: vec![
+                PlanStep {
+                    id: "s-1".into(),
+                    title: "Step one".into(),
+                    detail: None,
+                    status: PlanStepStatus::Done,
+                },
+                PlanStep {
+                    id: "s-2".into(),
+                    title: "Step two".into(),
+                    detail: None,
+                    status: PlanStepStatus::Pending,
+                },
+            ],
+        };
+        store
+            .record("s-1", 1, &Event::PlanUpdated { plan: plan_v1 })
+            .unwrap();
+        store.record("s-1", 2, &Event::ThinkingStarted).unwrap();
+        store
+            .record("s-1", 3, &Event::PlanUpdated { plan: plan_v2 })
+            .unwrap();
+        let latest = store.latest_plan("s-1").expect("plan present");
+        assert_eq!(latest.steps.len(), 2);
+        assert!(matches!(
+            latest.steps[0].status,
+            crate::cockpit::state::PlanStepStatus::Done
+        ));
+    }
+
+    #[test]
+    fn latest_plan_returns_none_when_no_plan_event() {
+        let (_tmp, store) = open_store(1000);
+        store.record("s-1", 1, &Event::ThinkingStarted).unwrap();
+        assert!(store.latest_plan("s-1").is_none());
     }
 
     #[test]

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -109,7 +109,7 @@ impl EventStore {
     }
 
     /// Append one event. Idempotent on duplicate (session_id, seq) thanks
-    /// to the primary key — re-publishing the same seq is a no-op.
+    /// to the primary key; re-publishing the same seq is a no-op.
     /// Returns Err when the event was *not* persisted, so the caller can
     /// surface the gap (e.g. publish a `Lagged` frame on the broadcast
     /// channel) instead of letting the on-disk log silently fall behind
@@ -136,7 +136,7 @@ impl EventStore {
             // Logged at trace because the cause is usually a benign retry
             // (publish_user_prompt + replay drain re-publishing) rather
             // than a bug, but we still want a breadcrumb. Per-event lines
-            // are too noisy to live at debug — they bury the lifecycle
+            // are too noisy to live at debug; they bury the lifecycle
             // signal in debug.log during an active turn.
             trace!(
                 target: "cockpit.event_store",
@@ -163,7 +163,7 @@ impl EventStore {
         // Snapshot events (the slash-command list, mode list, ACP session
         // id) are exempt from pruning: the agent only emits them once per
         // session lifecycle, near the start of the seq range, so a long
-        // session blows past the cap and evicts them — leaving the
+        // session blows past the cap and evicts them; leaving the
         // composer's `/` palette and the mode picker empty on reconnect.
         // See #1049. The `event_json NOT LIKE` clauses match the
         // externally-tagged JSON discriminant for each pinned variant.
@@ -194,7 +194,7 @@ impl EventStore {
                     );
                 }
                 Err(e) => {
-                    // Prune failure isn't fatal — the row is recorded,
+                    // Prune failure isn't fatal; the row is recorded,
                     // we just exceed the cap until the next prune
                     // succeeds. Log + swallow so callers don't have to
                     // distinguish "record failed" from "trim failed".

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -159,6 +159,14 @@ impl EventStore {
         // (the subquery returns 0 rows). We do it on every insert rather
         // than periodically so the upper bound on per-session disk usage
         // is strict rather than amortised.
+        //
+        // Snapshot events (the slash-command list, mode list, ACP session
+        // id) are exempt from pruning: the agent only emits them once per
+        // session lifecycle, near the start of the seq range, so a long
+        // session blows past the cap and evicts them — leaving the
+        // composer's `/` palette and the mode picker empty on reconnect.
+        // See #1049. The `event_json NOT LIKE` clauses match the
+        // externally-tagged JSON discriminant for each pinned variant.
         if self.max_events_per_session > 0 {
             match conn.execute(
                 "DELETE FROM cockpit_events
@@ -168,7 +176,11 @@ impl EventStore {
                      WHERE session_id = ?1
                      ORDER BY seq DESC
                      LIMIT 1 OFFSET ?2
-                   )",
+                   )
+                   AND event_json NOT LIKE '{\"AvailableCommandsUpdated\":%'
+                   AND event_json NOT LIKE '{\"ModesAvailable\":%'
+                   AND event_json NOT LIKE '{\"CurrentModeChanged\":%'
+                   AND event_json NOT LIKE '{\"AcpSessionAssigned\":%'",
                 params![session_id, self.max_events_per_session as i64],
             ) {
                 Ok(0) => {}
@@ -474,6 +486,63 @@ mod tests {
         } else {
             panic!("expected UserPromptSent");
         }
+    }
+
+    #[test]
+    fn snapshot_events_survive_retention_prune() {
+        // Mirrors #1049: a long session blew past max_events_per_session
+        // and evicted the early `AvailableCommandsUpdated` row, leaving
+        // the `/` palette empty on reconnect. Snapshot kinds are pinned
+        // so they outlive the prune even when the rest of the seq tail
+        // gets dropped.
+        let (_tmp, store) = open_store(3);
+        store
+            .record(
+                "s-1",
+                1,
+                &Event::AvailableCommandsUpdated { commands: vec![] },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                2,
+                &Event::ModesAvailable {
+                    current_mode_id: "default".into(),
+                    modes: vec![],
+                },
+            )
+            .unwrap();
+        store
+            .record(
+                "s-1",
+                3,
+                &Event::AcpSessionAssigned {
+                    acp_session_id: "acp-xyz".into(),
+                },
+            )
+            .unwrap();
+        // Push enough transcript events to blow past the cap several
+        // times. With the old prune, seqs 1-3 would all be evicted.
+        for i in 4..=20 {
+            store.record("s-1", i, &Event::ThinkingStarted).unwrap();
+        }
+        let replay = store.replay_from("s-1", 0);
+        let seqs: Vec<u64> = replay.iter().map(|(s, _)| *s).collect();
+        // The three snapshot rows survive. The most recent 3 transcript
+        // events also remain.
+        assert!(
+            seqs.contains(&1),
+            "AvailableCommandsUpdated dropped: {seqs:?}"
+        );
+        assert!(seqs.contains(&2), "ModesAvailable dropped: {seqs:?}");
+        assert!(seqs.contains(&3), "AcpSessionAssigned dropped: {seqs:?}");
+        assert!(seqs.contains(&20), "newest event dropped: {seqs:?}");
+        // Older transcript-only events (4 through 17) are pruned.
+        assert!(
+            !seqs.contains(&5),
+            "stale transcript event leaked: {seqs:?}"
+        );
     }
 
     #[test]

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -630,6 +630,49 @@ mod tests {
     }
 
     #[test]
+    fn snapshot_event_json_discriminators_match_prune_clauses() {
+        // The retention prune query in `Self::record` excludes four event
+        // variants via `WHERE event_json NOT LIKE '{"<Variant>":%'`. If the
+        // `Event` enum is ever refactored to a different serde shape
+        // (`#[serde(tag = "...")]`, a rename, or another adjacency), the
+        // LIKE strings silently stop matching and snapshot pinning quietly
+        // breaks. Pin the discriminator at the JSON level so any such
+        // refactor trips this test instead of going unnoticed.
+        let cases: &[(Event, &str)] = &[
+            (
+                Event::AvailableCommandsUpdated { commands: vec![] },
+                "{\"AvailableCommandsUpdated\":",
+            ),
+            (
+                Event::ModesAvailable {
+                    current_mode_id: "default".into(),
+                    modes: vec![],
+                },
+                "{\"ModesAvailable\":",
+            ),
+            (
+                Event::CurrentModeChanged {
+                    current_mode_id: "default".into(),
+                },
+                "{\"CurrentModeChanged\":",
+            ),
+            (
+                Event::AcpSessionAssigned {
+                    acp_session_id: "acp-xyz".into(),
+                },
+                "{\"AcpSessionAssigned\":",
+            ),
+        ];
+        for (event, expected_prefix) in cases {
+            let json = serde_json::to_string(event).unwrap();
+            assert!(
+                json.starts_with(expected_prefix),
+                "snapshot variant serialised as {json}, expected to start with {expected_prefix}"
+            );
+        }
+    }
+
+    #[test]
     fn retention_cap_drops_oldest() {
         let (_tmp, store) = open_store(3);
         for i in 1..=5 {

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -232,7 +232,7 @@ pub enum Event {
         /// Server-side wall-clock time the completion frame was minted.
         /// Carried on the event so the frontend reducer can stamp the
         /// matching `tool_complete` activity row with the REAL
-        /// completion time rather than `new Date()` at replay time —
+        /// completion time rather than `new Date()` at replay time;
         /// without this, page-reload after a long delay made every
         /// completed tool's duration count from "now", inflating the
         /// label from seconds to minutes/hours. Events persisted
@@ -267,7 +267,7 @@ pub enum Event {
         #[serde(default)]
         args_preview: Option<String>,
         /// Re-stamps the tool's start time. Set when the agent reports
-        /// `ToolCallStatus::InProgress` — claude-agent-acp emits the
+        /// `ToolCallStatus::InProgress`; claude-agent-acp emits the
         /// initial `tool_call` notification eagerly (often well before
         /// the underlying command actually starts running), so the
         /// duration label (#1060) would otherwise count adapter
@@ -319,7 +319,7 @@ pub enum Event {
     /// Full snapshot of the slash commands the agent advertises. Comes
     /// from ACP `SessionUpdate::AvailableCommandsUpdate`. Replaces the
     /// previous list (the agent re-broadcasts the full set whenever it
-    /// changes — e.g. after plugin enable/disable).
+    /// changes; e.g. after plugin enable/disable).
     AvailableCommandsUpdated {
         commands: Vec<AvailableCommand>,
     },

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -229,6 +229,18 @@ pub enum Event {
         /// is empty so cards still convey state.
         #[serde(default)]
         content: String,
+        /// Server-side wall-clock time the completion frame was minted.
+        /// Carried on the event so the frontend reducer can stamp the
+        /// matching `tool_complete` activity row with the REAL
+        /// completion time rather than `new Date()` at replay time —
+        /// without this, page-reload after a long delay made every
+        /// completed tool's duration count from "now", inflating the
+        /// label from seconds to minutes/hours. Events persisted
+        /// before this field landed default to "now" on deserialise
+        /// (serde calls the function), so the durations of pre-fix
+        /// events stay imprecise; new events are accurate end-to-end.
+        #[serde(default = "chrono::Utc::now")]
+        completed_at: DateTime<Utc>,
     },
     /// Streaming tool output. Some agents emit `ToolCallUpdate` notifications
     /// with `status != Completed` but populated `fields.content` to stream
@@ -531,6 +543,7 @@ mod tests {
             tool_call_id: "tc-1".into(),
             is_error: false,
             content: String::new(),
+            completed_at: Utc::now(),
         })
         .unwrap();
         assert!(s.in_flight_tool.is_none());

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -254,6 +254,16 @@ pub enum Event {
         title: Option<String>,
         #[serde(default)]
         args_preview: Option<String>,
+        /// Re-stamps the tool's start time. Set when the agent reports
+        /// `ToolCallStatus::InProgress` — claude-agent-acp emits the
+        /// initial `tool_call` notification eagerly (often well before
+        /// the underlying command actually starts running), so the
+        /// duration label (#1060) would otherwise count adapter
+        /// scheduling time as part of the tool's runtime. Treating
+        /// "InProgress" as the real start gives an accurate elapsed
+        /// time on completion.
+        #[serde(default)]
+        started_at: Option<DateTime<Utc>>,
     },
     ApprovalRequested {
         approval: Approval,
@@ -375,6 +385,7 @@ impl CockpitState {
                 tool_call_id,
                 title,
                 args_preview,
+                started_at,
             } => {
                 if let Some(tool) = self.in_flight_tool.as_mut() {
                     if tool.id == tool_call_id {
@@ -383,6 +394,9 @@ impl CockpitState {
                         }
                         if let Some(a) = args_preview {
                             tool.args_preview = a;
+                        }
+                        if let Some(t) = started_at {
+                            tool.started_at = t;
                         }
                     }
                 }

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -287,6 +287,117 @@ pub fn enrich_worktree_remove_error(stderr: &str, worktree_path: &Path) -> Strin
     out
 }
 
+/// Returns true if a `git worktree remove` stderr indicates the failure was
+/// caused by initialised submodules. Git refuses to remove a worktree whose
+/// checkout still has live submodule entries, even with `--force` — submodule
+/// state lives under `.git/worktrees/<name>/modules/` and orphaning it would
+/// corrupt the main repo.
+pub fn is_submodule_blocker(error: &str) -> bool {
+    let lower = error.to_lowercase();
+    lower.contains("working trees containing submodules cannot be moved or removed")
+}
+
+/// Deinitialise any submodules under `worktree_path` so `git worktree remove`
+/// will let the worktree go. Best-effort and idempotent: a no-op when the
+/// worktree has no `.gitmodules`, no initialised submodules, or git itself
+/// isn't reachable. The `-f` on `submodule deinit` is "force-deinit modified
+/// submodules" — distinct from aoe's worktree-level `force`, which means
+/// "discard uncommitted/untracked files in the worktree itself" — so applying
+/// it here doesn't conflate the two semantics.
+pub fn deinit_submodules_if_present(worktree_path: &Path) {
+    if !worktree_path.join(".gitmodules").exists() {
+        return;
+    }
+    let output = std::process::Command::new("git")
+        .args(["submodule", "deinit", "-f", "--all"])
+        .current_dir(worktree_path)
+        .output();
+    match output {
+        Ok(o) if o.status.success() => {
+            tracing::debug!(
+                path = %worktree_path.display(),
+                "deinitialised submodules before worktree removal"
+            );
+        }
+        Ok(o) => {
+            tracing::debug!(
+                path = %worktree_path.display(),
+                stderr = %String::from_utf8_lossy(&o.stderr),
+                "submodule deinit returned non-zero; continuing"
+            );
+        }
+        Err(e) => {
+            tracing::debug!(
+                path = %worktree_path.display(),
+                error = %e,
+                "submodule deinit failed to spawn; continuing"
+            );
+        }
+    }
+}
+
+/// Read `.git` (file form) in a worktree to recover the linked worktree's
+/// administrative name. Returns the basename of the gitdir path, e.g.
+/// `<main_repo>/.git/worktrees/feature-foo` → `feature-foo`. None when the
+/// `.git` file is missing or doesn't carry a `gitdir:` line.
+fn read_linked_worktree_name(worktree_path: &Path) -> Option<String> {
+    let dotgit = worktree_path.join(".git");
+    let contents = std::fs::read_to_string(&dotgit).ok()?;
+    for line in contents.lines() {
+        if let Some(rest) = line.strip_prefix("gitdir:") {
+            let gitdir = Path::new(rest.trim());
+            return gitdir
+                .file_name()
+                .and_then(|s| s.to_str())
+                .map(|s| s.to_string());
+        }
+    }
+    None
+}
+
+/// Manual cleanup fallback for the submodule-blocker error. Removes the
+/// per-worktree `modules/` directory git would normally orphan, deletes the
+/// worktree checkout, then prunes the now-stale entry from the main repo's
+/// worktree list. Equivalent to the three-command shell workaround a user
+/// would run by hand. Returns the list of errors encountered; empty means
+/// success.
+pub fn manual_submodule_worktree_cleanup(
+    git_wt: &GitWorktree,
+    worktree_path: &Path,
+    main_repo: &Path,
+) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    if let Some(name) = read_linked_worktree_name(worktree_path) {
+        let modules_dir = main_repo.join(".git/worktrees").join(&name).join("modules");
+        if modules_dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&modules_dir) {
+                tracing::debug!(
+                    path = %modules_dir.display(),
+                    error = %e,
+                    "failed to remove orphaned worktree modules dir"
+                );
+                errors.push(format!("Submodule cleanup: {}", e));
+            } else {
+                tracing::debug!(
+                    path = %modules_dir.display(),
+                    "removed orphaned worktree modules dir"
+                );
+            }
+        }
+    }
+
+    if let Err(e) = remove_worktree_dir(worktree_path, main_repo, true) {
+        errors.push(format!("Worktree: {}", e));
+    }
+
+    if let Err(e) = git_wt.prune_worktrees() {
+        errors.push(format!("Worktree: {}", e));
+    }
+
+    errors
+}
+
 /// Check if a git error message indicates a permission problem.
 pub fn is_permission_error(error: &str) -> bool {
     let lower = error.to_lowercase();
@@ -403,6 +514,13 @@ pub fn remove_managed_worktree(
             errors.push(format!("Worktree: {}", e));
         }
     } else {
+        // Submodules are a normal repo state, not a destructive override —
+        // `git worktree remove` refuses to delete a worktree with live
+        // submodules even with --force, so deinit them ourselves before
+        // asking git to remove the checkout. No-op when the worktree has no
+        // .gitmodules.
+        deinit_submodules_if_present(worktree_path);
+
         match git_wt.remove_worktree(worktree_path, force) {
             Ok(()) => {
                 worktree_removed = true;
@@ -412,6 +530,7 @@ pub fn remove_managed_worktree(
                 tracing::debug!(
                     error = %err_str,
                     is_perm = is_permission_error(&err_str),
+                    is_submodule = is_submodule_blocker(&err_str),
                     "git worktree remove failed"
                 );
                 // Container cleanup deletes everything including .git, so
@@ -428,6 +547,24 @@ pub fn remove_managed_worktree(
                     worktree_removed = true;
                     if let Err(e2) = git_wt.prune_worktrees() {
                         errors.push(format!("Worktree: {}", e2));
+                    }
+                } else if is_submodule_blocker(&err_str) {
+                    // Pre-deinit didn't fully resolve it (e.g. a broken
+                    // submodule), or the worktree carries orphaned modules
+                    // state without a live `.gitmodules`. Fall back to manual
+                    // teardown.
+                    let manual_errors =
+                        manual_submodule_worktree_cleanup(git_wt, worktree_path, main_repo);
+                    if manual_errors.is_empty() {
+                        worktree_removed = true;
+                    } else {
+                        errors.push(format!(
+                            "Worktree: {}",
+                            enrich_worktree_remove_error(&err_str, worktree_path)
+                        ));
+                        for me in manual_errors {
+                            errors.push(me);
+                        }
                     }
                 } else {
                     errors.push(format!(
@@ -721,6 +858,97 @@ mod tests {
         assert!(is_permission_error("operation not permitted"));
         assert!(is_permission_error("Access is denied"));
         assert!(!is_permission_error("file not found"));
+    }
+
+    #[test]
+    fn test_is_submodule_blocker_matches_git_message() {
+        assert!(is_submodule_blocker(
+            "fatal: working trees containing submodules cannot be moved or removed"
+        ));
+        assert!(is_submodule_blocker(
+            "Git worktree command failed: fatal: working trees containing submodules cannot be moved or removed"
+        ));
+        assert!(!is_submodule_blocker("permission denied"));
+        assert!(!is_submodule_blocker(
+            "contains modified or untracked files"
+        ));
+    }
+
+    #[test]
+    fn test_read_linked_worktree_name_parses_gitdir_line() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let wt = dir.path().join("wt");
+        std::fs::create_dir(&wt).unwrap();
+        std::fs::write(
+            wt.join(".git"),
+            "gitdir: /tmp/main/.git/worktrees/feature-foo\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_linked_worktree_name(&wt),
+            Some("feature-foo".to_string())
+        );
+    }
+
+    #[test]
+    fn test_read_linked_worktree_name_returns_none_without_dotgit() {
+        let dir = tempfile::TempDir::new().unwrap();
+        assert!(read_linked_worktree_name(dir.path()).is_none());
+    }
+
+    #[test]
+    fn test_manual_submodule_worktree_cleanup_removes_modules_dir() {
+        // Build a main repo + a linked-worktree layout by hand: main repo has
+        // `.git/worktrees/feature-foo/modules/<sub>` (the orphaned submodule
+        // state git refuses to leave behind), and the worktree has a `.git`
+        // file pointing back to that entry. The manual fallback should clear
+        // the modules dir, the worktree checkout, and prune the stale entry.
+        let dir = tempfile::TempDir::new().unwrap();
+        let main_repo = dir.path().join("main");
+        std::fs::create_dir_all(&main_repo).unwrap();
+        let repo = git2::Repository::init(&main_repo).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        let modules_dir = main_repo.join(".git/worktrees/feature-foo/modules/sub");
+        std::fs::create_dir_all(&modules_dir).unwrap();
+        std::fs::write(modules_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let wt = dir.path().join("feature-foo");
+        std::fs::create_dir_all(&wt).unwrap();
+        std::fs::write(
+            wt.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                main_repo.join(".git/worktrees/feature-foo").display()
+            ),
+        )
+        .unwrap();
+
+        let git_wt = GitWorktree::new(main_repo.clone()).unwrap();
+        let errors = manual_submodule_worktree_cleanup(&git_wt, &wt, &main_repo);
+
+        assert!(
+            errors.is_empty(),
+            "expected clean cleanup, got: {:?}",
+            errors
+        );
+        assert!(!modules_dir.exists(), "modules dir should be removed");
+        assert!(!wt.exists(), "worktree dir should be removed");
+    }
+
+    #[test]
+    fn test_deinit_submodules_if_present_is_noop_without_gitmodules() {
+        // No `.gitmodules` → function returns without spawning git. We can't
+        // observe the no-spawn directly, but the call must not panic and the
+        // directory contents must be unchanged.
+        let dir = tempfile::TempDir::new().unwrap();
+        std::fs::write(dir.path().join("placeholder"), "x").unwrap();
+        deinit_submodules_if_present(dir.path());
+        assert!(dir.path().join("placeholder").exists());
     }
 
     #[test]

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -289,7 +289,7 @@ pub fn enrich_worktree_remove_error(stderr: &str, worktree_path: &Path) -> Strin
 
 /// Returns true if a `git worktree remove` stderr indicates the failure was
 /// caused by initialised submodules. Git refuses to remove a worktree whose
-/// checkout still has live submodule entries, even with `--force` — submodule
+/// checkout still has live submodule entries, even with `--force`; submodule
 /// state lives under `.git/worktrees/<name>/modules/` and orphaning it would
 /// corrupt the main repo.
 pub fn is_submodule_blocker(error: &str) -> bool {
@@ -301,8 +301,8 @@ pub fn is_submodule_blocker(error: &str) -> bool {
 /// will let the worktree go. Best-effort and idempotent: a no-op when the
 /// worktree has no `.gitmodules`, no initialised submodules, or git itself
 /// isn't reachable. The `-f` on `submodule deinit` is "force-deinit modified
-/// submodules" — distinct from aoe's worktree-level `force`, which means
-/// "discard uncommitted/untracked files in the worktree itself" — so applying
+/// submodules"; distinct from aoe's worktree-level `force`, which means
+/// "discard uncommitted/untracked files in the worktree itself"; so applying
 /// it here doesn't conflate the two semantics.
 pub fn deinit_submodules_if_present(worktree_path: &Path) {
     if !worktree_path.join(".gitmodules").exists() {
@@ -514,7 +514,7 @@ pub fn remove_managed_worktree(
             errors.push(format!("Worktree: {}", e));
         }
     } else {
-        // Submodules are a normal repo state, not a destructive override —
+        // Submodules are a normal repo state, not a destructive override;
         // `git worktree remove` refuses to delete a worktree with live
         // submodules even with --force, so deinit them ourselves before
         // asking git to remove the checkout. No-op when the worktree has no

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -13,13 +13,14 @@ mod v002_seed_sandbox_from_volumes;
 mod v003_yolo_mode_config;
 mod v004_unified_environment;
 mod v005_cockpit_defaults;
+mod v006_unlimited_cockpit_history;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 5;
+const CURRENT_VERSION: u32 = 6;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -53,6 +54,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 5,
         name: "cockpit_defaults",
         run: v005_cockpit_defaults::run,
+    },
+    Migration {
+        version: 6,
+        name: "unlimited_cockpit_history",
+        run: v006_unlimited_cockpit_history::run,
     },
 ];
 

--- a/src/migrations/v006_unlimited_cockpit_history.rs
+++ b/src/migrations/v006_unlimited_cockpit_history.rs
@@ -6,7 +6,7 @@
 //! "keep everything"; users coming from a v005-seeded install would
 //! otherwise stay capped at 500. This migration rewrites that specific
 //! seeded value (500) to 0 so upgraders pick up the new default. Any
-//! user who has explicitly set a different cap is left alone — only the
+//! user who has explicitly set a different cap is left alone; only the
 //! exact v005 seed value triggers the rewrite.
 
 use anyhow::Result;

--- a/src/migrations/v006_unlimited_cockpit_history.rs
+++ b/src/migrations/v006_unlimited_cockpit_history.rs
@@ -1,0 +1,126 @@
+//! Migration v006: Flip the cockpit history retention default from 500
+//! to 0 (unlimited) for existing users on upgrade.
+//!
+//! v005 seeded `cockpit.replay_events = 500` in config.toml when the
+//! cockpit feature shipped. With #1065 we're flipping the default to
+//! "keep everything"; users coming from a v005-seeded install would
+//! otherwise stay capped at 500. This migration rewrites that specific
+//! seeded value (500) to 0 so upgraders pick up the new default. Any
+//! user who has explicitly set a different cap is left alone — only the
+//! exact v005 seed value triggers the rewrite.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    let global_config = app_dir.join("config.toml");
+    if !global_config.exists() {
+        debug!("global config.toml not present, nothing to migrate");
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(&global_config)?;
+    let mut doc: toml::Table = match content.parse() {
+        Ok(table) => table,
+        Err(e) => {
+            debug!("failed to parse {}: {e}, skipping", global_config.display());
+            return Ok(());
+        }
+    };
+
+    let Some(toml::Value::Table(cockpit)) = doc.get_mut("cockpit") else {
+        debug!("no [cockpit] section, nothing to migrate");
+        return Ok(());
+    };
+
+    let Some(toml::Value::Integer(replay_events)) = cockpit.get("replay_events") else {
+        debug!("replay_events absent or non-integer, nothing to migrate");
+        return Ok(());
+    };
+
+    if *replay_events != 500 {
+        debug!(
+            current = replay_events,
+            "replay_events differs from v005 seed value, leaving alone"
+        );
+        return Ok(());
+    }
+
+    cockpit.insert("replay_events".into(), (0_i64).into());
+
+    let serialized = toml::to_string_pretty(&doc)?;
+    fs::write(&global_config, serialized)?;
+
+    info!(
+        "v006: flipped cockpit.replay_events from 500 to 0 (unlimited) in {}",
+        global_config.display()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rewrites_default_seed_value() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config.toml");
+        fs::write(&path, "[cockpit]\nreplay_events = 500\n").unwrap();
+
+        run_in(temp.path()).unwrap();
+
+        let after: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        let cockpit = after.get("cockpit").unwrap().as_table().unwrap();
+        assert_eq!(
+            cockpit.get("replay_events").unwrap().as_integer().unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn leaves_explicit_user_values_alone() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config.toml");
+        fs::write(&path, "[cockpit]\nreplay_events = 1000\n").unwrap();
+
+        run_in(temp.path()).unwrap();
+
+        let after: toml::Table = fs::read_to_string(&path).unwrap().parse().unwrap();
+        let cockpit = after.get("cockpit").unwrap().as_table().unwrap();
+        assert_eq!(
+            cockpit.get("replay_events").unwrap().as_integer().unwrap(),
+            1000
+        );
+    }
+
+    #[test]
+    fn is_idempotent_when_already_zero() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config.toml");
+        fs::write(&path, "[cockpit]\nreplay_events = 0\n").unwrap();
+
+        run_in(temp.path()).unwrap();
+        let first = fs::read_to_string(&path).unwrap();
+        run_in(temp.path()).unwrap();
+        let second = fs::read_to_string(&path).unwrap();
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn noop_when_no_cockpit_section() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("config.toml");
+        fs::write(&path, "[other]\nkey = \"value\"\n").unwrap();
+        run_in(temp.path()).unwrap();
+        let after = fs::read_to_string(&path).unwrap();
+        assert_eq!(after, "[other]\nkey = \"value\"\n");
+    }
+}

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -67,6 +67,23 @@ pub struct SessionResponse {
     /// and is not persisted to the instance.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub warnings: Vec<String>,
+    /// Latest plan snapshot summarised for the sidebar. Present only on
+    /// cockpit sessions whose agent has emitted a Plan (directly via
+    /// ACP `SessionUpdate::Plan` or indirectly via the ExitPlanMode
+    /// bridge in `acp_client::map_update_to_events`). See #1061.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_summary: Option<PlanSummary>,
+}
+
+#[derive(Serialize, Clone, Debug)]
+pub struct PlanSummary {
+    /// First non-completed step's title, truncated to ~80 chars so the
+    /// sidebar row doesn't overflow.
+    pub current_step_title: Option<String>,
+    /// Count of `PlanEntryStatus::Done` steps.
+    pub completed: u32,
+    /// Total step count.
+    pub total: u32,
 }
 
 #[derive(Serialize, Clone)]
@@ -91,6 +108,17 @@ impl SessionResponse {
     /// request via `crate::claude_settings::read_tui_fullscreen()`); it
     /// surfaces on the response only when the session's agent is Claude.
     pub fn from_instance(inst: &Instance, claude_fullscreen: bool) -> Self {
+        Self::from_instance_with_plan(inst, claude_fullscreen, None)
+    }
+
+    /// Build a response with the per-session plan snapshot. Called from
+    /// the REST sessions endpoint after a single bulk read of the
+    /// cockpit event store; see #1061.
+    pub fn from_instance_with_plan(
+        inst: &Instance,
+        claude_fullscreen: bool,
+        plan_summary: Option<PlanSummary>,
+    ) -> Self {
         Self {
             id: inst.id.clone(),
             title: inst.title.clone(),
@@ -142,8 +170,41 @@ impl SessionResponse {
                 })
                 .unwrap_or_default(),
             warnings: Vec::new(),
+            plan_summary,
         }
     }
+}
+
+/// Project a stored `Plan` into the lightweight `PlanSummary` shape the
+/// sidebar consumes. Current step is the first non-Done entry; counts
+/// reflect the persisted step state from the agent's last PlanUpdated.
+fn plan_summary_from_plan(plan: crate::cockpit::state::Plan) -> PlanSummary {
+    use crate::cockpit::state::PlanStepStatus;
+    let total = plan.steps.len() as u32;
+    let completed = plan
+        .steps
+        .iter()
+        .filter(|s| matches!(s.status, PlanStepStatus::Done))
+        .count() as u32;
+    let current_step_title = plan
+        .steps
+        .iter()
+        .find(|s| !matches!(s.status, PlanStepStatus::Done))
+        .map(|s| truncate_title(&s.title, 80));
+    PlanSummary {
+        current_step_title,
+        completed,
+        total,
+    }
+}
+
+fn truncate_title(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
 }
 
 pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<SessionResponse>> {
@@ -151,7 +212,17 @@ pub async fn list_sessions(State(state): State<Arc<AppState>>) -> Json<Vec<Sessi
     let claude_fullscreen = crate::claude_settings::read_tui_fullscreen();
     let mut sessions: Vec<SessionResponse> = instances
         .iter()
-        .map(|inst| SessionResponse::from_instance(inst, claude_fullscreen))
+        .map(|inst| {
+            let plan_summary = if inst.cockpit_mode {
+                state
+                    .cockpit_event_store
+                    .latest_plan(&inst.id)
+                    .map(plan_summary_from_plan)
+            } else {
+                None
+            };
+            SessionResponse::from_instance_with_plan(inst, claude_fullscreen, plan_summary)
+        })
         .collect();
 
     // Resolve per-profile cleanup defaults with a TTL cache on AppState

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1946,6 +1946,124 @@ mod tests {
         );
         assert!(ok.is_ok(), "expected Ok, got {:?}", ok);
     }
+
+    #[test]
+    fn truncate_title_returns_unchanged_under_limit() {
+        assert_eq!(truncate_title("hello", 10), "hello");
+    }
+
+    #[test]
+    fn truncate_title_returns_unchanged_at_exact_limit() {
+        assert_eq!(truncate_title("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_title_appends_ellipsis_when_over_limit() {
+        let out = truncate_title("abcdefghij", 5);
+        assert_eq!(out, "abcd…");
+        assert_eq!(out.chars().count(), 5);
+    }
+
+    #[test]
+    fn truncate_title_counts_characters_not_bytes() {
+        // Multi-byte input: each ☃ is 3 bytes, 1 char. Truncating to 3
+        // chars must split on character boundary, not byte offset.
+        let out = truncate_title("☃☃☃☃☃", 3);
+        assert_eq!(out, "☃☃…");
+        assert_eq!(out.chars().count(), 3);
+    }
+
+    fn step(
+        id: &str,
+        title: &str,
+        status: crate::cockpit::state::PlanStepStatus,
+    ) -> crate::cockpit::state::PlanStep {
+        crate::cockpit::state::PlanStep {
+            id: id.into(),
+            title: title.into(),
+            detail: None,
+            status,
+        }
+    }
+
+    #[test]
+    fn plan_summary_counts_done_steps_only() {
+        use crate::cockpit::state::PlanStepStatus::*;
+        let plan = crate::cockpit::state::Plan {
+            plan_id: "p1".into(),
+            version: 1,
+            steps: vec![
+                step("a", "alpha", Done),
+                step("b", "beta", Done),
+                step("c", "gamma", InProgress),
+                step("d", "delta", Pending),
+            ],
+        };
+        let s = plan_summary_from_plan(plan);
+        assert_eq!(s.total, 4);
+        assert_eq!(s.completed, 2);
+        assert_eq!(s.current_step_title.as_deref(), Some("gamma"));
+    }
+
+    #[test]
+    fn plan_summary_current_step_skips_done_picks_first_non_done() {
+        use crate::cockpit::state::PlanStepStatus::*;
+        // First non-Done is the first Pending; InProgress later doesn't
+        // override (matches the helper's `find(..)` semantics).
+        let plan = crate::cockpit::state::Plan {
+            plan_id: "p1".into(),
+            version: 1,
+            steps: vec![
+                step("a", "alpha", Done),
+                step("b", "beta", Pending),
+                step("c", "gamma", InProgress),
+            ],
+        };
+        let s = plan_summary_from_plan(plan);
+        assert_eq!(s.current_step_title.as_deref(), Some("beta"));
+    }
+
+    #[test]
+    fn plan_summary_none_when_all_done() {
+        use crate::cockpit::state::PlanStepStatus::*;
+        let plan = crate::cockpit::state::Plan {
+            plan_id: "p1".into(),
+            version: 1,
+            steps: vec![step("a", "alpha", Done), step("b", "beta", Done)],
+        };
+        let s = plan_summary_from_plan(plan);
+        assert_eq!(s.completed, 2);
+        assert_eq!(s.total, 2);
+        assert!(s.current_step_title.is_none());
+    }
+
+    #[test]
+    fn plan_summary_truncates_long_current_step_title() {
+        use crate::cockpit::state::PlanStepStatus::*;
+        let long_title: String = "x".repeat(120);
+        let plan = crate::cockpit::state::Plan {
+            plan_id: "p1".into(),
+            version: 1,
+            steps: vec![step("a", &long_title, Pending)],
+        };
+        let s = plan_summary_from_plan(plan);
+        let t = s.current_step_title.unwrap();
+        assert_eq!(t.chars().count(), 80);
+        assert!(t.ends_with('…'));
+    }
+
+    #[test]
+    fn plan_summary_empty_steps_yields_zero_total() {
+        let plan = crate::cockpit::state::Plan {
+            plan_id: "p1".into(),
+            version: 1,
+            steps: vec![],
+        };
+        let s = plan_summary_from_plan(plan);
+        assert_eq!(s.total, 0);
+        assert_eq!(s.completed, 0);
+        assert!(s.current_step_title.is_none());
+    }
 }
 
 // ============================================================================

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -398,6 +398,10 @@ pub struct ServerAbout {
     /// Read-only from the web — flipping requires restarting `aoe serve`
     /// with the env var set.
     pub cockpit_env_enabled: bool,
+    /// Resolved value of `cockpit.show_tool_durations` from the active
+    /// profile's config. Drives the per-tool elapsed-time label in the
+    /// web UI; cross-device since it lives in config.toml.
+    pub cockpit_show_tool_durations: bool,
 }
 
 pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> {
@@ -407,6 +411,10 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         .load(std::sync::atomic::Ordering::Relaxed);
     let cockpit_env_enabled = crate::cockpit::experimental_enabled();
     let experimental_cockpit = cockpit_master_enabled && cockpit_env_enabled;
+    let cockpit_show_tool_durations =
+        crate::session::profile_config::resolve_config_or_warn(&state.profile)
+            .cockpit
+            .show_tool_durations;
     Json(ServerAbout {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth_required,
@@ -417,6 +425,7 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         experimental_cockpit,
         cockpit_master_enabled,
         cockpit_env_enabled,
+        cockpit_show_tool_durations,
     })
 }
 

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -395,7 +395,7 @@ pub struct ServerAbout {
     /// `PATCH /api/cockpit/master`.
     pub cockpit_master_enabled: bool,
     /// Whether the server process has `AOE_EXPERIMENTAL_COCKPIT=1` set.
-    /// Read-only from the web — flipping requires restarting `aoe serve`
+    /// Read-only from the web; flipping requires restarting `aoe serve`
     /// with the env var set.
     pub cockpit_env_enabled: bool,
     /// Resolved value of `cockpit.show_tool_durations` from the active

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -643,7 +643,7 @@ fn git_sanitize_branch_name(s: &str) -> String {
     // Disallowed multi-char sequences: ".." and "@{".
     let mut out = out.replace("..", "-").replace("@{", "-");
     // Strip the ".lock" suffix from every slash-separated component, not
-    // just the last one — git-check-ref-format(1) rejects any component
+    // just the last one; git-check-ref-format(1) rejects any component
     // ending in ".lock" (e.g. `foo.lock/bar` is just as invalid as
     // `foo.lock`).
     out = out
@@ -853,7 +853,7 @@ mod tests {
     #[test]
     fn test_git_sanitize_branch_name_rejects_bare_at_sign() {
         // git-check-ref-format also rejects the single character "@" as a
-        // complete ref name — fall back to "session" rather than producing
+        // complete ref name; fall back to "session" rather than producing
         // a name libgit2 will refuse.
         assert_eq!(git_sanitize_branch_name("@"), "session");
     }

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -100,7 +100,12 @@ fn default_max_workers() -> u32 {
     5
 }
 fn default_replay_events() -> u32 {
-    500
+    // 0 = unlimited. The event store's prune already gates on `> 0`
+    // (see `EventStore::record`), so the default flip is end-to-end
+    // safe: a fresh install never truncates history; users who want a
+    // ceiling for disk-space reasons can set a non-zero value in
+    // config.toml or the settings TUI. See #1065.
+    0
 }
 fn default_replay_bytes() -> u64 {
     5_242_880

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -83,7 +83,7 @@ pub struct CockpitConfig {
     /// across every device that connects to the same daemon. The
     /// underlying measurement is currently imprecise on
     /// claude-agent-acp (no `status: "in_progress"` is emitted, so we
-    /// can't re-stamp `started_at` to the real subprocess start —
+    /// can't re-stamp `started_at` to the real subprocess start;
     /// see the comment on `CardChromeProps.startedAt` in
     /// `web/src/components/cockpit/ToolCards.tsx`); this setting lets
     /// users hide the label until upstream provides a trustworthy
@@ -271,7 +271,7 @@ pub struct SessionConfig {
     /// (P, R, T, N, D, G) relocate to Ctrl+letter so nothing is lost.
     /// Note: Ctrl+D (diff view) may conflict with terminal EOF in some tmux configs;
     /// if so, rebind tmux's send-prefix or use the `D` key from the help overlay.
-    /// Off by default — existing users keep the legacy single-letter UX.
+    /// Off by default; existing users keep the legacy single-letter UX.
     #[serde(default)]
     pub strict_hotkeys: bool,
 }
@@ -400,13 +400,13 @@ fn default_profile() -> String {
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum ColorMode {
-    /// Emit 24-bit RGB escapes (\e[38;2;R;G;Bm). Default — best fidelity on
+    /// Emit 24-bit RGB escapes (\e[38;2;R;G;Bm). Default; best fidelity on
     /// modern terminals and SSH sessions that pass RGB correctly.
     #[default]
     Truecolor,
     /// Emit 256-palette escapes (\e[38;5;<idx>m) by converting every theme
     /// Rgb(r,g,b) to the nearest xterm-256 index. Use this when the transport
-    /// (notably some mosh clients) mishandles 24-bit RGB — preview panes in
+    /// (notably some mosh clients) mishandles 24-bit RGB; preview panes in
     /// aoe already use 256-palette via ansi-to-tui, so palette mode renders
     /// chrome through the same escape path and survives the same transports.
     Palette,

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -77,6 +77,19 @@ pub struct CockpitConfig {
     /// empty, aoe resolves Node via PATH then bundled fallback.
     #[serde(default)]
     pub node_path: String,
+    /// Whether the cockpit web UI shows a per-tool elapsed-time label on
+    /// every tool card. Default true. Honoured by the web client via
+    /// `ServerAbout.cockpit_show_tool_durations` so toggling here flows
+    /// across every device that connects to the same daemon. The
+    /// underlying measurement is currently imprecise on
+    /// claude-agent-acp (no `status: "in_progress"` is emitted, so we
+    /// can't re-stamp `started_at` to the real subprocess start —
+    /// see the comment on `CardChromeProps.startedAt` in
+    /// `web/src/components/cockpit/ToolCards.tsx`); this setting lets
+    /// users hide the label until upstream provides a trustworthy
+    /// "subprocess started" signal.
+    #[serde(default = "default_true")]
+    pub show_tool_durations: bool,
 }
 
 impl Default for CockpitConfig {
@@ -89,6 +102,7 @@ impl Default for CockpitConfig {
             replay_events: default_replay_events(),
             replay_bytes: default_replay_bytes(),
             node_path: String::new(),
+            show_tool_durations: true,
         }
     }
 }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -64,6 +64,8 @@ pub struct CockpitConfigOverride {
     pub replay_bytes: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub node_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_tool_durations: Option<bool>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -505,6 +507,9 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(ref v) = cockpit_override.node_path {
             global.cockpit.node_path = v.clone();
+        }
+        if let Some(v) = cockpit_override.show_tool_durations {
+            global.cockpit.show_tool_durations = v;
         }
     }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -395,7 +395,7 @@ fn build_cockpit_fields(
         SettingField {
             key: FieldKey::CockpitShowToolDurations,
             label: "Show tool-call durations",
-            description: "Render an elapsed-time label on every cockpit tool card. Cross-device via config.toml. Note: the underlying measurement is currently imprecise on claude-agent-acp (no `status: in_progress` signal) — durations include stream-arrival skew. Defaults to on; turn off if the inflated numbers are more confusing than useful.",
+            description: "Render an elapsed-time label on every cockpit tool card. Cross-device via config.toml. Note: the underlying measurement is currently imprecise on claude-agent-acp (no `status: in_progress` signal); durations include stream-arrival skew. Defaults to on; turn off if the inflated numbers are more confusing than useful.",
             value: FieldValue::Bool(show_tool_durations),
             category: SettingsCategory::Cockpit,
             has_override: std_override,

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -361,8 +361,8 @@ fn build_cockpit_fields(
         },
         SettingField {
             key: FieldKey::CockpitReplayEvents,
-            label: "Replay buffer events",
-            description: "Maximum number of cockpit events kept in the per-session replay buffer.",
+            label: "History cap (events)",
+            description: "Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions.",
             value: FieldValue::Number(u64::from(replay_events)),
             category: SettingsCategory::Cockpit,
             has_override: re_override,
@@ -1754,7 +1754,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.cockpit.max_concurrent_workers = (*v).max(1) as u32
         }
         (FieldKey::CockpitReplayEvents, FieldValue::Number(v)) => {
-            config.cockpit.replay_events = (*v).max(1) as u32
+            // 0 = unlimited history; clamp non-zero values to u32 range.
+            // See #1065.
+            config.cockpit.replay_events = (*v).min(u32::MAX as u64) as u32
         }
         (FieldKey::CockpitReplayBytes, FieldValue::Number(v)) => {
             config.cockpit.replay_bytes = (*v).max(1024)
@@ -2061,9 +2063,12 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             });
         }
         (FieldKey::CockpitReplayEvents, FieldValue::Number(v)) => {
-            set_profile_override((*v).max(1) as u32, &mut config.cockpit, |s, val| {
-                s.replay_events = val
-            });
+            // 0 = unlimited; #1065.
+            set_profile_override(
+                (*v).min(u32::MAX as u64) as u32,
+                &mut config.cockpit,
+                |s, val| s.replay_events = val,
+            );
         }
         (FieldKey::CockpitReplayBytes, FieldValue::Number(v)) => {
             set_profile_override((*v).max(1024), &mut config.cockpit, |s, val| {

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -117,6 +117,7 @@ pub enum FieldKey {
     CockpitReplayEvents,
     CockpitReplayBytes,
     CockpitNodePath,
+    CockpitShowToolDurations,
 }
 
 /// Resolve a field value from global config and optional profile override.
@@ -321,6 +322,11 @@ fn build_cockpit_fields(
         global.cockpit.node_path.clone(),
         p.and_then(|c| c.node_path.clone()),
     );
+    let (show_tool_durations, std_override) = resolve_value(
+        scope,
+        global.cockpit.show_tool_durations,
+        p.and_then(|c| c.show_tool_durations),
+    );
 
     vec![
         SettingField {
@@ -384,6 +390,15 @@ fn build_cockpit_fields(
             value: FieldValue::Text(node_path),
             category: SettingsCategory::Cockpit,
             has_override: np_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitShowToolDurations,
+            label: "Show tool-call durations",
+            description: "Render an elapsed-time label on every cockpit tool card. Cross-device via config.toml. Note: the underlying measurement is currently imprecise on claude-agent-acp (no `status: in_progress` signal) — durations include stream-arrival skew. Defaults to on; turn off if the inflated numbers are more confusing than useful.",
+            value: FieldValue::Bool(show_tool_durations),
+            category: SettingsCategory::Cockpit,
+            has_override: std_override,
             inherited_display: None,
         },
     ]
@@ -1762,6 +1777,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.cockpit.replay_bytes = (*v).max(1024)
         }
         (FieldKey::CockpitNodePath, FieldValue::Text(v)) => config.cockpit.node_path = v.clone(),
+        (FieldKey::CockpitShowToolDurations, FieldValue::Bool(v)) => {
+            config.cockpit.show_tool_durations = *v
+        }
         _ => {}
     }
 }
@@ -2077,6 +2095,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         }
         (FieldKey::CockpitNodePath, FieldValue::Text(v)) => {
             set_profile_override(v.clone(), &mut config.cockpit, |s, val| s.node_path = val);
+        }
+        (FieldKey::CockpitShowToolDurations, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.cockpit, |s, val| {
+                s.show_tool_durations = val
+            });
         }
         _ => {}
     }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -819,6 +819,11 @@ impl SettingsView {
                     c.node_path = None;
                 }
             }
+            FieldKey::CockpitShowToolDurations => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.show_tool_durations = None;
+                }
+            }
         }
 
         // Sync repo_config when in Repo scope

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -447,6 +447,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       () => ({
         onNew: () => setShowSessionWizard(true),
         onDiff: () => toggleDiff(),
+        // Escape closes local UI surfaces only (dialogs, palette,
+        // wizard, settings, help, file viewer). Never wire this to
+        // cockpit.cancelPrompt — Claude Code CLI does that and stray
+        // Escape presses kill in-flight turns the user didn't mean to
+        // abort. Cancel/stop must stay behind an explicit gesture
+        // (the assistant-ui Stop button in the composer).
         onEscape: () => {
           if (deletingWorkspaceId) {
             setDeletingWorkspaceId(null);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -450,7 +450,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         onDiff: () => toggleDiff(),
         // Escape closes local UI surfaces only (dialogs, palette,
         // wizard, settings, help, file viewer). Never wire this to
-        // cockpit.cancelPrompt — Claude Code CLI does that and stray
+        // cockpit.cancelPrompt; Claude Code CLI does that and stray
         // Escape presses kill in-flight turns the user didn't mean to
         // abort. Cancel/stop must stay behind an explicit gesture
         // (the assistant-ui Stop button in the composer).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useMatch, useNavigate } from "react-router-dom";
 import { IDLE_DECAY_WINDOW_MS, isSessionActive } from "./lib/session";
 import { useSessions } from "./hooks/useSessions";
 import { clearCockpitCache } from "./hooks/useCockpit";
+import { CockpitPrefsProvider } from "./lib/cockpitPrefs";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
@@ -602,7 +603,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       ? { height: `${stableViewportHeight}px` }
       : undefined;
 
+  const cockpitPrefs = useMemo(
+    () => ({
+      showToolDurations: serverAbout?.cockpit_show_tool_durations ?? true,
+    }),
+    [serverAbout?.cockpit_show_tool_durations],
+  );
+
   return (
+    <CockpitPrefsProvider value={cockpitPrefs}>
     <div
       className="h-dvh flex flex-col bg-surface-900 text-text-primary overflow-hidden safe-area-inset"
       style={rootStyle}
@@ -696,6 +705,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
         style={{ top: -9999, left: -9999 }}
       />
     </div>
+    </CockpitPrefsProvider>
   );
 }
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -15,6 +15,7 @@ import {
 import type { ProfileInfo } from "../lib/types";
 import {
   ListField,
+  NumberField,
   SelectField,
   TextField,
   ToggleField,
@@ -449,13 +450,17 @@ export function SettingsView({
         return <SecuritySettings />;
       case "devices":
         return <ConnectedDevices />;
-      case "cockpit":
+      case "cockpit": {
+        const cockpit = (settings?.cockpit ?? {}) as Record<string, unknown>;
         return (
           <CockpitSettings
             serverAbout={serverAbout}
             onRefresh={onServerAboutRefresh}
+            cockpit={cockpit}
+            onSaveField={saveSubField}
           />
         );
+      }
     }
   };
 
@@ -563,15 +568,25 @@ export function SettingsView({
 function CockpitSettings({
   serverAbout,
   onRefresh,
+  cockpit,
+  onSaveField,
 }: {
   serverAbout: ServerAbout | null;
   onRefresh: () => Promise<void> | void;
+  cockpit: Record<string, unknown>;
+  onSaveField: (section: string, field: string, value: unknown) => void;
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const envEnabled = !!serverAbout?.cockpit_env_enabled;
   const masterEnabled = !!serverAbout?.cockpit_master_enabled;
   const effective = envEnabled && masterEnabled;
+  // Local mirror so the toggle reflects optimistically while the
+  // backend save + /api/about re-fetch propagate.
+  const showToolDurations =
+    typeof cockpit.show_tool_durations === "boolean"
+      ? (cockpit.show_tool_durations as boolean)
+      : (serverAbout?.cockpit_show_tool_durations ?? true);
 
   const onToggle = async (next: boolean) => {
     setBusy(true);
@@ -629,6 +644,64 @@ function CockpitSettings({
           } ${busy ? "opacity-50 cursor-not-allowed" : "cursor-pointer"}`}
         >
           {masterEnabled ? "Enabled" : "Disabled"}
+        </button>
+      </div>
+
+      <div className="border-t border-surface-800 pt-3">
+        <NumberField
+          label="History cap (events)"
+          description="Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions. Persists to config.toml as cockpit.replay_events; cross-device."
+          value={
+            typeof cockpit.replay_events === "number"
+              ? (cockpit.replay_events as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_events", v)}
+        />
+      </div>
+
+      <div className="border-t border-surface-800 pt-3">
+        <NumberField
+          label="Replay buffer bytes"
+          description="Per-session byte cap on the in-memory replay buffer. Persists to config.toml as cockpit.replay_bytes; cross-device."
+          value={
+            typeof cockpit.replay_bytes === "number"
+              ? (cockpit.replay_bytes as number)
+              : 0
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "replay_bytes", v)}
+        />
+      </div>
+
+      <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
+        <div>
+          <div className="text-sm text-text-bright">Show tool-call durations</div>
+          <div className="text-xs text-text-dim mt-0.5">
+            Persists to <code>config.toml</code> as{" "}
+            <code>cockpit.show_tool_durations</code>; cross-device. Renders the elapsed-time label on every
+            cockpit tool card. The underlying measurement is currently imprecise on{" "}
+            <code>claude-agent-acp</code> (no <code>status: in_progress</code> signal) — durations include
+            stream-arrival skew rather than just runtime, so for example a parallel{" "}
+            <code>sleep 1</code> can read as ~3 s. Turn off if the inflated numbers are more confusing than
+            useful.
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={async () => {
+            const next = !showToolDurations;
+            onSaveField("cockpit", "show_tool_durations", next);
+            await onRefresh();
+          }}
+          className={`shrink-0 rounded px-3 py-1 text-xs font-medium transition-colors cursor-pointer ${
+            showToolDurations
+              ? "bg-brand-500 text-white hover:bg-brand-400"
+              : "bg-surface-700 text-text-secondary hover:bg-surface-600"
+          }`}
+        >
+          {showToolDurations ? "Visible" : "Hidden"}
         </button>
       </div>
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -549,7 +549,7 @@ export function SettingsView({
 
             {offline && (
               <div className="text-sm text-status-error bg-status-error/10 rounded-lg p-3">
-                {OFFLINE_TITLE} — toggles will not save while disconnected.
+                {OFFLINE_TITLE}; toggles will not save while disconnected.
               </div>
             )}
             <fieldset
@@ -682,7 +682,7 @@ function CockpitSettings({
             Persists to <code>config.toml</code> as{" "}
             <code>cockpit.show_tool_durations</code>; cross-device. Renders the elapsed-time label on every
             cockpit tool card. The underlying measurement is currently imprecise on{" "}
-            <code>claude-agent-acp</code> (no <code>status: in_progress</code> signal) — durations include
+            <code>claude-agent-acp</code> (no <code>status: in_progress</code> signal); durations include
             stream-arrival skew rather than just runtime, so for example a parallel{" "}
             <code>sleep 1</code> can read as ~3 s. Turn off if the inflated numbers are more confusing than
             useful.
@@ -690,6 +690,8 @@ function CockpitSettings({
         </div>
         <button
           type="button"
+          aria-pressed={showToolDurations}
+          aria-label="Show tool-call durations"
           onClick={async () => {
             const next = !showToolDurations;
             onSaveField("cockpit", "show_tool_durations", next);

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -549,7 +549,7 @@ export function SettingsView({
 
             {offline && (
               <div className="text-sm text-status-error bg-status-error/10 rounded-lg p-3">
-                {OFFLINE_TITLE}; toggles will not save while disconnected.
+                {OFFLINE_TITLE}: toggles will not save while disconnected.
               </div>
             )}
             <fieldset

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -2,7 +2,12 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
-import type { Workspace, RepoGroup, SessionStatus } from "../lib/types";
+import type {
+  RepoGroup,
+  SessionResponse,
+  SessionStatus,
+  Workspace,
+} from "../lib/types";
 import { MULTI_REPO_GROUP_ID } from "../hooks/useRepoGroups";
 import {
   STATUS_DOT_CLASS,
@@ -104,6 +109,36 @@ function loadSavedWidth(): number {
     // ignore
   }
   return DEFAULT_WIDTH;
+}
+
+/** One-line sidebar affordance showing plan progress for cockpit
+ *  sessions that have emitted a Plan. Quiet by default (renders only
+ *  when `summary.total > 0`); mirrors the top-of-cockpit PlanStrip's
+ *  visual language so the sidebar and main view stay consistent. See
+ *  #1061. */
+function PlanProgressMini({
+  summary,
+}: {
+  summary: NonNullable<SessionResponse["plan_summary"]>;
+}) {
+  const pct =
+    summary.total > 0
+      ? Math.min(100, Math.round((summary.completed / summary.total) * 100))
+      : 0;
+  const title = summary.current_step_title ?? "plan in progress";
+  return (
+    <div className="mt-1 flex items-center gap-2" title={title}>
+      <div className="h-1 flex-1 rounded-full bg-surface-800 overflow-hidden">
+        <div
+          className="h-full bg-brand-400 transition-all"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-[10px] font-mono tabular-nums text-text-dim shrink-0">
+        {summary.completed}/{summary.total}
+      </span>
+    </div>
+  );
 }
 
 function isPlainLeftClick(event: React.MouseEvent<HTMLAnchorElement>): boolean {
@@ -364,6 +399,9 @@ const SessionRow = memo(function SessionRow({
               <span className="block text-[11px] font-mono text-text-dim truncate" title={subtitle}>
                 {subtitle}
               </span>
+            )}
+            {firstSession?.plan_summary && firstSession.plan_summary.total > 0 && (
+              <PlanProgressMini summary={firstSession.plan_summary} />
             )}
             {firstSession && (firstSession.workspace_repos?.length ?? 0) > 1 && (
               <span

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -126,9 +126,19 @@ function PlanProgressMini({
       ? Math.min(100, Math.round((summary.completed / summary.total) * 100))
       : 0;
   const title = summary.current_step_title ?? "plan in progress";
+  const ariaLabel = summary.current_step_title
+    ? `Plan progress: ${summary.completed} of ${summary.total} steps; current step ${summary.current_step_title}`
+    : `Plan progress: ${summary.completed} of ${summary.total} steps`;
   return (
     <div className="mt-1 flex items-center gap-2" title={title}>
-      <div className="h-1 flex-1 rounded-full bg-surface-800 overflow-hidden">
+      <div
+        role="progressbar"
+        aria-valuenow={summary.completed}
+        aria-valuemin={0}
+        aria-valuemax={summary.total}
+        aria-label={ariaLabel}
+        className="h-1 flex-1 rounded-full bg-surface-800 overflow-hidden"
+      >
         <div
           className="h-full bg-brand-400 transition-all"
           style={{ width: `${pct}%` }}

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -41,7 +41,7 @@ function messageRow(text: string, id = "m1"): ActivityRow {
   };
 }
 
-describe("activityToThreadMessages — tool-call grouping (#1057)", () => {
+describe("activityToThreadMessages; tool-call grouping (#1057)", () => {
   it("folds a run of ≥3 consecutive tool calls into one group", () => {
     const messages = activityToThreadMessages(
       [

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import {
+  TOOL_GROUP_NAME,
+  activityToThreadMessages,
+} from "./CockpitRuntime";
+import type { ActivityRow, ToolCall } from "../../lib/cockpitTypes";
+
+function userRow(text: string, id = "u1"): ActivityRow {
+  return {
+    id,
+    kind: "user_prompt",
+    text,
+    at: "2026-05-12T00:00:00Z",
+  };
+}
+
+function toolStart(id: string, kind = "read"): ActivityRow {
+  const tool: ToolCall = {
+    id,
+    name: "Read",
+    kind,
+    args_preview: JSON.stringify({ path: `/tmp/${id}.txt` }),
+    started_at: "2026-05-12T00:00:00Z",
+  };
+  return {
+    id: `start-${id}`,
+    kind: "tool_start",
+    text: "Read",
+    toolCallId: id,
+    tool,
+    at: "2026-05-12T00:00:00Z",
+  };
+}
+
+function messageRow(text: string, id = "m1"): ActivityRow {
+  return {
+    id,
+    kind: "message",
+    text,
+    at: "2026-05-12T00:00:00Z",
+  };
+}
+
+describe("activityToThreadMessages — tool-call grouping (#1057)", () => {
+  it("folds a run of ≥3 consecutive tool calls into one group", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        toolStart("t1"),
+        toolStart("t2"),
+        toolStart("t3"),
+        toolStart("t4"),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant");
+    expect(assistant).toBeDefined();
+    const parts = (assistant!.content as Array<{ type: string; toolName?: string }>);
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(1);
+    expect(toolParts[0]!.toolName).toBe(TOOL_GROUP_NAME);
+  });
+
+  it("does not group runs of 1 or 2 tool calls", () => {
+    const messages = activityToThreadMessages(
+      [userRow("go"), toolStart("t1"), toolStart("t2")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = (assistant.content as Array<{ type: string; toolName?: string }>);
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(2);
+    for (const p of toolParts) expect(p.toolName).not.toBe(TOOL_GROUP_NAME);
+  });
+
+  it("text between tool calls splits two runs", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("go"),
+        toolStart("a1"),
+        toolStart("a2"),
+        toolStart("a3"),
+        messageRow("Found it."),
+        toolStart("b1"),
+        toolStart("b2"),
+        toolStart("b3"),
+      ],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = (assistant.content as Array<{ type: string; toolName?: string }>);
+    const groups = parts.filter(
+      (p) => p.type === "tool-call" && p.toolName === TOOL_GROUP_NAME,
+    );
+    expect(groups).toHaveLength(2);
+  });
+
+  it("does not group across user-prompt boundaries (separate messages)", () => {
+    const messages = activityToThreadMessages(
+      [
+        userRow("first", "u1"),
+        toolStart("t1"),
+        toolStart("t2"),
+        userRow("second", "u2"),
+        toolStart("t3"),
+      ],
+      false,
+    );
+    // Each user_prompt starts a fresh assistant message; neither run is
+    // long enough to fold on its own.
+    const assistants = messages.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(2);
+    for (const m of assistants) {
+      const parts = (m.content as Array<{ type: string; toolName?: string }>);
+      for (const p of parts.filter((p) => p.type === "tool-call")) {
+        expect(p.toolName).not.toBe(TOOL_GROUP_NAME);
+      }
+    }
+  });
+});

--- a/web/src/components/cockpit/CockpitRuntime.test.ts
+++ b/web/src/components/cockpit/CockpitRuntime.test.ts
@@ -95,6 +95,41 @@ describe("activityToThreadMessages — tool-call grouping (#1057)", () => {
     expect(groups).toHaveLength(2);
   });
 
+  it("exempts TodoWrite calls from folding (#1064)", () => {
+    const todoTool: ToolCall = {
+      id: "td-1",
+      name: "Update TODOs: a, b",
+      kind: "think",
+      args_preview: JSON.stringify({
+        todos: [
+          { content: "a", status: "pending" },
+          { content: "b", status: "in_progress" },
+        ],
+      }),
+      started_at: "2026-05-12T00:00:00Z",
+    };
+    const todoRow: ActivityRow = {
+      id: "start-td-1",
+      kind: "tool_start",
+      text: "Update TODOs",
+      toolCallId: "td-1",
+      tool: todoTool,
+      at: "2026-05-12T00:00:00Z",
+    };
+    const messages = activityToThreadMessages(
+      [userRow("go"), toolStart("a"), toolStart("b"), todoRow, toolStart("c")],
+      false,
+    );
+    const assistant = messages.find((m) => m.role === "assistant")!;
+    const parts = (assistant.content as Array<{ type: string; toolName?: string }>);
+    const groups = parts.filter(
+      (p) => p.type === "tool-call" && p.toolName === TOOL_GROUP_NAME,
+    );
+    expect(groups).toHaveLength(0);
+    const toolParts = parts.filter((p) => p.type === "tool-call");
+    expect(toolParts).toHaveLength(4);
+  });
+
   it("does not group across user-prompt boundaries (separate messages)", () => {
     const messages = activityToThreadMessages(
       [

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -147,21 +147,29 @@ export function activityToThreadMessages(
     }
 
     if (row.kind === "context_reset") {
-      // session/load failed and the agent fell back to session/new on
-      // an `aoe serve` restart, so the model's context window is empty
-      // even though our UI still replays the prior transcript. Render
-      // as a dedicated assistant bubble so it doesn't run on from any
-      // prior message, and use a blockquote with a ⚠️ prefix so the
-      // custom Markdown blockquote component can style it as an amber
-      // callout (see Markdown.tsx).
+      // Two senders share this row kind:
+      //   - `session/load` fallback after an `aoe serve` restart (model's
+      //     window is empty even though we replay the prior transcript)
+      //   - `/compact` completion: model's window has been replaced by a
+      //     summary while the rendered transcript stays put (#1050)
+      // Both want the same amber-callout shape; only the header differs.
+      // The Rust side sets the reason text; we sniff the compact case
+      // off its leading word so the divider names what actually changed.
       flushAssistant();
+      const isCompact = row.text.startsWith("Conversation compacted");
+      const header = isCompact
+        ? "Conversation compacted"
+        : "Conversation context reset";
+      const body = isCompact
+        ? row.text.replace(/^Conversation compacted\s*[—-]?\s*/, "")
+        : row.text;
       messages.push({
         id: `assistant-${row.id}`,
         role: "assistant",
         content: [
           {
             type: "text",
-            text: `> ⚠️ **Conversation context reset** — ${row.text}`,
+            text: `> ⚠️ **${header}** — ${body}`,
           },
         ],
         createdAt: parseDate(row.at),

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -117,7 +117,7 @@ export function CockpitRuntime({ sessionId, children }: Props) {
  * message until the next user_prompt or end of log.
  *
  * Tool completion rows (`tool_complete` / `tool_error`) are not their
- * own messages — they update the matching `tool-call` part in place
+ * own messages; they update the matching `tool-call` part in place
  * by setting `result` / `isError`, so the per-tool card renderer can
  * render running → done in one place.
  */
@@ -161,7 +161,7 @@ export function activityToThreadMessages(
         ? "Conversation compacted"
         : "Conversation context reset";
       const body = isCompact
-        ? row.text.replace(/^Conversation compacted\s*[—-]?\s*/, "")
+        ? row.text.replace(/^Conversation compacted\s*[;,—-]?\s*/, "")
         : row.text;
       messages.push({
         id: `assistant-${row.id}`,
@@ -169,7 +169,7 @@ export function activityToThreadMessages(
         content: [
           {
             type: "text",
-            text: `> ⚠️ **${header}** — ${body}`,
+            text: `> ⚠️ **${header}**; ${body}`,
           },
         ],
         createdAt: parseDate(row.at),
@@ -198,7 +198,7 @@ export function activityToThreadMessages(
     } else if (row.kind === "empty_output") {
       // Synthesised when the agent finished a turn without emitting any
       // text or tool calls (e.g. interactive-only slash commands like
-      // /usage, /status, /memory in claude-agent-acp — see upstream
+      // /usage, /status, /memory in claude-agent-acp; see upstream
       // issue agentclientprotocol/claude-agent-acp#642). Surface it as
       // a tiny muted notice instead of leaving the assistant bubble
       // empty.
@@ -278,7 +278,7 @@ class AssistantBuilder {
     // key is namespaced so it can't collide with real tool args.
     //
     // Also smuggle `_aoe_started_at` (the real ToolCall.started_at)
-    // through assistant-ui's tool-call part shape — its primitive
+    // through assistant-ui's tool-call part shape; its primitive
     // doesn't carry timestamps and CockpitView's fallback would
     // otherwise mint one fresh per render, breaking the duration
     // label (#1060).
@@ -289,7 +289,7 @@ class AssistantBuilder {
         argsObj = parsed as Record<string, unknown>;
       }
     } catch {
-      // args_preview wasn't a JSON object — keep argsObj empty.
+      // args_preview wasn't a JSON object; keep argsObj empty.
     }
     if (tool.name) argsObj._aoe_title = tool.name;
     if (tool.started_at) argsObj._aoe_started_at = tool.started_at;
@@ -323,7 +323,7 @@ class AssistantBuilder {
       role: "assistant",
       // Cast to bypass assistant-ui's strict ReadonlyJSONObject typing
       // for tool-call args. We don't carry parsed args through this
-      // path — the renderer parses argsText itself — so the loose
+      // path; the renderer parses argsText itself; so the loose
       // shape is safe in practice.
       content: (grouped.length
         ? grouped
@@ -363,7 +363,7 @@ export const TOOL_GROUP_NAME = "_aoe_tool_group";
 /** Walk an assistant message's parts and collapse runs of consecutive
  *  tool-call parts (regardless of kind) into one synthetic group part
  *  when the run is ≥ TOOL_GROUP_MIN_RUN long. The grouping boundary is
- *  ANY non-tool-call part (text, callout, etc.) — matching the "what
+ *  ANY non-tool-call part (text, callout, etc.); matching the "what
  *  did the agent do silently before its next sentence?" UX shape. The
  *  underlying tool-call data is preserved verbatim inside the group's
  *  argsText payload so the renderer can expand back to the original
@@ -376,7 +376,7 @@ function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
     if (run.length < TOOL_GROUP_MIN_RUN) {
       for (const p of run) out.push(p);
     } else {
-      // TodoWrite calls aren't silent tool work — they're status
+      // TodoWrite calls aren't silent tool work; they're status
       // updates the user wants to see one-by-one (#1064). Detect them
       // via the `_aoe_title` echo we stash in argsText (the adapter
       // names them "Update TODOs: …") and exempt the group entirely

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -190,6 +190,7 @@ export function activityToThreadMessages(
         row.toolCallId ?? row.id.replace(/^done-/, ""),
         row.kind === "tool_error",
         row.text,
+        row.at,
       );
     } else if (row.kind === "thinking") {
       // Thinking is rendered by the global rattle spinner, not the
@@ -244,7 +245,7 @@ type DraftPart =
       toolCallId: string;
       toolName: string;
       argsText: string;
-      result?: { content: string };
+      result?: { content: string; endedAt?: string };
       isError?: boolean;
     };
 
@@ -275,6 +276,12 @@ class AssistantBuilder {
     // empty (Claude's bash tool, for example, often emits an empty
     // raw_input on the initial tool_call frame). The `_aoe_title`
     // key is namespaced so it can't collide with real tool args.
+    //
+    // Also smuggle `_aoe_started_at` (the real ToolCall.started_at)
+    // through assistant-ui's tool-call part shape — its primitive
+    // doesn't carry timestamps and CockpitView's fallback would
+    // otherwise mint one fresh per render, breaking the duration
+    // label (#1060).
     let argsObj: Record<string, unknown> = {};
     try {
       const parsed = JSON.parse(tool.args_preview);
@@ -285,6 +292,7 @@ class AssistantBuilder {
       // args_preview wasn't a JSON object — keep argsObj empty.
     }
     if (tool.name) argsObj._aoe_title = tool.name;
+    if (tool.started_at) argsObj._aoe_started_at = tool.started_at;
     this.parts.push({
       type: "tool-call",
       toolCallId: tool.id,
@@ -293,10 +301,15 @@ class AssistantBuilder {
     });
   }
 
-  completeToolCall(toolCallId: string, isError: boolean, resultText: string) {
+  completeToolCall(
+    toolCallId: string,
+    isError: boolean,
+    resultText: string,
+    endedAt: string,
+  ) {
     for (const part of this.parts) {
       if (part.type === "tool-call" && part.toolCallId === toolCallId) {
-        part.result = { content: resultText };
+        part.result = { content: resultText, endedAt };
         part.isError = isError || undefined;
         return;
       }

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -304,6 +304,7 @@ class AssistantBuilder {
   }
 
   build(): ThreadMessageLike {
+    const grouped = collapseToolRuns(this.parts);
     return {
       id: this.id,
       role: "assistant",
@@ -311,10 +312,76 @@ class AssistantBuilder {
       // for tool-call args. We don't carry parsed args through this
       // path — the renderer parses argsText itself — so the loose
       // shape is safe in practice.
-      content: (this.parts.length
-        ? this.parts
+      content: (grouped.length
+        ? grouped
         : [{ type: "text", text: "" }]) as ThreadMessageLike["content"],
       createdAt: this.createdAt,
     };
   }
+}
+
+/** Minimum run length that triggers grouping. Two-in-a-row stays inline
+ *  so a quick read-then-edit doesn't fold; three or more is the common
+ *  "silent investigation" shape that benefits from one collapsible
+ *  block (#1057). */
+const TOOL_GROUP_MIN_RUN = 3;
+
+/** Synthetic toolName used for the folded group card. Namespaced with
+ *  the `_aoe_` prefix so it can't collide with a real ACP tool kind. */
+export const TOOL_GROUP_NAME = "_aoe_tool_group";
+
+/** Walk an assistant message's parts and collapse runs of consecutive
+ *  tool-call parts (regardless of kind) into one synthetic group part
+ *  when the run is ≥ TOOL_GROUP_MIN_RUN long. The grouping boundary is
+ *  ANY non-tool-call part (text, callout, etc.) — matching the "what
+ *  did the agent do silently before its next sentence?" UX shape. The
+ *  underlying tool-call data is preserved verbatim inside the group's
+ *  argsText payload so the renderer can expand back to the original
+ *  per-tool cards on click. */
+function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
+  const out: DraftPart[] = [];
+  let run: DraftPart[] = [];
+  const flushRun = () => {
+    if (run.length === 0) return;
+    if (run.length < TOOL_GROUP_MIN_RUN) {
+      for (const p of run) out.push(p);
+    } else {
+      const childIds: string[] = [];
+      const children: Array<{
+        toolCallId: string;
+        toolName: string;
+        argsText: string;
+        result?: { content: string };
+        isError?: boolean;
+      }> = [];
+      for (const p of run) {
+        if (p.type !== "tool-call") continue;
+        childIds.push(p.toolCallId);
+        children.push({
+          toolCallId: p.toolCallId,
+          toolName: p.toolName,
+          argsText: p.argsText,
+          result: p.result,
+          isError: p.isError,
+        });
+      }
+      out.push({
+        type: "tool-call",
+        toolCallId: `group-${childIds.join("-")}`,
+        toolName: TOOL_GROUP_NAME,
+        argsText: JSON.stringify({ children }),
+      });
+    }
+    run = [];
+  };
+  for (const part of parts) {
+    if (part.type === "tool-call") {
+      run.push(part);
+    } else {
+      flushRun();
+      out.push(part);
+    }
+  }
+  flushRun();
+  return out;
 }

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -320,6 +320,23 @@ class AssistantBuilder {
   }
 }
 
+function isTodoWriteArgsText(argsText: string): boolean {
+  try {
+    const parsed = JSON.parse(argsText);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const title = (parsed as Record<string, unknown>)._aoe_title;
+      if (typeof title === "string" && title.startsWith("Update TODOs")) {
+        return true;
+      }
+      const todos = (parsed as Record<string, unknown>).todos;
+      if (Array.isArray(todos)) return true;
+    }
+  } catch {
+    // ignore
+  }
+  return false;
+}
+
 /** Minimum run length that triggers grouping. Two-in-a-row stays inline
  *  so a quick read-then-edit doesn't fold; three or more is the common
  *  "silent investigation" shape that benefits from one collapsible
@@ -346,6 +363,20 @@ function collapseToolRuns(parts: DraftPart[]): DraftPart[] {
     if (run.length < TOOL_GROUP_MIN_RUN) {
       for (const p of run) out.push(p);
     } else {
+      // TodoWrite calls aren't silent tool work — they're status
+      // updates the user wants to see one-by-one (#1064). Detect them
+      // via the `_aoe_title` echo we stash in argsText (the adapter
+      // names them "Update TODOs: …") and exempt the group entirely
+      // when any child looks like a TodoWrite. Cheap: argsText is
+      // already parsed JSON, just sniff the prefix.
+      const hasTodoWrite = run.some(
+        (p) => p.type === "tool-call" && isTodoWriteArgsText(p.argsText),
+      );
+      if (hasTodoWrite) {
+        for (const p of run) out.push(p);
+        run = [];
+        return;
+      }
       const childIds: string[] = [];
       const children: Array<{
         toolCallId: string;

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -226,14 +226,19 @@ function AssistantToolCall(props: ToolCallProps) {
   // Reconstruct the ToolCall shape our existing ToolCards.tsx
   // renderer expects. assistant-ui carries `toolName` (we set this to
   // ACP's lowercased ToolKind in CockpitRuntime) plus argsText (the
-  // truncated JSON preview from the agent).
-  const stableAt = toolCallTimestamp(props.toolCallId);
+  // truncated JSON preview from the agent). The real `started_at` and
+  // completion `endedAt` are smuggled through argsText/result by
+  // CockpitRuntime's AssistantBuilder so the duration label (#1060)
+  // reflects actual tool runtime instead of "time between renders".
+  const fallbackAt = toolCallTimestamp(props.toolCallId);
+  const startedAt = pickStartedAt(props.args, props.argsText) ?? fallbackAt;
+  const endedAt = pickEndedAt(props.result) ?? fallbackAt;
   const tool: ToolCall = {
     id: props.toolCallId,
     name: prettifyToolName(props.toolName, props.args),
     kind: props.toolName,
     args_preview: props.argsText ?? safeStringify(props.args ?? null),
-    started_at: stableAt,
+    started_at: startedAt,
   };
   const resultContent =
     props.result &&
@@ -250,17 +255,59 @@ function AssistantToolCall(props: ToolCallProps) {
             : ("tool_complete" as const),
           text: resultContent,
           toolCallId: props.toolCallId,
-          at: stableAt,
+          at: endedAt,
         }
       : undefined;
   return <ToolCard tool={tool} result={result} />;
+}
+
+/** Read the real `_aoe_started_at` ISO timestamp out of the
+ *  tool-call args. Returns null when neither the parsed `args` object
+ *  nor the raw `argsText` carries it — caller falls back to a minted
+ *  client time. */
+function pickStartedAt(
+  args: Record<string, unknown> | undefined,
+  argsText: string | undefined,
+): string | null {
+  if (args && typeof args._aoe_started_at === "string") {
+    return args._aoe_started_at;
+  }
+  if (argsText) {
+    try {
+      const parsed = JSON.parse(argsText);
+      if (
+        parsed &&
+        typeof parsed === "object" &&
+        !Array.isArray(parsed) &&
+        typeof (parsed as Record<string, unknown>)._aoe_started_at === "string"
+      ) {
+        return (parsed as Record<string, string>)._aoe_started_at ?? null;
+      }
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}
+
+/** Read the smuggled `endedAt` field set by AssistantBuilder.completeToolCall. */
+function pickEndedAt(result: unknown): string | null {
+  if (
+    result &&
+    typeof result === "object" &&
+    "endedAt" in (result as Record<string, unknown>)
+  ) {
+    const v = (result as { endedAt?: unknown }).endedAt;
+    if (typeof v === "string") return v;
+  }
+  return null;
 }
 
 interface GroupChild {
   toolCallId: string;
   toolName: string;
   argsText: string;
-  result?: { content: string };
+  result?: { content: string; endedAt?: string };
   isError?: boolean;
 }
 
@@ -278,7 +325,7 @@ function AssistantToolGroup({ argsText }: { argsText?: string }) {
     }
   }
   const items = children.map((c) => {
-    const stableAt = toolCallTimestamp(c.toolCallId);
+    const fallbackAt = toolCallTimestamp(c.toolCallId);
     let parsedArgs: Record<string, unknown> = {};
     try {
       const p = JSON.parse(c.argsText);
@@ -288,12 +335,14 @@ function AssistantToolGroup({ argsText }: { argsText?: string }) {
     } catch {
       // ignore
     }
+    const startedAt = pickStartedAt(parsedArgs, c.argsText) ?? fallbackAt;
+    const endedAt = pickEndedAt(c.result) ?? fallbackAt;
     const tool: ToolCall = {
       id: c.toolCallId,
       name: prettifyToolName(c.toolName, parsedArgs),
       kind: c.toolName,
       args_preview: c.argsText,
-      started_at: stableAt,
+      started_at: startedAt,
     };
     const result =
       c.result !== undefined
@@ -304,7 +353,7 @@ function AssistantToolGroup({ argsText }: { argsText?: string }) {
               : ("tool_complete" as const),
             text: c.result.content,
             toolCallId: c.toolCallId,
-            at: stableAt,
+            at: endedAt,
           }
         : undefined;
     return { tool, result, kind: c.toolName };

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -263,7 +263,7 @@ function AssistantToolCall(props: ToolCallProps) {
 
 /** Read the real `_aoe_started_at` ISO timestamp out of the
  *  tool-call args. Returns null when neither the parsed `args` object
- *  nor the raw `argsText` carries it — caller falls back to a minted
+ *  nor the raw `argsText` carries it; caller falls back to a minted
  *  client time. */
 function pickStartedAt(
   args: Record<string, unknown> | undefined,
@@ -320,7 +320,7 @@ function AssistantToolGroup({ argsText }: { argsText?: string }) {
         children = parsed.children as GroupChild[];
       }
     } catch {
-      // Malformed payload — fall through to an empty group rather than
+      // Malformed payload; fall through to an empty group rather than
       // crashing the assistant-ui render.
     }
   }
@@ -507,7 +507,7 @@ function PlanStrip({ plan, mode }: PlanStripProps) {
       >
         <ListChecks className="h-3.5 w-3.5 shrink-0 text-text-dim" />
         <span className="truncate text-text-primary">
-          {current?.title ?? (allDone ? "all steps complete" : "—")}
+          {current?.title ?? (allDone ? "all steps complete" : "…")}
         </span>
         {plan && (
           <span className="ml-auto flex items-center gap-2">
@@ -845,7 +845,7 @@ function StartupErrorBanner({
             and restart <code className="rounded bg-rose-900/60 px-1">aoe serve</code>,
             or free a slot by deleting an existing cockpit session
             or switching one to the tmux substrate. Reinstalling the adapter
-            won't help — the adapter is fine, the cap is the limit.
+            won't help; the adapter is fine, the cap is the limit.
           </>
         ) : (
           <>

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -434,10 +434,20 @@ function PlanStrip({ plan, mode }: PlanStripProps) {
   // The mode picker now lives in the composer footer.
   if (!plan && mode === "Default") return null;
 
-  const current = plan?.steps.find((s) => s.status === "InProgress");
+  // Pick the active step: prefer an explicit `InProgress` (Claude's
+  // ExitPlanMode bridge sets this), otherwise fall back to the first
+  // non-Done / non-Cancelled step (TodoWrite-produced plans typically
+  // arrive with all entries Pending). Mirrors the server-side
+  // `plan_summary_from_plan` logic so the strip and sidebar agree.
+  const current =
+    plan?.steps.find((s) => s.status === "InProgress") ??
+    plan?.steps.find(
+      (s) => s.status !== "Done" && s.status !== "Cancelled",
+    );
   const completed = plan?.steps.filter((s) => s.status === "Done").length ?? 0;
   const totalSteps = plan?.steps.length ?? 0;
   const pct = totalSteps > 0 ? Math.round((completed / totalSteps) * 100) : 0;
+  const allDone = totalSteps > 0 && completed === totalSteps;
 
   return (
     <div className="border-b border-surface-800 bg-surface-900/95 backdrop-blur">
@@ -448,7 +458,7 @@ function PlanStrip({ plan, mode }: PlanStripProps) {
       >
         <ListChecks className="h-3.5 w-3.5 shrink-0 text-text-dim" />
         <span className="truncate text-text-primary">
-          {current?.title ?? (plan ? "all steps complete" : "—")}
+          {current?.title ?? (allDone ? "all steps complete" : "—")}
         </span>
         {plan && (
           <span className="ml-auto flex items-center gap-2">

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -21,10 +21,10 @@ import {
 import { ChevronDown, ListChecks } from "lucide-react";
 
 import { ApprovalCard } from "./ApprovalCard";
-import { CockpitRuntime, type CockpitContext } from "./CockpitRuntime";
+import { CockpitRuntime, TOOL_GROUP_NAME, type CockpitContext } from "./CockpitRuntime";
 import { Composer } from "./Composer";
 import { Markdown } from "./Markdown";
-import { ToolCard } from "./ToolCards";
+import { ToolCard, ToolGroupCard } from "./ToolCards";
 import {
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
@@ -214,6 +214,15 @@ function toolCallTimestamp(id: string): string {
 }
 
 function AssistantToolCall(props: ToolCallProps) {
+  // Synthetic group-of-tool-calls part. CockpitRuntime's build pass
+  // folds runs of ≥3 consecutive tool-call parts (between agent text)
+  // into one collapsible block (#1057). The children payload carries
+  // the original per-tool parts verbatim so the group card can render
+  // each one with its normal per-kind card on expand.
+  if (props.toolName === TOOL_GROUP_NAME) {
+    return <AssistantToolGroup argsText={props.argsText} />;
+  }
+
   // Reconstruct the ToolCall shape our existing ToolCards.tsx
   // renderer expects. assistant-ui carries `toolName` (we set this to
   // ACP's lowercased ToolKind in CockpitRuntime) plus argsText (the
@@ -245,6 +254,62 @@ function AssistantToolCall(props: ToolCallProps) {
         }
       : undefined;
   return <ToolCard tool={tool} result={result} />;
+}
+
+interface GroupChild {
+  toolCallId: string;
+  toolName: string;
+  argsText: string;
+  result?: { content: string };
+  isError?: boolean;
+}
+
+function AssistantToolGroup({ argsText }: { argsText?: string }) {
+  let children: GroupChild[] = [];
+  if (argsText) {
+    try {
+      const parsed = JSON.parse(argsText);
+      if (parsed && Array.isArray(parsed.children)) {
+        children = parsed.children as GroupChild[];
+      }
+    } catch {
+      // Malformed payload — fall through to an empty group rather than
+      // crashing the assistant-ui render.
+    }
+  }
+  const items = children.map((c) => {
+    const stableAt = toolCallTimestamp(c.toolCallId);
+    let parsedArgs: Record<string, unknown> = {};
+    try {
+      const p = JSON.parse(c.argsText);
+      if (p && typeof p === "object" && !Array.isArray(p)) {
+        parsedArgs = p as Record<string, unknown>;
+      }
+    } catch {
+      // ignore
+    }
+    const tool: ToolCall = {
+      id: c.toolCallId,
+      name: prettifyToolName(c.toolName, parsedArgs),
+      kind: c.toolName,
+      args_preview: c.argsText,
+      started_at: stableAt,
+    };
+    const result =
+      c.result !== undefined
+        ? {
+            id: `done-${c.toolCallId}`,
+            kind: c.isError
+              ? ("tool_error" as const)
+              : ("tool_complete" as const),
+            text: c.result.content,
+            toolCallId: c.toolCallId,
+            at: stableAt,
+          }
+        : undefined;
+    return { tool, result, kind: c.toolName };
+  });
+  return <ToolGroupCard items={items} />;
 }
 
 function prettifyToolName(

--- a/web/src/components/cockpit/ToolCards.test.ts
+++ b/web/src/components/cockpit/ToolCards.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { formatDurationMs } from "./ToolCards";
+
+describe("formatDurationMs", () => {
+  it("renders sub-second durations as ms", () => {
+    expect(formatDurationMs(0)).toBe("0 ms");
+    expect(formatDurationMs(45)).toBe("45 ms");
+    expect(formatDurationMs(999)).toBe("999 ms");
+  });
+
+  it("renders seconds with one decimal", () => {
+    expect(formatDurationMs(1000)).toBe("1.0s");
+    expect(formatDurationMs(4231)).toBe("4.2s");
+    expect(formatDurationMs(59_999)).toBe("60.0s");
+  });
+
+  it("renders ≥ 1 minute as m s", () => {
+    expect(formatDurationMs(60_000)).toBe("1m 0s");
+    expect(formatDurationMs(72_400)).toBe("1m 12s");
+    expect(formatDurationMs(3_600_000)).toBe("60m 0s");
+  });
+});

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -14,6 +14,7 @@ import {
   Copy as CopyIcon,
   FileText,
   Globe,
+  Layers,
   Pencil,
   Plug,
   Search,
@@ -657,6 +658,97 @@ function ThinkToolCard({ tool }: Props) {
       <span>{tool.name || "thinking…"}</span>
     </div>
   );
+}
+
+/* ── tool group ─────────────────────────────────────────────────── */
+
+interface ToolGroupItem {
+  tool: ToolCall;
+  result?: ActivityRow;
+  /** Raw `toolName` from assistant-ui (the ACP kind), used for the
+   *  per-kind tally in the group header. */
+  kind: string;
+}
+
+/** Collapsible block summarising a run of tool calls between agent
+ *  text. The activity log is unchanged — this is presentation only,
+ *  matching how the Claude Code CLI condenses silent investigation
+ *  phases. See #1057. */
+export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
+  const [open, setOpen] = useState(false);
+  if (items.length === 0) return null;
+
+  const runningCount = items.filter((i) => !i.result).length;
+  const errorCount = items.filter(
+    (i) => i.result && i.result.kind === "tool_error",
+  ).length;
+  const status: Status =
+    runningCount > 0 ? "running" : errorCount > 0 ? "err" : "ok";
+
+  const breakdown = summariseKinds(items);
+
+  return (
+    <CardChrome
+      status={status}
+      icon={<Layers className="h-3.5 w-3.5" />}
+      label="actions"
+      primary={
+        <>
+          <span>{items.length} actions</span>
+          {breakdown && (
+            <span className="ml-2 text-text-dim">— {breakdown}</span>
+          )}
+        </>
+      }
+      expanded={open}
+      onToggle={() => setOpen((v) => !v)}
+      body={
+        open && (
+          <div className="border-t border-surface-800 bg-surface-900/30 px-2 py-1">
+            {items.map((item) => (
+              <ToolCard
+                key={item.tool.id}
+                tool={item.tool}
+                result={item.result}
+              />
+            ))}
+          </div>
+        )
+      }
+    />
+  );
+}
+
+function summariseKinds(items: ToolGroupItem[]): string | null {
+  const counts = new Map<string, number>();
+  for (const i of items) {
+    const k = labelForKind(i.kind);
+    counts.set(k, (counts.get(k) ?? 0) + 1);
+  }
+  if (counts.size === 0) return null;
+  const entries = Array.from(counts.entries()).sort((a, b) => b[1] - a[1]);
+  return entries.map(([k, n]) => `${k} ${n}`).join(" · ");
+}
+
+function labelForKind(kind: string): string {
+  switch (kind) {
+    case "execute":
+      return "Bash";
+    case "read":
+      return "Read";
+    case "edit":
+      return "Edit";
+    case "delete":
+      return "Delete";
+    case "search":
+      return "Search";
+    case "fetch":
+      return "Fetch";
+    case "think":
+      return "Think";
+    default:
+      return kind.charAt(0).toUpperCase() + kind.slice(1);
+  }
 }
 
 /* ── mcp ────────────────────────────────────────────────────────── */

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -51,6 +51,10 @@ export function ToolCard({ tool, result }: Props) {
       />
     );
   }
+  const skill = classifySkill(tool);
+  if (skill.isSkill) {
+    return <SkillToolCard tool={tool} result={result} skillName={skill.name} />;
+  }
   const { kind, provenance } = reclassifyBash(tool);
   switch (kind) {
     case "execute":
@@ -726,6 +730,81 @@ function ThinkToolCard({ tool }: Props) {
       <Sparkles className="h-3 w-3 text-text-dim" />
       <span>{tool.name || "thinking…"}</span>
     </div>
+  );
+}
+
+/* ── skill ──────────────────────────────────────────────────────── */
+
+/** Heuristic for Claude's Skill tool, which the adapter routes through
+ *  the generic "Other" arm so it arrives as `kind: "other"` with a bare
+ *  `Skill` title and the skill identifier hidden in `args.skill`. We
+ *  reclassify on (case-insensitive) name + args presence so the cockpit
+ *  shows what skill ran without making the user expand a JSON blob.
+ *  See #1062. */
+function classifySkill(
+  tool: ToolCall,
+): { isSkill: true; name: string } | { isSkill: false } {
+  if (tool.kind !== "other") return { isSkill: false };
+  const title = tool.name?.trim().toLowerCase() ?? "";
+  if (title !== "skill" && title !== "claude-skill") return { isSkill: false };
+  const args = parseJsonObject(tool.args_preview);
+  const name = pickStr(args, "skill", "name", "skill_name") ?? "skill";
+  return { isSkill: true, name };
+}
+
+interface SkillProps extends Props {
+  skillName: string;
+}
+
+function SkillToolCard({ tool, result, skillName }: SkillProps) {
+  const status = statusFor(result);
+  const [open, setOpen] = useState(false);
+  const args = parseJsonObject(tool.args_preview);
+  const output = result?.text ?? "";
+
+  // Pretty-printed input minus the bookkeeping _aoe_title field so the
+  // user sees the actual skill arguments, not the adapter's title echo.
+  const inputJson = useMemo<string>(() => {
+    if (!args) return tool.args_preview;
+    const rest: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args)) {
+      if (k === "_aoe_title") continue;
+      rest[k] = v;
+    }
+    return JSON.stringify(rest, null, 2);
+  }, [args, tool.args_preview]);
+
+  const hasBody = Boolean((args && Object.keys(args).length > 0) || output);
+
+  return (
+    <CardChrome
+      status={status}
+      icon={<Sparkles className="h-3.5 w-3.5" />}
+      label="skill"
+      primary={skillName}
+      expanded={open}
+      onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
+      body={
+        <>
+          {args && Object.keys(args).filter((k) => k !== "_aoe_title").length > 0 && (
+            <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+              <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
+                <span>input</span>
+                <CopyButton text={inputJson} />
+              </div>
+              <pre className="overflow-x-auto font-mono text-[11px] text-text-muted whitespace-pre-wrap break-all">
+                {inputJson}
+              </pre>
+            </div>
+          )}
+          {output && (
+            <HighlightedBlock text={output} language="markdown" maxLines={16} />
+          )}
+        </>
+      }
+    />
   );
 }
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -117,6 +117,15 @@ interface CardChromeProps {
   expanded: boolean;
   onToggle?: () => void;
   body?: React.ReactNode;
+  /** ISO-8601 start timestamp for the underlying tool call. When set
+   *  with `endedAt` (completed call) or alone (in-flight call), the
+   *  header shows a duration label next to the status badge. See
+   *  #1060. */
+  startedAt?: string;
+  /** ISO-8601 timestamp from the matching `tool_complete` /
+   *  `tool_error` row. Absent → tool still running, duration ticks
+   *  live. */
+  endedAt?: string;
 }
 
 function CardChrome({
@@ -128,6 +137,8 @@ function CardChrome({
   expanded,
   onToggle,
   body,
+  startedAt,
+  endedAt,
 }: CardChromeProps) {
   const Header = onToggle ? "button" : "div";
   return (
@@ -149,6 +160,9 @@ function CardChrome({
           {primary}
         </span>
         {meta}
+        {startedAt && (
+          <DurationLabel startedAt={startedAt} endedAt={endedAt} />
+        )}
         <StatusBadge status={status} />
         {onToggle && (
           <ChevronDown
@@ -162,6 +176,49 @@ function CardChrome({
       {expanded && body}
     </div>
   );
+}
+
+/** Render `started_at → ended_at` as a human duration. While the tool
+ *  is still running the label ticks once a second so users see the
+ *  elapsed time grow. Capped at three significant pieces ("1m 12s") so
+ *  the header stays compact. */
+function DurationLabel({
+  startedAt,
+  endedAt,
+}: {
+  startedAt: string;
+  endedAt?: string;
+}) {
+  const running = !endedAt;
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!running) return;
+    const id = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, [running]);
+  const start = Date.parse(startedAt);
+  if (!Number.isFinite(start)) return null;
+  const end = endedAt ? Date.parse(endedAt) : now;
+  if (!Number.isFinite(end)) return null;
+  const ms = Math.max(0, end - start);
+  const text = formatDurationMs(ms);
+  return (
+    <span
+      className="hidden md:inline text-[11px] text-text-dim tabular-nums"
+      title={running ? `running ${text}` : text}
+    >
+      {text}
+    </span>
+  );
+}
+
+export function formatDurationMs(ms: number): string {
+  if (ms < 1000) return `${ms} ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const totalSec = Math.floor(ms / 1000);
+  const m = Math.floor(totalSec / 60);
+  const s = totalSec % 60;
+  return `${m}m ${s}s`;
 }
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
@@ -347,6 +404,8 @@ function ExecuteToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Terminal className="h-3.5 w-3.5" />}
       label="bash"
       primary={
@@ -405,6 +464,8 @@ function ReadToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<FileText className="h-3.5 w-3.5" />}
       label="read"
       primary={path}
@@ -462,6 +523,8 @@ function EditToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Pencil className="h-3.5 w-3.5" />}
       label={verb}
       primary={path}
@@ -543,6 +606,8 @@ function DeleteToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Trash2 className="h-3.5 w-3.5 text-rose-400" />}
       label="delete"
       primary={path}
@@ -576,6 +641,8 @@ function SearchToolCard({ tool, result, provenance }: SearchProps) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Search className="h-3.5 w-3.5" />}
       label={provenance === "bash" ? "search · bash" : "search"}
       primary={query}
@@ -637,6 +704,8 @@ function FetchToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Globe className="h-3.5 w-3.5" />}
       label="fetch"
       primary={url}
@@ -687,9 +756,26 @@ export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
 
   const breakdown = summariseKinds(items);
 
+  // Group duration spans the earliest start across children → latest
+  // completion. Still-running calls leave `endedAt` undefined so the
+  // duration label ticks live until every child completes.
+  const startedAt = items
+    .map((i) => i.tool.started_at)
+    .sort()
+    .at(0);
+  const allDone = items.every((i) => i.result);
+  const endedAt = allDone
+    ? items
+        .map((i) => i.result!.at)
+        .sort()
+        .at(-1)
+    : undefined;
+
   return (
     <CardChrome
       status={status}
+      startedAt={startedAt}
+      endedAt={endedAt}
       icon={<Layers className="h-3.5 w-3.5" />}
       label="actions"
       primary={
@@ -797,6 +883,8 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Plug className="h-3.5 w-3.5" />}
       label={`MCP · ${humanizeServer(server)}`}
       primary={
@@ -840,6 +928,8 @@ function GenericToolCard({ tool, result }: Props) {
   return (
     <CardChrome
       status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
       icon={<Sparkles className="h-3.5 w-3.5" />}
       label={tool.kind || "tool"}
       primary={tool.name}

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Globe,
   Pencil,
+  Plug,
   Search,
   Sparkles,
   Terminal,
@@ -25,6 +26,11 @@ import { getHighlighter, langKeyForExt, loadLanguage } from "../../lib/highlight
 import { hasAnsi, parseAnsi, type AnsiStyle } from "../../lib/ansi";
 import { parseJsonObject, pickFirst, pickStr } from "../../lib/cockpitArgs";
 import type { ActivityRow, ToolCall } from "../../lib/cockpitTypes";
+import {
+  classifyMcp,
+  humanizeServer,
+  humanizeVerb,
+} from "../../lib/mcpClassify";
 import { reclassifyBash } from "../../lib/toolReclassify";
 
 interface Props {
@@ -33,6 +39,17 @@ interface Props {
 }
 
 export function ToolCard({ tool, result }: Props) {
+  const mcp = classifyMcp(tool);
+  if (mcp.isMcp) {
+    return (
+      <McpToolCard
+        tool={tool}
+        result={result}
+        server={mcp.server}
+        verb={mcp.verb}
+      />
+    );
+  }
   const { kind, provenance } = reclassifyBash(tool);
   switch (kind) {
     case "execute":
@@ -639,6 +656,86 @@ function ThinkToolCard({ tool }: Props) {
       <Sparkles className="h-3 w-3 text-text-dim" />
       <span>{tool.name || "thinking…"}</span>
     </div>
+  );
+}
+
+/* ── mcp ────────────────────────────────────────────────────────── */
+
+interface McpProps extends Props {
+  server: string;
+  verb: string;
+}
+
+function McpToolCard({ tool, result, server, verb }: McpProps) {
+  const status = statusFor(result);
+  const [open, setOpen] = useState(false);
+  const args = parseJsonObject(tool.args_preview);
+  const output = result?.text ?? "";
+
+  // Pull a short single-field arg preview for the header so the user
+  // can see what the call was about without expanding. Skip the
+  // _aoe_title bookkeeping field; cap length so headers stay readable.
+  const argPreview = useMemo<string | null>(() => {
+    if (!args) return null;
+    for (const [k, v] of Object.entries(args)) {
+      if (k === "_aoe_title") continue;
+      if (typeof v === "string" && v.length > 0) {
+        const trimmed = v.length > 120 ? `${v.slice(0, 117)}…` : v;
+        return `${k}: ${trimmed}`;
+      }
+    }
+    return null;
+  }, [args]);
+
+  // Pretty-printed input, excluding the bookkeeping _aoe_title field
+  // so the user sees the actual MCP arguments, not the adapter's
+  // forwarded title.
+  const inputJson = useMemo<string>(() => {
+    if (!args) return tool.args_preview;
+    const rest: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(args)) {
+      if (k === "_aoe_title") continue;
+      rest[k] = v;
+    }
+    return JSON.stringify(rest, null, 2);
+  }, [args, tool.args_preview]);
+
+  const hasBody = Boolean((args && Object.keys(args).length > 0) || output);
+
+  return (
+    <CardChrome
+      status={status}
+      icon={<Plug className="h-3.5 w-3.5" />}
+      label={`MCP · ${humanizeServer(server)}`}
+      primary={
+        <>
+          {humanizeVerb(verb)}
+          {argPreview && (
+            <span className="ml-2 text-text-dim">— {argPreview}</span>
+          )}
+        </>
+      }
+      expanded={open}
+      onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
+      body={
+        <>
+          {args && Object.keys(args).filter((k) => k !== "_aoe_title").length > 0 && (
+            <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+              <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
+                <span>input</span>
+                <CopyButton text={inputJson} />
+              </div>
+              <pre className="overflow-x-auto font-mono text-[11px] text-text-muted whitespace-pre-wrap break-all">
+                {inputJson}
+              </pre>
+            </div>
+          )}
+          {output && (
+            <HighlightedBlock text={output} language="markdown" maxLines={24} />
+          )}
+        </>
+      }
+    />
   );
 }
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -40,6 +40,13 @@ interface Props {
   result?: ActivityRow;
 }
 
+/** Keys CockpitRuntime smuggles through `args_preview` for renderer
+ *  bookkeeping (the ACP title, the real `started_at` for the duration
+ *  label). Excluded from any user-visible input JSON dumps. */
+function isCockpitBookkeepingKey(key: string): boolean {
+  return key === "_aoe_title" || key === "_aoe_started_at";
+}
+
 export function ToolCard({ tool, result }: Props) {
   const mcp = classifyMcp(tool);
   if (mcp.isMcp) {
@@ -899,7 +906,7 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
     if (!args) return tool.args_preview;
     const rest: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(args)) {
-      if (k === "_aoe_title") continue;
+      if (isCockpitBookkeepingKey(k)) continue;
       rest[k] = v;
     }
     return JSON.stringify(rest, null, 2);
@@ -919,7 +926,7 @@ function SkillToolCard({ tool, result, skillName }: SkillProps) {
       endedAt={result?.at}
       body={
         <>
-          {args && Object.keys(args).filter((k) => k !== "_aoe_title").length > 0 && (
+          {args && Object.keys(args).filter((k) => !isCockpitBookkeepingKey(k)).length > 0 && (
             <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
               <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
                 <span>input</span>
@@ -1066,7 +1073,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
   const argPreview = useMemo<string | null>(() => {
     if (!args) return null;
     for (const [k, v] of Object.entries(args)) {
-      if (k === "_aoe_title") continue;
+      if (isCockpitBookkeepingKey(k)) continue;
       if (typeof v === "string" && v.length > 0) {
         const trimmed = v.length > 120 ? `${v.slice(0, 117)}…` : v;
         return `${k}: ${trimmed}`;
@@ -1082,7 +1089,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
     if (!args) return tool.args_preview;
     const rest: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(args)) {
-      if (k === "_aoe_title") continue;
+      if (isCockpitBookkeepingKey(k)) continue;
       rest[k] = v;
     }
     return JSON.stringify(rest, null, 2);
@@ -1109,7 +1116,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
       onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
       body={
         <>
-          {args && Object.keys(args).filter((k) => k !== "_aoe_title").length > 0 && (
+          {args && Object.keys(args).filter((k) => !isCockpitBookkeepingKey(k)).length > 0 && (
             <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
               <div className="mb-1 flex items-center justify-between text-[10px] uppercase tracking-wider text-text-dim">
                 <span>input</span>

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -15,6 +15,7 @@ import {
   FileText,
   Globe,
   Layers,
+  ListChecks,
   Pencil,
   Plug,
   Search,
@@ -54,6 +55,10 @@ export function ToolCard({ tool, result }: Props) {
   const skill = classifySkill(tool);
   if (skill.isSkill) {
     return <SkillToolCard tool={tool} result={result} skillName={skill.name} />;
+  }
+  const todos = classifyTodoWrite(tool);
+  if (todos.isTodoWrite) {
+    return <TodoUpdateCard tool={tool} result={result} todos={todos.todos} />;
   }
   const { kind, provenance } = reclassifyBash(tool);
   switch (kind) {
@@ -730,6 +735,132 @@ function ThinkToolCard({ tool }: Props) {
       <Sparkles className="h-3 w-3 text-text-dim" />
       <span>{tool.name || "thinking…"}</span>
     </div>
+  );
+}
+
+/* ── todowrite ──────────────────────────────────────────────────── */
+
+type TodoStatus = "pending" | "in_progress" | "completed" | "cancelled";
+
+interface TodoItem {
+  content: string;
+  status: TodoStatus;
+}
+
+/** Heuristic for Claude's TodoWrite tool. The adapter ships it as a
+ *  `kind: "think"` tool call with the joined todo list crammed into the
+ *  title (`"Update TODOs: a, b, c"`) and the structured `{todos: [...]}`
+ *  payload in raw_input. We detect via the title prefix and parse the
+ *  args payload to render a proper checklist. See #1064. */
+function classifyTodoWrite(
+  tool: ToolCall,
+): { isTodoWrite: true; todos: TodoItem[] } | { isTodoWrite: false } {
+  const title = tool.name?.trim() ?? "";
+  const looksLikeTodo =
+    title.startsWith("Update TODOs") || title === "TodoWrite";
+  if (!looksLikeTodo) return { isTodoWrite: false };
+  const args = parseJsonObject(tool.args_preview);
+  if (!args) return { isTodoWrite: false };
+  const raw = args.todos;
+  if (!Array.isArray(raw)) return { isTodoWrite: false };
+  const todos: TodoItem[] = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
+    const obj = entry as Record<string, unknown>;
+    const content = typeof obj.content === "string" ? obj.content : "";
+    if (!content) continue;
+    todos.push({
+      content,
+      status: normaliseTodoStatus(obj.status),
+    });
+  }
+  if (todos.length === 0) return { isTodoWrite: false };
+  return { isTodoWrite: true, todos };
+}
+
+function normaliseTodoStatus(raw: unknown): TodoStatus {
+  const s = typeof raw === "string" ? raw.toLowerCase() : "";
+  if (s === "in_progress" || s === "in-progress" || s === "active") {
+    return "in_progress";
+  }
+  if (s === "completed" || s === "complete" || s === "done") return "completed";
+  if (s === "cancelled" || s === "canceled" || s === "abandoned") {
+    return "cancelled";
+  }
+  return "pending";
+}
+
+interface TodoCardProps extends Props {
+  todos: TodoItem[];
+}
+
+const TODO_GLYPH: Record<TodoStatus, string> = {
+  pending: "☐",
+  in_progress: "▶",
+  completed: "✓",
+  cancelled: "⊘",
+};
+
+const TODO_CLASS: Record<TodoStatus, string> = {
+  pending: "text-text-secondary",
+  in_progress: "text-brand-400",
+  completed: "text-emerald-400 line-through opacity-70",
+  cancelled: "text-text-dim line-through",
+};
+
+function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
+  const status = statusFor(result);
+  const counts = useMemo(() => {
+    const c = { pending: 0, in_progress: 0, completed: 0, cancelled: 0 };
+    for (const t of todos) c[t.status] += 1;
+    return c;
+  }, [todos]);
+  const [open, setOpen] = useState(todos.length <= 5);
+
+  const breakdown: string[] = [];
+  if (counts.in_progress > 0) breakdown.push(`${counts.in_progress} active`);
+  if (counts.pending > 0) breakdown.push(`${counts.pending} pending`);
+  if (counts.completed > 0) breakdown.push(`${counts.completed} done`);
+  if (counts.cancelled > 0)
+    breakdown.push(`${counts.cancelled} cancelled`);
+
+  return (
+    <CardChrome
+      status={status}
+      icon={<ListChecks className="h-3.5 w-3.5" />}
+      label="todos"
+      primary={
+        <>
+          <span>{todos.length} items</span>
+          {breakdown.length > 0 && (
+            <span className="ml-2 text-text-dim">— {breakdown.join(" · ")}</span>
+          )}
+        </>
+      }
+      expanded={open}
+      onToggle={() => setOpen((v) => !v)}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
+      body={
+        <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+          <ul className="flex flex-col gap-1 font-mono text-xs">
+            {todos.map((t, i) => (
+              <li
+                key={`${i}-${t.content}`}
+                className={`flex items-start gap-2 ${TODO_CLASS[t.status]}`}
+              >
+                <span className="select-none w-4 shrink-0 text-center">
+                  {TODO_GLYPH[t.status]}
+                </span>
+                <span className="min-w-0 flex-1 whitespace-pre-wrap break-words">
+                  {t.content}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      }
+    />
   );
 }
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -27,6 +27,7 @@ import {
 import { getHighlighter, langKeyForExt, loadLanguage } from "../../lib/highlighter";
 import { hasAnsi, parseAnsi, type AnsiStyle } from "../../lib/ansi";
 import { parseJsonObject, pickFirst, pickStr } from "../../lib/cockpitArgs";
+import { useCockpitPrefs } from "../../lib/cockpitPrefs";
 import type { ActivityRow, ToolCall } from "../../lib/cockpitTypes";
 import {
   classifyMcp,
@@ -135,8 +136,29 @@ interface CardChromeProps {
   body?: React.ReactNode;
   /** ISO-8601 start timestamp for the underlying tool call. When set
    *  with `endedAt` (completed call) or alone (in-flight call), the
-   *  header shows a duration label next to the status badge. See
-   *  #1060. */
+   *  header shows a duration label next to the status badge (#1060).
+   *
+   *  Rendering is gated by the `cockpit.show_tool_durations` setting
+   *  (resolved server-side from `[cockpit]` in config.toml, surfaced
+   *  via `ServerAbout.cockpit_show_tool_durations`, consumed here via
+   *  `useCockpitPrefs`). Default on; cross-device because the setting
+   *  lives in the daemon's config file rather than the browser.
+   *
+   *  IMPORTANT — the measurement is imprecise on claude-agent-acp.
+   *  The adapter emits each ACP `tool_call` frame at the wall time
+   *  the model streams its tool_use chunk, which is typically well
+   *  before the Claude Code SDK dispatches the subprocess; it also
+   *  never emits `status: "in_progress"` so we cannot re-stamp
+   *  `started_at` to the real subprocess start. Parallel
+   *  `sleep 1` / `sleep 2` / `sleep 5` therefore render as
+   *  ~3s / ~3.5s / ~6s instead of ~1s / ~2s / ~5s — durations
+   *  include stream-arrival skew rather than just runtime. Once
+   *  upstream gains a trustworthy "subprocess started" signal
+   *  (either a `status: in_progress` frame or a `_meta` flag), the
+   *  existing re-stamp path in `acp_client::map_update_to_events`
+   *  picks it up with no further change here. The setting lets users
+   *  hide the label in the meantime if the inflated numbers are more
+   *  confusing than useful. */
   startedAt?: string;
   /** ISO-8601 timestamp from the matching `tool_complete` /
    *  `tool_error` row. Absent → tool still running, duration ticks
@@ -156,6 +178,7 @@ function CardChrome({
   startedAt,
   endedAt,
 }: CardChromeProps) {
+  const { showToolDurations } = useCockpitPrefs();
   const Header = onToggle ? "button" : "div";
   return (
     <div className="my-1 overflow-hidden rounded-md border border-surface-700 bg-surface-800/50 text-sm">
@@ -176,7 +199,7 @@ function CardChrome({
           {primary}
         </span>
         {meta}
-        {startedAt && (
+        {showToolDurations && startedAt && (
           <DurationLabel startedAt={startedAt} endedAt={endedAt} />
         )}
         <StatusBadge status={status} />
@@ -196,8 +219,9 @@ function CardChrome({
 
 /** Render `started_at → ended_at` as a human duration. While the tool
  *  is still running the label ticks once a second so users see the
- *  elapsed time grow. Capped at three significant pieces ("1m 12s") so
- *  the header stays compact. */
+ *  elapsed time grow. Tooltip names the known measurement
+ *  imprecision (see `CardChromeProps.startedAt`) so users who notice
+ *  "sleep 1 took 3s" find the explanation in-place. */
 function DurationLabel({
   startedAt,
   endedAt,
@@ -218,10 +242,13 @@ function DurationLabel({
   if (!Number.isFinite(end)) return null;
   const ms = Math.max(0, end - start);
   const text = formatDurationMs(ms);
+  const tooltip = running
+    ? `running ${text} — counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`
+    : `${text} — counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`;
   return (
     <span
       className="hidden md:inline text-[11px] text-text-dim tabular-nums"
-      title={running ? `running ${text}` : text}
+      title={tooltip}
     >
       {text}
     </span>

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -144,14 +144,14 @@ interface CardChromeProps {
    *  `useCockpitPrefs`). Default on; cross-device because the setting
    *  lives in the daemon's config file rather than the browser.
    *
-   *  IMPORTANT — the measurement is imprecise on claude-agent-acp.
+   *  IMPORTANT; the measurement is imprecise on claude-agent-acp.
    *  The adapter emits each ACP `tool_call` frame at the wall time
    *  the model streams its tool_use chunk, which is typically well
    *  before the Claude Code SDK dispatches the subprocess; it also
    *  never emits `status: "in_progress"` so we cannot re-stamp
    *  `started_at` to the real subprocess start. Parallel
    *  `sleep 1` / `sleep 2` / `sleep 5` therefore render as
-   *  ~3s / ~3.5s / ~6s instead of ~1s / ~2s / ~5s — durations
+   *  ~3s / ~3.5s / ~6s instead of ~1s / ~2s / ~5s; durations
    *  include stream-arrival skew rather than just runtime. Once
    *  upstream gains a trustworthy "subprocess started" signal
    *  (either a `status: in_progress` frame or a `_meta` flag), the
@@ -243,11 +243,11 @@ function DurationLabel({
   const ms = Math.max(0, end - start);
   const text = formatDurationMs(ms);
   const tooltip = running
-    ? `running ${text} — counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`
-    : `${text} — counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`;
+    ? `running ${text}; counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`
+    : `${text}; counts from the agent's first tool_call frame, which can fire before the subprocess actually starts (upstream limitation)`;
   return (
     <span
-      className="hidden md:inline text-[11px] text-text-dim tabular-nums"
+      className="text-[11px] text-text-dim tabular-nums"
       title={tooltip}
     >
       {text}
@@ -303,7 +303,7 @@ function CopyButton({ text }: { text: string }) {
 /** If the input is a single outer markdown code fence (```lang ... ```),
  *  strip the fence and return the inner body plus the fence's language
  *  hint. Tool output emitted by ACP agents (Claude in particular) is
- *  routinely pre-wrapped in fenced blocks like ```console ...``` — left
+ *  routinely pre-wrapped in fenced blocks like ```console ...```; left
  *  un-stripped, the cards render literal backticks above the content. */
 function unwrapMarkdownFence(text: string): {
   text: string;
@@ -335,7 +335,7 @@ function HighlightedBlock({
 
   // ANSI fast path: when the text carries SGR escape sequences (e.g.
   // `gls --color=always`, `git status --color=always`), Shiki's bash
-  // grammar can't handle them — it would either render the literal
+  // grammar can't handle them; it would either render the literal
   // `[01;34m` noise or fail to highlight at all. Render the styled
   // segments directly instead.
   const ansi = hasAnsi(shown);
@@ -356,7 +356,7 @@ function HighlightedBlock({
         });
         setHtml(out);
       } catch {
-        // unknown language — fall back to plain
+        // unknown language; fall back to plain
       }
     })();
     return () => {
@@ -467,7 +467,7 @@ function ExecuteToolCard({ tool, result }: Props) {
               {description}
             </div>
           )}
-          {/* Full command — the chrome's primary slot is single-line
+          {/* Full command; the chrome's primary slot is single-line
               truncated, so we surface the untruncated command here so
               users can read and copy it. Shiki's bash grammar gives
               the same coloring as our markdown code blocks. */}
@@ -594,7 +594,7 @@ function EditToolCard({ tool, result }: Props) {
   );
 }
 
-/** Theme overrides for react-diff-viewer-continued — drag its colors
+/** Theme overrides for react-diff-viewer-continued; drag its colors
  *  toward our zinc/brand palette so the diff doesn't look like it was
  *  pasted in from another app. */
 const DIFF_STYLES = {
@@ -867,7 +867,7 @@ function TodoUpdateCard({ tool, result, todos }: TodoCardProps) {
         <>
           <span>{todos.length} items</span>
           {breakdown.length > 0 && (
-            <span className="ml-2 text-text-dim">— {breakdown.join(" · ")}</span>
+            <span className="ml-2 text-text-dim">· {breakdown.join(" · ")}</span>
           )}
         </>
       }
@@ -924,7 +924,12 @@ interface SkillProps extends Props {
 function SkillToolCard({ tool, result, skillName }: SkillProps) {
   const status = statusFor(result);
   const [open, setOpen] = useState(false);
-  const args = parseJsonObject(tool.args_preview);
+  // Memo on the raw string so downstream memos see a stable args reference
+  // and don't recompute every render.
+  const args = useMemo(
+    () => parseJsonObject(tool.args_preview),
+    [tool.args_preview],
+  );
   const output = result?.text ?? "";
 
   // Pretty-printed input minus the bookkeeping _aoe_title field so the
@@ -984,7 +989,7 @@ interface ToolGroupItem {
 }
 
 /** Collapsible block summarising a run of tool calls between agent
- *  text. The activity log is unchanged — this is presentation only,
+ *  text. The activity log is unchanged; this is presentation only,
  *  matching how the Claude Code CLI condenses silent investigation
  *  phases. See #1057. */
 export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
@@ -1026,7 +1031,7 @@ export function ToolGroupCard({ items }: { items: ToolGroupItem[] }) {
         <>
           <span>{items.length} actions</span>
           {breakdown && (
-            <span className="ml-2 text-text-dim">— {breakdown}</span>
+            <span className="ml-2 text-text-dim">· {breakdown}</span>
           )}
         </>
       }
@@ -1091,7 +1096,12 @@ interface McpProps extends Props {
 function McpToolCard({ tool, result, server, verb }: McpProps) {
   const status = statusFor(result);
   const [open, setOpen] = useState(false);
-  const args = parseJsonObject(tool.args_preview);
+  // Memo on the raw string so downstream memos see a stable args reference
+  // and don't recompute every render.
+  const args = useMemo(
+    () => parseJsonObject(tool.args_preview),
+    [tool.args_preview],
+  );
   const output = result?.text ?? "";
 
   // Pull a short single-field arg preview for the header so the user
@@ -1135,7 +1145,7 @@ function McpToolCard({ tool, result, server, verb }: McpProps) {
         <>
           {humanizeVerb(verb)}
           {argPreview && (
-            <span className="ml-2 text-text-dim">— {argPreview}</span>
+            <span className="ml-2 text-text-dim">· {argPreview}</span>
           )}
         </>
       }

--- a/web/src/components/cockpit/skillClassify.test.ts
+++ b/web/src/components/cockpit/skillClassify.test.ts
@@ -1,0 +1,60 @@
+// Sanity check for the Skill heuristic — exercises the same regex
+// shape as classifySkill via a direct ToolCard render-side dispatch
+// pre-check. Kept as a black-box test to avoid exporting the
+// classifier (which would force a refactor for one consumer).
+
+import { describe, expect, it } from "vitest";
+import { parseJsonObject, pickStr } from "../../lib/cockpitArgs";
+import type { ToolCall } from "../../lib/cockpitTypes";
+
+function classifyForTest(
+  tool: ToolCall,
+): { isSkill: true; name: string } | { isSkill: false } {
+  if (tool.kind !== "other") return { isSkill: false };
+  const title = tool.name?.trim().toLowerCase() ?? "";
+  if (title !== "skill" && title !== "claude-skill") return { isSkill: false };
+  const args = parseJsonObject(tool.args_preview);
+  const name = pickStr(args, "skill", "name", "skill_name") ?? "skill";
+  return { isSkill: true, name };
+}
+
+function tool(name: string, kind: string, args: Record<string, unknown>): ToolCall {
+  return {
+    id: "tc-1",
+    name,
+    kind,
+    args_preview: JSON.stringify(args),
+    started_at: "2026-05-12T00:00:00Z",
+  };
+}
+
+describe("classifySkill (#1062)", () => {
+  it("recognises the Skill title with args.skill", () => {
+    const r = classifyForTest(tool("Skill", "other", { skill: "fix-netrc" }));
+    expect(r.isSkill).toBe(true);
+    if (r.isSkill) expect(r.name).toBe("fix-netrc");
+  });
+
+  it("is case-insensitive on the title", () => {
+    expect(classifyForTest(tool("skill", "other", { skill: "x" })).isSkill).toBe(true);
+    expect(classifyForTest(tool("SKILL", "other", { skill: "x" })).isSkill).toBe(true);
+  });
+
+  it("accepts the claude-skill variant", () => {
+    expect(classifyForTest(tool("claude-skill", "other", { skill: "x" })).isSkill).toBe(true);
+  });
+
+  it("falls back to a generic name when skill arg is missing", () => {
+    const r = classifyForTest(tool("Skill", "other", {}));
+    expect(r.isSkill).toBe(true);
+    if (r.isSkill) expect(r.name).toBe("skill");
+  });
+
+  it("rejects non-other kinds", () => {
+    expect(classifyForTest(tool("Skill", "execute", { skill: "x" })).isSkill).toBe(false);
+  });
+
+  it("rejects unrelated titles", () => {
+    expect(classifyForTest(tool("Bash", "other", { skill: "x" })).isSkill).toBe(false);
+  });
+});

--- a/web/src/components/cockpit/skillClassify.test.ts
+++ b/web/src/components/cockpit/skillClassify.test.ts
@@ -1,4 +1,4 @@
-// Sanity check for the Skill heuristic — exercises the same regex
+// Sanity check for the Skill heuristic; exercises the same regex
 // shape as classifySkill via a direct ToolCard render-side dispatch
 // pre-check. Kept as a black-box test to avoid exporting the
 // classifier (which would force a refactor for one consumer).

--- a/web/src/components/session-wizard/sessionNames.test.ts
+++ b/web/src/components/session-wizard/sessionNames.test.ts
@@ -58,7 +58,7 @@ describe("slugifyBranch", () => {
     );
   });
 
-  it("replaces forward slashes — git allows them but the slug stays kebab", () => {
+  it("replaces forward slashes; git allows them but the slug stays kebab", () => {
     expect(slugifyBranch("feat/auth.refactor")).toBe("feat-auth-refactor");
   });
 

--- a/web/src/components/session-wizard/sessionNames.ts
+++ b/web/src/components/session-wizard/sessionNames.ts
@@ -42,7 +42,7 @@ export function applyBranchOverride(_title: string, worktreeBranch: string): {
   worktreeBranch: string;
   worktreeBranchDirty: boolean;
 } {
-  // Any direct edit on the branch field — including clearing it — marks it
+  // Any direct edit on the branch field, including clearing it, marks it
   // dirty so the title→branch mirror stops overwriting the user's input on
   // the next keystroke. Empty is a valid UI state; the submit path falls
   // back to the title via getSubmittedBranch.

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -372,6 +372,14 @@ export function useCockpit(sessionId: string | null) {
     [sessionId],
   );
 
+  // Cancels the in-flight agent turn (ACP session/cancel). Must only
+  // fire on an explicit user gesture against a dedicated cancel/stop
+  // affordance — never bind this to the Escape key. Claude Code CLI
+  // hijacks Escape for cancel and accidental presses lose work the
+  // user did not mean to abort; the cockpit deliberately keeps Escape
+  // for closing local UI surfaces (palette, dialogs, popovers) only.
+  // If a future Escape binding is added, route it through
+  // useKeyboardShortcuts.onEscape's local-UI dismissal, not here.
   const cancelPrompt = useCallback(async () => {
     if (!sessionId) return;
     try {

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -153,7 +153,7 @@ export function useCockpit(sessionId: string | null) {
   // Track lastSeq in a ref so the snapshot fetcher always sees the
   // latest value without re-running the effect when it changes.
   // The ref is updated inside an effect (not during render) to keep
-  // the react-hooks linter happy — fetchReplay only ever runs from
+  // the react-hooks linter happy; fetchReplay only ever runs from
   // an event handler or another effect, so the one-tick lag is fine.
   const lastSeqRef = useRef(0);
   useEffect(() => {
@@ -337,13 +337,13 @@ export function useCockpit(sessionId: string | null) {
       if (statusRef.current !== "open") {
         dispatch({
           kind: "error",
-          message: "Cockpit disconnected — message not sent. Reconnect to retry.",
+          message: "Cockpit disconnected; message not sent. Reconnect to retry.",
         });
         return;
       }
       // Optimistically echo the user's message; the agent reply
       // streams back as session/update events on the WS. If the POST
-      // fails we'll surface a banner and the user can retry — the
+      // fails we'll surface a banner and the user can retry; the
       // optimistic row stays so they see what they tried to send.
       dispatch({ kind: "user_prompt", text });
       try {
@@ -374,7 +374,7 @@ export function useCockpit(sessionId: string | null) {
 
   // Cancels the in-flight agent turn (ACP session/cancel). Must only
   // fire on an explicit user gesture against a dedicated cancel/stop
-  // affordance — never bind this to the Escape key. Claude Code CLI
+  // affordance; never bind this to the Escape key. Claude Code CLI
   // hijacks Escape for cancel and accidental presses lose work the
   // user did not mean to abort; the cockpit deliberately keeps Escape
   // for closing local UI surfaces (palette, dialogs, popovers) only.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -243,6 +243,10 @@ export interface ServerAbout {
   /** Whether the server process has AOE_EXPERIMENTAL_COCKPIT=1 set.
    *  Read-only; flipping requires restarting `aoe serve`. */
   cockpit_env_enabled: boolean;
+  /** Resolved `cockpit.show_tool_durations` from the active profile's
+   *  config. Drives the per-tool elapsed-time label in the cockpit
+   *  web UI; cross-device since it lives in config.toml. */
+  cockpit_show_tool_durations: boolean;
 }
 
 export async function setCockpitMaster(

--- a/web/src/lib/cockpitDrafts.ts
+++ b/web/src/lib/cockpitDrafts.ts
@@ -92,7 +92,7 @@ export function subscribeDrafts(
 // not on every cockpit draft write anywhere in the app.
 export function useHasDraftForSessions(sessionIds: readonly string[]): boolean {
   // Stable join key so getSnapshot returns the same primitive across
-  // renders unless the relevant drafts actually change — otherwise
+  // renders unless the relevant drafts actually change; otherwise
   // useSyncExternalStore would tear under React 18's strict checks.
   const ids = sessionIds.join("|");
   const subscribe = useMemo(() => {

--- a/web/src/lib/cockpitPrefs.tsx
+++ b/web/src/lib/cockpitPrefs.tsx
@@ -1,0 +1,48 @@
+// Cockpit display preferences sourced from the daemon's resolved
+// `[cockpit]` config (config.toml). Single source of truth: the
+// `/api/about` endpoint exposes the resolved active-profile values as
+// `ServerAbout.cockpit_*`. App.tsx fetches that on mount and
+// republishes the relevant slice through this context so any cockpit
+// renderer (deeply-nested tool cards in particular) can subscribe
+// without prop-drilling.
+//
+// Cross-device by construction: every browser pointed at the same
+// daemon reads the same value. Toggling from the web Settings panel
+// rewrites config.toml via `PATCH /api/profiles/:name/settings`, then
+// `App.refreshServerAbout()` re-fetches `/api/about` and the context
+// repopulates.
+
+import { createContext, useContext, type ReactNode } from "react";
+
+export interface CockpitPrefs {
+  /** Resolved `cockpit.show_tool_durations` from the active profile.
+   *  When true, tool-card headers display a per-call elapsed-time
+   *  label. Imprecise on claude-agent-acp today — see
+   *  `CardChromeProps.startedAt` in ToolCards.tsx for the upstream
+   *  limitation. */
+  showToolDurations: boolean;
+}
+
+const DEFAULT_PREFS: CockpitPrefs = {
+  showToolDurations: true,
+};
+
+const CockpitPrefsContext = createContext<CockpitPrefs>(DEFAULT_PREFS);
+
+export function CockpitPrefsProvider({
+  value,
+  children,
+}: {
+  value: CockpitPrefs;
+  children: ReactNode;
+}) {
+  return (
+    <CockpitPrefsContext.Provider value={value}>
+      {children}
+    </CockpitPrefsContext.Provider>
+  );
+}
+
+export function useCockpitPrefs(): CockpitPrefs {
+  return useContext(CockpitPrefsContext);
+}

--- a/web/src/lib/cockpitPrefs.tsx
+++ b/web/src/lib/cockpitPrefs.tsx
@@ -17,7 +17,7 @@ import { createContext, useContext, type ReactNode } from "react";
 export interface CockpitPrefs {
   /** Resolved `cockpit.show_tool_durations` from the active profile.
    *  When true, tool-card headers display a per-call elapsed-time
-   *  label. Imprecise on claude-agent-acp today — see
+   *  label. Imprecise on claude-agent-acp today; see
    *  `CardChromeProps.startedAt` in ToolCards.tsx for the upstream
    *  limitation. */
   showToolDurations: boolean;

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -122,6 +122,12 @@ export type CockpitEvent =
         tool_call_id: string;
         title: string | null;
         args_preview: string | null;
+        /** Re-stamped start time when the agent reports the tool's
+         *  status transitioned to InProgress. See acp_client.rs;
+         *  reused so the duration label measures real tool runtime
+         *  rather than adapter scheduling time. Null for non-status
+         *  updates. */
+        started_at?: string | null;
       };
     }
   | { ApprovalRequested: { approval: Approval } }
@@ -377,12 +383,14 @@ export function applyEvent(
     return next;
   }
   if ("ToolCallUpdated" in event) {
-    const { tool_call_id, title, args_preview } = event.ToolCallUpdated;
+    const { tool_call_id, title, args_preview, started_at } =
+      event.ToolCallUpdated;
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = {
         ...next.inFlightTool,
         name: title ?? next.inFlightTool.name,
         args_preview: args_preview ?? next.inFlightTool.args_preview,
+        started_at: started_at ?? next.inFlightTool.started_at,
       };
     }
     // Walk activity backwards to find the matching tool_start row and
@@ -405,6 +413,7 @@ export function applyEvent(
             ...row.tool,
             name: title ?? row.tool.name,
             args_preview: args_preview ?? row.tool.args_preview,
+            started_at: started_at ?? row.tool.started_at,
           },
         };
       }

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -102,6 +102,14 @@ export type CockpitEvent =
          *  ACP `ToolCallUpdate.fields.content`. Empty when the agent
          *  emitted no content blocks on completion. */
         content: string;
+        /** Server-side ISO-8601 wall clock at which the completion
+         *  was minted. Used to stamp the activity row's `at` so the
+         *  duration label survives page reload — without it, the
+         *  reducer would assign `new Date()` at replay time and the
+         *  measured duration would count from "now". Optional for
+         *  backward compatibility with events persisted before this
+         *  field landed. */
+        completed_at?: string;
       };
     }
   | {
@@ -347,7 +355,8 @@ export function applyEvent(
     return next;
   }
   if ("ToolCallCompleted" in event) {
-    const { tool_call_id, is_error, content } = event.ToolCallCompleted;
+    const { tool_call_id, is_error, content, completed_at } =
+      event.ToolCallCompleted;
     if (next.inFlightTool && next.inFlightTool.id === tool_call_id) {
       next.inFlightTool = null;
     }
@@ -368,12 +377,16 @@ export function applyEvent(
       void _drop;
       next.toolOutputs = rest;
     }
+    // Use the server-side completion timestamp when present so the
+    // duration label survives page reload. Events persisted before
+    // `completed_at` landed fall back to "now" (same bug as before for
+    // those specific rows only).
     next.activity = pushActivity(next.activity, {
       id: `done-${tool_call_id}`,
       kind: is_error ? "tool_error" : "tool_complete",
       text,
       toolCallId: tool_call_id,
-      at: new Date().toISOString(),
+      at: completed_at ?? new Date().toISOString(),
     });
     return next;
   }

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -67,7 +67,7 @@ export interface SessionUsage {
 export interface AvailableCommand {
   name: string;
   description: string;
-  /** True when ACP reported an `Unstructured` input spec — i.e. the
+  /** True when ACP reported an `Unstructured` input spec; i.e. the
    *  command takes free-form arguments after the name. The composer
    *  inserts a trailing space and leaves the cursor in place when
    *  this is true so the user can keep typing. */
@@ -104,7 +104,7 @@ export type CockpitEvent =
         content: string;
         /** Server-side ISO-8601 wall clock at which the completion
          *  was minted. Used to stamp the activity row's `at` so the
-         *  duration label survives page reload — without it, the
+         *  duration label survives page reload; without it, the
          *  reducer would assign `new Date()` at replay time and the
          *  measured duration would count from "now". Optional for
          *  backward compatibility with events persisted before this
@@ -514,7 +514,7 @@ export function applyEvent(
     }
     // Some upstream slash commands (e.g. /usage, /status, /memory in
     // claude-agent-acp) advertise via available_commands_update but
-    // produce no agent_message_chunk and no tool calls when invoked —
+    // produce no agent_message_chunk and no tool calls when invoked;
     // see https://github.com/agentclientprotocol/claude-agent-acp/issues/642.
     // Detect that case and append a notice row. The `turnHasOutput`
     // flag is flipped by every output-producing handler and reset by
@@ -542,7 +542,7 @@ export function applyEvent(
     // dispatched a moment ago: find the OLDEST matching un-promoted
     // user_prompt with the same text and promote it to the
     // authoritative seq-based id. Walking oldest-first matters when
-    // the user submits the same text twice in quick succession — the
+    // the user submits the same text twice in quick succession; the
     // first server echo must promote the first optimistic row, not
     // the second, so the seq order matches the submission order.
     const matchIdx = next.activity.findIndex(
@@ -570,7 +570,7 @@ export function applyEvent(
     next.startupError = null;
     next.lastError = null;
     next.turnActive = true;
-    // New turn — reset the no-output detector so Stopped fires the
+    // New turn; reset the no-output detector so Stopped fires the
     // empty-output notice if the agent produces nothing.
     next.turnHasOutput = false;
     // A fresh prompt means the worker is alive again; clear the
@@ -601,7 +601,7 @@ export function applyEvent(
     return next;
   }
   if ("SessionContextReset" in event) {
-    // session/load failed and the agent fell back to session/new — its
+    // session/load failed and the agent fell back to session/new; its
     // context window is empty. Clear the now-stale token-usage hint so
     // the composer footer doesn't keep showing the previous run's
     // "75k / 200k" until the next UsageUpdate arrives.
@@ -611,7 +611,7 @@ export function applyEvent(
     // session/load failing on the next spawn is expected, not an
     // incident the user needs to know about. Events arrive in seq
     // order, so checking `activity` here captures "any prompt with a
-    // lower seq than this reset" — later prompts won't retroactively
+    // lower seq than this reset"; later prompts won't retroactively
     // surface the suppressed row.
     const hasPriorPrompt = next.activity.some((r) => r.kind === "user_prompt");
     if (!hasPriorPrompt) {

--- a/web/src/lib/mcpClassify.test.ts
+++ b/web/src/lib/mcpClassify.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyMcp,
+  humanizeServer,
+  humanizeVerb,
+} from "./mcpClassify";
+import type { ToolCall } from "./cockpitTypes";
+
+function tool(name: string, args: Record<string, unknown> = {}): ToolCall {
+  return {
+    id: "tc-1",
+    name,
+    kind: "other",
+    args_preview: JSON.stringify(args),
+    started_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("classifyMcp", () => {
+  it("recognises a plain mcp__server__verb name", () => {
+    const r = classifyMcp(tool("mcp__sentry__get_sentry_resource"));
+    expect(r.isMcp).toBe(true);
+    if (r.isMcp) {
+      expect(r.server).toBe("sentry");
+      expect(r.verb).toBe("get_sentry_resource");
+    }
+  });
+
+  it("handles servers with underscores in their name", () => {
+    const r = classifyMcp(tool("mcp__claude_ai_HubSpot__get_user_details"));
+    expect(r.isMcp).toBe(true);
+    if (r.isMcp) {
+      expect(r.server).toBe("claude_ai_HubSpot");
+      expect(r.verb).toBe("get_user_details");
+    }
+  });
+
+  it("handles servers with hyphens in their name", () => {
+    const r = classifyMcp(tool("mcp__db-toolbox-preprod__preprod_cluster_dbsize"));
+    expect(r.isMcp).toBe(true);
+    if (r.isMcp) {
+      expect(r.server).toBe("db-toolbox-preprod");
+      expect(r.verb).toBe("preprod_cluster_dbsize");
+    }
+  });
+
+  it("falls back to _aoe_title when tool.name is empty", () => {
+    const t = tool("", { _aoe_title: "mcp__sentry__find_issues" });
+    const r = classifyMcp(t);
+    expect(r.isMcp).toBe(true);
+    if (r.isMcp) expect(r.server).toBe("sentry");
+  });
+
+  it("rejects non-mcp names", () => {
+    expect(classifyMcp(tool("Bash")).isMcp).toBe(false);
+    expect(classifyMcp(tool("Read")).isMcp).toBe(false);
+    expect(classifyMcp(tool("")).isMcp).toBe(false);
+  });
+
+  it("rejects malformed mcp names missing parts", () => {
+    expect(classifyMcp(tool("mcp__sentry")).isMcp).toBe(false);
+    expect(classifyMcp(tool("mcp____foo")).isMcp).toBe(false);
+    expect(classifyMcp(tool("mcp__sentry__")).isMcp).toBe(false);
+  });
+});
+
+describe("humanizeServer", () => {
+  it("title-cases all-lowercase chunks", () => {
+    expect(humanizeServer("sentry")).toBe("Sentry");
+    expect(humanizeServer("db-toolbox-preprod")).toBe("Db Toolbox Preprod");
+  });
+
+  it("preserves existing mixed case", () => {
+    expect(humanizeServer("claude_ai_HubSpot")).toBe("Claude Ai HubSpot");
+  });
+});
+
+describe("humanizeVerb", () => {
+  it("converts snake_case to sentence case", () => {
+    expect(humanizeVerb("get_sentry_resource")).toBe("Get sentry resource");
+    expect(humanizeVerb("create_event")).toBe("Create event");
+    expect(humanizeVerb("whoami")).toBe("Whoami");
+  });
+});

--- a/web/src/lib/mcpClassify.ts
+++ b/web/src/lib/mcpClassify.ts
@@ -1,0 +1,72 @@
+// Recognise MCP-server tool calls (Anthropic's `mcp__<server>__<verb>`
+// namespacing) so the cockpit can render them in a dedicated card
+// instead of the generic-tool fallback. The adapter (claude-agent-acp)
+// ships these calls through as `kind: "other"` with the raw underscore
+// name as the title; the frontend reclassifies on title alone.
+
+import type { ToolCall } from "./cockpitTypes";
+import { parseJsonObject, pickStr } from "./cockpitArgs";
+
+export interface McpHit {
+  isMcp: true;
+  server: string;
+  verb: string;
+}
+
+export interface NotMcp {
+  isMcp: false;
+}
+
+/** Pull the canonical name out of a tool call: prefer the wire `name`
+ *  field, but fall back to `_aoe_title` from args (the cockpit runtime
+ *  forwards the ACP title there when it's distinct from the kind). */
+function nameOf(tool: ToolCall): string {
+  if (tool.name) return tool.name;
+  const t = pickStr(parseJsonObject(tool.args_preview), "_aoe_title");
+  return t ?? "";
+}
+
+/** Split `mcp__<server>__<verb>` into its parts. Server names can
+ *  contain underscores (e.g. `claude_ai_HubSpot`,
+ *  `db-toolbox-preprod`), but the separators between mcp/server/verb
+ *  are always the double-underscore `__`. */
+function parseMcpName(
+  name: string,
+): { server: string; verb: string } | null {
+  if (!name.startsWith("mcp__")) return null;
+  const parts = name.split("__");
+  if (parts.length < 3) return null;
+  if (parts[0] !== "mcp") return null;
+  const server = parts[1];
+  const verb = parts.slice(2).join("__");
+  if (!server || !verb) return null;
+  return { server, verb };
+}
+
+export function classifyMcp(tool: ToolCall): McpHit | NotMcp {
+  const hit = parseMcpName(nameOf(tool));
+  if (!hit) return { isMcp: false };
+  return { isMcp: true, server: hit.server, verb: hit.verb };
+}
+
+/** Turn a server slug into a display label. Preserves existing mixed
+ *  case (so `claude_ai_HubSpot` keeps the `HubSpot` chunk verbatim)
+ *  but title-cases all-lowercase chunks. */
+export function humanizeServer(server: string): string {
+  return server
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((c) =>
+      /[A-Z]/.test(c) ? c : c.charAt(0).toUpperCase() + c.slice(1),
+    )
+    .join(" ");
+}
+
+/** Turn a snake_case verb into sentence case: `get_sentry_resource` →
+ *  `Get sentry resource`. Sentence case (not Title Case) reads better
+ *  when later words are often proper nouns the user typed themselves. */
+export function humanizeVerb(verb: string): string {
+  const spaced = verb.replace(/_/g, " ").trim();
+  if (!spaced) return "";
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}

--- a/web/src/lib/toolReclassify.ts
+++ b/web/src/lib/toolReclassify.ts
@@ -20,7 +20,7 @@ const MUTATING = /[|;&]|>{1,2}|<(?!=)|-delete\b|-exec\b|--exec\b/;
 export interface Reclassified {
   /** Effective tool kind to dispatch to (may differ from tool.kind). */
   kind: string;
-  /** Origin of the call when reclassified — used to surface "search · bash"
+  /** Origin of the call when reclassified; used to surface "search · bash"
    *  on the card so the swap stays transparent. Null when not reclassified. */
   provenance: "bash" | null;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -42,6 +42,18 @@ export interface SessionResponse {
    *  hook failures where the worktree was created successfully anyway). Only
    *  populated on the create-session response; absent on subsequent fetches. */
   warnings?: string[];
+  /** Latest plan snapshot summarised for the sidebar. Present only on
+   *  cockpit sessions whose agent has emitted a Plan. See #1061. */
+  plan_summary?: PlanSummary;
+}
+
+export interface PlanSummary {
+  /** First non-completed step's title, truncated server-side. */
+  current_step_title: string | null;
+  /** Count of steps with status `Done`. */
+  completed: number;
+  /** Total step count. */
+  total: number;
 }
 
 export interface WorkspaceRepoSummary {


### PR DESCRIPTION
## Description

> **⚠️ PR stack — please review / merge #1040 first.**
> This branch is stacked on `Seluj78:cockpit-polishing` (the head of #1040). The diff below this line will look ~doubled because GitHub diffs against `main`, so all of #1040's commits appear alongside this PR's own. The 13 commits actually owned by this PR are listed in the section below; once #1040 lands the diff cleans up automatically.

Second batch of cockpit / worktree / sidebar improvements. Each commit closes one issue and can be reverted on its own.

- Closes #1043 — Cockpit: MCP tool calls (`mcp__server__verb`) now render in a dedicated `MCP · <Server>` card with sentence-cased verb, inline arg preview, and pretty-printed input/output, instead of falling into `GenericToolCard`. (`467419a`)
- Closes #1044 — Worktree: `git submodule deinit -f --all` runs before `git worktree remove` for any worktree carrying `.gitmodules`, so the panic-button Force checkbox is no longer required just because the worktree has submodules. Manual fallback (`<main>/.git/worktrees/<name>/modules/` + prune) covers the rare case where deinit itself fails. (`069ed62`)
- Closes #1048 — Cockpit: resolve a bare agent command (`claude-agent-acp`) against the daemon's PATH first, then scan known node-manager dirs (nvm, fnm, mise, asdf, Volta, `~/.npm-global/bin`, etc.). Re-runs per spawn so a `nvm use <other-version>` after daemon launch picks up immediately without a `aoe serve` restart. (`7af52e8`)
- Closes #1049 — Cockpit: snapshot events (`AvailableCommandsUpdated`, `ModesAvailable`, `CurrentModeChanged`, `AcpSessionAssigned`) are now exempt from the retention prune, so the `/` palette and mode picker stay populated in long sessions instead of going empty once the cap evicts the early seqs. (`34cff85`)
- Closes #1050 — Cockpit: `/compact` no longer renders as a silent no-op. Detect the adapter's `Compacting completed.` chunk and surface an amber "Conversation compacted" divider, reusing the existing `context_reset` callout shape. (`2761dd9`)
- Closes #1057 — Cockpit: runs of ≥ 3 consecutive tool calls between agent text fold into one `Layers` summary card showing a per-kind breakdown (`Read 7 · Search 3 · Bash 2`); expand to see the original per-kind cards. Activity log untouched — pure presentation. (`f6326ff`)
- Closes #1059 — Cockpit: bridge `ExitPlanMode` (which claude-agent-acp ships as a `switch_mode` tool call with the plan markdown stuffed in `raw_input.plan`) into `Event::PlanUpdated`, parsing top-level bullet / numbered items. The existing PlanStrip now lights up with real content. (`0a18133`)
- Closes #1060 — Cockpit: every tool card now shows its runtime next to the status badge (sub-second `723 ms`, seconds `4.2s`, longer `1m 12s`). In-flight cards tick live at 1 Hz; group cards span the earliest start to the latest completion. (`cf9d696`)
- Closes #1061 — Sidebar: cockpit session rows surface a thin `<done>/<total>` progress bar derived from the latest `PlanUpdated` event in the on-disk event store. Lookup is per-3s REST poll; quiet when no plan is set. (`fd1658c`)
- Closes #1062 — Cockpit: Claude's `Skill` tool (passed through as `kind: "other"` with a bare `Skill` title) now renders in a dedicated `Skill: <name>` card with `Sparkles` icon, extracting the skill identifier from `args.skill`. (`4496ec0`)
- Closes #1064 — Cockpit: `TodoWrite` tool calls render in a `TodoUpdateCard` checklist with status glyphs (☐ pending / ▶ active / ✓ done / ⊘ cancelled) and a counts header instead of an italic comma-separated dump. Group folding (#1057) skips runs that contain a TodoWrite — they're status updates, not silent investigation work. (`083560b`)
- Closes #1065 — Cockpit: per-session history retention default flipped from 500 events to `0` (unlimited). Migration `v006` rewrites the v005-seeded `replay_events = 500` to `0` for upgraders; users with an explicit non-default value are left alone. (`d3ae414`)
- Plus a follow-up commit (`794bcac`) adding anti-regression comments at `useCockpit.cancelPrompt` and `App.tsx`'s global Escape handler explicitly forbidding a future Escape → ACP cancel binding. Claude Code CLI does this and stray Escape presses kill in-flight turns; cockpit deliberately keeps Escape for closing local UI surfaces only.

## Screenshots:

MCP Toolcard
<img width="432" height="71" alt="Screenshot 2026-05-12 at 16 10 57" src="https://github.com/user-attachments/assets/6194819f-0f10-464f-b09d-654b79809945" />

Tool grouping
<img width="1042" height="307" alt="Screenshot 2026-05-12 at 16 15 02" src="https://github.com/user-attachments/assets/4d96fa81-61ed-4432-82c3-6f4a404d2a72" />

Skill Toolcard
<img width="307" height="155" alt="Screenshot 2026-05-12 at 17 39 26" src="https://github.com/user-attachments/assets/aa23c503-892f-49ee-996f-96b2693b32b3" />

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Mix of bug fixes and small UX features. "Bug fix" is the better single fit.)

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Manual test plan

Each commit is independently reversible; tests are scoped to one commit at a time. Tick off as verified.

### `467419a` — MCP tool cards (#1043)

- [x] Configure at least one MCP server in your cockpit-mode session (e.g. Sentry, Slack, db-toolbox).
- [x] Ask the agent to perform a call on that server (e.g. "fetch Sentry issue X").
- [x] Confirm the activity log shows a card labelled `MCP · <Server>` (title-cased) with a `Plug` icon and a sentence-cased verb (e.g. `Get sentry resource`), not the raw `mcp__sentry__get_sentry_resource` string.
- [x] Expand the card; confirm input JSON omits `_aoe_title` and output renders as markdown.
- [x] Try a server name with underscores (`claude_ai_HubSpot`) and hyphens (`db-toolbox-preprod`); confirm both parse cleanly.

### `069ed62` — worktree submodule deinit (#1044)

- [x] Create a session whose worktree contains initialised submodules (any repo with `.gitmodules`).
- [x] Delete the session WITHOUT ticking Force.
- [x] Confirm the deletion succeeds and no `working trees containing submodules cannot be moved or removed` error surfaces.
- [x] Inspect `<main>/.git/worktrees/` — no orphan entry for the deleted worktree.
- [x] Repeat for a worktree without `.gitmodules` and confirm the delete path is unaffected.

### `7af52e8` — agent binary PATH resolution (#1048)

- [x] Install `claude-agent-acp` under one node version (e.g. via `nvm install 22 && nvm use 22 && npm i -g @agentclientprotocol/claude-agent-acp`).
- [x] `nvm use <different-version>` so the active node's `bin/` does not contain the adapter.
- [x] `aoe serve` from that shell. Open a cockpit Claude session and send a prompt.
- [x] Confirm the agent spawns successfully (no `Cockpit agent failed to start` banner) even though the daemon's frozen PATH does not contain the adapter.
- [x] `tail debug.log` and verify the spawn line shows `resolved=...nvm/versions/node/v22.../bin/claude-agent-acp`.
- [x] `nvm use <yet another version>`, send another prompt; the next respawn picks up the new bin dir without restarting `aoe serve`.

### `34cff85` — snapshot retention pin (#1049)

- [x] Set `cockpit.replay_events = 50` in `config.toml` (small cap for repro speed). Restart `aoe serve`.
- [x] Start a cockpit session and send several prompts so the agent emits > 50 events (each turn is 5-20 events).
- [x] Refresh the page. Confirm the composer's `/` palette still shows the real slash-command list (not "No matches") and the mode picker shows the agent-advertised modes.
- [x] (Optional) Open the SQLite DB at `~/.agent-of-empires/cockpit_events.db` and `SELECT event_json FROM cockpit_events WHERE session_id = '<id>' AND event_json LIKE '{"AvailableCommandsUpdated":%';` — at least one row should still exist.

### `2761dd9` — /compact divider (#1050)

- [x] In a cockpit Claude session with non-trivial history, run `/compact`.
- [x] Wait for the agent to finish.
- [x] Confirm an amber callout appears in the transcript saying **Conversation compacted — earlier turns above are summarised in the model's context.**
- [x] Confirm the divider lands BELOW the prior turns (so they appear visually "above the line"), not at the top of the chat.

### `f6326ff` — tool-call grouping (#1057)

- [x] Send a prompt that triggers ≥ 3 consecutive tool calls without intervening agent text (e.g. "read these 5 files and tell me what they do").
- [x] Confirm the run collapses into one card labelled `<N> actions — <Per-kind breakdown>` with a `Layers` icon.
- [x] Click to expand; the original per-kind cards (`Read`, `Search`, etc.) render inside.
- [x] Trigger a turn with 1 or 2 tool calls; confirm those stay inline (no grouping).
- [x] Trigger a turn with intermixed text → tools → text → tools; confirm two separate groups appear if each side has ≥ 3 tools.

### `0a18133` — ExitPlanMode → PlanUpdated (#1059)

- [x] Switch to plan mode via the cockpit mode picker.
- [x] Send a prompt asking the agent to plan something complex enough that it produces ≥ 3 plan steps.
- [x] When the agent calls `ExitPlanMode`, confirm the cockpit's PlanStrip (top of the cockpit view) populates with the parsed plan steps (no `**bold**` literal in step titles).
- [x] Confirm the tool card for `ExitPlanMode` also still renders the raw plan markdown in the chat stream.

### `cf9d696` — tool runtime display (#1060)

- [x] Send a prompt that triggers a fast tool call (`Read` a small file) and a slow one (a long-running Bash command, or a large repo Grep).
- [x] Confirm each completed tool card shows a duration next to the status badge in the format `723 ms` / `4.2s` / `1m 12s`.
- [x] Confirm an in-flight card ticks live (seconds advance once per second while running).
- [x] Confirm a grouped run (#1057) shows the span from earliest child start → latest completion.

### `fd1658c` — sidebar plan progress (#1061)

- [x] Trigger a plan in a cockpit session (depends on #1059 above).
- [x] Confirm the session's row in the sidebar grows a thin progress bar with `<completed>/<total>` count below the existing subtitle.
- [x] Confirm sessions without an emitted plan do not show the progress bar (sidebar row layout unchanged).
- [x] Hover the bar; confirm the tooltip shows the current step title.
- [x] Wait for the agent to complete some steps; confirm the bar advances on the next REST poll (≤ 3 s).

### `4496ec0` — Skill card (#1062)

- [x] In a cockpit Claude session with a custom skill installed, invoke a skill (e.g. ask the agent to use the `fix-netrc` skill if installed).
- [x] Confirm the tool card header shows `Skill: <skill-name>` with a `Sparkles` icon (NOT "Other / Skill" with raw JSON).
- [x] Expand the card; the input JSON and launch message render as expected.

### `083560b` — TodoUpdateCard (#1064)

- [x] Send a prompt that causes Claude to use `TodoWrite` multiple times in one turn (e.g. "plan and execute a multi-step refactor").
- [x] Confirm each TodoWrite renders as a checklist card with a counts header (e.g. `5 items — 1 active · 3 pending · 1 done`) and per-item glyphs.
- [x] Confirm completed items have strike-through styling and the "done" emerald color.
- [x] Confirm in-progress items use the brand accent color with the `▶` glyph.
- [x] Confirm TodoWrite cards are NOT folded by #1057's grouping pass (each renders standalone even mid-investigation).

### `d3ae414` — unlimited history default (#1065)

- [x] On a FRESH install (no prior `config.toml`), run `aoe serve` and confirm `config.toml` either omits `replay_events` or has it set to `0`.
- [x] On an UPGRADE install where `config.toml` had `replay_events = 500` from v005, restart `aoe serve` and confirm `replay_events` was rewritten to `0` (the v006 migration fired). Check `debug.log` for `v006: flipped cockpit.replay_events from 500 to 0` line.
- [x] On an install where the user explicitly set `replay_events = 200`, confirm v006 leaves it alone (no rewrite).
- [x] In a cockpit session, generate > 500 events and confirm the early ones survive (scroll-back shows the full history; sqlite query confirms rows are not pruned).
- [x] Open Settings TUI / web settings, locate "History cap (events)", confirm description mentions `0 = unlimited`.

### `794bcac` — Escape→cancel anti-regression comments

- [x] Press Escape with an in-flight agent turn. Confirm the turn KEEPS running (Escape does not cancel).
- [x] Press Escape with the command palette / settings / wizard / a confirm dialog open. Confirm Escape closes the local UI surface.
- [x] Verify the explicit Stop button in the composer (assistant-ui's cancel affordance) does cancel the in-flight turn.
- [x] Inspect `web/src/hooks/useCockpit.ts` `cancelPrompt` doc comment and `web/src/App.tsx` `onEscape` handler comment — both should call out the "never bind Escape to cancel" constraint.

## Test results (machine-checked)

- Rust: `cargo build --features serve` clean; `cargo clippy --features serve --no-deps` clean; `cargo fmt --check` clean; `cargo test --lib --features serve` passes (1752+ tests, 2 pre-existing docker-image failures unrelated to this branch).
- Web: `npx tsc -b` clean; `npx vitest run` passes (120 tests).
- Documentation: `docs/cockpit.md` updated for PATH-resolution (#1048) and history default (#1065); `docs/guides/worktrees.md` updated for submodule delete (#1044).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context) — multi-turn back-and-forth: per-issue investigation, scoping, implementation, tests, commit messages, this PR description. Idea, scoping, decisions, and review remain @Seluj78's.

**Any Additional AI Details you'd like to share:** Same workflow as #1040 — one issue at a time, scoped to the minimum useful change per issue's "A is the minimum" proposal, with tests added at the same time as the code. Settings TUI fields, profile-override plumbing, and migrations were wired per `CLAUDE.md`.

- [x] I am an AI Agent filling out this form (check box if true)