### PR TITLE
fix(session): resume-fallback cascade for restart/start paths

### DIFF
--- a/docs/guides/session-resume.md
+++ b/docs/guides/session-resume.md
@@ -16,10 +16,6 @@ For sandboxed (Docker) sessions, the poller runs the same scan inside the contai
 - Runtime rotation via `/clear`, `--fork-session`, or fresh `claude` invocation in the same pane.
 - Manual override via the CLI when you want to point a session at a specific conversation.
 
-## What's not covered (yet)
-
-- Other agents (OpenCode, Codex, Gemini, Vibe, Pi). They're tracked behind separate follow-up PRs; their sessions still launch fresh until then.
-
 ## Manual override
 
 To point a session at a different Claude conversation ID without launching it:

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -51,8 +51,16 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
                         stale_history_suffix(&sid),
                     );
                 }
-                Ok(EnsureReadyOutcome::Started) => {
+                Ok(EnsureReadyOutcome::Started { stale_sid: None }) => {
                     eprintln!("  (started stopped session before send)");
+                }
+                Ok(EnsureReadyOutcome::Started {
+                    stale_sid: Some(sid),
+                }) => {
+                    eprintln!(
+                        "  (started stopped session before send){}",
+                        stale_history_suffix(&sid),
+                    );
                 }
                 Ok(EnsureReadyOutcome::AlreadyAlive) => {}
                 Err(EnsureReadyError::Transient(status)) => {

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
+use crate::cli::session::stale_history_suffix;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Storage};
 
 #[derive(Args)]
@@ -39,8 +40,16 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     if !args.no_revive {
         if let Some(target) = instances.iter_mut().find(|i| i.id == session_id) {
             match target.ensure_pane_ready() {
-                Ok(EnsureReadyOutcome::Respawned) => {
+                Ok(EnsureReadyOutcome::Respawned { stale_sid: None }) => {
                     eprintln!("  (respawned dead pane before send)");
+                }
+                Ok(EnsureReadyOutcome::Respawned {
+                    stale_sid: Some(sid),
+                }) => {
+                    eprintln!(
+                        "  (respawned dead pane before send){}",
+                        stale_history_suffix(&sid),
+                    );
                 }
                 Ok(EnsureReadyOutcome::Started) => {
                     eprintln!("  (started stopped session before send)");

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -332,7 +332,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                 .expect("semaphore not closed");
             let title = inst.title.clone();
             let res = tokio::task::spawn_blocking(move || {
-                let result = inst.restart_with_size(size);
+                let result = inst.restart_with_size(size).map(|_| ());
                 (inst, result)
             })
             .await;
@@ -425,13 +425,23 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // so restart-time config resolution honors the right profile's overrides.
     instances[idx].source_profile = profile.to_string();
     bail_if_cockpit(&instances[idx], "restart")?;
-    instances[idx].restart_with_size(crate::terminal::get_size())?;
+    let outcome = instances[idx].restart_with_size(crate::terminal::get_size())?;
     let title = instances[idx].title.clone();
 
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
     storage.save_with_groups(&instances, &group_tree)?;
 
-    println!("✓ Restarted session: {}", title);
+    match outcome {
+        crate::session::StartOutcome::Restarted { stale_sid } => {
+            println!(
+                "✓ Restarted session: {} (resume failed for sid {}; started fresh, prior history not loaded)",
+                title, stale_sid
+            );
+        }
+        crate::session::StartOutcome::Resumed | crate::session::StartOutcome::Fresh => {
+            println!("✓ Restarted session: {}", title);
+        }
+    }
     Ok(())
 }
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -4,7 +4,14 @@ use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 use serde::Serialize;
 
-use crate::session::{GroupTree, Storage};
+use crate::session::{GroupTree, StartOutcome, Storage};
+
+/// Wording used by both single-session and `--all` restart paths when the
+/// resume-fallback cascade cleared a stale agent_session_id. Centralized so
+/// drift between the two surfaces cannot happen.
+fn stale_history_suffix(stale_sid: &str) -> String {
+    format!(" (resume failed for sid {stale_sid}; started fresh, prior history not loaded)")
+}
 
 #[derive(Subcommand)]
 pub enum SessionCommands {
@@ -320,7 +327,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         usize,
         String,
         Option<crate::session::Instance>,
-        Result<()>,
+        Result<StartOutcome>,
     )> = tokio::task::JoinSet::new();
 
     for (idx, mut inst) in targets {
@@ -332,7 +339,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                 .expect("semaphore not closed");
             let title = inst.title.clone();
             let res = tokio::task::spawn_blocking(move || {
-                let result = inst.restart_with_size(size).map(|_| ());
+                let result = inst.restart_with_size(size);
                 (inst, result)
             })
             .await;
@@ -348,9 +355,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         });
     }
 
-    let mut succeeded: Vec<String> = Vec::new();
+    let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
-
     while let Some(joined) = join_set.join_next().await {
         let (idx, title, inst_opt, result) =
             joined.expect("JoinSet shouldn't panic on join itself");
@@ -358,7 +364,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             instances[idx] = inst;
         }
         match result {
-            Ok(()) => succeeded.push(title),
+            Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
+            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((title, None)),
             Err(e) => failed.push((title, e.to_string())),
         }
     }
@@ -366,9 +373,22 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let group_tree = GroupTree::new_with_groups(&instances, &groups);
     storage.save_with_groups(&instances, &group_tree)?;
 
-    println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
-    for title in &succeeded {
-        println!("  · {}", title);
+    let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
+    if stale_count == 0 {
+        println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
+    } else {
+        println!(
+            "✓ Restarted {}/{} sessions ({} without prior history):",
+            succeeded.len(),
+            total,
+            stale_count,
+        );
+    }
+    for (title, stale) in &succeeded {
+        match stale {
+            Some(sid) => println!("  · {}{}", title, stale_history_suffix(sid)),
+            None => println!("  · {}", title),
+        }
     }
     if !failed.is_empty() {
         println!("✗ {} failed:", failed.len());
@@ -432,13 +452,14 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     storage.save_with_groups(&instances, &group_tree)?;
 
     match outcome {
-        crate::session::StartOutcome::Restarted { stale_sid } => {
+        StartOutcome::Restarted { stale_sid } => {
             println!(
-                "✓ Restarted session: {} (resume failed for sid {}; started fresh, prior history not loaded)",
-                title, stale_sid
+                "✓ Restarted session: {}{}",
+                title,
+                stale_history_suffix(&stale_sid),
             );
         }
-        crate::session::StartOutcome::Resumed | crate::session::StartOutcome::Fresh => {
+        StartOutcome::Resumed | StartOutcome::Fresh => {
             println!("✓ Restarted session: {}", title);
         }
     }
@@ -958,5 +979,34 @@ mod target_filter_tests {
     #[test]
     fn empty_input_yields_empty_targets() {
         assert!(pick_targets_for_restart_all(&[]).is_empty());
+    }
+}
+
+#[cfg(test)]
+mod stale_history_suffix_tests {
+    use super::stale_history_suffix;
+
+    #[test]
+    fn matches_single_session_wording() {
+        let suffix = stale_history_suffix("11111111-1111-1111-1111-111111111111");
+        assert_eq!(
+            suffix,
+            " (resume failed for sid 11111111-1111-1111-1111-111111111111; \
+             started fresh, prior history not loaded)"
+        );
+    }
+
+    #[test]
+    fn renders_inline_with_title_correctly() {
+        let line = format!(
+            "  · {}{}",
+            "alpha",
+            stale_history_suffix("22222222-2222-2222-2222-222222222222"),
+        );
+        assert_eq!(
+            line,
+            "  · alpha (resume failed for sid 22222222-2222-2222-2222-222222222222; \
+             started fresh, prior history not loaded)"
+        );
     }
 }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -9,7 +9,7 @@ use crate::session::{GroupTree, StartOutcome, Storage};
 /// Wording used by both single-session and `--all` restart paths when the
 /// resume-fallback cascade cleared a stale agent_session_id. Centralized so
 /// drift between the two surfaces cannot happen.
-fn stale_history_suffix(stale_sid: &str) -> String {
+pub(crate) fn stale_history_suffix(stale_sid: &str) -> String {
     format!(" (resume failed for sid {stale_sid}; started fresh, prior history not loaded)")
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1188,10 +1188,18 @@ fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
 /// Read-only: in read-only mode, the endpoint may report `alive` but will
 /// refuse to kill+restart a session. Returns 403 when a restart is needed.
 ///
-/// Latency: the synchronous restart path includes Tier-1 probe (up to ~1s
-/// to detect a pane crash) plus, if the cascade fires, kill_clean + Tier-2
-/// spawn + Tier-2 probe grace (up to another ~3s). HTTP clients should
-/// budget ~3s worst-case for cold-start cascade scenarios.
+/// Latency: bounded by `RESUME_PROBE_MAX` (~3s) per probe.
+///   * No-op (pane alive): inspect-only, ~tmux RTT.
+///   * Healthy resume: Tier-1 probe only, returns after the
+///     `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) shortcut. Shell-wrapper
+///     overrides charitably burn the full ~3s instead (see
+///     `Instance::probe_settle`).
+///   * Cascade fires (Tier-1 detects a dead pane): Tier-1 returns Dead
+///     fast (`pane_dead`/`!exists` is unambiguous), then `kill_clean`
+///     (~100ms macOS grace) + Tier-2 tmux spawn + up to another
+///     `RESUME_PROBE_MAX`.
+/// HTTP clients should budget ~6-7s worst-case for the full Tier-1 +
+/// Tier-2 cascade and configure timeouts accordingly.
 pub async fn ensure_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1268,28 +1268,38 @@ pub async fn ensure_session(
         }
     }
 
-    let restart_result = tokio::task::spawn_blocking(move || -> anyhow::Result<Instance> {
-        let tmux_session = instance.tmux_session()?;
-        if tmux_session.exists() {
-            let _ = tmux_session.kill();
-        }
-        let mut inst = instance;
-        inst.start_with_size_opts(None, false)?;
-        Ok(inst)
-    })
+    let restart_result = tokio::task::spawn_blocking(
+        move || -> anyhow::Result<(Instance, crate::session::StartOutcome)> {
+            let tmux_session = instance.tmux_session()?;
+            if tmux_session.exists() {
+                let _ = tmux_session.kill();
+            }
+            let mut inst = instance;
+            let outcome = inst.start_with_resume_fallback(None, false)?;
+            Ok((inst, outcome))
+        },
+    )
     .await;
 
     match restart_result {
-        Ok(Ok(started)) => {
+        Ok(Ok((started, outcome))) => {
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
                 apply_post_restart_sync(inst, &started);
             }
-            (
-                StatusCode::OK,
-                Json(serde_json::json!({"status": "restarted"})),
-            )
-                .into_response()
+            let resume_outcome = match &outcome {
+                crate::session::StartOutcome::Resumed => "resumed",
+                crate::session::StartOutcome::Restarted { .. } => "restarted",
+                crate::session::StartOutcome::Fresh => "fresh",
+            };
+            let mut body = serde_json::json!({
+                "status": "restarted",
+                "resume_outcome": resume_outcome,
+            });
+            if let crate::session::StartOutcome::Restarted { stale_sid } = &outcome {
+                body["stale_session_id"] = serde_json::Value::String(stale_sid.clone());
+            }
+            (StatusCode::OK, Json(body)).into_response()
         }
         Ok(Err(e)) => {
             let msg = e.to_string();

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1191,7 +1191,7 @@ fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
 /// Latency: bounded by `RESUME_PROBE_MAX` (~3s) per probe.
 ///   * No-op (pane alive): inspect-only, ~tmux RTT.
 ///   * Healthy resume: Tier-1 probe only, returns after the
-///     `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) shortcut. Shell-wrapper
+///     `RESUME_PROBE_POST_SHELL_GRACE` (~2s) shortcut. Shell-wrapper
 ///     overrides charitably burn the full ~3s instead (see
 ///     `Instance::probe_settle`).
 ///   * Cascade fires (Tier-1 detects a dead pane): Tier-1 returns Dead

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1198,6 +1198,7 @@ fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
 ///     fast (`pane_dead`/`!exists` is unambiguous), then `kill_clean`
 ///     (~100ms macOS grace) + Tier-2 tmux spawn + up to another
 ///     `RESUME_PROBE_MAX`.
+///
 /// HTTP clients should budget ~6-7s worst-case for the full Tier-1 +
 /// Tier-2 cascade and configure timeouts accordingly.
 pub async fn ensure_session(
@@ -2696,10 +2697,16 @@ pub async fn send_message(
                 }
             });
             let mut body = serde_json::json!({"sent": true});
-            if let EnsureReadyOutcome::Respawned {
-                stale_sid: Some(sid),
-            } = outcome
-            {
+            let stale_sid = match &outcome {
+                EnsureReadyOutcome::Respawned {
+                    stale_sid: Some(sid),
+                }
+                | EnsureReadyOutcome::Started {
+                    stale_sid: Some(sid),
+                } => Some(sid.clone()),
+                _ => None,
+            };
+            if let Some(sid) = stale_sid {
                 body["stale_session_id"] = serde_json::Value::String(sid);
             }
             (StatusCode::OK, Json(body)).into_response()

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1170,6 +1170,11 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
 ///
 /// Read-only: in read-only mode, the endpoint may report `alive` but will
 /// refuse to kill+restart a session. Returns 403 when a restart is needed.
+///
+/// Latency: the synchronous restart path includes Tier-1 probe (up to ~1s
+/// to detect a pane crash) plus, if the cascade fires, kill_clean + Tier-2
+/// spawn + Tier-2 probe grace (up to another ~3s). HTTP clients should
+/// budget ~3s worst-case for cold-start cascade scenarios.
 pub async fn ensure_session(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -1270,16 +1275,27 @@ pub async fn ensure_session(
     }
 
     let restart_result = tokio::task::spawn_blocking(
-        move || -> anyhow::Result<(Instance, crate::session::StartOutcome)> {
+        move || -> Result<(Instance, crate::session::StartOutcome), Box<(Instance, anyhow::Error)>> {
             let mut inst = instance;
             // Use kill_clean (vs bare tmux kill) so a remain-on-exit dead
             // pane is respawned-then-killed; bare kill races against the
             // session cache on macOS and can leave the corpse pane behind,
             // which then trips the next start_with_resume_fallback's
             // `pane_was_preexisting` short-circuit. See `Instance::kill_clean`.
-            inst.kill_clean()?;
-            let outcome = inst.start_with_resume_fallback(None, false)?;
-            Ok((inst, outcome))
+            if let Err(e) = inst.kill_clean() {
+                return Err(Box::new((inst, e)));
+            }
+            // Surface the moved Instance on the Err arm so the caller can
+            // sync the cascade-cleared `agent_session_id` and updated
+            // `retroactive_capture_excludes` back to live state. Otherwise
+            // the live entry retains the stale sid in memory while disk has
+            // already been cleared, and subsequent calls within the
+            // `status_poll_loop` reload window (~2s) keep re-attempting
+            // resume with the bad sid. See `apply_post_restart_sync`.
+            match inst.start_with_resume_fallback(None, false) {
+                Ok(outcome) => Ok((inst, outcome)),
+                Err(e) => Err(Box::new((inst, e))),
+            }
         },
     )
     .await;
@@ -1304,11 +1320,13 @@ pub async fn ensure_session(
             }
             (StatusCode::OK, Json(body)).into_response()
         }
-        Ok(Err(e)) => {
+        Ok(Err(boxed)) => {
+            let (started, e) = *boxed;
             let msg = e.to_string();
             tracing::warn!("ensure_session restart failed for {id}: {msg}");
             let mut instances = state.instances.write().await;
             if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+                apply_post_restart_sync(inst, &started);
                 inst.status = crate::session::Status::Error;
                 inst.last_error = Some(msg.clone());
             }
@@ -2551,28 +2569,44 @@ pub async fn send_message(
     let message = req.message;
     let revive = req.revive;
     let send_result = tokio::task::spawn_blocking(
-        move || -> Result<(EnsureReadyOutcome, Instance), SendKeysError> {
+        move || -> Result<(EnsureReadyOutcome, Instance), Box<(Instance, SendKeysError)>> {
             // Revive the pane before sending. Without this, a send to a dead
             // pane silently writes keystrokes to a corpse with no agent.
             // Skipped when the caller opts out via `revive: false`.
+            //
+            // The closure surfaces `inst_owned` on BOTH arms so the caller
+            // can sync the cascade-cleared `agent_session_id` and updated
+            // `retroactive_capture_excludes` back to live state on Err.
+            // Otherwise a Tier-2 cascade failure leaves the live entry with
+            // a stale sid in memory while disk is already cleared, and
+            // subsequent sends keep re-attempting resume with the bad sid.
             let mut inst_owned = instance;
             let outcome = if revive {
-                inst_owned.ensure_pane_ready().map_err(|e| match e {
-                    EnsureReadyError::Transient(s) => SendKeysError::Transient(s),
-                    EnsureReadyError::CockpitMode => SendKeysError::CockpitMode,
-                    EnsureReadyError::Tmux(e) => SendKeysError::Tmux(e),
-                })?
+                match inst_owned.ensure_pane_ready() {
+                    Ok(o) => o,
+                    Err(e) => {
+                        let mapped = match e {
+                            EnsureReadyError::Transient(s) => SendKeysError::Transient(s),
+                            EnsureReadyError::CockpitMode => SendKeysError::CockpitMode,
+                            EnsureReadyError::Tmux(e) => SendKeysError::Tmux(e),
+                        };
+                        return Err(Box::new((inst_owned, mapped)));
+                    }
+                }
             } else {
                 EnsureReadyOutcome::AlreadyAlive
             };
-            let tmux_session = inst_owned.tmux_session().map_err(SendKeysError::Tmux)?;
+            let tmux_session = match inst_owned.tmux_session() {
+                Ok(s) => s,
+                Err(e) => return Err(Box::new((inst_owned, SendKeysError::Tmux(e)))),
+            };
             if !tmux_session.exists() {
-                return Err(SendKeysError::NotRunning);
+                return Err(Box::new((inst_owned, SendKeysError::NotRunning)));
             }
             let delay = crate::agents::send_keys_enter_delay(&tool);
-            tmux_session
-                .send_keys_with_delay(&message, delay)
-                .map_err(SendKeysError::Tmux)?;
+            if let Err(e) = tmux_session.send_keys_with_delay(&message, delay) {
+                return Err(Box::new((inst_owned, SendKeysError::Tmux(e))));
+            }
             Ok((outcome, inst_owned))
         },
     )
@@ -2624,31 +2658,54 @@ pub async fn send_message(
             }
             (StatusCode::OK, Json(body)).into_response()
         }
-        Ok(Err(SendKeysError::NotRunning)) => (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({"error": "session_not_running"})),
-        )
-            .into_response(),
-        Ok(Err(SendKeysError::Transient(status))) => (
-            StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "error": "session_transient",
-                "status": format!("{status:?}"),
-            })),
-        )
-            .into_response(),
-        Ok(Err(SendKeysError::CockpitMode)) => (
-            StatusCode::BAD_REQUEST,
-            Json(serde_json::json!({"error": "cockpit_mode_unsupported"})),
-        )
-            .into_response(),
-        Ok(Err(SendKeysError::Tmux(e))) => {
-            tracing::error!("send_message: tmux error for {id}: {e}");
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({"error": "tmux_error"})),
-            )
-                .into_response()
+        Ok(Err(boxed)) => {
+            let (started, send_err) = *boxed;
+            match send_err {
+                SendKeysError::NotRunning => (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({"error": "session_not_running"})),
+                )
+                    .into_response(),
+                SendKeysError::Transient(status) => (
+                    StatusCode::CONFLICT,
+                    Json(serde_json::json!({
+                        "error": "session_transient",
+                        "status": format!("{status:?}"),
+                    })),
+                )
+                    .into_response(),
+                SendKeysError::CockpitMode => (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({"error": "cockpit_mode_unsupported"})),
+                )
+                    .into_response(),
+                SendKeysError::Tmux(e) => {
+                    tracing::error!("send_message: tmux error for {id}: {e}");
+                    let msg = e.to_string();
+                    // Sync cascade-mutated fields back to live state. Only
+                    // the Tmux variant routes through `ensure_pane_ready` ->
+                    // cascade, so this is the sole arm where `started` may
+                    // carry the cleared sid + updated excludes. The other
+                    // variants leave `started` untouched and don't need a
+                    // sync (and a sync would clobber the live `last_error`
+                    // with `started.last_error = None`). Mirror
+                    // `ensure_session`'s Err arm: sync, then override
+                    // `status` and `last_error` so observers don't see
+                    // `Status::Starting` (set by `finalize_launch` before
+                    // Tier-2 bail) on a broken session.
+                    let mut instances = state.instances.write().await;
+                    if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                        apply_post_restart_sync(i, &started);
+                        i.status = crate::session::Status::Error;
+                        i.last_error = Some(msg);
+                    }
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({"error": "tmux_error"})),
+                    )
+                        .into_response()
+                }
+            }
         }
         Err(e) => {
             tracing::error!("send_message: blocking task panicked for {id}: {e}");

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1154,6 +1154,7 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
     live.last_error = None;
     live.agent_session_id = started.agent_session_id.clone();
     live.last_start_time = started.last_start_time;
+    live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
 
 /// Ensure the main agent tmux session is alive, restarting it if dead.
@@ -2612,7 +2613,14 @@ pub async fn send_message(
                     }
                 }
             });
