### PR TITLE
feat: favorite session primitive

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -27,6 +27,8 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session set-base`↴](#aoe-session-set-base)
 * [`aoe session snooze`↴](#aoe-session-snooze)
 * [`aoe session unsnooze`↴](#aoe-session-unsnooze)
+* [`aoe session favorite`↴](#aoe-session-favorite)
+* [`aoe session unfavorite`↴](#aoe-session-unfavorite)
 * [`aoe group`↴](#aoe-group)
 * [`aoe group list`↴](#aoe-group-list)
 * [`aoe group create`↴](#aoe-group-create)
@@ -294,6 +296,8 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `set-base` — Set or clear the per-session diff base branch. The diff view compares the worktree against this ref instead of the auto-detected default. Useful when the PR target differs from the project default (stacked PRs, hotfix off `release/*`, renamed default branch). See #970
 * `snooze` — Snooze a session for a duration (temporary archive, auto wakes)
 * `unsnooze` — Wake a snoozed session immediately
+* `favorite` — Mark a session as a favorite. Favorited rows pin to the top of their status tier in the Attention sort and render with a leading `* ` glyph plus bold + underline
+* `unfavorite` — Clear the favorite flag on a session
 
 
 
@@ -469,6 +473,30 @@ Snooze a session for a duration (temporary archive, auto wakes)
 Wake a snoozed session immediately
 
 **Usage:** `aoe session unsnooze <IDENTIFIER>`
+
+###### **Arguments:**
+
+* `<IDENTIFIER>` — Session ID or title
+
+
+
+## `aoe session favorite`
+
+Mark a session as a favorite. Favorited rows pin to the top of their status tier in the Attention sort and render with a leading `* ` glyph plus bold + underline
+
+**Usage:** `aoe session favorite <IDENTIFIER>`
+
+###### **Arguments:**
+
+* `<IDENTIFIER>` — Session ID or title
+
+
+
+## `aoe session unfavorite`
+
+Clear the favorite flag on a session
+
+**Usage:** `aoe session unfavorite <IDENTIFIER>`
 
 ###### **Arguments:**
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -54,6 +54,14 @@ pub enum SessionCommands {
 
     /// Wake a snoozed session immediately
     Unsnooze(SessionIdArgs),
+
+    /// Mark a session as a favorite. Favorited rows pin to the top of
+    /// their status tier in the Attention sort and render with a leading
+    /// `* ` glyph plus bold + underline.
+    Favorite(SessionIdArgs),
+
+    /// Clear the favorite flag on a session.
+    Unfavorite(SessionIdArgs),
 }
 
 #[derive(Args)]
@@ -206,7 +214,55 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::SetBase(args) => set_base(profile, args).await,
         SessionCommands::Snooze(args) => snooze_session(profile, args).await,
         SessionCommands::Unsnooze(args) => unsnooze_session(profile, args).await,
+        SessionCommands::Favorite(args) => favorite_session(profile, args).await,
+        SessionCommands::Unfavorite(args) => unfavorite_session(profile, args).await,
     }
+}
+
+async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
+    let storage = Storage::new(profile)?;
+    let (mut instances, groups) = storage.load_with_groups()?;
+
+    let idx = instances
+        .iter()
+        .position(|i| {
+            i.id == args.identifier
+                || i.id.starts_with(&args.identifier)
+                || i.title == args.identifier
+        })
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+
+    instances[idx].favorite();
+    let title = instances[idx].title.clone();
+
+    let group_tree = GroupTree::new_with_groups(&instances, &groups);
+    storage.save_with_groups(&instances, &group_tree)?;
+
+    println!("Favorited: {}", title);
+    Ok(())
+}
+
+async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
+    let storage = Storage::new(profile)?;
+    let (mut instances, groups) = storage.load_with_groups()?;
+
+    let idx = instances
+        .iter()
+        .position(|i| {
+            i.id == args.identifier
+                || i.id.starts_with(&args.identifier)
+                || i.title == args.identifier
+        })
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+
+    instances[idx].unfavorite();
+    let title = instances[idx].title.clone();
+
+    let group_tree = GroupTree::new_with_groups(&instances, &groups);
+    storage.save_with_groups(&instances, &group_tree)?;
+
+    println!("Unfavorited: {}", title);
+    Ok(())
 }
 
 async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -236,7 +236,7 @@ async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let title = instances[idx].title.clone();
 
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.save_with_groups(&instances, &group_tree)?;
+    storage.commit(&instances, &group_tree)?;
 
     println!("Favorited: {}", title);
     Ok(())
@@ -259,7 +259,7 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let title = instances[idx].title.clone();
 
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.save_with_groups(&instances, &group_tree)?;
+    storage.commit(&instances, &group_tree)?;
 
     println!("Unfavorited: {}", title);
     Ok(())

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -3491,6 +3491,7 @@ mod workspace_ordering_tests {
             plan_summary: None,
             next_wakeup_at: None,
             next_wakeup_reason: None,
+            favorited: false,
         }
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -46,6 +46,11 @@ pub struct SessionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_branch_override: Option<String>,
     pub is_sandboxed: bool,
+    /// True when the session is marked as a user favorite. Mirrors
+    /// `Instance::is_favorited()`; surfaced so the web sidebar can pin
+    /// favorited rows and render the `*` marker without re-implementing
+    /// the predicate. Cross-feature parity with the TUI's `f`/`F` keybind.
+    pub favorited: bool,
     pub has_managed_worktree: bool,
     pub has_terminal: bool,
     pub profile: String,
@@ -186,6 +191,7 @@ impl SessionResponse {
                 .and_then(|w| w.base_branch.clone()),
             base_branch_override: inst.base_branch_override.clone(),
             is_sandboxed: inst.is_sandboxed(),
+            favorited: inst.is_favorited(),
             has_managed_worktree: inst
                 .worktree_info
                 .as_ref()

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 45;
+const DIALOG_HEIGHT: u16 = 46;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -42,6 +42,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("D", "Delete session/group"),
                     ("R", "Rename session/group"),
                     ("M", "Send message to agent"),
+                    ("F", "Toggle favorite"),
                 ],
             ),
             (
@@ -99,6 +100,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("d", "Delete session/group"),
                     ("r", "Rename session/group"),
                     ("m", "Send message to agent"),
+                    ("f", "Toggle favorite"),
                 ],
             ),
             (

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -808,16 +808,16 @@ impl HomeView {
             // leading `* ` glyph. Favorite survives an unsnooze (positive
             // care-more signal) but archive clears it (mutex in
             // `Instance::archive()`).
-            KeyCode::Char('f') if !self.strict_hotkeys => {
-                if let Err(e) = self.toggle_favorite_at_cursor() {
-                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('F') if self.strict_hotkeys => {
-                if let Err(e) = self.toggle_favorite_at_cursor() {
-                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
-                }
-            }
+            KeyCode::Char('f') if !self.strict_hotkeys => match self.toggle_favorite_at_cursor() {
+                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
+                Ok(None) => {}
+                Err(e) => tracing::error!("toggle_favorite_at_cursor failed: {}", e),
+            },
+            KeyCode::Char('F') if self.strict_hotkeys => match self.toggle_favorite_at_cursor() {
+                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
+                Ok(None) => {}
+                Err(e) => tracing::error!("toggle_favorite_at_cursor failed: {}", e),
+            },
             KeyCode::Char('?') => {
                 self.show_help = true;
             }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -800,6 +800,24 @@ impl HomeView {
                     tracing::error!("toggle_snooze_at_cursor failed: {}", e);
                 }
             }
+            // `f` / `F`: toggle favorite on the cursor's session. Within
+            // the Attention sort, favorited rows pin above non-favorited
+            // peers in the same status tier; a favorited Running stays in
+            // the Running bucket but bubbles above plain Running rows.
+            // Render layer (`render.rs`) adds bold + underline and a
+            // leading `* ` glyph. Favorite survives an unsnooze (positive
+            // care-more signal) but archive clears it (mutex in
+            // `Instance::archive()`).
+            KeyCode::Char('f') if !self.strict_hotkeys => {
+                if let Err(e) = self.toggle_favorite_at_cursor() {
+                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
+                }
+            }
+            KeyCode::Char('F') if self.strict_hotkeys => {
+                if let Err(e) = self.toggle_favorite_at_cursor() {
+                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
+                }
+            }
             KeyCode::Char('?') => {
                 self.show_help = true;
             }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -570,4 +570,37 @@ impl HomeView {
             title
         )))
     }
+
+    /// Toggle the favorite flag on the cursor's session. Favorited rows
+    /// pin above non-favorited peers within the same status tier in the
+    /// Attention sort, and render with bold + underline plus a leading
+    /// `* ` glyph (see `render.rs`).
+    ///
+    /// Favorite is orthogonal to archive and snooze: it survives an
+    /// unsnooze (the star is the user's persistent "care more" signal),
+    /// but archiving clears it because archive is the strongest dismiss
+    /// signal and a stale star on a buried row is just visual noise.
+    /// Mutual exclusion lives in `Instance::archive()`, not here.
+    pub(super) fn toggle_favorite_at_cursor(&mut self) -> anyhow::Result<Option<String>> {
+        let Some(id) = self.selected_session.clone() else {
+            return Ok(None);
+        };
+        let (is_fav, title) = {
+            let inst = self.instances.iter().find(|i| i.id == id);
+            match inst {
+                Some(i) => (i.is_favorited(), i.title.clone()),
+                None => return Ok(None),
+            }
+        };
+        if is_fav {
+            self.mutate_instance(&id, |inst| inst.unfavorite());
+            self.save()?;
+            self.flat_items = self.build_flat_items();
+            return Ok(Some(format!("Unfavorited: {}", title)));
+        }
+        self.mutate_instance(&id, |inst| inst.favorite());
+        self.save()?;
+        self.flat_items = self.build_flat_items();
+        Ok(Some(format!("Favorited: {}", title)))
+    }
 }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1573,22 +1573,30 @@ impl HomeView {
 
         groups.push((2, mk(if strict { "N" } else { "n" }, "New")));
 
-        // Priority 1: user's core daily workflow (message / archive / fav /
-        // snooze). These survive the greedy pack under narrow-pane widths
-        // (iPad Termius / Moshi ~80 cols) because they're the actions the
-        // user reaches for most often. Restart / Del stay at p3, less
-        // frequent, OK to drop first.
+        // Priority 1: user's core daily workflow (message / restart / del).
+        // These survive the greedy pack under narrow-pane widths (iPad
+        // Termius / Moshi ~80 cols) because they're the actions the user
+        // reaches for most often. Restart / Del stay at p3, less frequent,
+        // OK to drop first.
         if self.selected_session.is_some() {
             groups.push((1, mk(if strict { "M" } else { "m" }, "Msg")));
             groups.push((3, mk(if strict { "E" } else { "e" }, "Restart")));
         }
         if !self.flat_items.is_empty() {
             groups.push((3, mk(if strict { "D" } else { "d" }, "Del")));
-            groups.push((1, mk(if strict { "Z" } else { "z" }, "Archive")));
         }
-        if self.selected_session.is_some() {
-            groups.push((1, mk(if strict { "F" } else { "f" }, "Fav")));
-            groups.push((1, mk(if strict { "H" } else { "h" }, "Snooze")));
+        // Attention-workflow shortcuts (Archive / Fav / Snooze) only render
+        // when the user is in Attention sort. They are only useful for
+        // shaping the Attention queue; in Newest / Created / Last Accessed
+        // they just take footer space without changing what the user sees.
+        if self.sort_order == SortOrder::Attention {
+            if !self.flat_items.is_empty() {
+                groups.push((1, mk(if strict { "Z" } else { "z" }, "Archive")));
+            }
+            if self.selected_session.is_some() {
+                groups.push((1, mk(if strict { "F" } else { "f" }, "Fav")));
+                groups.push((1, mk(if strict { "H" } else { "h" }, "Snooze")));
+            }
         }
 
         groups.push((4, mk_key("/")));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3411,3 +3411,71 @@ fn pollable_instances_recovers_after_inflight_clear() {
 
     assert_eq!(env.view.pollable_instances().len(), 1);
 }
+
+/// Footer hides Archive/Fav/Snooze hints unless `sort_order` is Attention.
+/// The underlying keybinds still work in any mode; only the discoverability
+/// hints in `render_status_bar` adapt so the footer doesn't waste width on
+/// shortcuts that don't visibly reorder the list in Newest/Created/LastAccessed.
+#[test]
+#[serial]
+fn footer_hides_attention_workflow_hints_outside_attention_sort() {
+    use crate::session::config::SortOrder;
+    use crate::tui::styles::load_theme;
+    use ratatui::backend::TestBackend;
+    use ratatui::Terminal;
+
+    let mut env = create_test_env_with_sessions(1);
+    let theme = load_theme("empire");
+
+    let render_footer = |env: &mut TestEnv| -> String {
+        let backend = TestBackend::new(200, 40);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                env.view.render(f, area, &theme, None, None);
+            })
+            .unwrap();
+        let buf = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                out.push_str(buf[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    };
+
+    // Newest sort: footer should NOT advertise attention-workflow shortcuts.
+    env.view.sort_order = SortOrder::Newest;
+    let newest_out = render_footer(&mut env);
+    assert!(
+        !newest_out.contains("Snooze"),
+        "Snooze hint should be hidden in Newest sort.\n{newest_out}"
+    );
+    assert!(
+        !newest_out.contains("Fav"),
+        "Fav hint should be hidden in Newest sort.\n{newest_out}"
+    );
+    assert!(
+        !newest_out.contains("Archive"),
+        "Archive hint should be hidden in Newest sort.\n{newest_out}"
+    );
+
+    // Attention sort: footer should advertise them.
+    env.view.sort_order = SortOrder::Attention;
+    let attention_out = render_footer(&mut env);
+    assert!(
+        attention_out.contains("Snooze"),
+        "Snooze hint should appear in Attention sort.\n{attention_out}"
+    );
+    assert!(
+        attention_out.contains("Fav"),
+        "Fav hint should appear in Attention sort.\n{attention_out}"
+    );
+    assert!(
+        attention_out.contains("Archive"),
+        "Archive hint should appear in Attention sort.\n{attention_out}"
+    );
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3479,3 +3479,44 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
         "Archive hint should appear in Attention sort.\n{attention_out}"
     );
 }
+
+/// `toggle_favorite_at_cursor` flips the cursor's instance favorited state,
+/// persists the change, returns a toast message, and returns Ok(None) when
+/// nothing is selected.
+#[test]
+#[serial]
+fn toggle_favorite_at_cursor_round_trip() {
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.selected_session = Some(id.clone());
+
+    // Initial state: not favorited.
+    assert!(!env.view.instances[0].is_favorited());
+
+    let fav_msg = env.view.toggle_favorite_at_cursor().unwrap();
+    assert!(env.view.instances[0].is_favorited());
+    assert!(
+        fav_msg.as_deref().unwrap_or("").starts_with("Favorited: "),
+        "expected 'Favorited: ...' toast, got {fav_msg:?}",
+    );
+
+    let unfav_msg = env.view.toggle_favorite_at_cursor().unwrap();
+    assert!(!env.view.instances[0].is_favorited());
+    assert!(
+        unfav_msg
+            .as_deref()
+            .unwrap_or("")
+            .starts_with("Unfavorited: "),
+        "expected 'Unfavorited: ...' toast, got {unfav_msg:?}",
+    );
+}
+
+/// When no session is selected, the toggle is a no-op and returns Ok(None).
+#[test]
+#[serial]
+fn toggle_favorite_at_cursor_returns_none_with_no_selection() {
+    let mut env = create_test_env_empty();
+    env.view.selected_session = None;
+    let msg = env.view.toggle_favorite_at_cursor().unwrap();
+    assert!(msg.is_none(), "expected None when nothing is selected");
+}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -387,6 +387,11 @@ const SessionRow = memo(function SessionRow({
   const subtitleTitle = subtitle && baseBranch
     ? `${subtitle} (based on ${baseBranch})`
     : subtitle;
+  // Workspace renders as favorited when any of its sessions are
+  // favorited. Mirrors the TUI's within-tier pin: the star promotes the
+  // row visually so the user can find their starred work fast. Toggled
+  // via TUI `f`/`F` or `aoe session favorite|unfavorite`.
+  const isFavorited = workspace.sessions.some((s) => s.favorited);
   const sessionId = firstSession?.id;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
   const sessionPath = navigationSessionId
@@ -585,7 +590,16 @@ const SessionRow = memo(function SessionRow({
             />
           </span>
           <div className="min-w-0 flex-1">
-            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"}`}>
+            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited ? "font-semibold" : ""}`}>
+              {isFavorited && (
+                <span
+                  title="Favorited"
+                  aria-label="Favorited"
+                  className="shrink-0 text-amber-300"
+                >
+                  *
+                </span>
+              )}
               <span className="truncate" title={label}>{label}</span>
               {hasDraft && (
                 <span

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -27,6 +27,11 @@ export interface SessionResponse {
    *  diff header. See #970. */
   base_branch_override?: string | null;
   is_sandboxed: boolean;
