### PR TITLE
feat(logging): consolidate sink + rotation under logging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,9 +110,10 @@ Keep the script ephemeral unless promoted to `web/tests/` with a mobile Playwrig
   - `serve.pid`: daemon PID for `--stop` and reattach detection.
   - `serve.url`: primary URL (includes the auth token) plus alternates.
   - `serve.mode`: `tunnel` / `tailscale` / `local`.
-  - `serve.log`: daemon stdout/stderr tail.
   - `serve.passphrase`: plaintext Tunnel passphrase, so the TUI can show it on reopen across restarts.
   - `serve.last_mode`, `serve.last_port`: picker defaults across launches.
+
+Daemon tracing and stdout/stderr now land in the configured `[logging].file_path` (default `~/.agent-of-empires/debug.log`) alongside the TUI and cockpit runners; see `docs/development/logging.md` for sinks and rotation.
 
 ## Data Migrations
 

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -81,7 +81,7 @@ Run without arguments to launch the TUI dashboard.
 * `agents` — List supported agents and their install status
 * `init` — Initialize .agent-of-empires/config.toml in a repository
 * `list` — List all sessions
-* `logs` — View AoE log files (debug.log, serve.log) with a pretty viewer
+* `logs` — View the configured AoE log file with a pretty viewer
 * `log-level` — Get or set the running daemon's log filter at runtime. Pass a bare level (debug/info/...) for the safe expansion, or `--filter <expr>` for raw EnvFilter syntax. `--get` prints the current filter. Changes are ephemeral and lost on daemon restart
 * `remove` — Remove a session
 * `send` — Send a message to a running agent session
@@ -182,19 +182,16 @@ List all sessions
 
 ## `aoe logs`
 
-View AoE log files (debug.log, serve.log) with a pretty viewer
+View the configured AoE log file with a pretty viewer
 
 **Usage:** `aoe logs [OPTIONS]`
 
 ###### **Options:**
 
-* `--debug` — View debug.log (default)
-* `--serve` — View serve.log (daemon stdout/stderr)
-* `--all` — View both debug.log and serve.log, merged by timestamp
 * `-f`, `--follow` — Live-tail the log
 * `-n`, `--lines <N>` — Show only the last N lines (fallback viewers; lnav handles its own)
 * `--no-pager` — Skip viewer detection; write plain log to stdout
-* `--path` — Print the resolved log file path(s) and exit (no viewing)
+* `--path` — Print the resolved log file path and exit (no viewing)
 
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -24,8 +24,6 @@ AOE_ACP_TRACE=1 cargo run            # Plus raw ACP JSON-RPC firehose; useful fo
                                      # it links a child tool call to a parent Task.
 AOE_TERMINAL_TRACE=1 cargo run       # Plus per-message bytes for the web terminal WS (spammy)
 aoe logs                       # View debug.log via lnav/bat/less (auto-detects)
