### PR TITLE
fix(cockpit): fire web push and play browser chime on approval requests

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -465,6 +465,26 @@ approval_timeout_secs = 300
 destructive_require_double_confirm = true
 ```
 
+### Notifications and sound
+
+When an approval lands, the cockpit fires two channels so a user away
+from the dashboard still sees the agent is blocked:
+
+- **Web push.** If the PWA is installed and notifications are
+  enabled, the daemon sends an OS-level push tagged
+  `cockpit-approval-<session>`. Tapping the notification deep-links
+  back to the cockpit. Unlike status-change pushes, approval pushes
+  are not suppressed when the dashboard or TUI is active; the service
+  worker routes focused clients to an in-app toast instead of an OS
+  banner. See [Push notifications](push-notifications.md).
+- **Browser sound.** The cockpit plays a chime in the dashboard tab
+  whenever pending approvals go from zero to non-zero. Configure the
+  file via `[sound] on_approval` in the daemon config or the Sound
+  category of the Settings TUI. The chime is independent of the
+  host-side audio used by the tmux status flow; the cockpit case
+  often runs `aoe serve` on a remote box and the host speaker would
+  be on the wrong side of the wire.
+
 ## Security
 
 - File system access uses ACP's `fs/read_text_file` and

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -16,7 +16,7 @@ Each session also has per-session overrides that beat the server-wide defaults: 
 
 The fourth event type comes from cockpit sessions and runs on its own rules:
 
-- **Cockpit approval**, a cockpit-driven agent emits an `ApprovalRequested` event because a tool needs your permission. Fires immediately (no dwell), tag `cockpit-approval-<session>`, and **bypasses** the TUI/web-active suppression below. Even when the dashboard or TUI is foregrounded the approval still routes through web push: the service worker forwards focused clients to an in-app toast instead of an OS banner so you still get an audible/visual cue. The cockpit also plays a browser-side chime keyed off `[sound] on_approval`; see [Sound effects](sounds.md).
+- **Cockpit approval**, a cockpit-driven agent emits an `ApprovalRequested` event because a tool needs your permission. Fires immediately (no dwell), tag `cockpit-approval-<session>`, and **bypasses** the TUI/web-active suppression below. Even when the dashboard or TUI is foregrounded the approval still routes through web push: the service worker forwards focused clients to an in-app toast instead of an OS banner so you still get an audible/visual cue. The cockpit also plays a browser-side chime keyed off `[sound] on_approval`; see [Sound effects](sounds.md). The corresponding `Waiting` status push is suppressed while the approval is unresolved, so you do not get a second OS banner for the same underlying event.
 
 Status notifications are suppressed when you're already looking at aoe (cockpit approvals ignore this list):
 

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -4,7 +4,7 @@ The web dashboard can send browser push notifications when an agent is waiting f
 
 ## What triggers a notification
 
-Three event types, each independently toggleable in Settings:
+Four event types. The first three are status-driven and independently toggleable in Settings:
 
 - **Waiting** — session transitions to `Waiting` and stays that way for at least five seconds (the most common pattern: agent paused to ask you something). Longer dwell because Claude sometimes pauses briefly before resolving.
 - **Idle** — session finishes a long-running job and settles into `Idle`.
@@ -14,7 +14,11 @@ A shared 60-second post-send cooldown per session prevents rapid re-buzzing when
 
 Each session also has per-session overrides that beat the server-wide defaults: you can enable `Idle` notifications only on the one long-running session you care about, for example, without flooding yourself every time any session finishes.
 
-Notifications are suppressed when you're already looking at aoe:
+The fourth event type comes from cockpit sessions and runs on its own rules:
+
+- **Cockpit approval**, a cockpit-driven agent emits an `ApprovalRequested` event because a tool needs your permission. Fires immediately (no dwell), tag `cockpit-approval-<session>`, and **bypasses** the TUI/web-active suppression below. Even when the dashboard or TUI is foregrounded the approval still routes through web push: the service worker forwards focused clients to an in-app toast instead of an OS banner so you still get an audible/visual cue. The cockpit also plays a browser-side chime keyed off `[sound] on_approval`; see [Sound effects](sounds.md).
+
+Status notifications are suppressed when you're already looking at aoe (cockpit approvals ignore this list):
 
 - **Dashboard focused (per-device):** if the PWA browser tab is visible and focused, that device skips the OS notification and shows an in-app toast instead.
 - **TUI active (all devices):** if the `aoe` TUI is running on the same machine as the server, all push notifications to all devices are suppressed. The TUI writes a heartbeat file (`$app_dir/tui.active`) every 10 seconds; the push consumer skips delivery when the file was modified within the last 30 seconds.

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -1,10 +1,11 @@
 # Sound Effects
 
-Agent of Empires can play sound effects when agent sessions change state, providing audio feedback for transitions like starting, running, waiting, idle, and error states.
+Agent of Empires can play sound effects when agent sessions change state, providing audio feedback for transitions like starting, running, waiting, idle, and error states. The cockpit also plays a browser-side chime when a pending approval lands.
 
 ## Features
 
 - 🔊 State transition sounds (start, running, waiting, idle, error)
+- 🛡️ Cockpit approval chime, played in the browser
 - 🎵 Multiple installation options (bundled, AoE II extraction, custom)
 - 🎨 Fully customizable - use any .wav/.ogg files
 - ⚙️ Configurable via Settings TUI
@@ -109,7 +110,8 @@ You can also edit configuration files directly:
 [sound]
 enabled = true
 mode = "random"
-on_error = "error"  # Use specific sound for errors
+on_error = "error"          # Use specific sound for errors
+on_approval = "approval"    # Cockpit only; browser-side chime
 ```
 
 **Profile**: `~/.config/agent-of-empires/profiles/<profile>/config.toml`