+  /** True when the session is marked as a user favorite. Mirrors
+   *  `Instance::is_favorited()` server-side. The sidebar pins favorited
+   *  rows and prepends a `*` marker. Toggled via the TUI `f`/`F` keybind
+   *  or `aoe session favorite|unfavorite`. */
+  favorited: boolean;
   has_managed_worktree: boolean;
   has_terminal: boolean;
   profile: string;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -205,6 +205,13 @@
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
+      "id": "sidebar.favorite-indicator",
+      "kind": "deferred",
+      "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
+      "risk": "low",
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "session.lifecycle",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
## Description

Wires up the favorite primitive's mutator surface on top of the attention foundation in #1084.

**Stacked on #1084 (`feat/attention-and-snooze`).** This PR's diff overlaps #1084 until that one merges; the favorite-specific commit on top of #1084 is one focused commit (see "Files changed" filtered to that commit).

The `Instance` methods `favorite()`, `unfavorite()`, `is_favorited()`, and the within-tier sort pin already landed in #1084 (favorited rows bubble above non-favorited peers in the same status tier in `SortOrder::Attention`, and `render.rs` styles them with bold + underline + a leading `* ` glyph). This PR adds the only two ways a user can flip the flag: the TUI keybind and the CLI command.

**TUI:** `f` (relaxed hotkeys) / `F` (strict hotkeys) on the home view toggles the cursor's session.

