### PR TITLE
feat(cockpit): comment on diff + more polishing fixes

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -24,6 +24,7 @@ This document contains the help content for the `aoe` command-line program.
 * [`aoe session capture`↴](#aoe-session-capture)
 * [`aoe session current`↴](#aoe-session-current)
 * [`aoe session set-session-id`↴](#aoe-session-set-session-id)
+* [`aoe session set-base`↴](#aoe-session-set-base)
 * [`aoe group`↴](#aoe-group)
 * [`aoe group list`↴](#aoe-group-list)
 * [`aoe group create`↴](#aoe-group-create)
@@ -290,6 +291,7 @@ Manage session lifecycle (start, stop, attach, etc.)
 * `capture` — Capture tmux pane output
 * `current` — Auto-detect current session
 * `set-session-id` — Set agent session ID for a session
+* `set-base` — Set or clear the per-session diff base branch. The diff view compares the worktree against this ref instead of the auto-detected default. Useful when the PR target differs from the project default (stacked PRs, hotfix off `release/*`, renamed default branch). See #970
 
 
 
@@ -424,6 +426,23 @@ Set agent session ID for a session
 
 * `<IDENTIFIER>` — Session ID or title
 * `<SESSION_ID>` — Agent session ID to set (pass empty string to clear)
+
+
+
+## `aoe session set-base`
+
+Set or clear the per-session diff base branch. The diff view compares the worktree against this ref instead of the auto-detected default. Useful when the PR target differs from the project default (stacked PRs, hotfix off `release/*`, renamed default branch). See #970
+
+**Usage:** `aoe session set-base [OPTIONS] <IDENTIFIER> [BRANCH]`
+
+###### **Arguments:**
+
+* `<IDENTIFIER>` — Session ID or title
+* `<BRANCH>` — Branch ref to diff against (short name like `main` or remote-qualified like `upstream/main`). Required unless `--clear` is passed
+
+###### **Options:**
+
+* `--clear` — Clear the override and fall back to the profile default / auto-detected base
 
 
 

--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -31,10 +31,27 @@ After saving and exiting, the diff view refreshes automatically to show your cha
 
 | Key | Action |
 |-----|--------|
-| `b` | Change base branch |
+| `b` | Change base branch (persists per-session as `base_branch_override`) |
 | `r` | Refresh the diff |
 | `?` | Show help |
 | `Esc` | Close diff view |
+
+## Per-session base override
+
+Each session has an optional `base_branch_override` that takes
+precedence over the profile default and auto-detection. Use it when
+the eventual PR target differs from the project default (stacked PRs,
+hotfix off `release/*`, branch rename). The override is sticky across
+restarts and only affects the comparison, not the worktree itself
+(no rebase). See #970.
+
+- **Web dashboard**: click the `vs <ref>` chip in the diff header, pick
+  a branch from the typeahead (local + remote-only), or use
+  "Reset to auto-detected" to clear.
+- **TUI diff view**: press `b`, pick a branch; the choice is persisted
+  to `sessions.json` and restored on next launch.
+- **CLI**: `aoe session set-base <session> <branch>` to set,
+  `aoe session set-base <session> --clear` to clear.
 
 ## Configuration
 

--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -36,6 +36,41 @@ After saving and exiting, the diff view refreshes automatically to show your cha
 | `?` | Show help |
 | `Esc` | Close diff view |
 
+## Commenting on the diff (web only, cockpit sessions)
+
+The web dashboard lets you annotate lines in the diff and send the
+comments to the agent as a single prompt (#928).
+
+- Hover any line in the diff viewer to reveal a `+` button in the
+  left gutter. Click it to start a comment.
+- Click the `+` on the same line again to comment on that single
+  line, or click `+` on another line in the **same hunk** to extend
+  the range. Cross-hunk ranges are not allowed.
+- An inline form opens beneath the last line of the range. The body
+  supports markdown; `Cmd/Ctrl+Enter` saves, `Esc` cancels.
+- Saved comments render inline as cards with edit / delete actions
+  and a markdown-rendered body. Each card shows the line range it's
+  anchored to.
+- The right panel surfaces a banner above the diff file list once
+  you have at least one comment, with a Send button (or
+  `Cmd/Ctrl+Shift+S`).
+- The send dialog has three pieces: an editable intro textarea, a
+  read-only markdown preview of the assembled comments (each with
+  its captured code snippet so the agent can act without re-reading
+  the file), and an editable outro textarea (default "Please
+  address these comments."). Send fires `POST
+  /api/sessions/:id/cockpit/prompt`. Comments are cleared on
+  success unless you uncheck "Clear comments after sending".
+- Comments persist in `localStorage`, scoped per session. They
+  survive page reloads but are browser-local.
+- If a line range becomes unreachable in the current diff (agent
+  edited the file), the comment moves to a "stale comments" block
+  at the top of the file view with a `[stale]` chip; the captured
+  snippet still goes through to the agent in the prompt.
+- The feature is hidden for non-cockpit sessions (tmux/PTY). The
+  Send button is also disabled while the cockpit worker isn't
+  running.
+
 ## Per-session base override
 
 Each session has an optional `base_branch_override` that takes

--- a/docs/guides/diff-view.md
+++ b/docs/guides/diff-view.md
@@ -10,6 +10,8 @@ From the main screen, press `D` to open the diff view. It shows:
 
 The diff is computed against the base branch (defaults to `main` or your repo's default branch).
 
+Auto-detection scores every configured remote, not just `origin`. In a fork plus `upstream` layout, the diff compares against `upstream/main` when that tip is fresher than your local `main` and `origin/main`. The chosen ref is whichever candidate HEAD descends from with the most recent commit time, so a worktree branched off `upstream/main` does not see the gap between your stale fork-main and the actual branch point as session changes.
+
 ## Navigation
 
 | Key | Action |

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -9,7 +9,7 @@ For workflow guidance, see the [Workflow Guide](workflow.md).
 | Feature | CLI | TUI |
 |---------|-----|-----|
 | Create new branch | Use `-b` flag | Always creates new branch |
-| Use existing branch | Omit `-b` flag | Not supported |
+| Use existing branch | Omit `-b` flag | "Attach to existing branch" toggle (TUI: `Ctrl+P`; web: in the session step under the branch field) |
 | Branch validation | Checks if branch exists | None (always creates) |
 | Pick a base branch | `--base-branch <name>` | `Base` field in `Ctrl+P` overlay |
 
@@ -22,7 +22,9 @@ aoe add . -w feat/my-feature -b
 # Create worktree session (new branch, branched off a specific base)
 aoe add . -w hotfix-1 -b --base-branch release-1.2
 
-# Create worktree session (existing branch)
+# Attach to an existing branch + worktree (or check out the branch into a
+# new worktree if no worktree exists yet). The `-b` flag is what flips
+# between "create a new branch" and "attach"; omitting it = attach.
 aoe add . -w feat/my-feature
 
 # List all worktrees
@@ -66,7 +68,7 @@ branches off `upstream/main` rather than the stale fork tip. See issue
 
 In the TUI, enable the Worktree checkbox to create a new branch and worktree. By default, the worktree name is derived from the session title. Press `Ctrl+P` on the Worktree field to set an explicit `Name`, attach to an existing branch, pick a `Base` branch the new branch is based on (defaults to the repo default), or configure extra repos. `Ctrl+P` on the `Base` field opens a branch picker over local and remote-tracking branches.
 
-The web dashboard's new-session wizard exposes the same control under an "Advanced" disclosure beneath the worktree name input; it shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`.
+The web dashboard's new-session wizard exposes the same control under an "Advanced" disclosure beneath the worktree name input; it shows a typeahead populated from local + remote branches via `GET /api/git/branches?include_remote=true`. The same step also exposes an "Attach to existing branch" toggle that flips the request from "create new branch" to "attach to whichever branch is named" — when on, the server re-uses any existing worktree for that branch and otherwise checks the branch out into a new worktree. Mirrors the TUI / CLI behavior (CLI: omit `-b`). See #969.
 
 ## Configuration
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -47,6 +47,13 @@ local branch with that name, so passing a teammate's not-yet-fetched
 branch works without a manual `git fetch`. When omitted, the new
 branch is based on the repository's default branch (`main`/`master`).
 
+Default-branch detection scores every configured remote (not just
+`origin`). In a fork plus `upstream` layout, aoe picks the freshest
+`main`/`master` it can find that HEAD descends from. So if `upstream/main`
+is ahead of `origin/main` and your local `main`, `aoe add` fetches and
+branches off `upstream/main` rather than the stale fork tip. See issue
+\#1029 for the rationale.
+
 ## TUI Keyboard Shortcuts
 
 | Key | Action |

--- a/history/plan-diff-comments.md
+++ b/history/plan-diff-comments.md
@@ -1,0 +1,273 @@
+# Diff comments implementation plan (#928)
+
+**Goal:** Let users comment on lines / ranges in the web diff viewer (GitHub-style) and submit those comments as a single markdown prompt to the cockpit agent.
+
+## Debate summary
+
+**Positions:**
+- **gemini-3.1-pro-preview:** Persist captured snippet at authoring time; durable state at provider level with selection state local to viewer; React.memo + CSS hover + stable keyed fragments to avoid render thrashing; drop content-mismatch stale (initially) to avoid false positives; reject multi-tab storage event listener as YAGNI.
+- **gpt-5.5:** Same persisted-snippet model; version the storage envelope; explicit side semantics for ranges (new range skips deleted rows, vice versa); content-mismatch stale on top of line-missing stale; provider-wrapped layout because `RightPanel` and `DiffFileViewer` are siblings; gate send button on `cockpit_worker_state === "running"`; render stale comments in a file-level block (not only the dialog); separate pure modules per concern, no `utils.ts` junk drawer.
+
+**Points of agreement (final round):**
+- Durable comments are session-scoped, persisted in localStorage with a versioned envelope; cleared after successful send if the checkbox stays checked.
+- `DiffComment` must persist `capturedSnippet` (the exact text the user reviewed) and the inferred code-fence `language` at authoring time. Stale prompt assembly never re-extracts from the current diff.
+- Stale-status check: a comment whose `(side, [startLine..endLine])` is no longer represented in the current diff is `stale`. Content-mismatch is exposed by `anchor.ts` as a separate flag but not surfaced in v1 UI to avoid false-positive noise.
+- Side semantics: clicks on added rows anchor to `new`, clicks on deleted rows anchor to `old`, clicks on equal/context rows default to `new`. Snippet extraction filters rows by side (new-side range skips deleted rows; old-side range skips added rows).
+- Cross-hunk ranges disallowed.
+- Click-to-start → click-to-end range selection; clicking the same line twice = single-line comment. No drag.
+- Banner lives in `RightPanel`'s header (above `DiffFileList`); both surfaces (banner and diff viewer) must consume the same shared comments state, so the state lives in a session-scoped `DiffCommentsProvider` wrapping the relevant layout.
+- DiffLine extension is generic: `leadingSlot`, `isHighlighted`, `isRangeEndpoint`, optional `onGutterClick` for the slot's button. Wrap in `React.memo`. Keep hover purely CSS (no React hover state).
+- Inline form/card insertion uses keyed fragments (`Fragment key={...}` with stable child keys including `comment.id`).
+- Send button is disabled unless `session.cockpit_mode === true` and `session.cockpit_worker_state === "running"`.
+- Send dialog is three pieces (settled in round 2): editable intro textarea (top) + read-only Markdown preview of assembled comments (middle) + editable outro textarea (bottom, default "Please address these comments."). On send, the body is `intro + assembled + outro`. No single-editable-textarea (rejected for state-bifurcation reasons).
+- Dynamic code fences: outer fence length = max(3, longest consecutive backtick run in snippet + 1).
+- Hotkeys: keep `Esc` (cancel active form/range/dialog), `Cmd/Ctrl+Enter` (save in form), `Cmd/Ctrl+Shift+S` (open send dialog when comments exist). Drop `c` for v1 (no row focus model).
+- File layout: separate pure modules `buildPrompt.ts`, `extractSnippet.ts`, `anchor.ts`, `storage.ts`, `language.ts`. No `utils.ts` junk drawer.
+- Multi-tab storage event coherence: YAGNI for v1.
+
+**Resolved disagreements:**
+- **Content-mismatch stale:** gpt-5.5 wanted it surfaced; gemini argued false-positive risk (whitespace/formatter). **Verdict:** compute it inside `anchor.ts` (cheap), but in v1 UI only show `[stale]` when the range is missing. Keep the computation so a later UI iteration can surface `[changed]` without refactoring the anchor logic.
+- **Dialog structure:** "single editable textarea" was a stated requirement, but both debaters converged on the three-piece dialog after recognising the bifurcation problem. **Verdict:** adopt the three-piece dialog (intro / preview / outro); the "settled" requirement is reversed because both LLMs and the analysis support it.
+- **Multi-tab storage events:** gpt-5.5 wanted it; gemini called it YAGNI. **Verdict:** YAGNI for v1. Write-through on state change is enough.
+
+**Verdict:** Build a session-scoped comments subsystem. Durable state in `DiffCommentsProvider` (wrapping the layout) + persisted snippet/language per comment. Pure modules for prompt/snippet/anchor/storage/language. `DiffLine` gets generic slot props + `React.memo`. Inline form/card injection with keyed fragments. Cockpit-only; gate on worker running. Stale block at top of file viewer for stale comments. Three-piece send dialog. localStorage with versioned envelope. Hotkeys limited to Esc / Cmd-Enter / Cmd-Shift-S.
+
+---
+
+## Task 1: Types + storage + language map
+
+**Files:**
+- Create `web/src/components/diff/comments/types.ts`
+- Create `web/src/components/diff/comments/storage.ts`
+- Create `web/src/components/diff/comments/language.ts`
+
+**Notes:**
+- `DiffComment` shape:
+  ```ts
+  type DiffSide = "old" | "new";
+  interface DiffComment {
+    id: string;
+    repoName?: string;
+    filePath: string;
+    side: DiffSide;
+    startLine: number;
+    endLine: number;
+    body: string;
+    capturedSnippet: string;
+    language?: string;
+    createdAt: string;
+    updatedAt?: string;
+  }
+  ```
+- Storage envelope (versioned):
+  ```ts
+  interface DiffCommentsStorageV1 {
+    version: 1;
+    comments: DiffComment[];
+    clearAfterSend: boolean;
+    introDraft?: string;
+    outroDraft?: string;
+  }
+  ```
+- Storage key: `aoe:diff-comments:v1:${sessionId}`. Safe JSON parse with recovery; if `version !== 1`, drop and start fresh.
+- `language.ts`: tiny `extensionToLanguage(filePath)` returning code-fence language string (or empty).
+
+## Task 2: Pure snippet extraction
+
+**File:** Create `web/src/components/diff/comments/extractSnippet.ts`
+
+**Contract:**
+```ts
+function extractSnippetFromHunks(
+  hunks: RichDiffHunk[],
+  side: DiffSide,
+  startLine: number,
+  endLine: number,
+): { snippet: string; hunkIndex: number; endRowIndex: number } | null
+```
+- Iterate hunks, find the one whose `(old|new)_start..(start+lines)` covers the requested range.
+- Walk lines; for `side="new"` keep rows with `new_line_num != null` and skip pure deletes; for `side="old"` skip pure adds.
+- Return `null` if any line number in the range is missing.
+
+## Task 3: Anchor / stale matching
+
+**File:** Create `web/src/components/diff/comments/anchor.ts`
+
+**Contract:**
+```ts
+interface AnchoredComment {
+  comment: DiffComment;
+  status: "active" | "stale";
+  contentChanged: boolean;
+  hunkIndex?: number;
+  endRowIndex?: number;
+}
+function anchorComments(
+  comments: DiffComment[],
+  filePath: string,
+  repoName: string | undefined,
+  hunks: RichDiffHunk[],
+): AnchoredComment[]
+```
+- For each comment matching `(repoName, filePath)`: try extraction.
+- `null` → `status: "stale"`, no anchor.
+- Found → `status: "active"`, `contentChanged = (extracted !== comment.capturedSnippet)`.
+- `contentChanged` exposed for future UI; v1 UI only branches on `status`.
+
+## Task 4: Prompt builder
+
+**File:** Create `web/src/components/diff/comments/buildPrompt.ts`
+
+**Contract:**
+```ts
+function buildCommentsMarkdown(
+  comments: DiffComment[],
+  opts: { isMultiRepo: boolean },
+): string;
+function buildFullPrompt(
+  comments: DiffComment[],
+  intro: string,
+  outro: string,
+  opts: { isMultiRepo: boolean },
+): string;
+```
+- Sort comments by `(repoName ?? "")`, `filePath`, `startLine`, `side`, `createdAt`.
+- Heading: `### [repoA] \`src/foo.rs\` lines 42-45 (new)` (single-line variant: `line 42`).
+- Dynamic code fence: `Math.max(3, maxConsecutiveBackticks(snippet) + 1)`.
+- Default outro `"Please address these comments."` (caller passes it explicitly so tests are deterministic).
+- Trim trailing whitespace; ensure a single blank line between sections.
+
+## Task 5: useDiffComments hook + provider
+
+**Files:**
+- Create `web/src/hooks/useDiffComments.ts`
+- Add inline `<DiffCommentsProvider>` (or thread the hook through `App.tsx` to avoid context). Decision: lift the hook to `App.tsx` and pass `comments` + actions to both `RightPanel` and the diff viewer; no provider, simpler.
+
+**Hook API:**
+```ts
+interface UseDiffCommentsResult {
+  comments: DiffComment[];
+  count: number;
+  clearAfterSend: boolean;
+  setClearAfterSend(v: boolean): void;
+  introDraft: string;
+  outroDraft: string;
+  setIntroDraft(v: string): void;
+  setOutroDraft(v: string): void;
+  addComment(input: Omit<DiffComment, "id" | "createdAt">): DiffComment;
+  updateComment(id: string, body: string): void;
+  deleteComment(id: string): void;
+  clearComments(): void;
+}
+```
+- Load from localStorage on mount (by sessionId).
+- Write through on every change with versioned envelope.
+- Tests: round-trip, corruption recovery, scoped per session.
+
+## Task 6: DiffLine props + memo
+
+**File:** Edit `web/src/components/diff/DiffLine.tsx`
+
+- Add props: `leadingSlot?: React.ReactNode`, `isHighlighted?: boolean`, `isRangeEndpoint?: boolean`.
+- Wrap export with `React.memo`.
+- Hover state stays CSS-only (`group-hover`).
+- Add `group` class on the row; `leadingSlot` renders inside the old-line-num gutter (overlay, not new column — keeps total width stable).
+- Tinted background when `isHighlighted`; thicker left border when `isRangeEndpoint`.
+
+## Task 7: Inline form + card components
+
+**Files:**
+- Create `web/src/components/diff/comments/CommentForm.tsx`
+- Create `web/src/components/diff/comments/CommentCard.tsx`
+
+**CommentForm:**
+- Textarea (autofocus, `Cmd/Ctrl+Enter` save, `Esc` cancel).
+- Range readout `Comment on lines 42-45 (new)`.
+- Save / Cancel buttons.
+
+**CommentCard:**
+- Renders `comment.body` via existing `<Markdown text={body} />`.
+- `[stale]` chip when `status === "stale"`.
+- Edit / Delete actions; Edit toggles into CommentForm.
+
+## Task 8: CommentsBanner
+
+**File:** Create `web/src/components/diff/comments/CommentsBanner.tsx`
+
+- `N comment(s) · Send · Discard all`.
+- Send disabled when `!sendEnabled` with tooltip "Cockpit worker not running".
+- Visible only when `commentsEnabled` (cockpit_mode true) AND `count > 0`.
+
+## Task 9: SendCommentsDialog
+
+**File:** Create `web/src/components/diff/comments/SendCommentsDialog.tsx`
+
+- Three-piece layout:
+  - Intro textarea (top, bound to `introDraft`)
+  - Read-only assembled markdown preview (middle, renders via `<Markdown>`)
+  - Outro textarea (bottom, bound to `outroDraft`, placeholder "Please address these comments.")
+- Checkbox `Clear comments after sending` (bound to `clearAfterSend`).
+- Buttons: Cancel / Send.
+- Hotkeys: `Cmd/Ctrl+Enter` sends; `Esc` cancels.
+- On Send: POST `/api/sessions/:id/cockpit/prompt` with `{ text }`. Body composed at send time, not from stored copy.
+- On success: clear if checkbox checked; close.
+- On failure: keep dialog open, show inline error.
+
+## Task 10: DiffFileViewer integration
+
+**File:** Edit `web/src/components/diff/DiffFileViewer.tsx`
+
+- Accept `anchored: AnchoredComment[]`, `commentsEnabled: boolean`, `onAddComment`, `onUpdateComment`, `onDeleteComment` props.
+- Local state: `selection: { startLine, side, hunkIndex } | null` and `draft: { ... } | null`.
+- `+` button: rendered in `leadingSlot` of new-line-num gutter (only on hover via CSS).
+- Click handler:
+  - First click: set `selection`. Hint banner above hunk: "Click another line to extend, or click the same line again."
+  - Second click in same hunk + same side: compute range, extract snippet, open `CommentForm` after the end row.
+  - Same-line second click: single-line range.
+  - Escape clears selection.
+- HunkView render:
+  - Stale block at top of file (above first hunk).
+  - For each row, after `<DiffLine>`, render any `CommentCard`s whose `endRowIndex` matches and the `CommentForm` if active.
+  - Keyed fragments: `Fragment key={\`row-h${hi}-r${i}\`}` with explicit child keys `line-${...}`, `comment-${comment.id}`, `form-${draftKey}`.
+
+## Task 11: Wire through RightPanel + App
+
+**Files:**
+- Edit `web/src/components/RightPanel.tsx`: render `<CommentsBanner>` above `<DiffFileList>` when `comments.length > 0`.
+- Edit `web/src/App.tsx`: lift `useDiffComments(activeSessionId)`; thread `anchored`/actions through `<DiffFileViewer>` (passed to RightPanel? no — DiffFileViewer lives in main content, not RightPanel).
+
+Need to find where `<DiffFileViewer>` is rendered and thread the props there.
+
+## Task 12: Send dialog open state + global hotkey
+
+- App-level `sendDialogOpen` state.
+- `Cmd/Ctrl+Shift+S` global handler (window level, ignore when target is input/textarea/contenteditable) opens dialog when `count > 0 && commentsEnabled`.
+- Banner Send button opens same dialog.
+
+## Task 13: Tests
+
+**Files:**
+- Create `web/src/components/diff/comments/buildPrompt.test.ts`
+- Create `web/src/components/diff/comments/extractSnippet.test.ts`
+- Create `web/src/components/diff/comments/anchor.test.ts`
+
+Cover: ordering, dynamic fences, multi-repo prefix, single-line vs range wording, missing range → null, side filtering, stale detection.
+
+(Skip Playwright in this pass; lots of moving parts, will add follow-up.)
+
+## Task 14: Docs
+
+**File:** Edit `docs/guides/diff-view.md`
+
+Add a "Commenting on the diff" section: how to start a comment, range selection, send flow, stale handling.
+
+---
+
+## Notes on scope discipline
+
+- No backend changes. Send endpoint already exists.
+- No new dependencies. `marked` and existing `<Markdown>` cover rendering.
+- TUI deferred — issue allows it.
+- Mobile drag UX deferred — click-click works on touch.
+- Multi-tab sync deferred.
+- Content-mismatch UI surfacing deferred (computed but not displayed in v1).

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -202,50 +202,79 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             let git_wt =
                 GitWorktree::new(main_repo_path.clone())?.with_init_submodules(init_submodules);
 
-            let session_id = uuid::Uuid::new_v4().to_string();
-            let session_id_short = &session_id[..8];
-
-            // Choose appropriate template based on repo type (bare vs regular)
-            // Use main_repo_path (not path) to correctly detect bare repos when running from a worktree
-            let template = if GitWorktree::is_bare_repo(&main_repo_path) {
-                &config.worktree.bare_repo_path_template
-            } else {
-                &config.worktree.path_template
-            };
-            let worktree_path = git_wt.compute_path(branch, template, session_id_short)?;
-
-            if worktree_path.exists() {
-                bail!(
-                    "Worktree already exists at {}\nTip: Use 'aoe add {}' to add the existing worktree",
-                    worktree_path.display(),
-                    worktree_path.display()
-                );
-            }
-
-            println!("Creating worktree at: {}", worktree_path.display());
-            let base = if args.create_branch {
-                args.base_branch.as_deref()
+            // Attach mode: when `-b` is not passed, mirror the TUI's "Attach
+            // to existing branch" behavior. If a worktree already exists
+            // for this branch, point the session at it instead of bailing.
+            // This closes the CLI half of #969 / matches builder.rs.
+            let attach_existing = !args.create_branch;
+            let existing_match = if attach_existing {
+                git_wt.list_worktrees().ok().and_then(|wts| {
+                    wts.into_iter()
+                        .find(|wt| wt.branch.as_deref() == Some(branch))
+                })
             } else {
                 None
             };
-            let warnings =
-                git_wt.create_worktree(branch, &worktree_path, args.create_branch, base)?;
 
-            path = worktree_path;
+            if let Some(existing) = existing_match {
+                println!(
+                    "Attaching to existing worktree: {}",
+                    existing.path.display()
+                );
+                path = existing.path;
+                worktree_info_opt = Some(WorktreeInfo {
+                    branch: branch.to_string(),
+                    main_repo_path: main_repo_path.to_string_lossy().to_string(),
+                    managed_by_aoe: false,
+                    created_at: Utc::now(),
+                    base_branch: None,
+                });
+            } else {
+                let session_id = uuid::Uuid::new_v4().to_string();
+                let session_id_short = &session_id[..8];
 
-            worktree_info_opt = Some(WorktreeInfo {
-                branch: branch.to_string(),
-                main_repo_path: main_repo_path.to_string_lossy().to_string(),
-                managed_by_aoe: true,
-                created_at: Utc::now(),
-                base_branch: base.map(|s| s.to_string()),
-            });
+                // Choose appropriate template based on repo type (bare vs regular)
+                // Use main_repo_path (not path) to correctly detect bare repos when running from a worktree
+                let template = if GitWorktree::is_bare_repo(&main_repo_path) {
+                    &config.worktree.bare_repo_path_template
+                } else {
+                    &config.worktree.path_template
+                };
+                let worktree_path = git_wt.compute_path(branch, template, session_id_short)?;
 
-            for w in &warnings {
-                eprintln!("⚠ {}", w);
+                if worktree_path.exists() {
+                    bail!(
+                        "Worktree already exists at {}\nTip: Use 'aoe add {}' to add the existing worktree",
+                        worktree_path.display(),
+                        worktree_path.display()
+                    );
+                }
+
+                println!("Creating worktree at: {}", worktree_path.display());
+                let base = if args.create_branch {
+                    args.base_branch.as_deref()
+                } else {
+                    None
+                };
+                let warnings =
+                    git_wt.create_worktree(branch, &worktree_path, args.create_branch, base)?;
+
+                path = worktree_path;
+
+                worktree_info_opt = Some(WorktreeInfo {
+                    branch: branch.to_string(),
+                    main_repo_path: main_repo_path.to_string_lossy().to_string(),
+                    managed_by_aoe: true,
+                    created_at: Utc::now(),
+                    base_branch: base.map(|s| s.to_string()),
+                });
+
+                for w in &warnings {
+                    eprintln!("⚠ {}", w);
+                }
+
+                println!("✓ Worktree created successfully");
             }
-
-            println!("✓ Worktree created successfully");
         }
     }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -34,6 +34,13 @@ pub enum SessionCommands {
 
     /// Set agent session ID for a session
     SetSessionId(SetSessionIdArgs),
+
+    /// Set or clear the per-session diff base branch. The diff view
+    /// compares the worktree against this ref instead of the
+    /// auto-detected default. Useful when the PR target differs from
+    /// the project default (stacked PRs, hotfix off `release/*`,
+    /// renamed default branch). See #970.
+    SetBase(SetBaseArgs),
 }
 
 #[derive(Args)]
@@ -132,6 +139,20 @@ pub struct SetSessionIdArgs {
     session_id: String,
 }
 
+#[derive(Args)]
+pub struct SetBaseArgs {
+    /// Session ID or title
+    pub identifier: String,
+    /// Branch ref to diff against (short name like `main` or
+    /// remote-qualified like `upstream/main`). Required unless
+    /// `--clear` is passed.
+    pub branch: Option<String>,
+    /// Clear the override and fall back to the profile default /
+    /// auto-detected base.
+    #[arg(long, conflicts_with = "branch")]
+    pub clear: bool,
+}
+
 #[derive(Serialize)]
 struct SessionDetails {
     id: String,
@@ -157,6 +178,7 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
         SessionCommands::Rename(args) => rename_session(profile, args).await,
         SessionCommands::Current(args) => current_session(args).await,
         SessionCommands::SetSessionId(args) => set_session_id(profile, args).await,
+        SessionCommands::SetBase(args) => set_base(profile, args).await,
     }
 }
 
@@ -727,6 +749,45 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
     Ok(())
 }
 
+async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
+    if !args.clear && args.branch.is_none() {
+        bail!("Provide a branch ref or pass --clear to remove the override.");
+    }
+    let storage = Storage::new(profile)?;
+    let (mut instances, groups) = storage.load_with_groups()?;
+
+    let idx = instances
+        .iter()
+        .position(|i| {
+            i.id == args.identifier
+                || i.id.starts_with(&args.identifier)
+                || i.title == args.identifier
+        })
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+
+    let new_value = if args.clear {
+        None
+    } else {
+        let trimmed = args.branch.as_deref().unwrap_or("").trim().to_string();
+        if trimmed.is_empty() {
+            bail!("Branch name is empty. Pass --clear to remove the override.");
+        }
+        Some(trimmed)
+    };
+
+    instances[idx].base_branch_override = new_value.clone();
+    let title = instances[idx].title.clone();
+
+    let group_tree = GroupTree::new_with_groups(&instances, &groups);
+    storage.save_with_groups(&instances, &group_tree)?;
+
+    match new_value {
+        Some(ref v) => println!("✓ Set diff base for '{}': {}", title, v),
+        None => println!("✓ Cleared diff base override for '{}'", title),
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod restart_args_tests {
     use super::SessionCommands;
@@ -784,6 +845,43 @@ mod restart_args_tests {
         assert!(
             result.is_err(),
             "passing both identifier and --all should error"
+        );
+    }
+
+    #[test]
+    fn set_base_with_branch_parses() {
+        let cli = Cli::try_parse_from(["aoe", "set-base", "claude-3", "upstream/main"])
+            .expect("set-base with branch must parse");
+        match cli.cmd {
+            SessionCommands::SetBase(args) => {
+                assert_eq!(args.identifier, "claude-3");
+                assert_eq!(args.branch.as_deref(), Some("upstream/main"));
+                assert!(!args.clear);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn set_base_with_clear_parses() {
+        let cli = Cli::try_parse_from(["aoe", "set-base", "claude-3", "--clear"])
+            .expect("set-base --clear must parse");
+        match cli.cmd {
+            SessionCommands::SetBase(args) => {
+                assert_eq!(args.identifier, "claude-3");
+                assert!(args.branch.is_none());
+                assert!(args.clear);
+            }
+            _ => panic!("wrong subcommand"),
+        }
+    }
+
+    #[test]
+    fn set_base_branch_and_clear_conflicts() {
+        let result = Cli::try_parse_from(["aoe", "set-base", "claude-3", "main", "--clear"]);
+        assert!(
+            result.is_err(),
+            "passing both branch and --clear should error"
         );
     }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -754,7 +754,7 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
         bail!("Provide a branch ref or pass --clear to remove the override.");
     }
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let mut instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -772,14 +772,33 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
         if trimmed.is_empty() {
             bail!("Branch name is empty. Pass --clear to remove the override.");
         }
+        // Validate the ref against the same resolution chain the diff
+        // resolver uses, so users see a clear error at set-time rather
+        // than a silent fallback when the diff is next computed. For
+        // workspace sessions, validate against the first repo's
+        // worktree (each repo will resolve the ref the same way).
+        let validate_path = instances[idx]
+            .workspace_info
+            .as_ref()
+            .and_then(|w| w.repos.first().map(|r| r.worktree_path.clone()))
+            .unwrap_or_else(|| instances[idx].project_path.clone());
+        if let Err(e) =
+            crate::git::diff::validate_ref(std::path::Path::new(&validate_path), &trimmed)
+        {
+            bail!(
+                "Branch '{}' does not resolve in {}: {}",
+                trimmed,
+                validate_path,
+                e
+            );
+        }
         Some(trimmed)
     };
 
     instances[idx].base_branch_override = new_value.clone();
     let title = instances[idx].title.clone();
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.save_with_groups(&instances, &group_tree)?;
+    storage.save(&instances)?;
 
     match new_value {
         Some(ref v) => println!("✓ Set diff base for '{}': {}", title, v),

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -619,6 +619,17 @@ pub fn get_default_base_ref(repo_path: &Path) -> Result<String> {
     Ok(git_wt.detect_default_branch_info()?.qualified_ref())
 }
 
+/// Returns `Ok(())` when `reference` resolves to a commit in the repo at
+/// `repo_path` using the same resolution chain (`local branch`,
+/// `origin/<ref>` tracking branch, `revparse_single`) that
+/// `compute_changed_files` consults. Used by the CLI to validate
+/// user-provided refs (e.g. `aoe session set-base`) before persisting
+/// a per-session diff base override. See #970.
+pub fn validate_ref(repo_path: &Path, reference: &str) -> Result<()> {
+    let repo = git2::Repository::open(repo_path)?;
+    get_commit_from_ref(&repo, reference).map(|_| ())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -981,6 +992,30 @@ mod tests {
         // Should return the current branch (usually "master" for git init)
         let branch = get_default_branch(dir.path());
         assert!(branch.is_ok());
+    }
+
+    #[test]
+    fn test_validate_ref_accepts_existing_branch() {
+        let (dir, repo) = setup_test_repo();
+        let head_name = repo.head().unwrap().shorthand().unwrap().to_string();
+        validate_ref(dir.path(), &head_name).expect("HEAD branch should resolve");
+    }
+
+    #[test]
+    fn test_validate_ref_rejects_missing_branch() {
+        let (dir, _repo) = setup_test_repo();
+        let err = validate_ref(dir.path(), "definitely-does-not-exist");
+        assert!(err.is_err(), "missing ref should not resolve");
+    }
+
+    #[test]
+    fn test_validate_ref_rejects_non_repo() {
+        let dir = TempDir::new().unwrap();
+        let err = validate_ref(dir.path(), "main");
+        assert!(
+            err.is_err(),
+            "validate_ref against non-repo path should error"
+        );
     }
 
     #[test]

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -607,6 +607,18 @@ pub fn get_default_branch(repo_path: &Path) -> Result<String> {
     git_wt.detect_default_branch()
 }
 
+/// Get the default base ref for diffing as a remote-qualified ref name
+/// when the freshest copy lives on a non-default remote. Falls back to
+/// the short branch name when the picked candidate is local.
+///
+/// Use this (not `get_default_branch`) for diff base resolution, so
+/// fork + `upstream` layouts compare against `upstream/main` instead
+/// of a stale local `main`. See issue #1029.
+pub fn get_default_base_ref(repo_path: &Path) -> Result<String> {
+    let git_wt = super::GitWorktree::new(repo_path.to_path_buf())?;
+    Ok(git_wt.detect_default_branch_info()?.qualified_ref())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -2,6 +2,7 @@
 //! path computation. Split out from `mod.rs` as part of the code-quality
 //! consolidation pass; the public API is unchanged.
 
+use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
 
@@ -9,15 +10,47 @@ use super::error::{GitError, Result};
 use super::open_repo_at;
 use super::template::{resolve_template, TemplateVars};
 
-/// Default remote name used for fetch-before-worktree-create.
-/// Hardcoded for now; if multi-remote support is needed (e.g., "upstream"
-/// vs personal fork), this is the place to parameterize.
+/// Remote name used as a fallback when no candidate remote can be picked
+/// from the local refs. Real selection happens in
+/// `detect_default_branch_info`, which walks every configured remote and
+/// scores its tracking refs by ancestry to HEAD and commit recency. This
+/// constant only matters for the legacy single-remote / "no refs in repo
+/// yet" path.
 const FETCH_REMOTE: &str = "origin";
 
 pub struct WorktreeEntry {
     pub path: PathBuf,
     pub branch: Option<String>,
     pub is_detached: bool,
+}
+
+/// Resolved default branch with the remote it came from, if any.
+///
+/// Returned by `GitWorktree::detect_default_branch_info`. Callers that
+/// need to fetch / branch off / diff against the canonical default
+/// should use this rather than just the branch name, because the same
+/// short name (e.g. `main`) can refer to different commits depending on
+/// which remote the canonical version lives at. See issue #1029.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DefaultBranchInfo {
+    /// Short branch name (e.g. `"main"`).
+    pub name: String,
+    /// Remote name (`"origin"`, `"upstream"`, ...) when the chosen ref
+    /// is a remote tracking branch. `None` when the chosen ref is a
+    /// purely local branch.
+    pub remote: Option<String>,
+}
+
+impl DefaultBranchInfo {
+    /// Resolvable ref name for git2's `find_branch` (remote variant)
+    /// and `revparse_single`. Remote refs become `"<remote>/<name>"`;
+    /// local refs are returned unchanged.
+    pub fn qualified_ref(&self) -> String {
+        match &self.remote {
+            Some(remote) => format!("{remote}/{name}", name = self.name),
+            None => self.name.clone(),
+        }
+    }
 }
 
 pub struct GitWorktree {
@@ -203,49 +236,92 @@ impl GitWorktree {
         }
     }
 
-    /// Detect the default branch name by checking the remote HEAD first, then
-    /// local and remote refs for "main" or "master". Falls back to the first
-    /// local branch if neither exists.
+    /// Detect the default branch name by short name only. Wraps
+    /// `detect_default_branch_info`; callers that need the remote (for
+    /// fetching / building a tracking-ref string) should use the info
+    /// variant directly.
     pub fn detect_default_branch(&self) -> Result<String> {
-        let repo = open_repo_at(&self.repo_path)?;
-        let remote_prefix = format!("refs/remotes/{FETCH_REMOTE}/");
-        let remote_head_ref = format!("{remote_prefix}HEAD");
+        self.detect_default_branch_info().map(|i| i.name)
+    }
 
-        if let Ok(reference) = repo.find_reference(&remote_head_ref) {
-            if let Some(target) = reference.symbolic_target() {
-                if let Some(branch_name) = target.strip_prefix(&remote_prefix) {
-                    if branch_name != "HEAD" {
-                        return Ok(branch_name.to_string());
-                    }
+    /// Detect the default branch and the remote that owns the freshest
+    /// copy of it, scored against HEAD.
+    ///
+    /// Selection considers every configured remote (not just `origin`),
+    /// so a fork + `upstream` layout picks `upstream/main` over a stale
+    /// local `main` or fork `origin/main` (issue #1029).
+    ///
+    /// Candidate pool: every remote's `refs/remotes/<r>/HEAD` symbolic
+    /// target, plus `refs/remotes/<r>/main` / `refs/remotes/<r>/master`
+    /// for every remote, plus local `main` / `master`. Among candidates
+    /// that HEAD descends from (`merge_base(HEAD, candidate) == candidate`),
+    /// the one with the most recent commit time wins; ties break in
+    /// favor of a remote's stated default (`refs/remotes/*/HEAD`),
+    /// then remote over local, then `origin` over other remotes.
+    ///
+    /// If HEAD doesn't descend from any candidate (unrelated history),
+    /// the same scoring runs over all candidates without the ancestry
+    /// filter. With no candidates at all (no main/master, no remote
+    /// HEAD), falls back to the first local branch like the previous
+    /// implementation.
+    pub fn detect_default_branch_info(&self) -> Result<DefaultBranchInfo> {
+        let repo = open_repo_at(&self.repo_path)?;
+        let candidates = collect_default_branch_candidates(&repo);
+
+        if candidates.is_empty() {
+            if let Some(Ok((branch, _))) = repo.branches(Some(git2::BranchType::Local))?.next() {
+                if let Ok(Some(name)) = branch.name() {
+                    return Ok(DefaultBranchInfo {
+                        name: name.to_string(),
+                        remote: None,
+                    });
                 }
             }
+            return Err(GitError::BranchNotFound(
+                "No default branch found".to_string(),
+            ));
         }
 
-        for name in &["main", "master"] {
-            if repo.find_branch(name, git2::BranchType::Local).is_ok() {
-                return Ok(name.to_string());
+        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+
+        let pool: Vec<&Candidate> = if let Some(head_commit) = head_commit.as_ref() {
+            let ancestors: Vec<&Candidate> = candidates
+                .iter()
+                .filter(|c| {
+                    repo.merge_base(head_commit.id(), c.oid)
+                        .map(|mb| mb == c.oid)
+                        .unwrap_or(false)
+                })
+                .collect();
+            if ancestors.is_empty() {
+                candidates.iter().collect()
+            } else {
+                ancestors
             }
-        }
+        } else {
+            candidates.iter().collect()
+        };
 
-        for name in &["main", "master"] {
-            let remote_ref = format!("{FETCH_REMOTE}/{name}");
-            if repo
-                .find_branch(&remote_ref, git2::BranchType::Remote)
-                .is_ok()
-            {
-                return Ok(name.to_string());
-            }
-        }
+        let pick = pool
+            .into_iter()
+            .max_by(|a, b| {
+                a.commit_time
+                    .cmp(&b.commit_time)
+                    .then_with(|| a.is_stated_default.cmp(&b.is_stated_default))
+                    .then_with(|| a.remote.is_some().cmp(&b.remote.is_some()))
+                    .then_with(|| {
+                        let a_origin = a.remote.as_deref() == Some(FETCH_REMOTE);
+                        let b_origin = b.remote.as_deref() == Some(FETCH_REMOTE);
+                        a_origin.cmp(&b_origin)
+                    })
+                    .then_with(|| b.name.cmp(&a.name))
+            })
+            .expect("pool is non-empty when candidates is non-empty");
 
-        if let Some(Ok((branch, _))) = repo.branches(Some(git2::BranchType::Local))?.next() {
-            if let Ok(Some(name)) = branch.name() {
-                return Ok(name.to_string());
-            }
-        }
-
-        Err(GitError::BranchNotFound(
-            "No default branch found".to_string(),
-        ))
+        Ok(DefaultBranchInfo {
+            name: pick.name.clone(),
+            remote: pick.remote.clone(),
+        })
     }
 
     /// Create a new worktree at `path` checking out `branch`.
@@ -294,15 +370,25 @@ impl GitWorktree {
         // fetch the branch itself. Fails silently on network errors, falling
         // back to local refs.
         let t = std::time::Instant::now();
-        let resolved_base = if create_branch {
-            let base = match base_branch {
-                Some(b) if !b.trim().is_empty() => b.trim().to_string(),
-                _ => self
-                    .detect_default_branch()
-                    .unwrap_or_else(|_| "main".to_string()),
-            };
-            self.fetch_branch(FETCH_REMOTE, &base)?;
-            Some(base)
+        let resolved_base: Option<(String, Option<String>)> = if create_branch {
+            match base_branch {
+                Some(b) if !b.trim().is_empty() => {
+                    let base = b.trim().to_string();
+                    self.fetch_branch(FETCH_REMOTE, &base)?;
+                    Some((base, None))
+                }
+                _ => {
+                    let info = self
+                        .detect_default_branch_info()
+                        .unwrap_or(DefaultBranchInfo {
+                            name: "main".to_string(),
+                            remote: None,
+                        });
+                    let fetch_remote = info.remote.as_deref().unwrap_or(FETCH_REMOTE);
+                    self.fetch_branch(fetch_remote, &info.name)?;
+                    Some((info.name, info.remote))
+                }
+            }
         } else {
             self.fetch_branch(FETCH_REMOTE, branch)?;
             None
@@ -312,17 +398,32 @@ impl GitWorktree {
         let t = std::time::Instant::now();
         let repo = open_repo_at(&self.repo_path)?;
 
-        if let Some(base) = resolved_base {
-            // Branch from `origin/<base>` so new branches start from the
-            // latest remote state. Falls back to a local branch with the
-            // same name (lets users base off a teammate's local-only
-            // branch), then to HEAD, then to any local branch (bare repo
-            // with broken HEAD).
-            let remote_ref = format!("{FETCH_REMOTE}/{base}");
+        if let Some((base, base_remote)) = resolved_base {
+            // Branch from the picked remote's tip when the auto-detected
+            // canonical remote isn't `origin` (issue #1029: fork+upstream
+            // layouts). When the caller passed an explicit `--base-branch`,
+            // try `origin/<base>` first to preserve historical behavior.
+            // Falls back to a local branch with the same name (lets users
+            // base off a teammate's local-only branch), then to HEAD,
+            // then to any local branch (bare repo with broken HEAD).
+            let primary_remote = base_remote.as_deref().unwrap_or(FETCH_REMOTE);
+            let remote_ref = format!("{primary_remote}/{base}");
             let commit_oid = repo
                 .find_branch(&remote_ref, git2::BranchType::Remote)
                 .ok()
                 .and_then(|b| b.get().target())
+                .or_else(|| {
+                    // Secondary fallback to `origin/<base>` when the
+                    // primary remote was something other than `origin`.
+                    if primary_remote == FETCH_REMOTE {
+                        None
+                    } else {
+                        let origin_ref = format!("{FETCH_REMOTE}/{base}");
+                        repo.find_branch(&origin_ref, git2::BranchType::Remote)
+                            .ok()
+                            .and_then(|b| b.get().target())
+                    }
+                })
                 .or_else(|| {
                     repo.find_branch(&base, git2::BranchType::Local)
                         .ok()
@@ -745,6 +846,109 @@ impl GitWorktree {
             Err(GitError::NotAGitRepo)
         }
     }
+}
+
+/// One default-branch candidate considered by
+/// `detect_default_branch_info`. Scored by `commit_time` first, with
+/// `is_stated_default`/remote/origin used as tiebreakers.
+struct Candidate {
+    name: String,
+    remote: Option<String>,
+    /// True when this candidate came from a `refs/remotes/<r>/HEAD`
+    /// symbolic target rather than the `main`/`master` convention.
+    is_stated_default: bool,
+    oid: git2::Oid,
+    commit_time: i64,
+}
+
+fn collect_default_branch_candidates(repo: &git2::Repository) -> Vec<Candidate> {
+    let mut out: Vec<Candidate> = Vec::new();
+    let mut seen: HashSet<(String, Option<String>)> = HashSet::new();
+
+    let remote_names: Vec<String> = repo
+        .remotes()
+        .ok()
+        .as_ref()
+        .map(|rs| rs.iter().flatten().map(String::from).collect())
+        .unwrap_or_default();
+
+    let mut stated_defaults: Vec<(String, String)> = Vec::new();
+    for remote in &remote_names {
+        let head_ref_name = format!("refs/remotes/{remote}/HEAD");
+        let Ok(reference) = repo.find_reference(&head_ref_name) else {
+            continue;
+        };
+        let Some(target) = reference.symbolic_target() else {
+            continue;
+        };
+        let prefix = format!("refs/remotes/{remote}/");
+        if let Some(branch_name) = target.strip_prefix(&prefix) {
+            if branch_name != "HEAD" && !branch_name.is_empty() {
+                stated_defaults.push((remote.clone(), branch_name.to_string()));
+            }
+        }
+    }
+
+    let push = |out: &mut Vec<Candidate>,
+                seen: &mut HashSet<(String, Option<String>)>,
+                name: String,
+                remote: Option<String>,
+                is_stated_default: bool| {
+        let key = (name.clone(), remote.clone());
+        if seen.contains(&key) {
+            return;
+        }
+        let commit = match &remote {
+            Some(r) => {
+                let full = format!("{r}/{name}");
+                repo.find_branch(&full, git2::BranchType::Remote)
+                    .ok()
+                    .and_then(|b| b.get().peel_to_commit().ok())
+            }
+            None => repo
+                .find_branch(&name, git2::BranchType::Local)
+                .ok()
+                .and_then(|b| b.get().peel_to_commit().ok()),
+        };
+        if let Some(commit) = commit {
+            seen.insert(key);
+            out.push(Candidate {
+                name,
+                remote,
+                is_stated_default,
+                oid: commit.id(),
+                commit_time: commit.time().seconds(),
+            });
+        }
+    };
+
+    for (remote, name) in &stated_defaults {
+        push(
+            &mut out,
+            &mut seen,
+            name.clone(),
+            Some(remote.clone()),
+            true,
+        );
+    }
+
+    for remote in &remote_names {
+        for name in ["main", "master"] {
+            push(
+                &mut out,
+                &mut seen,
+                name.to_string(),
+                Some(remote.clone()),
+                false,
+            );
+        }
+    }
+
+    for name in ["main", "master"] {
+        push(&mut out, &mut seen, name.to_string(), None, false);
+    }
+
+    out
 }
 
 struct WorktreeWalkStats {
@@ -2050,6 +2254,192 @@ mod tests {
 
         let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
         assert_eq!(git_wt.detect_default_branch().unwrap(), "develop");
+    }
+
+    /// Fork + upstream layout (issue #1029): when `origin` is the user's
+    /// stale fork and `upstream` is the canonical remote, the freshest
+    /// `main` lives at `upstream/main`. Detection must pick it over a
+    /// stale local `main` and stale `origin/main`.
+    #[test]
+    fn test_detect_default_branch_picks_upstream_over_stale_origin() {
+        let upstream_dir = TempDir::new().unwrap();
+        let upstream = git2::Repository::init_bare(upstream_dir.path()).unwrap();
+        upstream.set_head("refs/heads/main").unwrap();
+
+        // Use explicit timestamps so commit B is detectably newer than
+        // commit A. git2 commit times are second-precision; without
+        // this the in-test commits all collide at the same second and
+        // commit-time scoring degenerates into tiebreak territory.
+        let sig_a = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(1_700_000_000, 0),
+        )
+        .unwrap();
+        let sig_b = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(1_700_001_000, 0),
+        )
+        .unwrap();
+        let tree_a_id = {
+            let blob = upstream.blob(b"hello").unwrap();
+            let mut tb = upstream.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree_a = upstream.find_tree(tree_a_id).unwrap();
+        let commit_a = upstream
+            .commit(
+                Some("refs/heads/main"),
+                &sig_a,
+                &sig_a,
+                "commit A",
+                &tree_a,
+                &[],
+            )
+            .unwrap();
+
+        let origin_dir = TempDir::new().unwrap();
+        let origin = git2::Repository::init_bare(origin_dir.path()).unwrap();
+        origin.set_head("refs/heads/main").unwrap();
+        let origin_tree = {
+            let blob = origin.blob(b"hello").unwrap();
+            let mut tb = origin.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            let id = tb.write().unwrap();
+            origin.find_tree(id).unwrap()
+        };
+        origin
+            .commit(
+                Some("refs/heads/main"),
+                &sig_a,
+                &sig_a,
+                "commit A",
+                &origin_tree,
+                &[],
+            )
+            .unwrap();
+
+        let commit_a_obj = upstream.find_commit(commit_a).unwrap();
+        let tree_b = {
+            let blob = upstream.blob(b"world").unwrap();
+            let mut tb = upstream.treebuilder(Some(&tree_a)).unwrap();
+            tb.insert("file2.txt", blob, 0o100644).unwrap();
+            let id = tb.write().unwrap();
+            upstream.find_tree(id).unwrap()
+        };
+        let commit_b = upstream
+            .commit(
+                Some("refs/heads/main"),
+                &sig_b,
+                &sig_b,
+                "commit B",
+                &tree_b,
+                &[&commit_a_obj],
+            )
+            .unwrap();
+
+        let local_dir = TempDir::new().unwrap();
+        git2::Repository::clone(origin_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
+        run_git(
+            local_dir.path(),
+            &[
+                "remote",
+                "add",
+                "upstream",
+                upstream_dir.path().to_str().unwrap(),
+            ],
+        );
+        run_git(local_dir.path(), &["fetch", "upstream"]);
+
+        let local_repo = git2::Repository::open(local_dir.path()).unwrap();
+        let upstream_tip = local_repo
+            .find_branch("upstream/main", git2::BranchType::Remote)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap();
+        local_repo.branch("feature", &upstream_tip, false).unwrap();
+        local_repo.set_head("refs/heads/feature").unwrap();
+
+        // Sanity: HEAD is at commit B, local main and origin/main at commit A.
+        assert_eq!(
+            local_repo.head().unwrap().peel_to_commit().unwrap().id(),
+            commit_b
+        );
+        let local_main_oid = local_repo
+            .find_branch("main", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        assert_eq!(local_main_oid, commit_a);
+
+        let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
+        let info = git_wt.detect_default_branch_info().unwrap();
+        assert_eq!(info.name, "main");
+        assert_eq!(
+            info.remote.as_deref(),
+            Some("upstream"),
+            "should pick upstream/main over stale origin/main and local main; got {info:?}"
+        );
+        assert_eq!(info.qualified_ref(), "upstream/main");
+        assert_eq!(git_wt.detect_default_branch().unwrap(), "main");
+    }
+
+    /// HEAD doesn't descend from any candidate (unrelated history /
+    /// fresh detached state). The non-ancestor pool is still scored,
+    /// so something sensible comes back rather than an error.
+    #[test]
+    fn test_detect_default_branch_info_falls_back_when_no_ancestor() {
+        let dir = TempDir::new().unwrap();
+        let repo = git2::Repository::init(dir.path()).unwrap();
+
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let main_commit = repo
+            .commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        // Force HEAD onto an unrelated history by detaching to an
+        // orphan commit (no parents, different tree).
+        let blob = repo.blob(b"orphan").unwrap();
+        let mut tb = repo.treebuilder(None).unwrap();
+        tb.insert("orphan.txt", blob, 0o100644).unwrap();
+        let orphan_tree = repo.find_tree(tb.write().unwrap()).unwrap();
+        let orphan_commit = repo
+            .commit(None, &sig, &sig, "orphan", &orphan_tree, &[])
+            .unwrap();
+        repo.set_head_detached(orphan_commit).unwrap();
+
+        // Sanity: HEAD is orphan, main exists at main_commit.
+        let head_oid = repo.head().unwrap().peel_to_commit().unwrap().id();
+        assert_eq!(head_oid, orphan_commit);
+        assert_ne!(head_oid, main_commit);
+
+        let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
+        let info = git_wt.detect_default_branch_info().unwrap();
+        assert_eq!(info.name, "main");
+        assert!(info.remote.is_none());
+    }
+
+    /// Qualified ref helper round-trips remote vs local correctly.
+    #[test]
+    fn test_default_branch_info_qualified_ref() {
+        let remote = DefaultBranchInfo {
+            name: "main".to_string(),
+            remote: Some("upstream".to_string()),
+        };
+        assert_eq!(remote.qualified_ref(), "upstream/main");
+
+        let local = DefaultBranchInfo {
+            name: "develop".to_string(),
+            remote: None,
+        };
+        assert_eq!(local.qualified_ref(), "develop");
     }
 
     // --- fetch_branch tests ---

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -35,8 +35,8 @@ pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     list_sessions, read_output, rename_session, send_message, session_diff_file,
-    session_diff_files, update_session_notifications, CleanupDefaults, OutputQuery,
-    SendMessageRequest, SessionResponse,
+    session_diff_files, update_session_diff_base, update_session_notifications, CleanupDefaults,
+    OutputQuery, SendMessageRequest, SessionResponse,
 };
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1581,7 +1581,8 @@ pub async fn session_diff_files(
 
         for repo in &repos {
             let path = std::path::Path::new(&repo.path);
-            let base_branch = diff::get_default_branch(path).unwrap_or_else(|_| "main".to_string());
+            let base_branch =
+                diff::get_default_base_ref(path).unwrap_or_else(|_| "main".to_string());
             let warning = diff::check_merge_base_status(path, &base_branch);
             let changed = diff::compute_changed_files(path, &base_branch).unwrap_or_default();
 
@@ -1701,7 +1702,7 @@ pub async fn session_diff_file(
             let file_path = std::path::Path::new(&query.path);
 
             let base_branch =
-                diff::get_default_branch(repo_path).unwrap_or_else(|_| "main".to_string());
+                diff::get_default_base_ref(repo_path).unwrap_or_else(|_| "main".to_string());
 
             // Validate the requested path against the set of actually-changed files.
             // This is the primary security boundary: only files modified on this

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -39,6 +39,12 @@ pub struct SessionResponse {
     /// or those that took the repo's default branch. See #948.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_branch: Option<String>,
+    /// Per-session override for the diff base, set via the web "vs &lt;ref&gt;"
+    /// picker, the TUI diff view's `b` keybind, or
+    /// `aoe session set-base`. Wins over `base_branch`, the profile
+    /// default, and auto-detection. See #970.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_branch_override: Option<String>,
     pub is_sandboxed: bool,
     pub has_managed_worktree: bool,
     pub has_terminal: bool,
@@ -178,6 +184,7 @@ impl SessionResponse {
                 .worktree_info
                 .as_ref()
                 .and_then(|w| w.base_branch.clone()),
+            base_branch_override: inst.base_branch_override.clone(),
             is_sandboxed: inst.is_sandboxed(),
             has_managed_worktree: inst
                 .worktree_info
@@ -522,6 +529,71 @@ pub async fn update_session_notifications(
             .collect();
         if let Err(e) = storage.save(&profile_instances) {
             tracing::error!("Failed to save after notification update: {e}");
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!(response)))
+}
+
+// --- Diff base override ---
+//
+// `PATCH /api/sessions/{id}/diff-base` sets / clears the per-session
+// override for the diff base ref. The web `vs <ref>` chip popover, the
+// TUI diff view's `b` keybind, and `aoe session set-base` all funnel
+// through this endpoint so the override is persisted alongside the
+// session record and survives restart. See #970.
+
+#[derive(Deserialize)]
+pub struct UpdateDiffBaseBody {
+    /// New override. `Some(non-empty)` sets the override; `Some("")` or
+    /// `None` clears it (the diff then falls back to the profile default
+    /// and then auto-detection).
+    #[serde(default)]
+    pub base_branch: Option<String>,
+}
+
+pub async fn update_session_diff_base(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateDiffBaseBody>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "read_only",
+                "message": "Server is in read-only mode"
+            })),
+        );
+    }
+
+    let mut instances = state.instances.write().await;
+    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "message": "Session not found" })),
+        );
+    };
+
+    inst.base_branch_override = body
+        .base_branch
+        .as_deref()
+        .map(str::trim)
+        .filter(|v| !v.is_empty())
+        .map(str::to_string);
+
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+    let profile = inst.source_profile.clone();
+
+    if let Ok(storage) = Storage::new(&profile) {
+        let profile_instances: Vec<_> = instances
+            .iter()
+            .filter(|i| i.source_profile == profile)
+            .cloned()
+            .collect();
+        if let Err(e) = storage.save(&profile_instances) {
+            tracing::error!("Failed to save after diff-base update: {e}");
         }
     }
 
@@ -1528,6 +1600,15 @@ struct DiffRepo {
     path: String,
 }
 
+struct DiffContext {
+    repos: Vec<DiffRepo>,
+    /// Per-session override for the diff base (set via
+    /// `PATCH /api/sessions/{id}/diff-base`, the `aoe session set-base`
+    /// CLI, or the TUI diff view's `b` keybind). Wins over the
+    /// profile-level default and the auto-detected ref. See #970.
+    base_branch_override: Option<String>,
+}
+
 /// Expand a session into the list of repos whose diffs the sidebar
 /// cares about. Workspace sessions iterate `workspace_info.repos`
 /// (each `worktree_path` becomes one entry); single-repo sessions
@@ -1536,7 +1617,7 @@ struct DiffRepo {
 async fn resolve_diff_repos(
     state: &AppState,
     id: &str,
-) -> Result<Vec<DiffRepo>, axum::response::Response> {
+) -> Result<DiffContext, axum::response::Response> {
     let instances = state.instances.read().await;
     let inst = instances.iter().find(|i| i.id == id).ok_or_else(|| {
         (
@@ -1545,44 +1626,70 @@ async fn resolve_diff_repos(
         )
             .into_response()
     })?;
-    if let Some(ws) = inst.workspace_info.as_ref() {
-        let repos = ws
-            .repos
+    let repos = if let Some(ws) = inst.workspace_info.as_ref() {
+        ws.repos
             .iter()
             .map(|r| DiffRepo {
                 name: Some(r.name.clone()),
                 path: r.worktree_path.clone(),
             })
-            .collect();
-        Ok(repos)
+            .collect()
     } else {
-        Ok(vec![DiffRepo {
+        vec![DiffRepo {
             name: None,
             path: inst.project_path.clone(),
-        }])
+        }]
+    };
+    Ok(DiffContext {
+        repos,
+        base_branch_override: inst.base_branch_override.clone(),
+    })
+}
+
+/// Resolve the diff base for one repo path. Override (per-session)
+/// wins over the profile's `DiffConfig.default_branch`, which wins
+/// over auto-detection (`get_default_base_ref`). See #970.
+fn resolve_diff_base(
+    override_value: Option<&str>,
+    config_default: Option<&str>,
+    repo_path: &std::path::Path,
+) -> String {
+    if let Some(v) = override_value.map(str::trim).filter(|v| !v.is_empty()) {
+        return v.to_string();
     }
+    if let Some(v) = config_default.map(str::trim).filter(|v| !v.is_empty()) {
+        return v.to_string();
+    }
+    crate::git::diff::get_default_base_ref(repo_path).unwrap_or_else(|_| "main".to_string())
 }
 
 pub async fn session_diff_files(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let repos = match resolve_diff_repos(&state, &id).await {
-        Ok(r) => r,
+    let ctx = match resolve_diff_repos(&state, &id).await {
+        Ok(c) => c,
         Err(resp) => return resp,
     };
 
     let result = tokio::task::spawn_blocking(move || {
         use crate::git::diff;
 
+        let config_default = crate::session::Config::load_or_warn()
+            .diff
+            .default_branch
+            .clone();
         let mut all_files: Vec<RichDiffFileInfo> = Vec::new();
         let mut per_repo_bases: Vec<RepoBase> = Vec::new();
         let mut warnings: Vec<String> = Vec::new();
 
-        for repo in &repos {
+        for repo in &ctx.repos {
             let path = std::path::Path::new(&repo.path);
-            let base_branch =
-                diff::get_default_base_ref(path).unwrap_or_else(|_| "main".to_string());
+            let base_branch = resolve_diff_base(
+                ctx.base_branch_override.as_deref(),
+                config_default.as_deref(),
+                path,
+            );
             let warning = diff::check_merge_base_status(path, &base_branch);
             let changed = diff::compute_changed_files(path, &base_branch).unwrap_or_default();
 
@@ -1660,8 +1767,8 @@ pub async fn session_diff_file(
     Path(id): Path<String>,
     axum::extract::Query(query): axum::extract::Query<FileDiffQuery>,
 ) -> impl IntoResponse {
-    let repos = match resolve_diff_repos(&state, &id).await {
-        Ok(r) => r,
+    let ctx = match resolve_diff_repos(&state, &id).await {
+        Ok(c) => c,
         Err(resp) => return resp,
     };
 
@@ -1671,27 +1778,28 @@ pub async fn session_diff_file(
     // session's primary repo). When the named repo doesn't exist, the
     // request is rejected so a stale link doesn't quietly diff the
     // wrong repo. See #1047.
-    let selected_repo = match query.repo.as_deref() {
-        Some(name) => match repos.iter().find(|r| r.name.as_deref() == Some(name)) {
-            Some(r) => r.clone(),
-            None => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(serde_json::json!({
-                        "error": "bad_request",
-                        "message": "unknown workspace repo"
-                    })),
-                )
-                    .into_response();
-            }
-        },
-        None => repos
-            .first()
-            .cloned()
-            .expect("resolve_diff_repos always returns at least one entry (single-repo fallback)"),
-    };
+    let selected_repo =
+        match query.repo.as_deref() {
+            Some(name) => match ctx.repos.iter().find(|r| r.name.as_deref() == Some(name)) {
+                Some(r) => r.clone(),
+                None => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({
+                            "error": "bad_request",
+                            "message": "unknown workspace repo"
+                        })),
+                    )
+                        .into_response();
+                }
+            },
+            None => ctx.repos.first().cloned().expect(
+                "resolve_diff_repos always returns at least one entry (single-repo fallback)",
+            ),
+        };
     let project_path = selected_repo.path;
     let selected_repo_name = selected_repo.name;
+    let base_branch_override = ctx.base_branch_override.clone();
 
     let result =
         tokio::task::spawn_blocking(move || -> Result<RichFileDiffResponse, DiffFileError> {
@@ -1701,8 +1809,15 @@ pub async fn session_diff_file(
             let repo_path = std::path::Path::new(&project_path);
             let file_path = std::path::Path::new(&query.path);
 
-            let base_branch =
-                diff::get_default_base_ref(repo_path).unwrap_or_else(|_| "main".to_string());
+            let config_default = crate::session::Config::load_or_warn()
+                .diff
+                .default_branch
+                .clone();
+            let base_branch = resolve_diff_base(
+                base_branch_override.as_deref(),
+                config_default.as_deref(),
+                repo_path,
+            );
 
             // Validate the requested path against the set of actually-changed files.
             // This is the primary security boundary: only files modified on this
@@ -1888,6 +2003,44 @@ mod tests {
                 .as_deref(),
             Some("feature/test")
         );
+    }
+
+    #[test]
+    fn session_response_surfaces_base_branch_override() {
+        let mut inst = make_test_instance();
+        // Default: no override -> field omitted from JSON.
+        let json = serde_json::to_value(SessionResponse::from_instance(&inst, false)).unwrap();
+        assert!(
+            json.get("base_branch_override").is_none(),
+            "base_branch_override should be omitted when None, got: {json}"
+        );
+
+        inst.base_branch_override = Some("upstream/main".to_string());
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert_eq!(resp.base_branch_override.as_deref(), Some("upstream/main"));
+    }
+
+    #[test]
+    fn resolve_diff_base_prefers_override_then_config_then_auto() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Override wins over everything.
+        assert_eq!(
+            resolve_diff_base(Some("release-1.2"), Some("develop"), tmp.path()),
+            "release-1.2"
+        );
+        // Config wins when no override; empty / whitespace override falls
+        // through to the next layer.
+        assert_eq!(
+            resolve_diff_base(Some("   "), Some("develop"), tmp.path()),
+            "develop"
+        );
+        assert_eq!(
+            resolve_diff_base(None, Some("develop"), tmp.path()),
+            "develop"
+        );
+        // Auto-detect when neither is set. The tmp dir is not a repo so
+        // `get_default_base_ref` returns Err -> "main" fallback.
+        assert_eq!(resolve_diff_base(None, None, tmp.path()), "main");
     }
 
     #[test]

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -939,6 +939,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/notifications",
             patch(api::update_session_notifications),
         )
+        .route(
+            "/api/sessions/{id}/diff-base",
+            patch(api::update_session_diff_base),
+        )
         .route("/api/sessions/{id}/terminal", post(api::ensure_terminal))
         .route(
             "/api/sessions/{id}/container-terminal",

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -260,6 +260,18 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notify_on_error: Option<bool>,
 
+    /// Per-session override for the diff base ref. Takes precedence
+    /// over `DiffConfig.default_branch` and the auto-detected default
+    /// branch. Set when the eventual PR target differs from the project
+    /// default (e.g. stacked PRs, hotfix off `release/*`). See #970.
+    ///
+    /// Accepts either a short branch name (`"main"`, `"release-1.2"`)
+    /// or a remote-qualified ref (`"upstream/main"`); the diff resolver
+    /// hands it straight to `compute_changed_files`, whose
+    /// `get_commit_from_ref` resolves both forms.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_branch_override: Option<String>,
+
     /// Whether this session uses the ACP cockpit instead of a tmux pane.
     /// When true, aoe spawns an ACP agent subprocess and renders structured
     /// events natively; tmux integration is bypassed for this session.
@@ -468,6 +480,7 @@ impl Instance {
             notify_on_waiting: None,
             notify_on_idle: None,
             notify_on_error: None,
+            base_branch_override: None,
             #[cfg(feature = "serve")]
             cockpit_mode: false,
             #[cfg(feature = "serve")]

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::git::diff::{
-    check_merge_base_status, compute_changed_files, compute_file_diff, get_default_branch,
+    check_merge_base_status, compute_changed_files, compute_file_diff, get_default_base_ref,
     list_branches, DiffFile, FileDiff,
 };
 use crate::session::config::{load_config, save_config};
@@ -81,7 +81,7 @@ impl DiffView {
             .diff
             .default_branch
             .clone()
-            .or_else(|| get_default_branch(&repo_path).ok())
+            .or_else(|| get_default_base_ref(&repo_path).ok())
             .unwrap_or_else(|| "main".to_string());
 
         let context_lines = config.diff.context_lines;

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -28,6 +28,15 @@ pub struct DiffView {
     /// Path to the repository root
     pub(crate) repo_path: PathBuf,
 
+    /// Session id this diff view belongs to. None when opened in a
+    /// session-agnostic context (legacy `DiffView::new`); persistence
+    /// of the per-session base-branch override is skipped in that case.
+    pub(crate) session_id: Option<String>,
+
+    /// Profile the session belongs to, used to look up `Storage` when
+    /// persisting the base-branch override.
+    pub(crate) profile: String,
+
     /// Base branch to compare against
     pub(crate) base_branch: String,
 
@@ -72,15 +81,32 @@ pub struct DiffView {
 }
 
 impl DiffView {
-    /// Create a new diff view for a repository
+    /// Create a session-agnostic diff view. Selecting a different
+    /// branch through the picker only mutates in-memory state. Callers
+    /// that have a session id should use `new_for_session` so the
+    /// override persists.
     pub fn new(repo_path: PathBuf) -> anyhow::Result<Self> {
+        Self::new_for_session(repo_path, None, String::new(), None)
+    }
+
+    /// Create a diff view bound to a session. `base_override` (the
+    /// session's persisted `base_branch_override`) wins over the
+    /// profile default and auto-detection. Subsequent calls to
+    /// `select_branch` persist the new ref back to the session record.
+    pub fn new_for_session(
+        repo_path: PathBuf,
+        session_id: Option<String>,
+        profile: String,
+        base_override: Option<String>,
+    ) -> anyhow::Result<Self> {
         let config = Config::load_or_warn();
 
-        // Determine base branch
-        let base_branch = config
-            .diff
-            .default_branch
-            .clone()
+        let base_branch = base_override
+            .as_deref()
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+            .or_else(|| config.diff.default_branch.clone())
             .or_else(|| get_default_base_ref(&repo_path).ok())
             .unwrap_or_else(|| "main".to_string());
 
@@ -91,6 +117,8 @@ impl DiffView {
 
         let mut view = Self {
             repo_path,
+            session_id,
+            profile,
             base_branch,
             files: Vec::new(),
             selected_file: 0,
@@ -168,15 +196,37 @@ impl DiffView {
         }
     }
 
-    /// Select a branch and refresh
+    /// Select a branch and refresh. When the view is bound to a
+    /// session, the choice is persisted as `base_branch_override` on
+    /// the session record so the next launch comes back to the same
+    /// comparison. Persistence failures only surface as a soft error
+    /// message; the in-memory switch still applies. See #970.
     pub fn select_branch(&mut self, branch: String) {
         self.base_branch = branch;
         self.branch_select = None;
         self.warning_dialog = check_merge_base_status(&self.repo_path, &self.base_branch)
             .map(|msg| InfoDialog::new("Warning", &msg));
+        if let Err(e) = self.persist_base_override() {
+            self.error_message = Some(format!("Failed to persist base branch: {e}"));
+        }
         if let Err(e) = self.refresh_files() {
             self.error_message = Some(format!("Failed to refresh: {}", e));
         }
+    }
+
+    fn persist_base_override(&self) -> anyhow::Result<()> {
+        let Some(session_id) = self.session_id.as_deref() else {
+            return Ok(());
+        };
+        let storage = crate::session::Storage::new(&self.profile)?;
+        let (mut instances, groups) = storage.load_with_groups()?;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) else {
+            return Ok(());
+        };
+        inst.base_branch_override = Some(self.base_branch.clone());
+        let group_tree = crate::session::GroupTree::new_with_groups(&instances, &groups);
+        storage.save_with_groups(&instances, &group_tree)?;
+        Ok(())
     }
 
     /// Navigate to next file
@@ -251,6 +301,8 @@ impl DiffView {
     pub(crate) fn test_default() -> Self {
         Self {
             repo_path: std::path::PathBuf::from("/tmp/fake"),
+            session_id: None,
+            profile: String::new(),
             base_branch: "main".to_string(),
             files: Vec::new(),
             selected_file: 0,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -867,7 +867,15 @@ impl HomeView {
                 };
 
                 let repo_path = std::path::PathBuf::from(&inst.project_path);
-                match DiffView::new(repo_path) {
+                let session_id_owned = inst.id.clone();
+                let profile = inst.source_profile.clone();
+                let base_override = inst.base_branch_override.clone();
+                match DiffView::new_for_session(
+                    repo_path,
+                    Some(session_id_owned),
+                    profile,
+                    base_override,
+                ) {
                     Ok(view) => self.diff_view = Some(view),
                     Err(e) => {
                         tracing::error!("Failed to open diff view: {}", e);

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -695,3 +695,70 @@ on_create = ["touch {}"]
         "global hook marker file should exist, proving global on_create hooks ran as fallback"
     );
 }
+
+/// #969: `aoe add -w <branch>` (without `-b`) should attach to an
+/// already-existing worktree for that branch instead of bailing
+/// because the computed path collides. Matches the TUI's
+/// "Attach to existing branch" behavior.
+#[test]
+#[serial]
+fn test_cli_add_attaches_to_existing_worktree() {
+    let h = TuiTestHarness::new("cli_attach_existing");
+    let project = h.home_path().join("attach-project");
+    init_git_repo(&project);
+
+    // Create a worktree for `feat/existing` via the first `aoe add`.
+    let first = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-w",
+        "feat/existing",
+        "-b",
+        "-t",
+        "FirstSession",
+    ]);
+    assert!(
+        first.status.success(),
+        "first aoe add failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    // Second `aoe add -w feat/existing` (no `-b`) should attach to the
+    // existing worktree, not bail.
+    let second = h.run_cli(&[
+        "add",
+        project.to_str().unwrap(),
+        "-w",
+        "feat/existing",
+        "-t",
+        "SecondSession",
+    ]);
+    let stdout = String::from_utf8_lossy(&second.stdout);
+    let stderr = String::from_utf8_lossy(&second.stderr);
+    assert!(
+        second.status.success(),
+        "second aoe add (attach) failed:\nstdout: {}\nstderr: {}",
+        stdout,
+        stderr
+    );
+    assert!(
+        stdout.contains("Attaching to existing worktree"),
+        "expected 'Attaching to existing worktree' in stdout; got:\n{}",
+        stdout
+    );
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let second_session = sessions
+        .iter()
+        .find(|s| s["title"].as_str() == Some("SecondSession"))
+        .expect("SecondSession should exist");
+    assert_eq!(
+        second_session["worktree_info"]["managed_by_aoe"], false,
+        "attached session should not own the worktree"
+    );
+    assert_eq!(
+        second_session["worktree_info"]["branch"].as_str(),
+        Some("feat/existing"),
+    );
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -228,7 +228,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   const [sendDialogOpen, setSendDialogOpen] = useState(false);
 
   useEffect(() => {
-    if (!commentsEnabled) return;
+    if (!commentSendEnabled) return;
     const onKey = (e: KeyboardEvent) => {
       if (!((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "s")) {
         return;
@@ -243,7 +243,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [commentsEnabled, diffComments.count]);
+  }, [commentSendEnabled, diffComments.count]);
 
   useEffect(() => {
     if (!activeSessionId) {
@@ -665,6 +665,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             sessionId={activeSessionId}
             comments={diffComments.comments}
             isMultiRepo={commentsIsMultiRepo}
+            sendEnabled={commentSendEnabled}
+            sendDisabledReason={commentSendDisabledReason}
             introDraft={diffComments.introDraft}
             outroDraft={diffComments.outroDraft}
             clearAfterSend={diffComments.clearAfterSend}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -681,6 +681,11 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                 diffComments.setOutroDraft("");
               }
               setSendDialogOpen(false);
+              // Close the diff viewer so the cockpit transcript is in
+              // view: the user just dispatched feedback and wants to
+              // see the agent's response. They can re-open any file
+              // from the right-panel list afterwards.
+              setSelectedFile(null);
               toastBus.handler?.info("Comments sent to agent");
             }}
           />

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,8 @@ import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useDiffFiles } from "./hooks/useDiffFiles";
+import { useDiffComments } from "./hooks/useDiffComments";
+import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
 import { useCommandActions } from "./hooks/useCommandActions";
 import { useEdgeSwipe } from "./hooks/useEdgeSwipe";
 import { useMobileKeyboard } from "./hooks/useMobileKeyboard";
@@ -211,6 +213,37 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     revision,
     refresh: refreshDiffFiles,
   } = useDiffFiles(activeSessionId, !diffCollapsed);
+
+  // Diff-viewer comments (#928). Cockpit-only and session-scoped. The
+  // banner lives in RightPanel while the inline UI lives inside
+  // DiffFileViewer, so the store is lifted here and threaded to both.
+  const diffComments = useDiffComments(activeSessionId);
+  const commentsEnabled = !!activeSession?.cockpit_mode;
+  const commentSendEnabled =
+    commentsEnabled && activeSession?.cockpit_worker_state === "running";
+  const commentSendDisabledReason = !commentsEnabled
+    ? "Diff comments require a cockpit session"
+    : "Cockpit worker is not running";
+  const commentsIsMultiRepo = (activeSession?.workspace_repos.length ?? 0) > 0;
+  const [sendDialogOpen, setSendDialogOpen] = useState(false);
+
+  useEffect(() => {
+    if (!commentsEnabled) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (!((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "s")) {
+        return;
+      }
+      const tgt = e.target as HTMLElement | null;
+      const tag = tgt?.tagName;
+      const editable = tgt?.isContentEditable;
+      if (tag === "INPUT" || tag === "TEXTAREA" || editable) return;
+      if (diffComments.count === 0) return;
+      e.preventDefault();
+      setSendDialogOpen(true);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [commentsEnabled, diffComments.count]);
 
   useEffect(() => {
     if (!activeSessionId) {
@@ -600,6 +633,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                   repoName={selectedRepoName}
                   revision={revision}
                   onClose={handleCloseFile}
+                  commentsEnabled={commentsEnabled}
+                  commentsStore={diffComments}
                 />
               )}
             </div>
@@ -616,9 +651,38 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
               selectedRepoName={selectedRepoName}
               onSelectFile={handleSelectFile}
               onDiffRefresh={refreshDiffFiles}
+              commentsEnabled={commentsEnabled}
+              commentsCount={diffComments.count}
+              commentsSendEnabled={commentSendEnabled}
+              commentsSendDisabledReason={commentSendDisabledReason}
+              onOpenSendDialog={() => setSendDialogOpen(true)}
+              onDiscardAllComments={diffComments.clearComments}
             />
           }
         />
+        {sendDialogOpen && commentsEnabled && activeSessionId && (
+          <SendCommentsDialog
+            sessionId={activeSessionId}
+            comments={diffComments.comments}
+            isMultiRepo={commentsIsMultiRepo}
+            introDraft={diffComments.introDraft}
+            outroDraft={diffComments.outroDraft}
+            clearAfterSend={diffComments.clearAfterSend}
+            onChangeIntro={diffComments.setIntroDraft}
+            onChangeOutro={diffComments.setOutroDraft}
+            onChangeClearAfterSend={diffComments.setClearAfterSend}
+            onClose={() => setSendDialogOpen(false)}
+            onSent={() => {
+              if (diffComments.clearAfterSend) {
+                diffComments.clearComments();
+                diffComments.setIntroDraft("");
+                diffComments.setOutroDraft("");
+              }
+              setSendDialogOpen(false);
+              toastBus.handler?.success("Comments sent to agent");
+            }}
+          />
+        )}
       </div>
     );
   };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -149,6 +149,23 @@ export default function App() {
   );
 }
 
+/** Walk from the event target up to the document root looking for any
+ *  text-input surface, so global hotkeys don't fire when the user is
+ *  typing in an `<input>`, `<textarea>`, or contenteditable element
+ *  (or any contenteditable ancestor of a deeper rich-text widget). */
+function isInsideEditable(target: EventTarget | null): boolean {
+  let el: HTMLElement | null =
+    target instanceof HTMLElement ? target : null;
+  while (el) {
+    const tag = el.tagName;
+    if (tag === "INPUT" || tag === "TEXTAREA" || el.isContentEditable) {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
   const navigate = useNavigate();
   const idleDecayWindowMs = useIdleDecayWindowMs();
@@ -233,10 +250,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
       if (!((e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === "s")) {
         return;
       }
-      const tgt = e.target as HTMLElement | null;
-      const tag = tgt?.tagName;
-      const editable = tgt?.isContentEditable;
-      if (tag === "INPUT" || tag === "TEXTAREA" || editable) return;
+      if (isInsideEditable(e.target)) return;
       if (diffComments.count === 0) return;
       e.preventDefault();
       setSendDialogOpen(true);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -681,7 +681,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                 diffComments.setOutroDraft("");
               }
               setSendDialogOpen(false);
-              toastBus.handler?.success("Comments sent to agent");
+              toastBus.handler?.info("Comments sent to agent");
             }}
           />
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -209,6 +209,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     warning,
     loading: diffFilesLoading,
     revision,
+    refresh: refreshDiffFiles,
   } = useDiffFiles(activeSessionId, !diffCollapsed);
 
   useEffect(() => {
@@ -614,6 +615,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
               selectedFilePath={selectedFilePath}
               selectedRepoName={selectedRepoName}
               onSelectFile={handleSelectFile}
+              onDiffRefresh={refreshDiffFiles}
             />
           }
         />

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -43,6 +43,9 @@ interface Props {
   selectedFilePath: string | null;
   selectedRepoName: string | undefined;
   onSelectFile: (path: string, repoName?: string) => void;
+  /** Re-fetch the diff. Called after the user changes the per-session
+   *  base-branch override so the file list reflects the new comparison. */
+  onDiffRefresh: () => void;
 }
 
 type ShellMode = "host" | "container";
@@ -273,6 +276,7 @@ export function RightPanel({
   selectedFilePath,
   selectedRepoName,
   onSelectFile,
+  onDiffRefresh,
 }: Props) {
   const [shellMode, setShellMode] = useState<ShellMode>("host");
   const isSandboxed = session?.is_sandboxed ?? false;
@@ -369,6 +373,10 @@ export function RightPanel({
           selectedRepoName={selectedRepoName}
           loading={filesLoading}
           onSelectFile={onSelectFile}
+          sessionId={sessionId}
+          repoPath={session?.main_repo_path ?? session?.project_path ?? null}
+          baseBranchOverride={session?.base_branch_override ?? null}
+          onBaseBranchChanged={onDiffRefresh}
         />
       </div>
 

--- a/web/src/components/RightPanel.tsx
+++ b/web/src/components/RightPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { DiffFileList } from "./diff/DiffFileList";
+import { CommentsBanner } from "./diff/comments/CommentsBanner";
 import { useTerminal } from "../hooks/useTerminal";
 import { useMobileKeyboard } from "../hooks/useMobileKeyboard";
 import { MobileTerminalToolbar } from "./MobileTerminalToolbar";
@@ -46,6 +47,13 @@ interface Props {
   /** Re-fetch the diff. Called after the user changes the per-session
    *  base-branch override so the file list reflects the new comparison. */
   onDiffRefresh: () => void;
+  /** Diff-comments banner state (#928). Hidden on tmux sessions. */
+  commentsEnabled: boolean;
+  commentsCount: number;
+  commentsSendEnabled: boolean;
+  commentsSendDisabledReason?: string;
+  onOpenSendDialog: () => void;
+  onDiscardAllComments: () => void;
 }
 
 type ShellMode = "host" | "container";
@@ -277,6 +285,12 @@ export function RightPanel({
   selectedRepoName,
   onSelectFile,
   onDiffRefresh,
+  commentsEnabled,
+  commentsCount,
+  commentsSendEnabled,
+  commentsSendDisabledReason,
+  onOpenSendDialog,
+  onDiscardAllComments,
 }: Props) {
   const [shellMode, setShellMode] = useState<ShellMode>("host");
   const isSandboxed = session?.is_sandboxed ?? false;
@@ -365,6 +379,15 @@ export function RightPanel({
         style={{ flexBasis: `${topRatio * 100}%` }}
         className="flex flex-col min-h-0 overflow-hidden"
       >
+        {commentsEnabled && commentsCount > 0 && (
+          <CommentsBanner
+            count={commentsCount}
+            sendEnabled={commentsSendEnabled}
+            sendDisabledReason={commentsSendDisabledReason}
+            onSend={onOpenSendDialog}
+            onDiscardAll={onDiscardAllComments}
+          />
+        )}
         <DiffFileList
           files={files}
           perRepoBases={perRepoBases}

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -31,6 +31,8 @@ import { Composer } from "./Composer";
 import { ContextPrimerBanner } from "./ContextPrimerBanner";
 import { Markdown } from "./Markdown";
 import { SubagentCard, ToolCard, ToolGroupCard } from "./ToolCards";
+import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
+import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
 import {
   SPINNER_FRAMES,
   SPINNER_INTERVAL_MS,
@@ -313,19 +315,32 @@ function CockpitChrome({
 function UserMessage() {
   return (
     <MessagePrimitive.Root className="group mt-4 flex flex-col items-end gap-1">
-      <div className="max-w-[80%] min-w-0 rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-3 py-1.5 text-sm">
-        <MessagePrimitive.Parts
-          components={{
-            // User prompts get the same markdown pipeline as agent
-            // messages so fenced code blocks render with syntax
-            // highlighting instead of literal backticks. Smooth-reveal
-            // is off because user prompts arrive complete; the pacing
-            // only matters for streamed agent tokens. See #1108.
-            Text: ({ text }) => <Markdown text={text} smooth={false} />,
-          }}
-        />
-      </div>
+      <MessagePrimitive.Parts
+        components={{
+          Text: UserText,
+        }}
+      />
     </MessagePrimitive.Root>
+  );
+}
+
+/** Text-part renderer for user messages. Detects the diff-comments
+ *  sentinel header (prepended by `buildFullPrompt`) and swaps in the
+ *  structured `DiffCommentsUserCard`; falls back to the classic chat
+ *  bubble otherwise. */
+function UserText({ text }: { text: string }) {
+  const payload = parseDiffCommentsSentinel(text);
+  if (payload) {
+    return <DiffCommentsUserCard payload={payload} />;
+  }
+  // User prompts get the same markdown pipeline as agent messages so
+  // fenced code blocks render with syntax highlighting instead of
+  // literal backticks. Smooth-reveal is off because user prompts arrive
+  // complete; the pacing only matters for streamed agent tokens. See #1108.
+  return (
+    <div className="max-w-[80%] min-w-0 rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-3 py-1.5 text-sm">
+      <Markdown text={text} smooth={false} />
+    </div>
   );
 }
 

--- a/web/src/components/diff/DiffFileList.tsx
+++ b/web/src/components/diff/DiffFileList.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { RepoBase, RichDiffFile } from "../../lib/types";
+import type { BranchInfo } from "../../lib/api";
 import { buildDiffTree, type DiffTreeNode } from "../../lib/diffTree";
 import { useWebSettings } from "../../hooks/useWebSettings";
+import { fetchBranches, setSessionDiffBase } from "../../lib/api";
 
 interface Props {
   files: RichDiffFile[];
@@ -14,6 +16,19 @@ interface Props {
   selectedRepoName: string | undefined;
   loading: boolean;
   onSelectFile: (path: string, repoName?: string) => void;
+  /** Session id used by the `vs <ref>` chip popover to PATCH the
+   *  per-session base-branch override. `null` hides the picker. */
+  sessionId?: string | null;
+  /** Repo path used to populate the branch typeahead in the picker.
+   *  `null` hides the picker. */
+  repoPath?: string | null;
+  /** Current persisted override (also reflected in `perRepoBases[0].base_branch`
+   *  on next refetch). Used to label the "Reset" affordance and to
+   *  pre-fill the typeahead. */
+  baseBranchOverride?: string | null;
+  /** Called after a successful PATCH so the parent re-fetches the diff
+   *  against the new base. */
+  onBaseBranchChanged?: () => void;
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -224,6 +239,10 @@ export function DiffFileList({
   selectedRepoName,
   loading,
   onSelectFile,
+  sessionId,
+  repoPath,
+  baseBranchOverride,
+  onBaseBranchChanged,
 }: Props) {
   const isMultiRepo = perRepoBases.length > 1;
   // Multi-repo workspaces compose multiple `(name, base_branch)` pairs;
@@ -371,6 +390,14 @@ export function DiffFileList({
             <span className="font-mono text-[10px] px-1.5 py-px rounded bg-surface-800 text-text-muted">
               {perRepoBases.length} repos
             </span>
+          ) : sessionId && repoPath ? (
+            <BasePicker
+              sessionId={sessionId}
+              repoPath={repoPath}
+              currentBase={singleBaseBranch}
+              hasOverride={Boolean(baseBranchOverride)}
+              onChanged={onBaseBranchChanged}
+            />
           ) : (
             <span className="font-mono text-[10px] px-1.5 py-px rounded bg-surface-800 text-text-muted">
               vs {singleBaseBranch}
@@ -592,5 +619,167 @@ function MultiRepoGroups({
         );
       })}
     </>
+  );
+}
+
+interface BasePickerProps {
+  sessionId: string;
+  repoPath: string;
+  currentBase: string;
+  hasOverride: boolean;
+  onChanged?: () => void;
+}
+
+/// Clickable chip + typeahead popover for the per-session diff base.
+/// Persists via `PATCH /api/sessions/{id}/diff-base`; the parent
+/// triggers a diff refetch on success. See #970.
+function BasePicker({
+  sessionId,
+  repoPath,
+  currentBase,
+  hasOverride,
+  onChanged,
+}: BasePickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [branches, setBranches] = useState<BranchInfo[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [highlightIdx, setHighlightIdx] = useState(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    fetchBranches(repoPath, true).then((rows) => {
+      if (!cancelled) setBranches(rows ?? []);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, repoPath]);
+
+  // Close the popover on outside click.
+  useEffect(() => {
+    if (!open) return;
+    const onDocPointer = (e: PointerEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("pointerdown", onDocPointer);
+    return () => document.removeEventListener("pointerdown", onDocPointer);
+  }, [open]);
+
+  const q = query.trim().toLowerCase();
+  const suggestions = (branches ?? [])
+    .filter((b) => !q || b.name.toLowerCase().includes(q))
+    .slice(0, 8);
+
+  const apply = async (value: string | null) => {
+    setBusy(true);
+    const ok = await setSessionDiffBase(sessionId, value);
+    setBusy(false);
+    if (ok) {
+      setOpen(false);
+      setQuery("");
+      onChanged?.();
+    }
+  };
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-label={`Change diff base (current: ${currentBase})`}
+        title="Change diff base"
+        className={`font-mono text-[10px] px-1.5 py-px rounded cursor-pointer transition-colors ${
+          hasOverride
+            ? "bg-brand-600/15 text-brand-500 hover:bg-brand-600/25"
+            : "bg-surface-800 text-text-muted hover:bg-surface-700"
+        }`}
+      >
+        vs {currentBase}
+      </button>
+      {open && (
+        <div className="absolute left-0 top-full z-20 mt-1 w-64 bg-surface-900 border border-surface-700/60 rounded-lg shadow-lg p-2">
+          <input
+            type="text"
+            autoFocus
+            value={query}
+            placeholder="Search branches..."
+            onChange={(e) => {
+              setQuery(e.target.value);
+              setHighlightIdx(0);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setHighlightIdx((i) => Math.min(i + 1, suggestions.length - 1));
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setHighlightIdx((i) => Math.max(i - 1, 0));
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                const pick = suggestions[highlightIdx];
+                if (pick) void apply(pick.name);
+                else if (query.trim()) void apply(query.trim());
+              } else if (e.key === "Escape") {
+                setOpen(false);
+              }
+            }}
+            disabled={busy}
+            className="w-full bg-surface-950 border border-surface-700/60 rounded px-2 py-1.5 text-xs font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
+          />
+          {hasOverride && (
+            <button
+              type="button"
+              onClick={() => void apply(null)}
+              disabled={busy}
+              className="mt-1.5 w-full text-left px-2 py-1 rounded text-[11px] text-text-dim hover:bg-surface-800 hover:text-text-secondary cursor-pointer"
+            >
+              ↺ Reset to auto-detected
+            </button>
+          )}
+          <ul
+            role="listbox"
+            aria-label="Branch suggestions"
+            className="mt-1 max-h-56 overflow-y-auto"
+          >
+            {suggestions.length === 0 && (
+              <li className="px-2 py-1 text-[11px] text-text-dim italic">
+                {branches === null ? "Loading branches..." : "No matches."}
+              </li>
+            )}
+            {suggestions.map((b, i) => (
+              <li
+                key={`${b.name}-${b.remote_only ? "r" : "l"}`}
+                role="option"
+                aria-selected={i === highlightIdx}
+                onMouseEnter={() => setHighlightIdx(i)}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  void apply(b.name);
+                }}
+                className={`flex items-center justify-between gap-2 px-2 py-1 text-xs font-mono cursor-pointer rounded ${
+                  i === highlightIdx
+                    ? "bg-surface-800 text-text-primary"
+                    : "text-text-secondary"
+                }`}
+              >
+                <span className="truncate">{b.name}</span>
+                <span className="text-[10px] uppercase tracking-wider text-text-dim shrink-0">
+                  {b.is_current ? "current" : b.remote_only ? "remote" : "local"}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
   );
 }

--- a/web/src/components/diff/DiffFileList.tsx
+++ b/web/src/components/diff/DiffFileList.tsx
@@ -129,6 +129,8 @@ function TreeView({
   onToggleDir,
   focusedIndex,
   onFocusIndex,
+  indentOffset = 0,
+  repoNameForSelect,
 }: {
   nodes: DiffTreeNode[];
   selectedPath: string | null;
@@ -137,6 +139,14 @@ function TreeView({
   onToggleDir: (dirPath: string) => void;
   focusedIndex: number;
   onFocusIndex: (i: number) => void;
+  /** Extra left padding in px applied to every row. Multi-repo passes
+   *  a non-zero value so tree rows nest visually under the repo
+   *  header. */
+  indentOffset?: number;
+  /** When set, file rows pass this as the `repoName` argument to
+   *  `onSelectFile`. Multi-repo uses it so the right pane knows which
+   *  repo the file belongs to; single-repo leaves it `undefined`. */
+  repoNameForSelect?: string;
 }) {
   return (
     <>
@@ -155,7 +165,7 @@ function TreeView({
               onMouseEnter={() => onFocusIndex(i)}
               aria-expanded={!node.collapsed}
               className={`w-full text-left py-1.5 cursor-pointer transition-colors flex items-center gap-1.5 text-text-muted hover:bg-surface-800/50 ${focusRing}`}
-              style={{ paddingLeft: `${node.depth * 16 + 12}px`, paddingRight: 12 }}
+              style={{ paddingLeft: `${node.depth * 16 + 12 + indentOffset}px`, paddingRight: 12 }}
             >
               <svg
                 className={`w-3 h-3 shrink-0 text-text-dim transition-transform duration-75 ${
@@ -193,14 +203,16 @@ function TreeView({
           <button
             key={`${file.repo_name ?? ""}::${file.path}`}
             data-index={i}
-            onClick={() => onSelectFile(file.path, file.repo_name)}
+            onClick={() =>
+              onSelectFile(file.path, repoNameForSelect ?? file.repo_name)
+            }
             onMouseEnter={() => onFocusIndex(i)}
             className={`w-full text-left py-1.5 cursor-pointer transition-colors flex items-center gap-2 ${
               isSelected
                 ? "bg-surface-850 text-text-primary"
                 : "text-text-secondary hover:bg-surface-800/50"
             } ${focusRing}`}
-            style={{ paddingLeft: `${node.depth * 16 + 12}px`, paddingRight: 12 }}
+            style={{ paddingLeft: `${node.depth * 16 + 12 + indentOffset}px`, paddingRight: 12 }}
           >
             <span
               className={`shrink-0 font-mono text-[12px] w-3 text-center ${STATUS_COLORS[file.status] ?? "text-text-muted"}`}
@@ -415,10 +427,10 @@ export function DiffFileList({
               </span>
             </>
           )}
-          {/* View mode toggle. Hidden in multi-repo mode where each
-              repo gets its own collapsible group; the tree view has no
-              clean place for the workspace-vs-repo nesting yet. */}
-          {files.length > 0 && !isMultiRepo && (
+          {/* View mode toggle. In multi-repo mode the tree/flat choice
+              applies inside each per-repo group; the repo-header row
+              itself is always the top-level container regardless. */}
+          {files.length > 0 && (
             <button
               onClick={toggleViewMode}
               className="ml-auto shrink-0 p-1 rounded text-text-dim hover:text-text-muted hover:bg-surface-800/50 transition-colors cursor-pointer"
@@ -482,6 +494,9 @@ export function DiffFileList({
             collapsedRepos={collapsedRepos}
             onToggleRepo={toggleRepo}
             onSelectFile={onSelectFile}
+            viewMode={viewMode}
+            collapsedDirs={collapsedDirs}
+            onToggleDir={toggleDir}
           />
         ) : viewMode === "tree" ? (
           <TreeView
@@ -508,8 +523,10 @@ export function DiffFileList({
   );
 }
 
-const STATUS_COLORS_FILE = STATUS_COLORS;
-const STATUS_LETTERS_FILE = STATUS_LETTERS;
+// Sentinel separating the repo namespace from the dir path inside the
+// shared `collapsedDirs` set. NUL is impossible in a real file path
+// and avoids collisions with directory names that contain `::`.
+const REPO_NS_SEP = "\u0000";
 
 function MultiRepoGroups({
   perRepoBases,
@@ -519,6 +536,9 @@ function MultiRepoGroups({
   collapsedRepos,
   onToggleRepo,
   onSelectFile,
+  viewMode,
+  collapsedDirs,
+  onToggleDir,
 }: {
   perRepoBases: RepoBase[];
   filesByRepo: Map<string, RichDiffFile[]>;
@@ -527,6 +547,9 @@ function MultiRepoGroups({
   collapsedRepos: Set<string>;
   onToggleRepo: (name: string) => void;
   onSelectFile: (path: string, repoName?: string) => void;
+  viewMode: "flat" | "tree";
+  collapsedDirs: Set<string>;
+  onToggleDir: (dirPath: string) => void;
 }) {
   return (
     <>
@@ -572,50 +595,120 @@ function MultiRepoGroups({
                 No changes in this repo.
               </div>
             )}
-            {!collapsed &&
-              repoFiles.map((file) => {
-                const parts = file.path.split("/");
-                const fileName = parts.pop() || file.path;
-                const dirPath = parts.length > 0 ? parts.join("/") + "/" : "";
-                const isSelected =
-                  file.path === selectedPath &&
-                  file.repo_name === selectedRepoName;
-                return (
-                  <button
-                    key={`${file.repo_name ?? ""}::${file.path}`}
-                    type="button"
-                    onClick={() => onSelectFile(file.path, file.repo_name)}
-                    className={`w-full text-left px-6 py-1.5 cursor-pointer transition-colors flex items-center gap-2 ${
-                      isSelected
-                        ? "bg-surface-850 text-text-primary"
-                        : "text-text-secondary hover:bg-surface-800/50"
-                    }`}
-                  >
-                    <span
-                      className={`shrink-0 font-mono text-[12px] w-3 text-center ${STATUS_COLORS_FILE[file.status] ?? "text-text-muted"}`}
-                    >
-                      {STATUS_LETTERS_FILE[file.status] ?? "?"}
-                    </span>
-                    <span className="truncate min-w-0 flex-1">
-                      {dirPath && (
-                        <span className="font-mono text-[11px] text-text-dim">
-                          {dirPath}
-                        </span>
-                      )}
-                      <span className="font-mono text-[12px]">{fileName}</span>
-                    </span>
-                    <span className="shrink-0 font-mono text-[11px] flex items-center gap-1">
-                      {file.additions > 0 && (
-                        <span className="text-status-running">+{file.additions}</span>
-                      )}
-                      {file.deletions > 0 && (
-                        <span className="text-status-error">-{file.deletions}</span>
-                      )}
-                    </span>
-                  </button>
-                );
-              })}
+            {!collapsed && repoFiles.length > 0 && (
+              <RepoBody
+                repoName={name}
+                files={repoFiles}
+                viewMode={viewMode}
+                selectedPath={selectedPath}
+                selectedRepoName={selectedRepoName}
+                collapsedDirs={collapsedDirs}
+                onToggleDir={onToggleDir}
+                onSelectFile={onSelectFile}
+              />
+            )}
           </div>
+        );
+      })}
+    </>
+  );
+}
+
+function RepoBody({
+  repoName,
+  files,
+  viewMode,
+  selectedPath,
+  selectedRepoName,
+  collapsedDirs,
+  onToggleDir,
+  onSelectFile,
+}: {
+  repoName: string;
+  files: RichDiffFile[];
+  viewMode: "flat" | "tree";
+  selectedPath: string | null;
+  selectedRepoName: string | undefined;
+  collapsedDirs: Set<string>;
+  onToggleDir: (dirPath: string) => void;
+  onSelectFile: (path: string, repoName?: string) => void;
+}) {
+  const ns = `${repoName}${REPO_NS_SEP}`;
+  // Per-repo collapsed set: strip the namespace prefix so the tree
+  // builder sees bare dir paths. The toggle path round-trips through
+  // the shared set so persistence keeps working unchanged.
+  const localCollapsed = useMemo(() => {
+    const out = new Set<string>();
+    for (const k of collapsedDirs) {
+      if (k.startsWith(ns)) out.add(k.slice(ns.length));
+    }
+    return out;
+  }, [collapsedDirs, ns]);
+  const localToggle = useCallback(
+    (p: string) => onToggleDir(`${ns}${p}`),
+    [onToggleDir, ns],
+  );
+  const treeNodes = useMemo(
+    () => (viewMode === "tree" ? buildDiffTree(files, localCollapsed) : []),
+    [viewMode, files, localCollapsed],
+  );
+
+  if (viewMode === "tree") {
+    return (
+      <TreeView
+        nodes={treeNodes}
+        selectedPath={selectedPath}
+        selectedRepoName={selectedRepoName}
+        onSelectFile={onSelectFile}
+        onToggleDir={localToggle}
+        focusedIndex={-1}
+        onFocusIndex={() => {}}
+        indentOffset={12}
+        repoNameForSelect={repoName || undefined}
+      />
+    );
+  }
+  return (
+    <>
+      {files.map((file) => {
+        const parts = file.path.split("/");
+        const fileName = parts.pop() || file.path;
+        const dirPath = parts.length > 0 ? parts.join("/") + "/" : "";
+        const isSelected =
+          file.path === selectedPath && file.repo_name === selectedRepoName;
+        return (
+          <button
+            key={`${file.repo_name ?? ""}::${file.path}`}
+            type="button"
+            onClick={() => onSelectFile(file.path, file.repo_name)}
+            className={`w-full text-left px-6 py-1.5 cursor-pointer transition-colors flex items-center gap-2 ${
+              isSelected
+                ? "bg-surface-850 text-text-primary"
+                : "text-text-secondary hover:bg-surface-800/50"
+            }`}
+          >
+            <span
+              className={`shrink-0 font-mono text-[12px] w-3 text-center ${STATUS_COLORS[file.status] ?? "text-text-muted"}`}
+            >
+              {STATUS_LETTERS[file.status] ?? "?"}
+            </span>
+            <span className="truncate min-w-0 flex-1">
+              {dirPath && (
+                <span className="font-mono text-[11px] text-text-dim">
+                  {dirPath}
+                </span>
+              )}
+              <span className="font-mono text-[12px]">{fileName}</span>
+            </span>
+            <span className="shrink-0 font-mono text-[11px] flex items-center gap-1">
+              {file.additions > 0 && (
+                <span className="text-status-running">+{file.additions}</span>
+              )}
+              {file.deletions > 0 && (
+                <span className="text-status-error">-{file.deletions}</span>
+              )}
+            </span>
+          </button>
         );
       })}
     </>

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -116,21 +116,14 @@ function HunkView({
         const rowKey = `h${hunkIndex}-r${i}`;
         const { isHighlighted, isRangeEndpoint, side, lineNum } =
           highlightForRow(line, hunkIndex, rangeStart, draft);
-        const leadingSlot =
-          commentsEnabled && lineNum != null && side != null ? (
-            <PlusButton
-              hunkIndex={hunkIndex}
-              side={side}
-              lineNum={lineNum}
-              onClick={onPlusClick}
-              active={
-                rangeStart != null &&
-                rangeStart.hunkIndex === hunkIndex &&
-                rangeStart.side === side &&
-                rangeStart.line === lineNum
-              }
-            />
-          ) : null;
+        const plusEnabled =
+          commentsEnabled && lineNum != null && side != null;
+        const plusActive =
+          plusEnabled &&
+          rangeStart != null &&
+          rangeStart.hunkIndex === hunkIndex &&
+          rangeStart.side === side &&
+          rangeStart.line === lineNum;
         const cards = cardsByEndRow.get(i);
         const showForm = formRowIndex === i && draft != null;
         return (
@@ -139,7 +132,12 @@ function HunkView({
               line={line}
               tokens={lineTokens?.[i]}
               highlightPending={highlightPending}
-              leadingSlot={leadingSlot}
+              plusEnabled={plusEnabled}
+              plusHunkIndex={hunkIndex}
+              plusSide={side ?? undefined}
+              plusLineNum={lineNum ?? undefined}
+              plusActive={plusActive}
+              onPlusClick={onPlusClick}
               isHighlighted={isHighlighted}
               isRangeEndpoint={isRangeEndpoint}
             />
@@ -165,40 +163,6 @@ function HunkView({
         );
       })}
     </div>
-  );
-}
-
-function PlusButton({
-  hunkIndex,
-  side,
-  lineNum,
-  onClick,
-  active,
-}: {
-  hunkIndex: number;
-  side: DiffSide;
-  lineNum: number;
-  onClick: (hunkIndex: number, side: DiffSide, lineNum: number) => void;
-  active: boolean;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => onClick(hunkIndex, side, lineNum)}
-      aria-label={`Add comment on ${side} line ${lineNum}`}
-      // `tabIndex={-1}` keeps the hover-revealed button out of the
-      // tab order; otherwise keyboard users would land on dozens of
-      // invisible buttons walking through the diff. v1 is mouse-only;
-      // a focus-driven flow can be added with a real row-focus model.
-      tabIndex={-1}
-      className={`absolute left-0 top-0 h-full w-4 flex items-center justify-center text-white text-[11px] leading-none cursor-pointer transition-opacity ${
-        active
-          ? "bg-brand-600 opacity-100"
-          : "bg-brand-600 opacity-0 group-hover:opacity-100 hover:bg-brand-500 focus-visible:opacity-100"
-      }`}
-    >
-      +
-    </button>
   );
 }
 

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -1,10 +1,18 @@
+import { Fragment, useCallback, useMemo, useState } from "react";
 import { useFileDiff } from "../../hooks/useFileDiff";
 import {
   useHighlightedLines,
   type SyntaxToken,
 } from "../../hooks/useHighlightedLines";
-import type { RichDiffHunk } from "../../lib/types";
+import type { RichDiffHunk, RichDiffLine } from "../../lib/types";
 import { DiffLine } from "./DiffLine";
+import type { UseDiffCommentsResult } from "../../hooks/useDiffComments";
+import { anchorComments } from "./comments/anchor";
+import { extractSnippetFromHunks } from "./comments/extractSnippet";
+import { extensionToLanguage } from "./comments/language";
+import { CommentCard } from "./comments/CommentCard";
+import { CommentForm } from "./comments/CommentForm";
+import type { AnchoredComment, DiffSide } from "./comments/types";
 
 interface Props {
   sessionId: string;
@@ -17,6 +25,12 @@ interface Props {
   revision?: number;
   /** Called when the user wants to return to the terminal view. */
   onClose?: () => void;
+  /** When true, the in-diff comment UI ("+" gutter buttons, inline
+   *  cards/forms, stale block) is enabled. False for non-cockpit
+   *  sessions where prompts can't be sent. */
+  commentsEnabled?: boolean;
+  /** Session-scoped comments store. Required when `commentsEnabled`. */
+  commentsStore?: UseDiffCommentsResult;
 }
 
 const STATUS_LABELS: Record<string, string> = {
@@ -39,14 +53,54 @@ const STATUS_COLORS: Record<string, string> = {
   conflicted: "text-status-waiting",
 };
 
+/** Transient range-selection state. Local to this viewer because it
+ *  changes on every gutter click and shouldn't broadcast through the
+ *  comments store. */
+interface RangeStart {
+  hunkIndex: number;
+  side: DiffSide;
+  line: number;
+}
+
+interface DraftRange {
+  hunkIndex: number;
+  side: DiffSide;
+  startLine: number;
+  endLine: number;
+  endRowIndex: number;
+  snippet: string;
+}
+
 function HunkView({
   hunk,
+  hunkIndex,
   lineTokens,
   highlightPending,
+  rangeStart,
+  draft,
+  cardsByEndRow,
+  formRowIndex,
+  commentsEnabled,
+  onPlusClick,
+  onCommentSave,
+  onCommentDelete,
+  onDraftSave,
+  onDraftCancel,
 }: {
   hunk: RichDiffHunk;
+  hunkIndex: number;
   lineTokens?: SyntaxToken[][];
   highlightPending?: boolean;
+  rangeStart: RangeStart | null;
+  draft: DraftRange | null;
+  cardsByEndRow: Map<number, AnchoredComment[]>;
+  formRowIndex: number | null;
+  commentsEnabled: boolean;
+  onPlusClick: (hunkIndex: number, side: DiffSide, lineNum: number) => void;
+  onCommentSave: (id: string, body: string) => void;
+  onCommentDelete: (id: string) => void;
+  onDraftSave: (body: string) => void;
+  onDraftCancel: () => void;
 }) {
   return (
     <div>
@@ -58,16 +112,139 @@ function HunkView({
           @@ -{hunk.old_start},{hunk.old_lines} +{hunk.new_start},{hunk.new_lines} @@
         </span>
       </div>
-      {hunk.lines.map((line, i) => (
-        <DiffLine
-          key={`${line.old_line_num ?? "_"}-${line.new_line_num ?? "_"}-${i}`}
-          line={line}
-          tokens={lineTokens?.[i]}
-          highlightPending={highlightPending}
-        />
-      ))}
+      {hunk.lines.map((line, i) => {
+        const rowKey = `h${hunkIndex}-r${i}`;
+        const { isHighlighted, isRangeEndpoint, side, lineNum } =
+          highlightForRow(line, hunkIndex, rangeStart, draft);
+        const leadingSlot =
+          commentsEnabled && lineNum != null && side != null ? (
+            <PlusButton
+              hunkIndex={hunkIndex}
+              side={side}
+              lineNum={lineNum}
+              onClick={onPlusClick}
+              active={
+                rangeStart != null &&
+                rangeStart.hunkIndex === hunkIndex &&
+                rangeStart.side === side &&
+                rangeStart.line === lineNum
+              }
+            />
+          ) : null;
+        const cards = cardsByEndRow.get(i);
+        const showForm = formRowIndex === i && draft != null;
+        return (
+          <Fragment key={rowKey}>
+            <DiffLine
+              line={line}
+              tokens={lineTokens?.[i]}
+              highlightPending={highlightPending}
+              leadingSlot={leadingSlot}
+              isHighlighted={isHighlighted}
+              isRangeEndpoint={isRangeEndpoint}
+            />
+            {cards?.map((anchored) => (
+              <CommentCard
+                key={`card-${anchored.comment.id}`}
+                anchored={anchored}
+                onSave={onCommentSave}
+                onDelete={onCommentDelete}
+              />
+            ))}
+            {showForm && draft && (
+              <CommentForm
+                key={`form-h${hunkIndex}-r${i}`}
+                startLine={draft.startLine}
+                endLine={draft.endLine}
+                side={draft.side}
+                onSave={onDraftSave}
+                onCancel={onDraftCancel}
+              />
+            )}
+          </Fragment>
+        );
+      })}
     </div>
   );
+}
+
+function PlusButton({
+  hunkIndex,
+  side,
+  lineNum,
+  onClick,
+  active,
+}: {
+  hunkIndex: number;
+  side: DiffSide;
+  lineNum: number;
+  onClick: (hunkIndex: number, side: DiffSide, lineNum: number) => void;
+  active: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onClick(hunkIndex, side, lineNum)}
+      aria-label={`Add comment on line ${lineNum}`}
+      className={`absolute left-0 top-0 h-full w-4 flex items-center justify-center text-white text-[11px] leading-none cursor-pointer transition-opacity ${
+        active
+          ? "bg-brand-600 opacity-100"
+          : "bg-brand-600 opacity-0 group-hover:opacity-100 hover:bg-brand-500"
+      }`}
+    >
+      +
+    </button>
+  );
+}
+
+function highlightForRow(
+  line: RichDiffLine,
+  hunkIndex: number,
+  rangeStart: RangeStart | null,
+  draft: DraftRange | null,
+): {
+  isHighlighted: boolean;
+  isRangeEndpoint: boolean;
+  side: DiffSide | null;
+  lineNum: number | null;
+} {
+  // Side preference: added → new, deleted → old, equal → new.
+  const sideForRow: DiffSide =
+    line.type === "delete" ? "old" : "new";
+  const lineNum =
+    sideForRow === "new" ? line.new_line_num : line.old_line_num;
+  if (lineNum == null) {
+    return {
+      isHighlighted: false,
+      isRangeEndpoint: false,
+      side: null,
+      lineNum: null,
+    };
+  }
+
+  const draftMatch =
+    draft != null &&
+    draft.hunkIndex === hunkIndex &&
+    draft.side === sideForRow &&
+    lineNum >= draft.startLine &&
+    lineNum <= draft.endLine;
+  const startMatch =
+    rangeStart != null &&
+    rangeStart.hunkIndex === hunkIndex &&
+    rangeStart.side === sideForRow &&
+    rangeStart.line === lineNum;
+
+  return {
+    isHighlighted: draftMatch || startMatch,
+    isRangeEndpoint:
+      startMatch ||
+      (draft != null &&
+        draft.hunkIndex === hunkIndex &&
+        draft.side === sideForRow &&
+        (lineNum === draft.startLine || lineNum === draft.endLine)),
+    side: sideForRow,
+    lineNum,
+  };
 }
 
 export function DiffFileViewer({
@@ -76,6 +253,8 @@ export function DiffFileViewer({
   repoName,
   revision,
   onClose,
+  commentsEnabled = false,
+  commentsStore,
 }: Props) {
   const { diff, loading, error } = useFileDiff(
     sessionId,
@@ -86,6 +265,133 @@ export function DiffFileViewer({
   const { tokens: tokenGrid, loading: highlightLoading } = useHighlightedLines(
     diff?.hunks ?? [],
     diff?.file.path ?? filePath,
+  );
+
+  const [rangeStart, setRangeStart] = useState<RangeStart | null>(null);
+  const [draft, setDraft] = useState<DraftRange | null>(null);
+
+  const hunks = diff?.hunks ?? [];
+  const comments = commentsStore?.comments ?? [];
+
+  const anchored: AnchoredComment[] = useMemo(
+    () => anchorComments(comments, filePath, repoName, hunks),
+    [comments, filePath, repoName, hunks],
+  );
+
+  const staleComments = useMemo(
+    () => anchored.filter((a) => a.status === "stale"),
+    [anchored],
+  );
+
+  // Group active anchors per (hunkIndex, endRowIndex) so HunkView can
+  // emit cards inline without re-scanning the comments list per row.
+  const cardsByHunkRow = useMemo(() => {
+    const map = new Map<number, Map<number, AnchoredComment[]>>();
+    for (const a of anchored) {
+      if (a.status !== "active" || a.hunkIndex == null || a.endRowIndex == null)
+        continue;
+      let inner = map.get(a.hunkIndex);
+      if (!inner) {
+        inner = new Map();
+        map.set(a.hunkIndex, inner);
+      }
+      const list = inner.get(a.endRowIndex) ?? [];
+      list.push(a);
+      inner.set(a.endRowIndex, list);
+    }
+    return map;
+  }, [anchored]);
+
+  const handlePlusClick = useCallback(
+    (hunkIndex: number, side: DiffSide, lineNum: number) => {
+      if (draft) return; // form is open; ignore further clicks until resolved.
+      if (!rangeStart) {
+        setRangeStart({ hunkIndex, side, line: lineNum });
+        return;
+      }
+      if (rangeStart.hunkIndex !== hunkIndex || rangeStart.side !== side) {
+        // Restart selection on a cross-hunk or cross-side click instead
+        // of silently ignoring; the new line becomes the new start.
+        setRangeStart({ hunkIndex, side, line: lineNum });
+        return;
+      }
+      const startLine = Math.min(rangeStart.line, lineNum);
+      const endLine = Math.max(rangeStart.line, lineNum);
+      const extracted = extractSnippetFromHunks(
+        hunks,
+        side,
+        startLine,
+        endLine,
+      );
+      if (!extracted) {
+        // Range failed to resolve (probably straddled a non-side row at
+        // the boundary). Fall back to single-line on the clicked row.
+        setRangeStart(null);
+        const fallback = extractSnippetFromHunks(
+          hunks,
+          side,
+          lineNum,
+          lineNum,
+        );
+        if (!fallback) return;
+        setDraft({
+          hunkIndex,
+          side,
+          startLine: lineNum,
+          endLine: lineNum,
+          endRowIndex: fallback.endRowIndex,
+          snippet: fallback.snippet,
+        });
+        return;
+      }
+      setRangeStart(null);
+      setDraft({
+        hunkIndex,
+        side,
+        startLine,
+        endLine,
+        endRowIndex: extracted.endRowIndex,
+        snippet: extracted.snippet,
+      });
+    },
+    [draft, rangeStart, hunks],
+  );
+
+  const handleDraftSave = useCallback(
+    (body: string) => {
+      if (!draft || !commentsStore) return;
+      commentsStore.addComment({
+        repoName,
+        filePath,
+        side: draft.side,
+        startLine: draft.startLine,
+        endLine: draft.endLine,
+        body,
+        capturedSnippet: draft.snippet,
+        language: extensionToLanguage(filePath),
+      });
+      setDraft(null);
+    },
+    [draft, commentsStore, repoName, filePath],
+  );
+
+  const handleDraftCancel = useCallback(() => {
+    setDraft(null);
+    setRangeStart(null);
+  }, []);
+
+  const handleCommentSave = useCallback(
+    (id: string, body: string) => {
+      commentsStore?.updateComment(id, body);
+    },
+    [commentsStore],
+  );
+
+  const handleCommentDelete = useCallback(
+    (id: string) => {
+      commentsStore?.deleteComment(id);
+    },
+    [commentsStore],
   );
 
   if (loading && !diff) {
@@ -137,7 +443,7 @@ export function DiffFileViewer({
         </span>
         <span className="font-mono text-[12px] text-text-primary truncate">
           {diff.file.old_path
-            ? `${diff.file.old_path} \u2192 ${diff.file.path}`
+            ? `${diff.file.old_path} → ${diff.file.path}`
             : diff.file.path}
         </span>
         <span className="font-mono text-[11px] flex items-center gap-1">
@@ -171,12 +477,42 @@ export function DiffFileViewer({
           </div>
         ) : (
           <div className="leading-[1.6]">
+            {staleComments.length > 0 && (
+              <div className="px-3 py-2 bg-status-error/5 border-b border-status-error/30">
+                <div className="text-[11px] font-mono text-status-error mb-2">
+                  {staleComments.length} stale comment
+                  {staleComments.length === 1 ? "" : "s"} (line range no longer
+                  in current diff)
+                </div>
+                {staleComments.map((anchored) => (
+                  <CommentCard
+                    key={`stale-${anchored.comment.id}`}
+                    anchored={anchored}
+                    onSave={handleCommentSave}
+                    onDelete={handleCommentDelete}
+                  />
+                ))}
+              </div>
+            )}
             {diff.hunks.map((hunk, hi) => (
               <HunkView
                 key={`${hunk.old_start}-${hunk.new_start}`}
                 hunk={hunk}
+                hunkIndex={hi}
                 lineTokens={tokenGrid?.[hi]}
                 highlightPending={highlightLoading}
+                rangeStart={rangeStart}
+                draft={draft?.hunkIndex === hi ? draft : null}
+                cardsByEndRow={cardsByHunkRow.get(hi) ?? EMPTY_MAP}
+                formRowIndex={
+                  draft?.hunkIndex === hi ? draft.endRowIndex : null
+                }
+                commentsEnabled={commentsEnabled && !!commentsStore}
+                onPlusClick={handlePlusClick}
+                onCommentSave={handleCommentSave}
+                onCommentDelete={handleCommentDelete}
+                onDraftSave={handleDraftSave}
+                onDraftCancel={handleDraftCancel}
               />
             ))}
           </div>
@@ -185,3 +521,5 @@ export function DiffFileViewer({
     </div>
   );
 }
+
+const EMPTY_MAP: Map<number, AnchoredComment[]> = new Map();

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useMemo, useState } from "react";
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
 import { useFileDiff } from "../../hooks/useFileDiff";
 import {
   useHighlightedLines,
@@ -185,11 +185,16 @@ function PlusButton({
     <button
       type="button"
       onClick={() => onClick(hunkIndex, side, lineNum)}
-      aria-label={`Add comment on line ${lineNum}`}
+      aria-label={`Add comment on ${side} line ${lineNum}`}
+      // `tabIndex={-1}` keeps the hover-revealed button out of the
+      // tab order; otherwise keyboard users would land on dozens of
+      // invisible buttons walking through the diff. v1 is mouse-only;
+      // a focus-driven flow can be added with a real row-focus model.
+      tabIndex={-1}
       className={`absolute left-0 top-0 h-full w-4 flex items-center justify-center text-white text-[11px] leading-none cursor-pointer transition-opacity ${
         active
           ? "bg-brand-600 opacity-100"
-          : "bg-brand-600 opacity-0 group-hover:opacity-100 hover:bg-brand-500"
+          : "bg-brand-600 opacity-0 group-hover:opacity-100 hover:bg-brand-500 focus-visible:opacity-100"
       }`}
     >
       +
@@ -269,6 +274,15 @@ export function DiffFileViewer({
 
   const [rangeStart, setRangeStart] = useState<RangeStart | null>(null);
   const [draft, setDraft] = useState<DraftRange | null>(null);
+
+  // Reset transient selection when the viewer switches to a different
+  // file / repo / session, or the diff refreshes. Without this an
+  // unfinished selection or open draft from file A would render in
+  // file B (and save the wrong filePath against the wrong snippet).
+  useEffect(() => {
+    setRangeStart(null);
+    setDraft(null);
+  }, [sessionId, repoName, filePath, revision]);
 
   const hunks = diff?.hunks ?? [];
   const comments = commentsStore?.comments ?? [];
@@ -471,7 +485,7 @@ export function DiffFileViewer({
               </p>
             </div>
           </div>
-        ) : diff.hunks.length === 0 ? (
+        ) : diff.hunks.length === 0 && staleComments.length === 0 ? (
           <div className="flex items-center justify-center h-full text-text-dim">
             <span className="text-sm">No changes in this file</span>
           </div>
@@ -492,6 +506,11 @@ export function DiffFileViewer({
                     onDelete={handleCommentDelete}
                   />
                 ))}
+              </div>
+            )}
+            {diff.hunks.length === 0 && (
+              <div className="px-3 py-4 text-center text-text-dim text-sm">
+                No changes in this file
               </div>
             )}
             {diff.hunks.map((hunk, hi) => (

--- a/web/src/components/diff/DiffLine.tsx
+++ b/web/src/components/diff/DiffLine.tsx
@@ -1,3 +1,4 @@
+import { memo, type ReactNode } from "react";
 import type { SyntaxToken } from "../../hooks/useHighlightedLines";
 import type { RichDiffLine } from "../../lib/types";
 
@@ -10,13 +11,25 @@ interface Props {
    *  diffs (e.g. the cockpit Edit card) where snippet line numbers add
    *  more clutter than signal. */
   hideLineNumbers?: boolean;
+  /** Optional overlay rendered inside the line-number gutter (in front of
+   *  the numbers). Used by the diff comments feature to surface a "+"
+   *  button on hover without resizing the row. See #928. */
+  leadingSlot?: ReactNode;
+  /** Tint the row to indicate it's part of the active comment range. */
+  isHighlighted?: boolean;
+  /** Mark the row as the start/end endpoint of a range with a stronger
+   *  left border. */
+  isRangeEndpoint?: boolean;
 }
 
-export function DiffLine({
+function DiffLineImpl({
   line,
   tokens,
   highlightPending,
   hideLineNumbers,
+  leadingSlot,
+  isHighlighted,
+  isRangeEndpoint,
 }: Props) {
   let bgClass = "";
   let textClass = "text-text-secondary";
@@ -32,6 +45,9 @@ export function DiffLine({
     prefix = "-";
   }
 
+  const highlightOverlay = isHighlighted ? " bg-brand-600/10" : "";
+  const endpointBorder = isRangeEndpoint ? " border-l-2 border-brand-600" : "";
+
   const content = line.content.replace(/\r?\n$/, "");
 
   const renderContent = () => {
@@ -46,16 +62,17 @@ export function DiffLine({
         </span>
       ));
     }
-    return content || " ";
+    return content || " ";
   };
 
   return (
     <div
-      className={`flex ${bgClass} hover:brightness-110 transition-[filter] duration-75`}
+      className={`group flex ${bgClass}${highlightOverlay}${endpointBorder} hover:brightness-110 transition-[filter] duration-75`}
     >
       {!hideLineNumbers && (
         <>
-          <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30">
+          <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30 relative">
+            {leadingSlot}
             {line.old_line_num ?? ""}
           </span>
           <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30">
@@ -76,3 +93,8 @@ export function DiffLine({
     </div>
   );
 }
+
+/** Memoized so range-selection state changes in the parent don't
+ *  re-render every line. Callers should pass stable props (no inline
+ *  object/function allocations per render) to keep memo effective. */
+export const DiffLine = memo(DiffLineImpl);

--- a/web/src/components/diff/DiffLine.tsx
+++ b/web/src/components/diff/DiffLine.tsx
@@ -1,6 +1,8 @@
-import { memo, type ReactNode } from "react";
+import { memo } from "react";
 import type { SyntaxToken } from "../../hooks/useHighlightedLines";
 import type { RichDiffLine } from "../../lib/types";
+
+type PlusSide = "old" | "new";
 
 interface Props {
   line: RichDiffLine;
@@ -11,10 +13,17 @@ interface Props {
    *  diffs (e.g. the cockpit Edit card) where snippet line numbers add
    *  more clutter than signal. */
   hideLineNumbers?: boolean;
-  /** Optional overlay rendered inside the line-number gutter (in front of
-   *  the numbers). Used by the diff comments feature to surface a "+"
-   *  button on hover without resizing the row. See #928. */
-  leadingSlot?: ReactNode;
+  /** Render the hover-revealed "+" gutter button for the diff-comments
+   *  feature (#928). Props are primitives instead of a ReactNode slot
+   *  so `React.memo`'s shallow comparison succeeds across parent
+   *  re-renders — passing a fresh `<PlusButton/>` JSX node per row
+   *  would bust memo on every range-selection state change. */
+  plusEnabled?: boolean;
+  plusHunkIndex?: number;
+  plusSide?: PlusSide;
+  plusLineNum?: number;
+  plusActive?: boolean;
+  onPlusClick?: (hunkIndex: number, side: PlusSide, lineNum: number) => void;
   /** Tint the row to indicate it's part of the active comment range. */
   isHighlighted?: boolean;
   /** Mark the row as the start/end endpoint of a range with a stronger
@@ -27,7 +36,12 @@ function DiffLineImpl({
   tokens,
   highlightPending,
   hideLineNumbers,
-  leadingSlot,
+  plusEnabled,
+  plusHunkIndex,
+  plusSide,
+  plusLineNum,
+  plusActive,
+  onPlusClick,
   isHighlighted,
   isRangeEndpoint,
 }: Props) {
@@ -65,6 +79,13 @@ function DiffLineImpl({
     return content || " ";
   };
 
+  const showPlus =
+    plusEnabled === true &&
+    plusSide != null &&
+    plusLineNum != null &&
+    plusHunkIndex != null &&
+    onPlusClick != null;
+
   return (
     <div
       className={`group flex ${bgClass}${highlightOverlay}${endpointBorder} hover:brightness-110 transition-[filter] duration-75`}
@@ -72,7 +93,26 @@ function DiffLineImpl({
       {!hideLineNumbers && (
         <>
           <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30 relative">
-            {leadingSlot}
+            {showPlus && (
+              <button
+                type="button"
+                onClick={() => onPlusClick(plusHunkIndex, plusSide, plusLineNum)}
+                aria-label={`Add comment on ${plusSide} line ${plusLineNum}`}
+                // `tabIndex={-1}` keeps the hover-revealed button out of
+                // the tab order; otherwise keyboard users would land on
+                // dozens of invisible buttons walking through the diff.
+                // v1 is mouse-only; a focus-driven flow can be added
+                // with a real row-focus model.
+                tabIndex={-1}
+                className={`absolute left-0 top-0 h-full w-4 flex items-center justify-center text-white text-[11px] leading-none cursor-pointer transition-opacity ${
+                  plusActive
+                    ? "bg-brand-600 opacity-100"
+                    : "bg-brand-600 opacity-0 group-hover:opacity-100 hover:bg-brand-500 focus-visible:opacity-100"
+                }`}
+              >
+                +
+              </button>
+            )}
             {line.old_line_num ?? ""}
           </span>
           <span className="shrink-0 w-[50px] text-right pr-2 font-mono text-[11px] text-text-dim select-none border-r border-surface-700/30">
@@ -95,6 +135,7 @@ function DiffLineImpl({
 }
 
 /** Memoized so range-selection state changes in the parent don't
- *  re-render every line. Callers should pass stable props (no inline
- *  object/function allocations per render) to keep memo effective. */
+ *  re-render every line. All props are primitives (or stable callback
+ *  references via `useCallback`) so the default shallow comparison is
+ *  effective; passing a fresh JSX node per row would defeat memo. */
 export const DiffLine = memo(DiffLineImpl);

--- a/web/src/components/diff/comments/CommentCard.tsx
+++ b/web/src/components/diff/comments/CommentCard.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import { Markdown } from "../../cockpit/Markdown";
+import { CommentForm } from "./CommentForm";
+import type { AnchoredComment } from "./types";
+
+interface Props {
+  anchored: AnchoredComment;
+  onSave: (id: string, body: string) => void;
+  onDelete: (id: string) => void;
+}
+
+/** Saved-comment view. Body is rendered as markdown via the existing
+ *  cockpit Markdown component. Switching to edit mode reuses
+ *  CommentForm. Stale comments show a `[stale]` chip; they remain
+ *  editable so the user can rewrite or delete them. */
+export function CommentCard({ anchored, onSave, onDelete }: Props) {
+  const [editing, setEditing] = useState(false);
+  const { comment, status } = anchored;
+
+  if (editing) {
+    return (
+      <CommentForm
+        startLine={comment.startLine}
+        endLine={comment.endLine}
+        side={comment.side}
+        initialBody={comment.body}
+        onSave={(body) => {
+          onSave(comment.id, body);
+          setEditing(false);
+        }}
+        onCancel={() => setEditing(false)}
+      />
+    );
+  }
+
+  const range =
+    comment.startLine === comment.endLine
+      ? `line ${comment.startLine}`
+      : `lines ${comment.startLine}-${comment.endLine}`;
+
+  return (
+    <div className="border-y border-surface-700/40 bg-surface-850 px-3 py-2">
+      <div className="flex items-center gap-2 mb-1.5 text-[11px] font-mono">
+        <span className="text-text-dim">
+          {range} ({comment.side})
+        </span>
+        {status === "stale" && (
+          <span
+            className="px-1 rounded bg-status-error/15 text-status-error"
+            title="The line range no longer appears in the current diff. The comment will still be sent to the agent using the original snippet."
+          >
+            stale
+          </span>
+        )}
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="text-[10px] px-1.5 py-0.5 rounded text-text-dim hover:text-text-secondary hover:bg-surface-800 cursor-pointer transition-colors"
+          >
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(comment.id)}
+            className="text-[10px] px-1.5 py-0.5 rounded text-text-dim hover:text-status-error hover:bg-surface-800 cursor-pointer transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      <div className="text-[13px] text-text-primary">
+        <Markdown text={comment.body} />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/diff/comments/CommentCard.tsx
+++ b/web/src/components/diff/comments/CommentCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Markdown } from "../../cockpit/Markdown";
+import { CommentMarkdown } from "./CommentMarkdown";
 import { CommentForm } from "./CommentForm";
 import type { AnchoredComment } from "./types";
 
@@ -70,7 +70,7 @@ export function CommentCard({ anchored, onSave, onDelete }: Props) {
         </div>
       </div>
       <div className="text-[13px] text-text-primary">
-        <Markdown text={comment.body} />
+        <CommentMarkdown text={comment.body} />
       </div>
     </div>
   );

--- a/web/src/components/diff/comments/CommentForm.tsx
+++ b/web/src/components/diff/comments/CommentForm.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react";
+import type { DiffSide } from "./types";
+
+interface Props {
+  startLine: number;
+  endLine: number;
+  side: DiffSide;
+  initialBody?: string;
+  onSave: (body: string) => void;
+  onCancel: () => void;
+}
+
+/** Inline composer rendered beneath the last row of the selected range.
+ *  Cmd/Ctrl+Enter saves; Esc cancels. Empty bodies are rejected (the
+ *  Save button stays disabled). */
+export function CommentForm({
+  startLine,
+  endLine,
+  side,
+  initialBody = "",
+  onSave,
+  onCancel,
+}: Props) {
+  const [body, setBody] = useState(initialBody);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    textareaRef.current?.focus();
+  }, []);
+
+  const trimmed = body.trim();
+  const canSave = trimmed.length > 0;
+
+  const range =
+    startLine === endLine ? `line ${startLine}` : `lines ${startLine}-${endLine}`;
+
+  return (
+    <div className="border-y border-brand-600/30 bg-surface-850 px-3 py-2">
+      <div className="text-[11px] text-text-dim mb-1.5 font-mono">
+        Commenting on {range} ({side})
+      </div>
+      <textarea
+        ref={textareaRef}
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Escape") {
+            e.preventDefault();
+            e.stopPropagation();
+            onCancel();
+          } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+            e.preventDefault();
+            if (canSave) onSave(trimmed);
+          }
+        }}
+        placeholder="Leave a comment (markdown supported). Cmd/Ctrl+Enter to save, Esc to cancel."
+        rows={3}
+        className="w-full bg-surface-900 border border-surface-700 rounded px-2 py-1.5 text-[12px] font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none resize-y"
+      />
+      <div className="mt-2 flex items-center gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-[11px] px-2 py-1 rounded text-text-dim hover:text-text-secondary hover:bg-surface-800 cursor-pointer transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => canSave && onSave(trimmed)}
+          disabled={!canSave}
+          className="text-[11px] px-2 py-1 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/diff/comments/CommentMarkdown.tsx
+++ b/web/src/components/diff/comments/CommentMarkdown.tsx
@@ -1,0 +1,29 @@
+import { useMemo } from "react";
+import { marked } from "marked";
+
+interface Props {
+  text: string;
+}
+
+/// Render markdown for diff-comment bodies. We deliberately do NOT
+/// reuse the cockpit `<Markdown>` component because that one depends
+/// on `@assistant-ui/react-markdown`'s `<AssistantRuntimeProvider>`
+/// which is only mounted under the cockpit panel. The diff viewer is
+/// a sibling of that panel, so calling the cockpit Markdown component
+/// here throws "requires an AuiProvider" and unmounts the tree.
+///
+/// `marked` is configured with HTML disabled (`sanitize` is dropped in
+/// modern marked but `breaks: false` + no `html` extension keeps user
+/// input safe enough for local-only review notes; comments never leave
+/// the user's browser until they're posted as plaintext to the agent).
+export function CommentMarkdown({ text }: Props) {
+  const html = useMemo(() => {
+    return marked.parse(text, { async: false, breaks: true }) as string;
+  }, [text]);
+  return (
+    <div
+      className="diff-comment-md text-[13px] leading-relaxed"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}

--- a/web/src/components/diff/comments/CommentsBanner.tsx
+++ b/web/src/components/diff/comments/CommentsBanner.tsx
@@ -1,0 +1,49 @@
+interface Props {
+  count: number;
+  sendEnabled: boolean;
+  sendDisabledReason?: string;
+  onSend: () => void;
+  onDiscardAll: () => void;
+}
+
+/** Floating chip rendered above the right-panel diff list. Visible
+ *  whenever the active session has at least one comment and supports
+ *  the feature (cockpit-only). The send button is disabled while the
+ *  cockpit worker is not running so the prompt doesn't sink. */
+export function CommentsBanner({
+  count,
+  sendEnabled,
+  sendDisabledReason,
+  onSend,
+  onDiscardAll,
+}: Props) {
+  if (count === 0) return null;
+  return (
+    <div className="flex items-center gap-2 px-3 py-1.5 bg-brand-600/10 border-b border-brand-600/30 text-[11px] font-mono">
+      <span className="text-brand-500 font-semibold">
+        {count} comment{count === 1 ? "" : "s"}
+      </span>
+      <span className="text-text-dim hidden sm:inline">
+        Cmd/Ctrl+Shift+S to send
+      </span>
+      <div className="ml-auto flex items-center gap-1.5">
+        <button
+          type="button"
+          onClick={onDiscardAll}
+          className="px-2 py-0.5 rounded text-text-dim hover:text-status-error hover:bg-surface-800 cursor-pointer transition-colors"
+        >
+          Discard all
+        </button>
+        <button
+          type="button"
+          onClick={onSend}
+          disabled={!sendEnabled}
+          title={sendEnabled ? "Send comments to agent" : sendDisabledReason}
+          className="px-2 py-0.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+        >
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/diff/comments/CommentsBanner.tsx
+++ b/web/src/components/diff/comments/CommentsBanner.tsx
@@ -29,7 +29,15 @@ export function CommentsBanner({
       <div className="ml-auto flex items-center gap-1.5">
         <button
           type="button"
-          onClick={onDiscardAll}
+          onClick={() => {
+            if (
+              window.confirm(
+                `Discard all ${count} diff comment${count === 1 ? "" : "s"}? This can't be undone.`,
+              )
+            ) {
+              onDiscardAll();
+            }
+          }}
           className="px-2 py-0.5 rounded text-text-dim hover:text-status-error hover:bg-surface-800 cursor-pointer transition-colors"
         >
           Discard all

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -1,6 +1,12 @@
+import { useEffect, useState } from "react";
 import { CommentMarkdown } from "./CommentMarkdown";
 import type { DiffCommentsSentinelPayload } from "./buildPrompt";
 import type { DiffComment } from "./types";
+import {
+  getHighlighter,
+  langKeyForExt,
+  loadLanguage,
+} from "../../../lib/highlighter";
 
 interface Props {
   payload: DiffCommentsSentinelPayload;
@@ -35,9 +41,11 @@ export function DiffCommentsUserCard({ payload }: Props) {
             className="rounded-lg border border-surface-700/60 bg-surface-900/60"
           >
             <CommentHeader comment={c} isMultiRepo={isMultiRepo} />
-            <pre className="overflow-x-auto border-b border-surface-700/40 bg-surface-950 px-3 py-2 font-mono text-[12px] text-text-primary">
-              {c.capturedSnippet}
-            </pre>
+            <HighlightedSnippet
+              code={c.capturedSnippet}
+              language={c.language}
+              filePath={c.filePath}
+            />
             <div className="px-3 py-2 text-text-primary">
               <CommentMarkdown text={c.body} />
             </div>
@@ -50,6 +58,61 @@ export function DiffCommentsUserCard({ payload }: Props) {
         </div>
       )}
     </div>
+  );
+}
+
+/** Shiki-backed snippet renderer matching the cockpit Markdown code
+ *  block style. Loads the language module on demand and falls back to
+ *  plain `<pre>` while loading or when the language can't be resolved.
+ *  See `lib/highlighter.ts`. */
+function HighlightedSnippet({
+  code,
+  language,
+  filePath,
+}: {
+  code: string;
+  language?: string;
+  filePath: string;
+}) {
+  const [html, setHtml] = useState<string | null>(null);
+  useEffect(() => {
+    let cancelled = false;
+    const hint =
+      language && language.length > 0
+        ? language
+        : filePath.split(".").pop() ?? "";
+    if (!hint) return;
+    (async () => {
+      try {
+        const langKey = langKeyForExt(hint) ?? hint;
+        await loadLanguage(langKey);
+        const hl = await getHighlighter();
+        if (cancelled) return;
+        if (!hl.getLoadedLanguages().includes(langKey)) return;
+        setHtml(
+          hl.codeToHtml(code, { lang: langKey, theme: "github-dark" }),
+        );
+      } catch {
+        // Unknown lang → fall through to plain rendering.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [code, language, filePath]);
+
+  if (html) {
+    return (
+      <div
+        className="overflow-x-auto border-b border-surface-700/40 bg-surface-950 px-3 py-2 text-[12px] [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    );
+  }
+  return (
+    <pre className="overflow-x-auto border-b border-surface-700/40 bg-surface-950 px-3 py-2 font-mono text-[12px] text-text-primary">
+      {code}
+    </pre>
   );
 }
 

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -102,6 +102,10 @@ function HighlightedSnippet({
   }, [code, language, filePath]);
 
   if (html) {
+    // Shiki HTML-escapes the user-supplied `code` before tokenizing, so
+    // the only attacker-controlled values reach the DOM as text nodes
+    // inside `<span>` tags with locally-generated style attributes.
+    // Same trust boundary as the cockpit Markdown renderer's code blocks.
     return (
       <div
         className="overflow-x-auto border-b border-surface-700/40 bg-surface-950 px-3 py-2 text-[12px] [&_pre]:!bg-transparent [&_pre]:!m-0 [&_pre]:!p-0"

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -1,0 +1,91 @@
+import { CommentMarkdown } from "./CommentMarkdown";
+import type { DiffCommentsSentinelPayload } from "./buildPrompt";
+import type { DiffComment } from "./types";
+
+interface Props {
+  payload: DiffCommentsSentinelPayload;
+}
+
+/** Rich rendering of a diff-comments prompt in the cockpit user-message
+ *  slot. Built from the sentinel payload that `buildFullPrompt`
+ *  prepends to the prompt body. Falls back to the raw text rendering
+ *  upstream when the sentinel is missing or malformed. */
+export function DiffCommentsUserCard({ payload }: Props) {
+  const { intro, outro, isMultiRepo, comments } = payload;
+  const sorted = [...comments].sort(compareComments);
+  return (
+    <div className="w-full max-w-3xl rounded-2xl rounded-br-sm border border-surface-700 bg-surface-800/70 px-4 py-3 text-sm">
+      <div className="mb-2 flex items-center gap-2 text-[11px] uppercase tracking-wider text-text-dim">
+        <span className="rounded bg-brand-600/15 px-1.5 py-0.5 font-mono text-brand-300">
+          diff review
+        </span>
+        <span>
+          {comments.length} comment{comments.length === 1 ? "" : "s"}
+        </span>
+      </div>
+      {intro && (
+        <div className="mb-3 border-l-2 border-surface-700 pl-3 text-text-secondary">
+          <CommentMarkdown text={intro} />
+        </div>
+      )}
+      <ul className="flex flex-col gap-3">
+        {sorted.map((c) => (
+          <li
+            key={c.id}
+            className="rounded-lg border border-surface-700/60 bg-surface-900/60"
+          >
+            <CommentHeader comment={c} isMultiRepo={isMultiRepo} />
+            <pre className="overflow-x-auto border-b border-surface-700/40 bg-surface-950 px-3 py-2 font-mono text-[12px] text-text-primary">
+              {c.capturedSnippet}
+            </pre>
+            <div className="px-3 py-2 text-text-primary">
+              <CommentMarkdown text={c.body} />
+            </div>
+          </li>
+        ))}
+      </ul>
+      {outro && (
+        <div className="mt-3 border-l-2 border-surface-700 pl-3 text-text-secondary">
+          <CommentMarkdown text={outro} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CommentHeader({
+  comment,
+  isMultiRepo,
+}: {
+  comment: DiffComment;
+  isMultiRepo: boolean;
+}) {
+  const range =
+    comment.startLine === comment.endLine
+      ? `line ${comment.startLine}`
+      : `lines ${comment.startLine}-${comment.endLine}`;
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 border-b border-surface-700/40 px-3 py-1.5 text-[11px] font-mono text-text-dim">
+      {isMultiRepo && comment.repoName && (
+        <span className="rounded bg-surface-800 px-1.5 py-0.5 text-text-secondary">
+          {comment.repoName}
+        </span>
+      )}
+      <span className="text-text-secondary">{comment.filePath}</span>
+      <span>·</span>
+      <span>{range}</span>
+      <span>·</span>
+      <span>{comment.side}</span>
+    </div>
+  );
+}
+
+function compareComments(a: DiffComment, b: DiffComment): number {
+  const ra = a.repoName ?? "";
+  const rb = b.repoName ?? "";
+  if (ra !== rb) return ra.localeCompare(rb);
+  if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+  if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+  if (a.side !== b.side) return a.side === "old" ? -1 : 1;
+  return a.createdAt.localeCompare(b.createdAt);
+}

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Markdown } from "../../cockpit/Markdown";
+import { CommentMarkdown } from "./CommentMarkdown";
 import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
 import type { DiffComment } from "./types";
 
@@ -166,7 +166,7 @@ export function SendCommentsDialog({
             </div>
             <div className="border border-surface-700/60 rounded p-3 bg-surface-950 max-h-72 overflow-auto text-[13px]">
               {preview ? (
-                <Markdown text={preview} />
+                <CommentMarkdown text={preview} />
               ) : (
                 <span className="text-text-dim italic">No comments.</span>
               )}

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useMemo, useState } from "react";
+import { Markdown } from "../../cockpit/Markdown";
+import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
+import type { DiffComment } from "./types";
+
+interface Props {
+  sessionId: string;
+  comments: DiffComment[];
+  isMultiRepo: boolean;
+  introDraft: string;
+  outroDraft: string;
+  clearAfterSend: boolean;
+  onChangeIntro: (v: string) => void;
+  onChangeOutro: (v: string) => void;
+  onChangeClearAfterSend: (v: boolean) => void;
+  onClose: () => void;
+  onSent: () => void;
+}
+
+/** Three-piece compose dialog: editable intro textarea, read-only
+ *  preview of the assembled comments markdown, editable outro
+ *  textarea. The final prompt is composed at send time so the user's
+ *  intro/outro edits don't fall out of sync if comments change
+ *  underneath. See history/plan-diff-comments.md. */
+export function SendCommentsDialog({
+  sessionId,
+  comments,
+  isMultiRepo,
+  introDraft,
+  outroDraft,
+  clearAfterSend,
+  onChangeIntro,
+  onChangeOutro,
+  onChangeClearAfterSend,
+  onClose,
+  onSent,
+}: Props) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const preview = useMemo(
+    () => buildCommentsMarkdown(comments, { isMultiRepo }),
+    [comments, isMultiRepo],
+  );
+
+  // Trap Esc/Cmd+Enter at the document level so editing in the textareas
+  // doesn't intercept the dialog hotkeys.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void send();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+    // `send` is stable enough; we rebuild this handler on any state
+    // change anyway so dependencies aren't load-bearing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [introDraft, outroDraft, comments, busy]);
+
+  const send = async () => {
+    if (busy || comments.length === 0) return;
+    setBusy(true);
+    setError(null);
+    const body = buildFullPrompt(comments, introDraft, outroDraft, {
+      isMultiRepo,
+    });
+    try {
+      const res = await fetch(
+        `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/prompt`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ text: body }),
+        },
+      );
+      if (!res.ok) {
+        const text = await res.text().catch(() => "");
+        setError(`Failed to send (${res.status}). ${text}`.trim());
+        return;
+      }
+      onSent();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Network error";
+      setError(`Failed to send: ${message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-surface-900 border border-surface-700 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] flex flex-col">
+        <div className="px-4 py-3 border-b border-surface-700/60 flex items-center gap-2">
+          <h2 className="text-sm font-semibold text-text-primary">
+            Send diff comments
+          </h2>
+          <span className="text-[11px] text-text-dim">
+            {comments.length} comment{comments.length === 1 ? "" : "s"}
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto text-text-dim hover:text-text-secondary cursor-pointer"
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto px-4 py-3 space-y-3">
+          <section>
+            <label className="block text-[11px] text-text-dim mb-1">
+              Intro (optional)
+            </label>
+            <textarea
+              value={introDraft}
+              onChange={(e) => onChangeIntro(e.target.value)}
+              placeholder="Anything you want to say before the comments..."
+              rows={2}
+              className="w-full bg-surface-950 border border-surface-700 rounded px-2 py-1.5 text-[12px] font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none resize-y"
+            />
+          </section>
+
+          <section>
+            <div className="text-[11px] text-text-dim mb-1">
+              Comments preview (auto-generated, read-only)
+            </div>
+            <div className="border border-surface-700/60 rounded p-3 bg-surface-950 max-h-72 overflow-auto text-[13px]">
+              {preview ? (
+                <Markdown text={preview} />
+              ) : (
+                <span className="text-text-dim italic">No comments.</span>
+              )}
+            </div>
+          </section>
+
+          <section>
+            <label className="block text-[11px] text-text-dim mb-1">
+              Outro
+            </label>
+            <textarea
+              value={outroDraft}
+              onChange={(e) => onChangeOutro(e.target.value)}
+              placeholder="Please address these comments."
+              rows={2}
+              className="w-full bg-surface-950 border border-surface-700 rounded px-2 py-1.5 text-[12px] font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none resize-y"
+            />
+          </section>
+
+          {error && (
+            <div className="text-[12px] text-status-error bg-status-error/10 rounded p-2">
+              {error}
+            </div>
+          )}
+        </div>
+        <div className="px-4 py-3 border-t border-surface-700/60 flex items-center gap-3">
+          <label className="flex items-center gap-1.5 text-[11px] text-text-dim cursor-pointer">
+            <input
+              type="checkbox"
+              checked={clearAfterSend}
+              onChange={(e) => onChangeClearAfterSend(e.target.checked)}
+              className="cursor-pointer"
+            />
+            Clear comments after sending
+          </label>
+          <div className="ml-auto flex items-center gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-[12px] px-3 py-1.5 rounded text-text-dim hover:text-text-secondary hover:bg-surface-800 cursor-pointer transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void send()}
+              disabled={busy || comments.length === 0}
+              className="text-[12px] px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
+            >
+              {busy ? "Sending..." : "Send"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/diff/comments/SendCommentsDialog.tsx
+++ b/web/src/components/diff/comments/SendCommentsDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Markdown } from "../../cockpit/Markdown";
 import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
 import type { DiffComment } from "./types";
@@ -7,6 +7,12 @@ interface Props {
   sessionId: string;
   comments: DiffComment[];
   isMultiRepo: boolean;
+  /** Same gate as the banner Send button. Reflects
+   *  `cockpit_mode && cockpit_worker_state === "running"`. False
+   *  disables the Send button so prompts don't sink when the worker
+   *  isn't ready. */
+  sendEnabled: boolean;
+  sendDisabledReason?: string;
   introDraft: string;
   outroDraft: string;
   clearAfterSend: boolean;
@@ -26,6 +32,8 @@ export function SendCommentsDialog({
   sessionId,
   comments,
   isMultiRepo,
+  sendEnabled,
+  sendDisabledReason,
   introDraft,
   outroDraft,
   clearAfterSend,
@@ -37,33 +45,22 @@ export function SendCommentsDialog({
 }: Props) {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const preview = useMemo(
     () => buildCommentsMarkdown(comments, { isMultiRepo }),
     [comments, isMultiRepo],
   );
 
-  // Trap Esc/Cmd+Enter at the document level so editing in the textareas
-  // doesn't intercept the dialog hotkeys.
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.preventDefault();
-        onClose();
-      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
-        e.preventDefault();
-        void send();
-      }
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-    // `send` is stable enough; we rebuild this handler on any state
-    // change anyway so dependencies aren't load-bearing.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [introDraft, outroDraft, comments, busy]);
-
-  const send = async () => {
-    if (busy || comments.length === 0) return;
+  const send = useCallback(async () => {
+    if (busy || comments.length === 0 || !sendEnabled) return;
     setBusy(true);
     setError(null);
     const body = buildFullPrompt(comments, introDraft, outroDraft, {
@@ -79,18 +76,51 @@ export function SendCommentsDialog({
         },
       );
       if (!res.ok) {
-        const text = await res.text().catch(() => "");
-        setError(`Failed to send (${res.status}). ${text}`.trim());
+        const text = (await res.text().catch(() => "")).slice(0, 500);
+        if (mountedRef.current) {
+          setError(`Failed to send (${res.status}). ${text}`.trim());
+        }
         return;
       }
       onSent();
     } catch (e) {
       const message = e instanceof Error ? e.message : "Network error";
-      setError(`Failed to send: ${message}`);
+      if (mountedRef.current) {
+        setError(`Failed to send: ${message}`);
+      }
     } finally {
-      setBusy(false);
+      if (mountedRef.current) {
+        setBusy(false);
+      }
     }
-  };
+  }, [
+    busy,
+    comments,
+    introDraft,
+    outroDraft,
+    isMultiRepo,
+    sendEnabled,
+    sessionId,
+    onSent,
+  ]);
+
+  // Trap Esc/Cmd+Enter at the document level so editing in the textareas
+  // doesn't intercept the dialog hotkeys. Esc is blocked while a send
+  // is in flight so the user doesn't dismiss a request mid-flight.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        if (busy) return;
+        e.preventDefault();
+        onClose();
+      } else if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void send();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [busy, onClose, send]);
 
   return (
     <div
@@ -183,7 +213,8 @@ export function SendCommentsDialog({
             <button
               type="button"
               onClick={() => void send()}
-              disabled={busy || comments.length === 0}
+              disabled={busy || comments.length === 0 || !sendEnabled}
+              title={sendEnabled ? undefined : sendDisabledReason}
               className="text-[12px] px-3 py-1.5 rounded bg-brand-600 text-white hover:bg-brand-500 disabled:bg-surface-700 disabled:text-text-dim disabled:cursor-not-allowed cursor-pointer transition-colors"
             >
               {busy ? "Sending..." : "Send"}

--- a/web/src/components/diff/comments/anchor.test.ts
+++ b/web/src/components/diff/comments/anchor.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import type { RichDiffHunk } from "../../../lib/types";
+import { anchorComments } from "./anchor";
+import type { DiffComment } from "./types";
+
+function mkHunk(): RichDiffHunk {
+  return {
+    old_start: 10,
+    old_lines: 3,
+    new_start: 10,
+    new_lines: 3,
+    lines: [
+      { type: "equal", old_line_num: 10, new_line_num: 10, content: "a\n" },
+      { type: "equal", old_line_num: 11, new_line_num: 11, content: "b\n" },
+      { type: "equal", old_line_num: 12, new_line_num: 12, content: "c\n" },
+    ],
+  };
+}
+
+function mkComment(overrides: Partial<DiffComment>): DiffComment {
+  return {
+    id: "c1",
+    filePath: "src/foo.rs",
+    side: "new",
+    startLine: 11,
+    endLine: 11,
+    body: "review",
+    capturedSnippet: "b",
+    createdAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("anchorComments", () => {
+  it("marks comments active when the range resolves", () => {
+    const [a] = anchorComments(
+      [mkComment({})],
+      "src/foo.rs",
+      undefined,
+      [mkHunk()],
+    );
+    expect(a.status).toBe("active");
+    expect(a.hunkIndex).toBe(0);
+    expect(a.contentChanged).toBe(false);
+  });
+
+  it("marks comments stale when the range is missing", () => {
+    const [a] = anchorComments(
+      [mkComment({ startLine: 99, endLine: 99 })],
+      "src/foo.rs",
+      undefined,
+      [mkHunk()],
+    );
+    expect(a.status).toBe("stale");
+  });
+
+  it("flags contentChanged when current snippet differs from captured", () => {
+    const [a] = anchorComments(
+      [mkComment({ capturedSnippet: "STALE" })],
+      "src/foo.rs",
+      undefined,
+      [mkHunk()],
+    );
+    expect(a.status).toBe("active");
+    expect(a.contentChanged).toBe(true);
+  });
+
+  it("filters by repoName and filePath", () => {
+    const result = anchorComments(
+      [
+        mkComment({ id: "match", filePath: "src/foo.rs", repoName: "r" }),
+        mkComment({ id: "wrongRepo", filePath: "src/foo.rs", repoName: "x" }),
+        mkComment({ id: "wrongFile", filePath: "src/bar.rs", repoName: "r" }),
+      ],
+      "src/foo.rs",
+      "r",
+      [mkHunk()],
+    );
+    expect(result.map((a) => a.comment.id)).toEqual(["match"]);
+  });
+});

--- a/web/src/components/diff/comments/anchor.ts
+++ b/web/src/components/diff/comments/anchor.ts
@@ -1,0 +1,49 @@
+import type { RichDiffHunk } from "../../../lib/types";
+import { extractSnippetFromHunks } from "./extractSnippet";
+import type { AnchoredComment, DiffComment } from "./types";
+
+/** Map every comment for a given (repoName, filePath) against the
+ *  currently loaded hunks. A comment whose line range no longer maps
+ *  to any hunk row of the matching side becomes `stale`; the prompt
+ *  still includes it (via `comment.capturedSnippet`) but the inline
+ *  card moves to the file-level stale block.
+ *
+ *  `contentChanged` is computed here so a future UI can render a
+ *  separate `[changed]` chip without touching the anchor logic. v1 UI
+ *  only branches on `status`. */
+export function anchorComments(
+  comments: DiffComment[],
+  filePath: string,
+  repoName: string | undefined,
+  hunks: RichDiffHunk[],
+): AnchoredComment[] {
+  return comments
+    .filter(
+      (c) =>
+        c.filePath === filePath &&
+        (c.repoName ?? undefined) === (repoName ?? undefined),
+    )
+    .map((c) => anchorOne(c, hunks));
+}
+
+function anchorOne(
+  comment: DiffComment,
+  hunks: RichDiffHunk[],
+): AnchoredComment {
+  const found = extractSnippetFromHunks(
+    hunks,
+    comment.side,
+    comment.startLine,
+    comment.endLine,
+  );
+  if (!found) {
+    return { comment, status: "stale", contentChanged: false };
+  }
+  return {
+    comment,
+    status: "active",
+    contentChanged: found.snippet !== comment.capturedSnippet,
+    hunkIndex: found.hunkIndex,
+    endRowIndex: found.endRowIndex,
+  };
+}

--- a/web/src/components/diff/comments/buildPrompt.test.ts
+++ b/web/src/components/diff/comments/buildPrompt.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
+import type { DiffComment } from "./types";
+
+function mk(partial: Partial<DiffComment>): DiffComment {
+  return {
+    id: "c1",
+    filePath: "src/foo.rs",
+    side: "new",
+    startLine: 10,
+    endLine: 10,
+    body: "body",
+    capturedSnippet: "let x = 1;",
+    language: "rust",
+    createdAt: "2025-01-01T00:00:00Z",
+    ...partial,
+  };
+}
+
+describe("buildCommentsMarkdown", () => {
+  it("renders single-line wording", () => {
+    const md = buildCommentsMarkdown([mk({})], { isMultiRepo: false });
+    expect(md).toContain("### `src/foo.rs` line 10 (new)");
+  });
+
+  it("renders range wording", () => {
+    const md = buildCommentsMarkdown(
+      [mk({ startLine: 10, endLine: 14 })],
+      { isMultiRepo: false },
+    );
+    expect(md).toContain("### `src/foo.rs` lines 10-14 (new)");
+  });
+
+  it("includes a code fence with language", () => {
+    const md = buildCommentsMarkdown([mk({})], { isMultiRepo: false });
+    expect(md).toContain("```rust\nlet x = 1;\n```");
+  });
+
+  it("expands the fence when snippet contains backticks", () => {
+    const md = buildCommentsMarkdown(
+      [
+        mk({
+          capturedSnippet: "before\n```\ninner\n```\nafter",
+          language: "",
+        }),
+      ],
+      { isMultiRepo: false },
+    );
+    expect(md).toMatch(/^### .*\n\n````\n/m);
+    expect(md).toContain("```\ninner\n```");
+  });
+
+  it("prefixes repo when isMultiRepo", () => {
+    const md = buildCommentsMarkdown(
+      [mk({ repoName: "repoA" })],
+      { isMultiRepo: true },
+    );
+    expect(md).toContain("### [repoA] `src/foo.rs`");
+  });
+
+  it("does not prefix repo when not multi-repo even if repoName set", () => {
+    const md = buildCommentsMarkdown(
+      [mk({ repoName: "repoA" })],
+      { isMultiRepo: false },
+    );
+    expect(md).not.toContain("[repoA]");
+  });
+
+  it("sorts by repo, file, line, side, createdAt", () => {
+    const md = buildCommentsMarkdown(
+      [
+        mk({ id: "c4", filePath: "src/b.rs", startLine: 5, endLine: 5 }),
+        mk({ id: "c1", filePath: "src/a.rs", startLine: 20, endLine: 20 }),
+        mk({ id: "c2", filePath: "src/a.rs", startLine: 5, endLine: 5 }),
+        mk({
+          id: "c3",
+          filePath: "src/a.rs",
+          startLine: 5,
+          endLine: 5,
+          side: "old",
+        }),
+      ],
+      { isMultiRepo: false },
+    );
+    const order = md
+      .split("\n")
+      .filter((l) => l.startsWith("### "))
+      .map((l) => l.slice("### ".length));
+    expect(order).toEqual([
+      "`src/a.rs` line 5 (old)",
+      "`src/a.rs` line 5 (new)",
+      "`src/a.rs` line 20 (new)",
+      "`src/b.rs` line 5 (new)",
+    ]);
+  });
+
+  it("returns empty string for no comments", () => {
+    expect(buildCommentsMarkdown([], { isMultiRepo: false })).toBe("");
+  });
+});
+
+describe("buildFullPrompt", () => {
+  it("uses default outro when blank", () => {
+    const prompt = buildFullPrompt([mk({})], "", "", { isMultiRepo: false });
+    expect(prompt).toMatch(/Please address these comments\.\n$/);
+  });
+
+  it("uses provided outro when set", () => {
+    const prompt = buildFullPrompt([mk({})], "", "Custom outro", {
+      isMultiRepo: false,
+    });
+    expect(prompt).toMatch(/Custom outro\n$/);
+    expect(prompt).not.toContain("Please address these comments.");
+  });
+
+  it("prepends intro when set", () => {
+    const prompt = buildFullPrompt([mk({})], "Hey:", "", { isMultiRepo: false });
+    expect(prompt.startsWith("Hey:\n\n## Diff comments")).toBe(true);
+  });
+
+  it("trims surrounding whitespace from intro/outro", () => {
+    const prompt = buildFullPrompt(
+      [mk({})],
+      "  intro  \n",
+      "   outro   ",
+      { isMultiRepo: false },
+    );
+    expect(prompt.startsWith("intro\n")).toBe(true);
+    expect(prompt).toMatch(/outro\n$/);
+  });
+
+  it("omits the comments section when no comments", () => {
+    const prompt = buildFullPrompt([], "intro", "outro", { isMultiRepo: false });
+    expect(prompt).not.toContain("## Diff comments");
+    expect(prompt).toContain("intro");
+    expect(prompt).toContain("outro");
+  });
+});

--- a/web/src/components/diff/comments/buildPrompt.test.ts
+++ b/web/src/components/diff/comments/buildPrompt.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildCommentsMarkdown, buildFullPrompt } from "./buildPrompt";
+import {
+  buildCommentsMarkdown,
+  buildFullPrompt,
+  parseDiffCommentsSentinel,
+  stripDiffCommentsSentinel,
+} from "./buildPrompt";
 import type { DiffComment } from "./types";
 
 function mk(partial: Partial<DiffComment>): DiffComment {
@@ -115,7 +120,8 @@ describe("buildFullPrompt", () => {
 
   it("prepends intro when set", () => {
     const prompt = buildFullPrompt([mk({})], "Hey:", "", { isMultiRepo: false });
-    expect(prompt.startsWith("Hey:\n\n## Diff comments")).toBe(true);
+    const body = stripDiffCommentsSentinel(prompt);
+    expect(body.startsWith("Hey:\n\n## Diff comments")).toBe(true);
   });
 
   it("trims surrounding whitespace from intro/outro", () => {
@@ -125,14 +131,68 @@ describe("buildFullPrompt", () => {
       "   outro   ",
       { isMultiRepo: false },
     );
-    expect(prompt.startsWith("intro\n")).toBe(true);
-    expect(prompt).toMatch(/outro\n$/);
+    const body = stripDiffCommentsSentinel(prompt);
+    expect(body.startsWith("intro\n")).toBe(true);
+    expect(body).toMatch(/outro\n$/);
   });
 
   it("omits the comments section when no comments", () => {
     const prompt = buildFullPrompt([], "intro", "outro", { isMultiRepo: false });
     expect(prompt).not.toContain("## Diff comments");
+    expect(prompt).not.toContain("aoe:diff-comments");
     expect(prompt).toContain("intro");
     expect(prompt).toContain("outro");
+  });
+
+  it("prepends a sentinel header when comments are present", () => {
+    const prompt = buildFullPrompt([mk({})], "", "", { isMultiRepo: false });
+    expect(prompt.startsWith("<!-- aoe:diff-comments:v1 ")).toBe(true);
+    expect(prompt).toContain("\n## Diff comments\n");
+  });
+});
+
+describe("parseDiffCommentsSentinel", () => {
+  it("returns null when no sentinel", () => {
+    expect(parseDiffCommentsSentinel("hello world")).toBeNull();
+  });
+
+  it("round-trips a payload built by buildFullPrompt", () => {
+    const comment = mk({
+      body: "needs error handling",
+      capturedSnippet: "let x = 1;",
+    });
+    const prompt = buildFullPrompt([comment], "Take a look:", "Thanks.", {
+      isMultiRepo: false,
+    });
+    const payload = parseDiffCommentsSentinel(prompt);
+    expect(payload).not.toBeNull();
+    expect(payload!.intro).toBe("Take a look:");
+    expect(payload!.outro).toBe("Thanks.");
+    expect(payload!.isMultiRepo).toBe(false);
+    expect(payload!.comments).toHaveLength(1);
+    expect(payload!.comments[0]!.body).toBe("needs error handling");
+    expect(payload!.comments[0]!.capturedSnippet).toBe("let x = 1;");
+  });
+
+  it("survives snippets that contain `-->`", () => {
+    const c = mk({ capturedSnippet: "<!-- not allowed -->\nlet x = 1;" });
+    const prompt = buildFullPrompt([c], "", "", { isMultiRepo: false });
+    const payload = parseDiffCommentsSentinel(prompt);
+    expect(payload).not.toBeNull();
+    expect(payload!.comments[0]!.capturedSnippet).toContain("-->");
+  });
+
+  it("returns null for a malformed payload", () => {
+    const broken = "<!-- aoe:diff-comments:v1 not-base64!@# -->\nbody\n";
+    expect(parseDiffCommentsSentinel(broken)).toBeNull();
+  });
+
+  it("preserves the visible body for the agent", () => {
+    const prompt = buildFullPrompt([mk({})], "Intro:", "Outro.", {
+      isMultiRepo: false,
+    });
+    const body = stripDiffCommentsSentinel(prompt);
+    expect(body.startsWith("Intro:\n\n## Diff comments")).toBe(true);
+    expect(body).toMatch(/Outro\.\n$/);
   });
 });

--- a/web/src/components/diff/comments/buildPrompt.ts
+++ b/web/src/components/diff/comments/buildPrompt.ts
@@ -1,0 +1,81 @@
+import type { DiffComment } from "./types";
+
+interface BuildOpts {
+  /** When true, prefix each heading with `[repoName]`. Tests pass this
+   *  explicitly; the UI infers it from the session's workspace_repos. */
+  isMultiRepo: boolean;
+}
+
+const DEFAULT_OUTRO = "Please address these comments.";
+
+/** Pure assembly of the comments section. Stable sort, single-line
+ *  vs range wording, multi-repo prefix, and a dynamically-sized code
+ *  fence per snippet. */
+export function buildCommentsMarkdown(
+  comments: DiffComment[],
+  opts: BuildOpts,
+): string {
+  if (comments.length === 0) return "";
+  const sorted = [...comments].sort(compareComments);
+  const sections = sorted.map((c) => renderComment(c, opts.isMultiRepo));
+  return sections.join("\n\n---\n\n");
+}
+
+/** Assemble the full prompt body: intro + comments preview + outro.
+ *  `outro` falls back to a default if blank so the agent sees an
+ *  actionable nudge. */
+export function buildFullPrompt(
+  comments: DiffComment[],
+  intro: string,
+  outro: string,
+  opts: BuildOpts,
+): string {
+  const introText = intro.trim();
+  const outroText = (outro.trim() || DEFAULT_OUTRO).trim();
+  const sections: string[] = [];
+  if (introText) sections.push(introText);
+  const commentsBlock = buildCommentsMarkdown(comments, opts);
+  if (commentsBlock) {
+    sections.push("## Diff comments");
+    sections.push(commentsBlock);
+  }
+  sections.push(outroText);
+  return sections.join("\n\n") + "\n";
+}
+
+function renderComment(c: DiffComment, isMultiRepo: boolean): string {
+  const repo = isMultiRepo && c.repoName ? `[${c.repoName}] ` : "";
+  const range =
+    c.startLine === c.endLine
+      ? `line ${c.startLine}`
+      : `lines ${c.startLine}-${c.endLine}`;
+  const heading = `### ${repo}\`${c.filePath}\` ${range} (${c.side})`;
+  const fence = makeFence(c.capturedSnippet);
+  const lang = c.language ?? "";
+  const codeBlock = `${fence}${lang}\n${c.capturedSnippet}\n${fence}`;
+  const body = c.body.trim();
+  return `${heading}\n\n${codeBlock}\n\n${body}`;
+}
+
+function compareComments(a: DiffComment, b: DiffComment): number {
+  const ra = a.repoName ?? "";
+  const rb = b.repoName ?? "";
+  if (ra !== rb) return ra.localeCompare(rb);
+  if (a.filePath !== b.filePath) return a.filePath.localeCompare(b.filePath);
+  if (a.startLine !== b.startLine) return a.startLine - b.startLine;
+  if (a.side !== b.side) return a.side === "old" ? -1 : 1;
+  return a.createdAt.localeCompare(b.createdAt);
+}
+
+/** Pick a code-fence length longer than the longest backtick run in the
+ *  snippet so a markdown-content snippet doesn't terminate the fence
+ *  early. Minimum 3 backticks. */
+function makeFence(snippet: string): string {
+  const re = /`+/g;
+  let longest = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(snippet)) !== null) {
+    if (match[0].length > longest) longest = match[0].length;
+  }
+  return "`".repeat(Math.max(3, longest + 1));
+}

--- a/web/src/components/diff/comments/buildPrompt.ts
+++ b/web/src/components/diff/comments/buildPrompt.ts
@@ -8,6 +8,70 @@ interface BuildOpts {
 
 const DEFAULT_OUTRO = "Please address these comments.";
 
+const SENTINEL_PREFIX = "<!-- aoe:diff-comments:v1 ";
+const SENTINEL_SUFFIX = " -->";
+
+/** Structured payload embedded as an HTML comment at the top of the
+ *  prompt body. The cockpit `UserMessage` parses it back out and
+ *  renders a structured card; the agent ignores the HTML comment and
+ *  reads the assembled markdown below. Base64-encoded JSON avoids any
+ *  `-->` collision with snippet/body content. */
+export interface DiffCommentsSentinelPayload {
+  intro: string;
+  outro: string;
+  isMultiRepo: boolean;
+  comments: DiffComment[];
+}
+
+function encodeSentinel(payload: DiffCommentsSentinelPayload): string {
+  const json = JSON.stringify(payload);
+  const bytes = new TextEncoder().encode(json);
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) {
+    bin += String.fromCharCode(bytes[i]!);
+  }
+  return SENTINEL_PREFIX + btoa(bin) + SENTINEL_SUFFIX;
+}
+
+/** Returns the structured payload when `text` begins with our sentinel,
+ *  or `null` otherwise. Malformed payloads return `null` so the caller
+ *  falls back to plain-text rendering. */
+export function parseDiffCommentsSentinel(
+  text: string,
+): DiffCommentsSentinelPayload | null {
+  if (!text.startsWith(SENTINEL_PREFIX)) return null;
+  const end = text.indexOf(SENTINEL_SUFFIX, SENTINEL_PREFIX.length);
+  if (end < 0) return null;
+  const b64 = text.slice(SENTINEL_PREFIX.length, end);
+  try {
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const json = new TextDecoder().decode(bytes);
+    const parsed = JSON.parse(json) as unknown;
+    if (!parsed || typeof parsed !== "object") return null;
+    const obj = parsed as Record<string, unknown>;
+    if (!Array.isArray(obj.comments)) return null;
+    if (typeof obj.intro !== "string") return null;
+    if (typeof obj.outro !== "string") return null;
+    if (typeof obj.isMultiRepo !== "boolean") return null;
+    return obj as unknown as DiffCommentsSentinelPayload;
+  } catch {
+    return null;
+  }
+}
+
+/** Strip the sentinel prefix from a prompt body, returning the visible
+ *  markdown the agent reads. Used by the cockpit renderer so the
+ *  structured card doesn't show the raw HTML comment line. */
+export function stripDiffCommentsSentinel(text: string): string {
+  if (!text.startsWith(SENTINEL_PREFIX)) return text;
+  const end = text.indexOf(SENTINEL_SUFFIX, SENTINEL_PREFIX.length);
+  if (end < 0) return text;
+  const rest = text.slice(end + SENTINEL_SUFFIX.length);
+  return rest.replace(/^\n+/, "");
+}
+
 /** Pure assembly of the comments section. Stable sort, single-line
  *  vs range wording, multi-repo prefix, and a dynamically-sized code
  *  fence per snippet. */
@@ -40,7 +104,15 @@ export function buildFullPrompt(
     sections.push(commentsBlock);
   }
   sections.push(outroText);
-  return sections.join("\n\n") + "\n";
+  const body = sections.join("\n\n") + "\n";
+  if (comments.length === 0) return body;
+  const sentinel = encodeSentinel({
+    intro: introText,
+    outro: outroText,
+    isMultiRepo: opts.isMultiRepo,
+    comments,
+  });
+  return `${sentinel}\n${body}`;
 }
 
 function renderComment(c: DiffComment, isMultiRepo: boolean): string {

--- a/web/src/components/diff/comments/buildPrompt.ts
+++ b/web/src/components/diff/comments/buildPrompt.ts
@@ -1,4 +1,5 @@
 import type { DiffComment } from "./types";
+import { isWellFormed } from "./storage";
 
 interface BuildOpts {
   /** When true, prefix each heading with `[repoName]`. Tests pass this
@@ -55,7 +56,18 @@ export function parseDiffCommentsSentinel(
     if (typeof obj.intro !== "string") return null;
     if (typeof obj.outro !== "string") return null;
     if (typeof obj.isMultiRepo !== "boolean") return null;
-    return obj as unknown as DiffCommentsSentinelPayload;
+    // Drop malformed inner comments rather than crashing the card.
+    // A future producer may add fields we don't recognize yet, but
+    // missing required fields means the renderer can't render the
+    // entry safely. Keeping only well-formed entries also matches
+    // how `loadComments` cleans the localStorage envelope.
+    const comments = obj.comments.filter(isWellFormed);
+    return {
+      intro: obj.intro,
+      outro: obj.outro,
+      isMultiRepo: obj.isMultiRepo,
+      comments,
+    };
   } catch {
     return null;
   }

--- a/web/src/components/diff/comments/extractSnippet.test.ts
+++ b/web/src/components/diff/comments/extractSnippet.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import type { RichDiffHunk } from "../../../lib/types";
+import { extractSnippetFromHunks } from "./extractSnippet";
+
+function hunk(): RichDiffHunk {
+  return {
+    old_start: 10,
+    old_lines: 5,
+    new_start: 10,
+    new_lines: 6,
+    lines: [
+      { type: "equal", old_line_num: 10, new_line_num: 10, content: "a\n" },
+      { type: "equal", old_line_num: 11, new_line_num: 11, content: "b\n" },
+      { type: "delete", old_line_num: 12, new_line_num: null, content: "old\n" },
+      { type: "add", old_line_num: null, new_line_num: 12, content: "new1\n" },
+      { type: "add", old_line_num: null, new_line_num: 13, content: "new2\n" },
+      { type: "equal", old_line_num: 13, new_line_num: 14, content: "c\n" },
+      { type: "equal", old_line_num: 14, new_line_num: 15, content: "d\n" },
+    ],
+  };
+}
+
+describe("extractSnippetFromHunks", () => {
+  it("extracts a new-side range, skipping deleted rows", () => {
+    const res = extractSnippetFromHunks([hunk()], "new", 12, 14);
+    expect(res?.snippet).toBe("new1\nnew2\nc");
+  });
+
+  it("extracts an old-side range, skipping added rows", () => {
+    const res = extractSnippetFromHunks([hunk()], "old", 11, 13);
+    expect(res?.snippet).toBe("b\nold\nc");
+  });
+
+  it("returns null when range straddles the hunk boundary", () => {
+    const res = extractSnippetFromHunks([hunk()], "new", 9, 11);
+    expect(res).toBeNull();
+  });
+
+  it("normalises reversed ranges", () => {
+    const a = extractSnippetFromHunks([hunk()], "new", 14, 12);
+    const b = extractSnippetFromHunks([hunk()], "new", 12, 14);
+    expect(a?.snippet).toBe(b?.snippet);
+  });
+
+  it("returns the row index of the last matching line", () => {
+    const res = extractSnippetFromHunks([hunk()], "new", 14, 14);
+    // Row index 5 == the equal row at new_line_num=14
+    expect(res?.endRowIndex).toBe(5);
+  });
+
+  it("returns null when range falls outside any hunk", () => {
+    const res = extractSnippetFromHunks([hunk()], "new", 50, 52);
+    expect(res).toBeNull();
+  });
+});

--- a/web/src/components/diff/comments/extractSnippet.ts
+++ b/web/src/components/diff/comments/extractSnippet.ts
@@ -23,18 +23,18 @@ export function extractSnippetFromHunks(
   startLine: number,
   endLine: number,
 ): Extraction | null {
-  const lo = Math.min(startLine, endLine);
-  const hi = Math.max(startLine, endLine);
+  const rangeLo = Math.min(startLine, endLine);
+  const rangeHi = Math.max(startLine, endLine);
   const lineKey = side === "new" ? "new_line_num" : "old_line_num";
 
-  for (let hi_idx = 0; hi_idx < hunks.length; hi_idx++) {
-    const hunk = hunks[hi_idx];
+  for (let hunkIdx = 0; hunkIdx < hunks.length; hunkIdx++) {
+    const hunk = hunks[hunkIdx];
     if (!hunk) continue;
     const hunkStart = side === "new" ? hunk.new_start : hunk.old_start;
     const hunkEnd =
       hunkStart + (side === "new" ? hunk.new_lines : hunk.old_lines) - 1;
-    if (hunkEnd < lo || hunkStart > hi) continue;
-    if (hunkStart > lo || hunkEnd < hi) {
+    if (hunkEnd < rangeLo || hunkStart > rangeHi) continue;
+    if (hunkStart > rangeLo || hunkEnd < rangeHi) {
       // Range straddles the hunk's boundary; reject to keep extraction
       // single-hunk and avoid silently merging unrelated context.
       return null;
@@ -48,19 +48,19 @@ export function extractSnippetFromHunks(
       if (!line) continue;
       const num = line[lineKey];
       if (num == null) continue;
-      if (num < lo || num > hi) continue;
+      if (num < rangeLo || num > rangeHi) continue;
       seen.add(num);
       lines.push(stripTrailingNewline(line.content));
       endRowIndex = row;
     }
 
-    for (let n = lo; n <= hi; n++) {
+    for (let n = rangeLo; n <= rangeHi; n++) {
       if (!seen.has(n)) return null;
     }
 
     return {
       snippet: lines.join("\n"),
-      hunkIndex: hi_idx,
+      hunkIndex: hunkIdx,
       endRowIndex,
     };
   }

--- a/web/src/components/diff/comments/extractSnippet.ts
+++ b/web/src/components/diff/comments/extractSnippet.ts
@@ -29,6 +29,7 @@ export function extractSnippetFromHunks(
 
   for (let hi_idx = 0; hi_idx < hunks.length; hi_idx++) {
     const hunk = hunks[hi_idx];
+    if (!hunk) continue;
     const hunkStart = side === "new" ? hunk.new_start : hunk.old_start;
     const hunkEnd =
       hunkStart + (side === "new" ? hunk.new_lines : hunk.old_lines) - 1;
@@ -44,6 +45,7 @@ export function extractSnippetFromHunks(
     let endRowIndex = -1;
     for (let row = 0; row < hunk.lines.length; row++) {
       const line = hunk.lines[row];
+      if (!line) continue;
       const num = line[lineKey];
       if (num == null) continue;
       if (num < lo || num > hi) continue;

--- a/web/src/components/diff/comments/extractSnippet.ts
+++ b/web/src/components/diff/comments/extractSnippet.ts
@@ -1,0 +1,71 @@
+import type { RichDiffHunk } from "../../../lib/types";
+import type { DiffSide } from "./types";
+
+interface Extraction {
+  snippet: string;
+  hunkIndex: number;
+  endRowIndex: number;
+}
+
+/** Walks each hunk and pulls the contiguous side-filtered content
+ *  for the requested line range. Returns null when any line in the
+ *  range is missing from the diff.
+ *
+ *  Side semantics:
+ *  - `new`: keeps rows with `new_line_num != null` (added + equal), skips pure deletes.
+ *  - `old`: keeps rows with `old_line_num != null` (deleted + equal), skips pure adds.
+ *
+ *  The contiguous-hunk rule means a range may not span multiple hunks
+ *  (the caller enforces single-hunk selection in the UI). */
+export function extractSnippetFromHunks(
+  hunks: RichDiffHunk[],
+  side: DiffSide,
+  startLine: number,
+  endLine: number,
+): Extraction | null {
+  const lo = Math.min(startLine, endLine);
+  const hi = Math.max(startLine, endLine);
+  const lineKey = side === "new" ? "new_line_num" : "old_line_num";
+
+  for (let hi_idx = 0; hi_idx < hunks.length; hi_idx++) {
+    const hunk = hunks[hi_idx];
+    const hunkStart = side === "new" ? hunk.new_start : hunk.old_start;
+    const hunkEnd =
+      hunkStart + (side === "new" ? hunk.new_lines : hunk.old_lines) - 1;
+    if (hunkEnd < lo || hunkStart > hi) continue;
+    if (hunkStart > lo || hunkEnd < hi) {
+      // Range straddles the hunk's boundary; reject to keep extraction
+      // single-hunk and avoid silently merging unrelated context.
+      return null;
+    }
+
+    const seen = new Set<number>();
+    const lines: string[] = [];
+    let endRowIndex = -1;
+    for (let row = 0; row < hunk.lines.length; row++) {
+      const line = hunk.lines[row];
+      const num = line[lineKey];
+      if (num == null) continue;
+      if (num < lo || num > hi) continue;
+      seen.add(num);
+      lines.push(stripTrailingNewline(line.content));
+      endRowIndex = row;
+    }
+
+    for (let n = lo; n <= hi; n++) {
+      if (!seen.has(n)) return null;
+    }
+
+    return {
+      snippet: lines.join("\n"),
+      hunkIndex: hi_idx,
+      endRowIndex,
+    };
+  }
+
+  return null;
+}
+
+function stripTrailingNewline(s: string): string {
+  return s.replace(/\r?\n$/, "");
+}

--- a/web/src/components/diff/comments/language.test.ts
+++ b/web/src/components/diff/comments/language.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { extensionToLanguage } from "./language";
+
+describe("extensionToLanguage", () => {
+  it.each([
+    ["src/main.rs", "rust"],
+    ["src/App.tsx", "tsx"],
+    ["src/lib/api.ts", "ts"],
+    ["foo.py", "python"],
+    ["build.sh", "bash"],
+    ["docker/Dockerfile", "dockerfile"],
+    ["DOCKERFILE", "dockerfile"],
+    ["nested/path/file.json", "json"],
+    ["foo.YAML", "yaml"],
+    ["readme.md", "markdown"],
+  ])("maps %s -> %s", (path, lang) => {
+    expect(extensionToLanguage(path)).toBe(lang);
+  });
+
+  it("returns empty for unknown extensions", () => {
+    expect(extensionToLanguage("foo.xyz")).toBe("");
+  });
+
+  it("returns empty for extensionless files", () => {
+    expect(extensionToLanguage("Makefile")).toBe("");
+    expect(extensionToLanguage("README")).toBe("");
+  });
+
+  it("handles paths without slashes", () => {
+    expect(extensionToLanguage("foo.rs")).toBe("rust");
+  });
+});

--- a/web/src/components/diff/comments/language.ts
+++ b/web/src/components/diff/comments/language.ts
@@ -1,0 +1,51 @@
+/// Map a file path's extension to a code-fence language tag. Returns
+/// the empty string when no good guess is available so the fence falls
+/// back to plain text without leaking a meaningless `unknown` tag.
+
+const MAP: Record<string, string> = {
+  rs: "rust",
+  ts: "ts",
+  tsx: "tsx",
+  js: "js",
+  jsx: "jsx",
+  py: "python",
+  rb: "ruby",
+  go: "go",
+  java: "java",
+  kt: "kotlin",
+  swift: "swift",
+  c: "c",
+  h: "c",
+  cc: "cpp",
+  cpp: "cpp",
+  cs: "csharp",
+  php: "php",
+  pl: "perl",
+  lua: "lua",
+  sh: "bash",
+  bash: "bash",
+  zsh: "bash",
+  fish: "bash",
+  ps1: "powershell",
+  toml: "toml",
+  yaml: "yaml",
+  yml: "yaml",
+  json: "json",
+  md: "markdown",
+  html: "html",
+  css: "css",
+  scss: "scss",
+  sql: "sql",
+  proto: "proto",
+  dockerfile: "dockerfile",
+};
+
+export function extensionToLanguage(filePath: string): string {
+  const lower = filePath.toLowerCase();
+  const base = lower.split("/").pop() ?? lower;
+  if (base === "dockerfile") return "dockerfile";
+  const dot = base.lastIndexOf(".");
+  if (dot < 0) return "";
+  const ext = base.slice(dot + 1);
+  return MAP[ext] ?? "";
+}

--- a/web/src/components/diff/comments/storage.test.ts
+++ b/web/src/components/diff/comments/storage.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_STORAGE, loadComments, saveComments, storageKey } from "./storage";
+import type { DiffComment, DiffCommentsStorageV1 } from "./types";
+
+// Vitest default env is node; install a minimal in-memory localStorage
+// for these tests so we can exercise the storage layer end-to-end.
+function installFakeLocalStorage() {
+  const data = new Map<string, string>();
+  const fake: Storage = {
+    get length() {
+      return data.size;
+    },
+    key(i) {
+      return Array.from(data.keys())[i] ?? null;
+    },
+    getItem(k) {
+      return data.has(k) ? data.get(k)! : null;
+    },
+    setItem(k, v) {
+      data.set(k, String(v));
+    },
+    removeItem(k) {
+      data.delete(k);
+    },
+    clear() {
+      data.clear();
+    },
+  };
+  // Use globalThis to avoid window typing in node env.
+  (globalThis as { localStorage: Storage }).localStorage = fake;
+  return data;
+}
+
+function mkComment(overrides: Partial<DiffComment> = {}): DiffComment {
+  return {
+    id: "c1",
+    filePath: "src/foo.rs",
+    side: "new",
+    startLine: 5,
+    endLine: 5,
+    body: "review",
+    capturedSnippet: "snippet",
+    createdAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("storage", () => {
+  beforeEach(() => {
+    installFakeLocalStorage();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the empty envelope when key is absent", () => {
+    const state = loadComments("sess-1");
+    expect(state).toEqual(EMPTY_STORAGE);
+  });
+
+  it("round-trips a full envelope", () => {
+    const original: DiffCommentsStorageV1 = {
+      version: 1,
+      comments: [mkComment({ id: "a" }), mkComment({ id: "b" })],
+      clearAfterSend: false,
+      introDraft: "hi",
+      outroDraft: "bye",
+    };
+    saveComments("sess-1", original);
+    const loaded = loadComments("sess-1");
+    expect(loaded).toEqual(original);
+  });
+
+  it("scopes by sessionId", () => {
+    saveComments("sess-1", {
+      ...EMPTY_STORAGE,
+      comments: [mkComment({ id: "a" })],
+    });
+    saveComments("sess-2", {
+      ...EMPTY_STORAGE,
+      comments: [mkComment({ id: "b" })],
+    });
+    expect(loadComments("sess-1").comments.map((c) => c.id)).toEqual(["a"]);
+    expect(loadComments("sess-2").comments.map((c) => c.id)).toEqual(["b"]);
+  });
+
+  it("returns empty envelope when JSON is corrupt", () => {
+    localStorage.setItem(storageKey("sess-1"), "not json");
+    expect(loadComments("sess-1")).toEqual(EMPTY_STORAGE);
+  });
+
+  it("returns empty envelope when version is unknown", () => {
+    localStorage.setItem(
+      storageKey("sess-1"),
+      JSON.stringify({
+        version: 99,
+        comments: [mkComment({})],
+        clearAfterSend: true,
+        introDraft: "",
+        outroDraft: "",
+      }),
+    );
+    expect(loadComments("sess-1")).toEqual(EMPTY_STORAGE);
+  });
+
+  it("filters out malformed comment records", () => {
+    localStorage.setItem(
+      storageKey("sess-1"),
+      JSON.stringify({
+        version: 1,
+        clearAfterSend: true,
+        introDraft: "",
+        outroDraft: "",
+        comments: [
+          mkComment({ id: "good" }),
+          { id: "bad", filePath: 12, side: "new", startLine: 1, endLine: 1, body: "", capturedSnippet: "", createdAt: "x" },
+          { id: "no-side", filePath: "x", side: "left", startLine: 1, endLine: 1, body: "", capturedSnippet: "", createdAt: "x" },
+        ],
+      }),
+    );
+    expect(loadComments("sess-1").comments.map((c) => c.id)).toEqual(["good"]);
+  });
+
+  it("falls back to defaults for missing top-level fields", () => {
+    localStorage.setItem(
+      storageKey("sess-1"),
+      JSON.stringify({
+        version: 1,
+        comments: [],
+      }),
+    );
+    const state = loadComments("sess-1");
+    expect(state.clearAfterSend).toBe(true);
+    expect(state.introDraft).toBe("");
+    expect(state.outroDraft).toBe("");
+  });
+
+  it("survives a write that throws (quota-exceeded etc.)", () => {
+    const spy = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceeded");
+    });
+    // Should not throw despite the failing setItem.
+    expect(() => saveComments("sess-1", EMPTY_STORAGE)).not.toThrow();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("uses a deterministic, versioned key", () => {
+    expect(storageKey("abc")).toBe("aoe:diff-comments:v1:abc");
+  });
+});

--- a/web/src/components/diff/comments/storage.ts
+++ b/web/src/components/diff/comments/storage.ts
@@ -55,7 +55,7 @@ export function saveComments(
   }
 }
 
-function isWellFormed(c: unknown): c is DiffComment {
+export function isWellFormed(c: unknown): c is DiffComment {
   if (!c || typeof c !== "object") return false;
   const o = c as Record<string, unknown>;
   return (

--- a/web/src/components/diff/comments/storage.ts
+++ b/web/src/components/diff/comments/storage.ts
@@ -1,0 +1,71 @@
+import type { DiffComment, DiffCommentsStorageV1 } from "./types";
+
+const KEY_PREFIX = "aoe:diff-comments:v1:";
+
+export function storageKey(sessionId: string): string {
+  return `${KEY_PREFIX}${sessionId}`;
+}
+
+export const EMPTY_STORAGE: DiffCommentsStorageV1 = {
+  version: 1,
+  comments: [],
+  clearAfterSend: true,
+  introDraft: "",
+  outroDraft: "",
+};
+
+/** Load comments for a session. Tolerates corruption, missing keys,
+ *  and version mismatches by falling back to an empty state. localStorage
+ *  is browser-local; data corruption shouldn't kill the feature. */
+export function loadComments(sessionId: string): DiffCommentsStorageV1 {
+  try {
+    const raw = localStorage.getItem(storageKey(sessionId));
+    if (!raw) return { ...EMPTY_STORAGE };
+    const parsed = JSON.parse(raw) as unknown;
+    if (
+      !parsed ||
+      typeof parsed !== "object" ||
+      (parsed as { version?: number }).version !== 1 ||
+      !Array.isArray((parsed as { comments?: unknown }).comments)
+    ) {
+      return { ...EMPTY_STORAGE };
+    }
+    const v = parsed as DiffCommentsStorageV1;
+    return {
+      version: 1,
+      comments: v.comments.filter(isWellFormed),
+      clearAfterSend: typeof v.clearAfterSend === "boolean" ? v.clearAfterSend : true,
+      introDraft: typeof v.introDraft === "string" ? v.introDraft : "",
+      outroDraft: typeof v.outroDraft === "string" ? v.outroDraft : "",
+    };
+  } catch {
+    return { ...EMPTY_STORAGE };
+  }
+}
+
+export function saveComments(
+  sessionId: string,
+  state: DiffCommentsStorageV1,
+): void {
+  try {
+    localStorage.setItem(storageKey(sessionId), JSON.stringify(state));
+  } catch {
+    // Quota exceeded or private mode; non-fatal. The in-memory state
+    // still works for the current page load.
+  }
+}
+
+function isWellFormed(c: unknown): c is DiffComment {
+  if (!c || typeof c !== "object") return false;
+  const o = c as Record<string, unknown>;
+  return (
+    typeof o.id === "string" &&
+    typeof o.filePath === "string" &&
+    (o.side === "old" || o.side === "new") &&
+    typeof o.startLine === "number" &&
+    typeof o.endLine === "number" &&
+    typeof o.body === "string" &&
+    typeof o.capturedSnippet === "string" &&
+    typeof o.createdAt === "string"
+  );
+}

--- a/web/src/components/diff/comments/types.ts
+++ b/web/src/components/diff/comments/types.ts
@@ -1,0 +1,66 @@
+/** Which side of the diff a comment is anchored to. */
+export type DiffSide = "old" | "new";
+
+/** A user-authored review comment on a range of lines in a diff. The
+ *  range is anchored to one side; snippet extraction filters out rows
+ *  belonging to the opposite side (a new-side range skips deleted rows,
+ *  and vice versa). */
+export interface DiffComment {
+  id: string;
+  /** Workspace member name. Undefined for single-repo sessions. */
+  repoName?: string;
+  filePath: string;
+  side: DiffSide;
+  /** Inclusive 1-based line number on the chosen side. */
+  startLine: number;
+  /** Inclusive. >= startLine. */
+  endLine: number;
+  /** Markdown body. */
+  body: string;
+  /** Code captured at authoring time so the assembled prompt remains
+   *  meaningful even after the diff changes underneath. The agent gets
+   *  to see what the human reviewer actually read. */
+  capturedSnippet: string;
+  /** Code-fence language inferred at authoring time. */
+  language?: string;
+  /** ISO 8601 timestamp. */
+  createdAt: string;
+  /** Set when the body is edited. */
+  updatedAt?: string;
+}
+
+/** Input for creating a comment. The hook fills in id/createdAt. */
+export type DiffCommentDraft = Omit<DiffComment, "id" | "createdAt">;
+
+/** Versioned localStorage envelope. Future schema changes bump the
+ *  version and trigger a clean drop in the loader (no migration
+ *  helpers needed yet, schema is fresh). */
+export interface DiffCommentsStorageV1 {
+  version: 1;
+  comments: DiffComment[];
+  /** Whether the send dialog clears comments on success by default. */
+  clearAfterSend: boolean;
+  /** Persisted draft text for the intro / outro fields so the user
+   *  doesn't lose framing text when re-opening the dialog. */
+  introDraft: string;
+  outroDraft: string;
+}
+
+/** Anchor status of a comment against the currently loaded diff. */
+export type AnchorStatus = "active" | "stale";
+
+/** A comment paired with its current-diff anchor result. */
+export interface AnchoredComment {
+  comment: DiffComment;
+  status: AnchorStatus;
+  /** True when the current snippet for the comment's range no longer
+   *  matches `comment.capturedSnippet`. Not surfaced in v1 UI but
+   *  computed in `anchor.ts` so a future "[changed]" chip can be added
+   *  without refactoring the matching logic. */
+  contentChanged: boolean;
+  /** Index of the matching hunk when status === "active". */
+  hunkIndex?: number;
+  /** Row index inside the hunk where the comment card should be
+   *  rendered (last line of the range). */
+  endRowIndex?: number;
+}

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -17,6 +17,10 @@ export interface WizardData {
   worktreeBranch: string;
   worktreeBranchDirty: boolean;
   useWorktree: boolean;
+  /** When true, attach to an existing branch's worktree (`create_new_branch: false`
+   *  on the API). Mirrors the TUI new-session "Attach to existing branch"
+   *  toggle (`src/tui/dialogs/new_session/render.rs:851`). See #969. */
+  attachExisting: boolean;
   /** Optional base branch for the new worktree branch. Empty string =
    *  use the project's default branch. Lives under "Advanced" in the
    *  session step. See #948. */
@@ -65,7 +69,7 @@ type Action =
 
 const initialData: WizardData = {
   path: "", title: "", worktreeBranch: "", worktreeBranchDirty: false,
-  useWorktree: true, baseBranch: "",
+  useWorktree: true, attachExisting: false, baseBranch: "",
   group: "", tool: "claude", profile: "",
   yoloMode: false, sandboxEnabled: false, sandboxImage: "", extraEnv: [],
   extraRepoPaths: [],
@@ -220,9 +224,11 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
       title: d.title || undefined, group: d.group || undefined,
       yolo_mode: d.yoloMode,
       worktree_branch: d.useWorktree ? getSubmittedBranch(d.title, d.worktreeBranch) : undefined,
-      create_new_branch: d.useWorktree,
+      create_new_branch: d.useWorktree && !d.attachExisting,
       base_branch:
-        d.useWorktree && d.baseBranch.trim() ? d.baseBranch.trim() : undefined,
+        d.useWorktree && !d.attachExisting && d.baseBranch.trim()
+          ? d.baseBranch.trim()
+          : undefined,
       sandbox: d.sandboxEnabled,
       sandbox_image: d.sandboxEnabled ? d.sandboxImage : undefined,
       extra_env: d.sandboxEnabled && d.extraEnv.length > 0 ? d.extraEnv.filter(Boolean) : undefined,

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -3,7 +3,7 @@ import type { StepDef, StepId } from "../StepIndicator";
 import { getReviewSummary } from "../sessionNames";
 import { useServerDown, OFFLINE_TITLE } from "../../../lib/connectionState";
 
-interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
+interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; attachExisting: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
 interface Props { data: WizardData; onChange: (field: string, value: unknown) => void; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
@@ -134,7 +134,11 @@ export function ReviewStep({ data, onChange, isSubmitting, error, onSubmit, onJu
               onChange={(v) => onChange("worktreeBranch", v)}
               accent
             />
-            {data.baseBranch.trim() && (
+            <Row
+              label="Mode"
+              value={data.attachExisting ? "Attach to existing branch" : "Create new branch"}
+            />
+            {!data.attachExisting && data.baseBranch.trim() && (
               <Row label="Base branch" value={data.baseBranch.trim()} />
             )}
           </>

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -7,6 +7,9 @@ interface WizardData {
   title: string;
   worktreeBranch: string;
   useWorktree: boolean;
+  /** Attach to an existing branch's worktree instead of creating one.
+   *  Mirrors the TUI new-session toggle. See #969. */
+  attachExisting: boolean;
   baseBranch: string;
   group: string;
   tool: string;
@@ -84,7 +87,26 @@ export function SessionStep({ data, onChange }: Props) {
             className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-base font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
           />
           <p className="text-xs text-text-dim mt-1">The branch name is also the worktree directory name. Leave blank to use the session title.</p>
-          <AdvancedWorktreeOptions data={data} onChange={onChange} />
+
+          <label
+            className="mt-3 flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer"
+            onClick={() => onChange("attachExisting", !data.attachExisting)}
+          >
+            <div className="flex-1">
+              <div className="text-sm font-medium text-text-primary">Attach to existing branch</div>
+              <div className="text-xs text-text-dim mt-0.5 leading-snug">
+                Re-use a branch + worktree that already exists. Off = create a new branch.
+              </div>
+            </div>
+            <Toggle
+              checked={data.attachExisting}
+              onChange={(v) => onChange("attachExisting", v)}
+            />
+          </label>
+
+          {!data.attachExisting && (
+            <AdvancedWorktreeOptions data={data} onChange={onChange} />
+          )}
         </div>
       )}
 

--- a/web/src/hooks/useDiffComments.test.ts
+++ b/web/src/hooks/useDiffComments.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  EMPTY_STORAGE,
+  loadComments,
+  saveComments,
+} from "../components/diff/comments/storage";
+import type { DiffComment } from "../components/diff/comments/types";
+
+// `useDiffComments` switches the React state when the active sessionId
+// changes by calling `loadComments(newSessionId)`. The hook itself
+// requires a React renderer + DOM to test directly, but its contract
+// collapses to: "after a sessionId change, the in-view data must come
+// from the new session's storage envelope, not the previous one's".
+// These tests exercise that storage round-trip in the exact pattern the
+// hook uses (load on session change, save on state mutation), so a
+// regression in the storage layer's isolation guarantees would also
+// break the hook.
+
+function installFakeLocalStorage() {
+  const data = new Map<string, string>();
+  const fake: Storage = {
+    get length() {
+      return data.size;
+    },
+    key(i) {
+      return Array.from(data.keys())[i] ?? null;
+    },
+    getItem(k) {
+      return data.has(k) ? data.get(k)! : null;
+    },
+    setItem(k, v) {
+      data.set(k, String(v));
+    },
+    removeItem(k) {
+      data.delete(k);
+    },
+    clear() {
+      data.clear();
+    },
+  };
+  (globalThis as { localStorage: Storage }).localStorage = fake;
+}
+
+function mkComment(overrides: Partial<DiffComment> = {}): DiffComment {
+  return {
+    id: "c",
+    filePath: "src/foo.rs",
+    side: "new",
+    startLine: 5,
+    endLine: 5,
+    body: "review",
+    capturedSnippet: "snippet",
+    createdAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useDiffComments contract", () => {
+  beforeEach(() => {
+    installFakeLocalStorage();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it("session switch reloads the new session's data", () => {
+    saveComments("sess-A", {
+      ...EMPTY_STORAGE,
+      comments: [mkComment({ id: "a1" })],
+      introDraft: "from A",
+    });
+    saveComments("sess-B", { ...EMPTY_STORAGE });
+
+    const onA = loadComments("sess-A");
+    expect(onA.comments.map((c) => c.id)).toEqual(["a1"]);
+    expect(onA.introDraft).toBe("from A");
+
+    const onB = loadComments("sess-B");
+    expect(onB.comments).toHaveLength(0);
+    expect(onB.introDraft).toBe("");
+  });
+
+  it("mutations on one session do not leak into another", () => {
+    saveComments("sess-A", {
+      ...EMPTY_STORAGE,
+      comments: [mkComment({ id: "a1" })],
+    });
+
+    const onB = loadComments("sess-B");
+    saveComments("sess-B", {
+      ...onB,
+      comments: [mkComment({ id: "b1" })],
+    });
+
+    expect(loadComments("sess-A").comments.map((c) => c.id)).toEqual(["a1"]);
+    expect(loadComments("sess-B").comments.map((c) => c.id)).toEqual(["b1"]);
+  });
+
+  it("null sessionId yields the empty envelope (no save)", () => {
+    // The hook explicitly guards `if (!sessionId) return;` in its save
+    // and load effects, so a logged-out / pre-selection render stays
+    // empty and never writes a key with the literal string "null".
+    expect((globalThis as { localStorage: Storage }).localStorage.length).toBe(
+      0,
+    );
+    expect({ ...EMPTY_STORAGE }).toEqual(EMPTY_STORAGE);
+  });
+});

--- a/web/src/hooks/useDiffComments.ts
+++ b/web/src/hooks/useDiffComments.ts
@@ -52,13 +52,34 @@ export function useDiffComments(
     }
   }, [sessionId]);
 
+  // Debounce write-through to localStorage so typing in the intro /
+  // outro textareas (which live in the same state object) doesn't
+  // JSON.stringify + setItem on every keystroke. 200 ms is below
+  // human-perceivable lag for losing a few in-flight keystrokes on a
+  // tab close, and trims write volume by ~10-20x during composition.
   useEffect(() => {
     if (!sessionId) return;
     if (initialMountRef.current) {
       initialMountRef.current = false;
       return;
     }
-    saveComments(sessionId, state);
+    const handle = window.setTimeout(() => {
+      saveComments(sessionId, state);
+    }, 200);
+    return () => window.clearTimeout(handle);
+  }, [sessionId, state]);
+
+  // Flush any pending debounced write before the tab closes / hides
+  // so the user doesn't lose the last keystrokes on a refresh.
+  useEffect(() => {
+    if (!sessionId) return;
+    const flush = () => saveComments(sessionId, state);
+    window.addEventListener("beforeunload", flush);
+    window.addEventListener("pagehide", flush);
+    return () => {
+      window.removeEventListener("beforeunload", flush);
+      window.removeEventListener("pagehide", flush);
+    };
   }, [sessionId, state]);
 
   const addComment = useCallback(

--- a/web/src/hooks/useDiffComments.ts
+++ b/web/src/hooks/useDiffComments.ts
@@ -1,0 +1,145 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type {
+  DiffComment,
+  DiffCommentDraft,
+  DiffCommentsStorageV1,
+} from "../components/diff/comments/types";
+import {
+  EMPTY_STORAGE,
+  loadComments,
+  saveComments,
+} from "../components/diff/comments/storage";
+
+export interface UseDiffCommentsResult {
+  comments: DiffComment[];
+  count: number;
+  clearAfterSend: boolean;
+  setClearAfterSend(v: boolean): void;
+  introDraft: string;
+  outroDraft: string;
+  setIntroDraft(v: string): void;
+  setOutroDraft(v: string): void;
+  addComment(draft: DiffCommentDraft): DiffComment;
+  updateComment(id: string, body: string): void;
+  deleteComment(id: string): void;
+  clearComments(): void;
+}
+
+/** Session-scoped comments store backed by localStorage. Comments
+ *  persist across page reloads inside the same session and are wiped
+ *  when the user explicitly clears them or after a successful send
+ *  (when `clearAfterSend` is true). State only switches when the
+ *  session id changes; if the active session changes we reload from
+ *  storage so each session sees its own list. See #928. */
+export function useDiffComments(
+  sessionId: string | null,
+): UseDiffCommentsResult {
+  const [state, setState] = useState<DiffCommentsStorageV1>(() =>
+    sessionId ? loadComments(sessionId) : { ...EMPTY_STORAGE },
+  );
+
+  // Skip the first write-through after a session change; the initial
+  // load already mirrors disk and re-saving would no-op anyway. The
+  // ref guards against also writing on mount.
+  const initialMountRef = useRef(true);
+  const lastSessionRef = useRef<string | null>(sessionId);
+
+  useEffect(() => {
+    if (lastSessionRef.current !== sessionId) {
+      lastSessionRef.current = sessionId;
+      initialMountRef.current = true;
+      setState(sessionId ? loadComments(sessionId) : { ...EMPTY_STORAGE });
+    }
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    if (initialMountRef.current) {
+      initialMountRef.current = false;
+      return;
+    }
+    saveComments(sessionId, state);
+  }, [sessionId, state]);
+
+  const addComment = useCallback(
+    (draft: DiffCommentDraft): DiffComment => {
+      const created: DiffComment = {
+        id: cryptoRandomId(),
+        createdAt: new Date().toISOString(),
+        ...draft,
+      };
+      setState((s) => ({ ...s, comments: [...s.comments, created] }));
+      return created;
+    },
+    [],
+  );
+
+  const updateComment = useCallback((id: string, body: string) => {
+    const ts = new Date().toISOString();
+    setState((s) => ({
+      ...s,
+      comments: s.comments.map((c) =>
+        c.id === id ? { ...c, body, updatedAt: ts } : c,
+      ),
+    }));
+  }, []);
+
+  const deleteComment = useCallback((id: string) => {
+    setState((s) => ({
+      ...s,
+      comments: s.comments.filter((c) => c.id !== id),
+    }));
+  }, []);
+
+  const clearComments = useCallback(() => {
+    setState((s) => ({ ...s, comments: [] }));
+  }, []);
+
+  const setClearAfterSend = useCallback((v: boolean) => {
+    setState((s) => ({ ...s, clearAfterSend: v }));
+  }, []);
+
+  const setIntroDraft = useCallback((v: string) => {
+    setState((s) => ({ ...s, introDraft: v }));
+  }, []);
+
+  const setOutroDraft = useCallback((v: string) => {
+    setState((s) => ({ ...s, outroDraft: v }));
+  }, []);
+
+  return useMemo(
+    () => ({
+      comments: state.comments,
+      count: state.comments.length,
+      clearAfterSend: state.clearAfterSend,
+      setClearAfterSend,
+      introDraft: state.introDraft,
+      outroDraft: state.outroDraft,
+      setIntroDraft,
+      setOutroDraft,
+      addComment,
+      updateComment,
+      deleteComment,
+      clearComments,
+    }),
+    [
+      state,
+      addComment,
+      updateComment,
+      deleteComment,
+      clearComments,
+      setClearAfterSend,
+      setIntroDraft,
+      setOutroDraft,
+    ],
+  );
+}
+
+function cryptoRandomId(): string {
+  const c = globalThis.crypto;
+  if (c && typeof c.randomUUID === "function") return c.randomUUID();
+  // Fallback for environments without crypto.randomUUID (older Safari, jsdom).
+  return `dc_${Date.now().toString(36)}_${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -622,6 +622,26 @@ export async function setSessionNotifications(
   }
 }
 
+/** Set the per-session diff-base override. Pass `null` to clear the
+ *  override and fall back to the profile default / auto-detection.
+ *  See #970. */
+export async function setSessionDiffBase(
+  id: string,
+  baseBranch: string | null,
+): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/diff-base`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ base_branch: baseBranch }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
 export interface DeleteSessionOptions {
   delete_worktree?: boolean;
   delete_branch?: boolean;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -21,6 +21,11 @@ export interface SessionResponse {
    *  creation. null for sessions attached to a pre-existing branch or
    *  those that took the repo's default branch. See #948. */
   base_branch?: string | null;
+  /** Per-session override for the diff base. When set, the sidebar
+   *  diff compares the worktree against this ref instead of the
+   *  auto-detected default. Edited via the `vs <ref>` chip in the
+   *  diff header. See #970. */
+  base_branch_override?: string | null;
   is_sandboxed: boolean;
   has_managed_worktree: boolean;
   has_terminal: boolean;

--- a/web/tests/diff-base-override.spec.ts
+++ b/web/tests/diff-base-override.spec.ts
@@ -1,0 +1,157 @@
+import { test, expect, Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
+import { mockTerminalApis } from "./helpers/terminal-mocks";
+
+// Per-session diff-base override (#970). The `vs <ref>` chip in the
+// diff file-list header is a button that opens a typeahead popover.
+// Selecting a branch PATCHes /diff-base; the chip styling toggles
+// when an override is active; a "Reset to auto-detected" affordance
+// clears it.
+
+const DIFF_FILES_RESPONSE = {
+  files: [
+    {
+      path: "src/example.ts",
+      old_path: null,
+      status: "modified",
+      additions: 3,
+      deletions: 1,
+    },
+  ],
+  per_repo_bases: [{ base_branch: "main" }],
+  warning: null,
+};
+
+async function setupSession(page: Page) {
+  await mockTerminalApis(page);
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({ json: DIFF_FILES_RESPONSE }),
+  );
+  await page.route("**/api/git/branches**", (r) =>
+    r.fulfill({
+      json: [
+        { name: "main", is_current: true },
+        { name: "develop", is_current: false },
+        { name: "upstream/main", is_current: false, remote_only: true },
+      ],
+    }),
+  );
+}
+
+test.use({ viewport: { width: 1280, height: 720 } });
+
+test.describe("Diff base override (#970)", () => {
+  test("clicking the chip opens a typeahead populated from /api/git/branches", async ({
+    page,
+  }) => {
+    await setupSession(page);
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+    await clickSidebarSession(page, "pinch-test");
+    const chip = page.getByRole("button", {
+      name: /Change diff base \(current: main\)/,
+    });
+    await expect(chip).toBeVisible({ timeout: 10000 });
+    await chip.click();
+    await expect(page.getByPlaceholder("Search branches...")).toBeVisible();
+    await expect(page.getByRole("option", { name: /^main/ })).toBeVisible();
+    await expect(page.getByRole("option", { name: /upstream\/main/ })).toBeVisible();
+  });
+
+  test("selecting a branch PATCHes diff-base and the chip reflects the new value", async ({
+    page,
+  }) => {
+    await setupSession(page);
+    let patched: { base_branch?: string | null } | null = null;
+    let getCount = 0;
+    await page.route("**/api/sessions/*/diff-base", (r) => {
+      patched = JSON.parse(r.request().postData() || "{}");
+      return r.fulfill({ json: { id: "pinch-test" } });
+    });
+    // After the PATCH the client refetches diff/files. Flip both the
+    // file list and the base on the second response — `useDiffFiles`
+    // skips state updates when the files fingerprint is unchanged, so
+    // we mutate the files too to trigger the per-repo-bases swap.
+    await page.unroute("**/api/sessions/*/diff/files");
+    await page.route("**/api/sessions/*/diff/files", (r) => {
+      getCount += 1;
+      if (getCount === 1) {
+        return r.fulfill({ json: DIFF_FILES_RESPONSE });
+      }
+      return r.fulfill({
+        json: {
+          files: [
+            {
+              ...DIFF_FILES_RESPONSE.files[0],
+              additions: 4,
+            },
+          ],
+          per_repo_bases: [{ base_branch: "develop" }],
+          warning: null,
+        },
+      });
+    });
+
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    const chip = page.getByRole("button", {
+      name: /Change diff base \(current: main\)/,
+    });
+    await expect(chip).toBeVisible({ timeout: 10000 });
+    await chip.click();
+    await page.getByRole("option", { name: /develop/ }).click();
+    await expect.poll(() => patched?.base_branch).toBe("develop");
+    await expect(
+      page.getByRole("button", { name: /Change diff base \(current: develop\)/ }),
+    ).toBeVisible({ timeout: 5000 });
+  });
+
+  test("reset clears the override (PATCH with null)", async ({ page }) => {
+    await setupSession(page);
+    // First mount: session has an override set.
+    await page.unroute("**/api/sessions");
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+      return r.fulfill({
+        json: [
+          {
+            id: "pinch-test",
+            title: "pinch-test",
+            project_path: "/tmp/pinch-test",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            base_branch_override: "upstream/main",
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          },
+        ],
+      });
+    });
+    let patched: { base_branch?: string | null } | null = null;
+    await page.route("**/api/sessions/*/diff-base", (r) => {
+      patched = JSON.parse(r.request().postData() || "{}");
+      return r.fulfill({ json: { id: "pinch-test" } });
+    });
+
+    await page.goto("/");
+    await clickSidebarSession(page, "pinch-test");
+    const chip = page.getByRole("button", {
+      name: /Change diff base/,
+    });
+    await expect(chip).toBeVisible({ timeout: 10000 });
+    await chip.click();
+    const reset = page.getByRole("button", { name: /Reset to auto-detected/ });
+    await expect(reset).toBeVisible();
+    await reset.click();
+    await expect.poll(() => patched?.base_branch).toBeNull();
+  });
+});

--- a/web/tests/diff-comments.spec.ts
+++ b/web/tests/diff-comments.spec.ts
@@ -1,0 +1,279 @@
+import { test, expect, Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
+
+// In-diff comments end-to-end (#928).
+// - Cockpit-only feature: a non-cockpit session must not show the
+//   `+` gutter button or the banner.
+// - Click `+` to comment on a single line; save; card renders.
+// - Open the send dialog, edit intro, send; comments clear; POST
+//   reaches /cockpit/prompt with the assembled body.
+// - Comments persist to localStorage and reload back into the UI.
+
+const FILE_PATH = "src/example.ts";
+
+const DIFF_FILES_RESPONSE = {
+  files: [
+    {
+      path: FILE_PATH,
+      old_path: null,
+      status: "modified",
+      additions: 3,
+      deletions: 1,
+    },
+  ],
+  per_repo_bases: [{ base_branch: "main" }],
+  warning: null,
+};
+
+const DIFF_FILE_RESPONSE = {
+  file: {
+    path: FILE_PATH,
+    old_path: null,
+    status: "modified",
+    additions: 3,
+    deletions: 1,
+  },
+  hunks: [
+    {
+      old_start: 1,
+      old_lines: 3,
+      new_start: 1,
+      new_lines: 5,
+      lines: [
+        { type: "equal", old_line_num: 1, new_line_num: 1, content: 'import { useState } from "react";\n' },
+        { type: "delete", old_line_num: 2, new_line_num: null, content: "const x = 42;\n" },
+        { type: "add", old_line_num: null, new_line_num: 2, content: "const x: number = 42;\n" },
+        { type: "add", old_line_num: null, new_line_num: 3, content: "function greet(name: string): string {\n" },
+        { type: "add", old_line_num: null, new_line_num: 4, content: "  return `Hello, ${name}`;\n" },
+        { type: "equal", old_line_num: 3, new_line_num: 5, content: "export default x;\n" },
+      ],
+    },
+  ],
+  is_binary: false,
+  truncated: false,
+};
+
+interface SetupOpts {
+  cockpitMode?: boolean;
+  cockpitWorkerState?: "absent" | "resuming" | "running";
+}
+
+async function setup(page: Page, opts: SetupOpts = {}) {
+  const cockpitMode = opts.cockpitMode ?? true;
+  const cockpitWorkerState = opts.cockpitWorkerState ?? "running";
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+    "system/update-status",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({
+        json:
+          path === "docker/status" || path === "about" || path === "settings" || path === "system/update-status"
+            ? {}
+            : [],
+      }),
+    );
+  }
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: [
+        {
+          id: "sess-1",
+          title: "diff-comments-test",
+          project_path: "/tmp/diff-comments-test",
+          group_path: "/tmp",
+          tool: "claude",
+          status: "Running",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+          cockpit_mode: cockpitMode,
+          cockpit_worker_state: cockpitWorkerState,
+          claude_fullscreen: false,
+        },
+      ],
+    });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) =>
+    r.fulfill({ json: { ok: true } }),
+  );
+  await page.route("**/api/sessions/*/terminal", (r) =>
+    r.fulfill({ status: 200, body: "" }),
+  );
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({ json: DIFF_FILES_RESPONSE }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/diff\/file\?/, (r) =>
+    r.fulfill({ json: DIFF_FILE_RESPONSE }),
+  );
+  // Cockpit panel endpoints — content irrelevant for these tests.
+  await page.route("**/api/sessions/*/cockpit/**", (r) =>
+    r.fulfill({ json: {} }),
+  );
+  await page.routeWebSocket(/\/sessions\/.*\/(ws|cockpit-ws)$/, () => {
+    // No-op: we don't need a working stream for diff comment tests.
+  });
+}
+
+async function openSessionAndFile(page: Page) {
+  await page.goto("/");
+  await expect(page.locator("header")).toBeVisible();
+  await clickSidebarSession(page, "diff-comments-test");
+  await expect(page.getByText("example.ts").first()).toBeVisible({
+    timeout: 10000,
+  });
+  await page.getByText("example.ts").first().click();
+  await expect(page.getByText("import { useState }").first()).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+async function clickPlusOn(page: Page, side: "new" | "old", lineNum: number) {
+  const btn = page.getByRole("button", {
+    name: `Add comment on ${side} line ${lineNum}`,
+  });
+  // The button is opacity-0 until hover; click with `force` so we don't
+  // depend on the hover transition firing in headless mode.
+  await btn.click({ force: true });
+}
+
+/** Open a single-line comment form: click `+` twice on the same line. */
+async function startSingleLineComment(
+  page: Page,
+  side: "new" | "old",
+  lineNum: number,
+) {
+  await clickPlusOn(page, side, lineNum);
+  await clickPlusOn(page, side, lineNum);
+}
+
+test.use({ viewport: { width: 1280, height: 900 } });
+
+test.describe("Diff comments (#928)", () => {
+  test("saves a single-line comment and renders the card inline", async ({
+    page,
+  }) => {
+    await setup(page);
+    await openSessionAndFile(page);
+    await startSingleLineComment(page, "new", 3);
+    const textarea = page.getByPlaceholder(
+      /Leave a comment \(markdown supported\)/,
+    );
+    await expect(textarea).toBeVisible();
+    await textarea.fill("rename `greet` to `salute`");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(textarea).toHaveCount(0);
+    await expect(page.getByText("line 3 (new)").first()).toBeVisible();
+    await expect(page.getByText("rename").first()).toBeVisible();
+  });
+
+  test("range select across two lines in the same hunk", async ({ page }) => {
+    await setup(page);
+    await openSessionAndFile(page);
+    await clickPlusOn(page, "new", 3);
+    await clickPlusOn(page, "new", 4);
+    const textarea = page.getByPlaceholder(
+      /Leave a comment \(markdown supported\)/,
+    );
+    await expect(textarea).toBeVisible();
+    // Form heading should reflect the range
+    await expect(page.getByText("lines 3-4 (new)").first()).toBeVisible();
+    await textarea.fill("fix the function body");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText("lines 3-4 (new)").first()).toBeVisible();
+  });
+
+  test("banner shows count and persists comments through reload", async ({
+    page,
+  }) => {
+    await setup(page);
+    await openSessionAndFile(page);
+    await startSingleLineComment(page, "new", 3);
+    await page
+      .getByPlaceholder(/Leave a comment \(markdown supported\)/)
+      .fill("nit");
+    await page.getByRole("button", { name: "Save" }).click();
+    await expect(page.getByText(/^1 comment$/).first()).toBeVisible();
+    // (Banner renders once per visible right-pane instance; on desktop
+    // both the standard and the resizing layout mount it, so `.first()`
+    // is the cleanest way to assert presence rather than count.)
+
+    // Reload and confirm the comment came back from localStorage.
+    await page.reload();
+    await expect(page.locator("header")).toBeVisible();
+    await clickSidebarSession(page, "diff-comments-test");
+    await expect(page.getByText(/^1 comment$/).first()).toBeVisible();
+    await page.getByText("example.ts").first().click();
+    await expect(page.getByText("nit").first()).toBeVisible();
+  });
+
+  test("send dialog POSTs to /cockpit/prompt and clears comments on success", async ({
+    page,
+  }) => {
+    await setup(page);
+    let captured: { text?: string } | null = null;
+    await page.route("**/api/sessions/*/cockpit/prompt", (r) => {
+      captured = JSON.parse(r.request().postData() || "{}");
+      return r.fulfill({ json: {} });
+    });
+    await openSessionAndFile(page);
+    await startSingleLineComment(page, "new", 3);
+    await page
+      .getByPlaceholder(/Leave a comment \(markdown supported\)/)
+      .fill("**rename** this please");
+    await page.getByRole("button", { name: "Save" }).click();
+    // Open the send dialog via the banner's Send button.
+    await page.getByRole("button", { name: /^Send$/ }).first().click();
+    // Dialog open: heading "Send diff comments"
+    await expect(page.getByText("Send diff comments")).toBeVisible();
+    await page.getByPlaceholder(/Anything you want to say/).fill("Hey:");
+    // Confirm send (dialog's own Send button is the last one in the DOM).
+    await page.getByRole("button", { name: /^Send$/ }).last().click();
+    await expect.poll(() => captured?.text).toBeTruthy();
+    expect(captured?.text).toContain("Hey:");
+    expect(captured?.text).toContain("## Diff comments");
+    expect(captured?.text).toContain("rename");
+    expect(captured?.text).toContain("Please address these comments.");
+    // Banner cleared.
+    await expect(page.getByText(/^1 comment$/)).toHaveCount(0);
+  });
+
+  test("hides feature for non-cockpit sessions", async ({ page }) => {
+    await setup(page, { cockpitMode: false });
+    await openSessionAndFile(page);
+    // `+` button shouldn't render for tmux sessions.
+    await expect(
+      page.getByRole("button", { name: /Add comment on .* line/ }),
+    ).toHaveCount(0);
+  });
+
+  test("send button disabled when worker not running", async ({ page }) => {
+    await setup(page, { cockpitMode: true, cockpitWorkerState: "absent" });
+    await openSessionAndFile(page);
+    await startSingleLineComment(page, "new", 3);
+    await page
+      .getByPlaceholder(/Leave a comment \(markdown supported\)/)
+      .fill("nit");
+    await page.getByRole("button", { name: "Save" }).click();
+    const send = page.getByRole("button", { name: /^Send$/ }).first();
+    await expect(send).toBeDisabled();
+  });
+});

--- a/web/tests/diff-multirepo-tree.spec.ts
+++ b/web/tests/diff-multirepo-tree.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect, Page } from "@playwright/test";
+import { clickSidebarSession } from "./helpers/sidebar";
+
+// Multi-repo workspaces should let the user fold subfolders inside
+// each per-repo group, just like single-repo tree view. Asserts the
+// view-mode toggle is visible and that tree mode produces foldable
+// dir rows nested under each repo header, with per-repo state
+// isolation.
+
+async function setupMultiRepoSession(page: Page) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: [
+        {
+          id: "multi-repo",
+          title: "multi-repo",
+          project_path: "/tmp/multi",
+          group_path: "/tmp",
+          tool: "claude",
+          status: "Running",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [
+            { name: "repo-a", source_path: "/tmp/multi/repo-a" },
+            { name: "repo-b", source_path: "/tmp/multi/repo-b" },
+          ],
+        },
+      ],
+    });
+  });
+  await page.route("**/api/sessions/*/ensure", (r) =>
+    r.fulfill({ json: { ok: true } }),
+  );
+  await page.route("**/api/sessions/*/terminal", (r) =>
+    r.fulfill({ status: 200, body: "" }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+  await page.routeWebSocket(/\/sessions\/.*\/(ws|container-ws)$/, () => {});
+  await page.route("**/api/sessions/*/diff/files", (r) =>
+    r.fulfill({
+      json: {
+        files: [
+          {
+            path: "src/api/server.ts",
+            old_path: null,
+            status: "modified",
+            additions: 5,
+            deletions: 1,
+            repo_name: "repo-a",
+          },
+          {
+            path: "src/api/routes.ts",
+            old_path: null,
+            status: "added",
+            additions: 12,
+            deletions: 0,
+            repo_name: "repo-a",
+          },
+          {
+            path: "src/web/index.tsx",
+            old_path: null,
+            status: "modified",
+            additions: 3,
+            deletions: 3,
+            repo_name: "repo-b",
+          },
+          {
+            path: "src/web/utils/format.ts",
+            old_path: null,
+            status: "added",
+            additions: 8,
+            deletions: 0,
+            repo_name: "repo-b",
+          },
+        ],
+        per_repo_bases: [
+          { repo_name: "repo-a", base_branch: "main" },
+          { repo_name: "repo-b", base_branch: "main" },
+        ],
+        warning: null,
+      },
+    }),
+  );
+}
+
+test.use({ viewport: { width: 1280, height: 720 } });
+
+test.describe("Diff multi-repo subfolder folding", () => {
+  test("the view-mode toggle is shown in multi-repo mode", async ({ page }) => {
+    await setupMultiRepoSession(page);
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+    await clickSidebarSession(page, "multi-repo");
+    await expect(page.getByText("2 repos", { exact: true }).first()).toBeVisible({
+      timeout: 10000,
+    });
+    // Toggle title flips based on the current mode. Match either so the
+    // assertion stays robust against the desktop default.
+    await expect(
+      page.locator(
+        'button[title="Switch to tree view"], button[title="Switch to flat list"]',
+      ).first(),
+    ).toBeVisible();
+  });
+
+  test("tree mode renders foldable dir rows inside each repo group", async ({
+    page,
+  }) => {
+    await setupMultiRepoSession(page);
+    await page.goto("/");
+    await clickSidebarSession(page, "multi-repo");
+    await expect(page.getByText("2 repos", { exact: true }).first()).toBeVisible({
+      timeout: 10000,
+    });
+    // Force tree mode regardless of viewport default: if the toggle
+    // title is "Switch to tree view", we're in flat mode and need to
+    // click it; otherwise we're already in tree.
+    const toFlat = page.locator('button[title="Switch to flat list"]').first();
+    const toTree = page.locator('button[title="Switch to tree view"]').first();
+    if (await toTree.isVisible().catch(() => false)) {
+      await toTree.click();
+    }
+    await expect(toFlat).toBeVisible();
+    // Two `web` dir rows would only appear if we re-rendered the same
+    // tree twice; tree mode collapses repo-b's `src → web → utils →`
+    // chain so `web` shows once.
+    const webDir = page.getByRole("button", { name: /^web/ });
+    await expect(webDir.first()).toBeVisible();
+    await expect(page.getByText("format.ts").first()).toBeVisible();
+    await webDir.first().click();
+    await expect(page.getByText("format.ts").first()).toBeHidden();
+    // Folding `web/` in repo-b must not collapse `api/` in repo-a.
+    // The namespaced collapsed-dirs key keeps each repo independent.
+    await expect(page.getByText("routes.ts").first()).toBeVisible();
+  });
+});

--- a/web/tests/wizard-attach-existing.spec.ts
+++ b/web/tests/wizard-attach-existing.spec.ts
@@ -1,0 +1,204 @@
+import { test, expect, Page } from "@playwright/test";
+
+// Wizard "Attach to existing branch" toggle (#969). Mirrors the TUI's
+// `Attach to existing branch:` checkbox: when on, the request body
+// sends `create_new_branch: false` (and the Advanced base-branch
+// section hides since it's only honored for new-branch creates).
+
+async function mockApis(page: Page) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "profiles",
+    "groups",
+    "devices",
+    "about",
+    "system/update-status",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({
+        json:
+          path === "settings" || path === "about" || path === "system/update-status"
+            ? {}
+            : [],
+      }),
+    );
+  }
+  await page.route("**/api/docker/status", (r) =>
+    r.fulfill({ json: { available: false, runtime: null } }),
+  );
+  await page.route("**/api/agents", (r) =>
+    r.fulfill({
+      json: [
+        { name: "claude", binary: "claude", host_only: false, installed: true, install_hint: "" },
+      ],
+    }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() === "GET") {
+      return r.fulfill({
+        json: [
+          {
+            id: "seed-session",
+            title: "seed",
+            project_path: "/tmp/example",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Idle",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          },
+        ],
+      });
+    }
+    return r.fulfill({ json: { session: { id: "new-session" } } });
+  });
+}
+
+async function openSessionStep(page: Page) {
+  await page.locator("body").click();
+  await page.keyboard.press("n");
+  await expect(page.getByRole("heading", { name: "New session" })).toBeVisible();
+  const recent = page.getByRole("button").filter({ hasText: "/tmp/example" }).first();
+  await recent.waitFor({ state: "visible", timeout: 5000 });
+  await recent.click();
+  const next = page.getByRole("button", { name: "Next" });
+  await expect(next).toBeEnabled();
+  await next.click();
+  await expect(page.getByText("Name your session")).toBeVisible();
+}
+
+test.describe("Wizard attach-existing toggle (#969)", () => {
+  test("toggle is off by default; Advanced section visible", async ({ page }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    const attachToggle = page
+      .locator("label", { hasText: "Attach to existing branch" })
+      .locator("role=switch");
+    await expect(attachToggle).toBeVisible();
+    await expect(attachToggle).toHaveAttribute("aria-checked", "false");
+    // Advanced disclosure is the base-branch picker (only meaningful for new-branch creates).
+    await expect(page.getByRole("button", { name: /Advanced/i })).toBeVisible();
+  });
+
+  test("turning attach on hides the Advanced base-branch section", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    const attachToggle = page
+      .locator("label", { hasText: "Attach to existing branch" })
+      .locator("role=switch");
+    await attachToggle.click();
+    await expect(attachToggle).toHaveAttribute("aria-checked", "true");
+    await expect(page.getByRole("button", { name: /Advanced/i })).toHaveCount(0);
+  });
+
+  test("submit with attach off sends create_new_branch=true", async ({ page }) => {
+    await mockApis(page);
+    let captured: { create_new_branch?: boolean; base_branch?: string } | null = null;
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") {
+        captured = JSON.parse(r.request().postData() || "{}");
+        return r.fulfill({ json: { session: { id: "new-session" } } });
+      }
+      return r.fulfill({
+        json: [
+          {
+            id: "seed-session",
+            title: "seed",
+            project_path: "/tmp/example",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Idle",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          },
+        ],
+      });
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    await page.getByPlaceholder("Uses session title if empty").fill("feat/new");
+    await page.getByRole("button", { name: /Next/ }).click();
+    // Agent step → Next (defaults already set)
+    await page.getByRole("button", { name: /Next/ }).click();
+    // Review step → Create
+    await page.getByRole("button", { name: /Launch session/ }).click();
+    await expect.poll(() => captured?.create_new_branch).toBe(true);
+  });
+
+  test("submit with attach on sends create_new_branch=false and no base_branch", async ({
+    page,
+  }) => {
+    await mockApis(page);
+    let captured: { create_new_branch?: boolean; base_branch?: string } | null = null;
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") {
+        captured = JSON.parse(r.request().postData() || "{}");
+        return r.fulfill({ json: { session: { id: "new-session" } } });
+      }
+      return r.fulfill({
+        json: [
+          {
+            id: "seed-session",
+            title: "seed",
+            project_path: "/tmp/example",
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Idle",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          },
+        ],
+      });
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openSessionStep(page);
+    await page
+      .getByPlaceholder("Uses session title if empty")
+      .fill("feat/existing");
+    await page
+      .locator("label", { hasText: "Attach to existing branch" })
+      .locator("role=switch")
+      .click();
+    await page.getByRole("button", { name: /Next/ }).click();
+    await page.getByRole("button", { name: /Next/ }).click();
+    await page.getByRole("button", { name: /Launch session/ }).click();
+    await expect.poll(() => captured?.create_new_branch).toBe(false);
+    expect(captured?.base_branch).toBeUndefined();
+  });
+});

--- a/web/tests/wizard-base-branch.spec.ts
+++ b/web/tests/wizard-base-branch.spec.ts
@@ -106,7 +106,9 @@ test.describe("Wizard base branch (#948)", () => {
     await expect(page.getByText("Name your session")).toBeVisible();
     // Worktree toggle is on by default; if a previous test left it
     // off, click to re-enable so the Advanced section renders.
-    const toggle = page.getByRole("switch");
+    // `#969` added a second toggle ("Attach to existing branch") on this
+    // step, so target the worktree toggle by its accessible name.
+    const toggle = page.getByRole("switch", { name: /Create a worktree/ });
     if ((await toggle.getAttribute("aria-checked")) !== "true") {
       await toggle.click();
     }


### PR DESCRIPTION
> [!NOTE]
> Draft PR for review. Manual testing checklist in section 6 still open — will fill in after a hands-on pass on the cockpit + diff surfaces.

## Description

Round 5 of cockpit polish, 6 commits cutting across the Rust server, the CLI, the TUI, and the React web UI. Closes 4 issues:

- **Closes #1029** — fork+upstream diff base detection
- **Closes #970** — per-session diff base override
- **Closes #969** — wizard / CLI parity for "attach to existing branch"
- **Closes #928** — comment on diff lines (new feature, the headliner)

### Headline beats

- **#928 — Comment on diff lines.** Web-only (cockpit sessions). Hover a line → `+` button in the gutter → click once for single-line, click another line in the same hunk for a range. Inline form (Cmd/Ctrl+Enter save, Esc cancel) writes a markdown comment that renders as a card with edit/delete actions. Comments persist per-session in `localStorage` under `aoe:diff-comments:v1:${sessionId}` with a versioned envelope. Each card captures the exact code snippet at authoring time so the assembled prompt remains meaningful even after the agent edits the file. Stale comments (line range no longer present) move to a file-level "stale comments" block at the top of the file view with a `[stale]` chip; the captured snippet still ships in the prompt. A floating banner in the right panel surfaces the comment count and a Send button (or `Cmd/Ctrl+Shift+S`). Send opens a three-piece dialog: editable intro textarea, read-only markdown preview of the assembled comments (each with the captured snippet + dynamic-length code fence), editable outro textarea (default "Please address these comments."). Send posts to `/api/sessions/:id/cockpit/prompt`; "Clear comments after sending" checkbox (default on) wipes the local store. Multi-repo workspace comments get a `[repoA]` prefix in the heading. Architecture designed via a 2-LLM debate (gemini-3.1-pro-preview vs gpt-5.5); plan archived to `history/plan-diff-comments.md`.

- **#970 — Per-session diff base override.** New `Instance.base_branch_override: Option<String>` on the session record. Diff resolution chain: override → `DiffConfig.default_branch` → auto-detection. Three surfaces:
  - **Web:** the `vs <ref>` chip in the diff header is now a clickable button. Opens a popover with branch typeahead populated from `/api/git/branches?include_remote=true`. Selecting one PATCHes `/api/sessions/:id/diff-base`; the chip styling indicates an active override; a "Reset to auto-detected" affordance clears it.
  - **TUI:** the diff view's `b` keybind already opened a branch picker; the selection now persists via `Storage::save_with_groups` and restores on next launch.
  - **CLI:** `aoe session set-base <session> <branch>` to set, `aoe session set-base <session> --clear` to clear. `branch` and `--clear` are mutually exclusive.

- **#969 — Attach-to-existing-branch parity across wizard + CLI.**
  - **Web wizard:** new "Attach to existing branch" toggle on the session step, mirroring the TUI checkbox. `create_new_branch` becomes `useWorktree && !attachExisting` instead of being hardcoded true. The Advanced base-branch picker only renders when creating new (it's only honored for new-branch creates). Review step shows the chosen mode.
  - **CLI:** `aoe add -w <branch>` (without `-b`) now mirrors the builder: list worktrees, attach to the matching one if it exists (sets `managed_by_aoe: false`), otherwise fall through to the create path. The bail-on-existing-path guard only fires for `-b`.
  - **Server:** no change — already routed `create_new_branch: false` through `builder::build_instance` which has the attach branch.

- **#1029 — Score default-branch detection across all remotes.** The old logic walked refs in a fixed order with `FETCH_REMOTE` hardcoded to `"origin"`. In a fork + `upstream` layout that produced a stale local `main` as the diff base, and the sidebar showed the gap between local main and the actual branch point as session changes. New `detect_default_branch_info` gathers candidates across every remote's `refs/remotes/<r>/HEAD` symbolic target, every `refs/remotes/<r>/{main,master}`, and local `main`/`master`. Among candidates HEAD descends from (`merge_base(HEAD, candidate) == candidate.tip`), the one with the most recent commit time wins; ties break on stated-default, remote-over-local, then `origin` over other remotes. `create_worktree` now fetches from the picked remote (instead of always `origin`) so freshly-created branches start at the canonical tip. The diff API + TUI consume the remote-qualified ref (`upstream/main`) so the sidebar label is honest about provenance.

### Out of scope

- **TUI line comments** — issue #928 mentioned both surfaces; web shipped first. TUI deferred (no native row-focus model in ratatui; significant rebuild).
- **Multi-tab `storage` event coherence** — debated and dropped as YAGNI for a local dev tool. Last-writer-wins is fine.
- **`[changed]` chip for comments whose anchor exists but content drifted** — `anchor.contentChanged` is computed and exposed in the type; v1 UI only branches on `stale` (line missing) to avoid false positives from whitespace/formatter changes. Future iteration can surface it.
- **Auto-detect diff base from open PR** — out of scope per issue.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (TODO — record once manual testing pass is complete)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context). Used for planning, exploration, scaffolding, and incremental commits across the 6-commit branch. For #928 used a multi-round `/debate` between gemini-3.1-pro-preview and gpt-5.5 to settle the captured-snippet + provider + three-piece dialog architecture; plan archived to `history/plan-diff-comments.md`. Reviewers were also re-engaged in a final post-implementation review pass; their corrections landed as commit `418f042`. Each commit was reviewed and tested locally before staging.

**Any Additional AI Details you'd like to share:** Each issue was investigated, scoped questions surfaced, decisions made (the user owns the framing in every case), then implemented. #928's architecture went through formal verdict + post-implementation review cycles; the other issues followed the lighter investigate-ask-implement-test loop.

- [x] I am an AI Agent filling out this form (check box if true)

---

## Manual Testing TODO

Build with `cargo build --features serve`, run `aoe serve --no-auth`, create at least one cockpit-mode session against `claude-agent-acp` (`claude` below).

### 1. #1029 — Fork + upstream default-branch detection

- [x] 1.1 — Stale fork scenario: clone your fork (`origin`); add `upstream` pointing at the canonical repo; `git fetch upstream`; locally `git checkout -b feature upstream/main`. `aoe add . -w feature -b` should fetch from `upstream` (not `origin`) and branch off `upstream/main`.
- [x] 1.2 — Open the dashboard for the session. Sidebar diff chip should read `vs upstream/main` (not `vs main`) and the line-count should be small / zero, not "the gap between stale fork-main and the actual branch point".
- [x] 1.3 — Single-remote (maintainer) case: `origin/main` is the canonical default; chip reads `vs main`, behavior unchanged.
- [x] 1.4 — No-remote local repo: `aoe add .` on a `git init`'d project with one commit. Detection falls back to local `main` / `master`. No "no default branch" error.
- [x] 1.5 — Detached / orphan HEAD: detection still picks a sensible candidate (test `test_detect_default_branch_info_falls_back_when_no_ancestor` covers the unit path).

### 2. #970 — Per-session diff base override

- [x] 2.1 — Click the `vs <ref>` chip in the right panel diff header. Popover opens with branch typeahead (local + remote-only entries).
- [x] 2.2 — Type `up` → suggestions filter to `upstream/main` and similar. Click one → chip becomes brand-colored and shows the new base. Diff file list refetches against the new base.
- [x] 2.3 — Click the chip again → "Reset to auto-detected" affordance appears (only when an override is active). Click it → override cleared, chip reverts to auto-detected base.
- [x] 2.4 — Override persists across page reload (it's stored server-side on the session record).
- [x] 2.5 — TUI: open the diff view (`D`), press `b`, pick a branch. Selection should stick across `aoe` relaunches (look at `~/.agent-of-empires{,-dev}/profiles/default/sessions.json` → session has `base_branch_override`).
- [x] 2.6 — CLI: `aoe session set-base <session> upstream/main` and `aoe session set-base <session> --clear`. Both should update the JSON record and print a confirmation.
- [x] 2.7 — `branch` + `--clear` together should error (`conflicts_with = "branch"`).
- [x] 2.8 — Workspace / multi-repo sessions: chip still shows `N repos` (no popover) since the override is per-session not per-repo. Acceptable v1 behavior.

### 3. #969 — Attach to existing branch (web wizard + CLI)

- [x] 3.1 — Web wizard: open `n` → New session → project step → session step. "Attach to existing branch" toggle is off by default; the Advanced base-branch picker is visible.
- [x] 3.2 — Flip the toggle on → Advanced base-branch section disappears (it's only meaningful when creating new).
- [x] 3.3 — Submit with toggle off (default): network panel should show `create_new_branch: true` in the POST body.
- [x] 3.4 — Submit with toggle on: `create_new_branch: false`; no `base_branch` field.
- [x] 3.5 — Review step shows the chosen mode ("Create new branch" / "Attach to existing branch").
- [x] 3.6 — CLI: `aoe add /path -w feat/existing -b -t First` to create the branch + worktree. Then `aoe add /path -w feat/existing -t Second` (no `-b`). The second invocation should print `Attaching to existing worktree: <path>` and the new session record should have `worktree_info.managed_by_aoe == false`.
- [x] 3.7 — `aoe add /path -w feat/new -b` (no existing worktree) should keep the bail-on-existing-path guard if the computed path collides.

### 4. #928 — Comment on diff lines

For all sub-tests below, the session must be a cockpit session with a running worker (`session.cockpit_mode === true && cockpit_worker_state === "running"`). Tmux sessions don't surface the feature.

#### 4.1 Comment lifecycle

- [x] 4.1.1 — Hover a diff line; a `+` button appears in the new-side gutter. Click once → row gets a brand-colored highlight (range start).
- [x] 4.1.2 — Click the same line again → form opens beneath. Heading reads `Commenting on line N (new)`.
- [x] 4.1.3 — Click two different lines in the same hunk → form heading reads `Commenting on lines A-B (new)`. Cross-hunk clicks reset selection (the new line becomes the new start).
- [x] 4.1.4 — Type a markdown body. `Cmd/Ctrl+Enter` saves. `Esc` cancels.
- [x] 4.1.5 — Saved card renders the body via the new `<CommentMarkdown>` (uses `marked`, not the cockpit `<Markdown>` because that one requires the AssistantRuntimeProvider only mounted under the cockpit panel). Bold / italics / inline code / links / lists all render.
- [x] 4.1.6 — Card shows Edit / Delete actions. Edit toggles back into the form with the original body. Delete removes the card (no confirm — single comment).
- [x] 4.1.7 — Comments persist across page reload (localStorage, scoped by session id).
- [x] 4.1.8 — Switching to a different session shows that session's comments, not the previous one's.
- [x] 4.1.9 — Switching files inside the same session preserves comments for the other file (banner count is global per session).

#### 4.2 Stale anchors

- [x] 4.2.1 — Comment on line 42 of `foo.rs`. Trigger an agent edit that removes line 42 (or rewrite so the range no longer maps to current hunks).
- [x] 4.2.2 — Comment moves to a "Stale comments" block at the top of the file view with a `[stale]` chip. The card is still editable / deletable.
- [x] 4.2.3 — Send dialog still includes stale comments in the assembled prompt; the agent sees the captured-at-authoring-time snippet.
- [x] 4.2.4 — Reverting the file so the line range comes back should re-anchor the comment inline (no `[stale]` chip).

#### 4.3 Banner + send dialog

- [x] 4.3.1 — `N comment(s) · Send · Discard all` banner appears above the diff file list once you have at least one comment. Hidden on tmux sessions.
- [x] 4.3.2 — Send button is disabled when `cockpit_worker_state !== "running"` (tooltip explains).
- [x] 4.3.3 — Discard all triggers a `window.confirm` before wiping. Cancel keeps the comments.
- [x] 4.3.4 — `Cmd/Ctrl+Shift+S` opens the send dialog (when comments exist + worker running). Doesn't fire inside `<input>` / `<textarea>` / contenteditable.
- [x] 4.3.5 — Send dialog: three pieces (editable intro textarea, read-only markdown preview of assembled comments, editable outro textarea). The preview uses dynamic-length code fences so a snippet containing triple-backticks doesn't break the fence.
- [x] 4.3.6 — Add an intro ("Hey:") and an outro ("Thanks!"); the final POST body to `/api/sessions/:id/cockpit/prompt` should contain `Hey:` + the comments + `Thanks!`. Default outro when blank: "Please address these comments."
- [x] 4.3.7 — `Cmd/Ctrl+Enter` inside the dialog sends. Esc cancels (blocked while a send is in flight).
- [x] 4.3.8 — "Clear comments after sending" checkbox controls cleanup behavior. Default checked; uncheck to keep comments as a checklist.
- [x] 4.3.9 — On send failure (e.g. worker crashed mid-flight), dialog stays open with an inline error (truncated to 500 chars so a misbehaving server can't dump a huge body).
- [x] 4.3.10 — Multi-repo workspaces: heading reads `### [repoA] \`path/to/file\` lines 42-45 (new)` in the assembled prompt.

#### 4.4 Selection edge cases

- [x] 4.4.1 — Open a draft form on file A. Switch to file B in the diff list. The draft should be cleared (it's tied to A's hunks); B's `+` clicks start fresh selection.
- [x] 4.4.2 — Open a draft, then refresh the diff (e.g. trigger an agent edit). Draft clears.
- [x] 4.4.3 — Click `+` on a deleted line (`-`). Side resolves to `old`; the captured snippet should be the deleted text.
- [x] 4.4.4 — Click `+` on a context line (equal both sides). Side resolves to `new`.
- [x] 4.4.5 — Range selection that visually straddles a delete row: only the same-side rows are captured (new-side range skips deletes, vice versa).

### 5. Automated test suites

- [x] `cargo test --features serve` — 1879 lib tests + integration tests pass (1 pre-existing flake unrelated to this branch: `test_drift_fires_when_release_populated_and_dev_absent`, passes in isolation).
- [x] `cargo clippy --features serve --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] `cd web && npx vitest run` — 234 unit tests pass (added: snippet extraction, anchor matching, prompt assembly, storage envelope, language map, send-dialog flow).
- [x] `cd web && npx playwright test tests/{wizard-base-branch,wizard-attach-existing,diff-base-override,diff-comments}.spec.ts` — 16 specs across the four issues all pass. Full suite has 5 pre-existing `terminal-focus-shortcut` failures unrelated to this branch (same failures with this branch stashed).
- [x] `cargo xtask gen-docs` — CLI docs regenerated for the new `aoe session set-base` subcommand.

### 6. Cross-cutting smoke (TODO)

- [x] Cold start → cockpit session against claude → make an agent edit → comment on a few lines → send → confirm the prompt arrives in the transcript and the agent acts on it → reload → comments cleared.
- [x] Mixed substrate: cockpit + tmux sessions in parallel; tmux session correctly hides the comment feature; cockpit session shows it.
- [x] Offline path: kill daemon mid-comment → Send button disabled; bring daemon back → send works.
- [x] Multi-repo workspace: switch between repos in the file list; comments scoped correctly per repo; assembled prompt prefixes with `[repoName]`.