-aoe logs --serve               # View serve.log (daemon stdout/stderr)
-aoe logs --all --no-pager      # Merge both logs, plain stdout
 aoe logs --path                # Print the resolved log file path
 ```
 
@@ -44,8 +42,7 @@ collisions on sessions, settings, the tmux server, or `aoe serve`.
 | `tmux` session prefix | `aoe_` | `aoe_dev_` |
 | `aoe serve` default port | `8080` | `8081` |
 
-`debug.log` and `serve.log` live inside the app dir, so they are isolated
-automatically. Debug builds start with an empty namespace on first run, so
+`debug.log` lives inside the app dir, so it is isolated automatically. Debug builds start with an empty namespace on first run, so
 nothing migrates from your real `~/.agent-of-empires`. Wipe dev state any
 time with `rm -rf ~/.agent-of-empires-dev` (or the Linux XDG equivalent);
 release data is untouched.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Agent of Empires uses the [`tracing`](https://docs.rs/tracing) crate. The TUI, the `aoe serve` daemon, and the cockpit runner subprocesses all share `src/logging.rs` so they agree on env-var resolution, default filter construction, and the reloadable subscriber handle. TUI and runners append to the same `~/.agent-of-empires/debug.log` so a single tail covers an entire session; `aoe serve` writes to stdout (captured into `serve.log`).
+Agent of Empires uses the [`tracing`](https://docs.rs/tracing) crate. The TUI, the `aoe serve` daemon, the cockpit runner subprocesses, and env-overridden one-shot CLI invocations all share `src/logging.rs` so they agree on env-var resolution, default filter construction, the reloadable subscriber handle, and the sink resolver. Every process appends to the same configured log file (`~/.agent-of-empires/debug.log` by default) so a single tail covers an entire session.
 
 ## Targets
 
@@ -41,15 +41,20 @@ Resolved once at startup in `LogConfig::from_env`:
 
 ## Sinks by process
 
-| Invocation | Filter source | Sink |
-|---|---|---|
-| Any `aoe` with env var set | env | `debug.log` |
-| `aoe serve`, no env | `[logging]` config, else info baseline | stdout (captured into `serve.log` by the daemon redirect) |
-| TUI (`aoe` with no subcommand), no env | `[logging]` config, else info baseline | `debug.log` |
-| Cockpit runner subprocess | env (inherited) → `[logging]` config → info baseline; then `runtime_filter` if the daemon writes one | `debug.log` |
-| Other one-shot CLI, no env | — | no subscriber installed (opt in via `AOE_LOG_LEVEL` if you need a trace of one) |
+One sink resolver (`logging::resolve_sink`) picks where each process writes based on `ProcessContext` + `[logging]`:
 
-The TUI writes to a file rather than stderr because ratatui owns the alt-screen and a stderr subscriber would corrupt it. Daemon + runners + TUI all append to the same `debug.log` so a single tail covers a whole session.
+| Invocation | Context | `output = "stdout"` honored? | Default sink |
+|---|---|---:|---|
+| Any `aoe` with env var set, single-command | `OneShotCli` | yes | configured file (default `debug.log`) |
+| `aoe serve` (foreground) | `ServeForeground` | yes | configured file |
+| `aoe serve --daemon` child | `ServeDaemonChild` | no (coerced to file) | configured file |
+| TUI (`aoe` with no subcommand) | `Tui` | no (coerced to file) | configured file |
+| Cockpit runner subprocess | `Runner` | no (coerced to file) | configured file |
+| Other one-shot CLI, no env | — | n/a | no subscriber |
+
+The TUI, daemon child, and runner coerce because their stdout would corrupt the alt-screen, be detached to /dev/null, or be unreachable. Coercion surfaces a `log.runtime` warning at startup so users see why their `output = "stdout"` didn't apply.
+
+The daemon's stdout/stderr are also redirected at the OS level to the same configured log file. That preserves panic backtraces (and any stray `println!`) alongside the structured tracing stream. An inherited file descriptor may go stale after a mid-run rotation; the daemon keeps writing to the rotated `.1` until restart. This is best-effort, not load-bearing.
 
 ## Persistent configuration (`[logging]` in `config.toml`)
 
@@ -59,6 +64,13 @@ The settings UI (web dashboard *Settings → Logging*, TUI *Settings → Logging
 [logging]
 default_level = "info"
 
+# Sink and rotation knobs (changes require restart):
+output = "file"          # "file" | "stdout"
+file_path = "debug.log"  # relative -> app_dir, absolute -> verbatim
+rotation = "size"        # "size" | "never"
+max_size_mib = 50
+keep_count = 5
+
 [logging.targets]
 "cockpit.acp" = "trace"
 "auth.middleware" = "debug"
@@ -67,7 +79,31 @@ default_level = "info"
 
 `default_level` is the baseline; entries in `targets` override per target. The list of targets surfaced as dropdowns mirrors `KNOWN_SUB_TARGETS` in `src/logging.rs`. Anything else can still be set via raw EnvFilter syntax through the runtime endpoint or CLI.
 
-Changes via the settings UI live-apply through the same `FilterController` swap that powers `aoe log-level`, including propagation to cockpit runners via the `runtime_filter` notify watcher. No daemon restart needed. (The startup precedence is shown in the *Sinks by process* table above: env wins, then `[logging]`, then the info baseline.)
+**Hot-swap vs restart:** `default_level` and `targets` hot-swap through the same `FilterController` that powers `aoe log-level`, including propagation to cockpit runners via the `runtime_filter` notify watcher. No daemon restart needed for filter changes. The sink-shape fields (`output`, `file_path`, `rotation`, `max_size_mib`, `keep_count`) are set once at process startup and require a restart to take effect; the settings UI labels them accordingly.
+
+## Rotation
+
+When `rotation = "size"`, the writer rotates the live file whenever it crosses `max_size_mib`. The rename chain shifts `debug.log.N-1 → .N` down to `keep_count`, then renames the current `debug.log → debug.log.1` and opens a fresh `debug.log`. Older files (`> keep_count`) are dropped.
+
+**Multi-process safety.** The TUI + daemon + cockpit runners + env-overridden CLI invocations may all append to the same `debug.log` concurrently. The writer uses three mechanisms to keep that safe:
+
+1. **`fs2` advisory exclusive lock** on a sidecar `{path}.lock` file serializes the rename chain. The OS releases the lock on process exit, so a crashed rotater never wedges future rotations.
+2. **Inode tracking + reopen.** Each writer remembers the file's inode at open time and re-stats every 16 KiB. If another process rotated the file out from under us, the inode mismatch triggers a reopen so subsequent writes land in the new `debug.log` rather than the archived `.1`.
+3. **Line-buffered writes.** Tracing events accumulate in an internal buffer until a `\n` (or 8 KiB without one); only complete lines pass through the rotation check, so a rotation can never split one event across files.
+
+Set `rotation = "never"` to disable the size threshold entirely. The file grows unbounded; useful for debug sessions where rotation noise would interfere.
+
+## Startup marker
+
+`init_subscriber` writes a raw line to the sink before tracing takes ownership:
+
+```
+2025-08-15T... INFO log.runtime [AOE_START_MARKER] version=1.7.0 pid=12345 exe=/usr/local/bin/aoe
+```
+
+This is filter-immune (it bypasses the tracing subscriber entirely) so it survives any `default_level` setting and gives forensic readers a hard boundary between process runs. A parallel `tracing::info!(target: "log.runtime", "aoe started")` is also emitted once the subscriber is live; it respects the user's filter.
+
+The TUI serve dialog uses captured file-offset-before-spawn (not the marker) to bound its tail pane, so the marker is a forensic / `grep` convenience rather than UI-load-bearing.
 
 ## Runtime control
 
@@ -127,12 +163,16 @@ Not captured (intentional, v1): `console.error`. Wrapping it produces noisy dupl
 
 | Path | When it's written |
 |------|-------------------|
-| `~/.agent-of-empires/debug.log` | TUI, cockpit runners, and any `aoe` invocation with `AOE_LOG_LEVEL` set. `aoe serve` writes its own output to stdout (captured into `serve.log`). |
-| `~/.agent-of-empires/serve.log` | Daemon stdout/stderr tail captured by the `aoe serve --daemon` redirect. |
+| `<configured file_path>` (default `~/.agent-of-empires/debug.log`) | Every process that installs a tracing subscriber (TUI, foreground / daemon `aoe serve`, cockpit runner, env-overridden CLI). The daemon's stdout/stderr is also redirected here at the OS level for panic backtrace capture. |
+| `<configured>.1` ... `<configured>.<keep_count>` | Rotated files, oldest at the highest number. |
+| `<configured>.lock` | Idle `fs2` advisory lock file used to serialize rotation across processes. Always present after the first rotation; do not delete while any aoe process is running. |
 | `~/.agent-of-empires/runtime_filter` | Atomically written on every successful `aoe log-level` swap; consumed by runner watchers. |
-| `~/.agent-of-empires/cockpit-workers/<session-id>.log` | Touched for compatibility; structured tracing now lands in the shared `debug.log`. |
+| `~/.agent-of-empires/cockpit-workers/<session-id>.log` | Touched for compatibility; structured tracing lands in the shared configured log file. |
+| `~/.agent-of-empires/serve.log.legacy` | One-shot rename of the pre-consolidation `serve.log` by migration v007. Safe to delete once you've extracted any data you needed. |
 
 On Linux, replace `~/.agent-of-empires` with `$XDG_CONFIG_HOME/agent-of-empires`. Debug builds use `~/.agent-of-empires-dev` to avoid colliding with an installed release.
+
+The `aoe logs` viewer and the TUI serve dialog both call `logging::resolve_log_path` so the configured `file_path` is the single source of truth. `aoe logs --serve` and `aoe logs --all` were removed when `serve.log` was retired; the current default `debug.log` carries everything.
 
 ## Conventions
 

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -103,6 +103,8 @@ Set `rotation = "never"` to disable the size threshold entirely. The file grows 
 
 This is filter-immune (it bypasses the tracing subscriber entirely) so it survives any `default_level` setting and gives forensic readers a hard boundary between process runs. A parallel `tracing::info!(target: "log.runtime", "aoe started")` is also emitted once the subscriber is live; it respects the user's filter.
 
+When the sink is stdout (foreground `aoe serve` with `output = "stdout"`, or env-overridden one-shot CLI), the marker is written to stdout too. Any tool piping or capturing the output will see the line before any structured event. That is intentional, so a captured stream is grep-compatible with a captured log file.
+
 The TUI serve dialog uses captured file-offset-before-spawn (not the marker) to bound its tail pane, so the marker is a forensic / `grep` convenience rather than UI-load-bearing.
 
 ## Runtime control

--- a/src/cli/definition.rs
+++ b/src/cli/definition.rs
@@ -67,7 +67,7 @@ pub enum Commands {
     #[command(alias = "ls")]
     List(ListArgs),
 
-    /// View AoE log files (debug.log, serve.log) with a pretty viewer
+    /// View the configured AoE log file with a pretty viewer
     Logs(LogsArgs),
 
     /// Get or set the running daemon's log filter at runtime.

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -1,28 +1,16 @@
-//! `aoe logs` - view AoE log files (debug.log, serve.log) with a pretty viewer.
+//! `aoe logs` - view the configured AoE log file with a pretty viewer.
 //!
-//! Resolves the right path under the app data dir, picks the best available
+//! Resolves the path from `[logging].file_path`, picks the best available
 //! viewer (lnav > bat > less > plain stdout), and prints a one-line tip when
 //! `lnav` is missing so users know there's a better experience available.
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::Args;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 #[derive(Args)]
 pub struct LogsArgs {
-    /// View debug.log (default).
-    #[arg(long, conflicts_with_all = ["serve", "all"])]
-    pub debug: bool,
-
-    /// View serve.log (daemon stdout/stderr).
-    #[arg(long, conflicts_with_all = ["debug", "all"])]
-    pub serve: bool,
-
-    /// View both debug.log and serve.log, merged by timestamp.
-    #[arg(long, conflicts_with_all = ["debug", "serve"])]
-    pub all: bool,
-
     /// Live-tail the log.
     #[arg(short = 'f', long)]
     pub follow: bool,
@@ -35,7 +23,7 @@ pub struct LogsArgs {
     #[arg(long)]
     pub no_pager: bool,
 
-    /// Print the resolved log file path(s) and exit (no viewing).
+    /// Print the resolved log file path and exit (no viewing).
     #[arg(long)]
     pub path: bool,
 }
@@ -48,20 +36,14 @@ pub enum Viewer {
     PlainStdout,
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-enum Mode {
-    Debug,
-    Serve,
-    All,
-}
-
-fn debug_log_path() -> Result<PathBuf> {
-    Ok(crate::session::get_app_dir()?.join("debug.log"))
-}
-
-#[cfg(feature = "serve")]
-fn serve_log_path() -> Result<PathBuf> {
-    crate::cli::serve::daemon_log_path()
+fn resolved_log_path() -> Result<PathBuf> {
+    let dir = crate::session::get_app_dir()?;
+    let cfg = crate::session::load_config()
+        .ok()
+        .flatten()
+        .map(|c| c.logging)
+        .unwrap_or_default();
+    Ok(crate::logging::resolve_log_path(&cfg, &dir))
 }
 
 pub fn detect_viewer(no_pager: bool) -> Viewer {
@@ -90,59 +72,16 @@ fn viewer_name(v: Viewer) -> &'static str {
 }
 
 pub async fn run(args: LogsArgs) -> Result<()> {
-    let mode = if args.serve {
-        Mode::Serve
-    } else if args.all {
-        Mode::All
-    } else {
-        Mode::Debug
-    };
-
-    #[cfg(not(feature = "serve"))]
-    if matches!(mode, Mode::Serve | Mode::All) {
-        bail!(
-            "--serve and --all need a build with the `serve` feature; \
-             this binary was built without it. Use `--debug` (default) for debug.log."
-        );
-    }
-
-    let paths = resolve_paths(mode)?;
+    let target_path = resolved_log_path()?;
 
     if args.path {
-        for p in &paths {
-            println!("{}", p.display());
-        }
+        println!("{}", target_path.display());
         return Ok(());
     }
 
-    if args.follow && mode == Mode::All {
-        bail!("--follow is not supported with --all; pick --debug or --serve.");
-    }
-
-    // For --all, materialize a merged stream into a temp file and view that.
-    // _guard keeps the tempfile alive for the duration of the viewer. If no
-    // source file exists, print does-not-exist hints rather than opening an
-    // empty viewer, matching the --debug/--serve behavior below.
-    let (target_path, _guard) = match mode {
-        Mode::All => {
-            if paths.iter().all(|p| !p.exists()) {
-                for p in &paths {
-                    eprintln!("{} does not exist (yet).", p.display());
-                }
-                eprintln!("Tip: run with AGENT_OF_EMPIRES_DEBUG=1 to generate debug.log.");
-                return Ok(());
-            }
-            let merged = merged_temp_file(&paths)?;
-            (merged.path().to_path_buf(), Some(merged))
-        }
-        _ => (paths[0].clone(), None),
-    };
-
     if !target_path.exists() {
         eprintln!("{} does not exist (yet).", target_path.display());
-        if mode == Mode::Debug {
-            eprintln!("Tip: run with AGENT_OF_EMPIRES_DEBUG=1 to generate debug.log.");
-        }
+        eprintln!("Tip: start `aoe` (TUI) or `aoe serve`, or run with AOE_LOG_LEVEL=debug.");
         return Ok(());
     }
 
@@ -156,38 +95,6 @@ pub async fn run(args: LogsArgs) -> Result<()> {
     }
 
     run_viewer(viewer, &target_path, &args)
-}
-
-fn resolve_paths(mode: Mode) -> Result<Vec<PathBuf>> {
-    match mode {
-        Mode::Debug => Ok(vec![debug_log_path()?]),
-        #[cfg(feature = "serve")]
-        Mode::Serve => Ok(vec![serve_log_path()?]),
-        #[cfg(feature = "serve")]
-        Mode::All => Ok(vec![debug_log_path()?, serve_log_path()?]),
-        #[cfg(not(feature = "serve"))]
-        Mode::Serve | Mode::All => unreachable!("bailed earlier when serve feature is off"),
-    }
-}
-
-#[cfg(feature = "serve")]
-fn merged_temp_file(paths: &[PathBuf]) -> Result<tempfile::NamedTempFile> {
-    use std::io::Write;
-    let debug_text = std::fs::read_to_string(&paths[0]).unwrap_or_default();
-    let serve_text = std::fs::read_to_string(&paths[1]).unwrap_or_default();
-    let merged = merge_by_timestamp(&debug_text, &serve_text);
-    let mut tmp = tempfile::Builder::new()
-        .prefix("aoe-logs-merged-")
-        .suffix(".log")
-        .tempfile()?;
-    tmp.write_all(merged.as_bytes())?;
-    tmp.flush()?;
-    Ok(tmp)
-}
-
-#[cfg(not(feature = "serve"))]
-fn merged_temp_file(_paths: &[PathBuf]) -> Result<tempfile::NamedTempFile> {
-    unreachable!("--all requires the serve feature; bailed earlier")
 }
 
 fn run_viewer(viewer: Viewer, path: &Path, args: &LogsArgs) -> Result<()> {
@@ -297,95 +204,6 @@ fn tail_pipe_into(path: &Path, lines: usize, viewer: &mut Command) -> Result<()>
     Ok(())
 }
 
-/// Merge two tracing-formatted log streams by leading ISO-8601 timestamp.
-/// Each emitted line is prefixed with `[debug]` / `[serve]` so the source
-/// is unambiguous after merging. Continuation lines (no leading timestamp,
-/// e.g. multi-line tracing payloads) ride along with their preceding head.
-pub fn merge_by_timestamp(debug: &str, serve: &str) -> String {
-    let mut entries: Vec<(Option<String>, String, &'static str)> = Vec::new();
-    for (ts, body) in group_entries(debug) {
-        entries.push((ts, body, "debug"));
-    }
-    for (ts, body) in group_entries(serve) {
-        entries.push((ts, body, "serve"));
-    }
-    // Stable sort: timestamps strict-ordered; entries without a timestamp
-    // (e.g. orphan continuation at file start) sink to the end.
-    entries.sort_by(|a, b| match (&a.0, &b.0) {
-        (Some(x), Some(y)) => x.cmp(y),
-        (Some(_), None) => std::cmp::Ordering::Less,
-        (None, Some(_)) => std::cmp::Ordering::Greater,
-        (None, None) => std::cmp::Ordering::Equal,
-    });
-
-    let mut out = String::new();
-    for (_ts, body, tag) in entries {
-        for line in body.lines() {
-            out.push('[');
-            out.push_str(tag);
-            out.push_str("] ");
-            out.push_str(line);
-            out.push('\n');
-        }
-    }
-    out
-}
-
-fn group_entries(text: &str) -> Vec<(Option<String>, String)> {
-    let mut out: Vec<(Option<String>, String)> = Vec::new();
-    for line in text.lines() {
-        if let Some(ts) = leading_timestamp(line) {
-            out.push((Some(ts), line.to_string()));
-        } else if let Some(last) = out.last_mut() {
-            last.1.push('\n');
-            last.1.push_str(line);
-        } else {
-            out.push((None, line.to_string()));
-        }
-    }
-    out
-}
-
-/// `tracing-subscriber`'s default formatter prefixes each event with an
-/// ISO-8601 timestamp like `2024-09-12T18:42:11.305812Z`. Detect that
-/// prefix conservatively: if the first 19 chars match the date-time
-/// skeleton, return the full token up to the first whitespace. Otherwise
-/// return None (continuation line, blank line, or non-tracing format).
-fn leading_timestamp(line: &str) -> Option<String> {
-    let bytes = line.as_bytes();
-    if bytes.len() < 19 {
-        return None;
-    }
-    let shape_ok = bytes[0].is_ascii_digit()
-        && bytes[1].is_ascii_digit()
-        && bytes[2].is_ascii_digit()
-        && bytes[3].is_ascii_digit()
-        && bytes[4] == b'-'
-        && bytes[5].is_ascii_digit()
-        && bytes[6].is_ascii_digit()
-        && bytes[7] == b'-'
-        && bytes[8].is_ascii_digit()
-        && bytes[9].is_ascii_digit()
-        && bytes[10] == b'T'
-        && bytes[11].is_ascii_digit()
-        && bytes[12].is_ascii_digit()
-        && bytes[13] == b':'
-        && bytes[14].is_ascii_digit()
-        && bytes[15].is_ascii_digit()
-        && bytes[16] == b':'
-        && bytes[17].is_ascii_digit()
-        && bytes[18].is_ascii_digit();
-    if !shape_ok {
-        return None;
-    }
-    let end = line[19..]
-        .char_indices()
-        .find(|(_, c)| c.is_whitespace())
-        .map(|(i, _)| 19 + i)
-        .unwrap_or(line.len());
-    Some(line[..end].to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -421,75 +239,5 @@ mod tests {
     #[test]
     fn last_n_lines_empty_input() {
         assert_eq!(last_n_lines("", 5), "");
-    }
-
-    #[test]
-    fn leading_timestamp_extracts_iso8601_with_microseconds() {
-        let ts = leading_timestamp("2024-09-12T18:42:11.305812Z  INFO foo: bar");
-        assert_eq!(ts.as_deref(), Some("2024-09-12T18:42:11.305812Z"));
-    }
-
-    #[test]
-    fn leading_timestamp_extracts_iso8601_no_fraction() {
-        let ts = leading_timestamp("2024-09-12T18:42:11Z  INFO foo");
-        assert_eq!(ts.as_deref(), Some("2024-09-12T18:42:11Z"));
-    }
-
-    #[test]
-    fn leading_timestamp_rejects_non_timestamp_lines() {
-        assert_eq!(leading_timestamp("    at src/foo.rs:42"), None);
-        assert_eq!(leading_timestamp(""), None);
-        assert_eq!(leading_timestamp("    panicked at..."), None);
-    }
-
-    #[test]
-    fn merge_by_timestamp_interleaves_two_streams_in_order() {
-        let dbg = "2024-01-01T00:00:01Z  INFO d1\n\
-                   2024-01-01T00:00:03Z  INFO d2\n";
-        let srv = "2024-01-01T00:00:02Z  INFO s1\n\
-                   2024-01-01T00:00:04Z  INFO s2\n";
-        let merged = merge_by_timestamp(dbg, srv);
-        let lines: Vec<&str> = merged.lines().collect();
-        assert_eq!(
-            lines,
-            vec![
-                "[debug] 2024-01-01T00:00:01Z  INFO d1",
-                "[serve] 2024-01-01T00:00:02Z  INFO s1",
-                "[debug] 2024-01-01T00:00:03Z  INFO d2",
-                "[serve] 2024-01-01T00:00:04Z  INFO s2",
-            ]
-        );
-    }
-
-    #[test]
-    fn merge_by_timestamp_preserves_continuation_lines_with_their_head() {
-        // Continuation lines have no leading timestamp; they should attach
-        // to the previous head and travel together when the heads are
-        // re-sorted. Use explicit `\n` to keep the indentation intact (a
-        // `\`-continued raw string would strip the indent).
-        let dbg = "2024-01-01T00:00:01Z  ERROR boom\n    at src/foo.rs:42\n    at src/bar.rs:7\n2024-01-01T00:00:03Z  INFO recover\n";
-        let srv = "2024-01-01T00:00:02Z  INFO between\n";
-        let merged = merge_by_timestamp(dbg, srv);
-        let lines: Vec<&str> = merged.lines().collect();
-        assert_eq!(
-            lines,
-            vec![
-                "[debug] 2024-01-01T00:00:01Z  ERROR boom",
-                "[debug]     at src/foo.rs:42",
-                "[debug]     at src/bar.rs:7",
-                "[serve] 2024-01-01T00:00:02Z  INFO between",
-                "[debug] 2024-01-01T00:00:03Z  INFO recover",
-            ]
-        );
-    }
-
-    #[test]
-    fn merge_by_timestamp_handles_empty_inputs() {
-        assert_eq!(merge_by_timestamp("", ""), "");
-        let only_dbg = "2024-01-01T00:00:01Z  INFO hi\n";
-        assert_eq!(
-            merge_by_timestamp(only_dbg, ""),
-            "[debug] 2024-01-01T00:00:01Z  INFO hi\n"
-        );
     }
 }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -249,7 +249,6 @@ pub fn daemon_pid() -> Option<u32> {
                 let _ = std::fs::remove_file(&path);
                 if let Ok(dir) = crate::session::get_app_dir() {
                     let _ = std::fs::remove_file(dir.join("serve.url"));
-                    let _ = std::fs::remove_file(dir.join("serve.log"));
                     let _ = std::fs::remove_file(dir.join("serve.mode"));
                     let _ = std::fs::remove_file(dir.join("serve.passphrase"));
                 }
@@ -429,7 +428,6 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
             let _ = tokio::fs::remove_file(&path).await;
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
-                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }
@@ -441,9 +439,9 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
 
 /// Path the daemon's stdout/stderr are redirected to. Resolved from the
 /// configured `[logging].file_path` so panic backtraces interleave with
-/// the structured tracing stream rather than going to /dev/null or a
-/// separate `serve.log` (removed). The TUI serve dialog and `aoe logs`
-/// resolve this same path to tail the daemon.
+/// the structured tracing stream. Used by `start_daemon()` for the stdio
+/// redirect, by the TUI serve dialog for the tail pane, and by `aoe logs`
+/// for the viewer target.
 pub fn stdio_redirect_path() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?;
     let log_cfg = crate::session::load_config()
@@ -452,12 +450,6 @@ pub fn stdio_redirect_path() -> Result<PathBuf> {
         .map(|c| c.logging)
         .unwrap_or_default();
     Ok(crate::logging::resolve_log_path(&log_cfg, &dir))
-}
-
-/// Deprecated alias retained until commit 7 (drop serve.log everywhere)
-/// removes the last call sites in `aoe logs` and the TUI serve dialog.
-pub fn daemon_log_path() -> Result<PathBuf> {
-    stdio_redirect_path()
 }
 
 fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
@@ -612,7 +604,6 @@ async fn stop_daemon() -> Result<()> {
             let _ = tokio::fs::remove_file(&path).await;
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
-                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }
@@ -623,7 +614,6 @@ async fn stop_daemon() -> Result<()> {
             tokio::fs::remove_file(&path).await?;
             if let Ok(dir) = crate::session::get_app_dir() {
                 let _ = tokio::fs::remove_file(dir.join("serve.url")).await;
-                let _ = tokio::fs::remove_file(dir.join("serve.log")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.mode")).await;
                 let _ = tokio::fs::remove_file(dir.join("serve.passphrase")).await;
             }

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -694,9 +694,10 @@ fn print_local_status() -> Result<()> {
 
     let mode = read_serve_mode_label().unwrap_or("unknown");
     let urls = read_serve_urls();
-    let log_path = crate::session::get_app_dir()
-        .ok()
-        .map(|d| d.join("serve.log"));
+    // Resolve the configured log path (default debug.log under app_dir).
+    // The daemon's tracing and stdout/stderr both land here post-consolidation;
+    // `serve.log` is retired.
+    let log_path = stdio_redirect_path().ok();
 
     println!("Daemon: running (PID {})", pid);
     println!("Mode:   {}", mode);

--- a/src/cli/serve.rs
+++ b/src/cli/serve.rs
@@ -63,6 +63,14 @@ pub struct ServeArgs {
     /// no display server is reachable on Linux/BSD.
     #[arg(long)]
     pub open: bool,
+
+    /// Internal marker: this invocation is the detached child spawned by
+    /// `--daemon`. Set automatically by `start_daemon()`; never pass by hand.
+    /// Tells `main.rs` to classify the process as `ServeDaemonChild` so the
+    /// sink resolver routes tracing to the configured log file (its
+    /// stdout/stderr are detached). Hidden from `--help`.
+    #[arg(long, hide = true)]
+    pub daemon_child: bool,
 }
 
 impl ServeArgs {
@@ -431,12 +439,25 @@ pub async fn run(profile: &str, args: ServeArgs) -> Result<()> {
     result
 }
 
-/// Path to the daemon's combined stdout/stderr log.
-/// Kept alongside the PID file so the TUI can tail it while the
-/// server runs without attaching to the process directly.
-pub fn daemon_log_path() -> Result<PathBuf> {
+/// Path the daemon's stdout/stderr are redirected to. Resolved from the
+/// configured `[logging].file_path` so panic backtraces interleave with
+/// the structured tracing stream rather than going to /dev/null or a
+/// separate `serve.log` (removed). The TUI serve dialog and `aoe logs`
+/// resolve this same path to tail the daemon.
+pub fn stdio_redirect_path() -> Result<PathBuf> {
     let dir = crate::session::get_app_dir()?;
-    Ok(dir.join("serve.log"))
+    let log_cfg = crate::session::load_config()
+        .ok()
+        .flatten()
+        .map(|c| c.logging)
+        .unwrap_or_default();
+    Ok(crate::logging::resolve_log_path(&log_cfg, &dir))
+}
+
+/// Deprecated alias retained until commit 7 (drop serve.log everywhere)
+/// removes the last call sites in `aoe logs` and the TUI serve dialog.
+pub fn daemon_log_path() -> Result<PathBuf> {
+    stdio_redirect_path()
 }
 
 fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
@@ -446,6 +467,7 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
     let mut cmd = Command::new(exe);
     cmd.args([
         "serve",
+        "--daemon-child",
         "--port",
         &args.resolved_port().to_string(),
         "--host",
@@ -495,15 +517,22 @@ fn start_daemon(profile: &str, args: &ServeArgs) -> Result<()> {
         }
     }
 
-    // Redirect stdout/stderr to a log file so controllers like the TUI can
-    // tail the daemon's output. Truncate on each start so stale content from
-    // a prior run doesn't confuse the UI.
-    let log_path = daemon_log_path().ok();
-    match log_path
-        .as_ref()
-        .and_then(|p| std::fs::File::create(p).ok().map(|f| (p.clone(), f)))
-    {
-        Some((_, log_file)) => {
+    // Route the child's stdout/stderr into the configured log file so panic
+    // backtraces and stray prints land alongside structured tracing rather
+    // than disappearing into /dev/null. The tracing subscriber inside the
+    // child resolves the same path via `logging::resolve_log_path`, so the
+    // two streams interleave in one file. Inherited fds may go stale across
+    // a rotation; that is best-effort behavior documented in
+    // docs/development/logging.md.
+    let stdio_path = stdio_redirect_path().ok();
+    match stdio_path.as_ref().and_then(|p| {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(p)
+            .ok()
+    }) {
+        Some(log_file) => {
             let stdout = log_file.try_clone()?;
             let stderr = log_file;
             cmd.stdout(Stdio::from(stdout)).stderr(Stdio::from(stderr));

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -823,9 +823,9 @@ fn spawn_runner_detached(
     }
 
     // Redirect stdio: the runner writes its own log file. Inheriting our
-    // stdio would (a) pollute serve.log with the per-session noise and
-    // (b) keep a pipe open to the daemon, which then closes when we die,
-    // making the runner observe EOF on its own stdin/stdout.
+    // stdio would (a) pollute the shared debug.log with the per-session
+    // noise and (b) keep a pipe open to the daemon, which then closes
+    // when we die, making the runner observe EOF on its own stdin/stdout.
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -23,7 +23,8 @@
 //!
 //! Logging: the runner appends to
 //! `<app_dir>/cockpit-workers/<session_id>.log` so `aoe cockpit logs
