### PR TITLE
feat(new-session): show path field before title

### DIFF
--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -539,9 +539,9 @@ impl NewSessionDialog {
     }
 
     /// The field index of the path field. Path comes BEFORE title in the
-    /// dialog so the user browses to a directory first and the title can
-    /// then auto-fill from the folder basename. Shifts based on whether
-    /// the profile picker is visible at field 0.
+    /// dialog so the user picks the working directory before naming the
+    /// session. Shifts based on whether the profile picker is visible at
+    /// field 0.
     fn path_field(&self) -> usize {
         if self.has_profile_selection() {
             1
@@ -550,9 +550,7 @@ impl NewSessionDialog {
         }
     }
 
-    /// The field index of the title field. Title sits one slot AFTER path
-    /// so the picker-flow lands on title with a sensible default already
-    /// filled in (or empty if the user typed the path manually).
+    /// The field index of the title field. Title sits one slot AFTER path.
     fn title_field(&self) -> usize {
         if self.has_profile_selection() {
             2
@@ -836,19 +834,6 @@ impl NewSessionDialog {
                             .and_then(path_input::compute_path_ghost);
                         self.workspace_repo_dir_picker_active = false;
                     } else {
-                        // Auto-fill title from folder basename when the user
-                        // hasn't typed one yet. The folder name is almost
-                        // always what they'd call the session anyway, and
-                        // making it the default removes a second step after
-                        // the browse picker selects a directory.
-                        if self.title.value().is_empty() {
-                            if let Some(basename) = std::path::Path::new(&path)
-                                .file_name()
-                                .and_then(|n| n.to_str())
-                            {
-                                self.title = Input::new(basename.to_string());
-                            }
-                        }
                         self.path = Input::new(path);
                         self.recompute_path_ghost();
                     }
@@ -867,7 +852,6 @@ impl NewSessionDialog {
         let has_sandbox = self.docker_available && !is_host_only;
         let has_yolo = !self.selected_tool_always_yolo();
         // Field order: [profile], path, title, [tool], [yolo], worktree, [sandbox], group
-        // Path is first so browse → auto-fills title from folder basename.
         // Worktree sub-options (new_branch, extra_repos) are in a Ctrl+P overlay.
         // Tool config (extra_args, command_override) is in a Ctrl+P overlay on tool field.
         // Sandbox sub-options are in a separate sandbox_config_mode overlay.

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -538,8 +538,22 @@ impl NewSessionDialog {
         crate::agents::get_agent(tool_name).is_some_and(|a| a.host_only)
     }
 
-    /// The field index of the path field (shifts based on whether profile picker is visible)
+    /// The field index of the path field. Path comes BEFORE title in the
+    /// dialog so the user browses to a directory first and the title can
+    /// then auto-fill from the folder basename. Shifts based on whether
+    /// the profile picker is visible at field 0.
     fn path_field(&self) -> usize {
+        if self.has_profile_selection() {
+            1
+        } else {
+            0
+        }
+    }
+
+    /// The field index of the title field. Title sits one slot AFTER path
+    /// so the picker-flow lands on title with a sensible default already
+    /// filled in (or empty if the user typed the path manually).
+    fn title_field(&self) -> usize {
         if self.has_profile_selection() {
             2
         } else {
@@ -852,7 +866,8 @@ impl NewSessionDialog {
         let is_host_only = self.selected_tool_host_only();
         let has_sandbox = self.docker_available && !is_host_only;
         let has_yolo = !self.selected_tool_always_yolo();
-        // Field order: [profile], title, path, [tool], [yolo], worktree, [sandbox], group
+        // Field order: [profile], path, title, [tool], [yolo], worktree, [sandbox], group
+        // Path is first so browse → auto-fills title from folder basename.
         // Worktree sub-options (new_branch, extra_repos) are in a Ctrl+P overlay.
         // Tool config (extra_args, command_override) is in a Ctrl+P overlay on tool field.
         // Sandbox sub-options are in a separate sandbox_config_mode overlay.
@@ -1534,7 +1549,7 @@ impl NewSessionDialog {
         let group_field = fi;
 
         let path_field = self.path_field();
-        let title_field = if self.has_profile_selection() { 1 } else { 0 };
+        let title_field = self.title_field();
         match self.focused_field {
             n if n == title_field => &mut self.title,
             n if n == path_field => &mut self.path,

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -109,9 +109,11 @@ impl NewSessionDialog {
         // Render fields sequentially, tracking chunk index to match dynamic constraints
         let mut ci = 0; // chunk index
 
-        // Field index calculations (must match handle_key)
+        // Field index calculations (must match handle_key).
+        // Field order: [profile], path, title, [tool], ...
+        // Path is first so browse → auto-fills title from folder basename.
         let base = if has_profile_selection { 1 } else { 0 };
-        let title_field = base;
+        let title_field = base + 1;
         let mut fi = base + 2 + if has_tool_selection { 1 } else { 0 };
         let yolo_mode_field = if has_yolo {
             let f = fi;
@@ -142,25 +144,27 @@ impl NewSessionDialog {
             ci += 1;
         }
 
-        // Title
-        render_text_field(
-            frame,
-            chunks[ci],
-            "Title:",
-            &self.title,
-            self.focused_field == title_field,
-            Some("(random civ)"),
-            theme,
-        );
-        ci += 1;
-
-        // Path
+        // Path (rendered FIRST so the user browses to a directory, then
+        // the title auto-fills from the folder basename on the next chunk).
         let path_placeholder = if self.focused_field == self.path_field() {
             Some("(Ctrl+P to browse directories)")
         } else {
             None
         };
         self.render_path_field(frame, chunks[ci], path_placeholder, theme);
+        ci += 1;
+
+        // Title (auto-populated from the path's folder basename when the
+        // user picks a path via the Ctrl+P browser and hasn't typed one).
+        render_text_field(
+            frame,
+            chunks[ci],
+            "Title:",
+            &self.title,
+            self.focused_field == title_field,
+            Some("(folder name)"),
+            theme,
+        );
         ci += 1;
 
         // Tool (always shown, interactive or read-only)

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -111,7 +111,6 @@ impl NewSessionDialog {
 
         // Field index calculations (must match handle_key).
         // Field order: [profile], path, title, [tool], ...
-        // Path is first so browse → auto-fills title from folder basename.
         let base = if has_profile_selection { 1 } else { 0 };
         let title_field = base + 1;
         let mut fi = base + 2 + if has_tool_selection { 1 } else { 0 };
@@ -144,8 +143,8 @@ impl NewSessionDialog {
             ci += 1;
         }
 
-        // Path (rendered FIRST so the user browses to a directory, then
-        // the title auto-fills from the folder basename on the next chunk).
+        // Path (rendered first so the user picks the working directory
+        // before naming the session).
         let path_placeholder = if self.focused_field == self.path_field() {
             Some("(Ctrl+P to browse directories)")
         } else {
@@ -154,15 +153,14 @@ impl NewSessionDialog {
         self.render_path_field(frame, chunks[ci], path_placeholder, theme);
         ci += 1;
 
-        // Title (auto-populated from the path's folder basename when the
-        // user picks a path via the Ctrl+P browser and hasn't typed one).
+        // Title
         render_text_field(
             frame,
             chunks[ci],
             "Title:",
             &self.title,
             self.focused_field == title_field,
-            Some("(folder name)"),
+            Some("(random civ)"),
             theme,
         );
         ci += 1;

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -80,10 +80,10 @@ fn test_enter_preserves_custom_title() {
 #[test]
 fn test_tab_cycles_fields_single_tool() {
     let mut dialog = single_tool_dialog();
-    assert_eq!(dialog.focused_field, 0); // title (single profile, no profile field)
+    assert_eq!(dialog.focused_field, 0); // path (single profile, no profile field)
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1); // path
+    assert_eq!(dialog.focused_field, 1); // title
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // yolo mode
@@ -104,10 +104,10 @@ fn test_tab_cycles_fields_single_tool_with_worktree() {
     // so the main form has the same tab stops as without worktree.
     let mut dialog = single_tool_dialog();
     dialog.worktree_enabled = true;
-    assert_eq!(dialog.focused_field, 0); // title
+    assert_eq!(dialog.focused_field, 0); // path
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1); // path
+    assert_eq!(dialog.focused_field, 1); // title
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // yolo mode
@@ -125,10 +125,10 @@ fn test_tab_cycles_fields_single_tool_with_worktree() {
 #[test]
 fn test_tab_cycles_fields_multi_tool() {
     let mut dialog = multi_tool_dialog();
-    assert_eq!(dialog.focused_field, 0); // title
+    assert_eq!(dialog.focused_field, 0); // path
 
     dialog.handle_key(key(KeyCode::Tab));
-    assert_eq!(dialog.focused_field, 1); // path
+    assert_eq!(dialog.focused_field, 1); // title
 
     dialog.handle_key(key(KeyCode::Tab));
     assert_eq!(dialog.focused_field, 2); // tool selection
@@ -149,7 +149,7 @@ fn test_tab_cycles_fields_multi_tool() {
 #[test]
 fn test_backtab_cycles_fields_reverse() {
     let mut dialog = single_tool_dialog();
-    assert_eq!(dialog.focused_field, 0); // title
+    assert_eq!(dialog.focused_field, 0); // path
 
     dialog.handle_key(shift_key(KeyCode::BackTab));
     assert_eq!(dialog.focused_field, 4); // group (last field without worktree/docker)
@@ -161,10 +161,10 @@ fn test_backtab_cycles_fields_reverse() {
     assert_eq!(dialog.focused_field, 2); // yolo mode
 
     dialog.handle_key(shift_key(KeyCode::BackTab));
-    assert_eq!(dialog.focused_field, 1); // path
+    assert_eq!(dialog.focused_field, 1); // title
 
     dialog.handle_key(shift_key(KeyCode::BackTab));
-    assert_eq!(dialog.focused_field, 0); // title
+    assert_eq!(dialog.focused_field, 0); // path
 }
 
 #[test]

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -170,7 +170,7 @@ fn test_backtab_cycles_fields_reverse() {
 #[test]
 fn test_char_input_to_title() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 0; // title
+    dialog.focused_field = 1; // title
     dialog.handle_key(key(KeyCode::Char('H')));
     dialog.handle_key(key(KeyCode::Char('i')));
     assert_eq!(dialog.title.value(), "Hi");
@@ -179,7 +179,7 @@ fn test_char_input_to_title() {
 #[test]
 fn test_char_input_to_path() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.handle_key(key(KeyCode::Char('/')));
     dialog.handle_key(key(KeyCode::Char('a')));
     assert_eq!(dialog.path.value(), format!("{TEST_PATH}/a"));
@@ -192,7 +192,7 @@ fn test_ghost_text_appears_for_single_match() {
     fs::write(tmp.path().join("project-file"), "not a directory").expect("failed to write file");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -206,7 +206,7 @@ fn test_ghost_text_shows_common_prefix_for_multiple_matches() {
     fs::create_dir(tmp.path().join("client-web")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/cl", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -218,7 +218,7 @@ fn test_ghost_text_none_when_no_matches() {
     let tmp = tempfile::tempdir().expect("failed to create temp dir");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/zzz_nonexistent", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -231,7 +231,7 @@ fn test_ghost_shows_slash_for_exact_directory_match() {
     fs::create_dir(tmp.path().join("alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/alpha", tmp.path().display()));
     dialog.recompute_path_ghost();
 
@@ -244,7 +244,7 @@ fn test_right_arrow_accepts_ghost_text() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -263,7 +263,7 @@ fn test_end_key_accepts_ghost_text() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -279,7 +279,7 @@ fn test_end_key_accepts_ghost_text() {
 #[test]
 fn test_right_arrow_at_mid_input_moves_cursor_normally() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
     // Move cursor to start
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -299,7 +299,7 @@ fn test_ghost_recomputes_after_accepting() {
     fs::create_dir(tmp.path().join("alpha").join("inner")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/alp", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert_eq!(dialog.ghost_text(), Some("ha/"));
@@ -320,7 +320,7 @@ fn test_tab_always_navigates_from_path_field() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -328,7 +328,7 @@ fn test_tab_always_navigates_from_path_field() {
     dialog.handle_key(key(KeyCode::Tab));
 
     // Tab should navigate to next field, not accept ghost
-    assert_eq!(dialog.focused_field, 2); // yolo mode
+    assert_eq!(dialog.focused_field, 1); // title
 }
 
 #[test]
@@ -337,7 +337,7 @@ fn test_ghost_cleared_when_leaving_path_field() {
     fs::create_dir(tmp.path().join("project-alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/pro", tmp.path().display()));
     dialog.recompute_path_ghost();
     assert!(dialog.ghost_text().is_some());
@@ -353,7 +353,7 @@ fn test_ghost_not_shown_when_cursor_not_at_end() {
     fs::create_dir(tmp.path().join("alpha")).expect("failed to create directory");
 
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new(format!("{}/alp", tmp.path().display()));
     // Move cursor to start
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -365,7 +365,7 @@ fn test_ghost_not_shown_when_cursor_not_at_end() {
 #[test]
 fn test_invalid_path_flash_expires_after_tick() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path_invalid_flash_until =
         Some(std::time::Instant::now() - std::time::Duration::from_millis(1));
     assert!(dialog.tick());
@@ -375,7 +375,7 @@ fn test_invalid_path_flash_expires_after_tick() {
 #[test]
 fn test_ctrl_left_jumps_to_previous_path_segment() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(ctrl_key(KeyCode::Left));
@@ -387,7 +387,7 @@ fn test_ctrl_left_jumps_to_previous_path_segment() {
 #[test]
 fn test_alt_b_jumps_to_previous_path_segment() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(alt_key(KeyCode::Char('b')));
@@ -399,7 +399,7 @@ fn test_alt_b_jumps_to_previous_path_segment() {
 #[test]
 fn test_ctrl_a_jumps_to_start_of_path() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 1; // path
+    dialog.focused_field = 0; // path
     dialog.path = Input::new("/tmp/alpha/beta".to_string());
 
     dialog.handle_key(ctrl_key(KeyCode::Char('a')));
@@ -411,7 +411,7 @@ fn test_ctrl_a_jumps_to_start_of_path() {
 #[test]
 fn test_char_input_to_group() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 4; // group (single tool, single profile: title=0, path=1, yolo=2, worktree=3, group=4)
+    dialog.focused_field = 4; // group (single tool, single profile: path=0, title=1, yolo=2, worktree=3, group=4)
     dialog.handle_key(key(KeyCode::Char('w')));
     dialog.handle_key(key(KeyCode::Char('o')));
     dialog.handle_key(key(KeyCode::Char('r')));
@@ -422,7 +422,7 @@ fn test_char_input_to_group() {
 #[test]
 fn test_backspace_removes_char() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 0; // title
+    dialog.focused_field = 1; // title
     dialog.title = Input::new("Hello".to_string());
     dialog.handle_key(key(KeyCode::Backspace));
     assert_eq!(dialog.title.value(), "Hell");
@@ -431,7 +431,7 @@ fn test_backspace_removes_char() {
 #[test]
 fn test_backspace_on_empty_field() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 0; // title
+    dialog.focused_field = 1; // title
     dialog.handle_key(key(KeyCode::Backspace));
     assert_eq!(dialog.title.value(), "");
 }
@@ -439,7 +439,7 @@ fn test_backspace_on_empty_field() {
 #[test]
 fn test_tool_selection_left_right() {
     let mut dialog = multi_tool_dialog();
-    dialog.focused_field = 2; // tool field (single profile: title=0, path=1, tool=2)
+    dialog.focused_field = 2; // tool field (single profile: path=0, title=1, tool=2)
     assert_eq!(dialog.tool_index, 0);
 
     dialog.handle_key(key(KeyCode::Right));
@@ -492,7 +492,7 @@ fn test_tool_selection_space() {
 #[test]
 fn test_tool_selection_ignored_on_text_field() {
     let mut dialog = multi_tool_dialog();
-    dialog.focused_field = 0; // title
+    dialog.focused_field = 1; // title
     dialog.handle_key(key(KeyCode::Char(' ')));
     assert_eq!(dialog.title.value(), " ");
     assert_eq!(dialog.tool_index, 0);
@@ -532,7 +532,7 @@ fn test_unknown_key_continues() {
 #[test]
 fn test_error_clears_on_input() {
     let mut dialog = single_tool_dialog();
-    dialog.focused_field = 0; // title
+    dialog.focused_field = 1; // title
     dialog.error_message = Some("Some error".to_string());
 
     dialog.handle_key(key(KeyCode::Char('a')));
@@ -834,7 +834,7 @@ fn test_yolo_mode_toggle() {
     let mut dialog = multi_tool_dialog();
     dialog.docker_available = true;
     dialog.sandbox_enabled = true;
-    dialog.focused_field = 3; // yolo mode field (single profile: title=0, path=1, tool=2, yolo=3)
+    dialog.focused_field = 3; // yolo mode field (single profile: path=0, title=1, tool=2, yolo=3)
     assert!(!dialog.yolo_mode);
 
     dialog.handle_key(key(KeyCode::Char(' ')));


### PR DESCRIPTION
## Description

Renders the path field before the title field in the new-session dialog (`n` keybind in the TUI).

The natural reading order for "make a new session" is "pick the directory, then name it," but the dialog asked for the name first. Putting path first lets the user orient on the working directory before deciding what to call the session.

### Implementation

- Factor `title_field()` into a method paralleling `path_field()`; swap their return values (`path_field` is now `base`, `title_field` is now `base + 1`).
- Swap the render blocks at the top of the dialog.
- The `base + 2 + ...` math for downstream tool/yolo/worktree/sandbox/group fields is unchanged; only the relative position of title and path within the first two slots flips.
- Test updates: swap `focused_field` indices in new_session unit tests to match the new order, plus inline comments documenting the layout.

### Notes

- Initial focus on the dialog is `focused_field = 0`. For multi-profile users this is the profile field (unchanged). For single-profile users this is now the path field instead of the title field, so users who press `n` and immediately type a name now need one Tab first.
- The folder-basename auto-fill from #1077 was removed in the fixup commit so the random civ-name fallback (`src/cli/add.rs`) stays the canonical empty-submit behavior across all flows (typed path, default cwd, Ctrl+P browse).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --lib` 1556/1556, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt --check` clean)
- [x] Documentation was updated where necessary
- [x] For UI changes: manual TUI verification (open `n`, confirm path is on top)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (Anthropic), via Claude Code CLI.

**Any Additional AI Details you'd like to share:** The diff and rationale are mine; the assistant drafted the implementation and PR body from my direction. I reviewed and edited before pushing.

- [x] I am an AI Agent filling out this form (check box if true)