### PR TITLE
feat(send): respawn dead panes and start stopped sessions before send

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -218,12 +218,16 @@ Remove a session
 
 Send a message to a running agent session
 
-**Usage:** `aoe send <IDENTIFIER> <MESSAGE>`
+**Usage:** `aoe send [OPTIONS] <IDENTIFIER> <MESSAGE>`
 
 ###### **Arguments:**
 
 * `<IDENTIFIER>` — Session ID or title
 * `<MESSAGE>` — Message to send to the agent
+
+###### **Options:**
+
+* `--no-revive` — Fail loud on dead/stopped sessions instead of auto-respawning. Default behavior is to revive the session so a `send` after a crash or stop just works; pass this for scripts that want the previous bail-out
 
 
 

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -3,7 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::session::Storage;
+use crate::session::{EnsureReadyError, EnsureReadyOutcome, Storage};
 
 #[derive(Args)]
 pub struct SendArgs {
@@ -12,6 +12,12 @@ pub struct SendArgs {
 
     /// Message to send to the agent
     message: String,
+
+    /// Fail loud on dead/stopped sessions instead of auto-respawning. Default
+    /// behavior is to revive the session so a `send` after a crash or stop
+    /// just works; pass this for scripts that want the previous bail-out.
+    #[arg(long = "no-revive")]
+    no_revive: bool,
 }
 
 pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
@@ -26,8 +32,32 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     let session_id = inst.id.clone();
     let session_title = inst.title.clone();
     let tool = inst.tool.clone();
-    let tmux_session = crate::tmux::Session::new(&inst.id, &inst.title)?;
 
+    // Revive the pane if needed before delivering keystrokes. Without this,
+    // a send to a dead pane silently writes to a corpse with no agent to
+    // respond to it.
+    if !args.no_revive {
+        if let Some(target) = instances.iter_mut().find(|i| i.id == session_id) {
+            match target.ensure_pane_ready() {
+                Ok(EnsureReadyOutcome::Respawned) => {
+                    eprintln!("  (respawned dead pane before send)");
+                }
+                Ok(EnsureReadyOutcome::Started) => {
+                    eprintln!("  (started stopped session before send)");
+                }
+                Ok(EnsureReadyOutcome::AlreadyAlive) => {}
+                Err(EnsureReadyError::Transient(status)) => {
+                    bail!("Session is mid-lifecycle ({status:?}); cannot send right now")
+                }
+                Err(EnsureReadyError::CockpitMode) => {
+                    bail!("Cockpit-mode sessions have no tmux pane; send is not supported")
+                }
+                Err(EnsureReadyError::Tmux(e)) => bail!("{}", e),
+            }
+        }
+    }
+
+    let tmux_session = crate::tmux::Session::new(&session_id, &session_title)?;
     if !tmux_session.exists() {
         bail!(
             "Session is not running. Start it first with: aoe session start {}",

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -10,7 +10,7 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use crate::session::{Instance, Status, Storage};
+use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Status, Storage};
 
 use super::validate_no_shell_injection;
 use super::AppState;
@@ -2078,10 +2078,21 @@ mod tests {
 #[derive(Deserialize)]
 pub struct SendMessageRequest {
     pub message: String,
+    /// Whether to auto-revive a dead/stopped session before sending. Defaults
+    /// to `true`; set to `false` for fail-loud behavior (parity with the
+    /// `--no-revive` CLI flag).
+    #[serde(default = "default_revive")]
+    pub revive: bool,
+}
+
+fn default_revive() -> bool {
+    true
 }
 
 enum SendKeysError {
     NotRunning,
+    Transient(Status),
+    CockpitMode,
     Tmux(anyhow::Error),
 }
 
@@ -2125,25 +2136,49 @@ pub async fn send_message(
 
     let tool = instance.tool.clone();
     let message = req.message;
-    let send_result = tokio::task::spawn_blocking(move || -> Result<(), SendKeysError> {
-        let tmux_session = instance.tmux_session().map_err(SendKeysError::Tmux)?;
-        if !tmux_session.exists() {
-            return Err(SendKeysError::NotRunning);
-        }
-        let delay = crate::agents::send_keys_enter_delay(&tool);
-        tmux_session
-            .send_keys_with_delay(&message, delay)
-            .map_err(SendKeysError::Tmux)?;
-        Ok(())
-    })
+    let revive = req.revive;
+    let send_result = tokio::task::spawn_blocking(
+        move || -> Result<(EnsureReadyOutcome, Instance), SendKeysError> {
+            // Revive the pane before sending. Without this, a send to a dead
+            // pane silently writes keystrokes to a corpse with no agent.
+            // Skipped when the caller opts out via `revive: false`.
+            let mut inst_owned = instance;
+            let outcome = if revive {
+                inst_owned.ensure_pane_ready().map_err(|e| match e {
+                    EnsureReadyError::Transient(s) => SendKeysError::Transient(s),
+                    EnsureReadyError::CockpitMode => SendKeysError::CockpitMode,
+                    EnsureReadyError::Tmux(e) => SendKeysError::Tmux(e),
+                })?
+            } else {
+                EnsureReadyOutcome::AlreadyAlive
+            };
+            let tmux_session = inst_owned.tmux_session().map_err(SendKeysError::Tmux)?;
+            if !tmux_session.exists() {
+                return Err(SendKeysError::NotRunning);
+            }
+            let delay = crate::agents::send_keys_enter_delay(&tool);
+            tmux_session
+                .send_keys_with_delay(&message, delay)
+                .map_err(SendKeysError::Tmux)?;
+            Ok((outcome, inst_owned))
+        },
+    )
     .await;
 
     match send_result {
-        Ok(Ok(())) => {
-            // Stamp last_accessed_at so the activity column reflects API-driven
-            // interaction the same way TUI/web interaction does.
+        Ok(Ok((outcome, started))) => {
+            // ensure_pane_ready mutated `started` (status, agent_session_id,
+            // last_start_time, last_error) on the clone. Sync those back to
+            // the live entry so the next request sees a coherent view;
+            // without this, a rapid follow-up could generate a fresh
+            // `agent_session_id` and orphan the prior Claude conversation.
+            // See `apply_post_restart_sync`. Also stamp last_accessed_at so
+            // the activity column reflects API-driven interaction.
             let mut instances = state.instances.write().await;
             let profile = if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                if !matches!(outcome, EnsureReadyOutcome::AlreadyAlive) {
+                    apply_post_restart_sync(i, &started);
+                }
                 i.touch_last_accessed();
                 i.source_profile.clone()
             } else {
@@ -2172,6 +2207,19 @@ pub async fn send_message(
         Ok(Err(SendKeysError::NotRunning)) => (
             StatusCode::CONFLICT,
             Json(serde_json::json!({"error": "session_not_running"})),
+        )
+            .into_response(),
+        Ok(Err(SendKeysError::Transient(status))) => (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "session_transient",
+                "status": format!("{status:?}"),
+            })),
+        )
+            .into_response(),
+        Ok(Err(SendKeysError::CockpitMode)) => (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "cockpit_mode_unsupported"})),
         )
             .into_response(),
         Ok(Err(SendKeysError::Tmux(e))) => {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -49,6 +49,51 @@ pub enum Status {
     Creating,
 }
 
+/// Outcome of `Instance::ensure_pane_ready`. Callers surface this so the user
+/// knows what (if anything) happened on their behalf before a send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnsureReadyOutcome {
+    /// Pane was already alive; no action taken.
+    AlreadyAlive,
+    /// Pane was dead (`#{pane_dead}=1`) and was respawned via the restart path.
+    Respawned,
+    /// Tmux session did not exist and was started from scratch.
+    Started,
+}
+
+/// Errors `ensure_pane_ready` can return. Separating transient lifecycle
+/// states from real tmux failures lets HTTP callers map them to 409 (retry)
+/// vs 500 (real failure) instead of lumping everything as a tmux error.
+#[derive(Debug)]
+pub enum EnsureReadyError {
+    /// Instance is mid-lifecycle (Creating/Deleting). Caller should retry.
+    Transient(Status),
+    /// Instance is cockpit-mode (no backing tmux pane); send is not supported.
+    CockpitMode,
+    /// Underlying tmux operation failed.
+    Tmux(anyhow::Error),
+}
+
+impl std::fmt::Display for EnsureReadyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            EnsureReadyError::Transient(status) => {
+                write!(
+                    f,
+                    "Session is mid-lifecycle ({status:?}); cannot send right now"
+                )
+            }
+            EnsureReadyError::CockpitMode => write!(
+                f,
+                "Cockpit-mode sessions have no tmux pane; send is not supported"
+            ),
+            EnsureReadyError::Tmux(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for EnsureReadyError {}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorktreeInfo {
     pub branch: String,
@@ -1398,6 +1443,76 @@ impl Instance {
         self.start_with_size_opts(size, skip_on_launch)
     }
 
+    /// Smart-send precondition: bring this session's tmux pane to a state
+    /// where `send_keys_with_delay` is safe.
+    ///
+    /// Without this, a send to a dead pane silently writes keystrokes to a
+    /// corpse with no agent to respond, and the user sees no error.
+    ///
+    /// Handles three states the caller would otherwise hit:
+    /// - Tmux session missing: start from scratch via `start_with_size`.
+    /// - Pane dead (`#{pane_dead}=1`): reuse the restart path (same path
+    ///   E/F5 uses; well-tested).
+    /// - Already alive: no-op.
+    ///
+    /// Bails on Creating/Deleting (transient lifecycle states) and on
+    /// cockpit-mode sessions (no backing tmux pane).
+    ///
+    /// On `Started` / `Respawned`, polls briefly so keystrokes don't race the
+    /// agent's startup splash. Best-effort: returns after the timeout even if
+    /// the pane is still settling.
+    ///
+    /// Note: callers that mutate a clone (e.g. inside `spawn_blocking`) must
+    /// sync the post-start state (`status`, `agent_session_id`,
+    /// `last_start_time`, `last_error`) back onto the in-memory entry, since
+    /// `finalize_launch` writes those fields and they would otherwise be
+    /// dropped with the clone. See `apply_post_restart_sync`.
+    pub fn ensure_pane_ready(&mut self) -> Result<EnsureReadyOutcome, EnsureReadyError> {
+        if matches!(self.status, Status::Creating | Status::Deleting) {
+            return Err(EnsureReadyError::Transient(self.status));
+        }
+        #[cfg(feature = "serve")]
+        if self.cockpit_mode {
+            return Err(EnsureReadyError::CockpitMode);
+        }
+        let session = self.tmux_session().map_err(EnsureReadyError::Tmux)?;
+        if !session.exists() {
+            self.start_with_size(None).map_err(EnsureReadyError::Tmux)?;
+            self.wait_for_pane_ready(&session);
+            return Ok(EnsureReadyOutcome::Started);
+        }
+        if session.is_pane_dead() {
+            self.restart_with_size(None)
+                .map_err(EnsureReadyError::Tmux)?;
+            self.wait_for_pane_ready(&session);
+            return Ok(EnsureReadyOutcome::Respawned);
+        }
+        Ok(EnsureReadyOutcome::AlreadyAlive)
+    }
+
+    /// Best-effort wait for a freshly-started pane to settle past its initial
+    /// shell/splash so subsequent `send-keys` land in the agent instead of a
+    /// boot prompt. Polls up to 3s in 50ms increments; returns early once the
+    /// pane is alive and (for non-shell agents) no longer running a shell.
+    /// Returns even on timeout so a sluggish agent doesn't block the send
+    /// indefinitely.
+    fn wait_for_pane_ready(&self, session: &tmux::Session) {
+        let expects_shell = self.expects_shell();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_millis(3000);
+        loop {
+            if !session.exists() {
+                return;
+            }
+            if !session.is_pane_dead() && (expects_shell || !session.is_pane_running_shell()) {
+                return;
+            }
+            if std::time::Instant::now() >= deadline {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+    }
+
     pub fn kill(&self) -> Result<()> {
         self.stop_poller();
         let session = self.tmux_session()?;
@@ -1838,6 +1953,89 @@ mod tests {
 
         inst.parent_session_id = Some("parent123".to_string());
         assert!(inst.is_sub_session());
+    }
+
+    #[test]
+    fn test_ensure_pane_ready_bails_on_creating() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Creating;
+        match inst.ensure_pane_ready() {
+            Err(EnsureReadyError::Transient(Status::Creating)) => {}
+            other => panic!("expected Transient(Creating), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_ensure_pane_ready_bails_on_deleting() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.status = Status::Deleting;
+        match inst.ensure_pane_ready() {
+            Err(EnsureReadyError::Transient(Status::Deleting)) => {}
+            other => panic!("expected Transient(Deleting), got {other:?}"),
+        }
+    }
+
+    #[cfg(feature = "serve")]
+    #[test]
+    fn test_ensure_pane_ready_bails_on_cockpit_mode() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.cockpit_mode = true;
+        match inst.ensure_pane_ready() {
+            Err(EnsureReadyError::CockpitMode) => {}
+            other => panic!("expected CockpitMode, got {other:?}"),
+        }
+    }
+
+    /// Real-tmux integration: an alive pane yields AlreadyAlive with no
+    /// status/start_time mutations. Skipped if tmux isn't installed.
+    #[test]
+    fn test_ensure_pane_ready_alive_pane_is_noop() {
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .output()
+            .is_err()
+        {
+            eprintln!("tmux not available; skipping");
+            return;
+        }
+
+        let mut inst = Instance::new("ensure_alive_test", "/tmp/test");
+        let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &tmux_name])
+            .output();
+        let created = std::process::Command::new("tmux")
+            .args([
+                "new-session",
+                "-d",
+                "-s",
+                &tmux_name,
+                "-x",
+                "80",
+                "-y",
+                "24",
+                "sleep",
+                "60",
+            ])
+            .status();
+        if !created.map(|s| s.success()).unwrap_or(false) {
+            eprintln!("tmux new-session failed; skipping");
+            return;
+        }
+        crate::tmux::refresh_session_cache();
+
+        inst.status = Status::Running;
+        let prev_start = inst.last_start_time;
+        let prev_status = inst.status;
+
+        let outcome = inst.ensure_pane_ready().expect("ensure_pane_ready ok");
+        assert_eq!(outcome, EnsureReadyOutcome::AlreadyAlive);
+        assert_eq!(inst.last_start_time, prev_start);
+        assert_eq!(inst.status, prev_status);
+
+        let _ = std::process::Command::new("tmux")
+            .args(["kill-session", "-t", &tmux_name])
+            .output();
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1492,18 +1492,29 @@ impl Instance {
 
     /// Best-effort wait for a freshly-started pane to settle past its initial
     /// shell/splash so subsequent `send-keys` land in the agent instead of a
-    /// boot prompt. Polls up to 3s in 50ms increments; returns early once the
-    /// pane is alive and (for non-shell agents) no longer running a shell.
-    /// Returns even on timeout so a sluggish agent doesn't block the send
-    /// indefinitely.
+    /// boot prompt. Polls up to 3s in 50ms increments; returns even on
+    /// timeout so a sluggish agent doesn't block the send indefinitely.
+    ///
+    /// Readiness signal:
+    /// - Agents that expect a shell, run a custom command override, or have
+    ///   an active hook status file: just wait for the pane to not be dead.
+    ///   Wrapper scripts look like shells to tmux, so `is_pane_running_shell`
+    ///   would never clear for them and we would eat the full 3s every time.
+    ///   This mirrors the same guard chain `ensure_session` uses.
+    /// - Real agents (e.g. claude, opencode): also wait for the pane to no
+    ///   longer be running a shell, so a keystroke doesn't land in the boot
+    ///   prompt that runs before the agent binary takes over.
     fn wait_for_pane_ready(&self, session: &tmux::Session) {
-        let expects_shell = self.expects_shell();
+        let shell_check_unreliable = self.expects_shell()
+            || self.has_command_override()
+            || crate::hooks::read_hook_status(&self.id).is_some();
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(3000);
         loop {
             if !session.exists() {
                 return;
             }
-            if !session.is_pane_dead() && (expects_shell || !session.is_pane_running_shell()) {
+            let pane_alive = !session.is_pane_dead();
+            if pane_alive && (shell_check_unreliable || !session.is_pane_running_shell()) {
                 return;
             }
             if std::time::Instant::now() >= deadline {

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,7 +27,8 @@ pub(crate) use environment::user_shell;
 pub use environment::validate_env_entry;
 pub use groups::{flatten_tree, flatten_tree_all_profiles, Group, GroupTree, Item};
 pub use instance::{
-    Instance, SandboxInfo, Status, TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
+    EnsureReadyError, EnsureReadyOutcome, Instance, SandboxInfo, Status, TerminalInfo,
+    WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
 };
 pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -805,6 +805,20 @@ impl App {
             Action::SetTransientStatus(text) => {
                 self.update_status = Some(UpdateStatus::transient(text));
             }
+            Action::SendMessage(id, message) => {
+                // Flip the row to Starting and show a toast so the user has
+                // visible feedback during ensure_pane_ready, which can take
+                // several seconds on a cold-start sandboxed session (Docker
+                // pull) or while the readiness loop waits for an agent
+                // splash to clear. The status poller will correct the row
+                // back to the real state after we return.
+                self.home
+                    .set_instance_status(&id, crate::session::Status::Starting);
+                self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
+                terminal.draw(|f| self.render(f))?;
+                self.home.execute_send_message(&id, &message);
+                self.update_status = None;
+            }
         }
         Ok(())
     }
@@ -1074,6 +1088,11 @@ pub enum Action {
     SetTheme(String),
     SpawnUpdate(crate::update::install::InstallMethod, String),
     SetTransientStatus(String),
+    /// Send a message to a session. Deferred to `execute_action` (rather
+    /// than handled inline in the dialog Submit branch) so the app loop
+    /// can render a "Reviving..." status before the potentially-slow
+    /// ensure_pane_ready call.
+    SendMessage(String, String),
 }
 
 #[cfg(test)]

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -514,6 +514,18 @@ impl HomeView {
                 DialogResult::Submit(message) => {
                     self.send_message_dialog = None;
                     if let Some(session_id) = self.pending_send_session.take() {
+                        // Revive the pane before sending. Without this, a
+                        // send to a dead pane silently writes keystrokes to
+                        // a corpse with no agent to respond.
+                        if let Err(err) = self.try_mutate_instance(&session_id, |inst| {
+                            inst.ensure_pane_ready().map(drop).map_err(Into::into)
+                        }) {
+                            self.info_dialog = Some(InfoDialog::new(
+                                "Send Failed",
+                                &format!("Cannot prepare session: {}", err),
+                            ));
+                            return None;
+                        }
                         if let Some(inst) = self.get_instance(&session_id) {
                             match crate::tmux::Session::new(&inst.id, &inst.title) {
                                 Ok(tmux_session) => {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -514,41 +514,13 @@ impl HomeView {
                 DialogResult::Submit(message) => {
                     self.send_message_dialog = None;
                     if let Some(session_id) = self.pending_send_session.take() {
-                        // Revive the pane before sending. Without this, a
-                        // send to a dead pane silently writes keystrokes to
-                        // a corpse with no agent to respond.
-                        if let Err(err) = self.try_mutate_instance(&session_id, |inst| {
-                            inst.ensure_pane_ready().map(drop).map_err(Into::into)
-                        }) {
-                            self.info_dialog = Some(InfoDialog::new(
-                                "Send Failed",
-                                &format!("Cannot prepare session: {}", err),
-                            ));
-                            return None;
-                        }
-                        if let Some(inst) = self.get_instance(&session_id) {
-                            match crate::tmux::Session::new(&inst.id, &inst.title) {
-                                Ok(tmux_session) => {
-                                    let delay = crate::agents::send_keys_enter_delay(&inst.tool);
-                                    if let Err(e) =
-                                        tmux_session.send_keys_with_delay(&message, delay)
-                                    {
-                                        self.info_dialog = Some(InfoDialog::new(
-                                            "Send Failed",
-                                            &format!("Failed to send message: {}", e),
-                                        ));
-                                    } else {
-                                        self.stamp_last_accessed(&session_id);
-                                    }
-                                }
-                                Err(e) => {
-                                    self.info_dialog = Some(InfoDialog::new(
-                                        "Send Failed",
-                                        &format!("Failed to resolve session: {}", e),
-                                    ));
-                                }
-                            }
-                        }
+                        // Defer the actual work to execute_action so the app
+                        // loop can render a status indicator first. The send
+                        // path may need to start a Docker container or wait
+                        // for an agent splash to settle (up to several seconds
+                        // total); doing it inline here would freeze the TUI
+                        // with no feedback.
+                        return Some(Action::SendMessage(session_id, message));
                     }
                 }
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1346,6 +1346,44 @@ impl HomeView {
         self.mutate_instance(id, |inst| inst.touch_last_accessed());
     }
 
+    /// Run the send-message work after the dialog has been dismissed: call
+    /// `ensure_pane_ready` (which may auto-start or respawn), then deliver
+    /// the keystrokes. Errors are surfaced via `info_dialog` so the caller
+    /// (`execute_action`) only has to clear its transient status.
+    pub fn execute_send_message(&mut self, session_id: &str, message: &str) {
+        if let Err(err) = self.try_mutate_instance(session_id, |inst| {
+            inst.ensure_pane_ready().map(drop).map_err(Into::into)
+        }) {
+            self.info_dialog = Some(InfoDialog::new(
+                "Send Failed",
+                &format!("Cannot prepare session: {}", err),
+            ));
+            return;
+        }
+        let Some(inst) = self.get_instance(session_id) else {
+            return;
+        };
+        let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
+            Ok(s) => s,
+            Err(e) => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Send Failed",
+                    &format!("Failed to resolve session: {}", e),
+                ));
+                return;
+            }
+        };
+        let delay = crate::agents::send_keys_enter_delay(&inst.tool);
+        if let Err(e) = tmux_session.send_keys_with_delay(message, delay) {
+            self.info_dialog = Some(InfoDialog::new(
+                "Send Failed",
+                &format!("Failed to send message: {}", e),
+            ));
+            return;
+        }
+        self.stamp_last_accessed(session_id);
+    }
+
     pub fn save(&self) -> anyhow::Result<()> {
         for (profile_name, storage) in &self.storages {
             let profile_instances: Vec<Instance> = self


### PR DESCRIPTION
_Note: this PR description was rewritten by Claude via back-and-forth with @njbrake (PR maintainer). The reasoning and decisions are his; the prose is Claude's._

## Description

Before this change, `aoe send` (and the TUI send-message dialog, and `POST /sessions/:id/send_message`) wrote keystrokes straight to the tmux pane without checking whether the pane was still alive. If the agent process had exited, the pane was dead (`#{pane_dead}=1`) and the keystrokes silently went to the corpse with no agent to respond. The follow-up `touch_last_accessed` even made the session look healthier in the UI by stamping recent activity. The only way to actually revive a dead session was the explicit E/F5 restart key.

This PR adds `Instance::ensure_pane_ready()` and wires it into all three send call sites (`src/cli/send.rs`, `src/tui/home/input.rs`, `src/server/api/sessions.rs`). Before delivering keystrokes, the pane is inspected:

- alive: no-op, proceed.
- dead pane (`#{pane_dead}=1`): reuse the existing `restart_with_size` respawn path that E/F5 already uses.
- tmux session missing: start it from scratch via `start_with_size`.
- mid-lifecycle (Creating/Deleting) or cockpit-mode: bail with a typed error.

After a Started/Respawned outcome, a best-effort readiness loop polls up to 3s in 50ms increments waiting for the pane to settle past its initial shell/splash, so subsequent `send-keys` land in the agent rather than the boot prompt. Returns even on timeout so a sluggish agent doesn't block the send indefinitely.

User-visible effect: a `send` after a crashed agent is now idempotent. No more F5 plus re-typing; the CLI prints a one-line note like `(respawned dead pane before send)` and delivers the message to the freshly-spawned agent.

Errors from the helper are typed (`EnsureReadyError::{Transient, CockpitMode, Tmux}`) so the HTTP layer can return 409 for transient lifecycle states, 400 for cockpit-mode, and 500 for actual tmux failures, instead of lumping everything into a generic `tmux_error`.

### Opt-out for fail-loud callers

Scripts and integrations that want the previous bail-out semantics can opt out:

- CLI: `aoe send --no-revive <id> <message>`
- API: `POST /sessions/:id/send_message` with `{"message": "...", "revive": false}` (defaults to `true`)

### Server-side state sync

`ensure_pane_ready` is called on a clone inside `spawn_blocking` in the API path. When it triggers `start_with_size_opts` -> `finalize_launch`, several fields get written on the clone: `status`, `agent_session_id`, `last_start_time`, `last_error`. The PR copies those back to the in-memory entry via the existing `apply_post_restart_sync` helper. Without that sync, a rapid follow-up send could see a stale `agent_session_id = None` and generate a fresh UUID, orphaning the prior Claude conversation (the exact scenario `apply_post_restart_sync` was originally written to prevent).

## How tested

- `cargo fmt --all` clean.
- `cargo clippy --features serve --tests --no-deps -- -D warnings` clean.
- `cargo test --features serve --lib` (1830 tests pass).
- New unit tests for the synchronous bail paths: `Transient(Creating)`, `Transient(Deleting)`, `CockpitMode`.
- New real-tmux integration test for the `AlreadyAlive` no-op case (auto-skipped when `tmux` is not installed; passes when it is).
- `docs/cli/reference.md` regenerated via `cargo xtask gen-docs` for the `--no-revive` flag (CI enforces this).
- Manual verification of the dead-pane revive path with a Claude session that was killed mid-run; the next `aoe send` respawned the pane and delivered the message after the readiness poll, instead of writing into a corpse.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`docs/cli/reference.md` regenerated for `--no-revive`)
- [ ] For UI changes: included screenshot or recording (no visual UI changes)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:**

Claude Opus 4.7 (Anthropic), via Claude Code CLI.

**Any Additional AI Details you'd like to share:**

Used for drafting `ensure_pane_ready()`, wiring it into the three send call sites, and the review-feedback rounds (typed errors, post-restart state sync, readiness poll, API parity, tests, docs regen). Commit message and this PR body drafted with Claude assistance.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)
