### PR TITLE
fix(tui): strip ST-terminated OSC sequences so hyperlink text appears in preview

### DIFF
--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -28,7 +28,7 @@ pub fn strip_ansi(content: &str) -> String {
 
 /// Only targets ST-terminated (`\x1b\\`) OSC sequences; BEL-terminated ones
 /// must pass through unchanged since downstream parsers handle those correctly.
-pub fn strip_osc_st(content: &str) -> String {
+pub(crate) fn strip_osc_st(content: &str) -> String {
     const OSC: &str = "\x1b]";
     const ST: &str = "\x1b\\";
 

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -4,7 +4,7 @@ use std::process::Command;
 use std::sync::OnceLock;
 
 pub fn strip_ansi(content: &str) -> String {
-    let mut result = content.to_string();
+    let mut result = strip_osc_st(content);
 
     while let Some(start) = result.find("\x1b[") {
         let rest = &result[start + 2..];
@@ -23,6 +23,41 @@ pub fn strip_ansi(content: &str) -> String {
         }
     }
 
+    result
+}
+
+/// Only targets ST-terminated (`\x1b\\`) OSC sequences; BEL-terminated ones
+/// must pass through unchanged since downstream parsers handle those correctly.
+pub fn strip_osc_st(content: &str) -> String {
+    const OSC: &str = "\x1b]";
+    const ST: &str = "\x1b\\";
+
+    let mut result = String::with_capacity(content.len());
+    let mut remaining = content;
+
+    while let Some(osc_start) = remaining.find(OSC) {
+        result.push_str(&remaining[..osc_start]);
+        let payload = &remaining[osc_start + OSC.len()..];
+
+        let bel_pos = payload.find('\x07');
+        let st_pos = payload.find(ST);
+
+        match (bel_pos, st_pos) {
+            (Some(b), Some(s)) if b < s => {
+                let end = osc_start + OSC.len() + b + 1;
+                result.push_str(&remaining[osc_start..end]);
+                remaining = &remaining[end..];
+            }
+            (_, Some(s)) => {
+                remaining = &payload[s + ST.len()..];
+            }
+            _ => {
+                result.push_str(&remaining[osc_start..osc_start + OSC.len()]);
+                remaining = &remaining[osc_start + OSC.len()..];
+            }
+        }
+    }
+    result.push_str(remaining);
     result
 }
 
@@ -264,8 +299,68 @@ mod tests {
     }
 
     #[test]
-    fn test_strip_ansi_osc_sequences() {
+    fn test_strip_ansi_osc_bel() {
         assert_eq!(strip_ansi("\x1b]0;Window Title\x07text"), "text");
+    }
+
+    #[test]
+    fn test_strip_ansi_osc_st() {
+        assert_eq!(strip_ansi("\x1b]0;Window Title\x1b\\text"), "text");
+    }
+
+    #[test]
+    fn test_strip_osc_st_hyperlink() {
+        assert_eq!(
+            strip_osc_st("\x1b]8;;https://example.com\x1b\\Click Here\x1b]8;;\x1b\\"),
+            "Click Here"
+        );
+    }
+
+    #[test]
+    fn test_strip_osc_st_preserves_surrounding_text() {
+        assert_eq!(
+            strip_osc_st("before \x1b]8;;https://github.com\x1b\\link text\x1b]8;;\x1b\\ after"),
+            "before link text after"
+        );
+    }
+
+    #[test]
+    fn test_strip_osc_st_multiple_links() {
+        let input = "\x1b]8;;https://a.com\x1b\\A\x1b]8;;\x1b\\ and \x1b]8;;https://b.com\x1b\\B\x1b]8;;\x1b\\";
+        assert_eq!(strip_osc_st(input), "A and B");
+    }
+
+    #[test]
+    fn test_strip_osc_st_no_osc() {
+        assert_eq!(strip_osc_st("plain text"), "plain text");
+    }
+
+    #[test]
+    fn test_strip_osc_st_preserves_sgr() {
+        assert_eq!(
+            strip_osc_st("\x1b[32m\x1b]8;;url\x1b\\green link\x1b]8;;\x1b\\\x1b[0m"),
+            "\x1b[32mgreen link\x1b[0m"
+        );
+    }
+
+    #[test]
+    fn test_strip_osc_st_unterminated() {
+        assert_eq!(
+            strip_osc_st("\x1b]8;;url without terminator"),
+            "\x1b]8;;url without terminator"
+        );
+    }
+
+    #[test]
+    fn test_strip_osc_st_passes_bel_terminated_through() {
+        let bel_osc = "\x1b]0;Window Title\x07";
+        assert_eq!(strip_osc_st(bel_osc), bel_osc);
+    }
+
+    #[test]
+    fn test_strip_osc_st_mixed_bel_then_st() {
+        let input = "\x1b]0;Title\x07before\x1b]8;;https://x.com\x1b\\link\x1b]8;;\x1b\\after";
+        assert_eq!(strip_osc_st(input), "\x1b]0;Title\x07beforelinkafter");
     }
 
     #[test]

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -393,9 +393,8 @@ fn format_scroll_indicator(
 }
 
 fn parse_output_text(content: &str) -> Text<'static> {
-    content
-        .into_text()
-        .unwrap_or_else(|_| Text::from(content.to_string()))
+    let cleaned = crate::tmux::utils::strip_osc_st(content);
+    cleaned.into_text().unwrap_or_else(|_| Text::from(cleaned))
 }
 
 fn shorten_path(path: &str) -> String {


### PR DESCRIPTION
## Description

Fixes #1181.

`tmux capture-pane -e` emits OSC 8 hyperlinks with the ST terminator (`\x1b\\`). `ansi_to_tui` 8.0 handles BEL-terminated OSC fine but eats the visible text around ST-terminated ones, so any hyperlinked text (URLs, file paths) vanishes from the TUI preview panel.

Adds `strip_osc_st()` which removes ST-terminated OSC sequences while preserving visible text and passing BEL-terminated sequences through unchanged. Called from `parse_output_text()` before `into_text()`, and also wired into `strip_ansi()` for status detection.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.6)

- [x] I am an AI Agent filling out this form (check box if true)

## Test plan

- `cargo test --lib tmux::utils` (10 new tests covering hyperlinks, multiple links, surrounding text, SGR passthrough, BEL passthrough, mixed BEL+ST, unterminated, no-op)
- `cargo test --lib` (1632 tests pass)
- Manual: started a Claude Code session, confirmed link text now visible in the TUI preview panel