### PR TITLE
feat: observability + logging umbrella (closes #1096)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ website/src/pages/guides/*.md
 website/src/pages/docs/*.md
 website/src/pages/docs/guides/*.md
 website/src/pages/docs/cli/*.md
+website/src/pages/docs/development/*.md
 .worktrees/
 .gstack/
 .playwright-mcp/

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -10,6 +10,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe init`↴](#aoe-init)
 * [`aoe list`↴](#aoe-list)
 * [`aoe logs`↴](#aoe-logs)
+* [`aoe log-level`↴](#aoe-log-level)
 * [`aoe remove`↴](#aoe-remove)
 * [`aoe send`↴](#aoe-send)
 * [`aoe status`↴](#aoe-status)
@@ -81,6 +82,7 @@ Run without arguments to launch the TUI dashboard.
 * `init` — Initialize .agent-of-empires/config.toml in a repository
 * `list` — List all sessions
 * `logs` — View AoE log files (debug.log, serve.log) with a pretty viewer
+* `log-level` — Get or set the running daemon's log filter at runtime. Pass a bare level (debug/info/...) for the safe expansion, or `--filter <expr>` for raw EnvFilter syntax. `--get` prints the current filter. Changes are ephemeral and lost on daemon restart
 * `remove` — Remove a session
 * `send` — Send a message to a running agent session
 * `status` — Show session status summary
@@ -193,6 +195,23 @@ View AoE log files (debug.log, serve.log) with a pretty viewer
 * `-n`, `--lines <N>` — Show only the last N lines (fallback viewers; lnav handles its own)
 * `--no-pager` — Skip viewer detection; write plain log to stdout
 * `--path` — Print the resolved log file path(s) and exit (no viewing)
+
+
+
+## `aoe log-level`
+
+Get or set the running daemon's log filter at runtime. Pass a bare level (debug/info/...) for the safe expansion, or `--filter <expr>` for raw EnvFilter syntax. `--get` prints the current filter. Changes are ephemeral and lost on daemon restart
+
+**Usage:** `aoe log-level [OPTIONS] [LEVEL]`
+
+###### **Arguments:**
+
+* `<LEVEL>` — Bare level (trace|debug|info|warn|error). Expands to all known target roots, avoiding the firehose of dependency logs you would get from `RUST_LOG=debug`
+
+###### **Options:**
+
+* `--filter <FILTER>` — Raw EnvFilter directive. Use this for per-target tuning, e.g. `--filter cockpit.acp=trace,info`. Bare `--filter debug` is rejected; use the positional `level` form instead
+* `--get` — Print the current filter without changing it
 
 
 

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Agent of Empires uses the [`tracing`](https://docs.rs/tracing) crate. Both the main daemon and cockpit runner subprocesses share `src/logging.rs` so they agree on env-var resolution, default filter construction, and the reloadable subscriber handle. Daemon and runners append to the same file (`~/.agent-of-empires/debug.log`) so a single tail covers an entire session.
+Agent of Empires uses the [`tracing`](https://docs.rs/tracing) crate. The TUI, the `aoe serve` daemon, and the cockpit runner subprocesses all share `src/logging.rs` so they agree on env-var resolution, default filter construction, and the reloadable subscriber handle. TUI and runners append to the same `~/.agent-of-empires/debug.log` so a single tail covers an entire session; `aoe serve` writes to stdout (captured into `serve.log`).
 
 ## Targets
 
@@ -39,7 +39,17 @@ Resolved once at startup in `LogConfig::from_env`:
 | `AOE_ACP_TRACE` | Overlay: `agent_client_protocol=debug` + the JSON-RPC transport_actor at trace. |
 | `AOE_TERMINAL_TRACE` | Overlay: `terminal=trace` (per-byte firehose). |
 
-If no level env var is set and you're starting `aoe serve`, the daemon defaults to info-level stdout logging so the TUI Starting-screen log tail isn't empty. Outside of `aoe serve`, no subscriber is installed (TUI mode prints to ratatui's alt-screen; a tracing subscriber on stderr would garble it).
+## Sinks by process
+
+| Invocation | Filter source | Sink |
+|---|---|---|
+| Any `aoe` with env var set | env | `debug.log` |
+| `aoe serve`, no env | `[logging]` config, else info baseline | stdout (captured into `serve.log` by the daemon redirect) |
+| TUI (`aoe` with no subcommand), no env | `[logging]` config, else info baseline | `debug.log` |
+| Cockpit runner subprocess | env (inherited) → `[logging]` config → info baseline; then `runtime_filter` if the daemon writes one | `debug.log` |
+| Other one-shot CLI, no env | — | no subscriber installed (opt in via `AOE_LOG_LEVEL` if you need a trace of one) |
+
+The TUI writes to a file rather than stderr because ratatui owns the alt-screen and a stderr subscriber would corrupt it. Daemon + runners + TUI all append to the same `debug.log` so a single tail covers a whole session.
 
 ## Persistent configuration (`[logging]` in `config.toml`)
 
@@ -57,7 +67,7 @@ default_level = "info"
 
 `default_level` is the baseline; entries in `targets` override per target. The list of targets surfaced as dropdowns mirrors `KNOWN_SUB_TARGETS` in `src/logging.rs`. Anything else can still be set via raw EnvFilter syntax through the runtime endpoint or CLI.
 
-Precedence at startup: `AOE_LOG_LEVEL` env var → `[logging]` in config → built-in `info` fallback. Changes via the settings UI live-apply through the same `FilterController` swap that powers `aoe log-level`, including propagation to cockpit runners via the `runtime_filter` notify watcher. No daemon restart needed.
+Changes via the settings UI live-apply through the same `FilterController` swap that powers `aoe log-level`, including propagation to cockpit runners via the `runtime_filter` notify watcher. No daemon restart needed. (The startup precedence is shown in the *Sinks by process* table above: env wins, then `[logging]`, then the info baseline.)
 
 ## Runtime control
 
@@ -117,7 +127,7 @@ Not captured (intentional, v1): `console.error`. Wrapping it produces noisy dupl
 
 | Path | When it's written |
 |------|-------------------|
-| `~/.agent-of-empires/debug.log` | Both daemon and cockpit runner. Created when a log-level env var is set or via `aoe serve`. |
+| `~/.agent-of-empires/debug.log` | TUI, cockpit runners, and any `aoe` invocation with `AOE_LOG_LEVEL` set. `aoe serve` writes its own output to stdout (captured into `serve.log`). |
 | `~/.agent-of-empires/serve.log` | Daemon stdout/stderr tail captured by the `aoe serve --daemon` redirect. |
 | `~/.agent-of-empires/runtime_filter` | Atomically written on every successful `aoe log-level` swap; consumed by runner watchers. |
 | `~/.agent-of-empires/cockpit-workers/<session-id>.log` | Touched for compatibility; structured tracing now lands in the shared `debug.log`. |

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -41,6 +41,24 @@ Resolved once at startup in `LogConfig::from_env`:
 
 If no level env var is set and you're starting `aoe serve`, the daemon defaults to info-level stdout logging so the TUI Starting-screen log tail isn't empty. Outside of `aoe serve`, no subscriber is installed (TUI mode prints to ratatui's alt-screen; a tracing subscriber on stderr would garble it).
 
+## Persistent configuration (`[logging]` in `config.toml`)
+
+The settings UI (web dashboard *Settings → Logging*, TUI *Settings → Logging*) writes a `[logging]` section to `~/.agent-of-empires/config.toml`:
+
+```toml
+[logging]
+default_level = "info"
+
+[logging.targets]
+"cockpit.acp" = "trace"
+"auth.middleware" = "debug"
+"process.signal" = "warn"
+```
+
+`default_level` is the baseline; entries in `targets` override per target. The list of targets surfaced as dropdowns mirrors `KNOWN_SUB_TARGETS` in `src/logging.rs`. Anything else can still be set via raw EnvFilter syntax through the runtime endpoint or CLI.
+
+Precedence at startup: `AOE_LOG_LEVEL` env var → `[logging]` in config → built-in `info` fallback. Changes via the settings UI live-apply through the same `FilterController` swap that powers `aoe log-level`, including propagation to cockpit runners via the `runtime_filter` notify watcher. No daemon restart needed.
+
 ## Runtime control
 
 ### REST

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,0 +1,114 @@
+# Logging
+
+Agent of Empires uses the [`tracing`](https://docs.rs/tracing) crate. Both the main daemon and cockpit runner subprocesses share `src/logging.rs` so they agree on env-var resolution, default filter construction, and the reloadable subscriber handle. Daemon and runners append to the same file (`~/.agent-of-empires/debug.log`) so a single tail covers an entire session.
+
+## Targets
+
+Targets use the convention `<module>.<submodule>`. The default filter expands a chosen level to a directive per top-level root, so target names like `auth.token` inherit from `auth` without per-target env config.
+
+| Root | Sub-targets | What lands here |
+|------|-------------|-----------------|
+| `agent_of_empires` | (default crate path) | General library code emitting without `target:` |
+| `cockpit` | `cockpit.acp`, `cockpit.supervisor`, `cockpit.event_store`, `cockpit.runner`, `cockpit.acp.stderr` | ACP transport, supervisor lifecycle, event store, runner shim |
+| `terminal` | `terminal.ws`, `terminal.ws.bytes` | Web terminal WS relay + per-byte firehose (trace) |
+| `auth` | `auth.token`, `auth.middleware`, `auth.rate_limit`, `auth.passphrase`, `auth.device`, `auth.ip` | Token rotate, middleware accept/reject, rate-limit thresholds, login flow |
+| `process` | `process.signal`, `process.tree`, `process.reap`, `process.ppid` | Signal sends, process-tree walks, survivor reap, ppid resolution |
+| `update` | `update.fetch`, `update.cache`, `update.parse` | GitHub release polling, cache hits/misses, version compare |
+| `containers` | `containers.docker`, `containers.image`, `containers.runtime` | Docker daemon, image pull, container lifecycle |
+| `git` | `git.command` | Every `git` invocation with args, exit, duration |
+| `migrations` | (none — entry/exit on driver) | Per-migration progress with duration |
+| `web.client` | (fixed; module surfaced as `client_target` field) | Browser-side errors relayed via `/api/client-log` |
+| `log.runtime` | — | Filter swaps (REST + runner file-watch) |
+
+## Levels
+
+- **error** — user-visible failure or invariant violation
+- **warn** — recovered from, but worth investigating (rate-limit lockout, SIGTERM survivor, garbled runtime-filter file)
+- **info** — lifecycle / state transitions (token rotate, container start, migration completed)
+- **debug** — frequent / per-operation detail (every git invocation, every signal)
+- **trace** — per-byte / per-message firehose (`terminal.ws.bytes`, ACP JSON-RPC transport)
+
+## Env variables
+
+Resolved once at startup in `LogConfig::from_env`:
+
+| Var | Effect |
+|-----|--------|
+| `AOE_LOG_LEVEL` | `trace`/`debug`/`info`/`warn`/`error`. Sets the level across all known target roots. |
+| `AGENT_OF_EMPIRES_DEBUG` | Legacy alias for `AOE_LOG_LEVEL=debug`. |
+| `AOE_ACP_TRACE` | Overlay: `agent_client_protocol=debug` + the JSON-RPC transport_actor at trace. |
+| `AOE_TERMINAL_TRACE` | Overlay: `terminal=trace` (per-byte firehose). |
+
+If no level env var is set and you're starting `aoe serve`, the daemon defaults to info-level stdout logging so the TUI Starting-screen log tail isn't empty. Outside of `aoe serve`, no subscriber is installed (TUI mode prints to ratatui's alt-screen; a tracing subscriber on stderr would garble it).
+
+## Runtime control
+
+### REST
+
+| Method | Path | Body | Notes |
+|--------|------|------|-------|
+| `GET` | `/api/log-level` | — | `{current, reloadable, ephemeral}`. Returns 200 even when no controller is installed. |
+| `PATCH` | `/api/log-level` | `{"level": "<name>"}` or `{"filter": "<EnvFilter>"}` | Exactly one field. |
+
+`{"level": "debug"}` expands across all known target roots so you don't accidentally enable debug for transitive crates like `hyper`/`rustls`/`tower`.
+
+`{"filter": "..."}` accepts the full `EnvFilter` syntax. Regex matching is disabled (`with_regex(false)`) to reduce attack surface on an authenticated HTTP input. Bare global levels (`"filter": "debug"`) are rejected with 400; use the `level` form instead.
+
+Responses include `previous` and `current` directives. Changes are ephemeral; restart falls back to the env-var resolution.
+
+### CLI
+
+```
+aoe log-level <level>             # safe expansion across known roots
+aoe log-level --filter <expr>     # raw EnvFilter
+aoe log-level --get               # print current
+```
+
+Examples:
+
+```sh
+aoe log-level debug
+aoe log-level --filter cockpit.acp=trace,info
+aoe log-level --filter auth.rate_limit=debug,warn
+aoe log-level --get
+```
+
+The CLI reads the daemon URL from `serve.url` and authenticates via the token in the query string. Works against a foreground `aoe serve` too — it does not require the daemon mode.
+
+## Runner propagation
+
+When you `PATCH /api/log-level`, the daemon writes the new directive atomically to `~/.agent-of-empires/runtime_filter` (0600). Each cockpit runner subprocess uses `notify` to watch the file and applies updates to its own `FilterController`. Both daemon and runners stay in lockstep without restart, which is the point: you can pull from `info` to `trace` mid-incident without losing in-flight agent state.
+
+Edge cases:
+
+- File missing: runner no-ops until the daemon writes one.
+- Daemon stop: file removal does not revert runner filters; the next daemon start writes a fresh value.
+- Garbled content: runner logs a `warn` to `log.runtime` and keeps its prior filter.
+
+## Web client relay
+
+Browser-side `window.onerror`, `unhandledrejection`, React `ErrorBoundary`, and explicit `reportError()` calls are batched and POSTed to `/api/client-log`. The server re-emits them through `tracing` at target `web.client` so they land in the same `debug.log` as everything else.
+
+Throttle (frontend): token-bucket 10 cap, 10/s refill, batches flush every 2s / 20 entries / ~48 KB. `pagehide` and `visibilitychange === "hidden"` flush via `navigator.sendBeacon` with a JSON Blob so logs survive page navigation.
+
+Caps (server): max 50 entries per batch (413 otherwise), message truncated to 4 KB, stack to 16 KB, dynamic-target field sanitised and capped at 64 characters. URL is sanitised client-side to drop the `?token=` query param before transmission.
+
+Not captured (intentional, v1): `console.error`. Wrapping it produces noisy duplicates and recursion hazards; if you need it later, flag-gate it.
+
+## File locations
+
+| Path | When it's written |
+|------|-------------------|
+| `~/.agent-of-empires/debug.log` | Both daemon and cockpit runner. Created when a log-level env var is set or via `aoe serve`. |
+| `~/.agent-of-empires/serve.log` | Daemon stdout/stderr tail captured by the `aoe serve --daemon` redirect. |
+| `~/.agent-of-empires/runtime_filter` | Atomically written on every successful `aoe log-level` swap; consumed by runner watchers. |
+| `~/.agent-of-empires/cockpit-workers/<session-id>.log` | Touched for compatibility; structured tracing now lands in the shared `debug.log`. |
+
+On Linux, replace `~/.agent-of-empires` with `$XDG_CONFIG_HOME/agent-of-empires`. Debug builds use `~/.agent-of-empires-dev` to avoid colliding with an installed release.
+
+## Conventions
+
+- Set `target:` explicitly when filtering granularity below the crate level matters. The default crate path (`agent_of_empires`) suffices for grab-bag logs.
+- Use structured fields, not interpolated text: `tracing::warn!(target: "auth.rate_limit", ip = %addr, attempts = n, "lockout")` rather than `warn!("lockout for ip {addr} ({n} attempts)")`. Field-based filtering and grep both win.
+- Don't log secrets. Token material is never logged; auth events carry a `reason` field instead. Git command args are redacted (`https://***@host/...`) before tracing emit.
+- Add new top-level target roots to `DEFAULT_TARGET_ROOTS` in `src/logging.rs` so the runtime control's `{"level": ...}` expansion picks them up.

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -12,6 +12,8 @@ use super::cockpit::CockpitCommands;
 use super::group::GroupCommands;
 use super::init::InitArgs;
 use super::list::ListArgs;
+#[cfg(feature = "serve")]
+use super::log_level::LogLevelArgs;
 use super::logs::LogsArgs;
 use super::profile::ProfileCommands;
 use super::project::ProjectCommands;
@@ -67,6 +69,13 @@ pub enum Commands {
 
     /// View AoE log files (debug.log, serve.log) with a pretty viewer
     Logs(LogsArgs),
+
+    /// Get or set the running daemon's log filter at runtime.
+    /// Pass a bare level (debug/info/...) for the safe expansion, or
+    /// `--filter <expr>` for raw EnvFilter syntax. `--get` prints the
+    /// current filter. Changes are ephemeral and lost on daemon restart.
+    #[cfg(feature = "serve")]
+    LogLevel(LogLevelArgs),
 
     /// Remove a session
     #[command(alias = "rm")]

--- a/src/cli/log_level.rs
+++ b/src/cli/log_level.rs
@@ -1,0 +1,111 @@
+//! `aoe log-level` — get or change the running daemon's tracing filter.
+//!
+//! Calls the daemon's `/api/log-level` endpoint over HTTP using the
+//! token embedded in `serve.url`. Does not require the daemon to be
+//! daemonised — a foreground `aoe serve` is reachable if its
+//! `serve.url` file is current.
+
+use anyhow::{bail, Context, Result};
+use clap::Args;
+
+use super::serve::read_serve_urls;
+
+#[derive(Args)]
+pub struct LogLevelArgs {
+    /// Bare level (trace|debug|info|warn|error). Expands to all known
+    /// target roots, avoiding the firehose of dependency logs you would
+    /// get from `RUST_LOG=debug`.
+    pub level: Option<String>,
+
+    /// Raw EnvFilter directive. Use this for per-target tuning, e.g.
+    /// `--filter cockpit.acp=trace,info`. Bare `--filter debug` is
+    /// rejected; use the positional `level` form instead.
+    #[arg(long)]
+    pub filter: Option<String>,
+
+    /// Print the current filter without changing it.
+    #[arg(long, conflicts_with_all = ["level", "filter"])]
+    pub get: bool,
+}
+
+pub async fn run(args: LogLevelArgs) -> Result<()> {
+    let urls = read_serve_urls();
+    let Some(primary) = urls.first() else {
+        bail!("No aoe serve daemon is running, or serve.url is empty/missing.");
+    };
+
+    let base = primary
+        .url
+        .split('?')
+        .next()
+        .unwrap_or(&primary.url)
+        .trim_end_matches('/');
+    let endpoint = format!("{base}/api/log-level");
+    let token = extract_token(&primary.url);
+
+    let client = reqwest::Client::new();
+
+    if args.get || (args.level.is_none() && args.filter.is_none()) {
+        let mut req = client.get(&endpoint);
+        if let Some(t) = token {
+            req = req.bearer_auth(t);
+        }
+        let resp = req.send().await.context("GET /api/log-level")?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            bail!("server returned {status}: {body}");
+        }
+        println!("{body}");
+        return Ok(());
+    }
+
+    let body = match (args.level.as_deref(), args.filter.as_deref()) {
+        (Some(level), None) => {
+            if matches_known_level(level) {
+                serde_json::json!({ "level": level })
+            } else {
+                bail!(
+                    "{level:?} is not a known level. \
+                     Use trace|debug|info|warn|error, or pass --filter for raw EnvFilter syntax."
+                );
+            }
+        }
+        (None, Some(filter)) => serde_json::json!({ "filter": filter }),
+        (Some(_), Some(_)) => bail!("specify exactly one of <level> or --filter"),
+        (None, None) => unreachable!("guarded above"),
+    };
+
+    let mut req = client.patch(&endpoint).json(&body);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().await.context("PATCH /api/log-level")?;
+    let status = resp.status();
+    let text = resp.text().await.unwrap_or_default();
+    if !status.is_success() {
+        bail!("server returned {status}: {text}");
+    }
+    println!("{text}");
+    Ok(())
+}
+
+fn matches_known_level(s: &str) -> bool {
+    matches!(
+        s.trim().to_ascii_lowercase().as_str(),
+        "trace" | "debug" | "info" | "warn" | "warning" | "error"
+    )
+}
+
+fn extract_token(url: &str) -> Option<&str> {
+    let query = url.split_once('?').map(|(_, q)| q)?;
+    for pair in query.split('&') {
+        if let Some(rest) = pair.strip_prefix("token=") {
+            if rest.is_empty() {
+                return None;
+            }
+            return Some(rest);
+        }
+    }
+    None
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,8 @@ pub mod definition;
 pub mod group;
 pub mod init;
 pub mod list;
+#[cfg(feature = "serve")]
+pub mod log_level;
 pub mod logs;
 pub mod output;
 pub mod profile;

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -473,12 +473,13 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
     open_log_file(&per_session)?;
 
     let shared_path = crate::session::get_app_dir()?.join("debug.log");
-    let env_cfg = crate::logging::LogConfig::from_env();
-    let filter = env_cfg.filter_string().unwrap_or_else(|| {
-        crate::logging::LogConfig::serve_default()
-            .filter_string()
-            .expect("serve_default sets a level")
-    });
+    // Same precedence as main.rs: env > [logging] in config.toml > info
+    // baseline. The notify watcher on runtime_filter still takes over
+    // for live swaps once the daemon writes one.
+    let filter = crate::logging::LogConfig::from_env()
+        .filter_string()
+        .or_else(crate::logging::load_persisted_filter)
+        .unwrap_or_else(crate::logging::serve_default_filter);
 
     let init = crate::logging::init_subscriber(
         crate::logging::SubscriberTarget::File(shared_path),

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -108,6 +108,12 @@ pub async fn run(args: CockpitRunnerArgs) -> Result<()> {
     worker_registry::validate_session_id(&args.session_id).context("invalid --session-id")?;
     init_runner_logging(&args.session_id)?;
 
+    // Watch the shared runtime_filter file so `aoe log-level` from the
+    // daemon propagates to this runner subprocess without restart.
+    if let Ok(app_dir) = crate::session::get_app_dir() {
+        tokio::spawn(crate::logging::watch_runtime_filter(app_dir));
+    }
+
     info!(
         target: "cockpit.runner",
         session = %args.session_id,

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -459,23 +459,27 @@ async fn wait_for_shutdown() {
 }
 
 fn init_runner_logging(session_id: &str) -> Result<()> {
-    let log_path = worker_registry::log_path_for(session_id)?;
-    open_log_file(&log_path)?;
-    // tracing-subscriber may already be initialised by main; try_init
-    // silently no-ops in that case. If we're a fresh process (we are,
-    // when invoked as `aoe __cockpit-runner`), this wires the file
-    // writer so runner logs go to the per-session log file.
-    if let Ok(file) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-    {
-        tracing_subscriber::fmt()
-            .with_env_filter("cockpit=info,agent_of_empires=info")
-            .with_writer(std::sync::Mutex::new(file))
-            .with_ansi(false)
-            .try_init()
-            .ok();
+    // Keep the per-session log file path created so `aoe cockpit logs
+    // --session <id>` and any external tail works. The actual tracing
+    // output goes to the shared `debug.log` so daemon + every runner
+    // appear in one timeline; runner spans add `session_id` for filtering.
+    let per_session = worker_registry::log_path_for(session_id)?;
+    open_log_file(&per_session)?;
+
+    let shared_path = crate::session::get_app_dir()?.join("debug.log");
+    let env_cfg = crate::logging::LogConfig::from_env();
+    let filter = env_cfg.filter_string().unwrap_or_else(|| {
+        crate::logging::LogConfig::serve_default()
+            .filter_string()
+            .expect("serve_default sets a level")
+    });
+
+    let init = crate::logging::init_subscriber(
+        crate::logging::SubscriberTarget::File(shared_path),
+        filter,
+    );
+    if let Some(c) = init.controller {
+        crate::logging::install_controller(c);
     }
     Ok(())
 }

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -101,10 +101,21 @@ impl RuntimeBase {
         let mut cmd = self.command();
         cmd.args(self.pull_prefix);
         cmd.arg(image);
+        let start = std::time::Instant::now();
+        tracing::info!(target: "containers.image", runtime = %self.name, %image, "pulling image");
         let output = cmd.output()?;
+        let dur_ms = start.elapsed().as_millis() as u64;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
+            tracing::warn!(
+                target: "containers.image",
+                runtime = %self.name,
+                %image,
+                duration_ms = dur_ms,
+                stderr_summary = %stderr.trim().chars().take(200).collect::<String>(),
+                "image pull failed"
+            );
             return Err(DockerError::ImageNotFound(format!(
                 "{}: {}",
                 image,
@@ -112,6 +123,13 @@ impl RuntimeBase {
             )));
         }
 
+        tracing::info!(
+            target: "containers.image",
+            runtime = %self.name,
+            %image,
+            duration_ms = dur_ms,
+            "image pull completed"
+        );
         Ok(())
     }
 
@@ -244,6 +262,7 @@ impl RuntimeBase {
     }
 
     pub fn start_container(&self, name: &str) -> Result<()> {
+        tracing::info!(target: "containers.runtime", runtime = %self.name, %name, "starting container");
         let output = self.command().args(["start", name]).output()?;
 
         if !output.status.success() {
@@ -255,6 +274,7 @@ impl RuntimeBase {
     }
 
     pub fn stop_container(&self, name: &str) -> Result<()> {
+        tracing::info!(target: "containers.runtime", runtime = %self.name, %name, "stopping container");
         let output = self.command().args(["stop", name]).output()?;
 
         if !output.status.success() {
@@ -280,6 +300,7 @@ impl RuntimeBase {
         }
         args.push(name.to_string());
 
+        tracing::debug!(target: "containers.runtime", runtime = %self.name, %name, %force, "removing container");
         let output = self.command().args(&args).output()?;
 
         if !output.status.success() {

--- a/src/git/cleanup.rs
+++ b/src/git/cleanup.rs
@@ -308,10 +308,7 @@ pub fn deinit_submodules_if_present(worktree_path: &Path) {
     if !worktree_path.join(".gitmodules").exists() {
         return;
     }
-    let output = std::process::Command::new("git")
-        .args(["submodule", "deinit", "-f", "--all"])
-        .current_dir(worktree_path)
-        .output();
+    let output = super::command::run_git(worktree_path, ["submodule", "deinit", "-f", "--all"]);
     match output {
         Ok(o) if o.status.success() => {
             tracing::debug!(

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -1,0 +1,100 @@
+//! Thin tracing wrapper for `git` invocations.
+//!
+//! Used by the simpler call sites that just want `git foo bar`.output().
+//! Streaming-clone and other custom invocations stay inline and emit
+//! their own `git.command` events.
+
+use std::ffi::OsStr;
+use std::path::Path;
+use std::process::{Command, Output};
+use std::time::Instant;
+
+/// Run `git <args>` in `cwd`, instrumented with target `git.command`.
+/// Logs a debug line before, then debug (success) or warn (failure)
+/// after with exit code, duration, and a sanitized stderr summary.
+///
+/// `args` may contain URLs with embedded credentials; we strip the
+/// userinfo before logging so tokens don't end up on disk.
+pub fn run_git<I, S>(cwd: &Path, args: I) -> std::io::Result<Output>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<OsStr>,
+{
+    let argv: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_owned()).collect();
+    let redacted: Vec<String> = argv.iter().map(|a| redact(a.as_os_str())).collect();
+    let start = Instant::now();
+    tracing::debug!(
+        target: "git.command",
+        args = ?redacted,
+        cwd = %cwd.display(),
+        "running git"
+    );
+    let output = Command::new("git").args(&argv).current_dir(cwd).output()?;
+    let dur = start.elapsed().as_millis() as u64;
+    if output.status.success() {
+        tracing::debug!(
+            target: "git.command",
+            args = ?redacted,
+            exit = output.status.code(),
+            duration_ms = dur,
+            "git command completed"
+        );
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stderr_summary: String = stderr.chars().take(200).collect();
+        tracing::warn!(
+            target: "git.command",
+            args = ?redacted,
+            exit = output.status.code(),
+            duration_ms = dur,
+            stderr_summary = %stderr_summary,
+            "git command failed"
+        );
+    }
+    Ok(output)
+}
+
+fn redact(arg: &OsStr) -> String {
+    let s = arg.to_string_lossy();
+    if let Some(scheme_end) = s.find("://") {
+        let after = &s[scheme_end + 3..];
+        if let Some(at_off) = after.find('@') {
+            let prefix = &s[..scheme_end + 3];
+            let rest = &after[at_off + 1..];
+            return format!("{prefix}***@{rest}");
+        }
+    }
+    s.into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsString;
+
+    #[test]
+    fn redact_strips_basic_userinfo() {
+        assert_eq!(
+            redact(&OsString::from("https://user:pat@github.com/x/y.git")),
+            "https://***@github.com/x/y.git"
+        );
+    }
+
+    #[test]
+    fn redact_passes_clean_urls_through() {
+        assert_eq!(
+            redact(&OsString::from("git@github.com:foo/bar.git")),
+            "git@github.com:foo/bar.git"
+        );
+        assert_eq!(
+            redact(&OsString::from("https://github.com/foo/bar.git")),
+            "https://github.com/foo/bar.git"
+        );
+    }
+
+    #[test]
+    fn redact_passes_non_url_args_through() {
+        assert_eq!(redact(&OsString::from("--prune")), "--prune");
+        assert_eq!(redact(&OsString::from("main")), "main");
+    }
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -16,6 +16,7 @@ use std::ffi::OsStr;
 use std::path::Path;
 
 pub mod cleanup;
+pub(crate) mod command;
 pub mod diff;
 pub mod error;
 mod remote;

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -30,6 +30,13 @@ pub fn clone_repo(url: &str, destination: &Path, shallow: bool) -> Result<()> {
 
     // Pipe stdin to /dev/null so SSH passphrase prompts fail immediately
     // instead of hanging the blocking thread.
+    let redacted_url = redact_url(url);
+    tracing::debug!(
+        target: "git.command",
+        args = ?["clone", "--shallow=", &redacted_url, dest_str],
+        shallow,
+        "spawning git clone"
+    );
     let mut child = std::process::Command::new("git")
         .args(&args)
         .stdin(std::process::Stdio::null())
@@ -80,6 +87,19 @@ pub fn clone_repo(url: &str, destination: &Path, shallow: bool) -> Result<()> {
             }
         }
     }
+}
+
+/// Strip userinfo (`user:token@`) from a URL so credentials don't reach logs.
+fn redact_url(url: &str) -> String {
+    if let Some(scheme_end) = url.find("://") {
+        let after = &url[scheme_end + 3..];
+        if let Some(at_off) = after.find('@') {
+            let prefix = &url[..scheme_end + 3];
+            let rest = &after[at_off + 1..];
+            return format!("{prefix}***@{rest}");
+        }
+    }
+    url.to_string()
 }
 
 /// Extract the owner (first path segment) from a git remote URL.

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -31,10 +31,13 @@ pub fn clone_repo(url: &str, destination: &Path, shallow: bool) -> Result<()> {
     // Pipe stdin to /dev/null so SSH passphrase prompts fail immediately
     // instead of hanging the blocking thread.
     let redacted_url = redact_url(url);
+    let redacted_args: Vec<&str> = args
+        .iter()
+        .map(|a| if *a == url { redacted_url.as_str() } else { *a })
+        .collect();
     tracing::debug!(
         target: "git.command",
-        args = ?["clone", "--shallow=", &redacted_url, dest_str],
-        shallow,
+        args = ?redacted_args,
         "spawning git clone"
     );
     let mut child = std::process::Command::new("git")

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -153,7 +153,13 @@ impl GitWorktree {
         {
             Ok(child) => child,
             Err(e) => {
-                tracing::warn!("git fetch {remote}/{branch} spawn failed: {e}");
+                tracing::warn!(
+                    target: "git.command",
+                    remote = %remote,
+                    branch = %branch,
+                    error = %e,
+                    "git fetch spawn failed"
+                );
                 return Ok(());
             }
         };
@@ -371,10 +377,8 @@ impl GitWorktree {
             .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "Invalid path"))?;
 
         let t = std::time::Instant::now();
-        let output = std::process::Command::new("git")
-            .args(["worktree", "add", path_str, branch])
-            .current_dir(&self.repo_path)
-            .output()?;
+        let output =
+            super::command::run_git(&self.repo_path, ["worktree", "add", path_str, branch])?;
         let add_elapsed = t.elapsed();
 
         if !output.status.success() {
@@ -461,10 +465,7 @@ impl GitWorktree {
 
     /// Prune stale worktree entries whose directories no longer exist on disk.
     pub fn prune_worktrees(&self) -> Result<()> {
-        let output = std::process::Command::new("git")
-            .args(["worktree", "prune"])
-            .current_dir(&self.repo_path)
-            .output()?;
+        let output = super::command::run_git(&self.repo_path, ["worktree", "prune"])?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -527,10 +528,10 @@ impl GitWorktree {
             })
             .unwrap_or(0);
 
-        let output = std::process::Command::new("git")
-            .args(["submodule", "update", "--init", "--recursive"])
-            .current_dir(worktree_path)
-            .output()?;
+        let output = super::command::run_git(
+            worktree_path,
+            ["submodule", "update", "--init", "--recursive"],
+        )?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -640,10 +641,7 @@ impl GitWorktree {
         }
         args.push(path_str);
 
-        let output = std::process::Command::new("git")
-            .args(&args)
-            .current_dir(&self.repo_path)
-            .output()?;
+        let output = super::command::run_git(&self.repo_path, &args)?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
@@ -667,10 +665,7 @@ impl GitWorktree {
             repo = %self.repo_path.display(),
             "delete_branch: invoking `git branch -d`"
         );
-        let output = std::process::Command::new("git")
-            .args(["branch", "-d", branch])
-            .current_dir(&self.repo_path)
-            .output()?;
+        let output = super::command::run_git(&self.repo_path, ["branch", "-d", branch])?;
 
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
@@ -693,10 +688,8 @@ impl GitWorktree {
             }
             // If the branch has unmerged changes, try force delete
             if stderr.contains("not fully merged") {
-                let force_output = std::process::Command::new("git")
-                    .args(["branch", "-D", branch])
-                    .current_dir(&self.repo_path)
-                    .output()?;
+                let force_output =
+                    super::command::run_git(&self.repo_path, ["branch", "-D", branch])?;
 
                 if !force_output.status.success() {
                     let force_stderr = String::from_utf8_lossy(&force_output.stderr);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod cockpit;
 pub mod containers;
 pub mod git;
 pub mod hooks;
+pub mod logging;
 pub mod migrations;
 pub mod process;
 #[cfg(feature = "serve")]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -41,6 +41,65 @@ pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
     "log",
 ];
 
+/// Sub-targets users can tune individually from the settings UI.
+/// Order is the UI ordering. Anything not in this list still works
+/// in the runtime endpoint as a raw filter, but won't have a dropdown.
+pub const KNOWN_SUB_TARGETS: &[&str] = &[
+    "cockpit.acp",
+    "cockpit.acp.stderr",
+    "cockpit.supervisor",
+    "cockpit.event_store",
+    "cockpit.runner",
+    "terminal.ws",
+    "terminal.ws.bytes",
+    "auth.token",
+    "auth.middleware",
+    "auth.rate_limit",
+    "auth.passphrase",
+    "auth.device",
+    "auth.ip",
+    "process.signal",
+    "process.tree",
+    "process.reap",
+    "process.ppid",
+    "update.fetch",
+    "update.cache",
+    "update.parse",
+    "containers.docker",
+    "containers.image",
+    "containers.runtime",
+    "git.command",
+    "web.client",
+    "log.runtime",
+];
+
+/// Compose an EnvFilter directive from a baseline level + per-target overrides.
+/// Used both at startup (when no env var is set) and by the settings write path
+/// when a user updates `[logging]`.
+///
+/// Per-target overrides win over the baseline because EnvFilter is
+/// last-wins-per-target: the override directives are emitted AFTER the roots.
+pub fn build_filter_from_config(
+    default_level: &str,
+    targets: &std::collections::BTreeMap<String, String>,
+) -> Option<String> {
+    let baseline_level = LogLevel::parse(default_level)?;
+    let mut s = LogConfig::filter_for_level(baseline_level);
+    for (target, lvl) in targets {
+        if target.is_empty() {
+            continue;
+        }
+        if LogLevel::parse(lvl).is_none() {
+            continue;
+        }
+        s.push(',');
+        s.push_str(target);
+        s.push('=');
+        s.push_str(lvl);
+    }
+    Some(s)
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogLevel {
     Trace,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -35,6 +35,10 @@ pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
     "git",
     "migrations",
     "web",
+    // `log` is the meta-target prefix for filter-swap audit events
+    // (`log.runtime`). Without this, `log.runtime` would be dropped
+    // under any expanded-level filter that has no global default.
+    "log",
 ];
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -140,6 +140,24 @@ pub fn build_filter_from_config(
     Some(s)
 }
 
+/// Load `[logging]` from `config.toml` and build an EnvFilter directive.
+/// Returns `None` when no config file exists, when it fails to parse, or
+/// when the level value is unrecognised. Callers fall back to
+/// `serve_default_filter()` in that case.
+pub fn load_persisted_filter() -> Option<String> {
+    let config = crate::session::load_config().ok().flatten()?;
+    build_filter_from_config(&config.logging.default_level, &config.logging.targets)
+}
+
+/// Info-baseline filter directive. Used as the universal fallback when
+/// neither env nor config produce one — both `aoe serve` and the TUI
+/// must come up with *some* filter so the subscriber can be installed.
+pub fn serve_default_filter() -> String {
+    LogConfig::serve_default()
+        .filter_string()
+        .expect("serve_default sets a level")
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LogLevel {
     Trace,

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -73,6 +73,46 @@ pub const KNOWN_SUB_TARGETS: &[&str] = &[
     "log.runtime",
 ];
 
+/// Apply a persisted `LoggingConfig` to the running subscriber + persist
+/// runtime_filter so cockpit runners pick it up via the notify watcher.
+/// Both the TUI save path and the web `PATCH /api/settings` path call
+/// this after `save_config`, so settings changes take effect live
+/// without a daemon restart.
+pub fn apply_persisted_config(
+    default_level: &str,
+    targets: &std::collections::BTreeMap<String, String>,
+    app_dir: &std::path::Path,
+) {
+    let Some(filter) = build_filter_from_config(default_level, targets) else {
+        return;
+    };
+    match set_filter(&filter) {
+        Ok(swap) => {
+            tracing::info!(
+                target: "log.runtime",
+                previous = %swap.previous,
+                current = %swap.current,
+                source = "settings",
+                "filter swapped"
+            );
+            persist_runtime_filter(&swap.current, app_dir);
+        }
+        Err(LogFilterError::Unavailable) => {
+            // No reload handle installed (e.g. TUI process). Still persist
+            // so a runner watching the file gets the update.
+            persist_runtime_filter(&filter, app_dir);
+        }
+        Err(e) => {
+            tracing::warn!(
+                target: "log.runtime",
+                error = %e,
+                filter = %filter,
+                "settings-driven filter swap failed"
+            );
+        }
+    }
+}
+
 /// Compose an EnvFilter directive from a baseline level + per-target overrides.
 /// Used both at startup (when no env var is set) and by the settings write path
 /// when a user updates `[logging]`.

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -316,6 +316,105 @@ pub fn set_level(level: LogLevel) -> Result<SwapResult, LogFilterError> {
         .set_level(level)
 }
 
+/// Path of the shared runtime-filter file inside `app_dir`. Daemon writes
+/// here on every successful swap; cockpit runner subprocesses watch it
+/// with `notify` and apply the same filter to their own subscribers.
+pub fn runtime_filter_path(app_dir: &std::path::Path) -> std::path::PathBuf {
+    app_dir.join("runtime_filter")
+}
+
+/// Atomically persist a filter directive to `<app_dir>/runtime_filter`.
+/// Write-and-rename so concurrent readers never see a half-written file.
+/// Owner-only permissions match the other `serve.*` artifacts.
+pub fn persist_runtime_filter(directive: &str, app_dir: &std::path::Path) {
+    if let Err(e) = std::fs::create_dir_all(app_dir) {
+        tracing::warn!(target: "log.runtime", error = %e, "could not create app dir for runtime_filter");
+        return;
+    }
+    let path = runtime_filter_path(app_dir);
+    let tmp = app_dir.join("runtime_filter.tmp");
+    if let Err(e) = std::fs::write(&tmp, directive) {
+        tracing::warn!(target: "log.runtime", error = %e, "could not write runtime_filter.tmp");
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600));
+    }
+    if let Err(e) = std::fs::rename(&tmp, &path) {
+        tracing::warn!(target: "log.runtime", error = %e, "could not rename runtime_filter");
+    }
+}
+
+/// Background task: watch `<app_dir>/runtime_filter` and apply changes
+/// to this process's `FilterController`. Used by the cockpit runner so
+/// the daemon's `aoe log-level` propagates to runners without restart.
+///
+/// notify watches the parent directory (the file may not exist yet);
+/// the task filters events to those touching our target file.
+pub async fn watch_runtime_filter(app_dir: std::path::PathBuf) {
+    use notify::{RecursiveMode, Watcher};
+    use std::sync::mpsc;
+
+    let target = runtime_filter_path(&app_dir);
+
+    let (tx, rx) = mpsc::channel::<notify::Result<notify::Event>>();
+    let mut watcher = match notify::recommended_watcher(move |res| {
+        let _ = tx.send(res);
+    }) {
+        Ok(w) => w,
+        Err(e) => {
+            tracing::warn!(target: "log.runtime", error = %e, "notify init failed; live propagation disabled");
+            return;
+        }
+    };
+    if let Err(e) = watcher.watch(&app_dir, RecursiveMode::NonRecursive) {
+        tracing::warn!(target: "log.runtime", error = %e, dir = %app_dir.display(), "notify watch failed");
+        return;
+    }
+
+    // Apply once at startup if the file is already there.
+    apply_filter_file(&target);
+
+    loop {
+        let evt = match tokio::task::block_in_place(|| rx.recv()) {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        let Ok(evt) = evt else { continue };
+        if evt.paths.iter().any(|p| p == &target) {
+            apply_filter_file(&target);
+        }
+    }
+}
+
+fn apply_filter_file(path: &std::path::Path) {
+    let directive = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let directive = directive.trim();
+    if directive.is_empty() {
+        return;
+    }
+    match set_filter(directive) {
+        Ok(swap) => tracing::info!(
+            target: "log.runtime",
+            previous = %swap.previous,
+            current = %swap.current,
+            source = "file-watch",
+            "runner filter swapped"
+        ),
+        Err(e) => tracing::warn!(
+            target: "log.runtime",
+            error = %e,
+            directive = %directive,
+            "runner filter swap failed"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,475 @@
+//! Centralized logging configuration + runtime filter control.
+//!
+//! Single source of truth for env-var resolution, default-filter
+//! construction, and the reloadable subscriber handle. Both the main
+//! daemon and cockpit runner subprocesses use this module so they
+//! agree on what `AOE_LOG_LEVEL=debug` means.
+//!
+//! The process-global `FilterController` is exposed via free
+//! functions (`set_filter`, `set_level`, `current_filter`). Tracing's
+//! subscriber is already a process-wide singleton; we mirror that
+//! design rather than threading a handle through application state.
+//! `Mutex<Option<Arc<_>>>` (over `OnceLock`) so tests can reset.
+
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+use tracing_subscriber::filter::EnvFilter;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::reload;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Registry;
+
+/// Top-level tracing target roots. The default filter expands a
+/// single level (e.g. "debug") to one directive per root so user-defined
+/// targets like `auth.token`, `process.signal`, `git.command` inherit
+/// the same level.
+pub const DEFAULT_TARGET_ROOTS: &[&str] = &[
+    "agent_of_empires",
+    "cockpit",
+    "terminal",
+    "auth",
+    "process",
+    "update",
+    "containers",
+    "git",
+    "migrations",
+    "web",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogLevel {
+    Trace,
+    Debug,
+    Info,
+    Warn,
+    Error,
+}
+
+impl LogLevel {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "trace" => Some(Self::Trace),
+            "debug" => Some(Self::Debug),
+            "info" => Some(Self::Info),
+            "warn" | "warning" => Some(Self::Warn),
+            "error" => Some(Self::Error),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Trace => "trace",
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Warn => "warn",
+            Self::Error => "error",
+        }
+    }
+}
+
+/// Resolved logging configuration. Pure data; env-touching lives only in
+/// `from_env` so the rest of the module is unit-testable without env hacks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogConfig {
+    pub level: Option<LogLevel>,
+    pub acp_trace: bool,
+    pub terminal_trace: bool,
+}
+
+impl LogConfig {
+    pub fn from_env() -> Self {
+        let level = std::env::var("AOE_LOG_LEVEL")
+            .ok()
+            .and_then(|v| LogLevel::parse(&v))
+            .or_else(|| {
+                if std::env::var("AGENT_OF_EMPIRES_DEBUG").is_ok() {
+                    Some(LogLevel::Debug)
+                } else {
+                    None
+                }
+            });
+        Self {
+            level,
+            acp_trace: std::env::var("AOE_ACP_TRACE").is_ok(),
+            terminal_trace: std::env::var("AOE_TERMINAL_TRACE").is_ok(),
+        }
+    }
+
+    /// Default for foreground `aoe serve` (info level, no overlays).
+    pub fn serve_default() -> Self {
+        Self {
+            level: Some(LogLevel::Info),
+            acp_trace: false,
+            terminal_trace: false,
+        }
+    }
+
+    /// EnvFilter directive string. None when level unset.
+    pub fn filter_string(&self) -> Option<String> {
+        let level = self.level?;
+        let mut s = Self::filter_for_level(level);
+        if self.acp_trace {
+            s.push_str(
+                ",agent_client_protocol=debug,agent_client_protocol::jsonrpc::transport_actor=trace",
+            );
+        }
+        if self.terminal_trace {
+            s.push_str(",terminal=trace");
+        }
+        Some(s)
+    }
+
+    /// Expand a level to one directive per target root.
+    pub fn filter_for_level(level: LogLevel) -> String {
+        let lvl = level.as_str();
+        DEFAULT_TARGET_ROOTS
+            .iter()
+            .map(|t| format!("{t}={lvl}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    }
+}
+
+pub enum SubscriberTarget {
+    File(PathBuf),
+    Stdout,
+}
+
+pub struct InitResult {
+    pub controller: Option<Arc<FilterController>>,
+    pub warning: Option<String>,
+}
+
+pub struct FilterController {
+    inner: reload::Handle<EnvFilter, Registry>,
+    current: Mutex<String>,
+}
+
+impl FilterController {
+    pub fn current(&self) -> String {
+        self.current.lock().unwrap().clone()
+    }
+
+    pub fn set_filter(&self, directive: &str) -> Result<SwapResult, LogFilterError> {
+        let directive = directive.trim();
+        if directive.is_empty() {
+            return Err(LogFilterError::Invalid("empty filter".into()));
+        }
+        // Bare global levels would enable debug for hyper/rustls/tower etc.
+        // Use set_level when you mean "everything we own at this level".
+        if LogLevel::parse(directive).is_some() {
+            return Err(LogFilterError::BareGlobalLevel);
+        }
+        let filter = EnvFilter::builder()
+            .with_regex(false)
+            .parse(directive)
+            .map_err(|e| LogFilterError::Invalid(e.to_string()))?;
+        self.swap(filter, directive.to_string())
+    }
+
+    pub fn set_level(&self, level: LogLevel) -> Result<SwapResult, LogFilterError> {
+        let directive = LogConfig::filter_for_level(level);
+        let filter = EnvFilter::builder()
+            .with_regex(false)
+            .parse(&directive)
+            .map_err(|e| LogFilterError::Invalid(e.to_string()))?;
+        self.swap(filter, directive)
+    }
+
+    fn swap(&self, filter: EnvFilter, directive: String) -> Result<SwapResult, LogFilterError> {
+        let previous = self.current();
+        self.inner
+            .modify(|f| *f = filter)
+            .map_err(|e| LogFilterError::Invalid(e.to_string()))?;
+        *self.current.lock().unwrap() = directive.clone();
+        Ok(SwapResult {
+            previous,
+            current: directive,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SwapResult {
+    pub previous: String,
+    pub current: String,
+}
+
+#[derive(Debug)]
+pub enum LogFilterError {
+    Invalid(String),
+    BareGlobalLevel,
+    Unavailable,
+}
+
+impl std::fmt::Display for LogFilterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Invalid(msg) => write!(f, "invalid filter: {msg}"),
+            Self::BareGlobalLevel => write!(
+                f,
+                "bare global level not accepted in filter mode; use set_level instead"
+            ),
+            Self::Unavailable => write!(f, "log subscriber not initialized in reloadable mode"),
+        }
+    }
+}
+
+impl std::error::Error for LogFilterError {}
+
+pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
+    let parsed = match EnvFilter::builder().with_regex(false).parse(&filter) {
+        Ok(f) => f,
+        Err(e) => {
+            return InitResult {
+                controller: None,
+                warning: Some(format!("invalid initial filter {filter:?}: {e}")),
+            };
+        }
+    };
+    let (reload_layer, handle) = reload::Layer::new(parsed);
+
+    let install_result = match target {
+        SubscriberTarget::File(path) => match open_log_file(&path) {
+            Ok(file) => {
+                let writer = std::sync::Mutex::new(file);
+                let fmt_layer = tracing_subscriber::fmt::layer()
+                    .with_writer(writer)
+                    .with_ansi(false);
+                Registry::default()
+                    .with(reload_layer)
+                    .with(fmt_layer)
+                    .try_init()
+                    .map_err(|e| e.to_string())
+            }
+            Err(e) => Err(format!("open log file {}: {e}", path.display())),
+        },
+        SubscriberTarget::Stdout => {
+            let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false);
+            Registry::default()
+                .with(reload_layer)
+                .with(fmt_layer)
+                .try_init()
+                .map_err(|e| e.to_string())
+        }
+    };
+
+    match install_result {
+        Ok(()) => {
+            let controller = Arc::new(FilterController {
+                inner: handle,
+                current: Mutex::new(filter),
+            });
+            InitResult {
+                controller: Some(controller),
+                warning: None,
+            }
+        }
+        Err(msg) => InitResult {
+            controller: None,
+            warning: Some(msg),
+        },
+    }
+}
+
+fn open_log_file(path: &std::path::Path) -> std::io::Result<std::fs::File> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    let f = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+    }
+    Ok(f)
+}
+
+static CONTROLLER: Mutex<Option<Arc<FilterController>>> = Mutex::new(None);
+
+pub fn install_controller(c: Arc<FilterController>) {
+    *CONTROLLER.lock().unwrap() = Some(c);
+}
+
+pub fn controller() -> Option<Arc<FilterController>> {
+    CONTROLLER.lock().unwrap().clone()
+}
+
+pub fn current_filter() -> Option<String> {
+    controller().map(|c| c.current())
+}
+
+pub fn set_filter(directive: &str) -> Result<SwapResult, LogFilterError> {
+    controller()
+        .ok_or(LogFilterError::Unavailable)?
+        .set_filter(directive)
+}
+
+pub fn set_level(level: LogLevel) -> Result<SwapResult, LogFilterError> {
+    controller()
+        .ok_or(LogFilterError::Unavailable)?
+        .set_level(level)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Env-touching tests must serialize.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn log_level_parse_accepts_known() {
+        assert_eq!(LogLevel::parse("debug"), Some(LogLevel::Debug));
+        assert_eq!(LogLevel::parse("INFO"), Some(LogLevel::Info));
+        assert_eq!(LogLevel::parse("warning"), Some(LogLevel::Warn));
+        assert_eq!(LogLevel::parse("trace "), Some(LogLevel::Trace));
+        assert_eq!(LogLevel::parse("bogus"), None);
+    }
+
+    #[test]
+    fn filter_for_level_expands_all_roots() {
+        let s = LogConfig::filter_for_level(LogLevel::Debug);
+        for root in DEFAULT_TARGET_ROOTS {
+            assert!(
+                s.contains(&format!("{root}=debug")),
+                "missing {root} in {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn filter_string_overlay_acp() {
+        let cfg = LogConfig {
+            level: Some(LogLevel::Info),
+            acp_trace: true,
+            terminal_trace: false,
+        };
+        let s = cfg.filter_string().unwrap();
+        assert!(s.contains("agent_client_protocol=debug"));
+        assert!(s.contains("transport_actor=trace"));
+    }
+
+    #[test]
+    fn filter_string_overlay_terminal() {
+        let cfg = LogConfig {
+            level: Some(LogLevel::Info),
+            acp_trace: false,
+            terminal_trace: true,
+        };
+        let s = cfg.filter_string().unwrap();
+        assert!(s.ends_with(",terminal=trace"));
+    }
+
+    #[test]
+    fn filter_string_none_when_level_unset() {
+        let cfg = LogConfig {
+            level: None,
+            acp_trace: false,
+            terminal_trace: false,
+        };
+        assert!(cfg.filter_string().is_none());
+    }
+
+    #[test]
+    fn from_env_no_vars() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AOE_LOG_LEVEL");
+        std::env::remove_var("AGENT_OF_EMPIRES_DEBUG");
+        std::env::remove_var("AOE_ACP_TRACE");
+        std::env::remove_var("AOE_TERMINAL_TRACE");
+        let cfg = LogConfig::from_env();
+        assert_eq!(cfg.level, None);
+        assert!(!cfg.acp_trace);
+        assert!(!cfg.terminal_trace);
+    }
+
+    #[test]
+    fn from_env_aoe_log_level() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::set_var("AOE_LOG_LEVEL", "trace");
+        std::env::remove_var("AGENT_OF_EMPIRES_DEBUG");
+        let cfg = LogConfig::from_env();
+        std::env::remove_var("AOE_LOG_LEVEL");
+        assert_eq!(cfg.level, Some(LogLevel::Trace));
+    }
+
+    #[test]
+    fn from_env_legacy_debug_flag() {
+        let _g = ENV_LOCK.lock().unwrap();
+        std::env::remove_var("AOE_LOG_LEVEL");
+        std::env::set_var("AGENT_OF_EMPIRES_DEBUG", "1");
+        let cfg = LogConfig::from_env();
+        std::env::remove_var("AGENT_OF_EMPIRES_DEBUG");
+        assert_eq!(cfg.level, Some(LogLevel::Debug));
+    }
+
+    fn with_test_controller<F>(initial: &str, f: F)
+    where
+        F: FnOnce(&FilterController),
+    {
+        let filter = EnvFilter::builder()
+            .with_regex(false)
+            .parse(initial)
+            .unwrap();
+        let (layer, handle) = reload::Layer::<EnvFilter, Registry>::new(filter);
+        let subscriber = Registry::default().with(layer);
+        let c = FilterController {
+            inner: handle,
+            current: Mutex::new(initial.to_string()),
+        };
+        tracing::subscriber::with_default(subscriber, || f(&c));
+    }
+
+    #[test]
+    fn controller_swap_returns_previous() {
+        with_test_controller("info", |c| {
+            let r = c.set_level(LogLevel::Debug).unwrap();
+            assert_eq!(r.previous, "info");
+            assert!(r.current.contains("agent_of_empires=debug"));
+            assert_eq!(c.current(), r.current);
+        });
+    }
+
+    #[test]
+    fn controller_rejects_bare_global_level() {
+        with_test_controller("info", |c| {
+            let err = c.set_filter("debug").unwrap_err();
+            assert!(matches!(err, LogFilterError::BareGlobalLevel));
+        });
+    }
+
+    #[test]
+    fn controller_accepts_targeted_filter() {
+        with_test_controller("info", |c| {
+            c.set_filter("cockpit.acp=trace,info").unwrap();
+            assert_eq!(c.current(), "cockpit.acp=trace,info");
+        });
+    }
+
+    #[test]
+    fn controller_rejects_empty_filter() {
+        with_test_controller("info", |c| {
+            assert!(matches!(
+                c.set_filter("   ").unwrap_err(),
+                LogFilterError::Invalid(_)
+            ));
+        });
+    }
+
+    #[test]
+    fn controller_rejects_invalid_level() {
+        with_test_controller("info", |c| {
+            // Unknown level name; EnvFilter rejects.
+            assert!(matches!(
+                c.set_filter("cockpit=notalevel").unwrap_err(),
+                LogFilterError::Invalid(_)
+            ));
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 //! Agent of Empires - Terminal session manager for AI coding agents
 
 use agent_of_empires::cli::{self, Cli, Commands};
+use agent_of_empires::logging::{self, LogConfig, SubscriberTarget};
 use agent_of_empires::migrations;
 use agent_of_empires::tui;
 use anyhow::Result;
@@ -31,112 +32,65 @@ async fn main() -> Result<()> {
     let debug_namespace_drift = agent_of_empires::session::debug_namespace_drift();
 
     let mut debug_log_warning: Option<String> = None;
-    // File-logging gate. Two env vars are accepted:
+    // Logging gate. Env-var matrix lives in `LogConfig::from_env`:
+    //   AOE_LOG_LEVEL=trace|debug|info|warn|error   (preferred)
+    //   AGENT_OF_EMPIRES_DEBUG=1                    (legacy alias for debug)
+    //   AOE_ACP_TRACE=1                             (raw JSON-RPC firehose)
+    //   AOE_TERMINAL_TRACE=1                        (per-byte WS firehose)
     //
-    //   AOE_LOG_LEVEL=trace|debug|info|warn|error  (preferred)
-    //   AGENT_OF_EMPIRES_DEBUG=1                   (legacy alias for
-    //                                               AOE_LOG_LEVEL=debug)
-    //
-    // Either var on its own creates ~/.agent-of-empires-dev/debug.log
-    // (release: ~/.agent-of-empires/debug.log) and configures
-    // tracing-subscriber to write to it. The level is applied to
-    // `agent_of_empires=*` and `cockpit=*` together; the ACP
-    // framework's own tracing is OFF by default at every level so
-    // even AOE_LOG_LEVEL=trace stays focused on our code rather
-    // than dumping every JSON-RPC frame.
-    //
-    //   AOE_ACP_TRACE=1                            (orthogonal opt-in
-    //                                               for raw JSON-RPC
-    //                                               firehose)
-    //
-    // Adds `agent_client_protocol=debug` plus the JSON-RPC
-    // transport_actor at TRACE so every raw inbound/outbound frame
-    // lands in the log. Useful for chasing schema mismatches against
-    // newer adapter versions, but extremely chatty.
-    let log_level: Option<&'static str> = std::env::var("AOE_LOG_LEVEL")
-        .ok()
-        .and_then(|v| match v.to_ascii_lowercase().as_str() {
-            "trace" => Some("trace"),
-            "debug" => Some("debug"),
-            "info" => Some("info"),
-            "warn" | "warning" => Some("warn"),
-            "error" => Some("error"),
-            _ => None,
-        })
-        .or_else(|| {
-            if std::env::var("AGENT_OF_EMPIRES_DEBUG").is_ok() {
-                Some("debug")
-            } else {
-                None
-            }
-        });
-    if let Some(level) = log_level {
-        // Log to file to avoid corrupting the TUI on stderr.
+    // Level set → file logging to ~/.agent-of-empires/debug.log.
+    // Else `aoe serve` → stdout (captured into serve.log by the daemon
+    // redirect) so the TUI Starting-screen log tail isn't empty during
+    // cert provisioning.
+    // Else no subscriber installed.
+    let env_cfg = LogConfig::from_env();
+    let (init, log_path_for_msg) = if let Some(filter) = env_cfg.filter_string() {
         let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
-        let log_file = log_path
-            .as_ref()
-            .ok()
-            .and_then(|p| std::fs::File::create(p).ok());
-        if let Some(file) = log_file {
-            // Cockpit code uses custom log targets like `cockpit.acp`,
-            // `cockpit.supervisor`, `cockpit.acp.stderr`, etc., which
-            // don't match the `agent_of_empires` crate prefix. The web
-            // terminal WS handler uses `terminal.ws` and the per-byte
-            // firehose uses `terminal.ws.bytes`. List them explicitly so
-            // debug.log captures the full picture when chasing a crashed
-            // agent. Add new top-level targets here when introducing them.
-            let mut filter = format!("agent_of_empires={level},cockpit={level},terminal={level}");
-            if std::env::var("AOE_ACP_TRACE").is_ok() {
-                filter.push_str(
-                    ",agent_client_protocol=debug,\
-                     agent_client_protocol::jsonrpc::transport_actor=trace",
-                );
+        match log_path.as_ref() {
+            Ok(path) => {
+                let res = logging::init_subscriber(SubscriberTarget::File(path.clone()), filter);
+                (res, Some(path.clone()))
             }
-            // Per-WS-message byte firehose for the terminal relay, hidden
-            // behind its own opt-in. The bytes target (`terminal.ws.bytes`)
-            // logs at trace, so we only need to bump the `terminal` target
-            // up to trace when the user explicitly wants the firehose;
-            // a busy claude session emits thousands of frames/min and
-            // would drown the lifecycle signal otherwise. The duplicate
-            // directive overrides the baseline `terminal={level}` above
-            // (EnvFilter is last-wins per target).
-            if std::env::var("AOE_TERMINAL_TRACE").is_ok() {
-                filter.push_str(",terminal=trace");
-            }
-            tracing_subscriber::fmt()
-                .with_env_filter(filter)
-                .with_writer(std::sync::Mutex::new(file))
-                .with_ansi(false)
-                .init();
-            tracing::info!(
-                "Debug logging at {} to {}",
-                level,
-                log_path.unwrap().display()
-            );
-        } else {
-            debug_log_warning = Some(
-                "Log level requested but debug log file could not be created. File logging is disabled.".to_string(),
-            );
+            Err(_) => (
+                logging::InitResult {
+                    controller: None,
+                    warning: Some(
+                        "Log level requested but app dir unavailable; file logging disabled."
+                            .to_string(),
+                    ),
+                },
+                None,
+            ),
         }
     } else if is_serve_command(&cli) {
-        // `aoe serve` writes info-level tracing to stdout so the daemon
-        // path (which redirects child stdout/stderr into serve.log) can
-        // capture progress for the TUI's Starting-screen log tail.
-        // Without this, serve.log would be empty and the user would
-        // stare at "(waiting for daemon output...)" for 30-60s during
-        // cert provisioning. Foreground `aoe serve` just prints to
-        // the user's terminal; that's fine and matches other CLIs.
-        //
-        // `terminal=info` mirrors the file logger's target list so a
-        // default serve (no AOE_LOG_LEVEL set) still captures
-        // `terminal.ws` warn/error lines in serve.log. Without this,
-        // dead-pane warnings, idle-reaper firings, and ws send/recv
-        // errors would be silently dropped in production.
-        tracing_subscriber::fmt()
-            .with_env_filter("agent_of_empires=info,cockpit=info,terminal=info")
-            .with_ansi(false)
-            .try_init()
-            .ok();
+        let filter = LogConfig::serve_default()
+            .filter_string()
+            .expect("serve_default sets a level");
+        (
+            logging::init_subscriber(SubscriberTarget::Stdout, filter),
+            None,
+        )
+    } else {
+        (
+            logging::InitResult {
+                controller: None,
+                warning: None,
+            },
+            None,
+        )
+    };
+    if let Some(c) = init.controller.clone() {
+        logging::install_controller(c);
+    }
+    if let Some(msg) = init.warning {
+        debug_log_warning = Some(msg);
+    }
+    if let (Some(_), Some(path), Some(lvl)) = (
+        init.controller.as_ref(),
+        log_path_for_msg.as_ref(),
+        env_cfg.level,
+    ) {
+        tracing::info!("Debug logging at {} to {}", lvl.as_str(), path.display());
     }
 
     // CLI invocations get the dev-namespace drift warning on stderr right

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
     // Else no subscriber installed.
     let env_cfg = LogConfig::from_env();
     let (init, log_path_for_msg) = if let Some(filter) = env_cfg.filter_string() {
+        // Env-var wins. Writes file logs.
         let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
         match log_path.as_ref() {
             Ok(path) => {
@@ -63,11 +64,22 @@ async fn main() -> Result<()> {
             ),
         }
     } else if is_serve_command(&cli) {
-        let filter = LogConfig::serve_default()
-            .filter_string()
-            .expect("serve_default sets a level");
+        // Persistent settings (config.toml [logging]) drive the serve filter
+        // when no env var is set. Falls back to serve_default if config not
+        // readable for any reason — daemon must always come up.
+        let cfg_filter = agent_of_empires::session::load_config()
+            .ok()
+            .flatten()
+            .and_then(|c| {
+                logging::build_filter_from_config(&c.logging.default_level, &c.logging.targets)
+            })
+            .unwrap_or_else(|| {
+                LogConfig::serve_default()
+                    .filter_string()
+                    .expect("serve_default sets a level")
+            });
         (
-            logging::init_subscriber(SubscriberTarget::Stdout, filter),
+            logging::init_subscriber(SubscriberTarget::Stdout, cfg_filter),
             None,
         )
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,14 +38,21 @@ async fn main() -> Result<()> {
     //   AOE_ACP_TRACE=1                             (raw JSON-RPC firehose)
     //   AOE_TERMINAL_TRACE=1                        (per-byte WS firehose)
     //
-    // Level set → file logging to ~/.agent-of-empires/debug.log.
-    // Else `aoe serve` → stdout (captured into serve.log by the daemon
-    // redirect) so the TUI Starting-screen log tail isn't empty during
-    // cert provisioning.
-    // Else no subscriber installed.
+    // Sinks by process:
+    //   env set, any aoe → debug.log (file)
+    //   aoe serve, no env → stdout (captured into serve.log by the daemon
+    //     redirect; foreground serve writes to the user's terminal)
+    //   TUI (no subcommand), no env → debug.log (stderr would garble the
+    //     alt-screen, so we always write to file)
+    //   other one-shot CLI, no env → no subscriber (short-lived; opt in
+    //     via AOE_LOG_LEVEL if you need a trace of one)
     let env_cfg = LogConfig::from_env();
-    let (init, log_path_for_msg) = if let Some(filter) = env_cfg.filter_string() {
-        // Env-var wins. Writes file logs.
+    let env_filter = env_cfg.filter_string();
+    let is_serve = is_serve_command(&cli);
+    let is_tui = cli.command.is_none();
+    let (init, log_path_for_msg) = if let Some(filter) = env_filter {
+        // Env-var wins for every aoe invocation. Writes file logs so a
+        // foreground TUI isn't garbled.
         let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
         match log_path.as_ref() {
             Ok(path) => {
@@ -63,25 +70,35 @@ async fn main() -> Result<()> {
                 None,
             ),
         }
-    } else if is_serve_command(&cli) {
-        // Persistent settings (config.toml [logging]) drive the serve filter
-        // when no env var is set. Falls back to serve_default if config not
-        // readable for any reason — daemon must always come up.
-        let cfg_filter = agent_of_empires::session::load_config()
-            .ok()
-            .flatten()
-            .and_then(|c| {
-                logging::build_filter_from_config(&c.logging.default_level, &c.logging.targets)
-            })
-            .unwrap_or_else(|| {
-                LogConfig::serve_default()
-                    .filter_string()
-                    .expect("serve_default sets a level")
-            });
+    } else if is_serve {
+        // Persistent settings (config.toml [logging]) drive the filter when
+        // no env var is set. Falls back to info baseline if the config can't
+        // be read — daemon must always come up.
+        let filter = logging::load_persisted_filter().unwrap_or_else(logging::serve_default_filter);
         (
-            logging::init_subscriber(SubscriberTarget::Stdout, cfg_filter),
+            logging::init_subscriber(SubscriberTarget::Stdout, filter),
             None,
         )
+    } else if is_tui {
+        // Same filter source as `aoe serve`, but sink is the shared
+        // debug.log because ratatui owns the alt-screen and a stderr
+        // subscriber would corrupt the UI. Daemon + runners + TUI all
+        // append to the same file so a single tail covers a session.
+        let filter = logging::load_persisted_filter().unwrap_or_else(logging::serve_default_filter);
+        let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
+        match log_path.as_ref() {
+            Ok(path) => {
+                let res = logging::init_subscriber(SubscriberTarget::File(path.clone()), filter);
+                (res, Some(path.clone()))
+            }
+            Err(_) => (
+                logging::InitResult {
+                    controller: None,
+                    warning: None,
+                },
+                None,
+            ),
+        }
     } else {
         (
             logging::InitResult {

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,8 @@ async fn main() -> Result<()> {
         }
         Some(Commands::Agents) => return cli::agents::run(),
         Some(Commands::Logs(args)) => return cli::logs::run(args).await,
+        #[cfg(feature = "serve")]
+        Some(Commands::LogLevel(args)) => return cli::log_level::run(args).await,
         Some(Commands::Sounds { command }) => return cli::sounds::run(command).await,
         Some(Commands::Theme { command }) => {
             use cli::theme::ThemeCommands;

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -78,12 +78,22 @@ pub fn run_migrations() -> Result<()> {
 
     for migration in MIGRATIONS {
         if migration.version > current {
+            let start = std::time::Instant::now();
             info!(
-                "Running migration v{:03}: {}",
-                migration.version, migration.name
+                target: "migrations",
+                version = migration.version,
+                name = migration.name,
+                "running migration"
             );
             (migration.run)()?;
             set_version(migration.version)?;
+            info!(
+                target: "migrations",
+                version = migration.version,
+                name = migration.name,
+                duration_ms = start.elapsed().as_millis() as u64,
+                "migration completed"
+            );
         }
     }
 

--- a/src/process/mod.rs
+++ b/src/process/mod.rs
@@ -9,8 +9,6 @@ use nix::errno::Errno;
 use nix::sys::signal::{kill, Signal};
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 use nix::unistd::Pid;
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-use tracing::debug;
 
 #[cfg(target_os = "linux")]
 mod linux;
@@ -80,9 +78,14 @@ pub fn kill_process_tree(pid: u32) {
 /// graceful shutdown, then SIGKILL anything still alive.
 #[cfg(any(target_os = "linux", target_os = "macos"))]
 fn kill_with_fallback(pids: &[u32]) {
-    debug!(descendants = ?pids, "Killing process tree");
+    tracing::debug!(
+        target: "process.tree",
+        descendants = ?pids,
+        "killing process tree"
+    );
 
     for &p in pids.iter().rev() {
+        tracing::debug!(target: "process.signal", pid = p, signal = "SIGTERM", "sending signal");
         let _ = kill(Pid::from_raw(p as i32), Signal::SIGTERM);
     }
 
@@ -90,7 +93,12 @@ fn kill_with_fallback(pids: &[u32]) {
 
     for &p in pids.iter().rev() {
         if process_exists(p) {
-            debug!(pid = p, "Process survived SIGTERM, sending SIGKILL");
+            tracing::warn!(
+                target: "process.reap",
+                pid = p,
+                "pid survived SIGTERM after 100ms; sending SIGKILL"
+            );
+            tracing::info!(target: "process.signal", pid = p, signal = "SIGKILL", "sending signal");
             let _ = kill(Pid::from_raw(p as i32), Signal::SIGKILL);
         }
     }
@@ -145,11 +153,22 @@ fn signal_process_tree(pid: u32, signal: Signal) {
     #[cfg(target_os = "macos")]
     let pids = macos::collect_pid_tree(pid);
 
-    debug!(descendants = ?pids, ?signal, "Signaling process tree");
+    tracing::debug!(
+        target: "process.tree",
+        descendants = ?pids,
+        ?signal,
+        "signaling process tree"
+    );
     for &p in pids.iter().rev() {
         if let Err(e) = kill(Pid::from_raw(p as i32), signal) {
             if e != Errno::ESRCH {
-                debug!(pid = p, ?signal, error = %e, "signal_process_tree: kill failed");
+                tracing::debug!(
+                    target: "process.signal",
+                    pid = p,
+                    ?signal,
+                    error = %e,
+                    "kill failed"
+                );
             }
         }
     }

--- a/src/server/api/client_log.rs
+++ b/src/server/api/client_log.rs
@@ -1,0 +1,179 @@
+//! Browser-side log relay.
+//!
+//! POST /api/client-log accepts a batch of structured entries and
+//! re-emits them through `tracing` under target `web.client`, with
+//! the client-side module name preserved as the `client_target` field.
+//!
+//! Caps and truncation are enforced server-side because the frontend
+//! throttle is best-effort: a broken or malicious client can POST
+//! directly. We also reject the batch outright if it's too large.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::Deserialize;
+
+use super::AppState;
+
+const MAX_ENTRIES: usize = 50;
+const MAX_MESSAGE: usize = 4096;
+const MAX_STACK: usize = 16384;
+const MAX_PATH: usize = 512;
+const MAX_USER_AGENT: usize = 512;
+const MAX_TARGET: usize = 64;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClientLogEntry {
+    pub level: String,
+    pub message: String,
+    pub stack: Option<String>,
+    #[serde(rename = "componentStack")]
+    pub component_stack: Option<String>,
+    pub target: Option<String>,
+    #[serde(rename = "sessionId")]
+    pub session_id: Option<String>,
+    pub path: String,
+    #[serde(rename = "userAgent")]
+    pub user_agent: String,
+    pub ts: i64,
+    pub dropped: Option<u64>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ClientLogBatch {
+    pub entries: Vec<ClientLogEntry>,
+}
+
+pub async fn post_client_log(
+    State(_state): State<Arc<AppState>>,
+    Json(batch): Json<ClientLogBatch>,
+) -> Result<StatusCode, (StatusCode, String)> {
+    if batch.entries.len() > MAX_ENTRIES {
+        return Err((
+            StatusCode::PAYLOAD_TOO_LARGE,
+            format!("max {MAX_ENTRIES} entries per batch"),
+        ));
+    }
+    for entry in batch.entries {
+        emit_event(entry);
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        let mut end = max;
+        while !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        let mut out = s[..end].to_string();
+        out.push('…');
+        out
+    }
+}
+
+fn sanitize_target(s: Option<&str>) -> String {
+    let raw = s.unwrap_or("default");
+    raw.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-' | ':'))
+        .take(MAX_TARGET)
+        .collect()
+}
+
+fn emit_event(e: ClientLogEntry) {
+    let message = truncate(&e.message, MAX_MESSAGE);
+    let stack = e.stack.as_deref().map(|s| truncate(s, MAX_STACK));
+    let component_stack = e.component_stack.as_deref().map(|s| truncate(s, MAX_STACK));
+    let client_target = sanitize_target(e.target.as_deref());
+    let path = truncate(&e.path, MAX_PATH);
+    let ua = truncate(&e.user_agent, MAX_USER_AGENT);
+    let session = e.session_id.as_deref().map(|s| truncate(s, 128));
+    let dropped = e.dropped;
+    let ts = e.ts;
+
+    // Tracing macros require a static target; we use a fixed
+    // "web.client" and carry the dynamic client module name as a
+    // field. EnvFilter still scopes by `web.client` and downstream
+    // filters can match the `client_target` field.
+    match e.level.as_str() {
+        "error" => tracing::error!(
+            target: "web.client",
+            client_target = %client_target,
+            path = %path,
+            ua = %ua,
+            session = ?session,
+            stack = ?stack,
+            component_stack = ?component_stack,
+            ts,
+            dropped = ?dropped,
+            "{message}"
+        ),
+        "warn" => tracing::warn!(
+            target: "web.client",
+            client_target = %client_target,
+            path = %path,
+            ua = %ua,
+            session = ?session,
+            stack = ?stack,
+            component_stack = ?component_stack,
+            ts,
+            dropped = ?dropped,
+            "{message}"
+        ),
+        "info" => tracing::info!(
+            target: "web.client",
+            client_target = %client_target,
+            path = %path,
+            ua = %ua,
+            session = ?session,
+            ts,
+            "{message}"
+        ),
+        _ => tracing::debug!(
+            target: "web.client",
+            client_target = %client_target,
+            path = %path,
+            ua = %ua,
+            session = ?session,
+            ts,
+            "{message}"
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate("hello", 100), "hello");
+    }
+
+    #[test]
+    fn truncate_long_string_adds_ellipsis() {
+        let s = "a".repeat(50);
+        let t = truncate(&s, 10);
+        assert!(t.starts_with("aaaaaaaaaa"));
+        assert!(t.ends_with("…"));
+    }
+
+    #[test]
+    fn sanitize_target_strips_special_chars() {
+        assert_eq!(sanitize_target(Some("ok.module-1")), "ok.module-1");
+        assert_eq!(sanitize_target(Some("bad<script>")), "badscript");
+        assert_eq!(sanitize_target(None), "default");
+    }
+
+    #[test]
+    fn sanitize_target_caps_length() {
+        let raw = "a".repeat(200);
+        assert_eq!(sanitize_target(Some(&raw)).len(), MAX_TARGET);
+    }
+}

--- a/src/server/api/log_level.rs
+++ b/src/server/api/log_level.rs
@@ -50,9 +50,12 @@ pub async fn get_log_level(State(_state): State<Arc<AppState>>) -> Json<LogLevel
 }
 
 pub async fn patch_log_level(
-    State(_state): State<Arc<AppState>>,
+    State(state): State<Arc<AppState>>,
     Json(req): Json<PatchRequest>,
 ) -> Result<Json<LogLevelResponse>, (StatusCode, String)> {
+    if state.read_only {
+        return Err((StatusCode::FORBIDDEN, "Server is in read-only mode".into()));
+    }
     let result = match (req.level.as_deref(), req.filter.as_deref()) {
         (Some(_), Some(_)) => {
             return Err((

--- a/src/server/api/log_level.rs
+++ b/src/server/api/log_level.rs
@@ -1,0 +1,108 @@
+//! REST handlers for runtime log-level control.
+//!
+//! Two endpoints under `/api/log-level`:
+//!   - GET → current filter directive, reload availability
+//!   - PATCH → swap filter via `{level}` (expanded to known roots) or
+//!     `{filter}` (raw EnvFilter syntax with regex disabled)
+//!
+//! Backed by the process-global `FilterController` in `crate::logging`,
+//! not `AppState`. Same module is reused by the runner subprocess so
+//! a future runner-side IPC can swap filters with identical semantics.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+
+use crate::logging::{self, LogFilterError, LogLevel};
+
+use super::AppState;
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PatchRequest {
+    pub level: Option<String>,
+    pub filter: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct LogLevelResponse {
+    pub previous: String,
+    pub current: String,
+    pub ephemeral: bool,
+}
+
+#[derive(Serialize)]
+pub struct LogLevelStatus {
+    pub current: Option<String>,
+    pub reloadable: bool,
+    pub ephemeral: bool,
+}
+
+pub async fn get_log_level(State(_state): State<Arc<AppState>>) -> Json<LogLevelStatus> {
+    Json(LogLevelStatus {
+        current: logging::current_filter(),
+        reloadable: logging::controller().is_some(),
+        ephemeral: true,
+    })
+}
+
+pub async fn patch_log_level(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<PatchRequest>,
+) -> Result<Json<LogLevelResponse>, (StatusCode, String)> {
+    let result = match (req.level.as_deref(), req.filter.as_deref()) {
+        (Some(_), Some(_)) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "specify exactly one of {\"level\", \"filter\"}".into(),
+            ));
+        }
+        (None, None) => {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                "missing field; specify {\"level\"} or {\"filter\"}".into(),
+            ));
+        }
+        (Some(level), None) => {
+            let parsed = LogLevel::parse(level).ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("unknown level {level:?}; expected trace|debug|info|warn|error"),
+                )
+            })?;
+            logging::set_level(parsed)
+        }
+        (None, Some(filter)) => logging::set_filter(filter),
+    };
+
+    match result {
+        Ok(swap) => {
+            tracing::info!(
+                target: "log.runtime",
+                previous = %swap.previous,
+                current = %swap.current,
+                source = "rest",
+                "filter swapped"
+            );
+            Ok(Json(LogLevelResponse {
+                previous: swap.previous,
+                current: swap.current,
+                ephemeral: true,
+            }))
+        }
+        Err(LogFilterError::Unavailable) => Err((
+            StatusCode::SERVICE_UNAVAILABLE,
+            "log subscriber not initialized in reloadable mode".into(),
+        )),
+        Err(LogFilterError::BareGlobalLevel) => Err((
+            StatusCode::BAD_REQUEST,
+            "bare global level not accepted in filter mode; use {\"level\": ...} instead".into(),
+        )),
+        Err(LogFilterError::Invalid(msg)) => {
+            Err((StatusCode::BAD_REQUEST, format!("invalid filter: {msg}")))
+        }
+    }
+}

--- a/src/server/api/log_level.rs
+++ b/src/server/api/log_level.rs
@@ -87,6 +87,9 @@ pub async fn patch_log_level(
                 source = "rest",
                 "filter swapped"
             );
+            if let Ok(app_dir) = crate::session::get_app_dir() {
+                logging::persist_runtime_filter(&swap.current, &app_dir);
+            }
             Ok(Json(LogLevelResponse {
                 previous: swap.previous,
                 current: swap.current,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -13,6 +13,7 @@ pub(super) use super::AppState;
 #[cfg(feature = "serve")]
 mod cockpit;
 mod git;
+mod log_level;
 mod projects;
 mod sessions;
 mod system;
@@ -25,6 +26,7 @@ pub use cockpit::{
 };
 
 pub use git::{clone_repo, list_branches};
+pub use log_level::{get_log_level, patch_log_level};
 pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -66,6 +66,10 @@ pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
     // (notifications_enabled, notify_on_waiting, notify_on_idle, notify_on_error).
     // No shell commands, no binary paths, no RCE surface.
     "web",
+    // logging: persistent tracing filter (default_level + per-target map).
+    // No shell commands, no binary paths. Values are validated against the
+    // EnvFilter parser before being written back to disk.
+    "logging",
 ];
 
 pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
@@ -174,6 +178,9 @@ mod tests {
             // (notifications_enabled, notify_on_waiting, notify_on_idle,
             // notify_on_error). No shell commands, no binary paths.
             "web",
+            // logging: persistent tracing filter. EnvFilter parser
+            // validates every value before save_config writes it back.
+            "logging",
         ];
         assert_eq!(
             ALLOWED_SETTINGS_SECTIONS.len(),

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -11,6 +11,8 @@
 pub(super) use super::AppState;
 
 #[cfg(feature = "serve")]
+mod client_log;
+#[cfg(feature = "serve")]
 mod cockpit;
 mod git;
 mod log_level;
@@ -25,6 +27,8 @@ pub use cockpit::{
     shutdown_cockpit, spawn_cockpit,
 };
 
+#[cfg(feature = "serve")]
+pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};
 pub use log_level::{get_log_level, patch_log_level};
 pub use projects::{create_project, delete_project, list_projects};

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -135,34 +135,13 @@ pub async fn update_settings(
         Ok(Ok(config)) => {
             // Settings touched [logging]? Apply the new filter live to
             // the daemon + persist runtime_filter so cockpit runners pick
-            // it up via the notify watcher. Without this, settings edits
-            // would only take effect after `aoe serve --stop` + restart.
-            if let Some(filter) = crate::logging::build_filter_from_config(
-                &config.logging.default_level,
-                &config.logging.targets,
-            ) {
-                match crate::logging::set_filter(&filter) {
-                    Ok(swap) => {
-                        tracing::info!(
-                            target: "log.runtime",
-                            previous = %swap.previous,
-                            current = %swap.current,
-                            source = "settings",
-                            "filter swapped"
-                        );
-                        if let Ok(app_dir) = crate::session::get_app_dir() {
-                            crate::logging::persist_runtime_filter(&swap.current, &app_dir);
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            target: "log.runtime",
-                            error = %e,
-                            filter = %filter,
-                            "settings-driven filter swap failed"
-                        );
-                    }
-                }
+            // it up via the notify watcher.
+            if let Ok(app_dir) = crate::session::get_app_dir() {
+                crate::logging::apply_persisted_config(
+                    &config.logging.default_level,
+                    &config.logging.targets,
+                    &app_dir,
+                );
             }
             match serde_json::to_value(&config) {
                 Ok(val) => (StatusCode::OK, Json(val)).into_response(),

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -132,17 +132,50 @@ pub async fn update_settings(
     .await;
 
     match result {
-        Ok(Ok(config)) => match serde_json::to_value(&config) {
-            Ok(val) => (StatusCode::OK, Json(val)).into_response(),
-            Err(e) => {
-                tracing::error!("Settings serialization failed: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(serde_json::json!({"error": "serialize_failed", "message": "Failed to serialize settings"})),
-                )
-                    .into_response()
+        Ok(Ok(config)) => {
+            // Settings touched [logging]? Apply the new filter live to
+            // the daemon + persist runtime_filter so cockpit runners pick
+            // it up via the notify watcher. Without this, settings edits
+            // would only take effect after `aoe serve --stop` + restart.
+            if let Some(filter) = crate::logging::build_filter_from_config(
+                &config.logging.default_level,
+                &config.logging.targets,
+            ) {
+                match crate::logging::set_filter(&filter) {
+                    Ok(swap) => {
+                        tracing::info!(
+                            target: "log.runtime",
+                            previous = %swap.previous,
+                            current = %swap.current,
+                            source = "settings",
+                            "filter swapped"
+                        );
+                        if let Ok(app_dir) = crate::session::get_app_dir() {
+                            crate::logging::persist_runtime_filter(&swap.current, &app_dir);
+                        }
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            target: "log.runtime",
+                            error = %e,
+                            filter = %filter,
+                            "settings-driven filter swap failed"
+                        );
+                    }
+                }
             }
-        },
+            match serde_json::to_value(&config) {
+                Ok(val) => (StatusCode::OK, Json(val)).into_response(),
+                Err(e) => {
+                    tracing::error!("Settings serialization failed: {}", e);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": "serialize_failed", "message": "Failed to serialize settings"})),
+                    )
+                        .into_response()
+                }
+            }
+        }
         Ok(Err(e)) => {
             tracing::warn!("Settings update failed: {}", e);
             (

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -700,17 +700,26 @@ pub async fn get_profile_settings(
         )
             .into_response();
     }
-    let result =
-        tokio::task::spawn_blocking(move || crate::session::load_profile_config(&name)).await;
+    let result = tokio::task::spawn_blocking(move || {
+        let profile = crate::session::load_profile_config(&name)?;
+        let global = crate::session::Config::load_or_warn();
+        let mut val = serde_json::to_value(&profile)?;
+        // The `logging` section lives on global Config (no profile
+        // override surface yet). Splice it into the response so the
+        // settings UI can render its current values from a single
+        // GET — without this the dropdowns would reset on every page
+        // load even after a successful PATCH.
+        if let Some(obj) = val.as_object_mut() {
+            obj.insert(
+                "logging".to_string(),
+                serde_json::to_value(&global.logging)?,
+            );
+        }
+        Ok::<_, anyhow::Error>(val)
+    })
+    .await;
     match result {
-        Ok(Ok(config)) => match serde_json::to_value(&config) {
-            Ok(val) => (StatusCode::OK, Json(val)).into_response(),
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "serialize_failed", "message": e.to_string()})),
-            )
-                .into_response(),
-        },
+        Ok(Ok(val)) => (StatusCode::OK, Json(val)).into_response(),
         Ok(Err(e)) => (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({"error": "load_failed", "message": e.to_string()})),
@@ -762,6 +771,43 @@ pub async fn update_profile_settings(
     }
 
     let result = tokio::task::spawn_blocking(move || {
+        // The `logging` section is process-global (no profile overrides
+        // for v1), so peel it off the patch and write it into the
+        // global Config. Everything else stays a per-profile override.
+        let mut body = body;
+        let logging_patch = body.as_object_mut().and_then(|obj| obj.remove("logging"));
+        if let Some(patch) = logging_patch {
+            let global = crate::session::Config::load_or_warn();
+            let mut current = serde_json::to_value(&global)?;
+            if let Some(current_obj) = current.as_object_mut() {
+                match current_obj.get_mut("logging") {
+                    Some(existing) => {
+                        if let (Some(existing_obj), Some(new_obj)) =
+                            (existing.as_object_mut(), patch.as_object())
+                        {
+                            for (k, v) in new_obj {
+                                existing_obj.insert(k.clone(), v.clone());
+                            }
+                        } else {
+                            current_obj.insert("logging".to_string(), patch);
+                        }
+                    }
+                    None => {
+                        current_obj.insert("logging".to_string(), patch);
+                    }
+                }
+            }
+            let global: crate::session::Config = serde_json::from_value(current)?;
+            crate::session::save_config(&global)?;
+            if let Ok(app_dir) = crate::session::get_app_dir() {
+                crate::logging::apply_persisted_config(
+                    &global.logging.default_level,
+                    &global.logging.targets,
+                    &app_dir,
+                );
+            }
+        }
+
         let config = crate::session::load_profile_config(&name).unwrap_or_default();
         let mut current = serde_json::to_value(&config)?;
         if let (Some(current_obj), Some(update_obj)) = (current.as_object_mut(), body.as_object()) {

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -236,6 +236,15 @@ pub async fn auth_middleware(
     // AuthenticatedTokenHash so handlers that extract the extension
     // still succeed; all no-auth clients share the same "owner" value.
     if state.token_manager.is_no_auth().await {
+        // Once per process: surface that auth is disabled. Helps when a
+        // user is confused why their token isn't being checked.
+        static NO_AUTH_LOGGED: std::sync::Once = std::sync::Once::new();
+        NO_AUTH_LOGGED.call_once(|| {
+            tracing::info!(
+                target: "auth.token",
+                "running in no-auth mode; requests pass through without token check"
+            );
+        });
         request
             .extensions_mut()
             .insert(AuthenticatedTokenHash([0u8; 32]));
@@ -244,6 +253,12 @@ pub async fn auth_middleware(
 
     // Rate limit check BEFORE token validation
     if let Some(remaining_secs) = state.rate_limiter.check_locked(client_ip).await {
+        tracing::warn!(
+            target: "auth.rate_limit",
+            ip = %client_ip,
+            remaining_secs,
+            "rejecting request from locked-out IP"
+        );
         return (
             StatusCode::TOO_MANY_REQUESTS,
             [("Retry-After", remaining_secs.to_string())],
@@ -292,6 +307,13 @@ pub async fn auth_middleware(
     if let Some(source) = matched_source {
         // Record success
         state.rate_limiter.record_success(client_ip).await;
+        tracing::trace!(
+            target: "auth.middleware",
+            ip = %client_ip,
+            path = %request.uri().path(),
+            source = ?source,
+            "auth accepted"
+        );
 
         // Stamp web activity so the push consumer can suppress
         // notifications when the dashboard is actively in use.
@@ -427,11 +449,19 @@ pub async fn auth_middleware(
     }
 
     let locked = state.rate_limiter.record_failure(client_ip).await;
+    let reason = if extract_tokens(&request).is_empty() && extract_ws_protocols(&request).is_empty()
+    {
+        "missing"
+    } else {
+        "invalid"
+    };
     tracing::warn!(
+        target: "auth.middleware",
         ip = %client_ip,
         path = %path,
         locked = locked,
-        "Authentication failed"
+        reason = %reason,
+        "auth rejected"
     );
 
     (

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -241,7 +241,7 @@ pub async fn login_handler(
 
         let session_id = state.login_manager.create_session(client_ip).await;
 
-        tracing::info!(ip = %client_ip, "Login successful");
+        tracing::info!(target: "auth.passphrase", ip = %client_ip, "passphrase login successful");
 
         let cookie = build_login_cookie(&session_id, state.behind_tunnel);
         let mut response = Json(serde_json::json!({
@@ -257,7 +257,13 @@ pub async fn login_handler(
         response
     } else {
         let locked = state.rate_limiter.record_failure(client_ip).await;
-        tracing::warn!(ip = %client_ip, locked = locked, "Login failed: incorrect passphrase");
+        tracing::warn!(
+            target: "auth.passphrase",
+            ip = %client_ip,
+            locked = locked,
+            reason = "incorrect_passphrase",
+            "passphrase login failed"
+        );
 
         (
             StatusCode::UNAUTHORIZED,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -174,7 +174,11 @@ impl TokenManager {
             write_secret_file(&app_dir.join("serve.token"), &new_token).await;
         }
 
-        info!("Auth token rotated (previous token valid for 5 more minutes)");
+        info!(
+            target: "auth.token",
+            grace_secs = 300,
+            "auth token rotated"
+        );
     }
 
     /// Spawn a background rotation task (only in remote mode).

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1017,6 +1017,7 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/log-level",
             get(api::get_log_level).patch(api::patch_log_level),
         )
+        .route("/api/client-log", post(api::post_client_log))
         // Terminal WebSockets
         .route("/sessions/{id}/ws", get(ws::terminal_ws))
         .route("/sessions/{id}/terminal/ws", get(ws::paired_terminal_ws))

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1009,6 +1009,10 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/about", get(api::get_about))
         // Update status (latest release, available flag)
         .route("/api/system/update-status", get(api::get_update_status))
+        .route(
+            "/api/log-level",
+            get(api::get_log_level).patch(api::patch_log_level),
+        )
         // Terminal WebSockets
         .route("/sessions/{id}/ws", get(ws::terminal_ws))
         .route("/sessions/{id}/terminal/ws", get(ws::paired_terminal_ws))

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -117,7 +117,24 @@ impl RateLimiter {
 
         if record.count >= MAX_FAILURES {
             record.locked_until = Some(now + LOCKOUT_DURATION);
+            tracing::warn!(
+                target: "auth.rate_limit",
+                ip = %ip,
+                failures = record.count,
+                lockout_secs = LOCKOUT_DURATION.as_secs(),
+                "ip locked out after failed auth threshold"
+            );
             return true;
+        }
+
+        if record.count >= 3 {
+            tracing::info!(
+                target: "auth.rate_limit",
+                ip = %ip,
+                failures = record.count,
+                max = MAX_FAILURES,
+                "auth failures approaching lockout threshold"
+            );
         }
 
         false

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -48,6 +48,43 @@ pub struct Config {
 
     #[serde(default)]
     pub cockpit: CockpitConfig,
+
+    #[serde(default)]
+    pub logging: LoggingConfig,
+}
+
+/// Persistent logging configuration. Drives the default tracing
+/// filter when no `AOE_LOG_LEVEL` env var is set, and is the
+/// source of truth the settings UI writes to.
+///
+/// `default_level` is the baseline applied to every known target
+/// root (see `crate::logging::DEFAULT_TARGET_ROOTS`). Entries in
+/// `targets` override per-target.
+///
+/// Env var takes precedence: when `AOE_LOG_LEVEL` is set at startup,
+/// this config is ignored for the initial filter (env wins for
+/// CI/scripted runs). Runtime changes via `/api/log-level` always
+/// honor whichever is active.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoggingConfig {
+    #[serde(default = "default_log_level")]
+    pub default_level: String,
+
+    #[serde(default)]
+    pub targets: std::collections::BTreeMap<String, String>,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            default_level: default_log_level(),
+            targets: std::collections::BTreeMap::new(),
+        }
+    }
+}
+
+fn default_log_level() -> String {
+    "info".to_string()
 }
 
 /// Configuration for the cockpit (ACP-based native rendering of agent

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -24,6 +24,7 @@ pub enum SettingsCategory {
     Hooks,
     Web,
     Cockpit,
+    Logging,
 }
 
 impl SettingsCategory {
@@ -39,6 +40,7 @@ impl SettingsCategory {
             Self::Hooks => "Hooks",
             Self::Web => "Web",
             Self::Cockpit => "Cockpit",
+            Self::Logging => "Logging",
         }
     }
 }
@@ -122,6 +124,11 @@ pub enum FieldKey {
     CockpitShowToolDurations,
     CockpitQueueDrainMode,
     CockpitMaxConcurrentResumes,
+    // Logging
+    LoggingDefaultLevel,
+    /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
+    /// so the FieldKey enum stays `Copy` without carrying owned strings.
+    LoggingTarget(u8),
 }
 
 /// Resolve a field value from global config and optional profile override.
@@ -284,7 +291,61 @@ pub fn build_fields_for_category(
         SettingsCategory::Hooks => build_hooks_fields(scope, global, profile),
         SettingsCategory::Web => build_web_fields(scope, global, profile),
         SettingsCategory::Cockpit => build_cockpit_fields(scope, global, profile),
+        SettingsCategory::Logging => build_logging_fields(global),
     }
+}
+
+const LOG_LEVEL_OPTIONS: &[&str] = &["trace", "debug", "info", "warn", "error"];
+const LOG_LEVEL_OVERRIDE_OPTIONS: &[&str] =
+    &["(default)", "trace", "debug", "info", "warn", "error"];
+
+fn level_index(level: &str, opts: &[&str]) -> usize {
+    opts.iter().position(|&o| o == level).unwrap_or(0)
+}
+
+fn build_logging_fields(global: &Config) -> Vec<SettingField> {
+    let mut fields = Vec::with_capacity(1 + crate::logging::KNOWN_SUB_TARGETS.len());
+
+    let default_idx = level_index(&global.logging.default_level, LOG_LEVEL_OPTIONS);
+    fields.push(SettingField {
+        key: FieldKey::LoggingDefaultLevel,
+        label: "Default level",
+        description: "Baseline applied to every known target root. Per-target overrides win.",
+        value: FieldValue::Select {
+            selected: default_idx,
+            options: LOG_LEVEL_OPTIONS.iter().map(|s| s.to_string()).collect(),
+        },
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
+
+    for (i, target) in crate::logging::KNOWN_SUB_TARGETS.iter().enumerate() {
+        let current = global
+            .logging
+            .targets
+            .get(*target)
+            .map(|s| s.as_str())
+            .unwrap_or("(default)");
+        let idx = level_index(current, LOG_LEVEL_OVERRIDE_OPTIONS);
+        fields.push(SettingField {
+            key: FieldKey::LoggingTarget(i as u8),
+            label: target,
+            description: "Per-target override; (default) inherits the baseline.",
+            value: FieldValue::Select {
+                selected: idx,
+                options: LOG_LEVEL_OVERRIDE_OPTIONS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            },
+            category: SettingsCategory::Logging,
+            has_override: false,
+            inherited_display: None,
+        });
+    }
+
+    fields
 }
 
 fn build_cockpit_fields(
@@ -1859,6 +1920,22 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::CockpitMaxConcurrentResumes, FieldValue::Number(v)) => {
             config.cockpit.max_concurrent_resumes = (*v).max(1).min(u32::MAX as u64) as u32
+        }
+        // Logging
+        (FieldKey::LoggingDefaultLevel, FieldValue::Select { selected, options }) => {
+            if let Some(level) = options.get(*selected) {
+                config.logging.default_level = level.clone();
+            }
+        }
+        (FieldKey::LoggingTarget(idx), FieldValue::Select { selected, options }) => {
+            if let Some(target) = crate::logging::KNOWN_SUB_TARGETS.get(*idx as usize) {
+                let level = options.get(*selected).cloned().unwrap_or_default();
+                if level.is_empty() || level == "(default)" {
+                    config.logging.targets.remove(*target);
+                } else {
+                    config.logging.targets.insert(target.to_string(), level);
+                }
+            }
         }
         _ => {}
     }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -840,6 +840,9 @@ impl SettingsView {
                     c.max_concurrent_resumes = None;
                 }
             }
+            // Logging is global-only for v1 (no profile overrides); the
+            // "clear override" gesture is a no-op for these keys.
+            FieldKey::LoggingDefaultLevel | FieldKey::LoggingTarget(_) => {}
         }
 
         // Sync repo_config when in Repo scope

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -150,6 +150,7 @@ impl SettingsView {
             SettingsCategory::Tmux,
             SettingsCategory::Sound,
             SettingsCategory::Web,
+            SettingsCategory::Logging,
         ];
 
         let mut view = Self {
@@ -299,6 +300,17 @@ impl SettingsView {
                 save_config(&self.global_config)?;
                 self.resolved_base =
                     merge_configs(self.global_config.clone(), &self.profile_config);
+                // Persist + live-apply the logging filter so a running
+                // `aoe serve` daemon (and its cockpit runners) pick up the
+                // change without a restart. No-ops when no controller is
+                // installed (TUI-only process).
+                if let Ok(app_dir) = crate::session::get_app_dir() {
+                    crate::logging::apply_persisted_config(
+                        &self.global_config.logging.default_level,
+                        &self.global_config.logging.targets,
+                        &app_dir,
+                    );
+                }
             }
             SettingsScope::Profile => {
                 save_profile_config(&self.profile, &self.profile_config)?;

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -109,6 +109,12 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
             let current_is_newer = is_newer_version(current_version, &cache.latest_version);
 
             if age < max_age && !current_is_newer {
+                tracing::info!(
+                    target: "update.cache",
+                    age_hours = age.num_hours(),
+                    latest = %cache.latest_version,
+                    "update cache hit"
+                );
                 let available = is_newer_version(&cache.latest_version, current_version);
                 return Ok(UpdateInfo {
                     available,
@@ -116,6 +122,12 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
                     latest_version: cache.latest_version,
                 });
             }
+            tracing::info!(
+                target: "update.cache",
+                age_hours = age.num_hours(),
+                current_is_newer,
+                "update cache miss; refetching"
+            );
         }
     }
 
@@ -179,6 +191,13 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
     }
 
     let available = is_newer_version(&latest_version, current_version);
+    tracing::info!(
+        target: "update.parse",
+        current = %current_version,
+        latest = %latest_version,
+        available,
+        "version compared"
+    );
 
     Ok(UpdateInfo {
         available,
@@ -188,10 +207,19 @@ pub async fn check_for_update(current_version: &str, force: bool) -> Result<Upda
 }
 
 async fn fetch_releases(client: &reqwest::Client) -> Result<Vec<ReleaseInfo>> {
-    let response = client.get(github_api_releases_url()).send().await?;
+    let url = github_api_releases_url();
+    tracing::debug!(target: "update.fetch", %url, "GET releases");
+    let response = client.get(&url).send().await?;
+    let status = response.status();
+    tracing::debug!(
+        target: "update.fetch",
+        status = %status,
+        content_length = ?response.content_length(),
+        "releases response"
+    );
 
-    if !response.status().is_success() {
-        anyhow::bail!("Failed to fetch releases: HTTP {}", response.status());
+    if !status.is_success() {
+        anyhow::bail!("Failed to fetch releases: HTTP {}", status);
     }
 
     let github_releases: Vec<GitHubRelease> = response.json().await?;

--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,44 @@
+// React error boundary that reports caught render errors to the
+// client logger. Class component because function components cannot
+// catch render errors.
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { reportError } from "../lib/logger";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    reportError(error, {
+      componentStack: info.componentStack ?? undefined,
+      target: "react.errorboundary",
+    });
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback ?? (
+          <div style={{ padding: 24 }}>
+            <h2>Something went wrong</h2>
+            <p>The error has been reported. Reload the page to retry.</p>
+          </div>
+        )
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -24,6 +24,7 @@ import { ThemeSettings } from "./settings/ThemeSettings";
 import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
+import { LoggingSettings } from "./settings/LoggingSettings";
 import { ProfileSelector } from "./settings/ProfileSelector";
 
 type TabId =
@@ -38,7 +39,8 @@ type TabId =
   | "terminal"
   | "security"
   | "devices"
-  | "cockpit";
+  | "cockpit"
+  | "logging";
 
 type SidebarItem =
   | { kind: "tab"; id: TabId; label: string }
@@ -60,6 +62,8 @@ function buildSidebar(): SidebarItem[] {
     { kind: "tab", id: "security", label: "Security" },
     { kind: "tab", id: "devices", label: "Devices" },
     { kind: "tab", id: "cockpit", label: "Cockpit" },
+    { kind: "divider", label: "Diagnostics" },
+    { kind: "tab", id: "logging", label: "Logging" },
   ];
 }
 
@@ -84,6 +88,7 @@ const ALL_TAB_IDS = new Set<TabId>([
   "security",
   "devices",
   "cockpit",
+  "logging",
 ]);
 
 function isTabId(value: unknown): value is TabId {
@@ -396,6 +401,8 @@ export function SettingsView({
         return <TmuxSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
       case "updates":
         return <UpdateSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
+      case "logging":
+        return <LoggingSettings settings={settings!} onSaveField={saveSubField} onUpdate={updateLocal} />;
 
       case "notifications":
         return (

--- a/web/src/components/settings/FormFields.tsx
+++ b/web/src/components/settings/FormFields.tsx
@@ -160,16 +160,29 @@ export function SelectField({
   value,
   onChange,
   options,
+  labelClassName,
 }: {
   label: string;
   description?: string;
   value: string;
   onChange: (v: string) => void;
   options: { value: string; label: string }[];
+  /** Override the default `text-sm text-text-dim mb-1` label classes
+   *  (used by the Logging panel to render brighter section labels).
+   *  Pass `""` to suppress the label element entirely. */
+  labelClassName?: string;
 }) {
   return (
     <div>
-      <label className="block text-sm text-text-dim mb-1">{label}</label>
+      {label && (
+        <label
+          className={
+            labelClassName ?? "block text-sm text-text-dim mb-1"
+          }
+        >
+          {label}
+        </label>
+      )}
       {description && (
         <div className="text-xs text-text-dim mb-1">{description}</div>
       )}

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -91,6 +91,7 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
 
       <SelectField
         label="Default level"
+        labelClassName="block text-sm font-semibold text-text-primary mb-1"
         description="Baseline applied to every known target root. Per-target overrides below win over this."
         value={defaultLevel}
         onChange={saveDefaultLevel}
@@ -98,7 +99,7 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
       />
 
       <div className="space-y-4">
-        <h4 className="text-xs font-mono uppercase tracking-widest text-text-muted">
+        <h4 className="text-sm font-semibold text-text-primary">
           Per-target overrides
         </h4>
         <p className="text-xs text-text-dim">
@@ -106,7 +107,7 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
         </p>
         {Object.entries(grouped).map(([group, items]) => (
           <div key={group} className="space-y-2">
-            <h5 className="text-xs font-mono uppercase tracking-widest text-text-muted opacity-70">
+            <h5 className="text-xs font-mono uppercase tracking-widest text-text-primary">
               {group}
             </h5>
             <div className="grid gap-3 sm:grid-cols-2">

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -1,0 +1,128 @@
+import { SelectField } from "./FormFields";
+
+// Mirrors `KNOWN_SUB_TARGETS` in src/logging.rs. Keeping this list
+// hardcoded (rather than fetched) is intentional: it's the curated
+// dropdown surface; advanced users can still edit `config.toml`
+// directly or hit `PATCH /api/log-level` for arbitrary EnvFilter
+// directives.
+const KNOWN_TARGETS: { value: string; group: string }[] = [
+  { value: "cockpit.acp", group: "Cockpit" },
+  { value: "cockpit.acp.stderr", group: "Cockpit" },
+  { value: "cockpit.supervisor", group: "Cockpit" },
+  { value: "cockpit.event_store", group: "Cockpit" },
+  { value: "cockpit.runner", group: "Cockpit" },
+  { value: "terminal.ws", group: "Terminal" },
+  { value: "terminal.ws.bytes", group: "Terminal" },
+  { value: "auth.token", group: "Auth" },
+  { value: "auth.middleware", group: "Auth" },
+  { value: "auth.rate_limit", group: "Auth" },
+  { value: "auth.passphrase", group: "Auth" },
+  { value: "auth.device", group: "Auth" },
+  { value: "auth.ip", group: "Auth" },
+  { value: "process.signal", group: "Process" },
+  { value: "process.tree", group: "Process" },
+  { value: "process.reap", group: "Process" },
+  { value: "process.ppid", group: "Process" },
+  { value: "update.fetch", group: "Update" },
+  { value: "update.cache", group: "Update" },
+  { value: "update.parse", group: "Update" },
+  { value: "containers.docker", group: "Containers" },
+  { value: "containers.image", group: "Containers" },
+  { value: "containers.runtime", group: "Containers" },
+  { value: "git.command", group: "Git" },
+  { value: "web.client", group: "Web" },
+  { value: "log.runtime", group: "Meta" },
+];
+
+const LEVELS = [
+  { value: "", label: "(default)" },
+  { value: "trace", label: "trace" },
+  { value: "debug", label: "debug" },
+  { value: "info", label: "info" },
+  { value: "warn", label: "warn" },
+  { value: "error", label: "error" },
+];
+
+const DEFAULT_LEVELS = LEVELS.filter((l) => l.value !== "");
+
+interface Props {
+  settings: Record<string, unknown>;
+  onSaveField: (section: string, field: string, value: unknown) => void;
+  onUpdate: (patch: Record<string, unknown>) => void;
+}
+
+export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
+  const logging = (settings.logging ?? {}) as Record<string, unknown>;
+  const defaultLevel = (logging.default_level as string) ?? "info";
+  const targets = (logging.targets ?? {}) as Record<string, string>;
+
+  const saveDefaultLevel = (level: string) => {
+    onUpdate({ logging: { ...logging, default_level: level } });
+    onSaveField("logging", "default_level", level);
+  };
+
+  const saveTarget = (target: string, level: string) => {
+    const next = { ...targets };
+    if (level === "") {
+      delete next[target];
+    } else {
+      next[target] = level;
+    }
+    onUpdate({ logging: { ...logging, targets: next } });
+    onSaveField("logging", "targets", next);
+  };
+
+  // Group targets by their first segment for the UI.
+  const grouped = KNOWN_TARGETS.reduce<Record<string, typeof KNOWN_TARGETS>>(
+    (acc, t) => {
+      (acc[t.group] ||= []).push(t);
+      return acc;
+    },
+    {},
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <p className="text-xs text-text-dim">
+          Persists to <code>[logging]</code> in <code>config.toml</code>. Changes apply live to the running daemon and any cockpit subprocesses (no restart needed). The <code>AOE_LOG_LEVEL</code> env var, when set, overrides these settings at startup.
+        </p>
+      </div>
+
+      <SelectField
+        label="Default level"
+        description="Baseline applied to every known target root. Per-target overrides below win over this."
+        value={defaultLevel}
+        onChange={saveDefaultLevel}
+        options={DEFAULT_LEVELS}
+      />
+
+      <div className="space-y-4">
+        <h4 className="text-xs font-mono uppercase tracking-widest text-text-muted">
+          Per-target overrides
+        </h4>
+        <p className="text-xs text-text-dim">
+          Each dropdown overrides the default level for a single tracing target. Set to <em>(default)</em> to remove the override and inherit the baseline.
+        </p>
+        {Object.entries(grouped).map(([group, items]) => (
+          <div key={group} className="space-y-2">
+            <h5 className="text-xs font-mono uppercase tracking-widest text-text-muted opacity-70">
+              {group}
+            </h5>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {items.map((t) => (
+                <SelectField
+                  key={t.value}
+                  label={t.value}
+                  value={(targets[t.value] as string) ?? ""}
+                  onChange={(v) => saveTarget(t.value, v)}
+                  options={LEVELS}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/logger.ts
+++ b/web/src/lib/logger.ts
@@ -1,0 +1,193 @@
+// Browser-side error capture + batched relay to /api/client-log.
+//
+// Captures window.onerror, unhandledrejection, React ErrorBoundary
+// (via reportError), and explicit reportError() calls.
+//
+// Throttling: token-bucket (10 cap, 10/s refill) on entries. Batches
+// flush every 2s, on size threshold, on visibilitychange=hidden, and
+// on pagehide. Unload-time flush uses navigator.sendBeacon with a JSON
+// Blob since sendBeacon can't carry the Authorization header — the
+// cookie-mode auth still works in that path.
+//
+// URL sanitization: never log `window.location.href` raw, because we
+// embed the auth token in `?token=` and don't want it on disk.
+
+export type ClientLogLevel = "error" | "warn" | "info" | "debug";
+
+export interface ClientLogEntry {
+  level: ClientLogLevel;
+  message: string;
+  stack?: string;
+  componentStack?: string;
+  target?: string;
+  sessionId?: string;
+  path: string;
+  userAgent: string;
+  ts: number;
+  dropped?: number;
+}
+
+const ENDPOINT = "/api/client-log";
+const RATE_CAP = 10;
+const RATE_REFILL_PER_SEC = 10;
+const FLUSH_INTERVAL_MS = 2000;
+const MAX_BATCH = 20;
+const MAX_BATCH_BYTES = 48 * 1024;
+
+let installed = false;
+let queue: ClientLogEntry[] = [];
+let dropped = 0;
+let tokens = RATE_CAP;
+let lastRefill = Date.now();
+let isReporting = false;
+
+function sanitizedPath(): string {
+  try {
+    const u = new URL(window.location.href);
+    u.searchParams.delete("token");
+    return `${u.pathname}${u.search}${u.hash}`;
+  } catch {
+    return "/";
+  }
+}
+
+function refillTokens(): void {
+  const now = Date.now();
+  const delta = (now - lastRefill) / 1000;
+  if (delta <= 0) return;
+  tokens = Math.min(RATE_CAP, tokens + delta * RATE_REFILL_PER_SEC);
+  lastRefill = now;
+}
+
+function tryConsumeToken(): boolean {
+  refillTokens();
+  if (tokens >= 1) {
+    tokens -= 1;
+    return true;
+  }
+  return false;
+}
+
+function normalizeError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) {
+    return { message: err.message || String(err), stack: err.stack };
+  }
+  if (typeof err === "string") return { message: err };
+  try {
+    return { message: JSON.stringify(err) };
+  } catch {
+    return { message: String(err) };
+  }
+}
+
+function enqueue(entry: ClientLogEntry): void {
+  if (isReporting) return;
+  if (!tryConsumeToken()) {
+    dropped += 1;
+    return;
+  }
+  queue.push(entry);
+  if (queue.length >= MAX_BATCH) {
+    void flush(false);
+  }
+}
+
+async function flush(viaBeacon: boolean): Promise<void> {
+  if (queue.length === 0 && dropped === 0) return;
+  if (isReporting) return;
+  isReporting = true;
+  try {
+    let batch = queue;
+    queue = [];
+    if (dropped > 0) {
+      batch.push({
+        level: "warn",
+        message: `log relay dropped ${dropped} entries (rate-limited)`,
+        target: "logger.relay",
+        path: sanitizedPath(),
+        userAgent: navigator.userAgent,
+        ts: Date.now(),
+        dropped,
+      });
+      dropped = 0;
+    }
+    // Trim oversized payloads to fit the keepalive budget.
+    const body = trimToBudget(batch);
+    const json = JSON.stringify({ entries: body });
+
+    if (viaBeacon && typeof navigator.sendBeacon === "function") {
+      const blob = new Blob([json], { type: "application/json" });
+      navigator.sendBeacon(ENDPOINT, blob);
+      return;
+    }
+    await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: json,
+      keepalive: true,
+      credentials: "include",
+    });
+  } catch {
+    // Drop the batch on failure; don't recurse into the logger.
+  } finally {
+    isReporting = false;
+  }
+}
+
+function trimToBudget(batch: ClientLogEntry[]): ClientLogEntry[] {
+  let totalBytes = 0;
+  const out: ClientLogEntry[] = [];
+  for (const entry of batch) {
+    const size = JSON.stringify(entry).length;
+    if (out.length >= MAX_BATCH || totalBytes + size > MAX_BATCH_BYTES) {
+      dropped += batch.length - out.length;
+      break;
+    }
+    totalBytes += size;
+    out.push(entry);
+  }
+  return out;
+}
+
+export function reportError(
+  err: unknown,
+  ctx?: Partial<ClientLogEntry>,
+): void {
+  const { message, stack } = normalizeError(err);
+  enqueue({
+    level: ctx?.level ?? "error",
+    message,
+    stack: ctx?.stack ?? stack,
+    componentStack: ctx?.componentStack,
+    target: ctx?.target,
+    sessionId: ctx?.sessionId,
+    path: sanitizedPath(),
+    userAgent: navigator.userAgent,
+    ts: Date.now(),
+  });
+}
+
+export function installClientLogger(): void {
+  if (installed) return;
+  installed = true;
+
+  window.addEventListener("error", (e) => {
+    reportError(e.error ?? e.message, { target: "window.onerror" });
+  });
+
+  window.addEventListener("unhandledrejection", (e) => {
+    reportError(e.reason, { target: "window.unhandledrejection" });
+  });
+
+  setInterval(() => void flush(false), FLUSH_INTERVAL_MS);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden") {
+      void flush(true);
+    }
+  });
+
+  window.addEventListener("pagehide", () => {
+    void flush(true);
+  });
+}

--- a/web/src/logging-init.ts
+++ b/web/src/logging-init.ts
@@ -1,0 +1,7 @@
+// Side-effect module: installs the client logger before any other
+// module gets a chance to throw. main.tsx imports this first so the
+// global window error/unhandledrejection handlers are armed before
+// React or any async fetch can run.
+import { installClientLogger } from "./lib/logger";
+
+installClientLogger();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,6 @@
+// First: install global error capture so anything that throws during
+// the imports below gets reported to the server.
+import "./logging-init";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 // Imported first so the URL `?token=` capture runs before any fetch or render.
@@ -6,6 +9,7 @@ import "./lib/token";
 import "./lib/legacySessionRedirect";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
 import { ToastBusBridge, ToastProvider } from "./components/Toasts";
 import { installFetchErrorToasts } from "./lib/fetchInterceptor";
 import "./index.css";
@@ -18,11 +22,13 @@ installFetchErrorToasts();
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ToastProvider>
-      <ToastBusBridge />
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </ToastProvider>
+    <ErrorBoundary>
+      <ToastProvider>
+        <ToastBusBridge />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </ToastProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -126,6 +126,13 @@ const PAGES = [
       "Step-by-step guide for adding support for a new AI coding agent to AoE.",
   },
   {
+    source: "docs/development/logging.md",
+    dest: "docs/development/logging.md",
+    title: "Logging",
+    description:
+      "Logging targets, env-var matrix, runtime control endpoint, and browser-side error relay for Agent of Empires.",
+  },
+  {
     source: "docs/sounds.md",
     dest: "docs/sounds.md",
     title: "Sound Effects",
@@ -171,6 +178,7 @@ const URL_MAP = {
   "docs/sounds.md": "/docs/sounds/",
   "docs/development.md": "/docs/development/",
   "docs/development/adding-agents.md": "/docs/development/adding-agents/",
+  "docs/development/logging.md": "/docs/development/logging/",
   "docs/guides/configuration.md": "/docs/guides/configuration/",
   "docs/cli/reference.md": "/docs/cli/reference/",
   "docs/cockpit.md": "/docs/cockpit/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -47,6 +47,7 @@ export const docsNav: NavSection[] = [
     items: [
       { title: "Development", href: "/docs/development/" },
       { title: "Adding a New Agent", href: "/docs/development/adding-agents/" },
+      { title: "Logging", href: "/docs/development/logging/" },
     ],
   },
 ];


### PR DESCRIPTION
## Description

Observability/logging umbrella for AoE. Closes #1096. Stacked as 8 commits on one branch.

Headline:
- **Single shared `debug.log`** for daemon + every cockpit runner. No more tailing `<app_dir>/cockpit-workers/<id>.log` per worker to follow a session end-to-end.
- **Runtime filter swap** via `GET`/`PATCH /api/log-level` and `aoe log-level <level> | --filter <expr> | --get`. Live, no daemon restart, no env-var dance, no losing in-flight agent state.
- **Live propagation to runners** via `<app_dir>/runtime_filter` + `notify` file-watch, so a filter swap from the daemon side reaches every cockpit subprocess too.
- **Centralized subscriber + filter helper** in `src/logging.rs`. Main and the runner share env-var resolution, default filter construction, and the reloadable handle.
- **Default filter expanded to all in-use target roots** (`agent_of_empires`, `cockpit`, `terminal`, `auth`, `process`, `update`, `containers`, `git`, `migrations`, `web`) so any new instrumentation under those roots is visible under `AOE_LOG_LEVEL=debug` without per-target env config.
- **Structured tracing for previously silent / thin modules**: `auth.rs`, `process/mod.rs`, `update/mod.rs`, `git/*`, `containers/*`, `migrations/*`. Targets follow the `<module>.<submodule>` convention so the runtime control can scope them precisely.
- **Browser-side error capture** via new `web/src/lib/logger.ts` + React `ErrorBoundary`, batched POST to `/api/client-log`, re-emitted server-side at `web.client` target. `?token=` stripped from URLs before send; bounded server-side caps.
- **Docs**: `docs/development/logging.md` covers targets, env-var matrix, runtime control endpoint, CLI, runner propagation, file locations, and conventions. Wired into `website/scripts/sync-docs.mjs` and `docsNav.ts`.

### Commit stack (logical units)

1. `refactor(logging): centralize subscriber + expand target roots`
2. `feat(serve): runtime log-level control via REST + CLI`
3. `feat(cockpit): live propagation of log filter to runner subprocesses`
4. `feat: light-touch instrumentation across git, update, containers, migrations`
5. `feat(auth): structured tracing for auth middleware, token, rate limit, passphrase`
6. `feat(process): structured tracing for signals, tree walks, reap`
7. `feat(web): browser-side error capture + relay to /api/client-log`
8. `docs(development): add logging.md covering targets, env, runtime control`

### Open questions resolved in plan (3-LLM debate)

- Process-global `Mutex<Option<Arc<FilterController>>>` for the reload handle (testable; over `OnceLock`), not `AppState` plumbing.
- Dual `{level, filter}` API on the REST endpoint. Bare global level in filter mode rejected (400) so users don't firehose `hyper`/`rustls`/`tower`.
- `EnvFilter::builder().with_regex(false)` on REST input.
- Runner gets live propagation via file-watch (user explicitly wanted this).
- `console.error` wrap NOT installed v1; recursion + noise hazard. Future flag-gated.
- No persistence of runtime filter across restart; env wins on next startup.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib` → 1892 passed)
- [x] Documentation was updated where necessary (`docs/development/logging.md` + website nav + sync-docs entry)
- [ ] For UI changes: no UI surface in this PR (the web work is invisible error-capture wiring + a class `ErrorBoundary`; no new components in the visible tree).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context). Plan-mode design + 3-LLM debate (Gemini 3.1 Pro, GPT-5.5, Grok 4.3) before any code landed. Each commit was reviewed, tested locally (cargo build/test/clippy + fmt) before being staged.

**Additional details:** Investigation grounded in the actual ground truth (per-module line counts + existing log counts) before the plan was written. Debate verdict folded back into the plan file (`/Users/seluj78/.claude/plans/investigate-and-plan-for-misty-sparrow.md`). User (Seluj78) made the architecture calls (`Mutex<Option<Arc<_>>>` vs `OnceLock`, runner live propagation, shared single log file).

- [x] I am an AI Agent filling out this form (check box if true)

---

## Manual Testing TODO

Build with `cargo build --features serve`. Default app dir is `~/.agent-of-empires-dev` for debug builds.

### 1. Env-var resolution (commit 1)

- [x] 1.1 — `AOE_LOG_LEVEL=debug aoe serve` writes to `~/.agent-of-empires-dev/debug.log` with debug-level events from the daemon.
- [x] 1.2 — `AOE_LOG_LEVEL=debug aoe serve` + spawn a cockpit session. Runner subprocess ALSO emits debug to the same `debug.log` (previous behavior was hardcoded `info`-only; this is the core regression fix).
- [x] 1.3 — `AGENT_OF_EMPIRES_DEBUG=1 aoe serve` still works (legacy alias for `AOE_LOG_LEVEL=debug`).
- [x] 1.4 — `AOE_ACP_TRACE=1 AOE_LOG_LEVEL=debug aoe serve` adds `agent_client_protocol` debug + transport_actor trace overlay.
- [x] 1.5 — `AOE_TERMINAL_TRACE=1 AOE_LOG_LEVEL=debug aoe serve` overrides `terminal=debug` to `terminal=trace`; per-byte WS firehose visible.
- [x] 1.6 — No env vars + `aoe` (TUI mode) → no subscriber installed; no log file created; TUI doesn't get garbled by stderr.

### 2. Runtime control REST endpoint (commit 2)

- [x] 2.1 — `aoe serve --daemon`, then `curl -s "$URL/api/log-level?token=$T"` returns `{"current": "...", "reloadable": true, "ephemeral": true}`.
- [x] 2.2 — PATCH `{"level": "debug"}` → 200 with `previous` + `current`; `current` contains all 10 target roots at `=debug`.
- [x] 2.3 — PATCH `{"filter": "cockpit.acp=trace,info"}` → 200; `current` matches input.
- [x] 2.4 — PATCH `{"filter": "debug"}` → 400 with "use {\"level\": ...}" hint.
- [x] 2.5 — PATCH `{}` → 400 ("missing field").
- [x] 2.6 — PATCH `{"level": "x", "filter": "y"}` → 400 ("specify exactly one").
- [x] 2.7 — PATCH no auth → 401 (existing middleware covers it).
- [x] 2.8 — `tail -f debug.log` shows `log.runtime: filter swapped` with `source = "rest"` after each successful PATCH.

### 3. Runtime control CLI (commit 2)

- [x] 3.1 — `aoe log-level --get` prints status JSON.
- [x] 3.2 — `aoe log-level debug` → expanded-roots JSON; subsequent daemon output is debug.
- [x] 3.3 — `aoe log-level info` → drops back to info.
- [x] 3.4 — `aoe log-level --filter "cockpit.acp=trace,info"` → 200.
- [x] 3.5 — `aoe log-level --filter debug` → server-side 400 surfaced as error message.
- [x] 3.6 — `aoe log-level xyzzy` (unknown level, positional) → friendly client-side error suggesting `--filter`.
- [x] 3.7 — Works against foreground `aoe serve` too (not just `--daemon`); doesn't require `daemon_pid()`.
- [x] 3.8 — No daemon running → friendly bail ("No aoe serve daemon is running").

### 4. Runner live propagation (commit 3)

- [x] 4.1 — `aoe serve --daemon` + spawn cockpit session (claude). Run `aoe log-level debug`. Within ~1s the runner emits debug to `debug.log` too (filter the file by `process="runner"` field or use the cockpit.* targets).
- [x] 4.2 — `aoe log-level info` → runner drops back to info.
- [x] 4.3 — `aoe log-level --filter cockpit.acp=trace,info` → daemon AND runner emit ACP transport trace immediately.
- [x] 4.4 — `~/.agent-of-empires-dev/runtime_filter` exists after first PATCH; contents match `current`; mode `0600`.
- [x] 4.5 — Manually `echo bogus > ~/.agent-of-empires-dev/runtime_filter` → runner emits `log.runtime warn` with reason; prior filter kept.
- [x] 4.6 — Delete the file → runners keep last filter; no panic; next `aoe log-level …` rewrites and re-applies.

### 5. Auth instrumentation (commit 5)

- [x] 5.1 — Cold daemon start → `auth.token info "running in no-auth mode; ..."` emitted once when `--no-auth`; not repeated.
- [x] 5.2 — `aoe log-level --filter "auth=debug,info"` then unauthenticated `/api/sessions` → `auth.middleware debug` with reason+path+ip; no token material in fields.
- [x] 5.3 — 6 bad-token curls in a row from one IP: `auth.rate_limit info "approaching threshold"` at 3+, `auth.rate_limit warn "ip locked out"` at 5, subsequent attempts → `auth.rate_limit warn "rejecting request from locked-out IP"` + 429.
- [x] 5.4 — Trigger the daemon's rotation loop (or set short `--token-lifetime`) → `auth.token info "auth token rotated"` with `grace_secs=300`. No token value logged.
- [x] 5.5 — Passphrase login OK → `auth.passphrase info "passphrase login successful"`; wrong passphrase → `auth.passphrase warn "passphrase login failed"` with `reason="incorrect_passphrase"`.

### 6. Process instrumentation (commit 6)

- [x] 6.1 — `AOE_LOG_LEVEL=debug aoe`, then delete a tmux session from the TUI. `process.signal debug` events per pid with `signal="SIGTERM"`; `process.tree debug` with the descendants list.
- [x] 6.2 — Same path with a process that ignores SIGTERM (e.g. a `trap '' TERM` shell): `process.reap warn "pid survived SIGTERM after 100ms"` + `process.signal info "sending signal" signal="SIGKILL"`.
- [x] 6.3 — `signal_process_tree` debug visible during web-side stop (the SIGSTOP/SIGCONT path used by `pause_for_scrollback`).

### 7. Light-touch coverage (commit 4)

- [x] 7.1 — `aoe log-level --filter git.command=debug,info` then create a worktree from the TUI/web. `git.command debug` lines with args, cwd, exit, duration; URL passwords masked as `***@host` (no real credentials leaked even when configured).
- [x] 7.2 — `aoe update --check`: `update.fetch debug` for the GitHub API request + response status, `update.cache info` for hit/miss, `update.parse info` for version compare.
- [x] 7.3 — `containers.image info "pulling image"` + `containers.image info "image pull completed"` with duration when a Docker session is created; failure path → `containers.image warn "image pull failed"` with stderr summary.
- [x] 7.4 — `containers.runtime info "starting container"`/`"stopping container"` on session start/stop; `containers.runtime debug "removing container"` on session delete.
- [x] 7.5 — Migration run: `migrations info "running migration"` + `"migration completed"` with version, name, duration_ms.

### 8. Web frontend log relay (commit 7)

- [x] 8.1 — `AOE_LOG_LEVEL=debug aoe serve` with the dashboard open in Chrome. Devtools: `throw new Error("manual test")`. Within ~2s, `web.client error "manual test"` lands in `debug.log` with the path field showing only the pathname (no `?token=`).
- [x] 8.2 — Devtools: `Promise.reject(new Error("rej"))`. `web.client error "rej"` lands via `unhandledrejection`.
- [x] 8.3 — Wrap a component to throw on render → `ErrorBoundary` fallback renders + `web.client error` with `component_stack` field populated.
- [x] 8.4 — Burst-flood test: paste `for (let i=0;i<200;i++) throw new Error("burst")` in a loop (or trigger via a fast handler). Server receives bounded batches; later batch carries `dropped: N` summary entry. No browser hang.
- [x] 8.5 — Close the tab while logs are queued → on `pagehide`, `navigator.sendBeacon` POSTs the residual batch; server still receives it.
- [x] 8.6 — POST oversized batch (>50 entries) directly via curl → 413.
- [x] 8.7 — Verify `?token=` is NOT in the captured `path` field (open with `?token=abc` URL, throw an error, grep the log for the token — should be absent).

### 9. Shared log + cross-process correlation

- [x] 9.1 — Single `tail -f ~/.agent-of-empires-dev/debug.log` shows daemon AND runner events interleaved.
- [x] 9.2 — Runner events distinguishable from daemon events (`session` field on cockpit events, runner subprocess pid in the formatted prefix).
- [ x] 9.3 — `aoe log-level --filter cockpit.runner=trace,info` narrows to runner-only chatter without restart.

### 10. Automated suites

- [x] `cargo test --features serve --lib` — passes (1892 tests; new tests in `src/logging::tests`, `src/git/command::tests`, `src/server/api/client_log::tests`).
- [x] `cargo clippy --features serve --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all --check` — clean.
- [x] `cargo xtask gen-docs` — `docs/cli/reference.md` regenerated and committed.
- [x] `cd website && node scripts/sync-docs.mjs` — runs cleanly, picks up `docs/development/logging.md`.
- [x] `cd web && npm run typecheck` — clean (covers the new logger / ErrorBoundary).
