### PR TITLE
fix(cockpit): derive turnActive from prompt/stop seq counters to survive Stopped race

### DIFF
--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -12,6 +12,7 @@ import {
   applyEvent,
   emptyCockpitState,
   isTurnActive,
+  normaliseTurnCounters,
   setActivityLimit,
   type ApprovalDecision,
   type CockpitFrame,
@@ -113,30 +114,9 @@ function loadPersistedState(sessionId: string): CockpitState | undefined {
       return undefined;
     }
     // Backfill the seq-counter pair introduced by #1170 for entries
-    // persisted before the schema change. Treat any cached
-    // `turnActive=true` as one outstanding prompt (counter=1, stop=0)
-    // so the spinner gate stays consistent across the reload; otherwise
-    // start the counters at zero. The counters are the source of truth
-    // for `turnActive` from this point forward.
-    const pendingUserPromptSeq =
-      typeof state.pendingUserPromptSeq === "number"
-        ? state.pendingUserPromptSeq
-        : state.turnActive
-          ? 1
-          : 0;
-    const lastStoppedSeq =
-      typeof state.lastStoppedSeq === "number"
-        ? state.lastStoppedSeq
-        : state.turnActive
-          ? 0
-          : pendingUserPromptSeq;
-    const normalised: CockpitState = {
-      ...(state as CockpitState),
-      pendingUserPromptSeq,
-      lastStoppedSeq,
-      turnActive: pendingUserPromptSeq > lastStoppedSeq,
-    };
-    return normalised;
+    // persisted before the schema change; see `normaliseTurnCounters`
+    // for the rules.
+    return normaliseTurnCounters(state as CockpitState);
   } catch {
     return undefined;
   }

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import {
   applyEvent,
   emptyCockpitState,
+  isTurnActive,
   setActivityLimit,
   type ApprovalDecision,
   type CockpitFrame,
@@ -111,7 +112,31 @@ function loadPersistedState(sessionId: string): CockpitState | undefined {
       window.localStorage.removeItem(storageKey(sessionId));
       return undefined;
     }
-    return state as CockpitState;
+    // Backfill the seq-counter pair introduced by #1170 for entries
+    // persisted before the schema change. Treat any cached
+    // `turnActive=true` as one outstanding prompt (counter=1, stop=0)
+    // so the spinner gate stays consistent across the reload; otherwise
+    // start the counters at zero. The counters are the source of truth
+    // for `turnActive` from this point forward.
+    const pendingUserPromptSeq =
+      typeof state.pendingUserPromptSeq === "number"
+        ? state.pendingUserPromptSeq
+        : state.turnActive
+          ? 1
+          : 0;
+    const lastStoppedSeq =
+      typeof state.lastStoppedSeq === "number"
+        ? state.lastStoppedSeq
+        : state.turnActive
+          ? 0
+          : pendingUserPromptSeq;
+    const normalised: CockpitState = {
+      ...(state as CockpitState),
+      pendingUserPromptSeq,
+      lastStoppedSeq,
+      turnActive: pendingUserPromptSeq > lastStoppedSeq,
+    };
+    return normalised;
   } catch {
     return undefined;
   }