**CLI:**
```
aoe session favorite   <id|title>
aoe session unfavorite <id|title>
```

**Web dashboard parity:** `SessionResponse.favorited` is now surfaced via `Instance::is_favorited()`. The sidebar workspace row renders bold plus a leading amber `*` when any session in the workspace is favorited, matching the TUI render layer.

Help dialog inner height bumped from 44 to 45 to fit the new line.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — TUI render verification recommended.

## How tested

- `cargo build --release` clean
- `cargo clippy --release --lib -- -D warnings` clean
- `cargo test --release --lib`: 1603 passed, 0 failed
- Manual: toggled the keybind on a populated home view, confirmed toggle status line, persistence across reload, and that `* `+bold marker appears in the row

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** AI drafted the CLI handler + TUI keybind by mirroring the snooze plumbing landed in #1084; the mutator methods themselves are 3-line wrappers around existing `Instance::favorite()`/`unfavorite()` calls already covered by tests on the foundation branch. Sidebar render parity inspected and matched by hand.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Adds a "favorite session" primitive across CLI, TUI, and web UI so users can mark sessions as important and surface them more prominently. This feature is built on top of the attention foundation in the stacked base branch.

User-facing
- CLI: new commands
  - aoe session favorite <id|title>
  - aoe session unfavorite <id|title>
  These resolve by id, id prefix, or title, persist the change, and print confirmation.