-            (StatusCode::OK, Json(serde_json::json!({"sent": true}))).into_response()
+            let mut body = serde_json::json!({"sent": true});
+            if let EnsureReadyOutcome::Respawned {
+                stale_sid: Some(sid),
+            } = outcome
+            {
+                body["stale_session_id"] = serde_json::Value::String(sid);
+            }
+            (StatusCode::OK, Json(body)).into_response()
         }
         Ok(Err(SendKeysError::NotRunning)) => (
             StatusCode::CONFLICT,

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1157,6 +1157,23 @@ fn apply_post_restart_sync(live: &mut Instance, started: &Instance) {
     live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
 }
 
+/// Narrow sibling of [`apply_post_restart_sync`] that propagates only the
+/// fields the resume-fallback cascade is responsible for: the post-cascade
+/// `agent_session_id` (either `None` after a bailed Tier-1 cleanup, or a
+/// fresh UUID acquired by Tier-2's `start_with_size_opts` ->
+/// `acquire_session_id`) and the updated `retroactive_capture_excludes`.
+///
+/// Intended for error paths where the cascade may have run but the caller
+/// does not want to touch user-visible status fields. `NotRunning` is the
+/// canonical use case: a recoverable transient state where overwriting
+/// `live.status` with `started.status` (typically `Starting` from the
+/// post-cascade `finalize_launch`) would briefly mis-paint a broken pane
+/// as `Starting` until the 2s status poll loop reconciles.
+fn apply_cascade_state_sync(live: &mut Instance, started: &Instance) {
+    live.agent_session_id = started.agent_session_id.clone();
+    live.retroactive_capture_excludes = started.retroactive_capture_excludes.clone();
+}
+
 /// Ensure the main agent tmux session is alive, restarting it if dead.
 ///
 /// Mirrors the TUI's `attach_session` restart logic: checks the actual tmux
@@ -2527,6 +2544,9 @@ enum SendKeysError {
     Tmux(anyhow::Error),
 }
 
+type SendKeysResult =
+    Result<(EnsureReadyOutcome, Instance), Box<(Instance, EnsureReadyOutcome, SendKeysError)>>;
+
 pub async fn send_message(
     State(state): State<Arc<AppState>>,
     Path(id): Path<String>,
@@ -2568,48 +2588,66 @@ pub async fn send_message(
     let tool = instance.tool.clone();
     let message = req.message;
     let revive = req.revive;
-    let send_result = tokio::task::spawn_blocking(
-        move || -> Result<(EnsureReadyOutcome, Instance), Box<(Instance, SendKeysError)>> {
-            // Revive the pane before sending. Without this, a send to a dead
-            // pane silently writes keystrokes to a corpse with no agent.
-            // Skipped when the caller opts out via `revive: false`.
-            //
-            // The closure surfaces `inst_owned` on BOTH arms so the caller
-            // can sync the cascade-cleared `agent_session_id` and updated
-            // `retroactive_capture_excludes` back to live state on Err.
-            // Otherwise a Tier-2 cascade failure leaves the live entry with
-            // a stale sid in memory while disk is already cleared, and
-            // subsequent sends keep re-attempting resume with the bad sid.
-            let mut inst_owned = instance;
-            let outcome = if revive {
-                match inst_owned.ensure_pane_ready() {
-                    Ok(o) => o,
-                    Err(e) => {
-                        let mapped = match e {
-                            EnsureReadyError::Transient(s) => SendKeysError::Transient(s),
-                            EnsureReadyError::CockpitMode => SendKeysError::CockpitMode,
-                            EnsureReadyError::Tmux(e) => SendKeysError::Tmux(e),
-                        };
-                        return Err(Box::new((inst_owned, mapped)));
-                    }
+    let send_result = tokio::task::spawn_blocking(move || -> SendKeysResult {
+        // Revive the pane before sending. Without this, a send to a dead
+        // pane silently writes keystrokes to a corpse with no agent.
+        // Skipped when the caller opts out via `revive: false`.
+        //
+        // The closure surfaces both `inst_owned` AND the
+        // `EnsureReadyOutcome` on the Err arm so the caller can sync
+        // the post-cascade `agent_session_id` (None after Tier-1
+        // cleanup, or the fresh UUID acquired by Tier-2) and the
+        // updated `retroactive_capture_excludes` back to live state
+        // regardless of which post-cascade failure path fires. The
+        // outcome lets the caller distinguish cascade-fired
+        // (`Respawned`/`Started`) from the no-op `AlreadyAlive` path
+        // so a sync only happens when there's actual cascade state to
+        // propagate; this avoids clobbering live `last_error` on the
+        // `revive=false + NotRunning` path where `started` is
+        // unmutated.
+        let mut inst_owned = instance;
+        let outcome = if revive {
+            match inst_owned.ensure_pane_ready() {
+                Ok(o) => o,
+                Err(e) => {
+                    let mapped = match e {
+                        EnsureReadyError::Transient(s) => SendKeysError::Transient(s),
+                        EnsureReadyError::CockpitMode => SendKeysError::CockpitMode,
+                        EnsureReadyError::Tmux(e) => SendKeysError::Tmux(e),
+                    };
+                    // ensure_pane_ready did not mutate user-visible
+                    // state via the outcome path. Tag as AlreadyAlive
+                    // so the outer match's `did_work` flag stays
+                    // false. `EnsureReadyError::Tmux` may be either
+                    // pre-cascade (tmux_session() / start_with_size
+                    // subprocess failure: `inst_owned` unmutated) or
+                    // post-cascade (Tier-2 bail: mutations committed).
+                    // The Tmux outer arm syncs unconditionally and
+                    // covers both shapes; the others (Transient /
+                    // CockpitMode) bail before any mutation.
+                    return Err(Box::new((
+                        inst_owned,
+                        EnsureReadyOutcome::AlreadyAlive,
+                        mapped,
+                    )));
                 }
-            } else {
-                EnsureReadyOutcome::AlreadyAlive
-            };
-            let tmux_session = match inst_owned.tmux_session() {
-                Ok(s) => s,
-                Err(e) => return Err(Box::new((inst_owned, SendKeysError::Tmux(e)))),
-            };
-            if !tmux_session.exists() {
-                return Err(Box::new((inst_owned, SendKeysError::NotRunning)));
             }
-            let delay = crate::agents::send_keys_enter_delay(&tool);
-            if let Err(e) = tmux_session.send_keys_with_delay(&message, delay) {
-                return Err(Box::new((inst_owned, SendKeysError::Tmux(e))));
-            }
-            Ok((outcome, inst_owned))
-        },
-    )
+        } else {
+            EnsureReadyOutcome::AlreadyAlive
+        };
+        let tmux_session = match inst_owned.tmux_session() {
+            Ok(s) => s,
+            Err(e) => return Err(Box::new((inst_owned, outcome, SendKeysError::Tmux(e)))),
+        };
+        if !tmux_session.exists() {
+            return Err(Box::new((inst_owned, outcome, SendKeysError::NotRunning)));
+        }
+        let delay = crate::agents::send_keys_enter_delay(&tool);
+        if let Err(e) = tmux_session.send_keys_with_delay(&message, delay) {
+            return Err(Box::new((inst_owned, outcome, SendKeysError::Tmux(e))));
+        }
+        Ok((outcome, inst_owned))
+    })
     .await;
 
     match send_result {
@@ -2659,13 +2697,40 @@ pub async fn send_message(
             (StatusCode::OK, Json(body)).into_response()
         }
         Ok(Err(boxed)) => {
-            let (started, send_err) = *boxed;
+            let (started, outcome, send_err) = *boxed;
+            // ensure_pane_ready did mutate state when the outcome is
+            // anything other than AlreadyAlive. The cascade itself only
+            // runs in `Respawned { stale_sid: Some(_) }`, but `Started`
+            // and `Respawned { stale_sid: None }` also touch fields the
+            // live entry needs to reflect (fresh sid from acquire,
+            // last_start_time, etc.). Sync only when work happened.
+            let did_work = !matches!(outcome, EnsureReadyOutcome::AlreadyAlive);
             match send_err {
-                SendKeysError::NotRunning => (
-                    StatusCode::CONFLICT,
-                    Json(serde_json::json!({"error": "session_not_running"})),
-                )
-                    .into_response(),
+                SendKeysError::NotRunning => {
+                    // External kill or remain-on-exit-off Tier-2 crash can
+                    // race ensure_pane_ready's Alive decision against the
+                    // tmux_session.exists() check. Propagate the
+                    // post-cascade agent_session_id (fresh UUID acquired
+                    // in place of the stale, or None for Tier-1 cleanup)
+                    // and the updated excludes when applicable so the
+                    // next call won't orphan or re-attempt resume with
+                    // the bad sid; use the narrow sync helper to leave
+                    // status and last_error untouched (NotRunning is
+                    // recoverable; `started.status = Starting` from
+                    // finalize_launch would briefly mis-paint a broken
+                    // pane).
+                    if did_work {
+                        let mut instances = state.instances.write().await;
+                        if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
+                            apply_cascade_state_sync(i, &started);
+                        }
+                    }
+                    (
+                        StatusCode::CONFLICT,
+                        Json(serde_json::json!({"error": "session_not_running"})),
+                    )
+                        .into_response()
+                }
                 SendKeysError::Transient(status) => (
                     StatusCode::CONFLICT,
                     Json(serde_json::json!({
@@ -2682,17 +2747,15 @@ pub async fn send_message(
                 SendKeysError::Tmux(e) => {
                     tracing::error!("send_message: tmux error for {id}: {e}");
                     let msg = e.to_string();
-                    // Sync cascade-mutated fields back to live state. Only
-                    // the Tmux variant routes through `ensure_pane_ready` ->
-                    // cascade, so this is the sole arm where `started` may
-                    // carry the cleared sid + updated excludes. The other
-                    // variants leave `started` untouched and don't need a
-                    // sync (and a sync would clobber the live `last_error`
-                    // with `started.last_error = None`). Mirror
-                    // `ensure_session`'s Err arm: sync, then override
+                    // Sync cascade-mutated fields back to live state. Mirror
+                    // `ensure_session`'s Err arm: full sync, then override
                     // `status` and `last_error` so observers don't see
                     // `Status::Starting` (set by `finalize_launch` before
-                    // Tier-2 bail) on a broken session.
+                    // Tier-2 bail) on a broken session. Tmux Err is the
+                    // catch-all for both pre-cascade tmux failures (where
+                    // `started` is unmutated and the sync is a no-op) and
+                    // post-cascade Tier-2 bails (where the sync propagates
+                    // the cleared sid + updated excludes).
                     let mut instances = state.instances.write().await;
                     if let Some(i) = instances.iter_mut().find(|i| i.id == id) {
                         apply_post_restart_sync(i, &started);

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1271,11 +1271,13 @@ pub async fn ensure_session(
 
     let restart_result = tokio::task::spawn_blocking(
         move || -> anyhow::Result<(Instance, crate::session::StartOutcome)> {
-            let tmux_session = instance.tmux_session()?;
-            if tmux_session.exists() {
-                let _ = tmux_session.kill();
-            }
             let mut inst = instance;
+            // Use kill_clean (vs bare tmux kill) so a remain-on-exit dead
+            // pane is respawned-then-killed; bare kill races against the
+            // session cache on macOS and can leave the corpse pane behind,
+            // which then trips the next start_with_resume_fallback's
+            // `pane_was_preexisting` short-circuit. See `Instance::kill_clean`.
+            inst.kill_clean()?;
             let outcome = inst.start_with_resume_fallback(None, false)?;
             Ok((inst, outcome))
         },

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -634,7 +634,7 @@ pub(crate) fn compose_exclusion(
 /// the resume-fallback cascade's just-crashed sid) should use
 /// [`compose_exclusion`] instead, which composes this function with the
 /// per-instance exclusion list.
-pub(crate) fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
+fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
     let output = match std::process::Command::new("tmux")
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -171,6 +171,18 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 }
 
 /// Polling closure for Claude Code session tracking on the host filesystem.
+///
+/// Unlike the other agents' poll factories, this one does not take an
+/// `extra_excludes` parameter. Claude generates a fresh UUID at launch
+/// time (`generate_claude_session_id`) and the disk scan filters by file
+/// mtime against `should_attempt_resume`'s 5-minute window, so the
+/// resume-fallback cascade's just-cleared sid would be filtered out by
+/// the existing freshness check before reaching this closure. The
+/// defense-in-depth check in `apply_session_id_updates`
+/// (`tui/home/mod.rs`) guards against any edge case where a stale sid
+/// slips through. If you ever add a second consumer of the poller
+/// channel that bypasses that path, you must replicate the
+/// `retroactive_capture_excludes` filter here.
 pub(crate) fn claude_poll_fn(project_path: String) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
         capture_claude_session_id(&project_path)

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -189,7 +189,7 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 ///    still-fresh stale `<stale_sid>.jsonl`) is caught here.
 ///
 /// The 5-minute mtime check inside `capture_claude_session_id` is an
-/// upper bound on staleness, NOT a stale-sid filter -- a just-crashed
+/// upper bound on staleness, not a stale-sid filter; a just-crashed
 /// `<stale_sid>.jsonl` has a fresh mtime and passes that check.
 ///
 /// Serve-only mode never drains `result_rx` (the only consumer of

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -450,9 +450,10 @@ pub(crate) fn capture_pi_session_id(
 pub(crate) fn pi_poll_fn(
     project_path: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         capture_pi_session_id(&project_path, &exclusion)
             .map_err(|e| tracing::debug!("Pi poll capture failed: {}", e))
             .ok()
@@ -553,9 +554,10 @@ pub(crate) fn pi_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_pi_session_id_in_container(&container_name, &container_cwd, &exclusion)
             .map_err(|e| tracing::debug!("Pi container poll capture failed: {}", e))
             .ok()
@@ -571,6 +573,23 @@ pub(crate) fn is_valid_session_id(id: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
 }
 
+/// Compose [`build_exclusion_set`] (cross-instance live tmux scan) with a
+/// per-instance set of IDs the cascade has explicitly cleared but which
+/// may still live on disk for several minutes.
+///
+/// Both [`Instance::retroactive_capture_exclusion_set`] and the post-launch
+/// `*_poll_fn` closures route through this helper so the resume-fallback
+/// cascade's just-crashed sid is filtered identically on the synchronous
+/// pre-launch path and on the asynchronous polling path.
+pub(crate) fn compose_exclusion(
+    current_instance_id: &str,
+    extra: &HashSet<String>,
+) -> HashSet<String> {
+    let mut set = build_exclusion_set(current_instance_id);
+    set.extend(extra.iter().cloned());
+    set
+}
+
 /// Build the set of session IDs already claimed by other live AoE instances.
 ///
 /// Reads every other AoE-prefixed tmux session's hidden env to find which
@@ -581,8 +600,8 @@ pub(crate) fn is_valid_session_id(id: &str) -> bool {
 ///
 /// Callers that also need to exclude IDs not yet visible in tmux env (e.g.
 /// the resume-fallback cascade's just-crashed sid) should use
-/// [`Instance::retroactive_capture_exclusion_set`] instead, which composes
-/// this function with the per-instance exclusion list.
+/// [`compose_exclusion`] instead, which composes this function with the
+/// per-instance exclusion list.
 pub(crate) fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
     let output = match std::process::Command::new("tmux")
         .args(["list-sessions", "-F", "#{session_name}"])
@@ -725,9 +744,10 @@ fn parse_vibe_meta_json(content: &str) -> Option<(String, Option<String>)> {
 pub(crate) fn vibe_poll_fn(
     project_path: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         capture_vibe_session_id(&project_path, &exclusion)
             .map_err(|e| tracing::debug!("Vibe poll capture failed: {}", e))
             .ok()
@@ -828,9 +848,10 @@ pub(crate) fn vibe_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_vibe_session_id_in_container(&container_name, &container_cwd, &exclusion)
             .map_err(|e| tracing::debug!("Vibe container poll capture failed: {}", e))
             .ok()
@@ -1201,9 +1222,10 @@ pub(crate) fn opencode_poll_fn(
     project_path: String,
     instance_id: String,
     launch_time_ms: f64,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_opencode_session_id(&project_path, &exclusion, Some(launch_time_ms))
             .map_err(|e| tracing::debug!("OpenCode poll capture failed: {}", e))
             .ok()
@@ -1217,9 +1239,10 @@ pub(crate) fn opencode_poll_fn_sandboxed(
     container_cwd: String,
     instance_id: String,
     launch_time_ms: f64,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_opencode_session_id_in_container(
             &container_name,
             &container_cwd,
@@ -1439,9 +1462,10 @@ fn select_codex_session_in_container(
 pub(crate) fn codex_poll_fn(
     project_path: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         capture_codex_session_id(&project_path, &exclusion)
             .map_err(|e| tracing::debug!("Codex poll capture failed: {}", e))
             .ok()
@@ -1454,9 +1478,10 @@ pub(crate) fn codex_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_codex_session_id_in_container(&container_name, &container_cwd, &exclusion)
             .map_err(|e| tracing::debug!("Codex container poll capture failed: {}", e))
             .ok()
@@ -1470,9 +1495,10 @@ pub(crate) fn codex_poll_fn_sandboxed(
 pub(crate) fn gemini_poll_fn(
     project_path: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         capture_gemini_session_id(&project_path, &exclusion)
             .map_err(|e| tracing::debug!("Gemini poll capture failed: {}", e))
             .ok()
@@ -1578,9 +1604,10 @@ pub(crate) fn gemini_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_gemini_session_id_in_container(&container_name, &container_cwd, &exclusion)
             .map_err(|e| tracing::debug!("Gemini container poll capture failed: {}", e))
             .ok()
@@ -1862,9 +1889,10 @@ pub(crate) fn try_capture_hermes_session_id_in_container(
 pub(crate) fn hermes_poll_fn(
     project_path: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         capture_hermes_session_id(&project_path, &exclusion)
             .map_err(|e| tracing::debug!("Hermes poll capture failed: {}", e))
             .ok()
@@ -1877,9 +1905,10 @@ pub(crate) fn hermes_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
     instance_id: String,
+    extra_excludes: HashSet<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        let exclusion = build_exclusion_set(&instance_id);
+        let exclusion = compose_exclusion(&instance_id, &extra_excludes);
         try_capture_hermes_session_id_in_container(&container_name, &container_cwd, &exclusion)
             .map_err(|e| tracing::debug!("Hermes container poll capture failed: {}", e))
             .ok()
@@ -2607,6 +2636,55 @@ mod tests {
         assert!(
             result.is_err(),
             "Session with non-matching CWD should not be returned"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_vibe_poll_fn_honors_extra_excludes() {
+        // Regression for the resume-fallback cascade: after the cascade
+        // clears a bad sid, the freshly-spawned poll closure must NOT
+        // re-discover it via filesystem scan (the on-disk meta.json still
+        // references the bad sid for several minutes). Without this,
+        // `apply_session_id_updates` re-imports the cleared sid and the
+        // cascade's work is undone within ~2s.
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let sessions_dir = tmp.path().join("logs").join("session");
+        let s1_dir = sessions_dir.join("session-stale-on-disk");
+        std::fs::create_dir_all(&s1_dir).unwrap();
+        let s1_meta = serde_json::json!({
+            "session_id": "stale-sid-cleared-by-cascade",
+            "environment": {"working_directory": project_dir.to_str().unwrap()},
+        });
+        std::fs::write(s1_dir.join("meta.json"), s1_meta.to_string()).unwrap();
+
+        let _guard = VibeHomeGuard::set(tmp.path());
+
+        let mut extra = HashSet::new();
+        extra.insert("stale-sid-cleared-by-cascade".to_string());
+        let poll = vibe_poll_fn(
+            project_dir.to_string_lossy().into_owned(),
+            "test-instance".to_string(),
+            extra,
+        );
+        assert_eq!(
+            poll(),
+            None,
+            "poller must not re-import a sid present in extra_excludes",
+        );
+
+        let poll_no_excludes = vibe_poll_fn(
+            project_dir.to_string_lossy().into_owned(),
+            "test-instance".to_string(),
+            HashSet::new(),
+        );
+        assert_eq!(
+            poll_no_excludes(),
+            Some("stale-sid-cleared-by-cascade".to_string()),
+            "negative control: without the exclude, the poller surfaces the on-disk sid",
         );
     }
 

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -172,17 +172,37 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 
 /// Polling closure for Claude Code session tracking on the host filesystem.
 ///
-/// Unlike the other agents' poll factories, this one does not take an
-/// `extra_excludes` parameter. Claude generates a fresh UUID at launch
-/// time (`generate_claude_session_id`) and the disk scan filters by file
-/// mtime against `should_attempt_resume`'s 5-minute window, so the
-/// resume-fallback cascade's just-cleared sid would be filtered out by
-/// the existing freshness check before reaching this closure. The
-/// defense-in-depth check in `apply_session_id_updates`
-/// (`tui/home/mod.rs`) guards against any edge case where a stale sid
-/// slips through. If you ever add a second consumer of the poller
-/// channel that bypasses that path, you must replicate the
-/// `retroactive_capture_excludes` filter here.
+/// Unlike other agents' poll factories, this closure does not take an
+/// `extra_excludes` set. Claude is protected from re-importing the sid
+/// `start_with_resume_fallback` just cleared by a layered chain:
+///
+/// 1. `acquire_session_id` mints a fresh UUID for Claude and assigns it
+///    to `agent_session_id` BEFORE `maybe_start_poller` runs, so the
+///    poller's `initial_known` is the new UUID, not the stale one.
+/// 2. The poller's `last_known` dedupes once Claude writes
+///    `<new_uuid>.jsonl` and the disk scan returns it.
+/// 3. The defense-in-depth guard in `apply_session_id_updates`
+///    (`tui/home/mod.rs`) drops any poller report whose sid is in
+///    `retroactive_capture_excludes`. The cascade pre-loads that set
+///    before respawning, so a race where the immediate first poll fires
+///    before Claude writes the new `.jsonl` (and therefore returns the
+///    still-fresh stale `<stale_sid>.jsonl`) is caught here.
+///
+/// The 5-minute mtime check inside `capture_claude_session_id` is an
+/// upper bound on staleness, NOT a stale-sid filter -- a just-crashed
+/// `<stale_sid>.jsonl` has a fresh mtime and passes that check.
+///
+/// Serve-only mode never drains `result_rx` (the only consumer of
+/// `try_recv_session_update` is the TUI tick path), so the stale sid
+/// cannot reach in-memory `agent_session_id` or `sessions.json` via the
+/// poller in that mode either. The only residual effect is that
+/// `on_change` may briefly write the stale sid into the tmux env's
+/// `AOE_CAPTURED_SESSION_ID_KEY`; the next poll cycle overwrites it.
+///
+/// If you ever add a second consumer of the poller channel that
+/// bypasses `apply_session_id_updates`, replicate the
+/// `retroactive_capture_excludes` filter at the consumer or thread an
+/// `extra_excludes` set into this closure mirroring the other agents.
 pub(crate) fn claude_poll_fn(project_path: String) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
         capture_claude_session_id(&project_path)

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -609,7 +609,7 @@ pub(crate) fn is_valid_session_id(id: &str) -> bool {
 /// per-instance set of IDs the cascade has explicitly cleared but which
 /// may still live on disk for several minutes.
 ///
-/// Both [`Instance::retroactive_capture_exclusion_set`] and the post-launch
+/// Both `Instance::retroactive_capture_exclusion_set` and the post-launch
 /// `*_poll_fn` closures route through this helper so the resume-fallback
 /// cascade's just-crashed sid is filtered identically on the synchronous
 /// pre-launch path and on the asynchronous polling path.

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -571,11 +571,18 @@ pub(crate) fn is_valid_session_id(id: &str) -> bool {
             .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_' || b == b'.')
 }
 
-/// Build a set of session IDs already claimed by other AoE instances.
+/// Build the set of session IDs already claimed by other live AoE instances.
 ///
-/// Lists all tmux sessions with the AoE prefix, reads each one's hidden env vars
-/// to find its instance ID and captured session ID, and collects all captured IDs
-/// from instances other than `current_instance_id`.
+/// Reads every other AoE-prefixed tmux session's hidden env to find which
+/// session IDs are currently bound to which instance, and returns the set
+/// of captured IDs that belong to instances OTHER than `current_instance_id`.
+/// Used by post-launch poll closures to avoid re-importing another
+/// instance's session via filesystem scan.
+///
+/// Callers that also need to exclude IDs not yet visible in tmux env (e.g.
+/// the resume-fallback cascade's just-crashed sid) should use
+/// [`Instance::retroactive_capture_exclusion_set`] instead, which composes
+/// this function with the per-instance exclusion list.
 pub(crate) fn build_exclusion_set(current_instance_id: &str) -> HashSet<String> {
     let output = match std::process::Command::new("tmux")
         .args(["list-sessions", "-F", "#{session_name}"])

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -82,10 +82,20 @@ enum ProbeResult {
 const RESUME_PROBE_MAX: std::time::Duration = std::time::Duration::from_millis(3000);
 const RESUME_PROBE_POLL: std::time::Duration = std::time::Duration::from_millis(50);
 /// Grace window we keep observing after the pane stops running its boot
-/// shell, before declaring `Alive`. Without it, a Node.js agent that
-/// `exec`s past the wrapper at ~80ms and crashes at ~250ms is reported
-/// as alive on the first not-shell poll, defeating the cascade.
-const RESUME_PROBE_POST_SHELL_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
+/// shell, before declaring `Alive`. Sized to cover the longest in-pane
+/// boot a real agent takes before it would have crashed on a bad sid:
+/// opencode (bun-compiled native binary that loads JS, parses argv, and
+/// hits the session-not-found path) reaches `pane_dead = true` between
+/// ~900ms and ~1100ms after spawn on a warm cache, longer on cold or
+/// heavy projects. The earlier 500ms value caught Node.js agents that
+/// crashed in ~250ms but missed opencode's slower bun startup, leaving
+/// the cascade dormant on stale opencode sids: the user-visible bug is a
+/// dead pane after restart with the bad sid still on disk and no toast.
+/// Healthy resumes pay this entire window once on Tier-1 (and again on
+/// Tier-2 if it fires); the pane is fully attachable for the duration so
+/// the cost is purely in the synchronous restart path's latency, not in
+/// agent responsiveness afterward.
+const RESUME_PROBE_POST_SHELL_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 
 /// Pure decision: should the resume-fallback cascade probe and potentially
 /// retry without resume after the initial start? Extracted for unit-testability:
@@ -1723,21 +1733,22 @@ impl Instance {
     /// Returns `Dead` immediately if the pane dies or the session evaporates
     /// during the probe window. Returns `Alive` only after the pane has been
     /// off the boot shell for `RESUME_PROBE_POST_SHELL_GRACE` consecutive
-    /// time (handles Node.js agents that `exec` to `node` before crashing
-    /// on a bad sid), or charitably on full timeout for slow-start agents.
-    /// `pane_dead` is the unambiguous signal we trust to fire the cascade.
+    /// time (handles agents whose boot wrapper sits before the agent
+    /// crashes on a bad sid), or charitably on full timeout for slow-start
+    /// agents. `pane_dead` is the unambiguous signal we trust to fire the
+    /// cascade.
     ///
     /// For instances using a shell-wrapper command (`/bin/sh -c '...'`,
     /// agent-override scripts), `is_pane_running_shell` stays true for the
     /// entire probe and the post-shell grace shortcut never fires. Such
-    /// instances rely exclusively on `pane_dead` -- if the wrapper exits
+    /// instances rely exclusively on `pane_dead`: if the wrapper exits
     /// when the agent crashes, the cascade fires correctly; if the wrapper
     /// holds the pane open past the agent crash (e.g., trailing `sleep`),
     /// the cascade misses it. Pathological shape; not worth special-casing.
     ///
     /// Latency consequence: shell-wrapper instances therefore burn the full
     /// `RESUME_PROBE_MAX` on every healthy resume. Real agents settle in
-    /// ~`RESUME_PROBE_POST_SHELL_GRACE` (~500ms).
+    /// ~`RESUME_PROBE_POST_SHELL_GRACE`.
     fn probe_settle(
         &self,
         max: std::time::Duration,
@@ -1790,7 +1801,7 @@ impl Instance {
     ///
     /// Latency: only fires the probe when `--resume <sid>` is being passed
     /// to a freshly-created tmux session. Healthy resumes on real agents
-    /// pay `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) once on cold start;
+    /// pay `RESUME_PROBE_POST_SHELL_GRACE` (~2s) once on cold start;
     /// warm sessions and non-resume launches pay nothing. Shell-wrapper
     /// command overrides pay the full `RESUME_PROBE_MAX` (~3s) on every
     /// healthy resume because `is_pane_running_shell` never clears for

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1807,10 +1807,24 @@ impl Instance {
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
     ) -> Result<StartOutcome> {
-        // Clear stale Status::Error before any early-return so cockpit and
-        // non-cockpit paths behave consistently. Without this, a cockpit
-        // session entering with Status::Error keeps the error chip after a
-        // user-initiated restart.
+        // Clear stale Status::Error before any early-return so all restart
+        // paths (REST `ensure_session`, TUI Enter/restart, CLI `aoe session
+        // restart [id|--all]`) behave consistently. Pre-cascade only REST
+        // had a pre-restart reset (still inlined at
+        // `src/server/api/sessions.rs::ensure_session`, sets
+        // `status=Starting`, `last_error=None`); hoisting the reset here
+        // is a deliberate UX broadening so a TUI/CLI restart on a session
+        // sitting in `Status::Error` no longer leaves the error chip up
+        // after a successful relaunch, and cockpit-mode short-circuit
+        // sessions get the same treatment.
+        //
+        // `last_error_check` is cleared alongside `last_error` to mirror
+        // how the field is otherwise managed: `update_status` writes both
+        // together when transitioning into Error (see the write sites
+        // gated on the 30s rate-limit). The clear is functionally inert
+        // today because the only reader is gated on `status == Error` and
+        // we just left Error, but the symmetry is intentional defense
+        // against a future read site that drops that gate.
         if self.status == Status::Error {
             self.status = Status::Idle;
             self.last_error = None;

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -122,8 +122,12 @@ pub enum EnsureReadyOutcome {
     /// respawn, meaning the agent's prior conversation is gone; callers should
     /// surface this so the user understands why history disappeared.
     Respawned { stale_sid: Option<String> },
-    /// Tmux session did not exist and was started from scratch.
-    Started,
+    /// Tmux session did not exist and was started from scratch via the
+    /// resume-fallback cascade. `stale_sid` is `Some` when the cascade
+    /// fired during this start (sid was on disk from a prior run, the
+    /// agent crashed on it, and we cleared it before retrying), with the
+    /// same surface-to-user contract as `Respawned`.
+    Started { stale_sid: Option<String> },
 }
 
 /// Errors `ensure_pane_ready` can return. Separating transient lifecycle
@@ -1852,7 +1856,7 @@ impl Instance {
         // Defense in depth: every current caller runs `kill_clean()` (or
         // its equivalent) first, so this is normally false. It can still
         // be true if `kill_clean` raced the macOS tmux session cache
-        // (see `Instance::kill_clean` doc) -- in that case
+        // (see `Instance::kill_clean` doc): in that case
         // `start_with_size_opts` no-ops, the probe would have nothing to
         // detect, and reporting `Fresh` is the least-wrong outcome
         // (returning `Resumed` would mean lying about a `--resume <sid>`
@@ -1999,9 +2003,20 @@ impl Instance {
         }
         let session = self.tmux_session().map_err(EnsureReadyError::Tmux)?;
         if !session.exists() {
-            self.start_with_size(None).map_err(EnsureReadyError::Tmux)?;
+            // Route fresh starts through the cascade so a stale sid loaded
+            // from disk that crashes the agent on launch is detected,
+            // cleared, and retried. Without this, `aoe send` after a tmux
+            // server kill or reboot resurrects the same bad sid the
+            // restart paths exist to recover from.
+            let outcome = self
+                .start_with_resume_fallback(None, false)
+                .map_err(EnsureReadyError::Tmux)?;
             self.wait_for_pane_ready(&session);
-            return Ok(EnsureReadyOutcome::Started);
+            let stale_sid = match outcome {
+                StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+                StartOutcome::Resumed | StartOutcome::Fresh => None,
+            };
+            return Ok(EnsureReadyOutcome::Started { stale_sid });
         }
         if session.is_pane_dead() {
             let outcome = self
@@ -3726,32 +3741,22 @@ mod tests {
             assert_eq!(loaded[0].agent_session_id, None);
         }
 
+        #[cfg(feature = "serve")]
         #[test]
         #[serial]
         fn restart_outcome_for_cockpit_session_is_fresh() {
-            #[cfg(feature = "serve")]
-            {
-                if std::process::Command::new("tmux")
-                    .arg("-V")
-                    .output()
-                    .is_err()
-                {
-                    eprintln!("tmux not available; skipping");
-                    return;
-                }
-                let temp = tempdir().unwrap();
-                std::env::set_var("HOME", temp.path());
-                #[cfg(target_os = "linux")]
-                std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
-                let mut inst = Instance::new("cockpit_test", "/tmp/x");
-                inst.cockpit_mode = true;
-                inst.agent_session_id = Some("11111111-1111-1111-1111-111111111111".to_string());
-                inst.tool = "claude".to_string();
+            let mut inst = Instance::new("cockpit_test", "/tmp/x");
+            inst.cockpit_mode = true;
+            inst.agent_session_id = Some("11111111-1111-1111-1111-111111111111".to_string());
+            inst.tool = "claude".to_string();
 
-                let outcome = inst.start_with_resume_fallback(None, true).unwrap();
-                assert_eq!(outcome, StartOutcome::Fresh);
-            }
+            let outcome = inst.start_with_resume_fallback(None, true).unwrap();
+            assert_eq!(outcome, StartOutcome::Fresh);
         }
 
         #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -63,8 +63,13 @@ pub enum StartOutcome {
     /// fresh start succeeded. Caller should surface this: the user's prior
     /// conversation is gone. `stale_sid` is the sid that was cleared.
     Restarted { stale_sid: String },
-    /// No resume was attempted (no prior sid, agent doesn't support resume,
-    /// or sid was invalid). Started cleanly.
+    /// No resume cascade ran. Either no prior sid, the agent doesn't support
+    /// resume, the sid was invalid, the session is cockpit-mode (no tmux
+    /// pane), or the tmux session was already alive when entered (so
+    /// `start_with_size_opts` was a no-op and the probe had nothing to
+    /// detect). The pane is alive on return; whether a fresh launch
+    /// actually occurred this call depends on the caller having killed
+    /// any pre-existing pane first.
     Fresh,
 }
 
@@ -365,6 +370,14 @@ pub struct Instance {
     /// doesn't re-import the same bad sid via filesystem scan (opencode db,
     /// vibe meta.json, codex state, etc., all keep the bad session's row
     /// after the crash for several minutes).
+    ///
+    /// `#[serde(skip)]` is intentional. If the daemon dies between the
+    /// cascade clearing the on-disk sid and the on-disk artifact decaying
+    /// (~5-10 min), the next launch starts with this set empty and the
+    /// freshly-spawned poller can re-import the bad sid once. The next
+    /// `start_with_resume_fallback` then re-runs the cascade and clears it
+    /// again. Self-healing within one cycle; persisting a TTL set isn't
+    /// worth the schema cost.
     #[serde(skip)]
     pub(crate) retroactive_capture_excludes: HashSet<String>,
 }
@@ -1674,6 +1687,14 @@ impl Instance {
     /// time (handles Node.js agents that `exec` to `node` before crashing
     /// on a bad sid), or charitably on full timeout for slow-start agents.
     /// `pane_dead` is the unambiguous signal we trust to fire the cascade.
+    ///
+    /// For instances using a shell-wrapper command (`/bin/sh -c '...'`,
+    /// agent-override scripts), `is_pane_running_shell` stays true for the
+    /// entire probe and the post-shell grace shortcut never fires. Such
+    /// instances rely exclusively on `pane_dead` -- if the wrapper exits
+    /// when the agent crashes, the cascade fires correctly; if the wrapper
+    /// holds the pane open past the agent crash (e.g., trailing `sleep`),
+    /// the cascade misses it. Pathological shape; not worth special-casing.
     fn probe_settle(
         &self,
         max: std::time::Duration,
@@ -1738,16 +1759,20 @@ impl Instance {
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
     ) -> Result<StartOutcome> {
-        #[cfg(feature = "serve")]
-        if self.cockpit_mode {
-            self.start_with_size_opts(size, skip_on_launch)?;
-            return Ok(StartOutcome::Fresh);
-        }
-
+        // Clear stale Status::Error before any early-return so cockpit and
+        // non-cockpit paths behave consistently. Without this, a cockpit
+        // session entering with Status::Error keeps the error chip after a
+        // user-initiated restart.
         if self.status == Status::Error {
             self.status = Status::Idle;
             self.last_error = None;
             self.last_error_check = None;
+        }
+
+        #[cfg(feature = "serve")]
+        if self.cockpit_mode {
+            self.start_with_size_opts(size, skip_on_launch)?;
+            return Ok(StartOutcome::Fresh);
         }
 
         let attempting_resume = should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1715,6 +1715,10 @@ impl Instance {
     /// when the agent crashes, the cascade fires correctly; if the wrapper
     /// holds the pane open past the agent crash (e.g., trailing `sleep`),
     /// the cascade misses it. Pathological shape; not worth special-casing.
+    ///
+    /// Latency consequence: shell-wrapper instances therefore burn the full
+    /// `RESUME_PROBE_MAX` on every healthy resume. Real agents settle in
+    /// ~`RESUME_PROBE_POST_SHELL_GRACE` (~500ms).
     fn probe_settle(
         &self,
         max: std::time::Duration,
@@ -1766,9 +1770,14 @@ impl Instance {
     ///      `Status::Error` + `last_error` path takes over.
     ///
     /// Latency: only fires the probe when `--resume <sid>` is being passed
-    /// to a freshly-created tmux session. Healthy resumes pay
-    /// `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) once on cold start; warm
-    /// sessions and non-resume launches pay nothing.
+    /// to a freshly-created tmux session. Healthy resumes on real agents
+    /// pay `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) once on cold start;
+    /// warm sessions and non-resume launches pay nothing. Shell-wrapper
+    /// command overrides pay the full `RESUME_PROBE_MAX` (~3s) on every
+    /// healthy resume because `is_pane_running_shell` never clears for
+    /// them; see `probe_settle`. When the cascade fires, add `kill_clean`
+    /// (~100ms macOS grace) + Tier-2 spawn + a second `RESUME_PROBE_MAX`
+    /// window: ~6-7s total worst-case.
     ///
     /// Cockpit-mode sessions short-circuit (no tmux pane to probe).
     /// `StartOutcome::Fresh` is honest there: cockpit's resume concept lives
@@ -1922,6 +1931,14 @@ impl Instance {
     /// On `Started` / `Respawned`, polls briefly so keystrokes don't race the
     /// agent's startup splash. Best-effort: returns after the timeout even if
     /// the pane is still settling.
+    ///
+    /// Latency: `AlreadyAlive` is ~tmux RTT. The `Respawned` path routes
+    /// through `restart_with_size` -> `start_with_resume_fallback`, which
+    /// on a dead resume-eligible pane can block for the full Tier-1 +
+    /// Tier-2 cascade window (~6-7s; see `start_with_resume_fallback` for
+    /// the breakdown) plus up to 3s of `wait_for_pane_ready` polling.
+    /// Smart-send, TUI Enter, and `aoe send` callers should size timeouts
+    /// and spinner copy accordingly.
     ///
     /// Note: callers that mutate a clone (e.g. inside `spawn_blocking`) must
     /// sync the post-start state (`status`, `agent_session_id`,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -528,12 +528,28 @@ fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
     //   2. `persist_session_to_storage` (called from `finalize_launch`).
     //   3. Server `ensure_session` / `send_message` -> `storage.save`,
     //      both inside `tokio::task::spawn_blocking`.
+    //   4. CLI `aoe session restart --all` (`src/cli/session.rs::restart_all_sessions`):
+    //      up to `--parallel` workers spawned via `tokio::task::JoinSet` +
+    //      `tokio::sync::Semaphore`, each running the cascade inside
+    //      `spawn_blocking` on its own cloned Instance.
     //
     // In the TUI path, `start_with_resume_fallback` runs on the main
     // thread between ticks, so (1) cannot interleave. (2) is sequential
     // within the same thread (cascade calls clear, then start_with_size_opts
     // -> finalize_launch -> persist). In the server path the per-instance
-    // `instance_lock` mutex serializes (3) for the same session.
+    // `instance_lock` mutex serializes (3) for the same session; it does
+    // NOT cover (4), which runs out-of-process from the daemon.
+    //
+    // Path (4) has NO equivalent serializer. Two workers Tier-1-crashing
+    // concurrently can interleave their load-modify-save cycles here:
+    // worker B loads before A saves, then B's save resurrects the bad sid
+    // A just cleared. Steady-state disk converges because the parent
+    // reconciles via `storage.save_with_groups` after the JoinSet drains
+    // (`src/cli/session.rs::restart_all_sessions`, post-loop save). The
+    // residual hazard is daemon death between any worker's clear and that
+    // post-join reconcile: the next launch may then re-`--resume` a sid
+    // one worker thought it had cleared, in which case the cascade fires
+    // again on next start (not corruption, just an extra cascade pass).
     //
     // Stopping `session_id_poller` (done at the cascade call site) is NOT
     // what prevents the race: the poller's `on_change` callback only
@@ -545,7 +561,10 @@ fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
     // Storage::save is non-atomic (fs::write, not tempfile::persist), so
     // any concurrent save would corrupt or silently lose one party's
     // update. A future hardening is to make `Storage::save` atomic via
-    // an atomic-rename helper.
+    // an atomic-rename helper. Note that atomic rename does NOT close
+    // path (4)'s race: the lost-update is a load-modify-save interleave,
+    // independent of the save's atomicity. Closing (4) durably would
+    // require a cross-worker mutex on the per-profile file.
 
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1628,7 +1628,7 @@ impl Instance {
     /// down. Caller is responsible for the subsequent
     /// `start_with_size_opts` to recreate the session with the agent
     /// command.
-    fn kill_clean(&self) -> Result<()> {
+    pub(crate) fn kill_clean(&self) -> Result<()> {
         let session = self.tmux_session()?;
         if !session.exists() {
             return Ok(());
@@ -1770,7 +1770,7 @@ impl Instance {
         let stale_sid = self
             .agent_session_id
             .clone()
-            .unwrap_or_else(|| "<unknown>".to_string());
+            .expect("attempting_resume guarantees agent_session_id is Some");
         let profile = self.effective_profile();
         tracing::warn!(
             "start: resume with sid {} for session {} crashed pane within probe; \
@@ -1806,6 +1806,15 @@ impl Instance {
             self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL)?,
             ProbeResult::Dead
         ) {
+            // Symmetric teardown with the Tier-1->Tier-2 transition above:
+            // the Tier-2 spawn already started a fresh poller via
+            // `finalize_launch`, and bailing without stopping it leaves an
+            // orphan thread polling a dead pane. The pane stays in tmux
+            // (intentional, for `tmux attach` diagnostic on the crash),
+            // but the poller handle must be torn down so callers see a
+            // consistent post-error state.
+            self.stop_poller();
+            self.session_id_poller = None;
             anyhow::bail!(
                 "fresh restart after resume fallback crashed within probe for {} \
                  (stale sid {} was cleared; underlying issue persists)",
@@ -3542,7 +3551,19 @@ mod tests {
             #[cfg(target_os = "linux")]
             std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
 
-            clear_session_id_on_disk("test-profile-empty", "nonexistent-id");
+            let storage =
+                crate::session::storage::Storage::new("test-profile-already-none").unwrap();
+            let inst = Instance::new("title", "/tmp/x");
+            let id = inst.id.clone();
+            assert!(inst.agent_session_id.is_none());
+            storage.save(&[inst]).unwrap();
+
+            clear_session_id_on_disk("test-profile-already-none", &id);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].agent_session_id, None);
+            assert_eq!(loaded[0].id, id);
         }
 
         #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -520,12 +520,32 @@ fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str
 /// Tier 2's `finalize_launch`, the next launch would otherwise re-load the
 /// bad sid from disk and pass `--resume <bad>` again, looping.
 fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
-    // Invariant: caller must have stopped this instance's session_id_poller
-    // before calling. Otherwise the poller's `on_change` callback can race
-    // this load -> mutate -> save with its own write to `sessions.json` and
-    // either party's update is lost (Storage::save is non-atomic).
-    // start_with_resume_fallback enforces this via stop_poller() + nulling
-    // session_id_poller before the call site at L1736-1737.
+    // Invariant: this function must not run concurrently with any other
+    // writer to sessions.json for this profile. The live writers are:
+    //   1. TUI tick: `apply_session_id_updates` -> `HomeView::save()`,
+    //      which drains the poller's result channel and persists any new
+    //      session ID it finds.
+    //   2. `persist_session_to_storage` (called from `finalize_launch`).
+    //   3. Server `ensure_session` / `send_message` -> `storage.save`,
+    //      both inside `tokio::task::spawn_blocking`.
+    //
+    // In the TUI path, `start_with_resume_fallback` runs on the main
+    // thread between ticks, so (1) cannot interleave. (2) is sequential
+    // within the same thread (cascade calls clear, then start_with_size_opts
+    // -> finalize_launch -> persist). In the server path the per-instance
+    // `instance_lock` mutex serializes (3) for the same session.
+    //
+    // Stopping `session_id_poller` (done at the cascade call site) is NOT
+    // what prevents the race: the poller's `on_change` callback only
+    // writes to tmux env (`publish_session_to_tmux_env`), never to
+    // sessions.json. The stop is needed because the cascade also clears
+    // `agent_session_id` in memory and the TUI's reload merge would
+    // otherwise resurrect a stale poller-captured value.
+    //
+    // Storage::save is non-atomic (fs::write, not tempfile::persist), so
+    // any concurrent save would corrupt or silently lose one party's
+    // update. A future hardening is to make `Storage::save` atomic via
+    // an atomic-rename helper.
 
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
@@ -1776,10 +1796,22 @@ impl Instance {
         }
 
         let attempting_resume = should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);
-        // If the tmux session already existed when we entered, `start_with_size_opts`
-        // is a no-op (no `--resume <sid>` was passed in this call), so the probe
-        // would have nothing to detect; skip straight to `Fresh`.
+        // Defense in depth: every current caller runs `kill_clean()` (or
+        // its equivalent) first, so this is normally false. It can still
+        // be true if `kill_clean` raced the macOS tmux session cache
+        // (see `Instance::kill_clean` doc) -- in that case
+        // `start_with_size_opts` no-ops, the probe would have nothing to
+        // detect, and reporting `Fresh` is the least-wrong outcome
+        // (returning `Resumed` would mean lying about a `--resume <sid>`
+        // that was never passed). The debug_assert surfaces the protocol
+        // violation in dev/test if a future caller forgets to tear down.
         let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
+        debug_assert!(
+            !pane_was_preexisting,
+            "start_with_resume_fallback callers must kill_clean() first; \
+             tmux session for {} still exists on entry",
+            self.id
+        );
 
         self.start_with_size_opts(size, skip_on_launch)?;
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -769,7 +769,7 @@ impl Instance {
     /// Full set of session IDs that retroactive capture must skip for THIS
     /// instance: the live tmux-discovered set plus any sids the
     /// resume-fallback cascade has explicitly cleared. Composed of
-    /// [`build_exclusion_set`] (live tmux scan) and
+    /// `build_exclusion_set` (live tmux scan) and
     /// `self.retroactive_capture_excludes` (cascade memory) so the caller
     /// gets the complete picture in one call.
     fn retroactive_capture_exclusion_set(&self) -> HashSet<String> {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1575,10 +1575,6 @@ impl Instance {
         }
     }
 
-    pub fn restart(&mut self) -> Result<()> {
-        self.restart_with_size(None).map(|_| ())
-    }
-
     pub fn restart_with_size(&mut self, size: Option<(u16, u16)>) -> Result<StartOutcome> {
         self.restart_with_size_opts(size, false)
     }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -87,14 +87,10 @@ const RESUME_PROBE_POLL: std::time::Duration = std::time::Duration::from_millis(
 /// opencode (bun-compiled native binary that loads JS, parses argv, and
 /// hits the session-not-found path) reaches `pane_dead = true` between
 /// ~900ms and ~1100ms after spawn on a warm cache, longer on cold or
-/// heavy projects. The earlier 500ms value caught Node.js agents that
-/// crashed in ~250ms but missed opencode's slower bun startup, leaving
-/// the cascade dormant on stale opencode sids: the user-visible bug is a
-/// dead pane after restart with the bad sid still on disk and no toast.
-/// Healthy resumes pay this entire window once on Tier-1 (and again on
-/// Tier-2 if it fires); the pane is fully attachable for the duration so
-/// the cost is purely in the synchronous restart path's latency, not in
-/// agent responsiveness afterward.
+/// heavy projects. Healthy resumes pay this entire window once on Tier-1
+/// (and again on Tier-2 if it fires); the pane is fully attachable for
+/// the duration so the cost is purely in the synchronous restart path's
+/// latency, not in agent responsiveness afterward.
 const RESUME_PROBE_POST_SHELL_GRACE: std::time::Duration = std::time::Duration::from_millis(2000);
 
 /// Pure decision: should the resume-fallback cascade probe and potentially
@@ -122,11 +118,11 @@ pub enum EnsureReadyOutcome {
     /// respawn, meaning the agent's prior conversation is gone; callers should
     /// surface this so the user understands why history disappeared.
     Respawned { stale_sid: Option<String> },
-    /// Tmux session did not exist and was started from scratch via the
-    /// resume-fallback cascade. `stale_sid` is `Some` when the cascade
-    /// fired during this start (sid was on disk from a prior run, the
-    /// agent crashed on it, and we cleared it before retrying), with the
-    /// same surface-to-user contract as `Respawned`.
+    /// Tmux session did not exist and was started via the resume-fallback
+    /// cascade. `stale_sid` is `Some` when the cascade fired (sid was on
+    /// disk from a prior run, the agent crashed on it, and we cleared it
+    /// before retrying), `None` for a healthy resume or fresh launch
+    /// without resume. Same surface-to-user contract as `Respawned`.
     Started { stale_sid: Option<String> },
 }
 
@@ -1708,7 +1704,7 @@ impl Instance {
             let shell = super::environment::user_shell();
             if let Err(e) = session.respawn_dead_pane(&self.project_path, Some(&shell)) {
                 tracing::warn!(
-                    "respawn_dead_pane failed for {}: {} -- falling back to kill+start",
+                    "respawn_dead_pane failed for {}: {}; falling back to kill+start",
                     session.name(),
                     e
                 );
@@ -1822,16 +1818,12 @@ impl Instance {
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
     ) -> Result<StartOutcome> {
-        // Clear stale Status::Error before any early-return so all restart
-        // paths (REST `ensure_session`, TUI Enter/restart, CLI `aoe session
-        // restart [id|--all]`) behave consistently. Pre-cascade only REST
-        // had a pre-restart reset (still inlined at
-        // `src/server/api/sessions.rs::ensure_session`, sets
-        // `status=Starting`, `last_error=None`); hoisting the reset here
-        // is a deliberate UX broadening so a TUI/CLI restart on a session
-        // sitting in `Status::Error` no longer leaves the error chip up
-        // after a successful relaunch, and cockpit-mode short-circuit
-        // sessions get the same treatment.
+        // Clear `Status::Error` on entry so a successful relaunch from any
+        // restart surface (REST `ensure_session`, TUI Enter/restart, CLI
+        // `aoe session restart [id|--all]`, cockpit-mode short-circuit)
+        // does not leave a stale error chip up. REST `ensure_session`
+        // re-asserts `status=Starting`, `last_error=None` pre-call as
+        // defense in depth.
         //
         // `last_error_check` is cleared alongside `last_error` to mirror
         // how the field is otherwise managed: `update_status` writes both

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1819,7 +1819,20 @@ impl Instance {
             return Ok(StartOutcome::Fresh);
         }
 
-        match self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL)? {
+        // Tier-1 settle probe. On Err (rare: only when `tmux_session()`
+        // fails), tear down the Tier-1 poller spawned by the
+        // start_with_size_opts above before propagating, so a transient
+        // tmux failure cannot leak a poller thread onto a presumed-broken
+        // pane.
+        let probe = match self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL) {
+            Ok(p) => p,
+            Err(e) => {
+                self.stop_poller();
+                self.session_id_poller = None;
+                return Err(e);
+            }
+        };
+        match probe {
             ProbeResult::Alive => return Ok(StartOutcome::Resumed),
             ProbeResult::Dead => {}
         }
@@ -1859,10 +1872,18 @@ impl Instance {
         // exists to surface - would silently report `StartOutcome::Restarted`.
         // The dead pane is left in tmux; the next user-initiated restart
         // goes through `restart_with_size_opts` -> `kill_clean` and self-heals.
-        if matches!(
-            self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL)?,
-            ProbeResult::Dead
-        ) {
+        // Tier-2 settle probe. On Err (same rare condition as Tier-1),
+        // tear down the Tier-2 poller spawned by the second
+        // start_with_size_opts before propagating.
+        let probe = match self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL) {
+            Ok(p) => p,
+            Err(e) => {
+                self.stop_poller();
+                self.session_id_poller = None;
+                return Err(e);
+            }
+        };
+        if matches!(probe, ProbeResult::Dead) {
             // Symmetric teardown with the Tier-1->Tier-2 transition above:
             // the Tier-2 spawn already started a fresh poller via
             // `finalize_launch`, and bailing without stopping it leaves an
@@ -3768,6 +3789,12 @@ mod tests {
             // appends `--session-id <new_uuid>` (different value), so the
             // pattern does not match and `sleep 30` keeps the pane alive
             // past RESUME_PROBE_MAX (3s).
+            //
+            // Pinned: this discriminator relies on
+            // `ResumeStrategy::FlagPair` appending the sid to argv (see
+            // `src/agents.rs`). If a future variant ever passes the sid
+            // out of band (env var, stdin, file), update the wrapper to
+            // observe the new channel instead of `$*`.
             inst.command = format!(
                 "/bin/sh -c 'case \"$*\" in *{stale}*) exit 1 ;; esac; exec sleep 30' --",
                 stale = stale_sid,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1,9 +1,10 @@
 //! Session instance definition and operations
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
@@ -47,6 +48,52 @@ pub enum Status {
     Starting,
     Deleting,
     Creating,
+}
+
+/// Outcome of a `start_with_resume_fallback` cascade.
+///
+/// Failures (both tiers) propagate as `Err` so callers keep the existing
+/// `Status::Error` + `last_error` path. Only successful outcomes are
+/// enumerated; mirrors the `EnsureReadyOutcome` shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartOutcome {
+    /// Session ID was set and resume succeeded; pane is alive.
+    Resumed,
+    /// Resume attempt crashed the pane fast; the bad sid was cleared and a
+    /// fresh start succeeded. Caller should surface this: the user's prior
+    /// conversation is gone. `stale_sid` is the sid that was cleared.
+    Restarted { stale_sid: String },
+    /// No resume was attempted (no prior sid, agent doesn't support resume,
+    /// or sid was invalid). Started cleanly.
+    Fresh,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeResult {
+    Alive,
+    Dead,
+}
+
+const RESUME_PROBE_MAX: std::time::Duration = std::time::Duration::from_millis(3000);
+const RESUME_PROBE_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+/// Grace window we keep observing after the pane stops running its boot
+/// shell, before declaring `Alive`. Without it, a Node.js agent that
+/// `exec`s past the wrapper at ~80ms and crashes at ~250ms is reported
+/// as alive on the first not-shell poll, defeating the cascade.
+const RESUME_PROBE_POST_SHELL_GRACE: std::time::Duration = std::time::Duration::from_millis(500);
+
+/// Pure decision: should the resume-fallback cascade probe and potentially
+/// retry without resume after the initial start? Extracted for unit-testability:
+/// the cascade itself needs a real tmux session to test end-to-end.
+fn should_attempt_resume(agent_session_id: Option<&str>, tool: &str) -> bool {
+    let valid = agent_session_id.map(is_valid_session_id).unwrap_or(false);
+    if !valid {
+        return false;
+    }
+    !matches!(
+        crate::agents::get_agent(tool).map(|a| &a.resume_strategy),
+        Some(crate::agents::ResumeStrategy::Unsupported) | None,
+    )
 }
 
 /// Outcome of `Instance::ensure_pane_ready`. Callers surface this so the user
@@ -308,6 +355,15 @@ pub struct Instance {
     pub last_error: Option<String>,
     #[serde(skip)]
     pub session_id_poller: Option<Arc<Mutex<SessionPoller>>>,
+
+    /// Runtime-only set of session IDs that retroactive capture must NOT
+    /// re-discover from on-disk artifacts. Populated by the resume-fallback
+    /// cascade with the just-crashed session ID so the Tier-2 fresh start
+    /// doesn't re-import the same bad sid via filesystem scan (opencode db,
+    /// vibe meta.json, codex state, etc., all keep the bad session's row
+    /// after the crash for several minutes).
+    #[serde(skip)]
+    pub(crate) retroactive_capture_excludes: HashSet<String>,
 }
 
 /// Append yolo-mode flags or environment variables to a launch command.
@@ -439,6 +495,51 @@ fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str
     }
 }
 
+/// Clear the persisted `agent_session_id` for an instance.
+///
+/// Inverse of `persist_session_to_storage`. Used by the resume-fallback
+/// cascade after Tier 1 detects a crashed pane: the bad sid was already
+/// flushed to `sessions.json` by the Tier-1 `finalize_launch`, so an
+/// in-memory clear is not enough. If the daemon dies between Tier 1 and
+/// Tier 2's `finalize_launch`, the next launch would otherwise re-load the
+/// bad sid from disk and pass `--resume <bad>` again, looping.
+fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
+    debug_assert!(
+        std::thread::current()
+            .name()
+            .is_none_or(|n| n == "main" || !n.starts_with("aoe-")),
+        "clear_session_id_on_disk must not be called from background threads (was: {:?})",
+        std::thread::current().name()
+    );
+
+    let storage = match super::storage::Storage::new(profile) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("Failed to create storage to clear session ID: {}", e);
+            return;
+        }
+    };
+    let mut instances = match storage.load() {
+        Ok(i) => i,
+        Err(e) => {
+            tracing::warn!("Failed to load instances to clear session ID: {}", e);
+            return;
+        }
+    };
+    let Some(inst) = instances.iter_mut().find(|i| i.id == instance_id) else {
+        return;
+    };
+    if inst.agent_session_id.is_none() {
+        return;
+    }
+    inst.agent_session_id = None;
+    if let Err(e) = storage.save(&instances) {
+        tracing::warn!("Failed to save instances after clearing session ID: {}", e);
+    } else {
+        tracing::debug!("Session ID cleared on disk for {}", instance_id);
+    }
+}
+
 /// Publish a captured session ID to the tmux environment only.
 ///
 /// Background threads (poller on_change) call this so that
@@ -493,6 +594,7 @@ impl Instance {
             last_start_time: None,
             last_error: None,
             session_id_poller: None,
+            retroactive_capture_excludes: HashSet::new(),
         }
     }
 
@@ -610,8 +712,20 @@ impl Instance {
         (session_id, false)
     }
 
+    /// Full set of session IDs that retroactive capture must skip for THIS
+    /// instance: the live tmux-discovered set plus any sids the
+    /// resume-fallback cascade has explicitly cleared. Composed of
+    /// [`build_exclusion_set`] (live tmux scan) and
+    /// `self.retroactive_capture_excludes` (cascade memory) so the caller
+    /// gets the complete picture in one call.
+    fn retroactive_capture_exclusion_set(&self) -> HashSet<String> {
+        let mut set = build_exclusion_set(&self.id);
+        set.extend(self.retroactive_capture_excludes.iter().cloned());
+        set
+    }
+
     pub(crate) fn try_retroactive_capture(&self) -> Option<String> {
-        let exclusion = build_exclusion_set(&self.id);
+        let exclusion = self.retroactive_capture_exclusion_set();
         let result: Option<String> = match self.tool.as_str() {
             "opencode" => {
                 if self.is_sandboxed() {
@@ -1463,11 +1577,50 @@ impl Instance {
     }
 
     pub fn restart(&mut self) -> Result<()> {
-        self.restart_with_size(None)
+        self.restart_with_size(None).map(|_| ())
     }
 
-    pub fn restart_with_size(&mut self, size: Option<(u16, u16)>) -> Result<()> {
+    pub fn restart_with_size(&mut self, size: Option<(u16, u16)>) -> Result<StartOutcome> {
         self.restart_with_size_opts(size, false)
+    }
+
+    /// Tear down the current tmux session cleanly so a fresh
+    /// `start_with_size_opts` can recreate it.
+    ///
+    /// `remain-on-exit on` keeps the tmux session alive after the agent
+    /// process exits, leaving a frozen pane. The plain kill-session +
+    /// new-session flow can race against the session cache
+    /// (kill_process_tree on a defunct pid stalls on macOS, and the
+    /// subsequent kill can run while start's exists() check still sees the
+    /// cached entry), leaving the dead pane in place. Respawning the pane
+    /// into a shell first puts it back in a live state so the kill path
+    /// proceeds cleanly. The kill below then sees a live pane and tears it
+    /// down. Caller is responsible for the subsequent
+    /// `start_with_size_opts` to recreate the session with the agent
+    /// command.
+    fn kill_clean(&self) -> Result<()> {
+        let session = self.tmux_session()?;
+        if !session.exists() {
+            return Ok(());
+        }
+        if session.is_pane_dead() {
+            tracing::info!(
+                "restart: pane dead for session {} (remain-on-exit), \
+                 respawning shell before recreate",
+                session.name()
+            );
+            let shell = super::environment::user_shell();
+            if let Err(e) = session.respawn_dead_pane(&self.project_path, Some(&shell)) {
+                tracing::warn!(
+                    "respawn_dead_pane failed for {}: {} -- falling back to kill+start",
+                    session.name(),
+                    e
+                );
+            }
+        }
+        session.kill()?;
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        Ok(())
     }
 
     /// Restart the session, optionally skipping on_launch hooks (e.g. when
@@ -1476,44 +1629,127 @@ impl Instance {
         &mut self,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
-    ) -> Result<()> {
+    ) -> Result<StartOutcome> {
         self.stop_poller();
         self.session_id_poller = None;
+        self.kill_clean()?;
+        self.start_with_resume_fallback(size, skip_on_launch)
+    }
 
+    /// Settle-based pane probe used by the resume-fallback cascade.
+    ///
+    /// Returns `Dead` immediately if the pane dies or the session evaporates
+    /// during the probe window. Returns `Alive` only after the pane has been
+    /// off the boot shell for `RESUME_PROBE_POST_SHELL_GRACE` consecutive
+    /// time (handles Node.js agents that `exec` to `node` before crashing
+    /// on a bad sid), or charitably on full timeout for slow-start agents.
+    /// `pane_dead` is the unambiguous signal we trust to fire the cascade.
+    fn probe_settle(
+        &self,
+        max: std::time::Duration,
+        poll: std::time::Duration,
+    ) -> Result<ProbeResult> {
         let session = self.tmux_session()?;
-
-        if session.exists() {
-            // Dead-pane case: `remain-on-exit on` keeps the tmux session
-            // alive after the agent process exits, leaving a frozen pane.
-            // The plain kill-session + new-session flow can race against
-            // the session cache (kill_process_tree on a defunct pid
-            // stalls on macOS, and the subsequent kill can run while
-            // start's exists() check still sees the cached entry),
-            // leaving the dead pane in place. Respawning the pane into a
-            // shell first puts it back in a live state so the kill path
-            // proceeds cleanly. The kill below then sees a live pane and
-            // tears it down; start_with_size_opts recreates the session
-            // with the agent command.
-            if session.is_pane_dead() {
-                tracing::info!(
-                    "restart: pane dead for session {} (remain-on-exit), \
-                     respawning shell before recreate",
-                    session.name()
-                );
-                let shell = super::environment::user_shell();
-                if let Err(e) = session.respawn_dead_pane(&self.project_path, Some(&shell)) {
-                    tracing::warn!(
-                        "respawn_dead_pane failed for {}: {} -- falling back to kill+start",
-                        session.name(),
-                        e
-                    );
-                }
+        let deadline = std::time::Instant::now() + max;
+        let mut first_post_shell: Option<std::time::Instant> = None;
+        loop {
+            if !session.exists() {
+                return Ok(ProbeResult::Dead);
             }
-            session.kill()?;
-            std::thread::sleep(std::time::Duration::from_millis(100));
+            if session.is_pane_dead() {
+                return Ok(ProbeResult::Dead);
+            }
+            let now = std::time::Instant::now();
+            if !session.is_pane_running_shell() {
+                let started = *first_post_shell.get_or_insert(now);
+                if now.duration_since(started) >= RESUME_PROBE_POST_SHELL_GRACE {
+                    return Ok(ProbeResult::Alive);
+                }
+            } else {
+                first_post_shell = None;
+            }
+            if now >= deadline {
+                return Ok(ProbeResult::Alive);
+            }
+            std::thread::sleep(poll);
+        }
+    }
+
+    /// Start the session with a one-shot resume fallback.
+    ///
+    /// Cascade:
+    ///   1. If a valid `agent_session_id` is set and the agent supports
+    ///      resume, attempt the start (which appends `--resume <sid>` or
+    ///      equivalent). Probe the pane via `probe_settle`.
+    ///   2. If the pane went dead within the probe window, stop the Tier-1
+    ///      poller, tear down the dead tmux session, clear the bad sid
+    ///      (in memory, on disk, and from retroactive-capture re-discovery),
+    ///      and retry the start with `skip_on_launch=true` so on_launch
+    ///      hooks do not run twice.
+    ///   3. If the second start also fails, propagate `Err` so the caller's
+    ///      existing `Status::Error` + `last_error` path takes over.
+    ///
+    /// Cockpit-mode sessions short-circuit (no tmux pane to probe).
+    pub(crate) fn start_with_resume_fallback(
+        &mut self,
+        size: Option<(u16, u16)>,
+        skip_on_launch: bool,
+    ) -> Result<StartOutcome> {
+        #[cfg(feature = "serve")]
+        if self.cockpit_mode {
+            self.start_with_size_opts(size, skip_on_launch)?;
+            return Ok(StartOutcome::Fresh);
         }
 
-        self.start_with_size_opts(size, skip_on_launch)
+        if self.status == Status::Error {
+            self.status = Status::Idle;
+            self.last_error = None;
+            self.last_error_check = None;
+        }
+
+        let attempting_resume = should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);
+        let session_existed_before = self.tmux_session().is_ok_and(|s| s.exists());
+
+        self.start_with_size_opts(size, skip_on_launch)?;
+
+        if !attempting_resume || session_existed_before {
+            return Ok(StartOutcome::Fresh);
+        }
+
+        match self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL)? {
+            ProbeResult::Alive => return Ok(StartOutcome::Resumed),
+            ProbeResult::Dead => {}
+        }
+
+        let stale_sid = self
+            .agent_session_id
+            .clone()
+            .unwrap_or_else(|| "<unknown>".to_string());
+        let profile = self.effective_profile();
+        tracing::warn!(
+            "start: resume with sid {} for session {} crashed pane within probe; \
+             clearing sid and retrying without resume",
+            stale_sid,
+            self.id,
+        );
+
+        self.stop_poller();
+        self.session_id_poller = None;
+        self.kill_clean()
+            .with_context(|| format!("kill_clean before resume fallback for {}", self.id))?;
+
+        self.agent_session_id = None;
+        clear_session_id_on_disk(&profile, &self.id);
+        self.retroactive_capture_excludes.insert(stale_sid.clone());
+
+        self.start_with_size_opts(size, true).with_context(|| {
+            format!(
+                "fresh restart after resume fallback failed for {} (stale sid {} was cleared)",
+                self.id, stale_sid,
+            )
+        })?;
+
+        Ok(StartOutcome::Restarted { stale_sid })
     }
 
     /// Smart-send precondition: bring this session's tmux pane to a state
@@ -3176,6 +3412,182 @@ mod tests {
             );
 
             cleanup(&name);
+        }
+    }
+
+    mod resume_fallback {
+        use super::super::{
+            clear_session_id_on_disk, should_attempt_resume, Instance, StartOutcome, Status,
+        };
+        use serial_test::serial;
+        use tempfile::tempdir;
+
+        #[test]
+        fn no_sid_does_not_attempt_resume() {
+            assert!(!should_attempt_resume(None, "claude"));
+            assert!(!should_attempt_resume(Some(""), "claude"));
+            assert!(!should_attempt_resume(Some("   "), "claude"));
+        }
+
+        #[test]
+        fn invalid_sid_does_not_attempt_resume() {
+            assert!(!should_attempt_resume(Some("bad id!"), "claude"));
+            assert!(!should_attempt_resume(Some("path/slash"), "claude"));
+            assert!(!should_attempt_resume(Some(&"x".repeat(257)), "claude"));
+        }
+
+        #[test]
+        fn valid_sid_for_resume_supporting_agent_attempts() {
+            assert!(should_attempt_resume(
+                Some("11111111-1111-1111-1111-111111111111"),
+                "claude"
+            ));
+            assert!(should_attempt_resume(Some("session_abc.123"), "opencode"));
+            assert!(should_attempt_resume(Some("uuid-abc-123"), "codex"));
+            assert!(should_attempt_resume(Some("uuid-abc-123"), "gemini"));
+        }
+
+        #[test]
+        fn unsupported_agent_does_not_attempt_resume() {
+            assert!(!should_attempt_resume(
+                Some("11111111-1111-1111-1111-111111111111"),
+                "cursor"
+            ));
+            assert!(!should_attempt_resume(
+                Some("11111111-1111-1111-1111-111111111111"),
+                "copilot"
+            ));
+        }
+
+        #[test]
+        fn unknown_tool_does_not_attempt_resume() {
+            assert!(!should_attempt_resume(Some("uuid-abc-123"), "nonexistent"));
+        }
+
+        #[test]
+        #[serial]
+        fn clear_session_id_on_disk_is_idempotent_when_already_none() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            clear_session_id_on_disk("test-profile-empty", "nonexistent-id");
+        }
+
+        #[test]
+        #[serial]
+        fn clear_session_id_on_disk_clears_persisted_value() {
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage = crate::session::storage::Storage::new("clear-test").unwrap();
+            let mut inst = Instance::new("title", "/tmp/x");
+            inst.agent_session_id = Some("stale-uuid-1234".to_string());
+            let id = inst.id.clone();
+            storage.save(&[inst]).unwrap();
+
+            clear_session_id_on_disk("clear-test", &id);
+
+            let loaded = storage.load().unwrap();
+            assert_eq!(loaded.len(), 1);
+            assert_eq!(loaded[0].agent_session_id, None);
+        }
+
+        #[test]
+        #[serial]
+        fn restart_outcome_for_cockpit_session_is_fresh() {
+            #[cfg(feature = "serve")]
+            {
+                if std::process::Command::new("tmux")
+                    .arg("-V")
+                    .output()
+                    .is_err()
+                {
+                    eprintln!("tmux not available; skipping");
+                    return;
+                }
+                let temp = tempdir().unwrap();
+                std::env::set_var("HOME", temp.path());
+                #[cfg(target_os = "linux")]
+                std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+                let mut inst = Instance::new("cockpit_test", "/tmp/x");
+                inst.cockpit_mode = true;
+                inst.agent_session_id = Some("11111111-1111-1111-1111-111111111111".to_string());
+                inst.tool = "claude".to_string();
+
+                let outcome = inst.start_with_resume_fallback(None, true).unwrap();
+                assert_eq!(outcome, StartOutcome::Fresh);
+            }
+        }
+
+        #[test]
+        #[serial]
+        fn fallback_clears_sid_in_memory_and_on_disk_when_pane_dies() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let storage = crate::session::storage::Storage::new("fb-test").unwrap();
+
+            let stale_sid = "11111111-1111-1111-1111-111111111111".to_string();
+            let mut inst = Instance::new("fallback_dies_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-test".to_string();
+            inst.command = "/bin/false".to_string();
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+            let id = inst.id.clone();
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            storage.save(&[inst.clone()]).unwrap();
+
+            let outcome = inst.start_with_resume_fallback(None, true);
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            let outcome = outcome.expect("cascade must succeed: Tier-2 fresh start with /bin/false should always succeed at tmux level");
+            match outcome {
+                StartOutcome::Restarted { stale_sid: cleared } => {
+                    assert_eq!(cleared, stale_sid);
+                }
+                other => panic!("expected Restarted, got {other:?}"),
+            }
+            assert!(
+                inst.retroactive_capture_excludes.contains(&stale_sid),
+                "stale sid must be in exclusion set so retroactive capture cannot \
+                 re-import it on next launch"
+            );
+            assert_ne!(
+                inst.agent_session_id.as_deref(),
+                Some(stale_sid.as_str()),
+                "stale sid must not survive in memory (Tier 2 may regenerate a fresh sid for Claude, but never the stale one)"
+            );
+            let loaded = storage.load().unwrap();
+            let row = loaded.iter().find(|i| i.id == id).expect("instance");
+            assert_ne!(
+                row.agent_session_id.as_deref(),
+                Some(stale_sid.as_str()),
+                "stale sid must not survive on disk after fallback"
+            );
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -3890,5 +3890,88 @@ mod tests {
             assert!(inst.retroactive_capture_excludes.contains(&stale_sid));
             assert!(inst.agent_session_id.as_deref() != Some(stale_sid.as_str()));
         }
+
+        #[test]
+        #[serial]
+        fn cascade_fires_when_pane_dies_inside_post_shell_grace_window() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let _storage = crate::session::storage::Storage::new("fb-test-grace").unwrap();
+
+            let stale_sid = "33333333-3333-3333-3333-333333333333".to_string();
+            let mut inst = Instance::new("fallback_grace_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-test-grace".to_string();
+            // Regression guard for RESUME_PROBE_POST_SHELL_GRACE.
+            //
+            // The Tier-1 wrapper exits its boot shell immediately via `exec
+            // sleep N`, then the replacement process exits; tmux observes
+            // pane_dead at roughly t = N seconds. We pick N inside the
+            // window (current grace 2000ms, sleep 1.2s) so:
+            //   * with grace = 500ms, probe_settle returns Alive at t=500ms
+            //     before the death at t=1200ms; cascade misses it; the test
+            //     observes Resumed; assertion FAILS (regression caught).
+            //   * with grace >= ~1300ms, the grace timer is still open when
+            //     pane_dead fires; probe_settle returns Dead; cascade fires;
+            //     the test observes Restarted; assertion PASSES.
+            //
+            // This pins the LOWER bound of grace; the upper bound is
+            // implicitly RESUME_PROBE_MAX (3000ms) since deadline charity
+            // would otherwise mask future regressions.
+            //
+            // Tier-2 reuses the same wrapper but its sid differs from the
+            // stale one (cascade clears agent_session_id; Claude's FlagPair
+            // strategy regenerates a fresh UUID), so the case match misses
+            // and `exec sleep 30` keeps the pane alive past the second
+            // probe window.
+            inst.command = format!(
+                "/bin/sh -c 'case \"$*\" in *{stale}*) exec sleep 1.2 ;; esac; exec sleep 30' --",
+                stale = stale_sid,
+            );
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            let outcome = inst.start_with_resume_fallback(None, true);
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            match outcome {
+                Ok(StartOutcome::Restarted { stale_sid: cleared }) => {
+                    assert_eq!(cleared, stale_sid);
+                }
+                Ok(StartOutcome::Resumed) => panic!(
+                    "Tier-1 grace shortcut returned Alive before the t=1200ms pane_dead: \
+                     RESUME_PROBE_POST_SHELL_GRACE is too short. \
+                     Real opencode crashes at ~1000ms; raise the grace constant."
+                ),
+                Ok(other) => panic!(
+                    "Expected Restarted or Resumed; got {other:?} (probe path is taking an unexpected branch)"
+                ),
+                Err(e) => panic!(
+                    "Tier-2 must succeed because its wrapper does not match the stale sid: {e:#}; \
+                     either the cascade is misrouting the sid or Tier-2 spawn is failing"
+                ),
+            }
+            assert!(inst.retroactive_capture_excludes.contains(&stale_sid));
+            assert!(inst.agent_session_id.as_deref() != Some(stale_sid.as_str()));
+        }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -504,13 +504,12 @@ fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str
 /// Tier 2's `finalize_launch`, the next launch would otherwise re-load the
 /// bad sid from disk and pass `--resume <bad>` again, looping.
 fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
-    debug_assert!(
-        std::thread::current()
-            .name()
-            .is_none_or(|n| n == "main" || !n.starts_with("aoe-")),
-        "clear_session_id_on_disk must not be called from background threads (was: {:?})",
-        std::thread::current().name()
-    );
+    // Invariant: caller must have stopped this instance's session_id_poller
+    // before calling. Otherwise the poller's `on_change` callback can race
+    // this load -> mutate -> save with its own write to `sessions.json` and
+    // either party's update is lost (Storage::save is non-atomic).
+    // start_with_resume_fallback enforces this via stop_poller() + nulling
+    // session_id_poller before the call site at L1736-1737.
 
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
@@ -1685,11 +1684,24 @@ impl Instance {
     ///      poller, tear down the dead tmux session, clear the bad sid
     ///      (in memory, on disk, and from retroactive-capture re-discovery),
     ///      and retry the start with `skip_on_launch=true` so on_launch
-    ///      hooks do not run twice.
-    ///   3. If the second start also fails, propagate `Err` so the caller's
-    ///      existing `Status::Error` + `last_error` path takes over.
+    ///      hooks do not run twice. Probe the second pane the same way:
+    ///      `start_with_size_opts` only fails on tmux-subprocess errors, so
+    ///      an in-pane crash (missing binary, broken `docker exec`, agent
+    ///      panic on first run) would otherwise masquerade as
+    ///      `StartOutcome::Restarted` over a corpse pane.
+    ///   3. If the Tier-2 start fails at the tmux level *or* its pane crashes
+    ///      within the probe window, propagate `Err` so the caller's existing
+    ///      `Status::Error` + `last_error` path takes over.
+    ///
+    /// Latency: only fires the probe when `--resume <sid>` is being passed
+    /// to a freshly-created tmux session. Healthy resumes pay
+    /// `RESUME_PROBE_POST_SHELL_GRACE` (~500ms) once on cold start; warm
+    /// sessions and non-resume launches pay nothing.
     ///
     /// Cockpit-mode sessions short-circuit (no tmux pane to probe).
+    /// `StartOutcome::Fresh` is honest there: cockpit's resume concept lives
+    /// in `cockpit_acp_session_id` and is handled by the ACP supervisor, not
+    /// by this cascade.
     pub(crate) fn start_with_resume_fallback(
         &mut self,
         size: Option<(u16, u16)>,
@@ -1748,6 +1760,25 @@ impl Instance {
                 self.id, stale_sid,
             )
         })?;
+
+        // Tier-2 needs the same settle-probe as Tier-1: tmux can spawn the
+        // pane successfully while the agent inside crashes immediately
+        // (missing binary, gone docker image, agent panic on first run).
+        // Without this, the in-pane crash class - the very class the cascade
+        // exists to surface - would silently report `StartOutcome::Restarted`.
+        // The dead pane is left in tmux; the next user-initiated restart
+        // goes through `restart_with_size_opts` -> `kill_clean` and self-heals.
+        if matches!(
+            self.probe_settle(RESUME_PROBE_MAX, RESUME_PROBE_POLL)?,
+            ProbeResult::Dead
+        ) {
+            anyhow::bail!(
+                "fresh restart after resume fallback crashed within probe for {} \
+                 (stale sid {} was cleared; underlying issue persists)",
+                self.id,
+                stale_sid,
+            );
+        }
 
         Ok(StartOutcome::Restarted { stale_sid })
     }
@@ -3564,30 +3595,95 @@ mod tests {
                 .args(["kill-session", "-t", &tmux_name])
                 .output();
 
-            let outcome = outcome.expect("cascade must succeed: Tier-2 fresh start with /bin/false should always succeed at tmux level");
-            match outcome {
-                StartOutcome::Restarted { stale_sid: cleared } => {
-                    assert_eq!(cleared, stale_sid);
-                }
-                other => panic!("expected Restarted, got {other:?}"),
-            }
+            let err = outcome
+                .expect_err("Tier-2 with /bin/false must crash within probe and propagate Err");
+            let chain = format!("{:#}", err);
+            assert!(
+                chain.contains("crashed within probe") && chain.contains(&stale_sid),
+                "Tier-2 probe failure must surface the stale sid in its error chain, got: {chain}",
+            );
+
             assert!(
                 inst.retroactive_capture_excludes.contains(&stale_sid),
-                "stale sid must be in exclusion set so retroactive capture cannot \
-                 re-import it on next launch"
+                "stale sid must be in exclusion set even when Tier-2 ultimately fails: \
+                 the cleanup happens before the Tier-2 attempt and must survive the bail",
             );
             assert_ne!(
                 inst.agent_session_id.as_deref(),
                 Some(stale_sid.as_str()),
-                "stale sid must not survive in memory (Tier 2 may regenerate a fresh sid for Claude, but never the stale one)"
+                "stale sid must not survive in memory after fallback, even on Tier-2 failure",
             );
             let loaded = storage.load().unwrap();
             let row = loaded.iter().find(|i| i.id == id).expect("instance");
             assert_ne!(
                 row.agent_session_id.as_deref(),
                 Some(stale_sid.as_str()),
-                "stale sid must not survive on disk after fallback"
+                "stale sid must not survive on disk after fallback, even on Tier-2 failure",
             );
+        }
+
+        #[test]
+        #[serial]
+        fn fallback_returns_restarted_when_tier2_pane_lives() {
+            if std::process::Command::new("tmux")
+                .arg("-V")
+                .output()
+                .is_err()
+            {
+                eprintln!("tmux not available; skipping");
+                return;
+            }
+            let temp = tempdir().unwrap();
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+
+            let _storage = crate::session::storage::Storage::new("fb-test-live").unwrap();
+
+            let stale_sid = "22222222-2222-2222-2222-222222222222".to_string();
+            let mut inst = Instance::new("fallback_lives_test", "/tmp/x");
+            inst.tool = "claude".to_string();
+            inst.source_profile = "fb-test-live".to_string();
+            // Claude regenerates a fresh UUID on Tier-2 (acquire_session_id
+            // emits `--session-id <new_uuid>`), so we cannot just count argv.
+            // Match the *stale* sid specifically: Tier-1 appends `--resume
+            // <stale_sid>` and the script exits, firing the cascade. Tier-2
+            // appends `--session-id <new_uuid>` (different value), so the
+            // pattern does not match and `sleep 30` keeps the pane alive
+            // past RESUME_PROBE_MAX (3s).
+            inst.command = format!(
+                "/bin/sh -c 'case \"$*\" in *{stale}*) exit 1 ;; esac; exec sleep 30' --",
+                stale = stale_sid,
+            );
+            inst.agent_session_id = Some(stale_sid.clone());
+            inst.status = Status::Idle;
+
+            let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            let outcome = inst.start_with_resume_fallback(None, true);
+
+            let _ = std::process::Command::new("tmux")
+                .args(["kill-session", "-t", &tmux_name])
+                .output();
+
+            match outcome {
+                Ok(StartOutcome::Restarted { stale_sid: cleared }) => {
+                    assert_eq!(cleared, stale_sid);
+                }
+                Ok(other) => panic!(
+                    "Tier-2 success path must return Restarted, got {other:?}; \
+                     a different variant indicates the probe misfires"
+                ),
+                Err(e) => panic!(
+                    "Tier-2 with a live binary must succeed: {e:#}; \
+                     check probe_settle behavior on long-running shells"
+                ),
+            }
+            assert!(inst.retroactive_capture_excludes.contains(&stale_sid));
+            assert!(inst.agent_session_id.as_deref() != Some(stale_sid.as_str()));
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -17,16 +17,16 @@ use super::environment::{build_docker_env_args, shell_escape};
 use super::poller::SessionPoller;
 
 use crate::session::capture::{
-    build_exclusion_set, capture_codex_session_id, capture_gemini_session_id,
-    capture_hermes_session_id, capture_pi_session_id, capture_vibe_session_id, claude_poll_fn,
-    claude_poll_fn_sandboxed, codex_poll_fn, codex_poll_fn_sandboxed, gemini_poll_fn,
-    gemini_poll_fn_sandboxed, generate_claude_session_id, hermes_poll_fn, hermes_poll_fn_sandboxed,
-    is_valid_session_id, opencode_poll_fn, opencode_poll_fn_sandboxed, pi_poll_fn,
-    pi_poll_fn_sandboxed, try_capture_codex_session_id_in_container,
-    try_capture_gemini_session_id_in_container, try_capture_hermes_session_id_in_container,
-    try_capture_opencode_session_id, try_capture_opencode_session_id_in_container,
-    try_capture_pi_session_id_in_container, try_capture_vibe_session_id_in_container,
-    validated_session_id, vibe_poll_fn, vibe_poll_fn_sandboxed,
+    capture_codex_session_id, capture_gemini_session_id, capture_hermes_session_id,
+    capture_pi_session_id, capture_vibe_session_id, claude_poll_fn, claude_poll_fn_sandboxed,
+    codex_poll_fn, codex_poll_fn_sandboxed, gemini_poll_fn, gemini_poll_fn_sandboxed,
+    generate_claude_session_id, hermes_poll_fn, hermes_poll_fn_sandboxed, is_valid_session_id,
+    opencode_poll_fn, opencode_poll_fn_sandboxed, pi_poll_fn, pi_poll_fn_sandboxed,
+    try_capture_codex_session_id_in_container, try_capture_gemini_session_id_in_container,
+    try_capture_hermes_session_id_in_container, try_capture_opencode_session_id,
+    try_capture_opencode_session_id_in_container, try_capture_pi_session_id_in_container,
+    try_capture_vibe_session_id_in_container, validated_session_id, vibe_poll_fn,
+    vibe_poll_fn_sandboxed,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -98,12 +98,15 @@ fn should_attempt_resume(agent_session_id: Option<&str>, tool: &str) -> bool {
 
 /// Outcome of `Instance::ensure_pane_ready`. Callers surface this so the user
 /// knows what (if anything) happened on their behalf before a send.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EnsureReadyOutcome {
     /// Pane was already alive; no action taken.
     AlreadyAlive,
     /// Pane was dead (`#{pane_dead}=1`) and was respawned via the restart path.
-    Respawned,
+    /// `stale_sid` is `Some` when the resume-fallback cascade fired during the
+    /// respawn, meaning the agent's prior conversation is gone; callers should
+    /// surface this so the user understands why history disappeared.
+    Respawned { stale_sid: Option<String> },
     /// Tmux session did not exist and was started from scratch.
     Started,
 }
@@ -718,9 +721,7 @@ impl Instance {
     /// `self.retroactive_capture_excludes` (cascade memory) so the caller
     /// gets the complete picture in one call.
     fn retroactive_capture_exclusion_set(&self) -> HashSet<String> {
-        let mut set = build_exclusion_set(&self.id);
-        set.extend(self.retroactive_capture_excludes.iter().cloned());
-        set
+        super::capture::compose_exclusion(&self.id, &self.retroactive_capture_excludes)
     }
 
     pub(crate) fn try_retroactive_capture(&self) -> Option<String> {
@@ -1425,6 +1426,13 @@ impl Instance {
         let mut poller = SessionPoller::new(tmux_session_name.clone());
         let instance_id = self.id.clone();
         let initial_known = self.agent_session_id.clone();
+        // Snapshot per-instance excludes (sids cleared by the resume-fallback
+        // cascade) at poller-spawn time. The cascade always tears down the
+        // existing poller and re-enters this function AFTER inserting into
+        // `retroactive_capture_excludes` (see start_with_resume_fallback),
+        // so the freshly-spawned poller's first immediate poll sees the
+        // populated set and won't re-import the bad sid.
+        let extra_excludes = self.retroactive_capture_excludes.clone();
 
         let poll_fn: Box<dyn Fn() -> Option<String> + Send + 'static> = match tool {
             "claude" => {
@@ -1456,12 +1464,14 @@ impl Instance {
                         self.container_workdir(),
                         self.id.clone(),
                         launch_time_ms,
+                        extra_excludes.clone(),
                     ))
                 } else {
                     Box::new(opencode_poll_fn(
                         self.project_path.clone(),
                         self.id.clone(),
                         launch_time_ms,
+                        extra_excludes.clone(),
                     ))
                 }
             }
@@ -1475,9 +1485,14 @@ impl Instance {
                         container_name,
                         self.container_workdir(),
                         self.id.clone(),
+                        extra_excludes.clone(),
                     ))
                 } else {
-                    Box::new(vibe_poll_fn(self.project_path.clone(), self.id.clone()))
+                    Box::new(vibe_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
                 }
             }
             "pi" => {
@@ -1490,9 +1505,14 @@ impl Instance {
                         container_name,
                         self.container_workdir(),
                         self.id.clone(),
+                        extra_excludes.clone(),
                     ))
                 } else {
-                    Box::new(pi_poll_fn(self.project_path.clone(), self.id.clone()))
+                    Box::new(pi_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
                 }
             }
             "codex" => {
@@ -1505,9 +1525,14 @@ impl Instance {
                         container_name,
                         self.container_workdir(),
                         self.id.clone(),
+                        extra_excludes.clone(),
                     ))
                 } else {
-                    Box::new(codex_poll_fn(self.project_path.clone(), self.id.clone()))
+                    Box::new(codex_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
                 }
             }
             "gemini" => {
@@ -1520,9 +1545,14 @@ impl Instance {
                         container_name,
                         self.container_workdir(),
                         self.id.clone(),
+                        extra_excludes.clone(),
                     ))
                 } else {
-                    Box::new(gemini_poll_fn(self.project_path.clone(), self.id.clone()))
+                    Box::new(gemini_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes.clone(),
+                    ))
                 }
             }
             "hermes" => {
@@ -1535,9 +1565,14 @@ impl Instance {
                         container_name,
                         self.container_workdir(),
                         self.id.clone(),
+                        extra_excludes,
                     ))
                 } else {
-                    Box::new(hermes_poll_fn(self.project_path.clone(), self.id.clone()))
+                    Box::new(hermes_poll_fn(
+                        self.project_path.clone(),
+                        self.id.clone(),
+                        extra_excludes,
+                    ))
                 }
             }
             _ => return,
@@ -1716,11 +1751,14 @@ impl Instance {
         }
 
         let attempting_resume = should_attempt_resume(self.agent_session_id.as_deref(), &self.tool);
-        let session_existed_before = self.tmux_session().is_ok_and(|s| s.exists());
+        // If the tmux session already existed when we entered, `start_with_size_opts`
+        // is a no-op (no `--resume <sid>` was passed in this call), so the probe
+        // would have nothing to detect; skip straight to `Fresh`.
+        let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
 
         self.start_with_size_opts(size, skip_on_launch)?;
 
-        if !attempting_resume || session_existed_before {
+        if !attempting_resume || pane_was_preexisting {
             return Ok(StartOutcome::Fresh);
         }
 
@@ -1818,10 +1856,15 @@ impl Instance {
             return Ok(EnsureReadyOutcome::Started);
         }
         if session.is_pane_dead() {
-            self.restart_with_size(None)
+            let outcome = self
+                .restart_with_size(None)
                 .map_err(EnsureReadyError::Tmux)?;
             self.wait_for_pane_ready(&session);
-            return Ok(EnsureReadyOutcome::Respawned);
+            let stale_sid = match outcome {
+                StartOutcome::Restarted { stale_sid } => Some(stale_sid),
+                StartOutcome::Resumed | StartOutcome::Fresh => None,
+            };
+            return Ok(EnsureReadyOutcome::Respawned { stale_sid });
         }
         Ok(EnsureReadyOutcome::AlreadyAlive)
     }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -27,8 +27,8 @@ pub(crate) use environment::user_shell;
 pub use environment::validate_env_entry;
 pub use groups::{flatten_tree, flatten_tree_all_profiles, Group, GroupTree, Item};
 pub use instance::{
-    EnsureReadyError, EnsureReadyOutcome, Instance, SandboxInfo, Status, TerminalInfo,
-    WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
+    EnsureReadyError, EnsureReadyOutcome, Instance, SandboxInfo, StartOutcome, Status,
+    TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,
 };
 pub use profile_config::{
     load_profile_config, merge_configs, resolve_config, resolve_config_or_warn,

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -118,7 +118,7 @@ enum PollCommand {
 ///
 /// `stop()` sends an explicit `PollCommand::Stop` and joins the thread,
 /// providing a deterministic shutdown path for callers like `Instance::kill`
-/// and `Instance::restart`.
+/// and `Instance::restart_with_size`.
 pub struct SessionPoller {
     session_name: String,
     cmd_tx: mpsc::Sender<PollCommand>,

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1115,23 +1115,31 @@ impl App {
 
             self.home
                 .set_instance_status(session_id, crate::session::Status::Starting);
-            if let Err(e) =
-                self.home
-                    .restart_instance_with_size_opts(session_id, size, skip_on_launch)
+            match self
+                .home
+                .restart_instance_with_size_opts(session_id, size, skip_on_launch)
             {
-                let err_str = e.to_string();
-                self.home
-                    .set_instance_error(session_id, Some(err_str.clone()));
-                self.home
-                    .set_instance_status(session_id, crate::session::Status::Error);
-                // Without a toast, set_instance_error + Status::Error are
-                // invisible to the user: the TUI redraws on home as if Enter
-                // did nothing. Toast text is single-line; the bar truncates
-                // at terminal width without us needing to pre-clip.
-                self.update_status = Some(UpdateStatus::transient(format!(
-                    "restart failed: {err_str}"
-                )));
-                return Ok(());
+                Err(e) => {
+                    let err_str = e.to_string();
+                    self.home
+                        .set_instance_error(session_id, Some(err_str.clone()));
+                    self.home
+                        .set_instance_status(session_id, crate::session::Status::Error);
+                    // Without a toast, set_instance_error + Status::Error are
+                    // invisible to the user: the TUI redraws on home as if Enter
+                    // did nothing. Toast text is single-line; the bar truncates
+                    // at terminal width without us needing to pre-clip.
+                    self.update_status = Some(UpdateStatus::transient(format!(
+                        "restart failed: {err_str}"
+                    )));
+                    return Ok(());
+                }
+                Ok(crate::session::StartOutcome::Restarted { stale_sid }) => {
+                    self.update_status = Some(UpdateStatus::transient(format!(
+                        "Resume failed for sid {stale_sid}; started fresh (history not loaded)"
+                    )));
+                }
+                Ok(_) => {}
             }
             self.home.set_instance_error(session_id, None);
         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1001,8 +1001,17 @@ impl App {
                     .set_instance_status(&id, crate::session::Status::Starting);
                 self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
                 terminal.draw(|f| self.render(f))?;
-                self.home.execute_send_message(&id, &message);
-                self.update_status = None;
+                let stale_sid = self.home.execute_send_message(&id, &message);
+                match stale_sid {
+                    Some(sid) => {
+                        self.update_status = Some(UpdateStatus::transient(format!(
+                            "Resume failed for sid {sid}; sent to fresh session (history not loaded)"
+                        )));
+                    }
+                    None => {
+                        self.update_status = None;
+                    }
+                }
             }
             #[cfg(feature = "serve")]
             Action::OpenCockpit(id) => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1409,6 +1409,9 @@ impl HomeView {
         let stale_sid = match outcome {
             Ok(Some(EnsureReadyOutcome::Respawned {
                 stale_sid: Some(sid),
+            }))
+            | Ok(Some(EnsureReadyOutcome::Started {
+                stale_sid: Some(sid),
             })) => Some(sid),
             Ok(_) => None,
             Err(err) => {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1524,18 +1524,19 @@ impl HomeView {
     /// Like `mutate_instance`, but for fallible operations. Clones the entry,
     /// applies `f` to the clone, and writes back to both collections only on
     /// success -- neither collection is modified on error.
-    pub(super) fn try_mutate_instance(
+    pub(super) fn try_mutate_instance<T>(
         &mut self,
         id: &str,
-        f: impl FnOnce(&mut Instance) -> anyhow::Result<()>,
-    ) -> anyhow::Result<()> {
+        f: impl FnOnce(&mut Instance) -> anyhow::Result<T>,
+    ) -> anyhow::Result<Option<T>> {
         if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
             let mut updated = inst.clone();
-            f(&mut updated)?;
+            let out = f(&mut updated)?;
             *inst = updated.clone();
             self.instance_map.insert(id.to_string(), updated);
+            return Ok(Some(out));
         }
-        Ok(())
+        Ok(None)
     }
 
     pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
@@ -1557,8 +1558,10 @@ impl HomeView {
         id: &str,
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
-    ) -> anyhow::Result<()> {
-        self.try_mutate_instance(id, |inst| inst.restart_with_size_opts(size, skip_on_launch))
+    ) -> anyhow::Result<crate::session::StartOutcome> {
+        let outcome =
+            self.try_mutate_instance(id, |inst| inst.restart_with_size_opts(size, skip_on_launch))?;
+        outcome.ok_or_else(|| anyhow::anyhow!("session not found: {}", id))
     }
 
     pub fn select_session_by_id(&mut self, session_id: &str) {
@@ -1612,5 +1615,6 @@ impl HomeView {
         size: Option<(u16, u16)>,
     ) -> anyhow::Result<()> {
         self.try_mutate_instance(id, |inst| inst.start_container_terminal_with_size(size))
+            .map(|_| ())
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1403,7 +1403,7 @@ impl HomeView {
     /// during the implicit respawn so the caller can toast the user about
     /// the lost history; `None` otherwise.
     pub fn execute_send_message(&mut self, session_id: &str, message: &str) -> Option<String> {
-        let outcome = self.try_mutate_instance(session_id, |inst| {
+        let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
             inst.ensure_pane_ready().map_err(Into::into)
         });
         let stale_sid = match outcome {
@@ -1564,6 +1564,34 @@ impl HomeView {
         Ok(None)
     }
 
+    /// Like `try_mutate_instance`, but writes the mutated clone back even
+    /// when `f` returns `Err`.
+    ///
+    /// Required for callers of `Instance::restart_with_size_opts` /
+    /// `ensure_pane_ready`, because the resume-fallback cascade mutates
+    /// `agent_session_id` and `retroactive_capture_excludes` BEFORE
+    /// returning `Err` on Tier-2 failure. The default `try_mutate_instance`
+    /// drops the mutated clone on `Err`, leaving the live entry with the
+    /// stale sid in memory while disk has been cleared. Subsequent restarts
+    /// then loop indefinitely on the same bad sid (the TUI's `reload()`
+    /// merge prefers in-memory, so even the 5s disk refresh does not
+    /// recover). This helper preserves the cascade's partial mutations so
+    /// the live state stays consistent with disk.
+    pub(super) fn try_mutate_instance_writeback_on_err<T>(
+        &mut self,
+        id: &str,
+        f: impl FnOnce(&mut Instance) -> anyhow::Result<T>,
+    ) -> anyhow::Result<Option<T>> {
+        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
+            let mut updated = inst.clone();
+            let result = f(&mut updated);
+            *inst = updated.clone();
+            self.instance_map.insert(id.to_string(), updated);
+            return result.map(Some);
+        }
+        Ok(None)
+    }
+
     pub fn set_instance_error(&mut self, id: &str, error: Option<String>) {
         self.mutate_instance(id, |inst| inst.last_error = error);
     }
@@ -1584,8 +1612,9 @@ impl HomeView {
         size: Option<(u16, u16)>,
         skip_on_launch: bool,
     ) -> anyhow::Result<crate::session::StartOutcome> {
-        let outcome =
-            self.try_mutate_instance(id, |inst| inst.restart_with_size_opts(size, skip_on_launch))?;
+        let outcome = self.try_mutate_instance_writeback_on_err(id, |inst| {
+            inst.restart_with_size_opts(size, skip_on_launch)
+        })?;
         outcome.ok_or_else(|| anyhow::anyhow!("session not found: {}", id))
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -15,8 +15,8 @@ use tui_input::Input;
 
 use crate::session::{
     config::{load_config, save_config, GroupByMode, SortOrder},
-    flatten_tree, flatten_tree_all_profiles, resolve_config_or_warn, DefaultTerminalMode, Group,
-    GroupTree, Instance, Item, Storage,
+    flatten_tree, flatten_tree_all_profiles, resolve_config_or_warn, DefaultTerminalMode,
+    EnsureReadyOutcome, Group, GroupTree, Instance, Item, Storage,
 };
 use crate::tmux::AvailableTools;
 
@@ -712,6 +712,21 @@ impl HomeView {
                 else {
                     continue;
                 };
+                // Defense-in-depth against the resume-fallback cascade: a sid
+                // the cascade just cleared can still live on disk for several
+                // minutes (opencode db, vibe meta.json, codex/gemini/pi/hermes
+                // state). The poller closures filter via `compose_exclusion`,
+                // but if a closure factory ever forgets to thread the per-
+                // instance excludes, this guard prevents the cleared sid from
+                // being re-imported into memory and disk.
+                if inst.retroactive_capture_excludes.contains(&session_id) {
+                    tracing::debug!(
+                        "Ignoring poller-reported sid {} for {}: in retroactive_capture_excludes",
+                        session_id,
+                        inst.id,
+                    );
+                    continue;
+                }
                 if inst.agent_session_id.as_deref() != Some(session_id.as_str()) {
                     updates.push((inst.id.clone(), session_id));
                 }
@@ -1383,19 +1398,28 @@ impl HomeView {
     /// `ensure_pane_ready` (which may auto-start or respawn), then deliver
     /// the keystrokes. Errors are surfaced via `info_dialog` so the caller
     /// (`execute_action`) only has to clear its transient status.
-    pub fn execute_send_message(&mut self, session_id: &str, message: &str) {
-        if let Err(err) = self.try_mutate_instance(session_id, |inst| {
-            inst.ensure_pane_ready().map(drop).map_err(Into::into)
-        }) {
-            self.info_dialog = Some(InfoDialog::new(
-                "Send Failed",
-                &format!("Cannot prepare session: {}", err),
-            ));
-            return;
-        }
-        let Some(inst) = self.get_instance(session_id) else {
-            return;
+    ///
+    /// Returns `Some(stale_sid)` when the resume-fallback cascade fired
+    /// during the implicit respawn so the caller can toast the user about
+    /// the lost history; `None` otherwise.
+    pub fn execute_send_message(&mut self, session_id: &str, message: &str) -> Option<String> {
+        let outcome = self.try_mutate_instance(session_id, |inst| {
+            inst.ensure_pane_ready().map_err(Into::into)
+        });
+        let stale_sid = match outcome {
+            Ok(Some(EnsureReadyOutcome::Respawned {
+                stale_sid: Some(sid),
+            })) => Some(sid),
+            Ok(_) => None,
+            Err(err) => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Send Failed",
+                    &format!("Cannot prepare session: {}", err),
+                ));
+                return None;
+            }
         };
+        let inst = self.get_instance(session_id)?;
         let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
             Ok(s) => s,
             Err(e) => {
@@ -1403,7 +1427,7 @@ impl HomeView {
                     "Send Failed",
                     &format!("Failed to resolve session: {}", e),
                 ));
-                return;
+                return None;
             }
         };
         let delay = crate::agents::send_keys_enter_delay(&inst.tool);
@@ -1412,9 +1436,10 @@ impl HomeView {
                 "Send Failed",
                 &format!("Failed to send message: {}", e),
             ));
-            return;
+            return None;
         }
         self.stamp_last_accessed(session_id);
+        stale_sid
     }
 
     pub fn save(&self) -> anyhow::Result<()> {


### PR DESCRIPTION
## Description

Fixes the failure mode where `aoe session restart` leaves the user with a dead pane when the agent crashes at startup because of a stale `--resume <sid>` (transcript missing, sid invalid, autocompact thrash).

When restart-time start passes a resume flag and the pane dies within a settle probe, the cascade:

1. Stops the Tier-1 session-id poller so it cannot re-write the stale sid into tmux env after we clear it.
2. Tears down the dead tmux session via `kill_clean` (respawn-dead-pane + kill + 100ms sleep, the macOS dead-pane workaround).
3. Clears the stale sid in memory, on disk, and adds it to a per-instance retroactive-capture exclusion set so opencode/codex/gemini/pi/vibe/hermes cannot re-import it from on-disk artefacts on Tier 2.
4. Retries `start_with_size_opts` with `skip_on_launch=true` so `on_launch` hooks do not run twice.
5. If the retry also fails, propagates `Err`; the existing `Status::Error` + `last_error` path takes over unchanged.

The probe is settle-based: poll up to 3s for `pane_dead`, declare `Alive` only after a 2000ms post-shell grace window. The grace covers the gap between the boot shell `exec`ing into the agent binary and the agent crashing on the bad sid; opencode (Bun-compiled native binary) reaches `pane_dead` between ~900ms and ~1100ms after spawn on a warm cache, so the grace is sized at ~2x that p100 to stay comfortably inside `RESUME_PROBE_MAX = 3000ms`. Faster agents (Node-based: claude, codex, gemini, pi, qwen) crash well before the grace window closes; the grace cost is paid only once per Tier-1 cold restart that actually exercises `--resume`. `pane_dead` is the unambiguous trigger.

`build_exclusion_set` keeps its single-arg signature; the cascade path uses `Instance::retroactive_capture_exclusion_set`, which composes the live tmux scan with the per-instance excludes so poll-closure callers do not pay for an empty placeholder set.

The cascade is wired into:

| Surface | Behaviour on `Restarted { stale_sid }` |
| --- | --- |
| `aoe session restart <id>` | `✓ Restarted session: foo (resume failed for sid 1234; started fresh, prior history not loaded)` |
| `aoe session restart --all` | summary line `✓ Restarted N/M sessions (K without prior history):`, with a stale-history suffix appended to each affected entry |
| TUI Enter / attach | transient toast `Resume failed for sid 1234; started fresh (history not loaded)` |
| `POST /api/sessions/:id/ensure` | response includes `resume_outcome: "resumed" \| "restarted" \| "fresh"` and `stale_session_id` |

`aoe session start <id>` is intentionally NOT routed through the cascade: keeping it as a near-no-op on existing sessions preserves its idempotent contract. Only the explicit restart paths recover.

**`Status::Error` reset (behavior note).** `start_with_resume_fallback` clears `Status::Error`, `last_error`, and `last_error_check` on entry so a successful relaunch from any restart surface (TUI Enter/restart, `aoe session restart [id|--all]`, REST `ensure_session`, cockpit-mode short-circuit) does not leave a stale error chip up. The 30 s `last_error_check` debounce is reset on every user-initiated restart, including TUI/CLI surfaces. REST `ensure_session` re-asserts `status=Starting`, `last_error=None` pre-call as defense in depth.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording. N/A; backend-only. The TUI toast piggybacks on the existing `UpdateStatus::transient` channel and renders identically to the existing `restart failed: ...` toast.

Quality gates run locally on this branch:

```
cargo fmt --check
cargo clippy --release --lib -- -D warnings
cargo clippy --release --lib --features serve -- -D warnings
cargo test --release --lib                    # 1638 pass, 0 fail (10 in session::instance::tests::resume_fallback)
cargo test --release --lib --features serve   # adds cockpit short-circuit guard
cargo build --release
cargo build --features serve
```

All green. Integration tests under `mod resume_fallback` are gated on `tmux -V` per the existing convention; one test pins the lower bound of `RESUME_PROBE_POST_SHELL_GRACE` against a 1.2s post-shell-exit pane death so a future revert toward 500ms fails the suite.

## Breaking changes (intra-crate API)

- `Instance::restart()` (no-arg wrapper) is removed. Call `restart_with_size(None)` instead.
- `Instance::restart_with_size` and `Instance::restart_with_size_opts` now return `Result<StartOutcome>` instead of `Result<()>`. Callers that previously discarded `()` now need to `.map(drop)?` or destructure the outcome (e.g. to surface `StartOutcome::Restarted { stale_sid }` to the user).
- `Instance::kill_clean` is now `pub(crate)` so the REST `ensure_session` path can use it for parity with TUI/CLI restart paths (avoids the macOS dead-pane race on bare tmux kill).

No external consumers; all in-tree callers were updated in this PR.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (anthropic/claude-opus-4-7) via the OhMyOpenCode `Sisyphus` agent.

**Any Additional AI Details you'd like to share:**

Design and implementation by the AI agent under my direction.

- [x] I am an AI Agent filling out this form (check box if true)

