### PR TITLE
feat(send): auto-wake archived/snoozed rows + remap status on `aoe send`

### DIFF
--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -86,10 +86,19 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     let delay = crate::agents::send_keys_enter_delay(&tool);
     tmux_session.send_keys_with_delay(&args.message, delay)?;
 
+    // Stamp last_accessed_at so the "last activity" column reflects user
+    // interaction, and remap the status to Running. The agent has just been
+    // given fresh input; the next status poll will reconcile the real state,
+    // but flipping to Running immediately keeps the row from sticking on a
+    // stale Idle/Waiting label during the gap between send and poll.
+    // `touch_last_accessed` also auto-clears `archived_at` and `snoozed_until`
+    // (see Instance::touch_last_accessed), so a user can wake any sunk row by
+    // sending to it.
     let id_for_save = session_id.clone();
     storage.update(|instances, _groups| {
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id_for_save) {
             inst.touch_last_accessed();
+            inst.status = crate::session::Status::Running;
         }
         Ok(())
     })?;

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -95,13 +95,23 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     // (see Instance::touch_last_accessed), so a user can wake any sunk row by
     // sending to it.
     let id_for_save = session_id.clone();
-    storage.update(|instances, _groups| {
+    if let Err(err) = storage.update(|instances, _groups| {
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id_for_save) {
             inst.touch_last_accessed();
             inst.status = crate::session::Status::Running;
         }
         Ok(())
-    })?;
+    }) {
+        // The tmux send succeeded; the storage write is best-effort
+        // bookkeeping (status remap + auto-unarchive). Surfacing this as a
+        // hard error would tell the user "send failed" when the message
+        // actually reached the agent, so log a warning and keep the success
+        // line. The next status poll will reconcile the row anyway.
+        tracing::warn!(
+            ?err,
+            "send: failed to persist status remap after successful send"
+        );
+    }
 
     println!("Sent message to '{}'", session_title);
     Ok(())

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1253,10 +1253,13 @@ impl Instance {
     }
 
     /// Build the launch command string the way `start_with_size_opts` would,
-    /// but without creating a tmux session. Shared with the dead-pane
-    /// respawn path so we send the same command to `tmux respawn-pane` that
-    /// `tmux new-session` would have received. Returns `None` for cockpit
-    /// or other modes where there is no command to launch.
+    /// but without creating a tmux session. Returns `None` for cockpit or
+    /// other modes where there is no command to launch.
+    ///
+    /// Currently only called from `start_with_size_opts`; a future dead-pane
+    /// respawn path could route through here so `tmux respawn-pane` receives
+    /// the same command `tmux new-session` would have. For now the helper is
+    /// preparatory and has one caller.
     ///
     /// Side effects mirror the start path: agent status hooks are installed,
     /// and (for sandboxed sessions) on_launch hooks run inside the container.
@@ -2840,6 +2843,41 @@ mod tests {
 
         inst.parent_session_id = Some("parent123".to_string());
         assert!(inst.is_sub_session());
+    }
+
+    /// `touch_last_accessed` is what `aoe send` and the TUI dispatch path
+    /// call when the user interacts with a session. It must auto-wake
+    /// archived and snoozed rows so sending a message to a sunk session
+    /// brings it back, while preserving the favorite flag (favorite is a
+    /// positive "care more" signal, not a sink state).
+    #[test]
+    fn test_touch_last_accessed_clears_archived() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.archive();
+        assert!(inst.is_archived());
+        inst.touch_last_accessed();
+        assert!(!inst.is_archived());
+        assert!(inst.last_accessed_at.is_some());
+    }
+
+    #[test]
+    fn test_touch_last_accessed_clears_snooze() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.snooze(30);
+        assert!(inst.is_snoozed());
+        inst.touch_last_accessed();
+        assert!(!inst.is_snoozed());
+    }
+
+    #[test]
+    fn test_touch_last_accessed_preserves_favorite() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.favorite();
+        assert!(inst.is_favorited());
+        inst.touch_last_accessed();
+        // Favorite is orthogonal to sink states; user interaction must not
+        // clear it.
+        assert!(inst.is_favorited());
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1237,7 +1237,35 @@ impl Instance {
         }
 
         let profile = self.effective_profile();
