### PR TITLE
feat(cockpit): remove AOE_EXPERIMENTAL_COCKPIT env-var gate

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -1,24 +1,15 @@
 # Cockpit (Native Agent Rendering, Beta)
 
-> **Beta, opt-in.** Cockpit ships disabled by default behind two
-> independent gates:
+> **Beta, opt-in.** Cockpit ships disabled by default behind a single
+> master switch: `cockpit.enabled = true` in `config.toml` (default
+> `false` from migration v005). Toggle it from the web settings
+> (Cockpit tab) or by editing `config.toml` directly.
 >
-> 1. `cockpit.enabled = true` in `config.toml` (persistent master
->    switch; default `false` from migration v005). Editable via the
->    settings TUI.
-> 2. `AOE_EXPERIMENTAL_COCKPIT=1` env var on the process running
->    `aoe serve` (and the CLI for `aoe add --cockpit`). Per-process
->    opt-in for *new* sessions while the feature stabilises.
->
-> While either gate is off:
+> While the switch is off:
 >
 > - the web wizard auto-routes new sessions through tmux,
-> - `aoe add --cockpit` refuses with an actionable error.
->
-> Existing cockpit sessions still load and run when the env var is
-> unset (the env-var gate is for *new* sessions only); when the
-> master switch is off, the reconciler doesn't auto-spawn workers
-> for any session.
+> - `aoe add --cockpit` refuses with an actionable error,
+> - the reconciler doesn't auto-spawn workers for any session.
 >
 > The data model (`cockpit_mode: bool` per session) is stable; the
 > UI and reliability story are still evolving; see "What's deferred".
@@ -197,34 +188,26 @@ alone.
   flipping the switch shuts down running workers within a couple of
   seconds and respawns them when re-enabled, no `aoe serve --stop`
   required.
