### PR TITLE
fix(push): delay test notification by 3s so user can lock phone

### DIFF
--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -46,7 +46,7 @@ Push notifications on iOS require the dashboard to be installed as a Home Screen
 4. Open the app from your Home Screen (not from Safari).
 5. Go to Settings in the app.
 6. In the Notifications section, tap *Enable notifications* and grant permission when iOS asks.
-7. Tap *Send test notification*. A test notification should appear on your Lock Screen within a few seconds.
+7. Tap *Send test notification*. The server waits a few seconds before firing the push so you have time to lock your phone; the notification should then appear on your Lock Screen.
 
 If the test does not appear:
 - Make sure the app was opened from the Home Screen, not Safari.

--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -59,7 +59,7 @@ If the test does not appear:
 1. Open the dashboard URL.
 2. Go to Settings. In the Notifications section, click *Enable notifications*.
 3. Grant permission when the browser asks.
-4. Click *Send test notification*.
+4. Click *Send test notification*. The server waits a few seconds before firing, so the notification arrives shortly after the click.
 
 Desktop Safari requires macOS 13 or later and does not require the PWA install step.
 

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -56,7 +56,7 @@ pub const COOLDOWN_MS: u64 = 60_000;
 /// firing the push. Gives the user time to lock their phone so the
 /// notification lands on the Lock Screen instead of in the foreground
 /// app, which is what they actually want to verify.
-pub const TEST_DELAY_MS: u64 = 3_000;
+const TEST_DELAY_MS: u64 = 3_000;
 
 // ── VAPID keypair ───────────────────────────────────────────────────────────
 

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -52,6 +52,12 @@ pub const DWELL_TERMINAL_MS: u64 = 2_000;
 /// OR this long has passed, whichever comes second.
 pub const COOLDOWN_MS: u64 = 60_000;
 
+/// Delay between hitting "Send test notification" and the server actually
+/// firing the push. Gives the user time to lock their phone so the
+/// notification lands on the Lock Screen instead of in the foreground
+/// app, which is what they actually want to verify.
+pub const TEST_DELAY_MS: u64 = 3_000;
+
 // ── VAPID keypair ───────────────────────────────────────────────────────────
 
 /// Persisted form of the VAPID keypair. PKCS#8 PEM for the private key,
@@ -921,6 +927,8 @@ pub async fn test(
         tag: "aoe-test".to_string(),
         session_id: String::new(),
     };
+
+    tokio::time::sleep(std::time::Duration::from_millis(TEST_DELAY_MS)).await;
 
     let outcome = super::push_send::send_one(&client, push, &subscription, &payload).await;
     let mut result = TestResult {

--- a/web/src/components/NotificationSettings.tsx
+++ b/web/src/components/NotificationSettings.tsx
@@ -91,8 +91,8 @@ function StatusRow({ state }: { state: ReturnType<typeof usePushSubscription>["s
     case "sending-test":
       return (
         <p className="text-sm text-text-secondary">
-          Sending test notification in a few seconds. Lock your phone now to
-          see it land on the Lock Screen.
+          Sending test notification in a few seconds. On a phone, lock the
+          screen now to see it land on the Lock Screen.
         </p>
       );
     case "disabling":

--- a/web/src/components/NotificationSettings.tsx
+++ b/web/src/components/NotificationSettings.tsx
@@ -91,7 +91,8 @@ function StatusRow({ state }: { state: ReturnType<typeof usePushSubscription>["s
     case "sending-test":
       return (
         <p className="text-sm text-text-secondary">
-          Sending test notification...
+          Sending test notification in a few seconds. Lock your phone now to
+          see it land on the Lock Screen.
         </p>
       );
     case "disabling":


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The "Send test notification" button in the dashboard's Notification Settings is meant to verify that pushes land on the phone's Lock Screen. In practice on mobile, tapping the button fires the push fast enough that the notification arrives while the PWA is still in the foreground, so it shows up as an in-app toast instead of the thing the user wants to validate.

Server-side fix in `/api/push/test`: sleep 3 seconds (new `TEST_DELAY_MS` const in `src/server/push.rs`) before calling `send_one`. Doing the delay on the server (rather than `setTimeout` on the client) is robust against iOS Safari throttling timers when the tab is backgrounded after the user locks the device.

Client-side, the `sending-test` status row now tells the user to lock their phone while the push is pending. Docs updated to reflect the new behavior.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] Open the dashboard PWA on a phone with push already enabled.
- [x] Tap *Send test notification*.
- [x] Lock the phone within ~3 seconds.
- [x] Confirm the notification appears on the Lock Screen (not just as an in-app toast).
- [x] On desktop, click *Send test notification*, confirm the notification arrives ~3s later.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each change, made the design call (server-side delay over client-side), and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)