### PR TITLE
fix(status): detect codex request_user_input as Waiting

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -335,6 +335,12 @@ pub fn detect_codex_status(raw_content: &str) -> Status {
         .join("\n");
     let last_lines_lower = last_lines.to_lowercase();
 
+    if last_lines_lower.contains("enter to submit answer")
+        || last_lines_lower.contains("(unanswered)")
+    {
+        return Status::Waiting;
+    }
+
     if last_lines_lower.contains("esc to interrupt")
         || last_lines_lower.contains("ctrl+c to interrupt")
         || last_lines_lower.contains("working")
@@ -363,7 +369,7 @@ pub fn detect_codex_status(raw_content: &str) -> Status {
 
     for line in &lines {
         let trimmed = line.trim();
-        if trimmed.starts_with("❯") && trimmed.len() > 2 {
+        if (trimmed.starts_with("❯") || trimmed.starts_with("›")) && trimmed.len() > 2 {
             let after_cursor = trimmed.get(3..).unwrap_or("").trim_start();
             if after_cursor.starts_with("1.")
                 || after_cursor.starts_with("2.")
@@ -967,6 +973,37 @@ mod tests {
     fn test_detect_codex_status_idle() {
         assert_eq!(detect_codex_status("file saved"), Status::Idle);
         assert_eq!(detect_codex_status("random output text"), Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_codex_status_request_user_input() {
+        // Regression test for codex `request_user_input` (Plan-mode radio UI).
+        // The hint line contains "esc to interrupt", which previously
+        // short-circuited to Running before any Waiting heuristic could fire.
+        let pane = "\
+  Question 1/1 (1 unanswered)
+  Which fruit do you want?
+
+  › 1. Banana (Recommended)  Choose banana.
+    2. Orange                Choose orange.
+    3. Apple                 Choose apple.
+    4. None of the above     Optionally, add details in notes (tab).
+
+  tab to add notes | enter to submit answer | esc to interrupt
+";
+        assert_eq!(detect_codex_status(pane), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_codex_status_request_user_input_radio_only() {
+        // `›` (U+203A) menu cursor should also flip to Waiting on its own,
+        // independent of the hint-line tokens.
+        let pane = "\
+  › 1. Yes
+    2. No
+    3. Maybe
+";
+        assert_eq!(detect_codex_status(pane), Status::Waiting);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fixes #1120.

Codex's Plan-mode `request_user_input` tool renders a tabbed radio UI whose hint line ends with `tab to add notes | enter to submit answer | esc to interrupt`. The Running short-circuit in `detect_codex_status` (`src/tmux/status_detection.rs:338-344`) matched `esc to interrupt` anywhere in the last 30 non-empty lines and returned `Status::Running` before any Waiting heuristic could run, so the sidebar stayed green while codex was actually blocked on user input.

Two small additions to `detect_codex_status`:

1. **`request_user_input` Waiting heuristic** runs before the Running short-circuit. Matches `enter to submit answer` (unique to the tabbed UI hint line) and `(unanswered)` (from the `Question N/N (M unanswered)` header). Either token flips status to Waiting.
2. **Menu-cursor detection accepts `›` (U+203A)** alongside `❯` (U+276F). Codex's radio UI uses U+203A; Claude / Vibe / Copilot use U+276F. Defensive belt-and-suspenders so the radio UI hits a Waiting path through two independent signals.

Regression test uses the exact pane content from the reporter's `tmux capture-pane` dump.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`cargo test --lib status_detection` passes (44 tests). `cargo fmt --check` + `cargo clippy --lib --no-deps` clean. No user-facing docs surface for status-detection internals.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (claude-opus-4-7)

**Any Additional AI Details you'd like to share:**
Investigation and prose drafted via back-and-forth with Claude; idea, decisions, and code review by me.

- [x] I am an AI Agent filling out this form (check box if true)