### PR TITLE
fix(cockpit): slow working-spinner verb cycle from 4s to 18s

### DIFF
--- a/web/src/lib/cockpitRattle.ts
+++ b/web/src/lib/cockpitRattle.ts
@@ -26,7 +26,7 @@ export const SPINNER_FRAMES = [
 export const SPINNER_INTERVAL_MS = 80;
 
 /** Verb cycle interval — how often the working label rotates. */
-export const VERB_INTERVAL_MS = 4_000;
+export const VERB_INTERVAL_MS = 18_000;
 
 /**
  * General "agent is working" pool. Used when there's no thinking/tool


### PR DESCRIPTION
## Description

The cockpit working-spinner verb was rotating every 4 seconds, which felt twitchy and made it look like the agent was rapidly switching tasks. This bumps the cycle to 18s (within the 15-20s range suggested in the issue) so the spinner stays alive on long turns without churning so fast that the user can't read each verb.

Single-line change in `web/src/lib/cockpitRattle.ts`:

```ts
export const VERB_INTERVAL_MS = 18_000; // was 4_000
```

The braille spinner glyph itself is unchanged (still rattles at 80ms). Only the higher-level verb label slows down.

Fixes #1146

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No new screenshot needed: this is a timing tweak to an existing spinner, the visuals are unchanged.)

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:** Claude Opus 4.7 via Claude Code


**Any Additional AI Details you'd like to share:**

Verified by running `npm run build`, `npm run test:unit` (275/275 passing), and confirming the only consumer (`CockpitView.tsx`) uses the constant as a `setInterval` ms.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)