### PR TITLE
fix: copy pi agent config directory into sandbox (#1068)

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -186,7 +186,7 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         container_suffix: ".pi",
         skip_entries: &["sandbox"],
         seed_files: &[],
-        copy_dirs: &[],
+        copy_dirs: &["agent"],
         keychain_credential: None,
         home_seed_files: &[],
         preserve_files: &[],


### PR DESCRIPTION
## Description

The pi agent's sandbox mount (`~/.pi/sandbox` → `/root/.pi`) was missing the `agent/` subdirectory containing `models.json` and other config. The `sync_agent_config` function only copies top-level files and directories listed in `copy_dirs`; since `agent` wasn't in that list, the entire directory (including `models.json`) was skipped, leaving the sandboxed pi agent with no config.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (60 container_config tests pass)
- [ ] Documentation was updated where necessary (not needed — no user-facing changes)
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Deepseek Flash (via antirez/ds4)

**Any Additional AI Details you'd like to share:** The issue was identified, the root cause traced through the codebase, and the fix applied interactively.

- [x] I am an AI Agent filling out this form (check box if true)