### PR TITLE
fix(cockpit): dispatch InputEvent from toolbar inserts so popover trigger removeOnExecute works

### DIFF
--- a/web/src/components/cockpit/Composer.insert.test.ts
+++ b/web/src/components/cockpit/Composer.insert.test.ts
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+//
+// Regression test for #1149: clicking the @ or / toolbar buttons used
+// to leave a duplicate trigger character in the composer because we
+// dispatched a generic `Event("input")`. assistant-ui's
+// `Unstable_TriggerPopover` keys its trigger detection off
+// `InputEvent.inputType` + `data`; without those the popover's
+// `removeOnExecute` cannot strip the toolbar-injected character on
+// item selection, leaving `@@` / `//` in the input. We now dispatch a
+// real `InputEvent` carrying both fields.
+
+import { describe, expect, it } from "vitest";
+import { createRef } from "react";
+
+import { insertAtCaret } from "./Composer";
+
+describe("insertAtCaret (#1149)", () => {
+  it("dispatches an InputEvent with inputType=insertText and data=text", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    const ref = createRef<HTMLTextAreaElement>();
+    // React refs use a writable `current` property in tests like this.
+    (ref as { current: HTMLTextAreaElement }).current = ta;
+
+    const events: Event[] = [];
+    ta.addEventListener("input", (e) => events.push(e));
+
+    insertAtCaret(ref, "@");
+
+    expect(ta.value).toBe("@");
+    expect(events).toHaveLength(1);
+    const evt = events[0];
+    expect(evt).toBeInstanceOf(InputEvent);
+    expect((evt as InputEvent).inputType).toBe("insertText");
+    expect((evt as InputEvent).data).toBe("@");
+    expect(evt.bubbles).toBe(true);
+
+    document.body.removeChild(ta);
+  });
+
+  it("forwards the inserted text in the InputEvent.data field", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    const ref = createRef<HTMLTextAreaElement>();
+    (ref as { current: HTMLTextAreaElement }).current = ta;
+
+    const events: InputEvent[] = [];
+    ta.addEventListener("input", (e) => events.push(e as InputEvent));
+
+    insertAtCaret(ref, "/");
+
+    expect(ta.value).toBe("/");
+    expect(events).toHaveLength(1);
+    expect(events[0].inputType).toBe("insertText");
+    expect(events[0].data).toBe("/");
+
+    document.body.removeChild(ta);
+  });
+
+  it("pads with a leading space when caret is mid-word so trigger detection still fires", () => {
+    const ta = document.createElement("textarea");
+    document.body.appendChild(ta);
+    ta.value = "hello";
+    ta.setSelectionRange(5, 5);
+    const ref = createRef<HTMLTextAreaElement>();
+    (ref as { current: HTMLTextAreaElement }).current = ta;
+
+    insertAtCaret(ref, "@");
+
+    expect(ta.value).toBe("hello @");
+
+    document.body.removeChild(ta);
+  });
+});

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -509,8 +509,16 @@ function insertSlashCommand(
 
 /** Insert `text` at the textarea's caret and re-focus. The toolbar
  *  buttons use this to inject `@` or `/` so the trigger popover opens
- *  without forcing the user to grab the keyboard. */
-function insertAtCaret(
+ *  without forcing the user to grab the keyboard.
+ *
+ *  Exported for tests. We dispatch a real `InputEvent` (not a generic
+ *  `Event`) so assistant-ui's `Unstable_TriggerPopover` sees the
+ *  `inputType: "insertText"` + `data: text` fields it relies on for
+ *  trigger detection. Without those, the popover library treats the
+ *  toolbar-injected character as untracked text and a subsequent
+ *  `removeOnExecute` cannot find the trigger to strip, leaving a
+ *  duplicate `@@` / `//` in the input (#1149). */
+export function insertAtCaret(
   ref: React.RefObject<HTMLTextAreaElement | null>,
   text: string,
 ) {
@@ -529,7 +537,13 @@ function insertAtCaret(
     "value",
   )?.set;
   setter?.call(ta, next);
-  ta.dispatchEvent(new Event("input", { bubbles: true }));
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertText",
+      data: text,
+    }),
+  );
   const pos = before.length + needsSpace.length + text.length;
   ta.focus();
   ta.setSelectionRange(pos, pos);


### PR DESCRIPTION
## Description

Fixes #1149.

Clicking the @ or / toolbar buttons in the cockpit composer was leaving a duplicate trigger character in the input (`@@` / `//`). The buttons inject the trigger via `insertAtCaret` (`web/src/components/cockpit/Composer.tsx`), which dispatched a generic `Event("input")`. assistant-ui's `Unstable_TriggerPopover` keys its trigger detection off `InputEvent.inputType` + `data`; without those fields the popover treats the toolbar-injected character as untracked text. When the user later picks an item, the popover's `removeOnExecute` cannot find the trigger to strip, leaving the original character behind alongside the inserted result.

The fix dispatches a real `InputEvent` carrying `{ inputType: "insertText", data: text }` so the popover library tracks the toolbar-injected character the same way it would a typed one. `insertAtCaret` is now exported so we can unit-test the dispatched event shape with vitest + jsdom; the export mirrors the pre-existing `decideEnterAction` testing seam.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No screenshot: this is a one-line behavioural fix to event dispatch covered by a regression test; the visible difference is the absence of a duplicate `@`/`/` character.)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:**
Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**
Investigation traced the duplicate trigger to assistant-ui's popover relying on `InputEvent.inputType`/`data`. New vitest in `Composer.insert.test.ts` asserts the dispatched event carries `inputType: "insertText"` and `data: <inserted char>`.

- [x] I am an AI Agent filling out this form (check box if true)