-//! --session <id> --follow` can tail it independently of `serve.log`.
+//! --session <id> --follow` can tail it independently of the shared
+//! `debug.log` that all aoe processes append to.
 //!
 //! ## Why a shim and not "let the agent bind the socket"
 //!

--- a/src/cockpit/runner.rs
+++ b/src/cockpit/runner.rs
@@ -472,7 +472,6 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
     let per_session = worker_registry::log_path_for(session_id)?;
     open_log_file(&per_session)?;
 
-    let shared_path = crate::session::get_app_dir()?.join("debug.log");
     // Same precedence as main.rs: env > [logging] in config.toml > info
     // baseline. The notify watcher on runtime_filter still takes over
     // for live swaps once the daemon writes one.
@@ -481,12 +480,21 @@ fn init_runner_logging(session_id: &str) -> Result<()> {
         .or_else(crate::logging::load_persisted_filter)
         .unwrap_or_else(crate::logging::serve_default_filter);
 
-    let init = crate::logging::init_subscriber(
-        crate::logging::SubscriberTarget::File(shared_path),
-        filter,
-    );
+    let app_dir = crate::session::get_app_dir()?;
+    let log_cfg = crate::session::load_config()
+        .ok()
+        .flatten()
+        .map(|c| c.logging)
+        .unwrap_or_default();
+    let resolution =
+        crate::logging::resolve_sink(&log_cfg, &app_dir, crate::logging::ProcessContext::Runner);
+
+    let init = crate::logging::init_subscriber(resolution.target, filter);
     if let Some(c) = init.controller {
         crate::logging::install_controller(c);
+    }
+    if let Some(w) = resolution.warning {
+        tracing::warn!(target: "log.runtime", "{}", w);
     }
     Ok(())
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -11,16 +11,18 @@
 //! design rather than threading a handle through application state.
 //! `Mutex<Option<Arc<_>>>` (over `OnceLock`) so tests can reset.
 
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
+use fs2::FileExt;
 use tracing_subscriber::filter::EnvFilter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Registry;
 
-use crate::session::config::LoggingConfig;
+use crate::session::config::{LoggingConfig, RotationKind};
 
 /// Which context the running process is in. Drives whether `[logging].output`
 /// is honored or coerced to `File`. Contexts where the stdout sink would
@@ -82,8 +84,31 @@ pub fn resolve_sink(cfg: &LoggingConfig, app_dir: &Path, ctx: ProcessContext) ->
             None
         };
         SinkResolution {
-            target: SubscriberTarget::File(resolve_log_path(cfg, app_dir)),
+            target: SubscriberTarget::File(
+                resolve_log_path(cfg, app_dir),
+                RotationPolicy::from(cfg),
+            ),
             warning,
+        }
+    }
+}
+
+/// Rotation thresholds resolved from `[logging]`. Built once at subscriber
+/// init and held by the `SizeRotatingWriter`; not hot-swappable (sink and
+/// rotation knobs require restart, see `apply_persisted_config`).
+#[derive(Debug, Clone, Copy)]
+pub struct RotationPolicy {
+    pub kind: RotationKind,
+    pub max_size_bytes: u64,
+    pub keep_count: u8,
+}
+
+impl From<&LoggingConfig> for RotationPolicy {
+    fn from(cfg: &LoggingConfig) -> Self {
+        Self {
+            kind: cfg.rotation,
+            max_size_bytes: cfg.max_size_mib.saturating_mul(1024 * 1024),
+            keep_count: cfg.keep_count,
         }
     }
 }
@@ -322,7 +347,7 @@ impl LogConfig {
 }
 
 pub enum SubscriberTarget {
-    File(PathBuf),
+    File(PathBuf, RotationPolicy),
     Stdout,
 }
 
