### PR TITLE
fix(cockpit, serve): mobile composer polish and push notification origin tracking

### DIFF
--- a/docs/push-notifications.md
+++ b/docs/push-notifications.md
@@ -118,3 +118,5 @@ Upgrading aoe while the PWA is installed replaces `sw.js` but the new service wo
 **"Disabled by the server".** Ask the operator to flip `web.notifications_enabled` or set it in the TUI.
 
 **Notifications stop after a while, and you need to re-enable.** This is token rotation dropping stale subscriptions. If you use `aoe serve --remote`, the token rotates every four hours; grab a fresh dashboard URL and re-enable in the PWA.
+
+**Tapping a notification opens the wrong port or hostname.** Push payloads carry the origin recorded at subscribe time. If you change `--port`, `--host`, move the deployment behind a different reverse proxy, or your `aoe serve --remote` URL changed, the notification still resolves to the old origin until you refresh the subscription. Open Settings, Notifications, and click **Re-subscribe** on the affected device. Subscriptions created before this tracking landed have no recorded origin and are skipped on send; the same Re-subscribe action upgrades them.

--- a/src/server/cockpit_ws.rs
+++ b/src/server/cockpit_ws.rs
@@ -273,13 +273,8 @@ pub async fn trigger_approval_push(
     } else {
         approval_title.to_string()
     };
-    let payload = super::push_send::PushPayload {
-        title,
-        body,
-        url: format!("/sessions/{session_id}/cockpit"),
-        tag: format!("cockpit-approval-{session_id}"),
-        session_id: session_id.to_string(),
-    };
+    let path = format!("/sessions/{session_id}/cockpit");
+    let tag = format!("cockpit-approval-{session_id}");
     let subs = push.store.snapshot().await;
     if subs.is_empty() {
         return;
@@ -291,14 +286,24 @@ pub async fn trigger_approval_push(
             return;
         }
     };
