### PR TITLE
fix(web): add interactive-widget=resizes-content to viewport meta

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="color-scheme" content="dark" />
     <title>Agent of Empires</title>
     <link rel="manifest" href="/manifest.json" />


### PR DESCRIPTION
## Description

Fixes #1145.

On mobile (iOS Safari, iOS PWA), tapping the cockpit message-input textarea opened the soft keyboard and shifted the entire page upward, scrolling the TopBar header off-screen above the visual viewport. The header was inaccessible until the keyboard was dismissed.

**Root cause:** the App root pins to `stableViewportHeight` (`web/src/App.tsx:720-746`) so xterm doesn't `SIGWINCH` claude on every keyboard show/hide. With the keyboard up, the pinned root is ~350px taller than the visual viewport, and iOS auto-scrolls the document to keep the focused textarea on screen, sliding the header off the top. `overflow: hidden` on `html` doesn't block iOS's focus-scroll behavior. The viewport meta was missing `interactive-widget=resizes-content`, which would tell iOS Safari 16+ and Chrome to shrink the layout viewport instead of scrolling the document.

**Fix:** one-line addition to `web/index.html`:

```html
<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
```

**Compatibility with the existing pinned-height workaround:** the pinned-height fix in `App.tsx:720-746` was originally added so xterm doesn't resize when the keyboard opens. With `interactive-widget=resizes-content`, the layout viewport DOES shrink when the keyboard appears, but the pinned `stableViewportHeight` overrides keep the layout at the no-keyboard height, which is exactly the behavior we want for terminal stability. The two work together: the meta hint stops iOS from auto-scrolling the document (header stays put), and the pin keeps the terminal from being resized.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (no test changes; this is a viewport meta tag change with no JS/TS modified. `cd web && npm run build` succeeds.)
- [x] Documentation was updated where necessary (N/A)
- [x] For UI changes: included screenshot or recording (manual mobile verification needed; see Test plan below)

## Test plan

This is a viewport meta tag change, no unit test possible. Manual verification on mobile is required:

- [ ] On iOS Safari (16+): open cockpit, tap message input, confirm header remains visible (does not scroll off the top)
- [ ] On iOS PWA (installed to home screen): same check
- [ ] On Android Chrome: same check
- [ ] Confirm xterm terminal does not resize/SIGWINCH when keyboard opens or closes
- [x] `cd web && npm run build` passes

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

- [x] I am an AI Agent filling out this form (check box if true)