@@ -421,11 +446,17 @@ pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
     let (reload_layer, handle) = reload::Layer::new(parsed);
 
     let install_result = match target {
-        SubscriberTarget::File(path) => match open_log_file(&path) {
-            Ok(file) => {
-                let writer = std::sync::Mutex::new(file);
+        SubscriberTarget::File(path, policy) => match SizeRotatingWriter::new(path.clone(), policy)
+        {
+            Ok(mut writer) => {
+                // Raw marker is written before tracing takes ownership so it
+                // appears in the file even when the user's filter would drop
+                // an info-level event. Forensic boundary; not load-bearing
+                // for the TUI dialog (which uses captured offset).
+                write_raw_startup_marker(&mut writer);
+                let mw = std::sync::Mutex::new(writer);
                 let fmt_layer = tracing_subscriber::fmt::layer()
-                    .with_writer(writer)
+                    .with_writer(mw)
                     .with_ansi(false);
                 Registry::default()
                     .with(reload_layer)
@@ -436,6 +467,9 @@ pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
             Err(e) => Err(format!("open log file {}: {e}", path.display())),
         },
         SubscriberTarget::Stdout => {
+            // Marker on stdout too so a piped foreground serve preserves the
+            // boundary in tools that grep the captured output.
+            write_raw_startup_marker(&mut std::io::stdout());
             let fmt_layer = tracing_subscriber::fmt::layer().with_ansi(false);
             Registry::default()
                 .with(reload_layer)
@@ -451,6 +485,14 @@ pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
                 inner: handle,
                 current: Mutex::new(filter),
             });
+            // Best-effort tracing marker (respects user filter). Cheap to
+            // emit and useful for grep when filter allows info.
+            tracing::info!(
+                target: "log.runtime",
+                version = env!("CARGO_PKG_VERSION"),
+                pid = std::process::id(),
+                "aoe started"
+            );
             InitResult {
                 controller: Some(controller),
                 warning: None,
@@ -463,20 +505,230 @@ pub fn init_subscriber(target: SubscriberTarget, filter: String) -> InitResult {
     }
 }
 
-fn open_log_file(path: &std::path::Path) -> std::io::Result<std::fs::File> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent).ok();
+/// Append a one-line marker directly through the writer before the tracing
+/// subscriber takes it over. Filter-immune so it survives any user level
+/// setting and gives forensic readers a boundary between process runs.
+fn write_raw_startup_marker(writer: &mut dyn Write) {
+    let exe = std::env::current_exe()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let line = format!(
+        "{} INFO log.runtime [AOE_START_MARKER] version={} pid={} exe={}\n",
+        chrono::Utc::now().to_rfc3339(),
+        env!("CARGO_PKG_VERSION"),
+        std::process::id(),
+        exe,
+    );
+    let _ = writer.write_all(line.as_bytes());
+    let _ = writer.flush();
+}
+
+/// Multi-process safe size-based rotating file writer.
+///
+/// - Buffers bytes until `\n` so a rotation never splits one tracing event
+///   across `debug.log` and `debug.log.1`. A pathological 8 KiB without a
+///   newline still flushes to bound memory.
+/// - On every stat-on-tick (16 KiB written or any line >= 16 KiB), checks
+///   whether another process rotated the file out from under us via inode
+///   comparison, and reopens the current path if so.
+/// - When this process needs to rotate (file size >= threshold), takes a
+///   `fs2` advisory lock on `{path}.lock` and rotates under the lock. The
+///   OS releases the lock on process exit, so a crashed rotater never
+///   wedges future rotations. The lockfile is intentionally left on disk
+///   between rotations.
+pub struct SizeRotatingWriter {
+    path: PathBuf,
+    file: std::fs::File,
+    policy: RotationPolicy,
+    fd_inode: u64,
+    bytes_since_stat: u64,
+    line_buf: Vec<u8>,
+}
+
+const STAT_TICK_BYTES: u64 = 16 * 1024;
+const MAX_BUFFERED_LINE: usize = 8 * 1024;
+
+impl SizeRotatingWriter {
+    pub fn new(path: PathBuf, policy: RotationPolicy) -> std::io::Result<Self> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let (file, fd_inode) = Self::open_and_stat(&path)?;
+        let mut writer = Self {
+            path,
+            file,
+            policy,
+            fd_inode,
+            bytes_since_stat: 0,
+            line_buf: Vec::with_capacity(1024),
+        };
+        // Pre-existing oversized file gets rotated at startup so the first
+        // event of a fresh run isn't appended to a stale 50 MiB file.
+        let _ = writer.check_rotation();
+        Ok(writer)
     }
-    let f = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = f.set_permissions(std::fs::Permissions::from_mode(0o600));
+
+    fn open_and_stat(path: &Path) -> std::io::Result<(std::fs::File, u64)> {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let _ = file.set_permissions(std::fs::Permissions::from_mode(0o600));
+        }
+        let meta = file.metadata()?;
+        Ok((file, file_inode(&meta)))
     }
-    Ok(f)
+
+    fn emit_line(&mut self, line: &[u8]) -> std::io::Result<()> {
+        if line.is_empty() {
+            return Ok(());
+        }
+        self.bytes_since_stat = self.bytes_since_stat.saturating_add(line.len() as u64);
+        if self.bytes_since_stat >= STAT_TICK_BYTES || line.len() as u64 >= STAT_TICK_BYTES {
+            let _ = self.check_rotation();
+            self.bytes_since_stat = 0;
+        }
+        self.file.write_all(line)
+    }
+
+    fn check_rotation(&mut self) -> std::io::Result<()> {
+        if matches!(self.policy.kind, RotationKind::Never) {
+            return Ok(());
+        }
+        match std::fs::metadata(&self.path) {
+            Ok(meta) => {
+                let path_inode = file_inode(&meta);
+                if path_inode != self.fd_inode {
+                    // Another process rotated debug.log → debug.log.1 while we
+                    // had it open. Reopen the new current; our fd would
+                    // otherwise keep writing to the now-archived inode.
+                    let (file, ino) = Self::open_and_stat(&self.path)?;
+                    self.file = file;
+                    self.fd_inode = ino;
+                    return Ok(());
+                }
+                if meta.len() >= self.policy.max_size_bytes {
+                    self.try_rotate()?;
+                }
+            }
+            Err(_) => {
+                // Path missing (deleted out from under us). Reopen.
+                let (file, ino) = Self::open_and_stat(&self.path)?;
+                self.file = file;
+                self.fd_inode = ino;
+            }
+        }
+        Ok(())
+    }
+
+    fn try_rotate(&mut self) -> std::io::Result<()> {
+        let lock_path = path_with_suffix(&self.path, ".lock");
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .read(true)
+            .write(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        match lock_file.try_lock_exclusive() {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                // Another process is rotating; let them.
+                return Ok(());
+            }
+            Err(e) => return Err(e),
+        }
+
+        // Re-stat under lock to avoid double-rotation when two processes race
+        // through `check_rotation` simultaneously.
+        let size = std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
+        if size >= self.policy.max_size_bytes {
+            let _ = self.file.sync_all();
+            let keep = self.policy.keep_count;
+            if keep >= 1 {
+                for i in (1..keep).rev() {
+                    let src = path_with_suffix(&self.path, &format!(".{i}"));
+                    let dst = path_with_suffix(&self.path, &format!(".{}", i + 1));
+                    let _ = std::fs::rename(&src, &dst);
+                }
+                let dst = path_with_suffix(&self.path, ".1");
+                let _ = std::fs::rename(&self.path, &dst);
+            } else {
+                // keep_count == 0: drop the current file outright.
+                let _ = std::fs::remove_file(&self.path);
+            }
+            let (file, ino) = Self::open_and_stat(&self.path)?;
+            self.file = file;
+            self.fd_inode = ino;
+        }
+        // fs2 releases the lock when `lock_file` drops. We deliberately
+        // leave the lockfile on disk; removing it races with another
+        // process about to open and lock it.
+        Ok(())
+    }
+}
+
+impl Write for SizeRotatingWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        let mut consumed = 0;
+        while consumed < buf.len() {
+            let rest = &buf[consumed..];
+            match rest.iter().position(|&b| b == b'\n') {
+                Some(idx) => {
+                    self.line_buf.extend_from_slice(&rest[..=idx]);
+                    consumed += idx + 1;
+                    let line = std::mem::take(&mut self.line_buf);
+                    self.emit_line(&line)?;
+                }
+                None => {
+                    self.line_buf.extend_from_slice(rest);
+                    consumed = buf.len();
+                    if self.line_buf.len() >= MAX_BUFFERED_LINE {
+                        let line = std::mem::take(&mut self.line_buf);
+                        self.emit_line(&line)?;
+                    }
+                }
+            }
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        if !self.line_buf.is_empty() {
+            let line = std::mem::take(&mut self.line_buf);
+            self.emit_line(&line)?;
+        }
+        self.file.flush()
+    }
+}
+
+impl Drop for SizeRotatingWriter {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+fn path_with_suffix(path: &Path, suffix: &str) -> PathBuf {
+    let mut s = path.as_os_str().to_os_string();
+    s.push(suffix);
+    PathBuf::from(s)
+}
+
+#[cfg(unix)]
+fn file_inode(meta: &std::fs::Metadata) -> u64 {
+    use std::os::unix::fs::MetadataExt;
+    meta.ino()
+}
+#[cfg(windows)]
+fn file_inode(meta: &std::fs::Metadata) -> u64 {
+    use std::os::windows::fs::MetadataExt;
+    meta.file_index().unwrap_or(0)
+}
+#[cfg(not(any(unix, windows)))]
+fn file_inode(_meta: &std::fs::Metadata) -> u64 {
+    0
 }
 
 static CONTROLLER: Mutex<Option<Arc<FilterController>>> = Mutex::new(None);

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -11,7 +11,7 @@
 //! design rather than threading a handle through application state.
 //! `Mutex<Option<Arc<_>>>` (over `OnceLock`) so tests can reset.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
 use tracing_subscriber::filter::EnvFilter;
@@ -19,6 +19,74 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::reload;
 use tracing_subscriber::util::SubscriberInitExt;
 use tracing_subscriber::Registry;
+
+use crate::session::config::LoggingConfig;
+
+/// Which context the running process is in. Drives whether `[logging].output`
+/// is honored or coerced to `File`. Contexts where the stdout sink would
+/// corrupt the UI (TUI alt-screen) or get discarded (daemon child's
+/// detached stdio, cockpit runner) force the file sink.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProcessContext {
+    Tui,
+    ServeDaemonChild,
+    ServeForeground,
+    Runner,
+    OneShotCli,
+}
+
+/// Output of `resolve_sink`. The `warning` is deferred until after subscriber
+/// init so it can be emitted through tracing rather than dropped silently.
+pub struct SinkResolution {
+    pub target: SubscriberTarget,
+    pub warning: Option<String>,
+}
+
+/// Resolve the configured log file path. Relative `file_path` values join
+/// onto `app_dir`; absolute paths are used verbatim. Used by every site
+/// that names the log file (main, runner, aoe logs, TUI serve dialog).
+pub fn resolve_log_path(cfg: &LoggingConfig, app_dir: &Path) -> PathBuf {
+    let p = Path::new(&cfg.file_path);
+    if p.is_absolute() {
+        p.to_path_buf()
+    } else {
+        app_dir.join(p)
+    }
+}
+
+/// Pick the subscriber sink for this process. `output = "stdout"` is
+/// honored only when the context can safely write to stdout; otherwise
+/// the resolution carries a `warning` describing the coercion so the
+/// caller can emit it through the now-live subscriber.
+pub fn resolve_sink(cfg: &LoggingConfig, app_dir: &Path, ctx: ProcessContext) -> SinkResolution {
+    use crate::session::config::SinkKind;
+
+    let force_file = matches!(
+        ctx,
+        ProcessContext::Tui | ProcessContext::ServeDaemonChild | ProcessContext::Runner
+    );
+    let want_stdout = matches!(cfg.output, SinkKind::Stdout);
+
+    if want_stdout && !force_file {
+        SinkResolution {
+            target: SubscriberTarget::Stdout,
+            warning: None,
+        }
+    } else {
+        let warning = if want_stdout && force_file {
+            Some(format!(
+                "[logging].output = \"stdout\" ignored for {:?} (file required to avoid output corruption)",
+                ctx
+            ))
+        } else {
+            None
+        };
+        SinkResolution {
+            target: SubscriberTarget::File(resolve_log_path(cfg, app_dir)),
+            warning,
+        }
+    }
+}
 
 /// Top-level tracing target roots. The default filter expands a
 /// single level (e.g. "debug") to one directive per root so user-defined

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -105,10 +105,13 @@ pub struct RotationPolicy {
 
 impl From<&LoggingConfig> for RotationPolicy {
     fn from(cfg: &LoggingConfig) -> Self {
+        // Defensive clamp: a hand-edited keep_count = 0 would otherwise yield
+        // a rotation that deletes the only copy. UI fields enforce >= 1; this
+        // makes the invariant hold for any path into the writer.
         Self {
             kind: cfg.rotation,
             max_size_bytes: cfg.max_size_mib.saturating_mul(1024 * 1024),
-            keep_count: cfg.keep_count,
+            keep_count: cfg.keep_count.max(1),
         }
     }
 }
@@ -646,7 +649,11 @@ impl SizeRotatingWriter {
         match lock_file.try_lock_exclusive() {
             Ok(()) => {}
             Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
-                // Another process is rotating; let them.
+                // Another process is rotating; let them. Bounded loss: our fd
+                // still references the file that the winner is about to
+                // rename, so events written before the next stat tick land in
+                // `.1` rather than fresh `debug.log`. The next `check_rotation`
+                // detects the inode mismatch and reopens.
                 return Ok(());
             }
             Err(e) => return Err(e),
@@ -657,18 +664,29 @@ impl SizeRotatingWriter {
         let size = std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0);
         if size >= self.policy.max_size_bytes {
             let _ = self.file.sync_all();
-            let keep = self.policy.keep_count;
-            if keep >= 1 {
-                for i in (1..keep).rev() {
-                    let src = path_with_suffix(&self.path, &format!(".{i}"));
-                    let dst = path_with_suffix(&self.path, &format!(".{}", i + 1));
-                    let _ = std::fs::rename(&src, &dst);
+            let keep = self.policy.keep_count.max(1);
+            for i in (1..keep).rev() {
+                let src = path_with_suffix(&self.path, &format!(".{i}"));
+                let dst = path_with_suffix(&self.path, &format!(".{}", i + 1));
+                let _ = std::fs::rename(&src, &dst);
+            }
+            let dst = path_with_suffix(&self.path, ".1");
+            let _ = std::fs::rename(&self.path, &dst);
+            // Sweep orphan files above the current keep_count: if the user
+            // lowered the threshold between runs, the in-place rename chain
+            // doesn't touch indices > keep. Walk upward until two consecutive
+            // misses to keep the cost bounded.
+            let mut misses = 0;
+            let mut i = u32::from(keep) + 1;
+            while misses < 2 {
+                let p = path_with_suffix(&self.path, &format!(".{i}"));
+                if p.exists() {
+                    let _ = std::fs::remove_file(&p);
+                    misses = 0;
+                } else {
+                    misses += 1;
                 }
-                let dst = path_with_suffix(&self.path, ".1");
-                let _ = std::fs::rename(&self.path, &dst);
-            } else {
-                // keep_count == 0: drop the current file outright.
-                let _ = std::fs::remove_file(&self.path);
+                i += 1;
             }
             let (file, ino) = Self::open_and_stat(&self.path)?;
             self.file = file;
@@ -1185,5 +1203,51 @@ mod tests {
         let _w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
         // .1 should now exist (startup rotation triggered in new()).
         assert!(path.with_extension("log.1").exists());
+    }
+
+    #[test]
+    fn rotation_writer_sweeps_orphans_when_keep_count_reduced() {
+        // User lowered keep_count from 5 to 2 between runs. The rename chain
+        // only touches indices 1..=keep, so .3, .4, .5 would orphan forever
+        // without the sweep.
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        std::fs::write(path.with_extension("log.1"), b"old 1").unwrap();
+        std::fs::write(path.with_extension("log.2"), b"old 2").unwrap();
+        std::fs::write(path.with_extension("log.3"), b"old 3").unwrap();
+        std::fs::write(path.with_extension("log.4"), b"old 4").unwrap();
+        std::fs::write(path.with_extension("log.5"), b"old 5").unwrap();
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: 64,
+            keep_count: 2,
+        };
+        std::fs::write(&path, vec![b'x'; 200]).unwrap();
+        let _w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        // After startup rotation: .1 (was current), .2 (was .1) survive.
+        assert!(path.with_extension("log.1").exists(), ".1 must exist");
+        assert!(path.with_extension("log.2").exists(), ".2 must exist");
+        assert!(
+            !path.with_extension("log.3").exists(),
+            ".3 must be swept by orphan sweep"
+        );
+        assert!(
+            !path.with_extension("log.4").exists(),
+            ".4 must be swept by orphan sweep"
+        );
+        assert!(
+            !path.with_extension("log.5").exists(),
+            ".5 must be swept by orphan sweep"
+        );
+    }
+
+    #[test]
+    fn rotation_policy_clamps_keep_count_zero_to_one() {
+        // Defense-in-depth: a hand-edited config with keep_count = 0 would
+        // otherwise yield a writer that deletes the only copy on rotation.
+        let mut cfg = make_cfg(RotationKind::Size, 50, 0);
+        cfg.keep_count = 0;
+        let policy = RotationPolicy::from(&cfg);
+        assert_eq!(policy.keep_count, 1, "keep_count=0 must clamp to 1");
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -171,6 +171,13 @@ pub const KNOWN_SUB_TARGETS: &[&str] = &[
 /// Both the TUI save path and the web `PATCH /api/settings` path call
 /// this after `save_config`, so settings changes take effect live
 /// without a daemon restart.
+///
+/// Only the filter (default_level plus per-target overrides) hot-swaps.
+/// Sink-shape knobs (output, file_path, rotation, max_size_mib, keep_count)
+/// require a process restart: the tracing subscriber is a global singleton
+/// installed once at startup, and the rotating writer holds its policy
+/// and file handle for the life of the process. The settings UI surfaces
+/// a restart hint when those fields change.
 pub fn apply_persisted_config(
     default_level: &str,
     targets: &std::collections::BTreeMap<String, String>,
@@ -587,7 +594,11 @@ impl SizeRotatingWriter {
             return Ok(());
         }
         self.bytes_since_stat = self.bytes_since_stat.saturating_add(line.len() as u64);
-        if self.bytes_since_stat >= STAT_TICK_BYTES || line.len() as u64 >= STAT_TICK_BYTES {
+        // Stat every STAT_TICK_BYTES OR when accumulated bytes start
+        // approaching the threshold (so a small max_size_bytes doesn't get
+        // overshot N× before the stat tick fires).
+        let tick = STAT_TICK_BYTES.min(self.policy.max_size_bytes / 4).max(1);
+        if self.bytes_since_stat >= tick || line.len() as u64 >= tick {
             let _ = self.check_rotation();
             self.bytes_since_stat = 0;
         }
@@ -1011,5 +1022,168 @@ mod tests {
                 LogFilterError::Invalid(_)
             ));
         });
+    }
+
+    fn make_cfg(rotation: RotationKind, max_mib: u64, keep: u8) -> LoggingConfig {
+        LoggingConfig {
+            default_level: "info".into(),
+            targets: Default::default(),
+            output: crate::session::config::SinkKind::File,
+            file_path: "debug.log".into(),
+            rotation,
+            max_size_mib: max_mib,
+            keep_count: keep,
+        }
+    }
+
+    #[test]
+    fn resolve_log_path_relative_joins_app_dir() {
+        let cfg = make_cfg(RotationKind::Size, 50, 5);
+        let dir = std::path::PathBuf::from("/tmp/aoe-test");
+        assert_eq!(resolve_log_path(&cfg, &dir), dir.join("debug.log"));
+    }
+
+    #[test]
+    fn resolve_log_path_absolute_used_verbatim() {
+        let mut cfg = make_cfg(RotationKind::Size, 50, 5);
+        cfg.file_path = "/var/log/aoe.log".into();
+        let dir = std::path::PathBuf::from("/tmp/aoe-test");
+        assert_eq!(
+            resolve_log_path(&cfg, &dir),
+            std::path::PathBuf::from("/var/log/aoe.log")
+        );
+    }
+
+    #[test]
+    fn resolve_sink_tui_with_stdout_coerces_to_file_with_warning() {
+        let mut cfg = make_cfg(RotationKind::Size, 50, 5);
+        cfg.output = crate::session::config::SinkKind::Stdout;
+        let dir = std::path::PathBuf::from("/tmp/aoe-test");
+        let r = resolve_sink(&cfg, &dir, ProcessContext::Tui);
+        assert!(matches!(r.target, SubscriberTarget::File(_, _)));
+        assert!(r.warning.is_some(), "coercion should surface a warning");
+    }
+
+    #[test]
+    fn resolve_sink_serve_foreground_honors_stdout() {
+        let mut cfg = make_cfg(RotationKind::Size, 50, 5);
+        cfg.output = crate::session::config::SinkKind::Stdout;
+        let dir = std::path::PathBuf::from("/tmp/aoe-test");
+        let r = resolve_sink(&cfg, &dir, ProcessContext::ServeForeground);
+        assert!(matches!(r.target, SubscriberTarget::Stdout));
+        assert!(r.warning.is_none());
+    }
+
+    #[test]
+    fn rotation_writer_rotates_at_threshold() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        // 4 KiB threshold so the test runs fast.
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: 4 * 1024,
+            keep_count: 3,
+        };
+        let mut w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        // Write 5 KiB worth of one-line events; each line forces stat-on-tick
+        // when crossing 16 KiB but actual size check uses metadata so the
+        // 4 KiB threshold triggers on the first oversized stat.
+        for i in 0..200 {
+            writeln!(&mut w, "line {i:050}").unwrap();
+        }
+        w.flush().unwrap();
+        drop(w);
+        let rotated = path.with_extension("log.1");
+        assert!(rotated.exists(), "expected rotated file at {:?}", rotated);
+    }
+
+    #[test]
+    fn rotation_writer_keeps_at_most_keep_count() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        // Seed pre-existing rotated files to simulate prior rotations.
+        std::fs::write(path.with_extension("log.1"), b"old 1").unwrap();
+        std::fs::write(path.with_extension("log.2"), b"old 2").unwrap();
+        std::fs::write(path.with_extension("log.3"), b"old 3").unwrap();
+        // Threshold low enough to rotate on first emit.
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: 64,
+            keep_count: 3,
+        };
+        std::fs::write(&path, vec![b'x'; 200]).unwrap();
+        let mut w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        writeln!(&mut w, "trigger rotation now padded out to be large enough").unwrap();
+        w.flush().unwrap();
+        drop(w);
+        // .1, .2, .3 should exist; .4 should NOT.
+        assert!(
+            !path.with_extension("log.4").exists(),
+            "keep_count=3 must drop .4"
+        );
+    }
+
+    #[test]
+    fn rotation_writer_never_keeps_file_alone_when_disabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        let policy = RotationPolicy {
+            kind: RotationKind::Never,
+            max_size_bytes: 64,
+            keep_count: 3,
+        };
+        let mut w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        for _ in 0..100 {
+            writeln!(&mut w, "filler line that pushes well past 64 bytes here").unwrap();
+        }
+        w.flush().unwrap();
+        drop(w);
+        assert!(
+            !path.with_extension("log.1").exists(),
+            "rotation=never must not produce .1"
+        );
+        let size = std::fs::metadata(&path).unwrap().len();
+        assert!(size > 64, "file should have grown past threshold");
+    }
+
+    #[test]
+    fn rotation_writer_line_buffers_across_partial_writes() {
+        // Simulate the multi-write pattern from `tracing-subscriber::fmt`:
+        // two write() calls for the same logical event. Ensure both halves
+        // land in the same line (no rotation can split mid-line).
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: 1024 * 1024,
+            keep_count: 3,
+        };
+        let mut w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        w.write_all(b"first half ").unwrap();
+        w.write_all(b"second half\n").unwrap();
+        w.flush().unwrap();
+        drop(w);
+        let contents = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            contents.contains("first half second half\n"),
+            "split write should re-coalesce in one line, got: {:?}",
+            contents
+        );
+    }
+
+    #[test]
+    fn rotation_writer_startup_rotates_oversize_existing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("debug.log");
+        // Pre-seed oversized file.
+        std::fs::write(&path, vec![b'x'; 200]).unwrap();
+        let policy = RotationPolicy {
+            kind: RotationKind::Size,
+            max_size_bytes: 64,
+            keep_count: 3,
+        };
+        let _w = SizeRotatingWriter::new(path.clone(), policy).unwrap();
+        // .1 should now exist (startup rotation triggered in new()).
+        assert!(path.with_extension("log.1").exists());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,7 +92,7 @@ async fn main() -> Result<()> {
                     .unwrap_or_default();
                 let resolution = logging::resolve_sink(&log_cfg, &app_dir, ctx);
                 let path_for_msg = match &resolution.target {
-                    SubscriberTarget::File(p) => Some(p.clone()),
+                    SubscriberTarget::File(p, _) => Some(p.clone()),
                     SubscriberTarget::Stdout => None,
                 };
                 let res = logging::init_subscriber(resolution.target, filter);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,23 @@ fn is_serve_command(_cli: &Cli) -> bool {
     false
 }
 
+/// Did the parent `aoe serve --daemon` spawn this process as the detached
+/// child? Set by `start_daemon()` via the hidden `--daemon-child` flag.
+/// Drives sink resolution: child's stdout/stderr are redirected to the
+/// configured log file, so tracing must also write there (a Stdout sink
+/// would land bytes in the same file via the OS redirect, but mixing two
+/// writers on the same fd hurts ordering, and the configured-sink path
+/// is what the TUI dialog and `aoe logs` tail).
+#[cfg(feature = "serve")]
+fn is_serve_daemon_child(cli: &Cli) -> bool {
+    matches!(cli.command, Some(Commands::Serve(ref args)) if args.daemon_child)
+}
+
+#[cfg(not(feature = "serve"))]
+fn is_serve_daemon_child(_cli: &Cli) -> bool {
+    false
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -40,9 +57,12 @@ async fn main() -> Result<()> {
     let env_cfg = LogConfig::from_env();
     let env_filter = env_cfg.filter_string();
     let is_serve = is_serve_command(&cli);
+    let is_daemon_child = is_serve_daemon_child(&cli);
     let is_tui = cli.command.is_none();
 
-    let ctx = if is_serve {
+    let ctx = if is_daemon_child {
+        ProcessContext::ServeDaemonChild
+    } else if is_serve {
         ProcessContext::ServeForeground
     } else if is_tui {
         ProcessContext::Tui

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 //! Agent of Empires - Terminal session manager for AI coding agents
 
 use agent_of_empires::cli::{self, Cli, Commands};
-use agent_of_empires::logging::{self, LogConfig, SubscriberTarget};
+use agent_of_empires::logging::{self, LogConfig, ProcessContext, SubscriberTarget};
 use agent_of_empires::migrations;
 use agent_of_empires::tui;
 use anyhow::Result;
@@ -32,69 +32,67 @@ async fn main() -> Result<()> {
     let debug_namespace_drift = agent_of_empires::session::debug_namespace_drift();
 
     let mut debug_log_warning: Option<String> = None;
-    // Logging gate. Env-var matrix lives in `LogConfig::from_env`:
-    //   AOE_LOG_LEVEL=trace|debug|info|warn|error   (preferred)
-    //   AGENT_OF_EMPIRES_DEBUG=1                    (legacy alias for debug)
-    //   AOE_ACP_TRACE=1                             (raw JSON-RPC firehose)
-    //   AOE_TERMINAL_TRACE=1                        (per-byte WS firehose)
-    //
-    // Sinks by process:
-    //   env set, any aoe → debug.log (file)
-    //   aoe serve, no env → stdout (captured into serve.log by the daemon
-    //     redirect; foreground serve writes to the user's terminal)
-    //   TUI (no subcommand), no env → debug.log (stderr would garble the
-    //     alt-screen, so we always write to file)
-    //   other one-shot CLI, no env → no subscriber (short-lived; opt in
-    //     via AOE_LOG_LEVEL if you need a trace of one)
+    // Subscriber installation. One resolver picks the sink based on
+    // `ProcessContext` + `[logging]` config (see `logging::resolve_sink`).
+    // Filter precedence: env (AOE_LOG_LEVEL / AGENT_OF_EMPIRES_DEBUG /
+    // overlay vars) > `[logging]` config > info baseline. See
+    // `docs/development/logging.md` for the sink and filter matrix.
     let env_cfg = LogConfig::from_env();
     let env_filter = env_cfg.filter_string();
     let is_serve = is_serve_command(&cli);
     let is_tui = cli.command.is_none();
-    let (init, log_path_for_msg) = if let Some(filter) = env_filter {
-        // Env-var wins for every aoe invocation. Writes file logs so a
-        // foreground TUI isn't garbled.
-        let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
-        match log_path.as_ref() {
-            Ok(path) => {
-                let res = logging::init_subscriber(SubscriberTarget::File(path.clone()), filter);
-                (res, Some(path.clone()))
-            }
-            Err(_) => (
-                logging::InitResult {
-                    controller: None,
-                    warning: Some(
-                        "Log level requested but app dir unavailable; file logging disabled."
-                            .to_string(),
-                    ),
-                },
-                None,
-            ),
-        }
-    } else if is_serve {
-        // Persistent settings (config.toml [logging]) drive the filter when
-        // no env var is set. Falls back to info baseline if the config can't
-        // be read — daemon must always come up.
-        let filter = logging::load_persisted_filter().unwrap_or_else(logging::serve_default_filter);
-        (
-            logging::init_subscriber(SubscriberTarget::Stdout, filter),
-            None,
-        )
+
+    let ctx = if is_serve {
+        ProcessContext::ServeForeground
     } else if is_tui {
-        // Same filter source as `aoe serve`, but sink is the shared
-        // debug.log because ratatui owns the alt-screen and a stderr
-        // subscriber would corrupt the UI. Daemon + runners + TUI all
-        // append to the same file so a single tail covers a session.
-        let filter = logging::load_persisted_filter().unwrap_or_else(logging::serve_default_filter);
-        let log_path = agent_of_empires::session::get_app_dir().map(|d| d.join("debug.log"));
-        match log_path.as_ref() {
-            Ok(path) => {
-                let res = logging::init_subscriber(SubscriberTarget::File(path.clone()), filter);
-                (res, Some(path.clone()))
+        ProcessContext::Tui
+    } else {
+        ProcessContext::OneShotCli
+    };
+
+    // One-shot CLI without an env override gets no subscriber: short-lived,
+    // not worth the overhead. Opt in via `AOE_LOG_LEVEL=...`.
+    let should_init = matches!(
+        ctx,
+        ProcessContext::Tui | ProcessContext::ServeForeground | ProcessContext::ServeDaemonChild
+    ) || env_filter.is_some();
+
+    let (init, log_path_for_msg) = if should_init {
+        let filter = env_filter
+            .clone()
+            .or_else(logging::load_persisted_filter)
+            .unwrap_or_else(logging::serve_default_filter);
+
+        match agent_of_empires::session::get_app_dir() {
+            Ok(app_dir) => {
+                let log_cfg = agent_of_empires::session::load_config()
+                    .ok()
+                    .flatten()
+                    .map(|c| c.logging)
+                    .unwrap_or_default();
+                let resolution = logging::resolve_sink(&log_cfg, &app_dir, ctx);
+                let path_for_msg = match &resolution.target {
+                    SubscriberTarget::File(p) => Some(p.clone()),
+                    SubscriberTarget::Stdout => None,
+                };
+                let res = logging::init_subscriber(resolution.target, filter);
+                if let Some(w) = resolution.warning {
+                    // Emit through the subscriber that just came up.
+                    tracing::warn!(target: "log.runtime", "{}", w);
+                }
+                (res, path_for_msg)
             }
             Err(_) => (
                 logging::InitResult {
                     controller: None,
-                    warning: None,
+                    warning: if env_filter.is_some() {
+                        Some(
+                            "Log level requested but app dir unavailable; file logging disabled."
+                                .to_string(),
+                        )
+                    } else {
+                        None
+                    },
                 },
                 None,
             ),
@@ -108,6 +106,7 @@ async fn main() -> Result<()> {
             None,
         )
     };
+
     if let Some(c) = init.controller.clone() {
         logging::install_controller(c);
     }

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -14,13 +14,14 @@ mod v003_yolo_mode_config;
 mod v004_unified_environment;
 mod v005_cockpit_defaults;
 mod v006_unlimited_cockpit_history;
+mod v007_serve_log_to_legacy;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 6;
+const CURRENT_VERSION: u32 = 7;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -59,6 +60,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 6,
         name: "unlimited_cockpit_history",
         run: v006_unlimited_cockpit_history::run,
+    },
+    Migration {
+        version: 7,
+        name: "serve_log_to_legacy",
+        run: v007_serve_log_to_legacy::run,
     },
 ];
 

--- a/src/migrations/v007_serve_log_to_legacy.rs
+++ b/src/migrations/v007_serve_log_to_legacy.rs
@@ -1,0 +1,82 @@
+//! Migration v007: rename leftover `serve.log` to `serve.log.legacy`.
+//!
+//! The serve.log file was retired when foreground and daemon `aoe serve`
+//! consolidated onto the configured `[logging].file_path` (debug.log by
+//! default). Existing users have a serve.log file from before the upgrade;
+//! we rename it to `.legacy` so the bytes aren't lost but `aoe logs` and
+//! the TUI dialog no longer try to read it. Idempotent: skips when there
+//! is no serve.log to move.
+
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+use tracing::{debug, info};
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+    run_in(&app_dir)
+}
+
+pub(crate) fn run_in(app_dir: &Path) -> Result<()> {
+    let src = app_dir.join("serve.log");
+    if !src.exists() {
+        debug!("no serve.log to migrate");
+        return Ok(());
+    }
+    let dst = app_dir.join("serve.log.legacy");
+    // Best-effort overwrite: if a prior migration left a `.legacy`, drop it
+    // first so the rename can succeed.
+    if dst.exists() {
+        let _ = fs::remove_file(&dst);
+    }
+    fs::rename(&src, &dst)?;
+    info!(
+        target: "migrations",
+        from = %src.display(),
+        to = %dst.display(),
+        "renamed legacy serve.log; logging consolidated under [logging].file_path"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn renames_serve_log_to_legacy() {
+        let temp = tempfile::tempdir().unwrap();
+        let src = temp.path().join("serve.log");
+        fs::write(&src, "old daemon output\n").unwrap();
+
+        run_in(temp.path()).unwrap();
+
+        assert!(!src.exists(), "serve.log should be gone");
+        let legacy = temp.path().join("serve.log.legacy");
+        assert!(legacy.exists(), "serve.log.legacy should exist");
+        assert_eq!(fs::read_to_string(&legacy).unwrap(), "old daemon output\n");
+    }
+
+    #[test]
+    fn noop_when_no_serve_log() {
+        let temp = tempfile::tempdir().unwrap();
+        run_in(temp.path()).unwrap();
+        assert!(!temp.path().join("serve.log.legacy").exists());
+    }
+
+    #[test]
+    fn idempotent_with_existing_legacy() {
+        let temp = tempfile::tempdir().unwrap();
+        fs::write(temp.path().join("serve.log"), "new bytes\n").unwrap();
+        fs::write(temp.path().join("serve.log.legacy"), "old bytes\n").unwrap();
+
+        run_in(temp.path()).unwrap();
+
+        // Running again with no serve.log present should be a no-op.
+        run_in(temp.path()).unwrap();
+        assert_eq!(
+            fs::read_to_string(temp.path().join("serve.log.legacy")).unwrap(),
+            "new bytes\n"
+        );
+    }
+}

--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -257,10 +257,10 @@ impl TunnelHandle {
 
         // Spawn drain tasks for both streams. Tailscale emits progress
         // on stderr (most useful for diagnosing hangs); logged at info!
-        // so daemons writing to serve.log show it in the TUI Starting
-        // screen without needing AGENT_OF_EMPIRES_DEBUG=1. Stdout stays
-        // at debug! because Tailscale rarely prints there and the lines
-        // that do appear are noisier.
+        // so the TUI Starting screen surfaces it when tailing the
+        // configured log file, without needing AGENT_OF_EMPIRES_DEBUG=1.
+        // Stdout stays at debug! because Tailscale rarely prints there
+        // and the lines that do appear are noisier.
         //
         // Do NOT override the `target` on these log macros: the
         // EnvFilter uses `agent_of_empires=debug`, which matches the

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -86,6 +86,51 @@ pub struct LoggingConfig {
 
     #[serde(default)]
     pub targets: std::collections::BTreeMap<String, String>,
+
+    /// Where tracing output goes. `File` is the default; `Stdout` is only
+    /// honored for foreground `aoe serve` and env-overridden one-shot CLI
+    /// invocations. TUI, daemon child, and cockpit runners coerce to `File`
+    /// because their alt-screen / detached-stdio would otherwise corrupt or
+    /// discard the output.
+    #[serde(default)]
+    pub output: SinkKind,
+
+    /// Log file location. Relative paths resolve under the app data dir;
+    /// absolute paths are used verbatim. Defaults to `debug.log`.
+    #[serde(default = "default_file_path")]
+    pub file_path: String,
+
+    /// Rotation policy. `Size` rotates when the live file crosses
+    /// `max_size_mib`; `Never` disables rotation.
+    #[serde(default)]
+    pub rotation: RotationKind,
+
+    /// Size threshold (MiB) for `RotationKind::Size`. The file may
+    /// overshoot the threshold slightly between stat checks; bounded by
+    /// the writer's stat-on-tick interval.
+    #[serde(default = "default_max_size_mib")]
+    pub max_size_mib: u64,
+
+    /// How many rotated files to retain (`.1` through `.keep_count`).
+    /// Older rotations are dropped.
+    #[serde(default = "default_keep_count")]
+    pub keep_count: u8,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SinkKind {
+    #[default]
+    File,
+    Stdout,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RotationKind {
+    #[default]
+    Size,
+    Never,
 }
 
 impl Default for LoggingConfig {
@@ -93,12 +138,29 @@ impl Default for LoggingConfig {
         Self {
             default_level: default_log_level(),
             targets: std::collections::BTreeMap::new(),
+            output: SinkKind::default(),
+            file_path: default_file_path(),
+            rotation: RotationKind::default(),
+            max_size_mib: default_max_size_mib(),
+            keep_count: default_keep_count(),
         }
     }
 }
 
 fn default_log_level() -> String {
     "info".to_string()
+}
+
+fn default_file_path() -> String {
+    "debug.log".to_string()
+}
+
+fn default_max_size_mib() -> u64 {
+    50
+}
+
+fn default_keep_count() -> u8 {
+    5
 }
 
 /// Configuration for the cockpit (ACP-based native rendering of agent
@@ -1661,5 +1723,54 @@ mod tests {
 
         let serialized = toml::to_string(&parsed).unwrap();
         assert!(serialized.contains(r#"container_runtime = "podman""#));
+    }
+
+    #[test]
+    fn logging_config_old_shape_populates_new_defaults() {
+        // Existing user configs predate output/file_path/rotation; their
+        // [logging] section is just default_level + targets. The new fields
+        // must populate from serde defaults rather than failing to parse.
+        let toml_str = r#"
+default_level = "debug"
+
+[targets]
+"cockpit.acp" = "trace"
+"#;
+        let parsed: LoggingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.default_level, "debug");
+        assert_eq!(
+            parsed.targets.get("cockpit.acp"),
+            Some(&"trace".to_string())
+        );
+        assert_eq!(parsed.output, SinkKind::File);
+        assert_eq!(parsed.file_path, "debug.log");
+        assert_eq!(parsed.rotation, RotationKind::Size);
+        assert_eq!(parsed.max_size_mib, 50);
+        assert_eq!(parsed.keep_count, 5);
+    }
+
+    #[test]
+    fn logging_config_new_shape_round_trip() {
+        let toml_str = r#"
+default_level = "info"
+output = "stdout"
+file_path = "/tmp/aoe.log"
+rotation = "never"
+max_size_mib = 100
+keep_count = 10
+
+[targets]
+"#;
+        let parsed: LoggingConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.output, SinkKind::Stdout);
+        assert_eq!(parsed.file_path, "/tmp/aoe.log");
+        assert_eq!(parsed.rotation, RotationKind::Never);
+        assert_eq!(parsed.max_size_mib, 100);
+        assert_eq!(parsed.keep_count, 10);
+
+        let serialized = toml::to_string(&parsed).unwrap();
+        let reparsed: LoggingConfig = toml::from_str(&serialized).unwrap();
+        assert_eq!(reparsed.output, SinkKind::Stdout);
+        assert_eq!(reparsed.rotation, RotationKind::Never);
     }
 }

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -197,7 +197,7 @@ fn forget_passphrase_in_memory() {
 
 /// How long we wait for `serve.url` to appear after spawning the daemon.
 const TUNNEL_STARTUP_TIMEOUT_SECS: u64 = 60;
-/// How much of `serve.log` to keep in memory for the tail pane.
+/// How much of the configured log file to keep in memory for the tail pane.
 const LOG_TAIL_LINES: usize = 200;
 
 pub enum ServeViewState {
@@ -231,9 +231,10 @@ pub enum ServeViewState {
     },
     /// We issued `aoe serve --daemon`; now polling `serve.url`.
     /// `passphrase` is Some only for Tunnel spawns from this TUI.
-    /// `log_tail` is a rolling window of the daemon's serve.log so the
-    /// user sees real progress during the 30-60s cert-provisioning
-    /// wait on a fresh Tailscale node instead of a frozen screen.
+    /// `log_tail` is a rolling window of the configured log file (since the
+    /// captured offset taken before spawn) so the user sees real progress
+    /// during the 30-60s cert-provisioning wait on a fresh Tailscale node
+    /// instead of a frozen screen.
     Starting {
         mode: ServeMode,
         /// Remembered for restart. None for Local mode or external daemons.
@@ -899,7 +900,7 @@ impl ServeView {
                 log_tail,
                 log_offset,
             } => {
-                // Tail the daemon's serve.log so the user watches real
+                // Tail the configured log file so the user watches real
                 // progress (cert generation, tunnel handshake, etc.)
                 // during the 30-60s wait instead of a frozen screen.
                 let log_changed = append_new_log_lines(log_tail, log_offset);
@@ -1143,8 +1144,9 @@ fn spawn_daemon(
         }
     }
     cmd.stdin(std::process::Stdio::null())
-        // The daemon path forks and logs to serve.log; we only need its
-        // exit status here (it's synchronous since it just double-forks).
+        // The daemon path forks; the child's tracing + stdio land in the
+        // configured log file via stdio_redirect_path. We only need this
+        // wrapper's exit status (synchronous, just double-forks).
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null());
 
@@ -1289,7 +1291,7 @@ fn load_or_generate_port() -> u16 {
 }
 
 fn log_file_path() -> Option<PathBuf> {
-    crate::cli::serve::daemon_log_path().ok()
+    crate::cli::serve::stdio_redirect_path().ok()
 }
 
 fn log_file_size() -> u64 {
@@ -1307,8 +1309,19 @@ fn initial_log_tail() -> Vec<String> {
         return Vec::new();
     };
     let all: Vec<&str> = contents.lines().collect();
-    let start = all.len().saturating_sub(LOG_TAIL_LINES);
-    all[start..].iter().map(|s| s.to_string()).collect()
+    // debug.log carries TUI + runner + daemon lines now that serve.log is
+    // gone. Anchor the initial tail at the last [AOE_START_MARKER] (written
+    // by `init_subscriber` for every process) so we show the current
+    // daemon's run rather than mixed history. Falls back to the trailing
+    // window when no marker is found.
+    let anchor = all
+        .iter()
+        .rposition(|line| line.contains("[AOE_START_MARKER]"))
+        .unwrap_or_else(|| all.len().saturating_sub(LOG_TAIL_LINES));
+    let from = anchor.min(all.len());
+    let window = &all[from..];
+    let start = window.len().saturating_sub(LOG_TAIL_LINES);
+    window[start..].iter().map(|s| s.to_string()).collect()
 }
 
 /// Read any new bytes appended to the log file since `offset` and push the
@@ -2580,7 +2593,7 @@ mod tests {
     #[test]
     fn append_new_log_lines_initial_read() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("serve.log");
+        let path = tmp.path().join("debug.log");
         std::fs::write(&path, "first line\nsecond line\n").unwrap();
 
         let mut tail: Vec<String> = Vec::new();
@@ -2594,7 +2607,7 @@ mod tests {
     #[test]
     fn append_new_log_lines_detects_growth_and_truncation() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("serve.log");
+        let path = tmp.path().join("debug.log");
 
         // Seed.
         std::fs::write(&path, "one\ntwo\n").unwrap();
@@ -2624,7 +2637,7 @@ mod tests {
     #[test]
     fn append_new_log_lines_clamps_to_max_lines() {
         let tmp = tempfile::tempdir().unwrap();
-        let path = tmp.path().join("serve.log");
+        let path = tmp.path().join("debug.log");
 
         // Write well over LOG_TAIL_LINES.
         let mut big = String::new();

--- a/src/tui/dialogs/serve.rs
+++ b/src/tui/dialogs/serve.rs
@@ -473,6 +473,13 @@ impl ServeView {
                             ServeAction::Continue
                         }
                         ServeMode::Local => {
+                            // Capture the offset before spawn so the tail
+                            // pane starts at the byte boundary just past any
+                            // pre-existing TUI/runner content; the new
+                            // daemon's startup marker and first events are
+                            // appended past this point and stream in via
+                            // append_new_log_lines.
+                            let offset = log_file_size();
                             match spawn_daemon(ServeMode::Local, None, None) {
                                 Ok(()) => {
                                     remember_last_mode(ServeMode::Local);
@@ -482,7 +489,7 @@ impl ServeView {
                                         passphrase: None,
                                         started_at: Instant::now(),
                                         log_tail: initial_log_tail(),
-                                        log_offset: log_file_size(),
+                                        log_offset: offset,
                                     };
                                 }
                                 Err(e) => dialog.state = ServeViewState::Error(e),
@@ -592,6 +599,9 @@ impl ServeView {
                         }
                         return ServeAction::Continue;
                     }
+                    // Capture offset before spawn so the tail pane streams in
+                    // only the new daemon's startup events.
+                    let offset = log_file_size();
                     match spawn_daemon(
                         ServeMode::Tunnel,
                         Some(&dialog.pending_passphrase),
@@ -605,7 +615,7 @@ impl ServeView {
                                 passphrase: Some(dialog.pending_passphrase.clone()),
                                 started_at: Instant::now(),
                                 log_tail: initial_log_tail(),
-                                log_offset: log_file_size(),
+                                log_offset: offset,
                             };
                         }
                         Err(e) => dialog.state = ServeViewState::Error(e),
@@ -813,6 +823,9 @@ impl ServeView {
         passphrase: Option<String>,
     ) {
         let pp_ref = passphrase.as_deref();
+        // Capture offset before restart so the tail pane streams in only
+        // the new daemon's events.
+        let offset = log_file_size();
         match restart_daemon(mode, pp_ref, transport) {
             Ok(()) => {
                 if let Some(ref pp) = passphrase {
@@ -832,7 +845,7 @@ impl ServeView {
                         passphrase,
                         opened_at: Instant::now(),
                         log_tail: initial_log_tail(),
-                        log_offset: log_file_size(),
+                        log_offset: offset,
                     };
                 } else {
                     self.state = ServeViewState::Starting {
@@ -841,7 +854,7 @@ impl ServeView {
                         passphrase,
                         started_at: Instant::now(),
                         log_tail: initial_log_tail(),
-                        log_offset: log_file_size(),
+                        log_offset: offset,
                     };
                 }
             }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -130,6 +130,11 @@ pub enum FieldKey {
     /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
     /// so the FieldKey enum stays `Copy` without carrying owned strings.
     LoggingTarget(u8),
+    LoggingOutput,
+    LoggingFilePath,
+    LoggingRotation,
+    LoggingMaxSizeMib,
+    LoggingKeepCount,
 }
 
 /// Resolve a field value from global config and optional profile override.
@@ -299,6 +304,8 @@ pub fn build_fields_for_category(
 const LOG_LEVEL_OPTIONS: &[&str] = &["trace", "debug", "info", "warn", "error"];
 const LOG_LEVEL_OVERRIDE_OPTIONS: &[&str] =
     &["(default)", "trace", "debug", "info", "warn", "error"];
+const SINK_OPTIONS: &[&str] = &["file", "stdout"];
+const ROTATION_OPTIONS: &[&str] = &["size", "never"];
 
 fn level_index(level: &str, opts: &[&str]) -> usize {
     opts.iter().position(|&o| o == level).unwrap_or(0)
@@ -345,6 +352,80 @@ fn build_logging_fields(global: &Config) -> Vec<SettingField> {
             inherited_display: None,
         });
     }
+
+    // Sink-shape knobs. Changing any of these requires a process restart
+    // (the tracing subscriber is a global singleton; the rotating writer
+    // holds its policy + file handle for the life of the process).
+    let output_idx = level_index(
+        match global.logging.output {
+            crate::session::config::SinkKind::File => "file",
+            crate::session::config::SinkKind::Stdout => "stdout",
+        },
+        SINK_OPTIONS,
+    );
+    fields.push(SettingField {
+        key: FieldKey::LoggingOutput,
+        label: "Output (restart req.)",
+        description:
+            "Where tracing lands: file (default) or stdout. TUI / daemon child / runner coerce \
+             to file regardless. Restart aoe for changes to take effect.",
+        value: FieldValue::Select {
+            selected: output_idx,
+            options: SINK_OPTIONS.iter().map(|s| s.to_string()).collect(),
+        },
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
+    fields.push(SettingField {
+        key: FieldKey::LoggingFilePath,
+        label: "File path (restart req.)",
+        description: "Log file location. Relative paths resolve under the app data dir; absolute \
+                      paths are used verbatim. Restart aoe for changes.",
+        value: FieldValue::Text(global.logging.file_path.clone()),
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
+
+    let rotation_idx = level_index(
+        match global.logging.rotation {
+            crate::session::config::RotationKind::Size => "size",
+            crate::session::config::RotationKind::Never => "never",
+        },
+        ROTATION_OPTIONS,
+    );
+    fields.push(SettingField {
+        key: FieldKey::LoggingRotation,
+        label: "Rotation (restart req.)",
+        description: "size rotates when the live file crosses the threshold; never disables \
+                      rotation. Restart aoe for changes.",
+        value: FieldValue::Select {
+            selected: rotation_idx,
+            options: ROTATION_OPTIONS.iter().map(|s| s.to_string()).collect(),
+        },
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
+    fields.push(SettingField {
+        key: FieldKey::LoggingMaxSizeMib,
+        label: "Max size MiB (restart req.)",
+        description: "Rotation threshold in MiB. Ignored when rotation = never.",
+        value: FieldValue::Number(global.logging.max_size_mib),
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
+    fields.push(SettingField {
+        key: FieldKey::LoggingKeepCount,
+        label: "Keep count (restart req.)",
+        description: "How many rotated files to retain (.1 through .keep_count).",
+        value: FieldValue::Number(global.logging.keep_count as u64),
+        category: SettingsCategory::Logging,
+        has_override: false,
+        inherited_display: None,
+    });
 
     fields
 }
@@ -1955,6 +2036,36 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
                     config.logging.targets.insert(target.to_string(), level);
                 }
             }
+        }
+        (FieldKey::LoggingOutput, FieldValue::Select { selected, options }) => {
+            if let Some(value) = options.get(*selected) {
+                config.logging.output = match value.as_str() {
+                    "stdout" => crate::session::config::SinkKind::Stdout,
+                    _ => crate::session::config::SinkKind::File,
+                };
+            }
+        }
+        (FieldKey::LoggingFilePath, FieldValue::Text(v)) => {
+            let trimmed = v.trim();
+            config.logging.file_path = if trimmed.is_empty() {
+                "debug.log".to_string()
+            } else {
+                trimmed.to_string()
+            };
+        }
+        (FieldKey::LoggingRotation, FieldValue::Select { selected, options }) => {
+            if let Some(value) = options.get(*selected) {
+                config.logging.rotation = match value.as_str() {
+                    "never" => crate::session::config::RotationKind::Never,
+                    _ => crate::session::config::RotationKind::Size,
+                };
+            }
+        }
+        (FieldKey::LoggingMaxSizeMib, FieldValue::Number(v)) => {
+            config.logging.max_size_mib = (*v).max(1);
+        }
+        (FieldKey::LoggingKeepCount, FieldValue::Number(v)) => {
+            config.logging.keep_count = (*v).min(u8::MAX as u64) as u8;
         }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => config.environment = v.clone(),
         _ => {}

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -2065,7 +2065,7 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.logging.max_size_mib = (*v).max(1);
         }
         (FieldKey::LoggingKeepCount, FieldValue::Number(v)) => {
-            config.logging.keep_count = (*v).min(u8::MAX as u64) as u8;
+            config.logging.keep_count = (*v).clamp(1, u8::MAX as u64) as u8;
         }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => config.environment = v.clone(),
         _ => {}

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -842,7 +842,13 @@ impl SettingsView {
             }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
-            FieldKey::LoggingDefaultLevel | FieldKey::LoggingTarget(_) => {}
+            FieldKey::LoggingDefaultLevel
+            | FieldKey::LoggingTarget(_)
+            | FieldKey::LoggingOutput
+            | FieldKey::LoggingFilePath
+            | FieldKey::LoggingRotation
+            | FieldKey::LoggingMaxSizeMib
+            | FieldKey::LoggingKeepCount => {}
             FieldKey::HostEnvironment => {
                 config.environment = None;
             }

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -403,9 +403,11 @@ last_seen_version = "{}"
     /// isolation. Returns the `Output` (stdout, stderr, status).
     ///
     /// Clears `AGENT_OF_EMPIRES_DEBUG` and `AOE_LOG_LEVEL` from the inherited
-    /// env so tests run with a deterministic logging configuration: when
-    /// either is set, `aoe` truncates `debug.log` on startup, which would
-    /// silently destroy any fixture that an `aoe logs` test seeded.
+    /// env so tests run with a deterministic logging configuration. (aoe
+    /// itself appends to `debug.log` now rather than truncating, but a
+    /// child that opts in to file logging would still emit a marker line
+    /// and an "aoe started" event under the test fixture, perturbing
+    /// content-sensitive assertions.)
     pub fn run_cli(&self, args: &[&str]) -> Output {
         Command::new(&self.binary_path)
             .args(args)

--- a/tests/e2e/logs.rs
+++ b/tests/e2e/logs.rs
@@ -18,15 +18,6 @@ fn seed_debug_log(h: &TuiTestHarness, content: &str) -> std::path::PathBuf {
     path
 }
 
-/// Write a fake serve.log under the harness's isolated app dir.
-fn seed_serve_log(h: &TuiTestHarness, content: &str) -> std::path::PathBuf {
-    let app_dir = app_dir_in(h.home_path());
-    std::fs::create_dir_all(&app_dir).expect("create app dir");
-    let path = app_dir.join("serve.log");
-    std::fs::write(&path, content).expect("write serve.log");
-    path
-}
-
 #[test]
 #[serial]
 fn logs_no_pager_prints_debug_log_to_stdout() {
@@ -68,7 +59,7 @@ fn logs_lines_returns_only_tail() {
 
 #[test]
 #[serial]
-fn logs_path_prints_debug_log_path() {
+fn logs_path_prints_configured_log_path() {
     let h = TuiTestHarness::new("logs_path");
     let path = seed_debug_log(&h, "");
 
@@ -80,91 +71,31 @@ fn logs_path_prints_debug_log_path() {
 
 #[test]
 #[serial]
-fn logs_path_all_prints_both_paths() {
-    // --all is gated on the `serve` feature; this test runs only when the
-    // binary was built with it. `cargo test --features serve` covers it;
-    // plain `cargo test` builds without the feature, so skip in that case.
-    if !cfg!(feature = "serve") {
-        eprintln!("Skipping: built without `serve` feature");
-        return;
-    }
-
-    let h = TuiTestHarness::new("logs_path_all");
-    let dbg = seed_debug_log(&h, "");
-    let srv = seed_serve_log(&h, "");
-
-    let out = h.run_cli(&["logs", "--all", "--path"]);
-    assert!(out.status.success());
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let lines: Vec<&str> = stdout.lines().collect();
-    assert_eq!(lines.len(), 2, "expected 2 paths, got: {stdout}");
-    assert_eq!(lines[0], dbg.to_string_lossy());
-    assert_eq!(lines[1], srv.to_string_lossy());
-}
-
-#[test]
-#[serial]
-fn logs_serve_no_pager_prints_serve_log() {
-    if !cfg!(feature = "serve") {
-        eprintln!("Skipping: built without `serve` feature");
-        return;
-    }
-
-    let h = TuiTestHarness::new("logs_serve");
-    seed_serve_log(&h, "serve daemon line\n");
-
+fn logs_serve_flag_rejected() {
+    // `--serve` and `--all` were removed when serve.log was dropped; the
+    // configured log file (debug.log by default) carries everything now.
+    let h = TuiTestHarness::new("logs_serve_removed");
     let out = h.run_cli(&["logs", "--serve", "--no-pager"]);
     assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
+        !out.status.success(),
+        "removed --serve flag should exit non-zero"
     );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("serve daemon line"));
 }
 
 #[test]
 #[serial]
-fn logs_all_no_pager_merges_streams_with_tags() {
-    if !cfg!(feature = "serve") {
-        eprintln!("Skipping: built without `serve` feature");
-        return;
-    }
-
-    let h = TuiTestHarness::new("logs_all_merge");
-    seed_debug_log(
-        &h,
-        "2024-01-01T00:00:01Z  INFO debug-a\n\
-         2024-01-01T00:00:03Z  INFO debug-b\n",
-    );
-    seed_serve_log(
-        &h,
-        "2024-01-01T00:00:02Z  INFO serve-a\n\
-         2024-01-01T00:00:04Z  INFO serve-b\n",
-    );
-
+fn logs_all_flag_rejected() {
+    let h = TuiTestHarness::new("logs_all_removed");
     let out = h.run_cli(&["logs", "--all", "--no-pager"]);
     assert!(
-        out.status.success(),
-        "stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let lines: Vec<&str> = stdout.lines().collect();
-    assert_eq!(
-        lines,
-        vec![
-            "[debug] 2024-01-01T00:00:01Z  INFO debug-a",
-            "[serve] 2024-01-01T00:00:02Z  INFO serve-a",
-            "[debug] 2024-01-01T00:00:03Z  INFO debug-b",
-            "[serve] 2024-01-01T00:00:04Z  INFO serve-b",
-        ]
+        !out.status.success(),
+        "removed --all flag should exit non-zero"
     );
 }
 
 #[test]
 #[serial]
-fn logs_missing_debug_log_exits_zero_with_hint() {
+fn logs_missing_file_exits_zero_with_hint() {
     let h = TuiTestHarness::new("logs_missing");
     // Don't seed: app dir + debug.log absent.
     let out = h.run_cli(&["logs", "--no-pager"]);
@@ -173,32 +104,5 @@ fn logs_missing_debug_log_exits_zero_with_hint() {
     assert!(
         stderr.contains("does not exist"),
         "stderr should explain missing file: {stderr}"
-    );
-}
-
-#[test]
-#[serial]
-fn logs_all_missing_both_files_exits_zero_with_hints() {
-    if !cfg!(feature = "serve") {
-        eprintln!("Skipping: built without `serve` feature");
-        return;
-    }
-
-    let h = TuiTestHarness::new("logs_all_missing");
-    // Don't seed either log file.
-    let out = h.run_cli(&["logs", "--all", "--no-pager"]);
-    assert!(
-        out.status.success(),
-        "should exit 0 when both files missing; stderr: {}",
-        String::from_utf8_lossy(&out.stderr)
-    );
-    let stderr = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        stderr.matches("does not exist").count() >= 2,
-        "stderr should list both missing paths: {stderr}"
-    );
-    assert!(
-        String::from_utf8_lossy(&out.stdout).is_empty(),
-        "stdout should be empty when no viewer runs"
     );
 }

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -126,10 +126,10 @@ fn cli_serve_daemon_starts_and_stops_cleanly() {
         wait_for_port(port, Duration::from_secs(10)),
         "daemon never bound port {} (child likely self-detected and exited).\n\
          pid file exists: {}\n\
-         serve.log:\n{}",
+         debug.log:\n{}",
         port,
         pid_path.exists(),
-        std::fs::read_to_string(pid_path.with_file_name("serve.log")).unwrap_or_default(),
+        std::fs::read_to_string(pid_path.with_file_name("debug.log")).unwrap_or_default(),
     );
 
     let pid: i32 = std::fs::read_to_string(&pid_path)

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -166,3 +166,44 @@ fn cli_serve_daemon_starts_and_stops_cleanly() {
         pid_path.display()
     );
 }
+
+/// Regression guard for the sink consolidation (issue #1124): the daemon
+/// must write its tracing stream to the configured `debug.log`, and the
+/// retired `serve.log` must not reappear. Without this guard, a future
+/// change that misclassifies the daemon child as `ServeForeground` (or
+/// reintroduces the `serve.log` redirect) would slip through CI.
+#[test]
+#[serial]
+fn cli_serve_daemon_writes_marker_to_debug_log_not_serve_log() {
+    let h = TuiTestHarness::new("serve_daemon_logging_sinks");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&["serve", "--daemon", "--port", &port_s, "--no-auth"]);
+    assert!(start.status.success(), "aoe serve --daemon failed");
+
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    let app_dir = crate::harness::app_dir_in(h.home_path());
+    let debug_log = app_dir.join("debug.log");
+    let serve_log = app_dir.join("serve.log");
+
+    let debug_contents = std::fs::read_to_string(&debug_log)
+        .unwrap_or_else(|e| panic!("debug.log unreadable at {}: {}", debug_log.display(), e));
+    assert!(
+        debug_contents.contains("[AOE_START_MARKER]"),
+        "debug.log should carry the filter-immune startup marker; got: {:?}",
+        debug_contents
+    );
+    assert!(
+        !serve_log.exists(),
+        "serve.log must not be re-created post-consolidation, found at {}",
+        serve_log.display()
+    );
+
+    let _ = h.run_cli(&["serve", "--stop"]);
+}

--- a/web/src/components/settings/LoggingSettings.tsx
+++ b/web/src/components/settings/LoggingSettings.tsx
@@ -1,4 +1,4 @@
-import { SelectField } from "./FormFields";
+import { NumberField, SelectField, TextField } from "./FormFields";
 
 // Mirrors `KNOWN_SUB_TARGETS` in src/logging.rs. Keeping this list
 // hardcoded (rather than fetched) is intentional: it's the curated
@@ -45,6 +45,16 @@ const LEVELS = [
 
 const DEFAULT_LEVELS = LEVELS.filter((l) => l.value !== "");
 
+const SINK_OPTIONS = [
+  { value: "file", label: "file (default)" },
+  { value: "stdout", label: "stdout" },
+];
+
+const ROTATION_OPTIONS = [
+  { value: "size", label: "size (default)" },
+  { value: "never", label: "never" },
+];
+
 interface Props {
   settings: Record<string, unknown>;
   onSaveField: (section: string, field: string, value: unknown) => void;
@@ -55,6 +65,11 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
   const logging = (settings.logging ?? {}) as Record<string, unknown>;
   const defaultLevel = (logging.default_level as string) ?? "info";
   const targets = (logging.targets ?? {}) as Record<string, string>;
+  const output = (logging.output as string) ?? "file";
+  const filePath = (logging.file_path as string) ?? "debug.log";
+  const rotation = (logging.rotation as string) ?? "size";
+  const maxSizeMib = (logging.max_size_mib as number) ?? 50;
+  const keepCount = (logging.keep_count as number) ?? 5;
 
   const saveDefaultLevel = (level: string) => {
     onUpdate({ logging: { ...logging, default_level: level } });
@@ -70,6 +85,11 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
     }
     onUpdate({ logging: { ...logging, targets: next } });
     onSaveField("logging", "targets", next);
+  };
+
+  const saveSinkField = (field: string, value: unknown) => {
+    onUpdate({ logging: { ...logging, [field]: value } });
+    onSaveField("logging", field, value);
   };
 
   // Group targets by their first segment for the UI.
@@ -123,6 +143,55 @@ export function LoggingSettings({ settings, onSaveField, onUpdate }: Props) {
             </div>
           </div>
         ))}
+      </div>
+
+      <div className="space-y-3 border-t border-surface-700 pt-4">
+        <h4 className="text-sm font-semibold text-text-primary">
+          Sink &amp; rotation
+        </h4>
+        <p className="text-xs text-text-dim">
+          These fields change where logs land on disk and how they rotate. They are written to <code>config.toml</code> immediately but require restarting <code>aoe</code> to take effect (the tracing subscriber and rotating writer are installed once at process startup).
+        </p>
+        <SelectField
+          label="Output"
+          description="file (default) sends tracing to a log file. stdout is honored only for foreground aoe serve and env-overridden one-shot CLI; TUI / daemon child / cockpit runner coerce to file regardless."
+          value={output}
+          onChange={(v) => saveSinkField("output", v)}
+          options={SINK_OPTIONS}
+        />
+        <TextField
+          label="File path"
+          description="Relative paths resolve under the app data dir; absolute paths are used verbatim."
+          value={filePath}
+          onChange={(v) => saveSinkField("file_path", v.trim() === "" ? "debug.log" : v)}
+          placeholder="debug.log"
+          mono
+        />
+        <SelectField
+          label="Rotation"
+          description="size rotates when the live file crosses the threshold; never disables rotation."
+          value={rotation}
+          onChange={(v) => saveSinkField("rotation", v)}
+          options={ROTATION_OPTIONS}
+        />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <NumberField
+            label="Max size (MiB)"
+            description="Rotation threshold. Ignored when rotation = never."
+            value={maxSizeMib}
+            onChange={(v) => saveSinkField("max_size_mib", v)}
+            min={1}
+            max={4096}
+          />
+          <NumberField
+            label="Keep count"
+            description="How many rotated files to retain (.1 through .keep_count)."
+            value={keepCount}
+            onChange={(v) => saveSinkField("keep_count", v)}
+            min={1}
+            max={20}
+          />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
Closes #1046
Closes #1124

> Note: this PR was AI-assisted. The plan was workshopped through a multi-LLM debate (`gpt-5.5`, `gemini-3.1-pro-preview`, `grok-4.3`) and synthesized into the design described below before implementation. Idea, scope decisions, and review are mine.

## Description

Bundled implementation of #1124 (sink consolidation) and #1046 (rotation). Foreground `aoe serve`, daemon, TUI, cockpit runners, and env-overridden one-shot CLI invocations now route through a single sink resolver, all writing to the configured `[logging].file_path` (default `debug.log`). Size-based rotation is multi-process safe via `fs2` advisory locking, inode-reopen detection, and line-buffered event boundaries. The `serve.log` file is retired; the v007 migration renames any leftover to `serve.log.legacy`.

### Decisions of note

- **Hidden `--daemon-child` Clap arg** (not env var) for daemon-child detection. Env vars leak into spawned cockpit runner subprocesses; hidden flag is hermetic.
- **Daemon stdout/stderr → configured log file**, not `/dev/null`. Preserves panic backtraces alongside structured tracing. Inherited-fd staleness across a mid-run rotation is documented as best-effort.
- **Captured-offset-before-spawn** for the TUI serve dialog tail (immune to rotation timing; works at any log level).
- **`fs2::try_lock_exclusive`** on `{path}.lock`. OS releases on process exit, so a crashed rotater never wedges future rotations.
- **Line-buffered writer**: bytes accumulate to `
` (or 8 KiB) before the rotation check, so an event never splits across `debug.log` and `.1`.
- **Raw startup marker** (`[AOE_START_MARKER]`) written before tracing takes the file, filter-immune for forensic grep. Parallel `tracing::info!` for filter-respecting readers.
- **Sink-shape knobs require restart.** `output`, `file_path`, `rotation`, `max_size_mib`, `keep_count` are set at startup; settings UI labels them accordingly. `default_level` + `targets` continue to hot-swap.

### Breaking changes

- `aoe logs --serve` and `aoe logs --all` flags removed. The configured log file (default `debug.log`) carries everything now.
- `serve.log` no longer written. Migration v007 renames any pre-existing `serve.log` to `serve.log.legacy` so the bytes aren't silently lost.
- TUI serve-dialog tail now reads from the configured log file (anchored at `[AOE_START_MARKER]` for the reattach case).

## PR Type

- [x] New Feature
- [x] Refactor
- [x] Documentation

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --lib --features serve` → 1925 passed)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording — settings UI rows added but no visual recording captured

## Test plan

- [x] `cargo test --lib --features serve` (1925 passed)
- [x] `cargo clippy --features serve` (no warnings)
- [x] `cargo fmt --check` (clean)
- [x] `cargo xtask gen-docs` (CLI ref regenerated)
- [x] Unit tests for `SizeRotatingWriter`: rotation at threshold, keep_count drops oldest, rotation=never leaves file alone, line-buffering across partial writes, startup rotation of pre-existing oversized file
- [x] `resolve_sink` coerces TUI from stdout to file with warning; honors stdout for foreground serve
- [x] Config schema round-trip with old shape (no new keys) populates defaults
- [x] v007 migration: renames serve.log to .legacy, idempotent, no-op when serve.log absent
- [x] **Manual:** run `aoe serve --daemon`, confirm logs flow to `debug.log` and `serve.log` is no longer written
- [x] **Manual:** flip web Settings → Logging → Output to `stdout`, restart `aoe`, confirm foreground serve writes to stdout
- [x] **Manual:** flip web Settings → Logging → Default level live, confirm runner picks it up without restart
- [x] **Manual:** trigger rotation by setting `max_size_mib = 1` and running a few minutes; confirm `.1` appears and TUI keeps tailing the new current

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 (1M context). The implementation plan was workshopped through a `/debate` workflow with `gpt-5.5`, `gemini-3.1-pro-preview`, and `grok-4.3` to surface design issues (multi-process rotation hazards, daemon-child misclassification, marker-line reliability, env-var leakage) before any code was written.

**Any Additional AI Details you'd like to share:**

Code is mine in the sense that I reviewed and shaped every commit. The plan synthesis lives at `~/.claude/skills/debate/history/plan-logging-polishing.md` for reference. Happy to discuss the rotation-coordination choice (fs2 + inode reopen + line buffering) — that was the most-contested piece of the design.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