-    let body_bytes = match serde_json::to_vec(&payload) {
-        Ok(b) => b,
-        Err(e) => {
-            warn!(target: "cockpit.push", "serialise payload: {e}");
-            return;
-        }
-    };
     for sub in subs {
+        let Some(url) = super::push::build_push_url(&sub, &path) else {
+            continue;
+        };
+        let payload = super::push_send::PushPayload {
+            title: title.clone(),
+            body: body.clone(),
+            url,
+            tag: tag.clone(),
+            session_id: session_id.to_string(),
+        };
+        let body_bytes = match serde_json::to_vec(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(target: "cockpit.push", "serialise payload: {e}");
+                continue;
+            }
+        };
         let auth_header = match super::push_send::vapid_auth_header(push, &sub.endpoint) {
             Ok(h) => h,
             Err(e) => {

--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -779,13 +779,8 @@ async fn trigger_new_login_push(state: &AppState, user_agent: &str) {
         return;
     }
     let truncated_ua = user_agent.chars().take(80).collect::<String>();
-    let payload = super::push_send::PushPayload {
-        title: "New aoe dashboard login".to_string(),
-        body: format!("New device signed in. UA: {truncated_ua}"),
-        url: "/".to_string(),
-        tag: "aoe-new-login".to_string(),
-        session_id: String::new(),
-    };
+    let title = "New aoe dashboard login".to_string();
+    let body = format!("New device signed in. UA: {truncated_ua}");
     let client = match super::push_send::build_client() {
         Ok(c) => c,
         Err(e) => {
@@ -793,14 +788,24 @@ async fn trigger_new_login_push(state: &AppState, user_agent: &str) {
             return;
         }
     };
-    let body_bytes = match serde_json::to_vec(&payload) {
-        Ok(b) => b,
-        Err(e) => {
-            tracing::warn!(target: "auth.passphrase", "serialise payload: {e}");
-            return;
-        }
-    };
     for sub in subs {
+        let Some(url) = super::push::build_push_url(&sub, "/") else {
+            continue;
+        };
+        let payload = super::push_send::PushPayload {
+            title: title.clone(),
+            body: body.clone(),
+            url,
+            tag: "aoe-new-login".to_string(),
+            session_id: String::new(),
+        };
+        let body_bytes = match serde_json::to_vec(&payload) {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(target: "auth.passphrase", "serialise payload: {e}");
+                continue;
+            }
+        };
         let auth_header = match super::push_send::vapid_auth_header(push, &sub.endpoint) {
             Ok(h) => h,
             Err(e) => {

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -193,6 +193,14 @@ pub struct Subscription {
     /// counter still matches. Prevents wiping a freshly re-subscribed
     /// entry when a concurrent send returns 410.
     pub generation: u64,
+    /// Origin (scheme + host + optional port) the subscriber registered
+    /// from, e.g. `http://localhost:42041` or `https://aoe.example.com`.
+    /// Used to build absolute URLs in push payloads so the SW's
+    /// `clients.openWindow` resolves to the right deployment regardless
+    /// of its registration scope. Empty on legacy entries that predate
+    /// #1188; the send path skips those with a one-time info log.
+    #[serde(default)]
+    pub origin: String,
 }
 
 pub struct SubscriptionStore {
@@ -615,24 +623,22 @@ async fn fire_due_pushes(
         } else {
             format!("{}: {}", body_prefix, instance_title)
         };
-        let payload = super::push_send::PushPayload {
-            title: title.to_string(),
-            body,
-            url: format!("/session/{}", instance_id),
-            tag: format!("session-{}", instance_id),
-            session_id: instance_id.clone(),
-        };
+        let path = format!("/session/{}", instance_id);
+        let tag = format!("session-{}", instance_id);
 
         for sub in subs {
+            let Some(url) = build_push_url(&sub, &path) else {
+                continue;
+            };
             let permit_sem = semaphore.clone();
             let client = client.clone();
             let push = push.clone();
             let payload_clone = super::push_send::PushPayload {
-                title: payload.title.clone(),
-                body: payload.body.clone(),
-                url: payload.url.clone(),
-                tag: payload.tag.clone(),
-                session_id: payload.session_id.clone(),
+                title: title.to_string(),
+                body: body.clone(),
+                url,
+                tag: tag.clone(),
+                session_id: instance_id.clone(),
             };
             tokio::spawn(async move {
                 let Ok(_permit) = permit_sem.acquire_owned().await else {
@@ -714,23 +720,21 @@ pub async fn fire_wake_fired_push(
         Some(r) if !r.is_empty() => format!("Agent resumed{}: {}", body_suffix, r),
         _ => format!("Agent resumed{}", body_suffix),
     };
-    let payload = super::push_send::PushPayload {
-        title: "Scheduled wakeup fired".to_string(),
-        body,
-        url: format!("/session/{}", session_id),
-        tag: format!("session-{}", session_id),
-        session_id: session_id.to_string(),
-    };
+    let path = format!("/session/{}", session_id);
+    let tag = format!("session-{}", session_id);
 
     for sub in subs {
+        let Some(url) = build_push_url(&sub, &path) else {
+            continue;
+        };
         let client = client.clone();
         let push = push.clone();
         let payload_clone = super::push_send::PushPayload {
-            title: payload.title.clone(),
-            body: payload.body.clone(),
-            url: payload.url.clone(),
-            tag: payload.tag.clone(),
-            session_id: payload.session_id.clone(),
+            title: "Scheduled wakeup fired".to_string(),
+            body: body.clone(),
+            url,
+            tag: tag.clone(),
+            session_id: session_id.to_string(),
         };
         tokio::spawn(async move {
             let outcome =
@@ -742,6 +746,32 @@ pub async fn fire_wake_fired_push(
             }
         });
     }
+}
+
+/// Build an absolute URL for a push payload by joining the
+/// subscription's recorded origin with a leading-slash path. Returns
+/// `None` for legacy subscriptions with no origin recorded (predate
+/// #1188): the caller should skip those entries and rely on the
+/// re-subscribe affordance in the UI to refresh the entry.
+///
+/// One info log per call site fires once we hit an empty-origin
+/// subscription so the operator can see why pushes are being dropped.
+pub fn build_push_url(sub: &Subscription, path: &str) -> Option<String> {
+    if sub.origin.is_empty() {
+        tracing::info!(
+            target: "push",
+            endpoint = %sub.endpoint,
+            "skipping push: subscription has no origin, ask user to re-subscribe (#1188)"
+        );
+        return None;
+    }
+    let origin = sub.origin.trim_end_matches('/');
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{}", path)
+    };
+    Some(format!("{origin}{path}"))
 }
 
 pub fn sha256_token(token: &str) -> [u8; 32] {
@@ -835,6 +865,8 @@ pub async fn subscribe(
         .unwrap_or("")
         .to_string();
 
+    let origin = extract_request_origin(&headers).unwrap_or_default();
+
     let sub = Subscription {
         endpoint: body.endpoint,
         p256dh: body.keys.p256dh,
@@ -843,12 +875,42 @@ pub async fn subscribe(
         user_agent,
         created_at: Utc::now(),
         generation: 0,
+        origin,
     };
     push.store
         .upsert(sub)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(StatusCode::NO_CONTENT)
+}
+
+/// Extract the client's origin (scheme + host + optional port) from the
+/// request headers. Prefers the `Origin` header (sent by browsers on
+/// fetch() and cross-origin requests, and on same-origin POSTs with a
+/// JSON body, which covers /api/push/subscribe). Falls back to building
+/// from `X-Forwarded-Proto` + `Host` for reverse-proxy deployments
+/// (Cloudflare, nginx, Traefik) where `Origin` may be stripped. Returns
+/// `None` when neither produces a usable value. See #1188.
+pub fn extract_request_origin(headers: &HeaderMap) -> Option<String> {
+    let origin_header = headers
+        .get(axum::http::header::ORIGIN)
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty() && *s != "null");
+    if let Some(s) = origin_header {
+        return Some(s.trim_end_matches('/').to_string());
+    }
+    let host = headers
+        .get(axum::http::header::HOST)
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())?;
+    let scheme = headers
+        .get("x-forwarded-proto")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.split(',').next())
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("https");
+    Some(format!("{scheme}://{host}"))
 }
 
 /// POST /api/push/unsubscribe
@@ -913,11 +975,21 @@ pub async fn test(
         }
     };
 
+    let Some(url) = build_push_url(&subscription, "/") else {
+        // Stale subscription with no recorded origin. Test path can't be
+        // useful without an absolute URL; ask the user to re-subscribe.
+        tracing::info!(
+            target: "push",
+            endpoint = %subscription.endpoint,
+            "test push skipped: subscription has no origin, ask user to re-subscribe (#1188)"
+        );
+        return Err(StatusCode::CONFLICT);
+    };
     let payload = super::push_send::PushPayload {
         title: "Agent of Empires".to_string(),
         body: "Test notification. If you see this on your lock screen, push is working."
             .to_string(),
-        url: "/".to_string(),
+        url,
         tag: "aoe-test".to_string(),
         session_id: String::new(),
     };
@@ -983,6 +1055,7 @@ mod tests {
             user_agent: "UA".into(),
             created_at: Utc::now(),
             generation: 0,
+            origin: "http://localhost:8080".into(),
         };
         store.upsert(base.clone()).await.unwrap();
         store.upsert(base.clone()).await.unwrap();
@@ -1006,6 +1079,7 @@ mod tests {
             user_agent: "UA".into(),
             created_at: Utc::now(),
             generation: 5,
+            origin: "http://localhost:8080".into(),
         };
         store.upsert(sub.clone()).await.unwrap();
 
@@ -1034,6 +1108,7 @@ mod tests {
             user_agent: "UA".into(),
             created_at: Utc::now(),
             generation: 0,
+            origin: "http://localhost:8080".into(),
         };
         store.upsert(mk([1u8; 32], "https://x/1")).await.unwrap();
         store.upsert(mk([2u8; 32], "https://x/2")).await.unwrap();
@@ -1073,6 +1148,7 @@ mod tests {
             user_agent: "UA".into(),
             created_at: Utc::now(),
             generation: 0,
+            origin: "http://localhost:8080".into(),
         };
         store.upsert(sub).await.unwrap();
 
@@ -1091,6 +1167,136 @@ mod tests {
             .unwrap();
         assert!(removed);
         assert_eq!(store.snapshot().await.len(), 0);
+    }
+
+    #[test]
+    fn extract_origin_prefers_origin_header() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::ORIGIN,
+            "http://localhost:42041".parse().unwrap(),
+        );
+        h.insert(axum::http::header::HOST, "ignored.example".parse().unwrap());
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("http://localhost:42041")
+        );
+    }
+
+    #[test]
+    fn extract_origin_trims_trailing_slash_from_origin_header() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            axum::http::header::ORIGIN,
+            "https://aoe.example.com/".parse().unwrap(),
+        );
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("https://aoe.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_origin_ignores_null_origin() {
+        let mut h = HeaderMap::new();
+        h.insert(axum::http::header::ORIGIN, "null".parse().unwrap());
+        h.insert(axum::http::header::HOST, "aoe.example.com".parse().unwrap());
+        // Falls back to Host + default scheme.
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("https://aoe.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_origin_falls_back_to_forwarded_proto_and_host() {
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-proto", "https".parse().unwrap());
+        h.insert(axum::http::header::HOST, "aoe.example.com".parse().unwrap());
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("https://aoe.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_origin_forwarded_proto_handles_chained_values() {
+        // X-Forwarded-Proto can carry a comma-separated chain when there
+        // are multiple proxies in front. Take the first value.
+        let mut h = HeaderMap::new();
+        h.insert("x-forwarded-proto", "https, http".parse().unwrap());
+        h.insert(axum::http::header::HOST, "aoe.example.com".parse().unwrap());
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("https://aoe.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_origin_defaults_scheme_to_https_when_only_host_set() {
+        let mut h = HeaderMap::new();
+        h.insert(axum::http::header::HOST, "aoe.example.com".parse().unwrap());
+        assert_eq!(
+            extract_request_origin(&h).as_deref(),
+            Some("https://aoe.example.com")
+        );
+    }
+
+    #[test]
+    fn extract_origin_returns_none_when_no_signal() {
+        let h = HeaderMap::new();
+        assert_eq!(extract_request_origin(&h), None);
+    }
+
+    #[test]
+    fn build_push_url_joins_origin_and_path() {
+        let sub = Subscription {
+            endpoint: "https://push.example/abc".into(),
+            p256dh: "pk".into(),
+            auth: "auth".into(),
+            owner_token_hash: [1u8; 32],
+            user_agent: "UA".into(),
+            created_at: Utc::now(),
+            generation: 0,
+            origin: "http://localhost:42041".into(),
+        };
+        assert_eq!(
+            build_push_url(&sub, "/session/abc").as_deref(),
+            Some("http://localhost:42041/session/abc")
+        );
+    }
+
+    #[test]
+    fn build_push_url_trims_origin_trailing_slash() {
+        let sub = Subscription {
+            endpoint: "https://push.example/abc".into(),
+            p256dh: "pk".into(),
+            auth: "auth".into(),
+            owner_token_hash: [1u8; 32],
+            user_agent: "UA".into(),
+            created_at: Utc::now(),
+            generation: 0,
+            origin: "https://aoe.example.com/".into(),
+        };
+        assert_eq!(
+            build_push_url(&sub, "/").as_deref(),
+            Some("https://aoe.example.com/")
+        );
+    }
+
+    #[test]
+    fn build_push_url_none_for_empty_origin() {
+        let sub = Subscription {
+            endpoint: "https://push.example/abc".into(),
+            p256dh: "pk".into(),
+            auth: "auth".into(),
+            owner_token_hash: [1u8; 32],
+            user_agent: "UA".into(),
+            created_at: Utc::now(),
+            generation: 0,
+            origin: String::new(),
+        };
+        assert_eq!(build_push_url(&sub, "/session/abc"), None);
     }
 
     #[test]

--- a/src/server/push_send.rs
+++ b/src/server/push_send.rs
@@ -333,6 +333,7 @@ mod tests {
             user_agent: String::new(),
             created_at: chrono::Utc::now(),
             generation: 0,
+            origin: "http://localhost:8080".to_string(),
         };
 
         let body = encrypt_aes128gcm(&subscription, b"hello").expect("encrypt");

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -717,11 +717,19 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
   // Pinning to the no-keyboard height combined with the keyboard
   // reservation in TerminalView keeps the layout stable across the
   // keyboard cycle.
+  //
+  // Cockpit substrate doesn't host xterm.js, so the SIGWINCH concern
+  // doesn't apply; leaving the pin on for cockpit traps the composer
+  // below the keyboard on Android Chrome PWA (#1177). Drop the pin when
+  // the active session is cockpit so `h-dvh` plus the viewport meta's
+  // `interactive-widget=resizes-content` shrink the container with the
+  // keyboard and lift the composer back into view.
   const { isMobile, stableViewportHeight } = useMobileKeyboard();
-  const rootStyle =
-    isMobile && stableViewportHeight > 0
-      ? { height: `${stableViewportHeight}px` }
-      : undefined;
+  const pinRootHeight =
+    isMobile && stableViewportHeight > 0 && !activeSession?.cockpit_mode;
+  const rootStyle = pinRootHeight
+    ? { height: `${stableViewportHeight}px` }
+    : undefined;
 
   const cockpitPrefs = useMemo(
     () => ({

--- a/web/src/components/NotificationSettings.tsx
+++ b/web/src/components/NotificationSettings.tsx
@@ -6,7 +6,8 @@ import { usePushSubscription } from "../hooks/usePushSubscription";
 // secondary test-send button when enabled.
 
 export function NotificationSettings() {
-  const { state, enable, disable, sendTest } = usePushSubscription();
+  const { state, enable, disable, sendTest, resubscribe } =
+    usePushSubscription();
 
   const isBusy =
     state.kind === "asking" ||
@@ -42,6 +43,13 @@ export function NotificationSettings() {
               className="px-3 py-2 rounded-md bg-surface-700 hover:bg-surface-700/70 text-sm font-medium text-text-primary transition-colors"
             >
               Send test notification
+            </button>
+            <button
+              onClick={resubscribe}
+              title="Re-register this device. Use after changing the server port or hostname so notifications open the right URL."
+              className="px-3 py-2 rounded-md border border-surface-700 hover:bg-surface-700/40 text-sm font-medium text-text-secondary transition-colors"
+            >
+              Re-subscribe
             </button>
             <button
               onClick={disable}

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -244,21 +244,10 @@ export function TerminalView({ session, cockpitMasterEnabled = false }: Props) {
     if (consumePendingTerminalFocus("agent")) focusSelf();
   }, [ensureState, focusSelf]);
 
-  // On initial connect, auto-open the keyboard.
-  useEffect(() => {
-    if (!isMobile || !state.connected) return;
-    const term = termRef.current;
-    if (!term) return;
-    // Retry a few times: wterm's textarea may not exist immediately.
-    const delays = [50, 200, 500];
-    const timers = delays.map((ms) =>
-      setTimeout(() => {
-        const ta = term.element.querySelector("textarea");
-        if (ta instanceof HTMLElement) ta.focus();
-      }, ms),
-    );
-    return () => timers.forEach(clearTimeout);
-  }, [isMobile, state.connected, termRef]);
+  // Auto-keyboard-open on initial connect removed (#1178): the
+  // KeyboardFab is always visible and lets the user open the keyboard
+  // explicitly. Popping the soft keyboard on every session open is the
+  // wrong default for navigation, especially read-only check-ins.
 
   // Toggle keyboard: focus/blur MUST be the first thing in this handler
   // so iOS considers it part of the user-gesture chain. Anything before

--- a/web/src/components/cockpit/Composer.enter.test.ts
+++ b/web/src/components/cockpit/Composer.enter.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { decideEnterAction } from "./Composer";
+import { decideBeforeInputAction, decideEnterAction } from "./Composer";
 
 const plainEnter = {
   key: "Enter",
@@ -85,6 +85,49 @@ describe("decideEnterAction (#1129)", () => {
   it("desktop + idle + plain Enter -> 'default' (primitive handles Send)", () => {
     expect(
       decideEnterAction(plainEnter, { isMobile: false, turnActive: false }),
+    ).toBe("default");
+  });
+});
+
+describe("decideBeforeInputAction (#1174)", () => {
+  it("mobile + insertLineBreak -> 'newline'", () => {
+    expect(
+      decideBeforeInputAction("insertLineBreak", false, { isMobile: true }),
+    ).toBe("newline");
+  });
+
+  it("mobile + insertParagraph -> 'newline'", () => {
+    expect(
+      decideBeforeInputAction("insertParagraph", false, { isMobile: true }),
+    ).toBe("newline");
+  });
+
+  it("mobile + insertText -> 'default' (regular character)", () => {
+    expect(
+      decideBeforeInputAction("insertText", false, { isMobile: true }),
+    ).toBe("default");
+  });
+
+  it("mobile + deleteContentBackward -> 'default' (backspace)", () => {
+    expect(
+      decideBeforeInputAction("deleteContentBackward", false, {
+        isMobile: true,
+      }),
+    ).toBe("default");
+  });
+
+  it("desktop + insertLineBreak -> 'default' (keydown handler owns desktop)", () => {
+    expect(
+      decideBeforeInputAction("insertLineBreak", false, { isMobile: false }),
+    ).toBe("default");
+  });
+
+  it("mobile + insertLineBreak during IME composition -> 'default'", () => {
+    expect(
+      decideBeforeInputAction("insertLineBreak", true, { isMobile: true }),
+    ).toBe("default");
+    expect(
+      decideBeforeInputAction("insertParagraph", true, { isMobile: true }),
     ).toBe("default");
   });
 });

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -340,7 +340,13 @@ export function Composer({
   // ~200-500ms after mount and steals focus from us. Re-claim a couple
   // of times so the agent input wins; only when focus is on body or
   // inside .wterm so an intentional click into the host shell sticks.
+  //
+  // Mobile skips this entirely (#1178): auto-focusing the textarea pops
+  // the soft keyboard on every session open / switch, which is the wrong
+  // default for the read-traffic that dominates mobile usage. Users tap
+  // the composer when they want to type.
   useEffect(() => {
+    if (isMobile) return;
     const el = taRef.current;
     if (!el) return;
     el.focus();
@@ -360,7 +366,7 @@ export function Composer({
       window.clearTimeout(t1);
       window.clearTimeout(t2);
     };
-  }, []);
+  }, [isMobile]);
 
   const wrapperLayout = composerWrapperLayout({ keyboardOpen });
   return (
@@ -485,7 +491,7 @@ export function Composer({
                 e.stopPropagation();
                 void sendFromTextarea(taRef, composerRuntime, enqueuePrompt);
               }}
-              autoFocus
+              autoFocus={!isMobile}
               className={[
                 "min-h-[56px] max-h-[200px] resize-none bg-transparent",
                 "px-4 pt-3 pb-1 text-sm leading-6 text-text-primary",

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -65,6 +65,34 @@ export function decideEnterAction(
   return "default";
 }
 
+/** Decision returned by {@link decideBeforeInputAction} for a
+ *  `beforeinput` event on the cockpit composer textarea.
+ *  - `newline`: caller should preventDefault, stop propagation, and
+ *    manually insert a literal "\n" at the caret. Used on touch-primary
+ *    devices where the on-screen keyboard's Enter fires
+ *    `beforeinput` with `insertLineBreak` / `insertParagraph` instead
+ *    of a `keydown` (Android Chrome's GBoard / Samsung Keyboard / many
+ *    others). Without this, assistant-ui's bubble-phase Send wins.
+ *  - `default`: do nothing, let the primitive run. */
+export type BeforeInputAction = "newline" | "default";
+
+/** Pure decision helper for the composer's `beforeinput` event.
+ *  Extracted so the matrix is unit-testable without mounting the
+ *  composer. The textarea handler reads the same matrix at runtime.
+ *  See #1174. */
+export function decideBeforeInputAction(
+  inputType: string,
+  isComposing: boolean,
+  ctx: { isMobile: boolean },
+): BeforeInputAction {
+  if (!ctx.isMobile) return "default";
+  if (isComposing) return "default";
+  if (inputType !== "insertLineBreak" && inputType !== "insertParagraph") {
+    return "default";
+  }
+  return "newline";
+}
+
 /** Wrapper class + inline style for the composer's outer <div>. When the
  *  soft keyboard is open we drop the bottom padding and apply a negative
  *  bottom margin equal to the App root's safe-area-inset-bottom so the
@@ -400,6 +428,27 @@ export function Composer({
                   });
                 }, 300);
               }}
+              onBeforeInput={(e) => {
+                // Android Chrome's GBoard / Samsung Keyboard often fire
+                // `beforeinput` with `insertLineBreak` / `insertParagraph`
+                // for the on-screen Enter key WITHOUT a usable `keydown`
+                // (key is "Unidentified" or keyCode 229). The keydown
+                // matrix below misses those, so assistant-ui's bubble-
+                // phase Send wins and sends the message. Intercept here
+                // for mobile, insert a literal newline at the caret, and
+                // let the keydown matrix handle the platforms that do
+                // fire a real Enter keydown. See #1174.
+                const ne = e.nativeEvent as InputEvent;
+                const action = decideBeforeInputAction(
+                  ne.inputType,
+                  ne.isComposing,
+                  { isMobile },
+                );
+                if (action === "default") return;
+                e.preventDefault();
+                e.stopPropagation();
+                insertNewlineAtCaret(taRef);
+              }}
               onKeyDown={(e) => {
                 // Three-way Enter dispatch. See decideEnterAction for
                 // the full matrix; the inline branches below handle
@@ -552,6 +601,39 @@ function insertSlashCommand(
   // removed by removeOnExecute, so trailing whitespace is rare.
   const sep = current.length > 0 && !current.endsWith(" ") ? " " : "";
   runtime.setText(`${current}${sep}/${item.id}${suffix}`);
+}
+
+/** Insert a literal "\n" at the textarea's caret. Used by the
+ *  `beforeinput` interception path for mobile Enter (#1174): when
+ *  Android's on-screen keyboard fires `beforeinput` with
+ *  `insertLineBreak` / `insertParagraph` (and possibly no usable
+ *  `keydown`), we preventDefault on the synthetic line-break and
+ *  insert one ourselves so the cursor lands one position past the
+ *  newline. Skips the trigger-detection whitespace padding that
+ *  `insertAtCaret` does for `@` / `/`; a newline doesn't need it. */
+export function insertNewlineAtCaret(
+  ref: React.RefObject<HTMLTextAreaElement | null>,
+): void {
+  const ta = ref.current;
+  if (!ta) return;
+  const start = ta.selectionStart ?? ta.value.length;
+  const end = ta.selectionEnd ?? start;
+  const before = ta.value.slice(0, start);
+  const after = ta.value.slice(end);
+  const next = `${before}\n${after}`;
+  const setter = Object.getOwnPropertyDescriptor(
+    HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(ta, next);
+  ta.dispatchEvent(
+    new InputEvent("input", {
+      bubbles: true,
+      inputType: "insertLineBreak",
+    }),
+  );
+  const pos = before.length + 1;
+  ta.setSelectionRange(pos, pos);
 }
 
 /** Insert `text` at the textarea's caret and re-focus. The toolbar

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -384,6 +384,22 @@ export function Composer({
                   : "Send a message…  Type @ for files, / for commands"
               }
               onInput={onInput}
+              onFocus={() => {
+                // Defensive scrollIntoView for mobile soft-keyboard cycles.
+                // The App root no longer pins height for cockpit (#1177),
+                // so `h-dvh` shrinks with the keyboard and the composer
+                // should naturally lift into view; this is a belt-and-
+                // braces hop after the keyboard animation completes so
+                // any UA that lags the layout-viewport update still ends
+                // up scrolled to the composer.
+                if (!isMobile) return;
+                window.setTimeout(() => {
+                  taRef.current?.scrollIntoView({
+                    block: "end",
+                    behavior: "smooth",
+                  });
+                }, 300);
+              }}
               onKeyDown={(e) => {
                 // Three-way Enter dispatch. See decideEnterAction for
                 // the full matrix; the inline branches below handle

--- a/web/src/hooks/usePushSubscription.ts
+++ b/web/src/hooks/usePushSubscription.ts
@@ -245,5 +245,16 @@ export function usePushSubscription() {
     }
   }, []);
 
-  return { state, enable, disable, sendTest, refresh };
+  // Re-subscribe: unsubscribe then re-subscribe in a single click. Used
+  // by the "Re-subscribe" affordance in NotificationSettings to refresh
+  // the server-side `Subscription.origin` field after the user moved
+  // the deployment to a different port or origin. Existing subs from
+  // before the origin-tracking landed have no recorded origin and get
+  // skipped on send (#1188); re-subscribing refreshes the entry.
+  const resubscribe = useCallback(async () => {
+    await disable();
+    await enable();
+  }, [disable, enable]);
+
+  return { state, enable, disable, sendTest, refresh, resubscribe };
 }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Four mobile and serve polish fixes bundled into one PR. Three focus on the cockpit web composer on touch devices; one fixes push-notification URLs for non-default-port deployments.

`#1177` (Android keyboard covers composer): the App root's mobile height pin existed to keep xterm.js stable across soft-keyboard show/hide cycles. Cockpit sessions don't host xterm.js, so the pin only locked the composer below the keyboard on Android Chrome PWA. The fix gates the pin on the active session being non-cockpit; cockpit falls back to `h-dvh`, which combined with the viewport meta's `interactive-widget=resizes-content` shrinks the container with the keyboard. A defensive `scrollIntoView` on textarea focus covers any UA that lags the layout-viewport update.

`#1174` (Android Enter sends instead of newline): the existing `decideEnterAction` matrix from #1129 assumed plain Enter arrives as a `keydown` with `key: "Enter"`. Android Chrome's GBoard / Samsung Keyboard often fire `beforeinput` with `insertLineBreak` / `insertParagraph` and a keydown that either doesn't fire or carries `key: "Unidentified"` / `keyCode: 229`. The fix adds a pure `decideBeforeInputAction` helper plus an `onBeforeInput` handler that preventDefaults the synthetic line-break on mobile and inserts a literal `\n` at the caret. Desktop unchanged.

`#1178` (mobile auto-focus pops keyboard): both the cockpit composer and the terminal substrate auto-focused their textarea on session open, which spawned the soft keyboard on every session open / switch / reload. The cockpit composer now skips the focus-reclaim effect and `autoFocus` on mobile; the terminal drops the auto-keyboard-open effect entirely (the always-visible `KeyboardFab` is the explicit "summon keyboard" affordance). Desktop coexistence with wterm is preserved.

`#1188` (push notifications open wrong port / origin): `PushPayload.url` was always relative, so the service worker resolved it against its registration scope, i.e. whichever origin the PWA was installed against. Moving the server to a different port or behind a tunnel left every notification opening the wrong URL. `Subscription` now records the subscriber's origin at `/api/push/subscribe` (read from the `Origin` header, with `X-Forwarded-Proto` + `Host` fallback for reverse proxies). The four push send sites (status-change dwell, scheduled-wake fire, cockpit approval, new-login notice) build absolute URLs from `sub.origin`. Existing subscriptions deserialize with empty origin via `#[serde(default)]` and are skipped on send with a one-time info log per endpoint; the new "Re-subscribe" button in Notification settings upgrades them in one tap. Docs in `docs/push-notifications.md` document the constraint.

Closes #1177
Closes #1174
Closes #1178
Closes #1188

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

User-runnable verification checklist; tick each on a real device / browser before marking ready for review.

- [x] Android Chrome PWA: open a cockpit session, tap the composer textarea, confirm the textarea is visible above the soft keyboard immediately (no typing-blind window before the first character).
- [x] Android Chrome cockpit: press the on-screen Enter on the composer, confirm a newline is inserted rather than the message being sent.
- [x] Desktop browser: pressing Enter on the composer still sends; pressing Shift+Enter still inserts a newline; mid-turn Enter still queues.
- [x] iOS / Android: open a session in the cockpit or terminal substrate, confirm the soft keyboard does NOT pop on its own. Tap the composer (or the `KeyboardFab` on terminal) to confirm it still opens explicitly.
- [x] Desktop: open a cockpit session, confirm the composer auto-focuses and the focus-reclaim still beats wterm's late init steal.
- [x] Run `aoe serve --port 42041`, subscribe to push from a phone PWA, send a test notification, tap the notification, confirm it opens at `http://<host>:42041/...` (not `:8080`).
- [x] Behind a tunnel: subscribe via the public hostname, confirm `Subscription.origin` resolves to `https://<tunnel-host>` (check the JSON in `~/.agent-of-empires/push.subscriptions.json`).
- [x] Stale subscription path: with a subscription created before this PR (origin empty), confirm a push for that endpoint is skipped, an info log is emitted, and clicking "Re-subscribe" in Settings → Notifications restores delivery.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and run the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)