### PR TITLE
feat(tui): auto-disable mouse capture under Mosh

### DIFF
--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -90,12 +90,17 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     // Setup terminal
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(
-        stdout,
-        EnterAlternateScreen,
-        EnableBracketedPaste,
-        EnableMouseCapture
-    )?;
+    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
+    // Mosh mangles xterm mouse-tracking escapes, producing inverted or
+    // duplicated scroll on mobile clients (Termius, Blink, Mosh4iOS) and
+    // breaking right-click selection on desktop Mosh. MOSH_CONNECTION is
+    // set by mosh-server and propagates through the user's environment;
+    // when present, fall back to the terminal's native scroll and let
+    // the user select text without aoe eating mouse events.
+    let mosh_active = std::env::var_os("MOSH_CONNECTION").is_some();
+    if !mosh_active {
+        execute!(stdout, EnableMouseCapture)?;
+    }
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
@@ -133,9 +138,11 @@ pub async fn run(profile: &str, startup_warning: Option<String>) -> Result<()> {
     execute!(
         terminal.backend_mut(),
         LeaveAlternateScreen,
-        DisableBracketedPaste,
-        DisableMouseCapture
+        DisableBracketedPaste
     )?;
+    if !mosh_active {
+        execute!(terminal.backend_mut(), DisableMouseCapture)?;
+    }
     terminal.show_cursor()?;
 
     result


### PR DESCRIPTION
## Description

Mosh mangles xterm mouse-tracking escape sequences (`\e[?1000h` family). On iOS Mosh clients (Termius, Blink, Mosh4iOS) this produces inverted or duplicated scroll inside the aoe TUI; on desktop Mosh it intercepts right-click and click-drag selection. With mouse capture left ON unconditionally, both Mosh paths are unusable.

Detect Mosh via `MOSH_CONNECTION`, the env var that `mosh-server` sets on connection and which propagates through the user's tmux/zsh environment. When set, skip `EnableMouseCapture` so the terminal handles scroll and selection natively. The matching `DisableMouseCapture` on shutdown is gated by the same flag to keep the enable/disable pair balanced.

Non-Mosh sessions (plain SSH, local terminal) see zero change: capture still engages unconditionally and #795's preview-pane wheel scroll keeps working.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(No visual change to capture; behavior swap is observable only on a live Mosh client where this fixes inverted scroll and restores selection.)

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Code (Opus 4.7), under direct supervision from a Mosh-on-iOS user who hit this regression and verified the fix on their device.

- [x] I am an AI Agent filling out this form (check box if true)