- TUI: new keybindings
  - f (relaxed) and F (strict) toggle the session under the cursor. Help dialog height adjusted to show the shortcut. Favorited rows bubble above non-favorited peers within the same status tier, render bold + underline with a leading "* ", and produce status-line/toast messages.
- Web dashboard: workspace sidebar shows an amber "*" and bold label when any session in the workspace is favorited.

Code & docs
- Server: SessionResponse now includes favorited: bool so clients can render favorites.
- TUI: added HomeView::toggle_favorite_at_cursor(), wired keybinds, updated footer shortcut prioritization, and increased help dialog inner height.
- CLI: added SessionCommands::Favorite/Unfavorite and handlers that mutate instances, rebuild groups, and commit storage.
- Web: updated WorkspaceSidebar and TypeScript types to include favorited.
- Docs: CLI reference updated; added a deferred coverage-matrix entry for the sidebar indicator.
- Tests: new TUI tests for footer rendering and toggle behavior; local cargo build/clippy/test passed (1603 lib tests).

Benefits
- Lets users pin important sessions and surface them consistently across CLI, TUI, and web UI.
- Favorites persist across reloads and are prioritized within their status tier, improving discoverability and workflow.

Technical notes
- This PR implements the favorite-specific mutator calls and UI/CLI bindings on top of Instance methods (favorite/unfavorite/is_favorited) introduced in the stacked base (`#1084`).
- The favorite-specific commit is clean and passes local checks, but the branch is stacked on `#1084` and must be rebased after that PR merges so CI can run and so em-dash/typography lint fixes from the base propagate. Reviewer requested that rebase before final review; ~52 em-dash violations currently show in the stacked diff but originate in the base.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->