@@ -140,9 +142,11 @@ cp ~/Downloads/wololo.wav ~/.config/agent-of-empires/sounds/
 
 ## Audio Playback
 
-Sounds are played using platform-native audio players:
+Status transition sounds (start, running, waiting, idle, error) play on the **server host** using platform-native audio players:
 - **macOS**: `afplay`
 - **Linux**: `aplay` (ALSA) or `paplay` (PulseAudio)
+
+The cockpit `on_approval` sound is the exception: it plays in the **browser** where the dashboard is open, not on the host. Approvals are user-facing and the dashboard is often on a different machine from `aoe serve`. Browsers enforce an autoplay policy, so the first approval after a fresh page load may stay silent until the user interacts with the cockpit tab; the OS push notification still surfaces the approval in that case.
 
 If sounds don't play, ensure you have audio tools installed:
 ```bash

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -73,11 +73,14 @@ pub enum SupervisorError {
 /// Frame published to the broadcast channel; mirrors
 /// `crate::server::CockpitBroadcastFrame` so the supervisor can be
 /// tested without pulling in the server module.
+///
+/// Approval pushes are no longer driven from here: the cockpit event
+/// listener in the server module subscribes to the same broadcast and
+/// matches `Event::ApprovalRequested` with `Arc<AppState>` already in
+/// scope, which removed the need for a separate approval callback path.
+/// See #1038.
 pub trait BroadcastSink: Send + Sync + 'static {
     fn publish(&self, session_id: &str, seq: u64, event: &Event);
-    fn approval_requested(&self, _session_id: &str, _approval_title: &str, _destructive: bool) {
-        // Default: no-op. The server impl fires a push notification.
-    }
     /// Approval nonces from `ApprovalRequested` events on disk with no
     /// matching `ApprovalResolved`. Used by `Supervisor::attach` to
     /// cancel approvals whose responder died with the previous daemon.
@@ -741,13 +744,6 @@ impl<S: BroadcastSink> Supervisor<S> {
                     }
                     let seq = next_seq(&next_seqs, &session_id);
                     sink.publish(&session_id, seq, &event);
-                    if let Event::ApprovalRequested { approval } = &event {
-                        sink.approval_requested(
-                            &session_id,
-                            &approval.tool_call.name,
-                            approval.destructive,
-                        );
-                    }
                 }
 
                 // Channel closed: the agent's connection task ended.
@@ -1593,11 +1589,6 @@ fn next_seq(next_seqs: &SeqMap, session_id: &str) -> u64 {
     *entry
 }
 
-/// Callback fired when the supervisor observes an ApprovalRequested
-/// event for a session. The server impl uses this to trigger a Web
-/// Push notification; the test impl just records the call.
-pub type ApprovalHook = Arc<dyn Fn(&str, &str, bool) + Send + Sync>;
-
 /// A `BroadcastSink` impl backed by a tokio broadcast channel. The
 /// AppState in the server module wires this so cockpit events flow
 /// straight into the existing WebSocket fanout, and snapshots them
@@ -1611,7 +1602,6 @@ pub type ApprovalHook = Arc<dyn Fn(&str, &str, bool) + Send + Sync>;
 /// this lock briefly.
 pub struct ChannelSink {
     pub tx: broadcast::Sender<crate::server::CockpitBroadcastFrame>,
-    pub on_approval: ApprovalHook,
     /// Disk-backed event log. The single source of truth for replay:
     /// the WS-on-connect drain, the `/cockpit/replay` REST endpoint,
     /// and the supervisor's startup `hydrate_seqs` all read from here.
@@ -1655,10 +1645,6 @@ impl BroadcastSink for ChannelSink {
         let _ = self.tx.send(frame);
     }
 
-    fn approval_requested(&self, session_id: &str, approval_title: &str, destructive: bool) {
-        (self.on_approval)(session_id, approval_title, destructive);
-    }
-
     fn unresolved_approval_nonces(&self, session_id: &str) -> Vec<Nonce> {
         self.event_store.unresolved_approval_nonces(session_id)
     }
@@ -1671,21 +1657,18 @@ mod tests {
     /// In-memory sink that captures published frames.
     struct VecSink {
         frames: std::sync::Mutex<Vec<(String, u64, Event)>>,
-        approvals: std::sync::Mutex<Vec<(String, String, bool)>>,
         stale_nonces: std::sync::Mutex<Vec<Nonce>>,
     }
     impl VecSink {
         fn new() -> Arc<Self> {
             Arc::new(Self {
                 frames: std::sync::Mutex::new(Vec::new()),
-                approvals: std::sync::Mutex::new(Vec::new()),
                 stale_nonces: std::sync::Mutex::new(Vec::new()),
             })
         }
         fn with_stale_nonces(nonces: Vec<Nonce>) -> Arc<Self> {
             Arc::new(Self {
                 frames: std::sync::Mutex::new(Vec::new()),
-                approvals: std::sync::Mutex::new(Vec::new()),
                 stale_nonces: std::sync::Mutex::new(nonces),
             })
         }
@@ -1696,13 +1679,6 @@ mod tests {
                 .lock()
                 .unwrap()
                 .push((session_id.to_string(), seq, event.clone()));
-        }
-        fn approval_requested(&self, session: &str, title: &str, destructive: bool) {
-            self.approvals.lock().unwrap().push((
-                session.to_string(),
-                title.to_string(),
-                destructive,
-            ));
         }
         fn unresolved_approval_nonces(&self, _session_id: &str) -> Vec<Nonce> {
             self.stale_nonces.lock().unwrap().clone()
@@ -2568,10 +2544,8 @@ mod tests {
         let db_path = tmp.path().join("cockpit.db");
         let event_store = Arc::new(EventStore::open(&db_path, 1000).unwrap());
         let (tx, mut rx) = broadcast::channel(16);
-        let on_approval: ApprovalHook = Arc::new(|_, _, _| {});
         let sink = Arc::new(ChannelSink {
             tx,
-            on_approval,
             event_store: event_store.clone(),
         });
 
@@ -2630,10 +2604,8 @@ mod tests {
         {
             let event_store = Arc::new(EventStore::open(&db_path, 1000).unwrap());
             let (tx, _rx) = broadcast::channel(16);
-            let on_approval: ApprovalHook = Arc::new(|_, _, _| {});
             let sink = Arc::new(ChannelSink {
                 tx,
-                on_approval,
                 event_store: event_store.clone(),
             });
             let sup = Supervisor::new(sink);
@@ -2650,10 +2622,8 @@ mod tests {
         assert_eq!(event_store.highest_seq("s-99"), 3);
 
         let (tx, mut rx) = broadcast::channel(16);
-        let on_approval: ApprovalHook = Arc::new(|_, _, _| {});
         let sink = Arc::new(ChannelSink {
             tx,
-            on_approval,
             event_store: event_store.clone(),
         });
         let sup = Supervisor::new(sink);

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -42,7 +42,7 @@ pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,
     filesystem_home, get_about, get_profile_settings, get_settings, get_update_status, list_agents,
     list_devices, list_groups, list_profiles, list_sounds, list_themes, rename_profile,
-    update_profile_settings, update_settings,
+    serve_sound_file, update_profile_settings, update_settings,
 };
 
 const SHELL_METACHARACTERS: &[char] = &[

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -914,43 +914,49 @@ pub async fn list_sounds() -> Json<Vec<String>> {
 pub async fn serve_sound_file(
     axum::extract::Path(name): axum::extract::Path<String>,
 ) -> impl IntoResponse {
+    // The validation step (directory enumeration) stays on the blocking
+    // pool because `list_available_sounds` does sync `read_dir`. The
+    // file read itself uses `tokio::fs::read` so the larger I/O cost
+    // does not block a runtime worker.
     let lookup_name = name.clone();
-    let result =
-        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, &'static str), StatusCode> {
-            if !crate::sound::list_available_sounds().contains(&lookup_name) {
-                return Err(StatusCode::NOT_FOUND);
-            }
-            let Some(dir) = crate::sound::get_sounds_dir() else {
-                return Err(StatusCode::NOT_FOUND);
-            };
-            let path = dir.join(&lookup_name);
-            let bytes = std::fs::read(&path).map_err(|_| StatusCode::NOT_FOUND)?;
-            let content_type = match std::path::Path::new(&lookup_name)
-                .extension()
-                .and_then(|e| e.to_str())
-                .map(|e| e.to_ascii_lowercase())
-                .as_deref()
-            {
-                Some("ogg") => "audio/ogg",
-                _ => "audio/wav",
-            };
-            Ok((bytes, content_type))
-        })
-        .await;
+    let validated = tokio::task::spawn_blocking(move || {
+        if !crate::sound::list_available_sounds().contains(&lookup_name) {
+            return None;
+        }
+        crate::sound::get_sounds_dir().map(|dir| dir.join(&lookup_name))
+    })
+    .await;
 
-    match result {
-        Ok(Ok((bytes, content_type))) => (
-            StatusCode::OK,
-            [
-                (axum::http::header::CONTENT_TYPE, content_type),
-                (axum::http::header::CACHE_CONTROL, "private, max-age=3600"),
-            ],
-            bytes,
-        )
-            .into_response(),
-        Ok(Err(status)) => status.into_response(),
-        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
+    let path = match validated {
+        Ok(Some(p)) => p,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(_) => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    };
+
+    let bytes = match tokio::fs::read(&path).await {
+        Ok(b) => b,
+        Err(_) => return StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let content_type = match std::path::Path::new(&name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("ogg") => "audio/ogg",
+        _ => "audio/wav",
+    };
+
+    (
+        StatusCode::OK,
+        [
+            (axum::http::header::CONTENT_TYPE, content_type),
+            (axum::http::header::CACHE_CONTROL, "private, max-age=3600"),
+        ],
+        bytes,
+    )
+        .into_response()
 }
 
 #[cfg(test)]
@@ -972,7 +978,10 @@ mod tests {
             .await
             .into_response();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        // A NOT_FOUND that somehow still streamed a body would be a
+        // worse failure than the wrong status, so assert the body is
+        // empty rather than just "not /etc/passwd".
         let body = to_bytes(resp.into_body(), 1024).await.unwrap();
-        assert!(body.is_empty() || !body.starts_with(b"root:"));
+        assert!(body.is_empty(), "unexpected body bytes: {body:?}");
     }
 }

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -904,3 +904,75 @@ pub async fn update_profile_settings(
 pub async fn list_sounds() -> Json<Vec<String>> {
     Json(crate::sound::list_available_sounds())
 }
+
+/// Serve a sound file by name so the cockpit's browser-side approval
+/// player can fetch it from the same origin as the dashboard. The name
+/// is validated against `list_available_sounds()` to block path
+/// traversal: an attacker who can hit `/api/sounds/file/<x>` cannot
+/// read arbitrary disk paths, only files already present in the user's
+/// `sounds/` directory.
+pub async fn serve_sound_file(
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> impl IntoResponse {
+    let lookup_name = name.clone();
+    let result =
+        tokio::task::spawn_blocking(move || -> Result<(Vec<u8>, &'static str), StatusCode> {
+            if !crate::sound::list_available_sounds().contains(&lookup_name) {
+                return Err(StatusCode::NOT_FOUND);
+            }
+            let Some(dir) = crate::sound::get_sounds_dir() else {
+                return Err(StatusCode::NOT_FOUND);
+            };
+            let path = dir.join(&lookup_name);
+            let bytes = std::fs::read(&path).map_err(|_| StatusCode::NOT_FOUND)?;
+            let content_type = match std::path::Path::new(&lookup_name)
+                .extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e.to_ascii_lowercase())
+                .as_deref()
+            {
+                Some("ogg") => "audio/ogg",
+                _ => "audio/wav",
+            };
+            Ok((bytes, content_type))
+        })
+        .await;
+
+    match result {
+        Ok(Ok((bytes, content_type))) => (
+            StatusCode::OK,
+            [
+                (axum::http::header::CONTENT_TYPE, content_type),
+                (axum::http::header::CACHE_CONTROL, "private, max-age=3600"),
+            ],
+            bytes,
+        )
+            .into_response(),
+        Ok(Err(status)) => status.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+
+    #[tokio::test]
+    async fn serve_sound_file_rejects_unknown_name() {
+        let resp = serve_sound_file(axum::extract::Path("does-not-exist-xyz.wav".to_string()))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn serve_sound_file_rejects_path_traversal() {
+        let resp = serve_sound_file(axum::extract::Path("../../../etc/passwd".to_string()))
+            .await
+            .into_response();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert!(body.is_empty() || !body.starts_with(b"root:"));
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -986,6 +986,7 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/themes", get(api::list_themes))
         .route("/api/sounds", get(api::list_sounds))
+        .route("/api/sounds/file/{name}", get(api::serve_sound_file))
         // Push notifications
         .route("/api/push/status", get(push::get_status))
         .route(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -479,33 +479,14 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     };
     #[cfg(feature = "serve")]
     let cockpit_supervisor = {
-        let push_for_sink = push_state.clone();
-        let push_enabled_for_sink = push_enabled;
-        let on_approval =
-            std::sync::Arc::new(move |session_id: &str, title: &str, destructive: bool| {
-                let session_id = session_id.to_string();
-                let title = title.to_string();
-                let push = push_for_sink.clone();
-                tokio::spawn(async move {
-                    if let Some(_push) = push {
-                        if push_enabled_for_sink {
-                            // We re-enter the cockpit_ws helper when we have
-                            // an AppState in scope; the standalone trigger
-                            // here just logs intent. The full server-driven
-                            // path lives at cockpit_ws::trigger_approval_push,
-                            // invoked from the API handler that receives
-                            // the cockpit broadcast.
-                            tracing::debug!(
-                                target: "cockpit.supervisor",
-                                session = %session_id,
-                                title = %title,
-                                destructive,
-                                "approval event observed (push delivery handled via api layer)"
-                            );
-                        }
-                    }
-                });
-            }) as std::sync::Arc<dyn Fn(&str, &str, bool) + Send + Sync>;
+        // Approval pushes are dispatched from `cockpit_event_listener`,
+        // which subscribes to the broadcast that ChannelSink::publish
+        // feeds and has `Arc<AppState>` in scope without the closure
+        // dance. The supervisor's `on_approval` callback survives only
+        // because the test sinks set it directly; in production it is
+        // a no-op. See #1038.
+        let on_approval = std::sync::Arc::new(|_: &str, _: &str, _: bool| {})
+            as std::sync::Arc<dyn Fn(&str, &str, bool) + Send + Sync>;
         let sink = std::sync::Arc::new(crate::cockpit::supervisor::ChannelSink {
             tx: cockpit_events_tx.clone(),
             on_approval,
@@ -1550,6 +1531,29 @@ async fn cockpit_event_listener(state: Arc<AppState>) {
                     );
                 }
             }
+        }
+
+        // Approval push: when the worker emits an `ApprovalRequested`
+        // event, trigger a Web Push so the user sees a "needs approval"
+        // alert even when the dashboard is backgrounded. Unlike the
+        // status-change pushes in `push.rs`, approvals do NOT honour
+        // the TUI/web active-session suppression; the service worker
+        // still routes focused clients to an in-app toast via the
+        // existing `aoe-push` postMessage path. See #1038.
+        if let crate::cockpit::state::Event::ApprovalRequested { approval } = frame.event.as_ref() {
+            let state_for_push = state.clone();
+            let session_id = frame.session_id.clone();
+            let approval_title = approval.tool_call.name.clone();
+            let destructive = approval.destructive;
+            tokio::spawn(async move {
+                cockpit_ws::trigger_approval_push(
+                    &state_for_push,
+                    &session_id,
+                    &approval_title,
+                    destructive,
+                )
+                .await;
+            });
         }
 
         let status_intent = derive_cockpit_status(frame.event.as_ref());

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -481,15 +481,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     let cockpit_supervisor = {
         // Approval pushes are dispatched from `cockpit_event_listener`,
         // which subscribes to the broadcast that ChannelSink::publish
-        // feeds and has `Arc<AppState>` in scope without the closure
-        // dance. The supervisor's `on_approval` callback survives only
-        // because the test sinks set it directly; in production it is
-        // a no-op. See #1038.
-        let on_approval = std::sync::Arc::new(|_: &str, _: &str, _: bool| {})
-            as std::sync::Arc<dyn Fn(&str, &str, bool) + Send + Sync>;
+        // feeds and has `Arc<AppState>` in scope without a closure
+        // dance through the supervisor. See #1038.
         let sink = std::sync::Arc::new(crate::cockpit::supervisor::ChannelSink {
             tx: cockpit_events_tx.clone(),
-            on_approval,
             event_store: cockpit_event_store.clone(),
         });
         let supervisor =

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -600,6 +600,22 @@ async fn fire_due_pushes(
             continue;
         }
 
+        // Cockpit approval pushes are dispatched immediately from
+        // `cockpit_event_listener` with their own tag and bypass the
+        // TUI/web active-session suppression. If the session has any
+        // unresolved cockpit approvals, the user has already been
+        // notified through that channel; a second status-change push
+        // five seconds later for the same underlying event would just
+        // be noise. See #1038.
+        if event == NotificationEvent::Waiting
+            && !app_state
+                .cockpit_event_store
+                .unresolved_approval_nonces(&instance_id)
+                .is_empty()
+        {
+            continue;
+        }
+
         let subs = push.store.snapshot().await;
         if subs.is_empty() {
             continue;

--- a/src/sound/config.rs
+++ b/src/sound/config.rs
@@ -41,6 +41,14 @@ pub struct SoundConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_error: Option<String>,
 
+    /// Sound to play when a cockpit session emits an `ApprovalRequested`
+    /// event. Surfaced in the browser by the cockpit's approval hook
+    /// (host-side playback intentionally has no approval transition; the
+    /// host audio device is the wrong side of the wire when the user is
+    /// running the dashboard on a separate machine). See #1038.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_approval: Option<String>,
+
     /// Playback volume (0.1 = min, 1.0 = normal, 1.5 = max)
     #[serde(default = "default_volume", skip_serializing_if = "is_default_volume")]
     pub volume: f64,
@@ -56,6 +64,7 @@ impl Default for SoundConfig {
             on_waiting: None,
             on_idle: None,
             on_error: None,
+            on_approval: None,
             volume: default_volume(),
         }
     }
@@ -94,6 +103,9 @@ pub struct SoundConfigOverride {
     pub on_error: Option<String>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_approval: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume: Option<f64>,
 }
 
@@ -119,6 +131,9 @@ pub fn apply_sound_overrides(target: &mut SoundConfig, source: &SoundConfigOverr
     }
     if source.on_error.is_some() {
         target.on_error = source.on_error.clone();
+    }
+    if source.on_approval.is_some() {
+        target.on_approval = source.on_approval.clone();
     }
     if let Some(volume) = source.volume {
         target.volume = volume;
@@ -154,6 +169,7 @@ mod tests {
         assert!(config.on_waiting.is_none());
         assert!(config.on_idle.is_none());
         assert!(config.on_error.is_none());
+        assert!(config.on_approval.is_none());
         // Fresh installs load `Config::default()` when no config.toml exists;
         // a 0.0 default here would mute all playback on first run.
         assert!((config.volume - 1.0).abs() < 1e-9);
@@ -208,6 +224,31 @@ mod tests {
         assert_eq!(config.on_error, Some("alarm".to_string()));
         // Non-overridden fields stay default
         assert_eq!(config.mode, SoundMode::Random);
+    }
+
+    #[test]
+    fn test_apply_sound_overrides_on_approval() {
+        let mut config = SoundConfig {
+            on_approval: Some("waiting".to_string()),
+            ..Default::default()
+        };
+        let ovr = SoundConfigOverride {
+            on_approval: Some("alarm".to_string()),
+            ..Default::default()
+        };
+        apply_sound_overrides(&mut config, &ovr);
+        assert_eq!(config.on_approval, Some("alarm".to_string()));
+    }
+
+    #[test]
+    fn test_sound_config_deserialize_on_approval() {
+        let toml = r#"
+            enabled = true
+            on_approval = "alarm"
+        "#;
+        let config: SoundConfig = toml::from_str(toml).unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.on_approval, Some("alarm".to_string()));
     }
 
     #[test]

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -102,6 +102,7 @@ pub enum FieldKey {
     SoundOnWaiting,
     SoundOnIdle,
     SoundOnError,
+    SoundOnApproval,
     // Hooks
     HookOnCreate,
     HookOnLaunch,
@@ -264,7 +265,8 @@ impl SettingField {
                 | FieldKey::SoundOnRunning
                 | FieldKey::SoundOnWaiting
                 | FieldKey::SoundOnIdle
-                | FieldKey::SoundOnError,
+                | FieldKey::SoundOnError
+                | FieldKey::SoundOnApproval,
                 FieldValue::OptionalText(Some(name)),
             ) => {
                 if !name.is_empty() {
@@ -1641,6 +1643,12 @@ fn build_sound_fields(
         snd.and_then(|s| s.on_error.clone()),
         snd.map(|s| s.on_error.is_some()).unwrap_or(false),
     );
+    let (on_approval, o8) = resolve_optional(
+        scope,
+        global.sound.on_approval.clone(),
+        snd.and_then(|s| s.on_approval.clone()),
+        snd.map(|s| s.on_approval.is_some()).unwrap_or(false),
+    );
 
     let global_mode_selected = match &global.sound.mode {
         SoundMode::Random => 0,
@@ -1756,6 +1764,18 @@ fn build_sound_fields(
             inherited_display: inherited_if(
                 o7,
                 FieldValue::OptionalText(global.sound.on_error.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::SoundOnApproval,
+            label: "On Approval",
+            description: "Cockpit only. Played in the browser when a session needs permission. Specify file name with extension",
+            value: FieldValue::OptionalText(on_approval),
+            category: SettingsCategory::Sound,
+            has_override: o8,
+            inherited_display: inherited_if(
+                o8,
+                FieldValue::OptionalText(global.sound.on_approval.clone()),
             ),
         },
     ]
@@ -1982,6 +2002,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::SoundOnError, FieldValue::OptionalText(v)) => {
             config.sound.on_error = v.clone();
+        }
+        (FieldKey::SoundOnApproval, FieldValue::OptionalText(v)) => {
+            config.sound.on_approval = v.clone();
         }
         // Hooks
         (FieldKey::HookOnCreate, FieldValue::List(v)) => config.hooks.on_create = v.clone(),
@@ -2363,6 +2386,12 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 .sound
                 .get_or_insert_with(crate::sound::SoundConfigOverride::default);
             s.on_error = v.clone();
+        }
+        (FieldKey::SoundOnApproval, FieldValue::OptionalText(v)) => {
+            let s = config
+                .sound
+                .get_or_insert_with(crate::sound::SoundConfigOverride::default);
+            s.on_approval = v.clone();
         }
         // Hooks
         (FieldKey::HookOnCreate, FieldValue::List(v)) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -767,6 +767,11 @@ impl SettingsView {
                     s.on_error = None;
                 }
             }
+            FieldKey::SoundOnApproval => {
+                if let Some(ref mut s) = config.sound {
+                    s.on_approval = None;
+                }
+            }
             // Hooks
             FieldKey::HookOnCreate => {
                 if let Some(ref mut h) = config.hooks {

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -41,6 +41,7 @@ import {
   chooseVerb,
 } from "../../lib/cockpitRattle";
 import { useCockpitPrefs } from "../../lib/cockpitPrefs";
+import { useApprovalSound } from "../../hooks/useApprovalSound";
 import type {
   Approval,
   ApprovalDecision,
@@ -139,6 +140,12 @@ function CockpitChrome({
   const [primerPrefill, setPrimerPrefill] = useState<
     { id: string; text: string } | null
   >(null);
+
+  // Browser-side approval chime. Fires once on the 0 -> >=1 edge of
+  // pendingApprovals; complements the OS push (delivered via the SW
+  // when the dashboard is backgrounded) and the in-app toast (when
+  // foregrounded). See #1038.
+  useApprovalSound(state.pendingApprovals.length);
 
   // Re-pin the chat viewport to the bottom when the composer (or any
   // sibling below it: queued strip, primer banner) grows. assistant-ui's

--- a/web/src/components/settings/SoundSettings.tsx
+++ b/web/src/components/settings/SoundSettings.tsx
@@ -19,7 +19,9 @@ export function SoundSettings({ settings, onSaveField, onUpdate }: Props) {
   return (
     <div className="space-y-4">
       <p className="text-xs text-text-dim">
-        Audio alerts play on the server host machine, not in your browser.
+        Status-change alerts (start, waiting, idle, error) play on the
+        server host machine. Cockpit approval chimes play in your
+        browser, where the dashboard is open.
       </p>
       <ToggleField
         label="Enabled"
@@ -77,6 +79,14 @@ export function SoundSettings({ settings, onSaveField, onUpdate }: Props) {
             value={(sound.on_error as string) ?? ""}
             onChange={(v) => save("on_error", v || null)}
             placeholder="e.g. error.wav"
+            mono
+          />
+          <TextField
+            label="On approval"
+            description="Cockpit only. Played in the browser when a session needs permission."
+            value={(sound.on_approval as string) ?? ""}
+            onChange={(v) => save("on_approval", v || null)}
+            placeholder="e.g. approval.wav"
             mono
           />
         </>

--- a/web/src/hooks/useApprovalSound.ts
+++ b/web/src/hooks/useApprovalSound.ts
@@ -1,0 +1,115 @@
+// Browser-side approval sound for the cockpit.
+//
+// When the cockpit transitions from "no pending approvals" to "at least
+// one pending approval", play the configured sound (from `[sound]` in
+// the daemon's config) in the browser. The host-side sound module only
+// fires on session-status transitions and runs on the server host, so
+// it is the wrong side of the wire when the dashboard is on a separate
+// machine. See #1038.
+//
+// Trade-offs:
+//   - Autoplay policies: the first play() may reject if the user has
+//     not interacted with the dashboard yet. We swallow the rejection;
+//     the OS push notification and in-app toast still surface the
+//     approval, so the missing sound is graceful, not fatal.
+//   - Auth: `<audio src>` cannot carry an Authorization header, so the
+//     blob is fetched through the authenticated fetch path and handed
+//     to Audio via `URL.createObjectURL`.
+
+import { useEffect, useRef } from "react";
+import { fetchSettings, fetchSounds, fetchSoundBlob } from "../lib/api";
+
+interface SoundSettings {
+  enabled?: boolean;
+  volume?: number;
+  mode?: "random" | { specific: string };
+  on_approval?: string | null;
+}
+
+interface CachedSound {
+  name: string;
+  url: string;
+}
+
+let cachedSettings: SoundSettings | null = null;
+let cachedSettingsAt = 0;
+const SETTINGS_TTL_MS = 30_000;
+
+let cachedSound: CachedSound | null = null;
+
+async function loadSettings(): Promise<SoundSettings | null> {
+  const now = Date.now();
+  if (cachedSettings && now - cachedSettingsAt < SETTINGS_TTL_MS) {
+    return cachedSettings;
+  }
+  const data = await fetchSettings();
+  const sound = data?.sound as SoundSettings | undefined;
+  cachedSettings = sound ?? null;
+  cachedSettingsAt = now;
+  return cachedSettings;
+}
+
+async function resolveSoundName(
+  sound: SoundSettings,
+): Promise<string | null> {
+  const override = sound.on_approval?.trim();
+  if (override) return override;
+  if (typeof sound.mode === "object" && sound.mode !== null) {
+    const specific = sound.mode.specific?.trim();
+    if (specific) return specific;
+  }
+  if (sound.mode === "random") {
+    const list = await fetchSounds();
+    if (list.length > 0) {
+      return list[Math.floor(Math.random() * list.length)] ?? null;
+    }
+  }
+  return null;
+}
+
+async function ensureSoundUrl(name: string): Promise<string | null> {
+  if (cachedSound && cachedSound.name === name) {
+    return cachedSound.url;
+  }
+  const blob = await fetchSoundBlob(name);
+  if (!blob) return null;
+  if (cachedSound) {
+    URL.revokeObjectURL(cachedSound.url);
+  }
+  const url = URL.createObjectURL(blob);
+  cachedSound = { name, url };
+  return url;
+}
+
+async function playApprovalSound(): Promise<void> {
+  const sound = await loadSettings();
+  if (!sound || !sound.enabled) return;
+  const name = await resolveSoundName(sound);
+  if (!name) return;
+  const url = await ensureSoundUrl(name);
+  if (!url) return;
+  const audio = new Audio(url);
+  const volume = typeof sound.volume === "number" ? sound.volume : 1.0;
+  audio.volume = Math.max(0, Math.min(1, volume / 1.5));
+  try {
+    await audio.play();
+  } catch {
+    // Autoplay policy or backgrounded tab. The push and in-app toast
+    // still cover the user-visible signal; the missing chime is not
+    // worth a retry storm.
+  }
+}
+
+/** Watch `pendingCount` for a 0 -> >=1 edge and play the configured
+ *  approval sound. Pure passive: the hook does not mount any UI and
+ *  has no return value. */
+export function useApprovalSound(pendingCount: number): void {
+  const lastCount = useRef(pendingCount);
+  useEffect(() => {
+    const prev = lastCount.current;
+    lastCount.current = pendingCount;
+    if (prev === 0 && pendingCount > 0) {
+      void playApprovalSound();
+    }
+  }, [pendingCount]);
+}

--- a/web/src/hooks/useApprovalSound.ts
+++ b/web/src/hooks/useApprovalSound.ts
@@ -133,12 +133,24 @@ async function playApprovalSound(): Promise<void> {
  *  has no return value. */
 export function useApprovalSound(pendingCount: number): void {
   const lastCount = useRef(pendingCount);
-  const mountedAt = useRef(Date.now());
+  // `mountedAt` is set once in the mount effect rather than in the
+  // useRef initialiser so `Date.now()` isn't re-evaluated on every
+  // render. The sentinel 0 doubles as a "not yet armed" marker; the
+  // transition effect treats 0 the same as a too-recent mount.
+  const mountedAt = useRef<number>(0);
+  useEffect(() => {
+    mountedAt.current = Date.now();
+  }, []);
   useEffect(() => {
     const prev = lastCount.current;
     lastCount.current = pendingCount;
     if (prev !== 0 || pendingCount === 0) return;
-    if (Date.now() - mountedAt.current < REPLAY_QUIET_MS) return;
+    if (
+      mountedAt.current === 0 ||
+      Date.now() - mountedAt.current < REPLAY_QUIET_MS
+    ) {
+      return;
+    }
     void playApprovalSound();
   }, [pendingCount]);
 }

--- a/web/src/hooks/useApprovalSound.ts
+++ b/web/src/hooks/useApprovalSound.ts
@@ -12,9 +12,10 @@
 //     not interacted with the dashboard yet. We swallow the rejection;
 //     the OS push notification and in-app toast still surface the
 //     approval, so the missing sound is graceful, not fatal.
-//   - Auth: `<audio src>` cannot carry an Authorization header, so the
-//     blob is fetched through the authenticated fetch path and handed
-//     to Audio via `URL.createObjectURL`.
+//   - Auth: the fetch interceptor injects `Authorization: Bearer` on
+//     every fetch (web/src/lib/fetchInterceptor.ts), and `<audio src>`
+//     does not run through that interceptor, so the bytes are fetched
+//     and handed to Audio via `URL.createObjectURL`.
 
 import { useEffect, useRef } from "react";
 import { fetchSettings, fetchSounds, fetchSoundBlob } from "../lib/api";
@@ -36,6 +37,30 @@ let cachedSettingsAt = 0;
 const SETTINGS_TTL_MS = 30_000;
 
 let cachedSound: CachedSound | null = null;
+
+/** Grace window after mount during which 0->>=1 transitions are
+ *  swallowed. The cockpit WS replays every stored event for the
+ *  session on connect, so a fresh page load on a session with pending
+ *  approvals would otherwise ring the chime even though nothing new
+ *  happened. The OS push only fires on the live broadcast edge in the
+ *  supervisor (no replay path), so the two channels stay consistent.
+ *
+ *  Reconnects do not unmount `CockpitView`, so this gate only swallows
+ *  the initial-load case; new approvals that arrive while the socket
+ *  is offline still chime after the reducer applies them on reconnect. */
+const REPLAY_QUIET_MS = 1500;
+
+/** Drop the module-level caches. Called by the logout flow so the next
+ *  authenticated user sees their own settings and doesn't replay the
+ *  previous user's blob URL. */
+export function clearApprovalSoundCache(): void {
+  cachedSettings = null;
+  cachedSettingsAt = 0;
+  if (cachedSound) {
+    URL.revokeObjectURL(cachedSound.url);
+    cachedSound = null;
+  }
+}
 
 async function loadSettings(): Promise<SoundSettings | null> {
   const now = Date.now();
@@ -90,7 +115,10 @@ async function playApprovalSound(): Promise<void> {
   if (!url) return;
   const audio = new Audio(url);
   const volume = typeof sound.volume === "number" ? sound.volume : 1.0;
-  audio.volume = Math.max(0, Math.min(1, volume / 1.5));
+  // The host-side scale is 0.1-1.5 with 1.0 = normal; HTMLAudioElement
+  // tops out at 1.0, so clamp directly rather than rescaling 1.5 down
+  // to a 0.667 audible "normal".
+  audio.volume = Math.max(0, Math.min(1, volume));
   try {
     await audio.play();
   } catch {
@@ -105,11 +133,12 @@ async function playApprovalSound(): Promise<void> {
  *  has no return value. */
 export function useApprovalSound(pendingCount: number): void {
   const lastCount = useRef(pendingCount);
+  const mountedAt = useRef(Date.now());
   useEffect(() => {
     const prev = lastCount.current;
     lastCount.current = pendingCount;
-    if (prev === 0 && pendingCount > 0) {
-      void playApprovalSound();
-    }
+    if (prev !== 0 || pendingCount === 0) return;
+    if (Date.now() - mountedAt.current < REPLAY_QUIET_MS) return;
+    void playApprovalSound();
   }, [pendingCount]);
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -227,10 +227,11 @@ export async function fetchSounds(): Promise<string[]> {
   return (await fetchJson<string[]>("/api/sounds")) ?? [];
 }
 
-/** Fetch a sound file as a Blob through the authenticated fetch path so
- *  the cockpit's browser-side approval player can hand a blob URL to
- *  `new Audio(...)`. Auth lives on a header, not on the audio element,
- *  so the raw `<audio src>` cannot be used directly. See #1038. */
+/** Fetch a sound file as a Blob so the cockpit's browser-side approval
+ *  player can hand a blob URL to `new Audio(...)`. The fetch path runs
+ *  through `fetchInterceptor.ts`, which injects `Authorization: Bearer`
+ *  on every request; an `<audio src="...">` element does not, so a
+ *  blob round-trip is necessary in PWA mode. See #1038. */
 export async function fetchSoundBlob(name: string): Promise<Blob | null> {
   try {
     const res = await fetch(`/api/sounds/file/${encodeURIComponent(name)}`);

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -697,6 +697,17 @@ export async function logout(): Promise<void> {
     } catch {
       // ignore
     }
+    // Drop the in-memory approval-sound caches so a future user on the
+    // same tab does not see the previous user's settings snapshot or
+    // hear their cached blob.
+    try {
+      const { clearApprovalSoundCache } = await import(
+        "../hooks/useApprovalSound"
+      );
+      clearApprovalSoundCache();
+    } catch {
+      // ignore
+    }
   }
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -227,6 +227,20 @@ export async function fetchSounds(): Promise<string[]> {
   return (await fetchJson<string[]>("/api/sounds")) ?? [];
 }
 
+/** Fetch a sound file as a Blob through the authenticated fetch path so
+ *  the cockpit's browser-side approval player can hand a blob URL to
+ *  `new Audio(...)`. Auth lives on a header, not on the audio element,
+ *  so the raw `<audio src>` cannot be used directly. See #1038. */
+export async function fetchSoundBlob(name: string): Promise<Blob | null> {
+  try {
+    const res = await fetch(`/api/sounds/file/${encodeURIComponent(name)}`);
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
+}
+
 // --- About / server info ---
 
 export interface ServerAbout {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Closes #1038. Two independent gaps were keeping a cockpit user from learning that the agent had blocked on a permission request: the web-push helper existed but had zero call sites, and the only sound channel ran on the server host where the user almost never is.

This PR wires both channels end to end:

1. **Approval push (server side).** The cockpit event listener already subscribes to every broadcast frame with `Arc<AppState>` in scope; it now matches `Event::ApprovalRequested` and calls the existing `cockpit_ws::trigger_approval_push` helper. The supervisor's `on_approval` closure (which previously just logged the event) becomes a no-op kept only for test sinks. The push payload reuses the helper's existing shape (`tag: cockpit-approval-<session>`, deep-link URL `/sessions/<id>/cockpit`), so the service worker coalesces repeated approvals and the in-app toast path at `web/src/components/Toasts.tsx` still fires for foregrounded clients. Approval pushes deliberately bypass the TUI-active / web-active suppression that gates status-change pushes; a foregrounded user still benefits from the immediate cue.

2. **Browser-side sound (web).** Adds an additive `on_approval: Option<String>` to `SoundConfig` / `SoundConfigOverride` with full settings parity (`FieldKey::SoundOnApproval`, build_sound_fields entry, validator arm, global / profile apply, `clear_profile_override` case, merge in `apply_sound_overrides`). A new authenticated `GET /api/sounds/file/{name}` endpoint serves bytes, whitelisting names against `list_available_sounds()` so the route cannot read arbitrary disk paths. A small `useApprovalSound` hook watches the cockpit's `pendingApprovals.length` for a 0 -> >=1 edge and plays the configured sound via an ObjectURL fed to `new Audio(...)` (raw `<audio src>` cannot carry an Authorization header, hence the fetch + blob round-trip). Failed autoplay rejections are caught silently; the push and in-app toast still cover the user-visible signal.

3. **Docs and settings UI.** `docs/sounds.md`, `docs/push-notifications.md`, and `docs/cockpit.md` describe both new channels and how approval pushes differ from the dwell/cooldown-driven status pushes. The Sound Settings panel exposes the new `on_approval` field next to `on_waiting` / `on_error` and the panel header is rewritten to call out the host-vs-browser split.

Issue #1038 explicitly deferred Part C (introducing a dedicated `Status::AwaitingApproval` variant) and that scope decision is preserved here; the existing `Status::Waiting` mapping for approval requests is unchanged, so tmux flows are not affected.

Closes #1038

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] Start `aoe serve --remote` (or any tunneled mode), open the cockpit on a phone/laptop with the PWA installed, ensure notifications are enabled in Settings.
- [x] Background the cockpit tab, fire an approval (e.g. ask the agent to delete a file). Verify an OS push arrives titled `<session> needs approval` with tag `cockpit-approval-<session>`.
- [x] Foreground the cockpit tab on a desktop, fire an approval. Verify an in-app toast appears (not a duplicate OS banner) and the configured chime plays in the browser.
- [x] Confirm approval pushes fire even when the dashboard is foregrounded or the TUI is running on the host (status-change pushes still suppress under those conditions).
- [x] Open `aoe` TUI, Settings -> Sound, set a value in the new "On Approval" field, save. Trigger another approval and verify the configured file plays in the browser (random fallback applies when the field is empty and mode is "random").
- [x] Hit `GET /api/sounds/file/../../../etc/passwd` directly; expect 404, not a file dump.
- [x] Disable sounds entirely (`[sound] enabled = false`), trigger an approval; expect no chime but the push still arrives.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I approved the plan before any code was written, reviewed each of the seven commits, and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)