### PR TITLE
fix(tui): keep command palette selection visible past viewport

### DIFF
--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -400,13 +400,9 @@ impl CommandPaletteDialog {
         // List
         let list_area = chunks[2];
         let visible = list_area.height as usize;
-        let scroll_offset = if self.selected >= visible {
-            self.selected - visible + 1
-        } else {
-            0
-        };
 
         let mut lines: Vec<Line> = Vec::new();
+        let mut selected_line: usize = 0;
         if self.matches.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  No matches",
@@ -414,13 +410,7 @@ impl CommandPaletteDialog {
             )));
         } else {
             let mut last_group: Option<PaletteGroup> = None;
-            for (display_idx, &entry_idx) in self
-                .matches
-                .iter()
-                .enumerate()
-                .skip(scroll_offset)
-                .take(visible)
-            {
+            for (display_idx, &entry_idx) in self.matches.iter().enumerate() {
                 let cmd = &self.entries[entry_idx];
 
                 // Show group header on transition (only when no query, since
@@ -435,6 +425,9 @@ impl CommandPaletteDialog {
                 }
 
                 let is_selected = display_idx == self.selected;
+                if is_selected {
+                    selected_line = lines.len();
+                }
                 let prefix = if is_selected { "▶ " } else { "  " };
                 let title_style = if is_selected {
                     Style::default().fg(theme.title).bold()
@@ -468,7 +461,9 @@ impl CommandPaletteDialog {
                 lines.push(Line::from(spans));
             }
         }
-        frame.render_widget(Paragraph::new(lines), list_area);
+        let start = selected_line.saturating_sub(visible.saturating_sub(1));
+        let end = (start + visible).min(lines.len());
+        frame.render_widget(Paragraph::new(lines[start..end].to_vec()), list_area);
 
         // Hint footer
         let footer_left = Line::from(vec![


### PR DESCRIPTION
<!-- Title:
fix(tui): keep command palette selection visible past viewport
-->

## Description

> **Disclosure**: This PR was drafted by Claude. The bug was reproduced
> and the fix was verified by me (@bell-hyun) before posting.

Closes #1186.

Command palette (Ctrl+K) selection highlight scrolled off the bottom of the visible list when group headers were present. The previous `scroll_offset` counted match indices, but the rendered `lines` vec also contains group header rows ("Actions", "Views", "Settings"), so `lines.len()` exceeded `list_area.height` and `Paragraph` silently clipped the bottom.

**Fix**: window the rendered lines in *line-index units*. Iterate all matches, record `selected_line = lines.len()` immediately before pushing the selected entry, then render `lines[start..end]` with `start = selected_line.saturating_sub(visible - 1)`. +8 / −13 in one function, no API changes.

**Known limitation (pre-existing)**: scroll position is stateless, so the highlight pins to the viewport's bottom edge once scrolled. Same behavior as the original code; band-style scrolling would need a persistent scroll field and is a separate UX improvement.

**Before:**
<img width="720" height="430" alt="before" src="https://github.com/user-attachments/assets/ac12dbef-9d4b-471a-b5d6-e7610d14df3f" />

**After:**
<img width="720" height="608" alt="after" src="https://github.com/user-attachments/assets/f329a4ae-3ffc-40a3-8c6c-7370c2b29b04" />

---

_Verified locally_: `cargo test` (1605 passed), `cargo test --test e2e` (55 passed, 2 ignored), `cargo clippy --all-targets -- -D warnings` (clean), `cargo fmt -- --check` (clean).

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no doc changes for an internal rendering fix)
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude (Anthropic) via Claude Code

**Any Additional AI Details you'd like to share:** Symptom reproduced by hand on macOS before drafting; fix tested locally with `cargo test` + manual TUI verification. I will respond to review comments myself.

- [ ] I am an AI Agent filling out this form (check box if true)