@@ -275,6 +300,13 @@ function reducer(state: CockpitState, action: Action): CockpitState {
     return action.state;
   }
   if (action.kind === "user_prompt") {
+    // Bump `pendingUserPromptSeq` rather than touching `turnActive`
+    // directly. `turnActive` derives from `pendingUserPromptSeq >
+    // lastStoppedSeq`; the derived alias is recomputed here so any
+    // existing `state.turnActive` reads stay consistent without a
+    // selector hop. Without this the late `Stopped` from the prior
+    // turn could clobber the spinner mid follow-up. See #1170.
+    const pendingUserPromptSeq = state.pendingUserPromptSeq + 1;
     return {
       ...state,
       activity: state.activity.concat({
@@ -288,7 +320,11 @@ function reducer(state: CockpitState, action: Action): CockpitState {
       // they're trying again, so don't keep nagging them.
       startupError: null,
       lastError: null,
-      turnActive: true,
+      pendingUserPromptSeq,
+      turnActive: isTurnActive({
+        pendingUserPromptSeq,
+        lastStoppedSeq: state.lastStoppedSeq,
+      }),
     };
   }
   if (action.kind === "enqueue_prompt") {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -15,6 +15,7 @@ import {
   applyEvent,
   emptyCockpitState,
   isTurnActive,
+  normaliseTurnCounters,
   type CockpitFrame,
   type CockpitState,
 } from "./cockpitTypes";
@@ -28,9 +29,12 @@ function frame(seq: number, text: string): CockpitFrame {
 }
 
 function withOptimisticPrompt(state: CockpitState, text: string): CockpitState {
-  // Mirrors the optimistic dispatch in useCockpit.sendPrompt — the
-  // row id includes the wall-clock timestamp, distinct from the
-  // `user-seq-N` form the reducer assigns when the server echoes.
+  // Mirrors the optimistic dispatch in useCockpit.sendPrompt: row id
+  // includes the wall-clock timestamp (distinct from the `user-seq-N`
+  // form the reducer assigns when the server echoes), and
+  // `pendingUserPromptSeq` bumps so a subsequent server echo on the
+  // matching row doesn't double-count. See #1170.
+  const pendingUserPromptSeq = state.pendingUserPromptSeq + 1;
   return {
     ...state,
     activity: state.activity.concat({
@@ -39,7 +43,8 @@ function withOptimisticPrompt(state: CockpitState, text: string): CockpitState {
       text,
       at: new Date().toISOString(),
     }),
-    turnActive: true,
+    pendingUserPromptSeq,
+    turnActive: pendingUserPromptSeq > state.lastStoppedSeq,
   };
 }
 
@@ -996,6 +1001,83 @@ describe("turnActive derivation from prompt/stop counters (#1170)", () => {
     expect(state.lastStoppedSeq).toBe(1);
     expect(state.turnActive).toBe(false);
     expect(state.startupError).toBe("boom");
+  });
+
+  it("optimistic-match UserPromptSent resets per-turn flags (turnHasOutput, worker banners, wakeup)", () => {
+    // The optimistic-match branch used to early-return after just
+    // promoting the row id, leaving `turnHasOutput`, `workerStopped`,
+    // `workerRestarting`, and the wakeup countdown stale from the
+    // prior turn. With #1170's race-safe semantics that desync can
+    // suppress the empty-output notice on a follow-up that produces
+    // nothing, so the resets now run on BOTH UserPromptSent branches.
+    const stale: CockpitState = {
+      ...withOptimisticPrompt(emptyCockpitState(), "follow-up"),
+      turnHasOutput: true,
+      workerStopped: true,
+      workerRestarting: true,
+      nextWakeupAt: new Date(Date.now() - 1_000).toISOString(),
+      nextWakeupReason: "tick",
+    };
+    const next = applyEvent(stale, {
+      session_id: "s-1",
+      seq: 9,
+      event: { UserPromptSent: { text: "follow-up" } },
+    });
+    expect(next.activity).toHaveLength(1);
+    expect(next.activity[0].id).toBe("user-seq-9");
+    expect(next.turnHasOutput).toBe(false);
+    expect(next.workerStopped).toBe(false);
+    expect(next.workerRestarting).toBe(false);
+    expect(next.nextWakeupAt).toBeNull();
+    expect(next.nextWakeupReason).toBeNull();
+    // pendingUserPromptSeq must NOT double-count: withOptimisticPrompt
+    // bumped it to 1, the server echo matched the optimistic row, so
+    // it stays at 1.
+    expect(next.pendingUserPromptSeq).toBe(1);
+    expect(next.turnActive).toBe(true);
+  });
+});
+
+describe("normaliseTurnCounters (#1170 persisted-state backfill)", () => {
+  it("backfills counters from cached turnActive=true", () => {
+    const cached = {
+      ...emptyCockpitState(),
+      turnActive: true,
+    } as CockpitState & { pendingUserPromptSeq?: number; lastStoppedSeq?: number };
+    delete cached.pendingUserPromptSeq;
+    delete cached.lastStoppedSeq;
+    const normalised = normaliseTurnCounters(cached);
+    expect(normalised.pendingUserPromptSeq).toBe(1);
+    expect(normalised.lastStoppedSeq).toBe(0);
+    expect(normalised.turnActive).toBe(true);
+  });
+
+  it("backfills counters from cached turnActive=false", () => {
+    const cached = {
+      ...emptyCockpitState(),
+      turnActive: false,
+    } as CockpitState & { pendingUserPromptSeq?: number; lastStoppedSeq?: number };
+    delete cached.pendingUserPromptSeq;
+    delete cached.lastStoppedSeq;
+    const normalised = normaliseTurnCounters(cached);
+    expect(normalised.pendingUserPromptSeq).toBe(0);
+    expect(normalised.lastStoppedSeq).toBe(0);
+    expect(normalised.turnActive).toBe(false);
+  });
+
+  it("passes through entries that already carry counters", () => {
+    const fresh: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 5,
+      lastStoppedSeq: 3,
+      turnActive: false,
+    };
+    const normalised = normaliseTurnCounters(fresh);
+    expect(normalised.pendingUserPromptSeq).toBe(5);
+    expect(normalised.lastStoppedSeq).toBe(3);
+    // Even if the cached `turnActive` boolean was stale, the derived
+    // value wins so the spinner gate matches the counters.
+    expect(normalised.turnActive).toBe(true);
   });
 });
 

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyEvent,
   emptyCockpitState,
+  isTurnActive,
   type CockpitFrame,
   type CockpitState,
 } from "./cockpitTypes";
@@ -838,6 +839,163 @@ describe("applyEvent / ConversationCompacted", () => {
       event: "ConversationCompacted",
     });
     expect(next.contextPrimerAvailable).toBeNull();
+  });
+});
+
+describe("turnActive derivation from prompt/stop counters (#1170)", () => {
+  // `turnActive` derives from `pendingUserPromptSeq > lastStoppedSeq`.
+  // The boolean field is kept on `CockpitState` as a memoised alias so
+  // existing `state.turnActive` reads stay correct, but the counters
+  // are the source of truth a late `Stopped` cannot clobber.
+
+  it("isTurnActive flips on / off when counters cross", () => {
+    expect(
+      isTurnActive({ pendingUserPromptSeq: 2, lastStoppedSeq: 1 }),
+    ).toBe(true);
+    expect(
+      isTurnActive({ pendingUserPromptSeq: 1, lastStoppedSeq: 1 }),
+    ).toBe(false);
+    expect(
+      isTurnActive({ pendingUserPromptSeq: 0, lastStoppedSeq: 0 }),
+    ).toBe(false);
+  });
+
+  it("Stopped advances lastStoppedSeq by one and recomputes turnActive", () => {
+    // Single-prompt happy path: send → Stopped flips turnActive off.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "hi" } },
+    });
+    expect(state.pendingUserPromptSeq).toBe(1);
+    expect(state.lastStoppedSeq).toBe(0);
+    expect(state.turnActive).toBe(true);
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.pendingUserPromptSeq).toBe(1);
+    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("late Stopped from prior turn does NOT clobber turnActive after a fresh follow-up", async () => {
+    // The bug. Prior turn: pendingUserPromptSeq=1, lastStoppedSeq=0
+    // (turnActive=true). User submits a follow-up before the prior
+    // turn's Stopped frame has been applied client-side; the
+    // optimistic `user_prompt` action bumps pending to 2. A beat
+    // later the Stopped frame for turn 1 lands. Under the old
+    // unconditional `turnActive=false`, the spinner died and the
+    // late agent chunks reordered visually below the new prompt.
+    // Under the counter model, lastStoppedSeq advances to 1
+    // (capped at pending) and `2 > 1` keeps turnActive true.
+    const { cockpitHookReducer } = await import("../hooks/useCockpit");
+
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "first turn" } },
+    });
+    expect(state.turnActive).toBe(true);
+    // User taps Send the instant the turn ends; the optimistic
+    // dispatch lands BEFORE the Stopped frame for the prior turn.
+    state = cockpitHookReducer(state, {
+      kind: "user_prompt",
+      text: "follow-up",
+    });
+    expect(state.pendingUserPromptSeq).toBe(2);
+    expect(state.turnActive).toBe(true);
+    // Late Stopped (was for turn 1) now arrives. Must NOT kill the
+    // spinner because turn 2 is the active turn.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.pendingUserPromptSeq).toBe(2);
+    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.turnActive).toBe(true);
+
+    // Eventually turn 2's own Stopped lands and flips it off.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.lastStoppedSeq).toBe(2);
+    expect(state.turnActive).toBe(false);
+  });
+
+  it("spurious Stopped on an idle session does not flip a future prompt off", () => {
+    // Defence-in-depth: a Stopped frame arriving with no outstanding
+    // turn must not advance `lastStoppedSeq` past `pendingUserPromptSeq`,
+    // otherwise the next prompt's increment wouldn't catch up and
+    // `turnActive` would stay false even with a real turn in flight.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "hi" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.turnActive).toBe(false);
+    // Spurious extra Stopped (e.g. duplicate replay of the close).
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { Stopped: { reason: "prompt_complete" } },
+    });
+    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.pendingUserPromptSeq).toBe(1);
+    // Next real prompt: turn must reactivate.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: { UserPromptSent: { text: "second" } },
+    });
+    expect(state.pendingUserPromptSeq).toBe(2);
+    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.turnActive).toBe(true);
+  });
+
+  it("optimistic user_prompt + matching server echo only bump pending once", async () => {
+    // Avoids double-counting: the server's UserPromptSent that matches
+    // and promotes an existing optimistic row must not bump
+    // `pendingUserPromptSeq` again.
+    const { cockpitHookReducer } = await import("../hooks/useCockpit");
+    let state = cockpitHookReducer(emptyCockpitState(), {
+      kind: "user_prompt",
+      text: "echo me",
+    });
+    expect(state.pendingUserPromptSeq).toBe(1);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 5,
+      event: { UserPromptSent: { text: "echo me" } },
+    });
+    expect(state.pendingUserPromptSeq).toBe(1);
+    expect(state.turnActive).toBe(true);
+  });
+
+  it("AgentStartupError advances lastStoppedSeq, preserving the race-safe semantics", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { UserPromptSent: { text: "first" } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AgentStartupError: { message: "boom" } },
+    });
+    expect(state.lastStoppedSeq).toBe(1);
+    expect(state.turnActive).toBe(false);
+    expect(state.startupError).toBe("boom");
   });
 });
 

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -220,8 +220,26 @@ export interface CockpitState {
   /** True between sending a user prompt and receiving the
    *  `Stopped { reason: "prompt_complete" }` event. Drives the global
    *  "working" spinner so the UI feels alive even when the agent
-   *  isn't streaming text or running a tool yet. */
+   *  isn't streaming text or running a tool yet.
+   *
+   *  Derived from `pendingUserPromptSeq > lastStoppedSeq`; never
+   *  written directly. Keeping it on the state shape (instead of
+   *  exporting a selector) lets all the existing `state.turnActive`
+   *  reads stay unchanged. The counter pair is the source of truth so
+   *  a late `Stopped` from a prior turn can't clobber a fresh
+   *  follow-up that's already incremented `pendingUserPromptSeq`.
+   *  See #1170. */
   turnActive: boolean;
+  /** Monotonic count of user prompts the client has dispatched (either
+   *  via the optimistic `user_prompt` action or via a server-confirmed
+   *  `UserPromptSent` echo that didn't match an outstanding optimistic
+   *  row). Source of truth for `turnActive`; never decremented. */
+  pendingUserPromptSeq: number;
+  /** Snapshot of `pendingUserPromptSeq` at the moment the most recent
+   *  `Stopped` (or `AgentStartupError`) arrived. `turnActive` derives
+   *  to false only when no further prompt has bumped
+   *  `pendingUserPromptSeq` past this snapshot. */
+  lastStoppedSeq: number;
   /** Real ACP-advertised modes from the agent's NewSessionResponse,
    *  plus the agent's currently-active mode id. Empty until the
    *  agent reports them; the picker falls back to the hard-coded
@@ -348,6 +366,8 @@ export function emptyCockpitState(): CockpitState {
     startupError: null,
     lastError: null,
     turnActive: false,
+    pendingUserPromptSeq: 0,
+    lastStoppedSeq: 0,
     availableModes: [],
     currentModeId: null,
     availableCommands: [],
@@ -608,10 +628,23 @@ export function applyEvent(
   }
   if ("Stopped" in event) {
     // Final marker; nothing to mutate, but reset the inflight tool just
-    // in case the agent forgot to emit a completion. Also clears the
-    // turn-active flag so the global "working" spinner stops.
+    // in case the agent forgot to emit a completion.
+    //
+    // `turnActive` is derived from `pendingUserPromptSeq > lastStoppedSeq`;
+    // we advance `lastStoppedSeq` by one (capped at `pendingUserPromptSeq`)
+    // so this Stopped only retires ONE turn's worth of activity. If a
+    // fresh user prompt landed client-side between the turn this Stopped
+    // is closing and now, `pendingUserPromptSeq` was already bumped past
+    // the cap and `turnActive` stays true. Without this, a late Stopped
+    // would clobber the spinner mid follow-up and reorder the user's
+    // optimistic message above any still-arriving prior-turn agent
+    // chunks. See #1170.
     next.inFlightTool = null;
-    next.turnActive = false;
+    next.lastStoppedSeq = Math.min(
+      next.lastStoppedSeq + 1,
+      next.pendingUserPromptSeq,
+    );
+    next.turnActive = isTurnActive(next);
     // The "user_stopped" / "restart_pending" reasons are published by
     // the supervisor's reap_user_stopped pass when it detects an
     // out-of-band CLI teardown. Surface a distinct UI state for each:
@@ -648,7 +681,15 @@ export function applyEvent(
   if ("AgentStartupError" in event) {
     next.startupError = event.AgentStartupError.message;
     next.inFlightTool = null;
-    next.turnActive = false;
+    // Same race-safe semantics as `Stopped`: advance `lastStoppedSeq`
+    // by one so a startup failure for the prior turn doesn't kill the
+    // spinner for a freshly-typed follow-up the user has already
+    // submitted. See #1170.
+    next.lastStoppedSeq = Math.min(
+      next.lastStoppedSeq + 1,
+      next.pendingUserPromptSeq,
+    );
+    next.turnActive = isTurnActive(next);
     return next;
   }
   if ("UserPromptSent" in event) {
@@ -684,7 +725,15 @@ export function applyEvent(
     next.assistantMessage = "";
     next.startupError = null;
     next.lastError = null;
-    next.turnActive = true;
+    // No optimistic row matched: this is a server-confirmed prompt the
+    // client didn't dispatch (replay path, server-initiated, or user
+    // action without optimistic local dispatch). Bump the prompt
+    // counter so `turnActive` derives true. The optimistic-match branch
+    // above already covered the case where the client's `user_prompt`
+    // action bumped the counter; bumping again here would double-count.
+    // See #1170.
+    next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
+    next.turnActive = isTurnActive(next);
     // New turn; reset the no-output detector so Stopped fires the
     // empty-output notice if the agent produces nothing.
     next.turnHasOutput = false;
@@ -785,4 +834,14 @@ function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {
     return next.slice(next.length - activityLimit);
   }
   return next;
+}
+
+/** Derived `turnActive` from the prompt / stop seq counters. Exported
+ *  so any new consumer can compute it from the counters directly; the
+ *  reducer also calls this to keep `state.turnActive` in lockstep so
+ *  existing `state.turnActive` reads stay correct. See #1170. */
+export function isTurnActive(
+  state: Pick<CockpitState, "pendingUserPromptSeq" | "lastStoppedSeq">,
+): boolean {
+  return state.pendingUserPromptSeq > state.lastStoppedSeq;
 }

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -668,6 +668,15 @@ export function applyEvent(
     // flag is flipped by every output-producing handler and reset by
     // UserPromptSent, so this check is O(1) instead of walking the
     // full activity array on every Stopped.
+    //
+    // `state.turnActive` is read on the PRE-event state. Under the
+    // counter derivation it means "at least one outstanding prompt
+    // hasn't been retired yet," which is exactly what we want: it
+    // skips spurious Stopped frames (no open turn to attribute the
+    // notice to) and fires for the turn this Stopped is actually
+    // retiring. In the race case, `turnHasOutput` still reflects the
+    // turn being retired because UserPromptSent (which resets it) for
+    // the follow-up hasn't been applied yet.
     if (state.turnActive && !state.turnHasOutput) {
       next.activity = pushActivity(next.activity, {
         id: `empty-${frame.seq}`,
@@ -708,31 +717,38 @@ export function applyEvent(
         !r.id.startsWith("user-seq-"),
     );
     if (matchIdx >= 0) {
+      // Optimistic-match path: promote the placeholder's id. The
+      // client's `user_prompt` action already bumped
+      // `pendingUserPromptSeq`, so we don't bump again here. The
+      // per-turn resets below STILL apply: `turnHasOutput`, the
+      // worker banners, and the wakeup countdown all reset on every
+      // server-confirmed UserPromptSent regardless of which branch
+      // promoted the row. See #1170.
       const match = next.activity[matchIdx];
       if (match) {
         const updated = next.activity.slice();
         updated[matchIdx] = { ...match, id: `user-seq-${frame.seq}` };
         next.activity = updated;
-        return next;
       }
+    } else {
+      // No optimistic row matched: this is a server-confirmed prompt
+      // the client didn't dispatch (replay path, server-initiated, or
+      // user action without optimistic local dispatch). Append a fresh
+      // row and bump the prompt counter so `turnActive` derives true.
+      // The optimistic-match branch above is reached when the client's
+      // `user_prompt` action already bumped the counter; bumping again
+      // here would double-count. See #1170.
+      next.activity = pushActivity(next.activity, {
+        id: `user-seq-${frame.seq}`,
+        kind: "user_prompt",
+        text,
+        at: new Date().toISOString(),
+      });
+      next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
     }
-    next.activity = pushActivity(next.activity, {
-      id: `user-seq-${frame.seq}`,
-      kind: "user_prompt",
-      text,
-      at: new Date().toISOString(),
-    });
     next.assistantMessage = "";
     next.startupError = null;
     next.lastError = null;
-    // No optimistic row matched: this is a server-confirmed prompt the
-    // client didn't dispatch (replay path, server-initiated, or user
-    // action without optimistic local dispatch). Bump the prompt
-    // counter so `turnActive` derives true. The optimistic-match branch
-    // above already covered the case where the client's `user_prompt`
-    // action bumped the counter; bumping again here would double-count.
-    // See #1170.
-    next.pendingUserPromptSeq = next.pendingUserPromptSeq + 1;
     next.turnActive = isTurnActive(next);
     // New turn; reset the no-output detector so Stopped fires the
     // empty-output notice if the agent produces nothing.
@@ -839,9 +855,47 @@ function pushActivity(rows: ActivityRow[], row: ActivityRow): ActivityRow[] {
 /** Derived `turnActive` from the prompt / stop seq counters. Exported
  *  so any new consumer can compute it from the counters directly; the
  *  reducer also calls this to keep `state.turnActive` in lockstep so
- *  existing `state.turnActive` reads stay correct. See #1170. */
+ *  existing `state.turnActive` reads stay correct. See #1170.
+ *
+ *  Invariant: `lastStoppedSeq <= pendingUserPromptSeq` always holds.
+ *  Both counters start at 0; `pendingUserPromptSeq` increments by one
+ *  on every dispatched user prompt, and `lastStoppedSeq` advances by
+ *  one per `Stopped` / `AgentStartupError` but is capped at
+ *  `pendingUserPromptSeq` so spurious extra Stopped frames cannot
+ *  poison a future turn. */
 export function isTurnActive(
   state: Pick<CockpitState, "pendingUserPromptSeq" | "lastStoppedSeq">,
 ): boolean {
   return state.pendingUserPromptSeq > state.lastStoppedSeq;
+}
+
+/** Normalise a partial CockpitState so the turn counters are populated.
+ *  Used by the localStorage loader after the #1170 schema change: pre-
+ *  schema persisted entries have no counters, so we backfill from the
+ *  cached `turnActive` boolean (true → one outstanding prompt, false →
+ *  fully retired) and re-derive `turnActive` from the counters. */
+export function normaliseTurnCounters(
+  state: CockpitState & {
+    pendingUserPromptSeq?: number;
+    lastStoppedSeq?: number;
+  },
+): CockpitState {
+  const pendingUserPromptSeq =
+    typeof state.pendingUserPromptSeq === "number"
+      ? state.pendingUserPromptSeq
+      : state.turnActive
+        ? 1
+        : 0;
+  const lastStoppedSeq =
+    typeof state.lastStoppedSeq === "number"
+      ? state.lastStoppedSeq
+      : state.turnActive
+        ? 0
+        : pendingUserPromptSeq;
+  return {
+    ...state,
+    pendingUserPromptSeq,
+    lastStoppedSeq,
+    turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),
+  };
 }


### PR DESCRIPTION
## Description

Fixes #1170. When a user sends a follow-up prompt the instant a turn ends, the `Stopped` frame from the prior turn can arrive client-side AFTER the local optimistic `user_prompt` dispatch. The old `applyEvent` branch for `Stopped` unconditionally set `turnActive = false`, which:

1. Killed the spinner mid follow-up (the UI looked dead while the agent was already working on the new prompt).
2. Created a visual reorder where late prior-turn agent chunks landed below the new user message.

Replace the boolean source of truth with two counters on `CockpitState`:

- `pendingUserPromptSeq` is incremented on every user prompt the client dispatches (optimistic `user_prompt` action OR server `UserPromptSent` echo that didn't match an outstanding optimistic row, so we don't double-count).
- `lastStoppedSeq` is advanced by one on every `Stopped` / `AgentStartupError`, capped at `pendingUserPromptSeq` so a spurious extra `Stopped` can't poison a future prompt.

`turnActive` stays on `CockpitState` as a memoised alias computed from `pendingUserPromptSeq > lastStoppedSeq`, so every existing `state.turnActive` reader (Composer, CockpitRuntime, CockpitView, useCockpit's drain effect, the existing tests) keeps working unchanged. The race now resolves correctly: when a fresh follow-up bumps `pendingUserPromptSeq` to 2 before the prior turn's `Stopped` lands, that `Stopped` only advances `lastStoppedSeq` to 1 and `2 > 1` keeps `turnActive` true.

The persisted-state loader normalises older entries (no counters) by backfilling from the cached `turnActive` boolean so cached sessions don't go inert on first reload after the schema change.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No new visual surface, only behavioural; the spinner now stays alive across the follow-up handoff.)

Test plan:
- `cd web && npm run test:unit` (292 tests pass, includes 6 new race-regression cases).
- `cd web && npm run build` (clean).
- `cd web && npm run lint` (no new errors; pre-existing lint debt unchanged).

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Filed and triaged via the cockpit; the model recommended the lower-disruption "keep the boolean as a derived alias" shape so consumers stay on `state.turnActive` reads.

- [x] I am an AI Agent filling out this form (check box if true)