-- Don't set `AOE_EXPERIMENTAL_COCKPIT` (per-process). With the master
-  switch on but the env var unset, *new* browser sessions still get
-  tmux; existing cockpit sessions keep running with a one-time warn
-  log on startup.
 - `AOE_COCKPIT_NODE=/path/to/node` overrides Node discovery for one
   process (useful when the host's PATH-side Node is the wrong version
   and you can't change PATH).
 
 ### Fully turn cockpit off
 
+The fastest path: open the web settings, go to the Cockpit tab, and
+flip the master switch off. Workers exit within a couple of seconds.
+
+Or edit `config.toml` directly and restart:
+
 ```bash
-# 1. Stop the daemon.
 aoe serve --stop
-
-# 2. Set the master switch off in config.toml.
 $EDITOR ~/.config/agent-of-empires/config.toml  # [cockpit] enabled = false
-
-# 3. Make sure AOE_EXPERIMENTAL_COCKPIT is NOT in your shell init
-#    (.zshrc/.bashrc), systemd unit, launchd plist, etc.
-
-# 4. Start serve again.
 aoe serve
 ```
 
-`aoe cockpit doctor` reports the gate state up front. `aoe cockpit
-doctor --fix` will install missing ACP tooling but **will not** flip
-`cockpit.enabled` on for you; toggling that is always an explicit
-operator action.
+`aoe cockpit doctor --fix` will install missing ACP tooling but **will
+not** flip `cockpit.enabled` on for you; toggling that is always an
+explicit operator action.
 
 ## TUI vs web dashboard
 
@@ -489,9 +472,8 @@ These are tracked for follow-up releases:
 - Voice input/output on mobile.
 - A read-only cockpit transcript view inside the TUI (today the TUI
   shows a `[web]` badge and an "open in dashboard" hint).
-- Promotion out of `AOE_EXPERIMENTAL_COCKPIT`: once the
-  default-cockpit-on-web flow has burned in for one release,
-  `default_cockpit_for_web()` flips back to `true` for browser
-  clients and the wizard shows the substrate picker by default.
+- Default `cockpit.enabled = true`: once the default-cockpit-on-web
+  flow has burned in for one release, the master switch flips on by
+  default and the wizard shows the substrate picker out of the box.
 - Docker sandbox unix-socket transport for cockpit sessions running
   inside containers.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -393,41 +393,25 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     // forces terminal mode; otherwise honor the config default for
     // claude on supported platforms.
     //
-    // Two independent gates:
-    //   - `cockpit.enabled = false` in config.toml is the persistent
-    //     master switch.
-    //   - `AOE_EXPERIMENTAL_COCKPIT=1` is the per-process opt-in for
-    //     *new* sessions while the feature stabilises.
-    // Each refuses `--cockpit` with its own actionable error so the
-    // user knows which knob to flip.
+    // `cockpit.enabled = false` in config.toml is the master switch
+    // that gates `--cockpit`. The toggle lives in the web settings.
     #[cfg(feature = "serve")]
     {
         let user_picked_cockpit = args.cockpit || args.agent.is_some();
         let user_forced_terminal = args.no_cockpit;
-        if user_picked_cockpit {
-            if !config.cockpit.enabled {
-                bail!(
-                    "Cockpit is disabled by config (`cockpit.enabled = false` in config.toml). \
-                     Toggle it on (e.g. via the settings TUI) and try again, or omit --cockpit \
-                     for a tmux session."
-                );
-            }
-            if !crate::cockpit::experimental_enabled() {
-                bail!(
-                    "Cockpit is experimental. Set AOE_EXPERIMENTAL_COCKPIT=1 to opt in, or omit --cockpit / --agent for a tmux session."
-                );
-            }
+        if user_picked_cockpit && !config.cockpit.enabled {
+            bail!(
+                "Cockpit is disabled by config (`cockpit.enabled = false` in config.toml). \
+                 Toggle it on (e.g. via the web settings) and try again, or omit --cockpit \
+                 for a tmux session."
+            );
         }
-        let allow_default_cockpit = crate::cockpit::experimental_enabled();
         instance.cockpit_mode = if user_forced_terminal {
             false
         } else if user_picked_cockpit {
             true
         } else {
-            allow_default_cockpit
-                && config.cockpit.enabled
-                && config.cockpit.default_for_claude
-                && instance.tool == "claude"
+            config.cockpit.enabled && config.cockpit.default_for_claude && instance.tool == "claude"
         };
         instance.cockpit_agent = args.agent.clone();
         instance.cockpit_model = args.model.clone();

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -218,16 +218,6 @@ async fn doctor(json: bool, fix: bool) -> Result<()> {
     println!("Cockpit doctor  (Beta)");
     println!("======================");
     println!();
-    // Surface the gate state up front so users investigating "why
-    // doesn't cockpit work for me" don't have to read the docs to
-    // notice that they need an env var.
-    if !crate::cockpit::experimental_enabled() {
-        println!("[!! ] AOE_EXPERIMENTAL_COCKPIT is not set.");
-        println!("    Cockpit is gated behind this env var while it stabilises.");
-        println!("    Set AOE_EXPERIMENTAL_COCKPIT=1 in the env that runs `aoe serve`");
-        println!("    (and the CLI for `aoe add --cockpit`) to opt in.");
-        println!();
-    }
     println!("Cockpit is the structured-rendering substrate (ACP-based).");
     println!("Tmux passthrough remains the default for tool sessions; cockpit");
     println!("is opt-in per session via `aoe add --cockpit` or the web wizard.");

--- a/src/cockpit/mod.rs
+++ b/src/cockpit/mod.rs
@@ -29,15 +29,3 @@ pub mod worker_registry;
 pub use agent_registry::{AgentRegistry, AgentSpec};
 pub use approvals::{Approval, ApprovalDecision, Nonce};
 pub use state::{CockpitState, Event};
-
-/// Returns true when the operator has opted in to cockpit via
-/// `AOE_EXPERIMENTAL_COCKPIT=1`. Cockpit is gated behind this flag
-/// while it stabilises: when unset, the web dashboard defaults to
-/// tmux, the wizard hides the substrate picker, and existing cockpit
-/// sessions still load (the gate is for *new* sessions).
-pub fn experimental_enabled() -> bool {
-    matches!(
-        std::env::var("AOE_EXPERIMENTAL_COCKPIT").as_deref(),
-        Ok("1") | Ok("true")
-    )
-}

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -66,16 +66,10 @@ pub(crate) fn read_only_block(state: &AppState) -> Option<axum::response::Respon
     None
 }
 
-/// Single chokepoint for cockpit-availability checks. Both gates must
-/// be on for any cockpit-spawning endpoint to succeed:
-///   - `cockpit_master_enabled`: persistent config switch, toggleable
-///     via `PATCH /api/cockpit/master`.
-///   - `experimental_enabled()`: process-scoped `AOE_EXPERIMENTAL_COCKPIT=1`.
-///
-/// Used by `spawn_cockpit`, `cockpit_enable`, and `set_cockpit_master`
-/// so they can't drift out of sync (which previously let
-/// `spawn_cockpit` succeed against an unset env var while
-/// `cockpit_enable` 403'd).
+/// Single chokepoint for cockpit-availability checks. The persistent
+/// master switch (`cockpit.enabled` in config.toml, toggleable via
+/// `PATCH /api/cockpit/master`) must be on for any cockpit-spawning
+/// endpoint to succeed.
 pub(crate) fn cockpit_gate(state: &AppState) -> Result<(), (StatusCode, &'static str)> {
     if !state
         .cockpit_master_enabled
@@ -85,13 +79,6 @@ pub(crate) fn cockpit_gate(state: &AppState) -> Result<(), (StatusCode, &'static
             StatusCode::SERVICE_UNAVAILABLE,
             "cockpit is disabled (config.toml `cockpit.enabled = false`); \
              enable it from the web settings or set the field to true",
-        ));
-    }
-    if !crate::cockpit::experimental_enabled() {
-        return Err((
-            StatusCode::FORBIDDEN,
-            "cockpit is experimental; restart `aoe serve` with \
-             AOE_EXPERIMENTAL_COCKPIT=1 to enable",
         ));
     }
     Ok(())
@@ -762,16 +749,11 @@ pub struct SetMasterRequest {
 #[derive(Debug, Serialize)]
 pub struct MasterStateResponse {
     pub master_enabled: bool,
-    pub env_enabled: bool,
-    pub effective: bool,
 }
 
 /// Toggle `config.cockpit.enabled` from the web UI. Persists to
 /// `config.toml` and updates the live atomic so the reconciler and
 /// gating endpoints pick up the new value without a server restart.
-/// `AOE_EXPERIMENTAL_COCKPIT` is process-scoped and not affected;
-/// it's reported in the response so the UI can explain why cockpit
-/// may still be unavailable after enabling the master switch.
 pub async fn set_cockpit_master(
     State(state): State<Arc<AppState>>,
     Json(req): Json<SetMasterRequest>,
@@ -782,16 +764,6 @@ pub async fn set_cockpit_master(
             Json(serde_json::json!({
                 "error": "read_only",
                 "message": "Server is in read-only mode",
-            })),
-        )
-            .into_response();
-    }
-    if !crate::cockpit::experimental_enabled() {
-        return (
-            StatusCode::FORBIDDEN,
-            Json(serde_json::json!({
-                "error": "experimental_disabled",
-                "message": "cockpit is experimental; restart `aoe serve` with AOE_EXPERIMENTAL_COCKPIT=1 to manage the master switch",
             })),
         )
             .into_response();
@@ -813,18 +785,13 @@ pub async fn set_cockpit_master(
     })
     .await;
     match result {
-        Ok(Ok(())) => {
-            let env_enabled = crate::cockpit::experimental_enabled();
-            (
-                StatusCode::OK,
-                Json(MasterStateResponse {
-                    master_enabled: new_value,
-                    env_enabled,
-                    effective: new_value && env_enabled,
-                }),
-            )
-                .into_response()
-        }
+        Ok(Ok(())) => (
+            StatusCode::OK,
+            Json(MasterStateResponse {
+                master_enabled: new_value,
+            }),
+        )
+            .into_response(),
         Ok(Err(e)) => {
             // Persist failed: roll the atomic back so the live state
             // matches what's actually on disk. A subsequent gating

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -717,12 +717,11 @@ pub struct CreateSessionBody {
     pub profile: Option<String>,
     /// Whether the new session should run in cockpit mode. The
     /// bundled wizard always sends an explicit value (true for ACP-
-    /// capable tools when the server has `AOE_EXPERIMENTAL_COCKPIT`
-    /// set, false otherwise); other API callers may omit the field,
-    /// in which case it defaults to false. Either way the value is
-    /// re-gated by `allow_cockpit` below before being persisted, so
-    /// a tampered request can't escalate cockpit on past the env-
-    /// var, master-switch, or no-cockpit gates.
+    /// capable tools when the master switch is on, false otherwise);
+    /// other API callers may omit the field, in which case it
+    /// defaults to false. Either way the value is re-gated by the
+    /// master switch below before being persisted, so a tampered
+    /// request can't escalate cockpit on past the master switch.
     #[cfg(feature = "serve")]
     #[serde(default)]
     pub cockpit_mode: bool,
@@ -898,14 +897,11 @@ pub async fn create_session(
         }
 
         // Apply cockpit fields from the request body. cockpit_mode is
-        // silently downgraded to tmux when either gate says no:
-        // `cockpit.enabled = false` in config.toml (persistent master),
-        // or `AOE_EXPERIMENTAL_COCKPIT` not set (per-process opt-in for
-        // new sessions).
+        // silently downgraded to tmux when the master switch is off
+        // (`cockpit.enabled = false` in config.toml).
         #[cfg(feature = "serve")]
         {
-            let allow_cockpit = cockpit_master_enabled && crate::cockpit::experimental_enabled();
-            instance.cockpit_mode = body.cockpit_mode && allow_cockpit;
+            instance.cockpit_mode = body.cockpit_mode && cockpit_master_enabled;
             instance.cockpit_agent = body.cockpit_agent;
             instance.cockpit_model = body.cockpit_model;
         }

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -385,19 +385,12 @@ pub struct ServerAbout {
     pub read_only: bool,
     pub behind_tunnel: bool,
     pub profile: String,
-    /// True when `AOE_EXPERIMENTAL_COCKPIT=1` is set on the server
-    /// process AND the master switch (`cockpit.enabled`) is on. The
-    /// wizard uses this to decide whether new sessions auto-route
-    /// through cockpit; when false, every new session is tmux.
-    pub experimental_cockpit: bool,
     /// Live value of the `cockpit.enabled` master switch. The settings
     /// UI binds its toggle to this and updates it via
-    /// `PATCH /api/cockpit/master`.
+    /// `PATCH /api/cockpit/master`. When true, new sessions for ACP-
+    /// capable tools default to cockpit mode; when false, every new
+    /// session is tmux.
     pub cockpit_master_enabled: bool,
-    /// Whether the server process has `AOE_EXPERIMENTAL_COCKPIT=1` set.
-    /// Read-only from the web; flipping requires restarting `aoe serve`
-    /// with the env var set.
-    pub cockpit_env_enabled: bool,
     /// Resolved value of `cockpit.show_tool_durations` from the active
     /// profile's config. Drives the per-tool elapsed-time label in the
     /// web UI; cross-device since it lives in config.toml.
@@ -420,8 +413,6 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
     let cockpit_master_enabled = state
         .cockpit_master_enabled
         .load(std::sync::atomic::Ordering::Relaxed);
-    let cockpit_env_enabled = crate::cockpit::experimental_enabled();
-    let experimental_cockpit = cockpit_master_enabled && cockpit_env_enabled;
     let cockpit_cfg =
         crate::session::profile_config::resolve_config_or_warn(&state.profile).cockpit;
     let cockpit_show_tool_durations = cockpit_cfg.show_tool_durations;
@@ -434,9 +425,7 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         read_only: state.read_only,
         behind_tunnel: state.behind_tunnel,
         profile: state.profile.clone(),
-        experimental_cockpit,
         cockpit_master_enabled,
-        cockpit_env_enabled,
         cockpit_show_tool_durations,
         cockpit_queue_drain_mode,
         cockpit_max_concurrent_resumes,

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -289,23 +289,6 @@ async fn resume_one(state: Arc<AppState>, target: ResumeTarget) -> ResumeOutcome
             .synthesize_stopped_for_orphan(&id, "orphaned_at_restart");
     }
 
-    // Persisted cockpit-mode sessions auto-spawn even when
-    // `AOE_EXPERIMENTAL_COCKPIT` is unset (the env-var gate is for
-    // *new* sessions, not pre-existing ones). Log a warning per
-    // session so operators who unset the env var on a daemon with
-    // existing cockpit sessions know why those are still running.
-    if !crate::cockpit::experimental_enabled() {
-        tracing::warn!(
-            target: "cockpit.supervisor",
-            session = %id,
-            "auto-spawning persisted cockpit-mode session while \
-             AOE_EXPERIMENTAL_COCKPIT is not set. To stop cockpit \
-             from running existing sessions, set \
-             `cockpit.enabled = false` in config.toml and restart \
-             `aoe serve`. To stop just this one, switch its \
-             substrate to tmux from the dashboard."
-        );
-    }
     let supervisor = Arc::clone(&state.cockpit_supervisor);
     let agent = supervisor
         .pick_agent_for_tool(&tool, agent_override.as_deref())

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -585,8 +585,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                   <TerminalView
                     key={activeSessionId}
                     session={activeSession}
-                    experimentalCockpit={
-                      !!serverAbout?.experimental_cockpit
+                    cockpitMasterEnabled={
+                      !!serverAbout?.cockpit_master_enabled
                     }
                   />
                 )}
@@ -705,8 +705,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             setWizardPrefill(undefined);
           }}
           prefill={wizardPrefill}
-          experimentalCockpit={
-            !!serverAbout?.experimental_cockpit
+          cockpitMasterEnabled={
+            !!serverAbout?.cockpit_master_enabled
           }
         />
       )}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -44,8 +44,8 @@ type SidebarItem =
   | { kind: "tab"; id: TabId; label: string }
   | { kind: "divider"; label: string };
 
-function buildSidebar(showCockpit: boolean): SidebarItem[] {
-  const items: SidebarItem[] = [
+function buildSidebar(): SidebarItem[] {
+  return [
     { kind: "divider", label: "General" },
     { kind: "tab", id: "session", label: "Session" },
     { kind: "tab", id: "sandbox", label: "Sandbox" },
@@ -59,11 +59,8 @@ function buildSidebar(showCockpit: boolean): SidebarItem[] {
     { kind: "tab", id: "terminal", label: "Terminal" },
     { kind: "tab", id: "security", label: "Security" },
     { kind: "tab", id: "devices", label: "Devices" },
+    { kind: "tab", id: "cockpit", label: "Cockpit" },
   ];
-  if (showCockpit) {
-    items.push({ kind: "tab", id: "cockpit", label: "Cockpit" });
-  }
-  return items;
 }
 
 interface Props {
@@ -107,14 +104,11 @@ export function SettingsView({
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [selectedProfile, setSelectedProfile] = useState("default");
-  const cockpitEnvEnabled = !!serverAbout?.cockpit_env_enabled;
-  const sidebar = buildSidebar(cockpitEnvEnabled);
+  const sidebar = buildSidebar();
   const tabs = sidebar.filter(
     (s): s is { kind: "tab"; id: TabId; label: string } => s.kind === "tab",
   );
-  const requested: TabId = isTabId(tab) ? tab : "session";
-  const activeTab: TabId =
-    requested === "cockpit" && !cockpitEnvEnabled ? "session" : requested;
+  const activeTab: TabId = isTabId(tab) ? tab : "session";
   const [profiles, setProfiles] = useState<ProfileInfo[]>([]);
 
   useEffect(() => {
@@ -578,9 +572,7 @@ function CockpitSettings({
 }) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const envEnabled = !!serverAbout?.cockpit_env_enabled;
   const masterEnabled = !!serverAbout?.cockpit_master_enabled;
-  const effective = envEnabled && masterEnabled;
   // Local mirror so the toggle reflects optimistically while the
   // backend save + /api/about re-fetch propagate.
   const showToolDurations =
@@ -613,24 +605,15 @@ function CockpitSettings({
       <div className="rounded border border-surface-700 bg-surface-800/40 p-3 text-xs text-text-dim space-y-1">
         <div>
           <span className="text-text-muted">Status:</span>{" "}
-          {effective ? (
+          {masterEnabled ? (
             <span className="text-emerald-400">Cockpit available for new sessions</span>
           ) : (
-            <span className="text-amber-400">Cockpit unavailable</span>
+            <span className="text-amber-400">Cockpit disabled</span>
           )}
-        </div>
-        <div>
-          <span className="text-text-muted">AOE_EXPERIMENTAL_COCKPIT:</span>{" "}
-          <code className="rounded bg-surface-900 px-1">{envEnabled ? "1" : "(unset)"}</code>
         </div>
         <div>
           <span className="text-text-muted">cockpit.enabled:</span>{" "}
           <code className="rounded bg-surface-900 px-1">{masterEnabled ? "true" : "false"}</code>
-        </div>
-        <div className="text-text-dim pt-1">
-          Both gates must be on. The env var is per-process and only flips by restarting{" "}
-          <code className="rounded bg-surface-900 px-1">aoe serve</code> with{" "}
-          <code className="rounded bg-surface-900 px-1">AOE_EXPERIMENTAL_COCKPIT=1</code>.
         </div>
       </div>
 

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -26,15 +26,15 @@ import "@wterm/dom/css";
 interface Props {
   session: SessionResponse;
   /** When false (the default) the switch-to-cockpit pill is hidden
-   *  entirely so users on a non-experimental server aren't tempted
+   *  entirely so users with the master switch off aren't tempted
    *  by a button that the server will reject. */
-  experimentalCockpit?: boolean;
+  cockpitMasterEnabled?: boolean;
 }
 
 const SCROLL_HINT_SEEN_KEY = "aoe-mobile-scroll-hint-seen";
 const SCROLL_HINT_TIMEOUT_MS = 8000;
 
-export function TerminalView({ session, experimentalCockpit = false }: Props) {
+export function TerminalView({ session, cockpitMasterEnabled = false }: Props) {
   const [ensureState, setEnsureState] = useState<"pending" | "ready" | "error">(
     "pending",
   );
@@ -337,9 +337,9 @@ export function TerminalView({ session, experimentalCockpit = false }: Props) {
     >
       {/* Top-right substrate switch — discreet pill that lets the
           user flip this session into cockpit mode. Only rendered
-          when the operator opted into AOE_EXPERIMENTAL_COCKPIT, and
-          only enabled for tools whose ACP adapter we ship. */}
-      {session?.id && experimentalCockpit && (
+          when the cockpit master switch is on, and only enabled
+          for tools whose ACP adapter we ship. */}
+      {session?.id && cockpitMasterEnabled && (
         <div className="absolute right-2 top-2 z-10">
           <SwitchSubstrateAction
             sessionId={session.id}

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -154,14 +154,13 @@ interface Props {
   onClose: () => void;
   onCreated: (session?: SessionResponse) => void;
   prefill?: WizardPrefill;
-  /** Server-resolved cockpit availability (master switch on AND
-   *  AOE_EXPERIMENTAL_COCKPIT set). When true, ACP-capable tools
-   *  create cockpit sessions automatically; when false, every new
-   *  session is tmux. */
-  experimentalCockpit: boolean;
+  /** Live value of the cockpit master switch (`config.cockpit.enabled`).
+   *  When true, ACP-capable tools create cockpit sessions automatically;
+   *  when false, every new session is tmux. */
+  cockpitMasterEnabled: boolean;
 }
 
-export function SessionWizard({ onClose, onCreated, prefill, experimentalCockpit }: Props) {
+export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnabled }: Props) {
   const prefillData: WizardData = prefill
     ? {
         ...initialData,
@@ -232,12 +231,12 @@ export function SessionWizard({ onClose, onCreated, prefill, experimentalCockpit
       command_override: d.commandOverride || undefined,
       custom_instruction: d.customInstruction || undefined,
       profile: d.profile || undefined,
-      // Cockpit is auto-on for ACP-capable tools when the server
-      // exposes AOE_EXPERIMENTAL_COCKPIT; non-ACP tools and unset
-      // env both fall back to tmux. The server re-applies the same
-      // gate (see allow_cockpit in src/server/api/sessions.rs), so
-      // a tampered client request can't escalate cockpit on.
-      cockpit_mode: experimentalCockpit && ACP_CAPABLE_TOOLS.has(d.tool),
+      // Cockpit is auto-on for ACP-capable tools when the master
+      // switch is on; non-ACP tools and a disabled master switch
+      // both fall back to tmux. The server re-applies the master
+      // switch (see src/server/api/sessions.rs), so a tampered
+      // client request can't escalate cockpit on.
+      cockpit_mode: cockpitMasterEnabled && ACP_CAPABLE_TOOLS.has(d.tool),
     };
     const result = await createSession(body);
     if (result.ok) {
@@ -269,7 +268,7 @@ export function SessionWizard({ onClose, onCreated, prefill, experimentalCockpit
             profiles={state.profiles}
             dockerAvailable={state.dockerAvailable}
             onApplyProfileDefaults={handleApplyProfileDefaults}
-            experimentalCockpit={experimentalCockpit}
+            cockpitMasterEnabled={cockpitMasterEnabled}
           />
         );
       case "review":

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -28,11 +28,11 @@ interface Props {
   profiles: ProfileInfo[];
   dockerAvailable: boolean;
   onApplyProfileDefaults: (defaults: { yoloMode: boolean; sandboxEnabled: boolean; tool: string; extraEnv: string[] }) => void;
-  /** Server-side AOE_EXPERIMENTAL_COCKPIT flag. When true, sessions
+  /** Live value of the cockpit master switch. When true, sessions
    *  the user creates here run in cockpit mode automatically (for
    *  tools with an ACP adapter); when false, every session is tmux.
-   *  No per-session picker — the env var is the opt-in. */
-  experimentalCockpit: boolean;
+   *  No per-session picker; the master switch is the opt-in. */
+  cockpitMasterEnabled: boolean;
 }
 
 function SubstrateNotice({ tool, acpCapable }: { tool: string; acpCapable: boolean }) {
@@ -54,7 +54,7 @@ function SubstrateNotice({ tool, acpCapable }: { tool: string; acpCapable: boole
       </div>
       <p className="mt-1 text-xs text-text-dim leading-snug">
         {acpCapable
-          ? "AOE_EXPERIMENTAL_COCKPIT is set, so this session will run in the structured cockpit UI. Switch to terminal substrate from the session view if needed."
+          ? "Cockpit is enabled, so this session will run in the structured cockpit UI. Switch to terminal substrate from the session view if needed."
           : `${tool} has no ACP adapter yet, so this session falls back to the tmux terminal. Pick a tool with cockpit support (e.g. claude, opencode, gemini) to use the structured UI.`}
       </p>
     </div>
@@ -82,7 +82,7 @@ function Toggle({ checked, onChange, disabled }: { checked: boolean; onChange: (
   );
 }
 
-export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, onApplyProfileDefaults, experimentalCockpit }: Props) {
+export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, onApplyProfileDefaults, cockpitMasterEnabled }: Props) {
   const installedAgents = agents.filter((a) => a.installed);
   const selectedAgent = agents.find((a) => a.name === data.tool);
   const isHostOnly = selectedAgent?.host_only ?? false;
@@ -165,13 +165,13 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
       </div>
 
       {/* Substrate notice. Cockpit mode is auto-selected for ACP-capable
-          tools when the server has AOE_EXPERIMENTAL_COCKPIT set; non-ACP
-          tools fall back to tmux silently. The notice tells the user
-          which one they'll get without giving them a per-session toggle
-          (the env var is the opt-in, and the session view has a
-          post-creation switch if they need to flip). When the env var is
-          unset, every new session is tmux and no notice is shown. */}
-      {experimentalCockpit && (
+          tools when the master switch is on; non-ACP tools fall back to
+          tmux silently. The notice tells the user which one they'll get
+          without giving them a per-session toggle (the master switch is
+          the opt-in, and the session view has a post-creation switch if
+          they need to flip). When the master switch is off, every new
+          session is tmux and no notice is shown. */}
+      {cockpitMasterEnabled && (
         <SubstrateNotice
           tool={data.tool}
           acpCapable={ACP_CAPABLE_TOOLS.has(data.tool)}

--- a/web/src/lib/acpCapableTools.ts
+++ b/web/src/lib/acpCapableTools.ts
@@ -1,7 +1,7 @@
 // Tools known to have a published ACP server. Anything not in this
-// set falls back to tmux automatically; when the server has
-// AOE_EXPERIMENTAL_COCKPIT set, the wizard creates cockpit sessions
-// only for tools listed here.
+// set falls back to tmux automatically; when the cockpit master
+// switch is on, the wizard creates cockpit sessions only for tools
+// listed here.
 //
 // SOURCE OF TRUTH: src/cockpit/agent_registry.rs. If you add a new
 // ACP adapter to that registry, also add it here; otherwise the web

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -236,16 +236,11 @@ export interface ServerAbout {
   read_only: boolean;
   behind_tunnel: boolean;
   profile: string;
-  /** True when cockpit is available for new sessions (master switch
-   *  is on AND AOE_EXPERIMENTAL_COCKPIT=1 is set). When false, every
-   *  new session is tmux. */
-  experimental_cockpit: boolean;
   /** Live value of the cockpit master switch (`config.cockpit.enabled`).
-   *  Toggleable from the web settings via PATCH /api/cockpit/master. */
+   *  Toggleable from the web settings via PATCH /api/cockpit/master.
+   *  When true, new sessions for ACP-capable tools default to cockpit
+   *  mode; when false, every new session is tmux. */
   cockpit_master_enabled: boolean;
-  /** Whether the server process has AOE_EXPERIMENTAL_COCKPIT=1 set.
-   *  Read-only; flipping requires restarting `aoe serve`. */
-  cockpit_env_enabled: boolean;
   /** Resolved `cockpit.show_tool_durations` from the active profile's
    *  config. Drives the per-tool elapsed-time label in the cockpit
    *  web UI; cross-device since it lives in config.toml. */
@@ -265,7 +260,7 @@ export interface ServerAbout {
 
 export async function setCockpitMaster(
   enabled: boolean,
-): Promise<{ master_enabled: boolean; env_enabled: boolean; effective: boolean } | null> {
+): Promise<{ master_enabled: boolean } | null> {
   try {
     const res = await fetch("/api/cockpit/master", {
       method: "PATCH",


### PR DESCRIPTION
## Description

Cockpit is now gated solely by the `cockpit.enabled` master switch in `config.toml` (still default `false`, toggleable from the web settings → Cockpit tab). Drops the `AOE_EXPERIMENTAL_COCKPIT` env-var second gate.

**Why:** the env var added friction without much defense-in-depth value, since `aoe serve` itself is already beta. A user running `aoe serve` has already opted into "things may break"; layering a second beta-gate inside the first was redundant. The master switch defaults off, is toggleable live from the web UI, and shuts down running workers within ~2s when flipped off, so users still have an obvious opt-in and a clean recovery path.

**Behavior summary**

- `cockpit.enabled = false` (default): wizard hides the cockpit substrate notice, `aoe add --cockpit` refuses, reconciler doesn't spawn workers — same as before.
- `cockpit.enabled = true`: cockpit available for everyone, no env var required.
- Settings sidebar always shows the Cockpit tab so users can find the toggle.

**Tradeoffs considered**

- No process-level kill switch anymore; recovery from a cockpit regression means editing `config.toml` or flipping via web. Given the live web toggle and 2s reconciler shutdown, this seems fine.
- Anyone with write access to web settings can now enable cockpit (read-only mode still blocks the PATCH).
- Existing scripts setting `AOE_EXPERIMENTAL_COCKPIT=1` keep working (silently ignored); any CI asserting the *refusal* will break.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib` 1871 pass; `cargo clippy --features serve --all-targets` clean; `cargo fmt`; web `npm run build` clean. The 4 `cockpit_acp_smoke` failures reproduce on `main` in this sandbox — pre-existing environmental ACP-handshake flake, not touched by this change.)
- [x] Documentation was updated where necessary (`docs/cockpit.md` rewritten around the single master switch)
- [ ] For UI changes: included screenshot or recording

The UI delta is small and mechanical (the Cockpit settings tab is now always visible; the status panel drops the env-var row), so no screenshot.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Pair-programmed with Claude end-to-end: discussed the framing, walked through the removal sites together, reviewed the risk list before committing.

- [x] I am an AI Agent filling out this form (check box if true)