-        let on_launch_hooks = self.resolve_on_launch_hooks(skip_on_launch, &profile);
+        let cmd = self.build_launch_command(skip_on_launch, &profile)?;
+
+        tracing::debug!(target: "session.store",
+            "container cmd: {}",
+            cmd.as_ref().map_or("none".to_string(), |v| {
+                super::environment::redact_env_values(v)
+            })
+        );
+        session.create_with_size(&self.project_path, cmd.as_deref(), size)?;
+
+        self.finalize_launch(session.name(), &profile);
+
+        Ok(())
+    }
+
+    /// Build the launch command string the way `start_with_size_opts` would,
+    /// but without creating a tmux session. Shared with the dead-pane
+    /// respawn path so we send the same command to `tmux respawn-pane` that
+    /// `tmux new-session` would have received. Returns `None` for cockpit
+    /// or other modes where there is no command to launch.
+    ///
+    /// Side effects mirror the start path: agent status hooks are installed,
+    /// and (for sandboxed sessions) on_launch hooks run inside the container.
+    fn build_launch_command(
+        &mut self,
+        skip_on_launch: bool,
+        profile: &str,
+    ) -> Result<Option<String>> {
+        let on_launch_hooks = self.resolve_on_launch_hooks(skip_on_launch, profile);
 
         let agent = crate::agents::get_agent(&self.tool)
             .or_else(|| crate::agents::get_agent(&self.detect_as));
@@ -1312,17 +1340,7 @@ impl Instance {
             self.build_host_command(agent, &on_launch_hooks)
         };
 
-        tracing::debug!(target: "session.store",
-            "container cmd: {}",
-            cmd.as_ref().map_or("none".to_string(), |v| {
-                super::environment::redact_env_values(v)
-            })
-        );
-        session.create_with_size(&self.project_path, cmd.as_deref(), size)?;
-
-        self.finalize_launch(session.name(), &profile);
-
-        Ok(())
+        Ok(cmd)
     }
 
     /// Resolve on_launch hooks from the full config chain (global > profile > repo).


### PR DESCRIPTION
## Description

Wires user-interaction signals into the new attention-state model from #1084. After a successful `aoe send`, the target session:

1. Has its `last_accessed_at` stamped via `touch_last_accessed()`. That helper (landed in #1084) also auto-clears `archived_at` and `snoozed_until`, so sending a message to a sunk row wakes it.
2. Has its in-memory status flipped to `Running`. The next status poll reconciles the real state, but the immediate flip keeps the row from sticking on a stale `Idle` / `Waiting` label during the gap between send and poll.

The storage write is best-effort. If it fails AFTER the tmux send succeeded, the agent already received the keys; surfacing this as a "send failed" error would lie about the user-visible outcome. The failure is logged via `tracing::warn!` and the success line still prints.

## What's NOT in this PR

The original branch title (`auto-unarchive on send, respawn dead panes, and remap status`) overclaimed two things:

- **Respawn dead panes** is unchanged from main. `ensure_pane_ready()` already handles dead-pane revive on `aoe send`; that code is on main and not touched here.
- **`build_launch_command` is preparatory only.** This PR extracts the command-building from `start_with_size_opts` into a private helper so a future dead-pane respawn caller could route `tmux respawn-pane` through it, but no such caller is wired up. The helper currently has exactly one call site. The doc reflects that.

A real dead-pane respawn caller is a follow-up, not part of this change.

### Stacking note

Logically depends on #1084 for `touch_last_accessed`'s auto-clear semantics. Now that #1084 / #1085 / #1086 are merged, this PR's incremental diff vs main is the +39 LoC `send.rs` + `instance.rs` change plus three regression tests pinning the `touch_last_accessed` contract.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording. N/A; CLI send-path change.

## Testing

- `cargo build --release`: clean
- `cargo test --lib`: 1857 pass, 0 fail (3 new tests for `touch_last_accessed`)
- `cargo clippy --lib --tests -- -D warnings`: clean
- `cargo fmt --check`: clean

Three regression tests added in `src/session/instance.rs`:
- `test_touch_last_accessed_clears_archived` — archive then touch unarchives
- `test_touch_last_accessed_clears_snooze` — snooze then touch wakes
- `test_touch_last_accessed_preserves_favorite` — favorite survives touch (orthogonal signal)

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Code (Anthropic)

Note: title and body rewritten by Claude via back-and-forth with @njbrake during a PR review session. The original framing predated the dead-pane respawn wiring being descoped to a follow-up.

- [x] I am an AI Agent filling out this form