### PR TITLE
feat(theme): web dashboard runtime palette swap

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 # Design System -- Agent of Empires
 
-> **Scope note (2026-04-15):** The system below applies to the TUI, the marketing site (`website/`), and anywhere brand identity is expressed. The **web dashboard** (`web/`) runs a deliberately lighter subset documented in the [Web Dashboard section](#web-dashboard-subset) at the bottom. When you touch `web/`, read that section first.
+> **Scope note (2026-05-17):** Color is unified across the TUI and the web dashboard via the canonical theme TOML model. The TUI renders directly from a `Theme`; the web dashboard renders from a server-side projection (`ResolvedTheme`) of the same `Theme`. Surfaces (TUI vs web vs marketing) still differ on typography, density, and motion, but the color palette follows the user's chosen theme on both code surfaces. See the [Theme system](#theme-system) and [Web Dashboard subset](#web-dashboard-subset) sections below.
 
 ## Product Context
 - **What this is:** Terminal session manager for AI coding agents (Claude Code, Gemini CLI, OpenCode, Codex, Mistral Vibe, etc.)
@@ -206,10 +206,32 @@ This makes the two panels feel like one cohesive surface with a divider rather t
 | 2026-03-22 | Inner padding in TUI panels | 1 char horizontal padding prevents content from touching borders. Gives breathing room without sacrificing density. |
 | 2026-03-22 | Single panel seam | Double-border between list and preview panels looks heavy. One shared divider line reads as a cohesive surface. |
 | 2026-04-15 | Web dashboard diverges to Geist + neutral zinc | The web dashboard is a utility surface (sessions, terminals, diffs) not a brand surface. Warm copper at full saturation competes with terminal content and xterm ANSI colors. Geist + zinc surfaces let the content lead; brand amber stays as the accent for CTAs, focus rings, and the logo. See the Web Dashboard section below. |
+| 2026-05-17 | Unified theme system across TUI and web | Issue #1189: the web dashboard's theme picker did nothing. Surface palette is now driven by the user's chosen `Theme` on both TUI and web via a server-side projection (`ResolvedTheme`); the "web deliberately diverges to neutral zinc" rule from 2026-04-15 is retired in favour of "Empire is the default but the user picks." Builtins moved to TOML (issue #1097) so adding a theme is a one-file drop. Geist typography on the dashboard is unchanged; only color is unified. |
+
+## Theme system
+
+The user's chosen theme is the source of truth for color on both the TUI and the web dashboard. Themes live as TOML files: builtins under `themes/builtin/*.toml` (embedded at compile time via `include_str!`); user-defined themes under `~/.agent-of-empires/themes/*.toml`. The canonical schema is the flat color palette in `src/tui/styles/themes.rs` (24 hex fields) plus two optional metadata fields: `appearance = "dark" | "light"` and `[syntax].shiki_theme = "..."`.
+
+### Surfaces and projections
+
+- **TUI** renders directly from the `Theme` struct via `src/tui/styles/themes.rs`. Every ratatui widget reads from the named fields (`background`, `border`, `text`, `accent`, `running`, ...).
+- **Web dashboard** renders from a server-side projection (`ResolvedTheme` in `src/tui/styles/resolved.rs`) of the same `Theme`. The projection maps named TUI fields onto the Tailwind CSS variables the dashboard consumes (`--color-surface-900`, `--color-text-primary`, `--color-status-running`, etc.) and derives a few shades (surface-950/850, brand ramp, ANSI 16 for the embedded terminal) from background luminance and the appearance flag. Light themes (Catppuccin Latte) invert the ramp direction so the dashboard reads correctly on light surfaces.
+- **Embedded terminal** (`web/src/hooks/useTerminal.ts`) inherits `--term-*` CSS variables (background, foreground, cursor, ANSI 16) from the same projection. wterm reads CSS variables at draw time; the hook fires `term.resize(...)` on theme change so the live terminal repaints under the new palette without waiting for the next PTY byte.
+- **Syntax highlighting** (Shiki) selects a bundled Shiki theme per AoE theme via `[syntax].shiki_theme`. Built-ins map to closely matching upstream Shiki themes (`empire` → `github-dark`, `dracula` → `dracula`, `catppuccin-latte` → `catppuccin-latte`, etc.); user themes default to `github-dark` / `github-light` by appearance.
+
+### Compatibility
+
+- Adding a built-in theme is a one-file drop: `themes/builtin/<name>.toml` + one entry in `BUILTIN_THEMES`. No per-theme Rust constructor, no per-theme test stamp-out.
+- Existing custom TOML themes (`~/.agent-of-empires/themes/*.toml`) parse unchanged. The new optional metadata fields default to `None` / empty for custom themes that omit them; the server falls back to luminance classification and appearance-based syntax theme selection.
+- The TOML schema does **not** declare ANSI 16 colors per theme; the resolver derives them from semantic fields (ANSI 1 = error, 2 = running, ...). An optional `[terminal]` override section is future work; v1 derives so user themes work without authoring 16 hexes.
+
+### Marketing site (`website/`)
+
+The marketing site has its own palette (the original warm-navy Empire-aligned ramp documented in the [Color](#color) section above). It is brand expression, not user surface, so the user's theme picker doesn't affect it.
 
 ## Web Dashboard subset
 
-The web dashboard (`web/`) is a utility that sits between a developer and a terminal. It is dark-only, dense, keyboard-driven, and deliberately quieter than the marketing site. Use these rules when editing anything under `web/`.
+The web dashboard (`web/`) is a utility that sits between a developer and a terminal. It is dense, keyboard-driven, and deliberately quieter than the marketing site. Use these rules when editing anything under `web/`.
 
 ### Typography
 
@@ -220,11 +242,11 @@ The web dashboard (`web/`) is a utility that sits between a developer and a term
 
 ### Color
 
-- **Brand amber** is still the primary and still uses the same brand-400 through brand-700 tokens as the rest of the system. It appears on CTAs, focus rings, the logo mark, section anchors, and the inline code color. Do not introduce a separate brand palette for the dashboard.
-- **Accent teal** appears on secondary affordances: branch names in breadcrumbs, diff file count badges, keyboard shortcut pills in the help overlay.
-- **Surfaces** are neutral zinc (`--color-surface-700` through `--color-surface-950` in `web/src/index.css`), not the warm navy from the brand system. Neutral surfaces keep xterm's ANSI colors legible and prevent the "everything is orange-tinted" feeling that a warm surface palette produces behind a terminal.
-- **Status colors** (running, waiting, idle, error, starting, stopped) are defined as semantic tokens in `web/src/index.css` and are the only non-brand/non-accent colors allowed in the dashboard chrome.
-- **Text contrast.** Every text token in the ramp (`text-primary` through `text-dim`) must clear WCAG AA body contrast (4.5:1) against both `surface-900` and `surface-800`; that's the surface set body copy lives on. The `text-dim` slot is the floor: tertiary descriptive copy under settings controls, helper hints next to inputs, status info rows. Decorative non-text uses that need to read quieter (separator hairlines, faint chrome) can drop to a surface token directly rather than darkening the text ramp.
+- **All color** comes from the user's chosen theme via the resolved theme projection (see [Theme system](#theme-system)). The dashboard does not pin its own palette; the build-time defaults in `web/src/index.css` exist only as a cold-load fallback before `useResolvedTheme` fetches and applies the user's selection.
+- **Empire** (the default theme) is the documented baseline: warm amber/copper brand on warm navy surfaces, derived through the projection. Tailwind utilities like `bg-surface-900`, `text-text-primary`, `text-status-running` resolve to whichever theme the user has selected.
+- **Light theme support.** Catppuccin Latte is a first-class theme on both TUI and web. The projection inverts the surface ramp direction for light backgrounds and sets `color-scheme: light` on the root so native form controls render correctly.
+- **Status colors** (running, waiting, fresh-idle, idle, error, starting, stopped) come from the matching TUI semantic fields. `starting` and `stopped` have no TUI equivalent; the projection derives them by darkening `waiting` and `dimmed` respectively.
+- **Text contrast.** Every text token in the ramp (`text-primary` through `text-dim`) must clear WCAG AA body contrast (4.5:1) against the surfaces body copy lives on. Builtins are tuned for AA; custom themes are the user's responsibility.
 
 ### Density and motion
 
@@ -232,17 +254,15 @@ The web dashboard (`web/`) is a utility that sits between a developer and a term
 - Border radii: `rounded-md` (6px) for inline affordances, `rounded-lg` (8px) for panels and dialogs. No `rounded-xl` or larger in the dashboard.
 - Motion: `animate-fade-in` and `animate-slide-up` are the only named transitions. Prefer `transition-colors` for hover/focus. Avoid scaling, parallax, or layered motion.
 
-### What stays consistent with the brand system
+### What stays per-surface
 
-- Brand amber is still the primary.
-- Accent teal is still the secondary.
-- Status color semantics are unchanged.
-- The "engineer-made, warm when it matters" tone still applies; the dashboard is just quieter about it so the terminal can lead.
+- Font families (Geist on the dashboard, Satoshi/DM Sans on marketing).
+- Density (denser on the dashboard than on the marketing site).
+- Motion (minimal-functional on both; no decorative motion in the dashboard).
 
-### What is explicitly allowed to differ
+### What to avoid
 
-- Font families (Geist everywhere, not Satoshi/DM Sans/JetBrains Mono).
-- Surface palette (neutral zinc, not warm navy).
-- Brand saturation (used as an accent, not a primary surface treatment).
+- **No hardcoded chrome colors.** Use semantic tokens (`bg-surface-900`, `text-status-running`, `border-surface-700`). Hardcoded hex / rgb / `bg-[#...]` arbitrary classes don't repaint under theme changes. The few existing exceptions are: brand-mark SVGs in `Dashboard.tsx` (these stay brand amber regardless of theme), `lib/ansi.ts` (renders user-produced ANSI escape content, not chrome).
+- **No new build-time `@theme [data-theme=...]` blocks.** The runtime palette swap goes through CSS variables on `documentElement`; build-time scoped themes can't support user-defined TOML themes without rebuilds.
 
 If a change to `web/` would require deviating from any of the above, update this section first.

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -45,11 +45,35 @@ All settings below can also be edited from the TUI settings screen (press `s` or
 ```toml
 [theme]
 name = "empire"   # empire, phosphor, tokyo-night-storm, catppuccin-latte, dracula, rose-pine
+color_mode = "truecolor"   # truecolor | palette (TUI only)
 ```
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `name` | `"empire"` | TUI color theme. Available: `empire` (warm navy/amber), `phosphor` (green), `tokyo-night-storm` (dark blue/purple), `catppuccin-latte` (light pastel), `dracula` (dark purple/pink), `rose-pine` (dark muted purple/pink). |
+| `name` | `"empire"` | Color theme. Applies to **both the TUI and the web dashboard**. Available builtins: `empire` (warm navy/amber), `phosphor` (green), `tokyo-night-storm` (dark blue/purple), `catppuccin-latte` (light pastel), `dracula` (dark purple/pink), `rose-pine` (dark muted purple/pink). Custom TOML themes in `~/.agent-of-empires/themes/*.toml` also appear in the picker. |
+| `color_mode` | `"truecolor"` | TUI only. `palette` downsamples to xterm-256 for transports that mangle 24-bit RGB (e.g. some `mosh` setups). The web dashboard always renders truecolor. |
+
+### Builtin themes
+
+Each builtin theme is a TOML file under `themes/builtin/` in the repo, embedded into the binary at build time. The schema matches the custom-theme format below, plus two optional metadata fields:
+
+- `appearance = "dark" | "light"` declares the surface polarity. Drives the web dashboard's surface-ramp derivation (lighten vs darken from background) and selects the fallback Shiki syntax theme. If omitted, the server classifies from background luminance.
+- `[syntax].shiki_theme = "..."` names the bundled Shiki theme the web dashboard loads for code blocks. If omitted, falls back by appearance (`github-dark` / `github-light`).
+
+### Custom themes
+
+Drop a TOML file in `~/.agent-of-empires/themes/<name>.toml` (or `$XDG_CONFIG_HOME/agent-of-empires/themes/` on Linux). The file appears in the theme picker under its filename stem.
+
+Export a builtin as a starting point:
+
+```bash
+aoe theme export empire             # writes ~/.agent-of-empires/themes/custom-empire.toml
+aoe theme export dracula -o my.toml # writes to my.toml
+aoe theme list                      # show all available themes
+aoe theme dir                       # print the custom themes directory
+```
+
+The schema is flat; every field is optional and missing fields fall back to Empire's defaults. The 24 color fields cover background, borders, text, status semantics, diff colors, branch/sandbox chips, and accent. Add the optional `appearance` and `[syntax]` table to control the web surface.
 
 ## Session
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -40,9 +40,10 @@ pub use sessions::{
 };
 pub use system::{
     browse_filesystem, create_profile, default_profile, delete_profile, docker_status,
-    filesystem_home, get_about, get_profile_settings, get_settings, get_update_status, list_agents,
-    list_devices, list_groups, list_profiles, list_sounds, list_themes, rename_profile,
-    serve_sound_file, update_profile_settings, update_settings,
+    filesystem_home, get_about, get_current_theme, get_profile_settings, get_resolved_theme,
+    get_settings, get_update_status, list_agents, list_devices, list_groups, list_profiles,
+    list_sounds, list_themes, rename_profile, serve_sound_file, update_profile_settings,
+    update_settings,
 };
 
 const SHELL_METACHARACTERS: &[char] = &[

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -198,26 +198,40 @@ pub async fn list_themes() -> Json<Vec<String>> {
 /// CSS vars, terminal CSS vars, syntax highlighter selection,
 /// appearance) for the named theme. Unknown names resolve to Empire
 /// with `source: "fallback"`, mirroring `load_theme`'s behaviour.
+///
+/// Wrapped in `spawn_blocking`: the resolver does sync file I/O
+/// (`discover_custom_themes` directory scan + TOML parse) which must
+/// not run on a tokio worker thread.
 pub async fn get_resolved_theme(
     axum::extract::Path(name): axum::extract::Path<String>,
 ) -> Json<crate::tui::styles::ResolvedTheme> {
-    Json(crate::tui::styles::resolve_theme(&name))
+    let resolved = tokio::task::spawn_blocking(move || crate::tui::styles::resolve_theme(&name))
+        .await
+        .unwrap_or_else(|_| crate::tui::styles::resolve_theme("empire"));
+    Json(resolved)
 }
 
 /// `GET /api/theme/current` returns the resolved theme for the active
 /// profile (the picker's current selection). Resolved through
 /// `profile_config::resolve_config_or_warn` so per-profile theme
-/// overrides land in the right place.
+/// overrides land in the right place. Sync work runs in
+/// `spawn_blocking`.
 pub async fn get_current_theme(
     State(state): State<Arc<AppState>>,
 ) -> Json<crate::tui::styles::ResolvedTheme> {
-    let cfg = crate::session::profile_config::resolve_config_or_warn(&state.profile);
-    let name = if cfg.theme.name.is_empty() {
-        "empire".to_string()
-    } else {
-        cfg.theme.name
-    };
-    Json(crate::tui::styles::resolve_theme(&name))
+    let profile = state.profile.clone();
+    let resolved = tokio::task::spawn_blocking(move || {
+        let cfg = crate::session::profile_config::resolve_config_or_warn(&profile);
+        let name = if cfg.theme.name.is_empty() {
+            "empire".to_string()
+        } else {
+            cfg.theme.name
+        };
+        crate::tui::styles::resolve_theme(&name)
+    })
+    .await
+    .unwrap_or_else(|_| crate::tui::styles::resolve_theme("empire"));
+    Json(resolved)
 }
 
 // --- Wizard support ---
@@ -496,13 +510,27 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
     let cockpit_max_concurrent_resumes = cockpit_cfg.max_concurrent_resumes;
     let cockpit_force_end_turn_threshold_secs = cockpit_cfg.force_end_turn_threshold_secs;
     let cockpit_replay_events = cockpit_cfg.replay_events;
-    let profile_cfg = crate::session::profile_config::resolve_config_or_warn(&state.profile);
-    let theme_name = if profile_cfg.theme.name.is_empty() {
-        "empire".to_string()
-    } else {
-        profile_cfg.theme.name.clone()
-    };
-    let theme_appearance = crate::tui::styles::resolve_theme(&theme_name).appearance;
+    // Theme resolution does sync file I/O (profile config read +
+    // discover_custom_themes dir scan + TOML parse for the resolved
+    // appearance). Run off the runtime thread.
+    let theme_profile = state.profile.clone();
+    let (theme_name, theme_appearance) = tokio::task::spawn_blocking(move || {
+        let profile_cfg = crate::session::profile_config::resolve_config_or_warn(&theme_profile);
+        let name = if profile_cfg.theme.name.is_empty() {
+            "empire".to_string()
+        } else {
+            profile_cfg.theme.name.clone()
+        };
+        let appearance = crate::tui::styles::resolve_theme(&name).appearance;
+        (name, appearance)
+    })
+    .await
+    .unwrap_or_else(|_| {
+        (
+            "empire".to_string(),
+            crate::tui::styles::ThemeAppearance::Dark,
+        )
+    });
     Json(ServerAbout {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth_required,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -194,6 +194,32 @@ pub async fn list_themes() -> Json<Vec<String>> {
     )
 }
 
+/// `GET /api/themes/:name` returns the resolved theme projection (web
+/// CSS vars, terminal CSS vars, syntax highlighter selection,
+/// appearance) for the named theme. Unknown names resolve to Empire
+/// with `source: "fallback"`, mirroring `load_theme`'s behaviour.
+pub async fn get_resolved_theme(
+    axum::extract::Path(name): axum::extract::Path<String>,
+) -> Json<crate::tui::styles::ResolvedTheme> {
+    Json(crate::tui::styles::resolve_theme(&name))
+}
+
+/// `GET /api/theme/current` returns the resolved theme for the active
+/// profile (the picker's current selection). Resolved through
+/// `profile_config::resolve_config_or_warn` so per-profile theme
+/// overrides land in the right place.
+pub async fn get_current_theme(
+    State(state): State<Arc<AppState>>,
+) -> Json<crate::tui::styles::ResolvedTheme> {
+    let cfg = crate::session::profile_config::resolve_config_or_warn(&state.profile);
+    let name = if cfg.theme.name.is_empty() {
+        "empire".to_string()
+    } else {
+        cfg.theme.name
+    };
+    Json(crate::tui::styles::resolve_theme(&name))
+}
+
 // --- Wizard support ---
 
 #[derive(Serialize)]
@@ -437,6 +463,17 @@ pub struct ServerAbout {
     /// honours the user's chosen ceiling instead of clipping at a
     /// hard-coded constant. See #1111.
     pub cockpit_replay_events: u32,
+    /// Active theme name (resolved through the profile). The frontend
+    /// uses this as the cache key for the resolved-theme payload it
+    /// reads from `/api/theme/current`, so a settings update reflects
+    /// in the dashboard chrome on the next theme fetch without a
+    /// settings round-trip. Empty config maps to `"empire"`. See #1189.
+    pub theme_name: String,
+    /// Resolved appearance (dark/light) of the active theme. Surfaced
+    /// here so the pre-React bootstrap script in `web/index.html` can
+    /// pick the right cached CSS variable set and `color-scheme`
+    /// before the React app hydrates. See #1189.
+    pub theme_appearance: crate::tui::styles::ThemeAppearance,
 }
 
 pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> {
@@ -459,6 +496,13 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
     let cockpit_max_concurrent_resumes = cockpit_cfg.max_concurrent_resumes;
     let cockpit_force_end_turn_threshold_secs = cockpit_cfg.force_end_turn_threshold_secs;
     let cockpit_replay_events = cockpit_cfg.replay_events;
+    let profile_cfg = crate::session::profile_config::resolve_config_or_warn(&state.profile);
+    let theme_name = if profile_cfg.theme.name.is_empty() {
+        "empire".to_string()
+    } else {
+        profile_cfg.theme.name.clone()
+    };
+    let theme_appearance = crate::tui::styles::resolve_theme(&theme_name).appearance;
     Json(ServerAbout {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth_required,
@@ -473,6 +517,8 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         cockpit_max_concurrent_resumes,
         cockpit_force_end_turn_threshold_secs,
         cockpit_replay_events,
+        theme_name,
+        theme_appearance,
     })
 }
 

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -485,17 +485,6 @@ pub struct ServerAbout {
     /// honours the user's chosen ceiling instead of clipping at a
     /// hard-coded constant. See #1111.
     pub cockpit_replay_events: u32,
-    /// Active theme name (resolved through the profile). The frontend
-    /// uses this as the cache key for the resolved-theme payload it
-    /// reads from `/api/theme/current`, so a settings update reflects
-    /// in the dashboard chrome on the next theme fetch without a
-    /// settings round-trip. Empty config maps to `"empire"`. See #1189.
-    pub theme_name: String,
-    /// Resolved appearance (dark/light) of the active theme. Surfaced
-    /// here so the pre-React bootstrap script in `web/index.html` can
-    /// pick the right cached CSS variable set and `color-scheme`
-    /// before the React app hydrates. See #1189.
-    pub theme_appearance: crate::tui::styles::ThemeAppearance,
 }
 
 pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> {
@@ -518,33 +507,6 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
     let cockpit_max_concurrent_resumes = cockpit_cfg.max_concurrent_resumes;
     let cockpit_force_end_turn_threshold_secs = cockpit_cfg.force_end_turn_threshold_secs;
     let cockpit_replay_events = cockpit_cfg.replay_events;
-    // Theme resolution does sync file I/O (profile config read +
-    // discover_custom_themes dir scan + TOML parse for the resolved
-    // appearance). Run off the runtime thread.
-    let theme_profile = state.profile.clone();
-    let (theme_name, theme_appearance) = tokio::task::spawn_blocking(move || {
-        let profile_cfg = crate::session::profile_config::resolve_config_or_warn(&theme_profile);
-        let name = if profile_cfg.theme.name.is_empty() {
-            "empire".to_string()
-        } else {
-            profile_cfg.theme.name.clone()
-        };
-        let appearance = crate::tui::styles::resolve_theme(&name).appearance;
-        (name, appearance)
-    })
-    .await
-    .unwrap_or_else(|e| {
-        tracing::warn!(error = %e, "about theme resolve task panicked, defaulting to empire/dark");
-        (
-            "empire".to_string(),
-            crate::tui::styles::ThemeAppearance::Dark,
-        )
-    });
-    tracing::debug!(
-        theme_name = %theme_name,
-        theme_appearance = ?theme_appearance,
-        "GET /api/about (theme bits)"
-    );
     Json(ServerAbout {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth_required,
@@ -559,8 +521,6 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         cockpit_max_concurrent_resumes,
         cockpit_force_end_turn_threshold_secs,
         cockpit_replay_events,
-        theme_name,
-        theme_appearance,
     })
 }
 

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -205,9 +205,13 @@ pub async fn list_themes() -> Json<Vec<String>> {
 pub async fn get_resolved_theme(
     axum::extract::Path(name): axum::extract::Path<String>,
 ) -> Json<crate::tui::styles::ResolvedTheme> {
+    tracing::debug!(theme = %name, "GET /api/themes/{{name}}");
     let resolved = tokio::task::spawn_blocking(move || crate::tui::styles::resolve_theme(&name))
         .await
-        .unwrap_or_else(|_| crate::tui::styles::resolve_theme("empire"));
+        .unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "theme resolve task panicked, falling back to empire");
+            crate::tui::styles::resolve_theme("empire")
+        });
     Json(resolved)
 }
 
@@ -220,6 +224,7 @@ pub async fn get_current_theme(
     State(state): State<Arc<AppState>>,
 ) -> Json<crate::tui::styles::ResolvedTheme> {
     let profile = state.profile.clone();
+    tracing::debug!(profile = %profile, "GET /api/theme/current");
     let resolved = tokio::task::spawn_blocking(move || {
         let cfg = crate::session::profile_config::resolve_config_or_warn(&profile);
         let name = if cfg.theme.name.is_empty() {
@@ -230,7 +235,10 @@ pub async fn get_current_theme(
         crate::tui::styles::resolve_theme(&name)
     })
     .await
-    .unwrap_or_else(|_| crate::tui::styles::resolve_theme("empire"));
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "current theme resolve task panicked, falling back to empire");
+        crate::tui::styles::resolve_theme("empire")
+    });
     Json(resolved)
 }
 
@@ -525,12 +533,18 @@ pub async fn get_about(State(state): State<Arc<AppState>>) -> Json<ServerAbout> 
         (name, appearance)
     })
     .await
-    .unwrap_or_else(|_| {
+    .unwrap_or_else(|e| {
+        tracing::warn!(error = %e, "about theme resolve task panicked, defaulting to empire/dark");
         (
             "empire".to_string(),
             crate::tui::styles::ThemeAppearance::Dark,
         )
     });
+    tracing::debug!(
+        theme_name = %theme_name,
+        theme_appearance = ?theme_appearance,
+        "GET /api/about (theme bits)"
+    );
     Json(ServerAbout {
         version: env!("CARGO_PKG_VERSION").to_string(),
         auth_required,

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -194,6 +194,13 @@ pub async fn list_themes() -> Json<Vec<String>> {
     )
 }
 
+/// Upper bound on the `:name` path segment for `/api/themes/:name`.
+/// Builtin names are <= 20 chars and custom theme filenames are
+/// inherently capped by the host filesystem; 128 is far past any
+/// real theme name. Past the cap we resolve Empire without logging
+/// the body to keep tracing output sane under fuzzing.
+const MAX_THEME_NAME_LEN: usize = 128;
+
 /// `GET /api/themes/:name` returns the resolved theme projection (web
 /// CSS vars, terminal CSS vars, syntax highlighter selection,
 /// appearance) for the named theme. Unknown names resolve to Empire
@@ -205,6 +212,14 @@ pub async fn list_themes() -> Json<Vec<String>> {
 pub async fn get_resolved_theme(
     axum::extract::Path(name): axum::extract::Path<String>,
 ) -> Json<crate::tui::styles::ResolvedTheme> {
+    if name.len() > MAX_THEME_NAME_LEN {
+        tracing::warn!(
+            len = name.len(),
+            "GET /api/themes/{{name}} rejected: name exceeds {} bytes",
+            MAX_THEME_NAME_LEN,
+        );
+        return Json(crate::tui::styles::resolve_theme("empire"));
+    }
     tracing::debug!(theme = %name, "GET /api/themes/{{name}}");
     let resolved = tokio::task::spawn_blocking(move || crate::tui::styles::resolve_theme(&name))
         .await

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -967,6 +967,8 @@ fn build_router(state: Arc<AppState>) -> Router {
             get(api::get_settings).patch(api::update_settings),
         )
         .route("/api/themes", get(api::list_themes))
+        .route("/api/themes/{name}", get(api::get_resolved_theme))
+        .route("/api/theme/current", get(api::get_current_theme))
         .route("/api/sounds", get(api::list_sounds))
         .route("/api/sounds/file/{name}", get(api::serve_sound_file))
         // Push notifications

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -289,6 +289,25 @@ mod tests {
     }
 
     #[test]
+    fn default_matches_empire_toml() {
+        // Drift guard: every color field in `impl Default for Theme`
+        // (which serde's container `#[serde(default)]` uses as the
+        // fallback for partial custom TOMLs) must match the corresponding
+        // hex in `themes/builtin/empire.toml`. A future Empire palette
+        // tweak that updates the TOML but not the hand-mirrored Default
+        // would otherwise leave partial custom TOMLs inheriting stale
+        // colors silently. Per the review on PR #1197.
+        let defaulted = Theme::default();
+        let from_toml = load_theme("empire");
+        assert_eq!(
+            defaulted.color_fields().to_vec(),
+            from_toml.color_fields().to_vec(),
+            "Theme::default() color fields drifted from themes/builtin/empire.toml; \
+             sync the hand-mirrored values in `impl Default for Theme` (themes.rs)"
+        );
+    }
+
+    #[test]
     fn default_does_not_recurse_through_load_theme() {
         // Regression for the OnceLock-via-load_theme deadlock the
         // first cut of this work shipped: serde's container-level

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -13,9 +13,7 @@ mod resolved;
 mod themes;
 
 #[cfg(feature = "serve")]
-pub use resolved::{
-    resolve_theme, CssVarProjection, ResolvedTheme, ResolvedThemeSource, SyntaxProjection,
-};
+pub use resolved::{resolve_theme, ResolvedTheme};
 #[cfg(any(feature = "serve", test))]
 pub use themes::ThemeAppearance;
 pub use themes::{idle_decay_window, Theme};

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -289,25 +289,6 @@ mod tests {
     }
 
     #[test]
-    fn default_matches_empire_toml() {
-        // Drift guard: every color field in `impl Default for Theme`
-        // (which serde's container `#[serde(default)]` uses as the
-        // fallback for partial custom TOMLs) must match the corresponding
-        // hex in `themes/builtin/empire.toml`. A future Empire palette
-        // tweak that updates the TOML but not the hand-mirrored Default
-        // would otherwise leave partial custom TOMLs inheriting stale
-        // colors silently.
-        let defaulted = Theme::default();
-        let from_toml = load_theme("empire");
-        assert_eq!(
-            defaulted.color_fields().to_vec(),
-            from_toml.color_fields().to_vec(),
-            "Theme::default() color fields drifted from themes/builtin/empire.toml; \
-             sync the hand-mirrored values in `impl Default for Theme` (themes.rs)"
-        );
-    }
-
-    #[test]
     fn default_does_not_recurse_through_load_theme() {
         // Regression for the OnceLock-via-load_theme deadlock the
         // first cut of this work shipped: serde's container-level

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -19,7 +19,7 @@ pub use themes::ThemeAppearance;
 pub use themes::{idle_decay_window, Theme};
 
 use std::path::PathBuf;
-use tracing::warn;
+use tracing::{debug, warn};
 
 /// One built-in theme. `source` is the TOML body embedded at compile time
 /// via `include_str!`. Adding a new builtin is: drop `themes/builtin/X.toml`
@@ -140,11 +140,18 @@ fn parse_builtin(builtin: &BuiltinTheme) -> Theme {
 
 pub fn load_theme(name: &str) -> Theme {
     if let Some(builtin) = BUILTIN_THEMES.iter().find(|b| b.name == name) {
+        debug!(theme = name, source = "builtin", "loaded theme");
         return parse_builtin(builtin);
     }
     for (theme_name, path) in discover_custom_themes() {
         if theme_name == name {
             if let Some(theme) = load_custom_theme(&path) {
+                debug!(
+                    theme = name,
+                    source = "custom",
+                    path = %path.display(),
+                    "loaded theme"
+                );
                 return theme;
             }
         }

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -8,8 +8,16 @@
 //! Public surface is re-exported here so callers keep `crate::tui::styles::*`.
 
 mod palette;
+#[cfg(feature = "serve")]
+mod resolved;
 mod themes;
 
+#[cfg(feature = "serve")]
+pub use resolved::{
+    resolve_theme, CssVarProjection, ResolvedTheme, ResolvedThemeSource, SyntaxProjection,
+};
+#[cfg(any(feature = "serve", test))]
+pub use themes::ThemeAppearance;
 pub use themes::{idle_decay_window, Theme};
 
 use std::path::PathBuf;

--- a/src/tui/styles/resolved.rs
+++ b/src/tui/styles/resolved.rs
@@ -22,6 +22,7 @@ use std::collections::BTreeMap;
 
 use ratatui::style::Color;
 use serde::Serialize;
+use tracing::debug;
 
 use super::{load_theme, Theme, ThemeAppearance};
 
@@ -91,13 +92,22 @@ pub fn resolve_theme(name: &str) -> ResolvedTheme {
         name.to_string()
     };
     let appearance = resolved_appearance(&theme);
+    let syntax = syntax_projection(&theme, appearance);
+    debug!(
+        requested = name,
+        resolved = %resolved_name,
+        source = ?source,
+        appearance = ?appearance,
+        shiki_theme = %syntax.shiki_theme,
+        "resolved theme projection"
+    );
     ResolvedTheme {
         name: resolved_name,
         source,
         appearance,
         web: web_projection(&theme, appearance),
         terminal: terminal_projection(&theme, appearance),
-        syntax: syntax_projection(&theme, appearance),
+        syntax,
     }
 }
 

--- a/src/tui/styles/resolved.rs
+++ b/src/tui/styles/resolved.rs
@@ -1,0 +1,426 @@
+//! Server-side theme projections.
+//!
+//! `ResolvedTheme` is the payload the web dashboard consumes from
+//! `GET /api/themes/:name` and `GET /api/theme/current`. It is derived
+//! from the canonical [`Theme`] (loaded from a builtin TOML or a custom
+//! TOML in `~/.agent-of-empires/themes/*.toml`) by:
+//!
+//! - emitting the named TUI color fields as CSS variables the web's
+//!   Tailwind tokens consume (`--color-surface-900`, `--color-text-primary`,
+//!   etc.),
+//! - deriving lifted/recessed shades from the background luminance,
+//! - deriving an ANSI 16 palette from the semantic color fields so the
+//!   embedded terminal repaints under user themes without an extra schema
+//!   field per theme,
+//! - resolving the `[syntax].shiki_theme` selection (with appearance-based
+//!   fallback when none is declared).
+//!
+//! `ResolvedTheme` is never persisted. It's a serialization of the
+//! projection logic the web needs at runtime.
+
+use std::collections::BTreeMap;
+
+use ratatui::style::Color;
+use serde::Serialize;
+
+use super::{load_theme, Theme, ThemeAppearance};
+
+/// Source classification for a resolved theme. Frontends use this to
+/// label the picker entry (e.g. "(custom)" vs the builtin name) and to
+/// decide whether unknown-theme fallback paths fired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ResolvedThemeSource {
+    Builtin,
+    Custom,
+    /// The requested theme name didn't match any builtin or custom
+    /// theme; the resolver returned Empire as a safety net.
+    Fallback,
+}
+
+/// CSS-variable map for one surface (web chrome or embedded terminal).
+/// Wrapped so the JSON shape is `{ "cssVars": { ... } }` instead of a
+/// bare map, which gives room to add per-surface metadata (e.g. a
+/// `colorScheme` hint) later without breaking the wire format.
+#[derive(Debug, Clone, Serialize)]
+pub struct CssVarProjection {
+    #[serde(rename = "cssVars")]
+    pub css_vars: BTreeMap<String, String>,
+}
+
+/// Syntax-highlighter projection. Web loads the named shiki theme on
+/// theme switch.
+#[derive(Debug, Clone, Serialize)]
+pub struct SyntaxProjection {
+    #[serde(rename = "shikiTheme")]
+    pub shiki_theme: String,
+}
+
+/// Full resolved theme payload for the web. JSON shape (subset):
+///
+/// ```json
+/// {
+///   "name": "empire",
+///   "source": "builtin",
+///   "appearance": "dark",
+///   "web": { "cssVars": { "--color-surface-900": "#0f172a", ... } },
+///   "terminal": { "cssVars": { "--term-bg": "#0f172a", ... } },
+///   "syntax": { "shikiTheme": "github-dark" }
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize)]
+pub struct ResolvedTheme {
+    pub name: String,
+    pub source: ResolvedThemeSource,
+    pub appearance: ThemeAppearance,
+    pub web: CssVarProjection,
+    pub terminal: CssVarProjection,
+    pub syntax: SyntaxProjection,
+}
+
+/// Resolve a theme name into the full projection. Always succeeds:
+/// unknown names fall back to Empire (matching `load_theme`'s
+/// behaviour) and the returned `source` reports `Fallback` so the
+/// frontend can surface that.
+pub fn resolve_theme(name: &str) -> ResolvedTheme {
+    let theme = load_theme(name);
+    let source = classify_source(name);
+    let resolved_name = if matches!(source, ResolvedThemeSource::Fallback) {
+        "empire".to_string()
+    } else {
+        name.to_string()
+    };
+    let appearance = resolved_appearance(&theme);
+    ResolvedTheme {
+        name: resolved_name,
+        source,
+        appearance,
+        web: web_projection(&theme, appearance),
+        terminal: terminal_projection(&theme, appearance),
+        syntax: syntax_projection(&theme, appearance),
+    }
+}
+
+fn classify_source(name: &str) -> ResolvedThemeSource {
+    if super::is_builtin_theme(name) {
+        return ResolvedThemeSource::Builtin;
+    }
+    if super::discover_custom_themes()
+        .iter()
+        .any(|(n, _)| n == name)
+    {
+        return ResolvedThemeSource::Custom;
+    }
+    ResolvedThemeSource::Fallback
+}
+
+fn resolved_appearance(theme: &Theme) -> ThemeAppearance {
+    if let Some(a) = theme.appearance {
+        return a;
+    }
+    if relative_luminance(theme.background) >= 0.5 {
+        ThemeAppearance::Light
+    } else {
+        ThemeAppearance::Dark
+    }
+}
+
+fn web_projection(theme: &Theme, appearance: ThemeAppearance) -> CssVarProjection {
+    let mut css = BTreeMap::new();
+    let bg = theme.background;
+
+    // Named surfaces derived from background luminance. Dark themes
+    // get a deeper/lighter ramp by mixing toward black/white; light
+    // themes invert (recess toward grey, elevate toward white). See
+    // mix() and DESIGN.md for the rationale.
+    let (deeper, elevated_1, elevated_2) = match appearance {
+        ThemeAppearance::Dark => (
+            mix(bg, BLACK, 0.45),
+            mix(bg, WHITE, 0.05),
+            mix(bg, WHITE, 0.08),
+        ),
+        ThemeAppearance::Light => (
+            mix(bg, BLACK, 0.05),
+            mix(bg, WHITE, 0.35),
+            mix(bg, BLACK, 0.03),
+        ),
+    };
+    css.insert("--color-surface-950".into(), hex(deeper));
+    css.insert("--color-surface-900".into(), hex(bg));
+    css.insert("--color-surface-850".into(), hex(elevated_1));
+    css.insert("--color-surface-800".into(), hex(elevated_2));
+    css.insert("--color-surface-700".into(), hex(theme.border));
+
+    // Brand ramp anchored on theme.accent. Up two rungs lifts toward
+    // text (legibility for hover/CTAs); down one rung sinks toward
+    // background (button bodies). Matches the original Empire
+    // brand-400/500/600/700 progression so existing Tailwind classes
+    // keep their visual relationship to chrome.
+    let accent = theme.accent;
+    css.insert("--color-brand-400".into(), hex(mix(accent, WHITE, 0.2)));
+    css.insert("--color-brand-500".into(), hex(accent));
+    css.insert("--color-brand-600".into(), hex(mix(accent, BLACK, 0.15)));
+    css.insert("--color-brand-700".into(), hex(mix(accent, BLACK, 0.3)));
+
+    // Accent ramp anchored on theme.terminal_border (the existing
+    // teal-style anchor used by the TUI's accent surface), so secondary
+    // affordances like branch chips still read as the theme's secondary
+    // hue.
+    let secondary = theme.terminal_border;
+    css.insert("--color-accent-500".into(), hex(secondary));
+    css.insert(
+        "--color-accent-600".into(),
+        hex(mix(secondary, BLACK, 0.15)),
+    );
+    css.insert("--color-accent-700".into(), hex(mix(secondary, BLACK, 0.3)));
+
+    // Text ramp. text-bright is the most readable; dim is the WCAG-AA
+    // floor for descriptive copy (validated by the issue #1105 work).
+    css.insert("--color-text-primary".into(), hex(theme.text));
+    css.insert("--color-text-secondary".into(), hex(theme.hint));
+    css.insert("--color-text-muted".into(), hex(theme.hint));
+    css.insert("--color-text-dim".into(), hex(theme.dimmed));
+    css.insert("--color-text-bright".into(), hex(theme.title));
+
+    // Status colors map directly onto the TUI's semantic fields.
+    // starting + stopped don't have TUI equivalents; derive from
+    // waiting + dimmed so they still pulse against the picked theme.
+    css.insert("--color-status-running".into(), hex(theme.running));
+    css.insert("--color-status-waiting".into(), hex(theme.waiting));
+    css.insert("--color-status-fresh-idle".into(), hex(theme.fresh_idle));
+    css.insert("--color-status-idle".into(), hex(theme.idle));
+    css.insert("--color-status-error".into(), hex(theme.error));
+    css.insert(
+        "--color-status-starting".into(),
+        hex(mix(theme.waiting, BLACK, 0.1)),
+    );
+    css.insert(
+        "--color-status-stopped".into(),
+        hex(mix(theme.dimmed, BLACK, 0.1)),
+    );
+
+    // Diff + extras. Diff tokens are exposed even though the current
+    // diff cards use ad-hoc Tailwind classes; web can migrate to them
+    // incrementally without server changes.
+    css.insert("--color-diff-add".into(), hex(theme.diff_add));
+    css.insert("--color-diff-delete".into(), hex(theme.diff_delete));
+    css.insert("--color-diff-modified".into(), hex(theme.diff_modified));
+    css.insert("--color-diff-header".into(), hex(theme.diff_header));
+    css.insert("--color-selection".into(), hex(theme.selection));
+    css.insert(
+        "--color-session-selection".into(),
+        hex(theme.session_selection),
+    );
+    css.insert("--color-terminal-active".into(), hex(theme.terminal_active));
+    css.insert("--color-branch".into(), hex(theme.branch));
+    css.insert("--color-sandbox".into(), hex(theme.sandbox));
+
+    CssVarProjection { css_vars: css }
+}
+
+fn terminal_projection(theme: &Theme, appearance: ThemeAppearance) -> CssVarProjection {
+    let mut css = BTreeMap::new();
+    css.insert("--term-bg".into(), hex(theme.background));
+    css.insert("--term-fg".into(), hex(theme.text));
+    css.insert("--term-cursor".into(), hex(theme.accent));
+
+    // Derived ANSI 16 palette. Maps semantic fields to the standard
+    // ANSI slots (red=error, green=running, etc.) and lifts each by
+    // ~20% mixed toward white (dark themes) or black (light themes)
+    // for the bright variants. Not aesthetically perfect for every
+    // user theme, but it ensures the terminal honours the picked
+    // palette without forcing users to declare 16 hexes per theme.
+    let lift = match appearance {
+        ThemeAppearance::Dark => WHITE,
+        ThemeAppearance::Light => BLACK,
+    };
+    let lift_amt = 0.2;
+
+    let base = [
+        ("--term-color-0", theme.background),
+        ("--term-color-1", theme.error),
+        ("--term-color-2", theme.running),
+        ("--term-color-3", theme.waiting),
+        ("--term-color-4", theme.branch),
+        ("--term-color-5", theme.accent),
+        ("--term-color-6", theme.terminal_active),
+        ("--term-color-7", theme.text),
+    ];
+    for (name, color) in base {
+        css.insert(name.into(), hex(color));
+    }
+    css.insert("--term-color-8".into(), hex(theme.dimmed));
+    let bright = [
+        ("--term-color-9", theme.error),
+        ("--term-color-10", theme.running),
+        ("--term-color-11", theme.waiting),
+        ("--term-color-12", theme.branch),
+        ("--term-color-13", theme.accent),
+        ("--term-color-14", theme.terminal_active),
+    ];
+    for (name, color) in bright {
+        css.insert(name.into(), hex(mix(color, lift, lift_amt)));
+    }
+    css.insert("--term-color-15".into(), hex(theme.title));
+
+    CssVarProjection { css_vars: css }
+}
+
+fn syntax_projection(theme: &Theme, appearance: ThemeAppearance) -> SyntaxProjection {
+    let shiki_theme = theme
+        .syntax
+        .shiki_theme
+        .clone()
+        .unwrap_or_else(|| match appearance {
+            ThemeAppearance::Dark => "github-dark".to_string(),
+            ThemeAppearance::Light => "github-light".to_string(),
+        });
+    SyntaxProjection { shiki_theme }
+}
+
+// --- color math ---
+
+const BLACK: Color = Color::Rgb(0, 0, 0);
+const WHITE: Color = Color::Rgb(255, 255, 255);
+
+fn rgb_components(c: Color) -> (u8, u8, u8) {
+    match c {
+        Color::Rgb(r, g, b) => (r, g, b),
+        // Non-RGB colors should never reach the projection (the API
+        // loads themes in truecolor mode, never palette). Treat as
+        // black for safety.
+        _ => (0, 0, 0),
+    }
+}
+
+fn hex(c: Color) -> String {
+    let (r, g, b) = rgb_components(c);
+    format!("#{:02x}{:02x}{:02x}", r, g, b)
+}
+
+/// Linear-channel mix of two RGB colors. `t = 0` returns `a`, `t = 1`
+/// returns `b`. Not gamma-correct; that's fine for chrome derivation
+/// where the goal is visible separation, not perceptual uniformity.
+fn mix(a: Color, b: Color, t: f32) -> Color {
+    let t = t.clamp(0.0, 1.0);
+    let (ar, ag, ab) = rgb_components(a);
+    let (br, bg, bb) = rgb_components(b);
+    let lerp = |x: u8, y: u8| -> u8 {
+        let result = (x as f32) * (1.0 - t) + (y as f32) * t;
+        result.round().clamp(0.0, 255.0) as u8
+    };
+    Color::Rgb(lerp(ar, br), lerp(ag, bg), lerp(ab, bb))
+}
+
+/// Rec. 601 relative luminance (0.0 to 1.0). Coarser than WCAG's
+/// gamma-corrected formula but adequate for the dark/light split: only
+/// custom themes with mid-tone backgrounds (around 0.5) sit near the
+/// cutoff, and those are the ones that should declare `appearance`
+/// explicitly anyway.
+fn relative_luminance(c: Color) -> f32 {
+    let (r, g, b) = rgb_components(c);
+    (0.299 * r as f32 + 0.587 * g as f32 + 0.114 * b as f32) / 255.0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::tui::styles::builtin_theme_names;
+
+    #[test]
+    fn resolve_all_builtins() {
+        for name in builtin_theme_names() {
+            let r = resolve_theme(name);
+            assert_eq!(r.name, name);
+            assert_eq!(r.source, ResolvedThemeSource::Builtin);
+            assert!(
+                r.web.css_vars.contains_key("--color-surface-900"),
+                "{name}: web projection missing surface-900"
+            );
+            assert!(
+                r.terminal.css_vars.contains_key("--term-bg"),
+                "{name}: terminal projection missing term-bg"
+            );
+            assert!(
+                !r.syntax.shiki_theme.is_empty(),
+                "{name}: shiki theme empty"
+            );
+        }
+    }
+
+    #[test]
+    fn catppuccin_latte_resolves_as_light() {
+        let r = resolve_theme("catppuccin-latte");
+        assert_eq!(r.appearance, ThemeAppearance::Light);
+        assert_eq!(r.syntax.shiki_theme, "catppuccin-latte");
+    }
+
+    #[test]
+    fn dracula_resolves_as_dark_with_shiki_dracula() {
+        let r = resolve_theme("dracula");
+        assert_eq!(r.appearance, ThemeAppearance::Dark);
+        assert_eq!(r.syntax.shiki_theme, "dracula");
+    }
+
+    #[test]
+    fn unknown_theme_resolves_to_fallback() {
+        let r = resolve_theme("does-not-exist");
+        assert_eq!(r.source, ResolvedThemeSource::Fallback);
+        assert_eq!(r.name, "empire");
+    }
+
+    #[test]
+    fn css_vars_are_valid_hex() {
+        for name in builtin_theme_names() {
+            let r = resolve_theme(name);
+            for (key, value) in r.web.css_vars.iter().chain(r.terminal.css_vars.iter()) {
+                assert!(
+                    value.starts_with('#') && value.len() == 7,
+                    "{name}: var {key} = {value} not a #rrggbb"
+                );
+                assert!(
+                    value
+                        .chars()
+                        .skip(1)
+                        .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+                    "{name}: var {key} = {value} contains non-hex or uppercase",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn light_theme_inverts_surface_ramp_direction() {
+        // For a dark theme, surface-950 should be DARKER than surface-900
+        // (background); for a light theme, surface-950 should be SLIGHTLY
+        // DARKER than surface-900 as a recessed edge, while surface-850
+        // / surface-800 lift toward white. Sanity-check the ordering by
+        // luminance on Catppuccin Latte vs Empire.
+        let light = resolve_theme("catppuccin-latte");
+        let bg_light = parse_hex(light.web.css_vars.get("--color-surface-900").unwrap());
+        let elevated_light = parse_hex(light.web.css_vars.get("--color-surface-850").unwrap());
+        assert!(
+            luminance_of_hex(&elevated_light) >= luminance_of_hex(&bg_light),
+            "light theme: surface-850 ({elevated_light}) should be >= surface-900 ({bg_light})"
+        );
+
+        let dark = resolve_theme("empire");
+        let bg_dark = parse_hex(dark.web.css_vars.get("--color-surface-900").unwrap());
+        let deeper_dark = parse_hex(dark.web.css_vars.get("--color-surface-950").unwrap());
+        assert!(
+            luminance_of_hex(&deeper_dark) <= luminance_of_hex(&bg_dark),
+            "dark theme: surface-950 ({deeper_dark}) should be <= surface-900 ({bg_dark})"
+        );
+    }
+
+    fn parse_hex(s: &str) -> String {
+        s.to_string()
+    }
+    fn luminance_of_hex(hex: &str) -> f32 {
+        let s = hex.trim_start_matches('#');
+        let r = u8::from_str_radix(&s[0..2], 16).unwrap();
+        let g = u8::from_str_radix(&s[2..4], 16).unwrap();
+        let b = u8::from_str_radix(&s[4..6], 16).unwrap();
+        relative_luminance(Color::Rgb(r, g, b))
+    }
+}

--- a/src/tui/styles/resolved.rs
+++ b/src/tui/styles/resolved.rs
@@ -84,29 +84,39 @@ pub struct ResolvedTheme {
 /// behaviour) and the returned `source` reports `Fallback` so the
 /// frontend can surface that.
 pub fn resolve_theme(name: &str) -> ResolvedTheme {
+    debug!("resolve_theme enter name={}", name);
     let theme = load_theme(name);
+    debug!("resolve_theme: load_theme returned");
     let source = classify_source(name);
+    debug!("resolve_theme: classify_source -> {:?}", source);
     let resolved_name = if matches!(source, ResolvedThemeSource::Fallback) {
         "empire".to_string()
     } else {
         name.to_string()
     };
     let appearance = resolved_appearance(&theme);
+    debug!("resolve_theme: appearance -> {:?}", appearance);
     let syntax = syntax_projection(&theme, appearance);
     debug!(
-        requested = name,
-        resolved = %resolved_name,
-        source = ?source,
-        appearance = ?appearance,
-        shiki_theme = %syntax.shiki_theme,
-        "resolved theme projection"
+        "resolved theme projection name={} source={:?} appearance={:?} shiki_theme={}",
+        resolved_name, source, appearance, syntax.shiki_theme
+    );
+    let web = web_projection(&theme, appearance);
+    debug!(
+        "resolve_theme: web projection done ({} vars)",
+        web.css_vars.len()
+    );
+    let terminal = terminal_projection(&theme, appearance);
+    debug!(
+        "resolve_theme: terminal projection done ({} vars)",
+        terminal.css_vars.len()
     );
     ResolvedTheme {
         name: resolved_name,
         source,
         appearance,
-        web: web_projection(&theme, appearance),
-        terminal: terminal_projection(&theme, appearance),
+        web,
+        terminal,
         syntax,
     }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -13,6 +13,39 @@
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="preload" href="/fonts/Geist-Regular.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/GeistMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
+    <script>
+      // Pre-React theme bootstrap. Reads the cached ResolvedTheme
+      // payload from localStorage and applies its CSS variables on
+      // documentElement before React mounts. Prevents a flash of the
+      // default Empire palette when the user has picked a different
+      // theme. Safe to fail silently: useResolvedTheme will refetch
+      // and reapply once React boots. See #1189.
+      (function () {
+        try {
+          var raw = localStorage.getItem('aoe-resolved-theme');
+          if (!raw) return;
+          var theme = JSON.parse(raw);
+          var root = document.documentElement;
+          var apply = function (vars) {
+            if (!vars) return;
+            for (var k in vars) {
+              if (Object.prototype.hasOwnProperty.call(vars, k)) {
+                root.style.setProperty(k, vars[k]);
+              }
+            }
+          };
+          apply(theme && theme.web && theme.web.cssVars);
+          apply(theme && theme.terminal && theme.terminal.cssVars);
+          if (theme && theme.name) root.dataset.theme = theme.name;
+          if (theme && theme.appearance) {
+            root.dataset.themeAppearance = theme.appearance;
+            root.style.colorScheme = theme.appearance;
+          }
+        } catch (_) {
+          // Quota / parse error; fall through to React-side fetch.
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/index.html
+++ b/web/index.html
@@ -13,39 +13,16 @@
     <link rel="apple-touch-icon" href="/icon-192.png" />
     <link rel="preload" href="/fonts/Geist-Regular.woff2" as="font" type="font/woff2" crossorigin />
     <link rel="preload" href="/fonts/GeistMono-Regular.woff2" as="font" type="font/woff2" crossorigin />
-    <script>
-      // Pre-React theme bootstrap. Reads the cached ResolvedTheme
-      // payload from localStorage and applies its CSS variables on
-      // documentElement before React mounts. Prevents a flash of the
-      // default Empire palette when the user has picked a different
-      // theme. Safe to fail silently: useResolvedTheme will refetch
-      // and reapply once React boots. See #1189.
-      (function () {
-        try {
-          var raw = localStorage.getItem('aoe-resolved-theme');
-          if (!raw) return;
-          var theme = JSON.parse(raw);
-          var root = document.documentElement;
-          var apply = function (vars) {
-            if (!vars) return;
-            for (var k in vars) {
-              if (Object.prototype.hasOwnProperty.call(vars, k)) {
-                root.style.setProperty(k, vars[k]);
-              }
-            }
-          };
-          apply(theme && theme.web && theme.web.cssVars);
-          apply(theme && theme.terminal && theme.terminal.cssVars);
-          if (theme && theme.name) root.dataset.theme = theme.name;
-          if (theme && theme.appearance) {
-            root.dataset.themeAppearance = theme.appearance;
-            root.style.colorScheme = theme.appearance;
-          }
-        } catch (_) {
-          // Quota / parse error; fall through to React-side fetch.
-        }
-      })();
-    </script>
+    <!--
+      Pre-React theme bootstrap. Applies the cached ResolvedTheme
+      payload from localStorage to documentElement before React
+      mounts so the dashboard doesn't flash the default Empire
+      palette when the user has picked a different theme. Loaded as
+      an external script (not inline) because the dashboard's CSP
+      is `script-src 'self' 'wasm-unsafe-eval'` with no unsafe-inline.
+      See #1189 + the review on PR #1197.
+    -->
+    <script src="/theme-bootstrap.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/theme-bootstrap.js
+++ b/web/public/theme-bootstrap.js
@@ -1,0 +1,36 @@
+// Pre-React theme bootstrap. Reads the cached ResolvedTheme payload
+// from localStorage and applies its CSS variables on documentElement
+// before React mounts. Prevents a flash of the default Empire palette
+// when the user has picked a different theme. Safe to fail silently:
+// useResolvedTheme will refetch and reapply once React boots.
+//
+// Lives as a static file (not inline in index.html) because the
+// dashboard's CSP is `script-src 'self' 'wasm-unsafe-eval'` with no
+// `unsafe-inline` / nonce / hash, so the browser would refuse to run
+// an inline <script>. Referenced from web/index.html via
+// `<script src="/theme-bootstrap.js"></script>`. See #1189.
+(function () {
+  try {
+    var raw = localStorage.getItem('aoe-resolved-theme');
+    if (!raw) return;
+    var theme = JSON.parse(raw);
+    var root = document.documentElement;
+    var apply = function (vars) {
+      if (!vars) return;
+      for (var k in vars) {
+        if (Object.prototype.hasOwnProperty.call(vars, k)) {
+          root.style.setProperty(k, vars[k]);
+        }
+      }
+    };
+    apply(theme && theme.web && theme.web.cssVars);
+    apply(theme && theme.terminal && theme.terminal.cssVars);
+    if (theme && theme.name) root.dataset.theme = theme.name;
+    if (theme && theme.appearance) {
+      root.dataset.themeAppearance = theme.appearance;
+      root.style.colorScheme = theme.appearance;
+    }
+  } catch (_) {
+    // Quota / parse error; fall through to React-side fetch.
+  }
+})();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,8 +76,9 @@ const RIGHT_PANEL_COLLAPSED_KEY = "aoe-right-collapsed";
 export default function App() {
   // Apply the user-selected theme as CSS custom properties on the root
   // element. Runs once on mount + on settings-driven theme changes.
-  // The pre-React script in index.html paints the cached theme before
-  // hydration; this hook keeps it in sync with the server's view.
+  // The pre-React /theme-bootstrap.js (referenced from index.html)
+  // paints the cached theme before hydration; this hook keeps it in
+  // sync with the server's view.
   useResolvedTheme();
   const [loginRequired, setLoginRequired] = useState<boolean | null>(null);
   const [loginAuthenticated, setLoginAuthenticated] = useState(true);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { CockpitPrefsProvider } from "./lib/cockpitPrefs";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
+import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
@@ -73,6 +74,11 @@ import { UpdateBanner } from "./components/UpdateBanner";
 const RIGHT_PANEL_COLLAPSED_KEY = "aoe-right-collapsed";
 
 export default function App() {
+  // Apply the user-selected theme as CSS custom properties on the root
+  // element. Runs once on mount + on settings-driven theme changes.
+  // The pre-React script in index.html paints the cached theme before
+  // hydration; this hook keeps it in sync with the server's view.
+  useResolvedTheme();
   const [loginRequired, setLoginRequired] = useState<boolean | null>(null);
   const [loginAuthenticated, setLoginAuthenticated] = useState(true);
   const [tokenExpired, setTokenExpired] = useState(false);

--- a/web/src/components/cockpit/Markdown.tsx
+++ b/web/src/components/cockpit/Markdown.tsx
@@ -126,7 +126,7 @@ function ShikiSyntaxHighlighter({
   code,
 }: SyntaxHighlighterProps) {
   const [html, setHtml] = useState<string | null>(null);
-  const shikiTheme = useShikiTheme();
+  const shiki = useShikiTheme();
   useEffect(() => {
     let cancelled = false;
     if (!language) return;
@@ -134,7 +134,10 @@ function ShikiSyntaxHighlighter({
       try {
         const langKey = langKeyForExt(language) ?? language;
         await loadLanguage(langKey);
-        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
+        const resolvedTheme = await ensureThemeLoaded(
+          shiki.theme,
+          shiki.appearance,
+        );
         const hl = await getHighlighter();
         if (cancelled) return;
         setHtml(
@@ -147,7 +150,7 @@ function ShikiSyntaxHighlighter({
     return () => {
       cancelled = true;
     };
-  }, [language, code, shikiTheme]);
+  }, [language, code, shiki.theme, shiki.appearance]);
 
   if (html) {
     return (

--- a/web/src/components/cockpit/Markdown.tsx
+++ b/web/src/components/cockpit/Markdown.tsx
@@ -22,10 +22,12 @@ import { useEffect, useState } from "react";
 import remarkGfm from "remark-gfm";
 
 import {
+  ensureThemeLoaded,
   getHighlighter,
   langKeyForExt,
   loadLanguage,
 } from "../../lib/highlighter";
+import { useShikiTheme } from "../../hooks/useShikiTheme";
 
 interface Props {
   text: string;
@@ -115,15 +117,16 @@ function TableWithScroll({
 
 /**
  * Shiki-backed code block. Loads the language module on demand the
- * first time we see it, then re-renders with the `github-dark` theme.
- * Falls back to a plain <pre> while the language is loading or for
- * unknown languages.
+ * first time we see it, then renders against the current resolved
+ * theme (from useShikiTheme). Falls back to a plain <pre> while the
+ * language is loading or for unknown languages.
  */
 function ShikiSyntaxHighlighter({
   language,
   code,
 }: SyntaxHighlighterProps) {
   const [html, setHtml] = useState<string | null>(null);
+  const shikiTheme = useShikiTheme();
   useEffect(() => {
     let cancelled = false;
     if (!language) return;
@@ -131,10 +134,11 @@ function ShikiSyntaxHighlighter({
       try {
         const langKey = langKeyForExt(language) ?? language;
         await loadLanguage(langKey);
+        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
         const hl = await getHighlighter();
         if (cancelled) return;
         setHtml(
-          hl.codeToHtml(code, { lang: langKey, theme: "github-dark" }),
+          hl.codeToHtml(code, { lang: langKey, theme: resolvedTheme }),
         );
       } catch {
         // Unknown lang → fall through to plain rendering.
@@ -143,7 +147,7 @@ function ShikiSyntaxHighlighter({
     return () => {
       cancelled = true;
     };
-  }, [language, code]);
+  }, [language, code, shikiTheme]);
 
   if (html) {
     return (

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -34,7 +34,13 @@ import {
   Trash2,
 } from "lucide-react";
 
-import { getHighlighter, langKeyForExt, loadLanguage } from "../../lib/highlighter";
+import {
+  ensureThemeLoaded,
+  getHighlighter,
+  langKeyForExt,
+  loadLanguage,
+} from "../../lib/highlighter";
+import { useShikiTheme } from "../../hooks/useShikiTheme";
 import { hasAnsi, parseAnsi, type AnsiStyle } from "../../lib/ansi";
 import { parseJsonObject, pickFirst, pickStr } from "../../lib/cockpitArgs";
 import { useCockpitPrefs } from "../../lib/cockpitPrefs";
@@ -412,6 +418,7 @@ function HighlightedBlock({
 }) {
   const [html, setHtml] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
+  const shikiTheme = useShikiTheme();
   const unwrapped = unwrapMarkdownFence(text);
   const effectiveText = unwrapped.text;
   const effectiveLang = unwrapped.lang ?? language;
@@ -435,11 +442,12 @@ function HighlightedBlock({
       try {
         const langKey = langKeyForExt(effectiveLang) ?? effectiveLang;
         await loadLanguage(langKey);
+        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
         const hl = await getHighlighter();
         if (cancelled) return;
         const out = hl.codeToHtml(shown, {
           lang: langKey,
-          theme: "github-dark",
+          theme: resolvedTheme,
         });
         setHtml(out);
       } catch {
@@ -449,7 +457,7 @@ function HighlightedBlock({
     return () => {
       cancelled = true;
     };
-  }, [effectiveLang, shown]);
+  }, [effectiveLang, shown, shikiTheme, ansi]);
 
   return (
     <div className="border-t border-surface-800 bg-surface-950">

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -418,7 +418,7 @@ function HighlightedBlock({
 }) {
   const [html, setHtml] = useState<string | null>(null);
   const [showAll, setShowAll] = useState(false);
-  const shikiTheme = useShikiTheme();
+  const shiki = useShikiTheme();
   const unwrapped = unwrapMarkdownFence(text);
   const effectiveText = unwrapped.text;
   const effectiveLang = unwrapped.lang ?? language;
@@ -442,7 +442,10 @@ function HighlightedBlock({
       try {
         const langKey = langKeyForExt(effectiveLang) ?? effectiveLang;
         await loadLanguage(langKey);
-        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
+        const resolvedTheme = await ensureThemeLoaded(
+          shiki.theme,
+          shiki.appearance,
+        );
         const hl = await getHighlighter();
         if (cancelled) return;
         const out = hl.codeToHtml(shown, {
@@ -457,7 +460,7 @@ function HighlightedBlock({
     return () => {
       cancelled = true;
     };
-  }, [effectiveLang, shown, shikiTheme, ansi]);
+  }, [effectiveLang, shown, shiki.theme, shiki.appearance, ansi]);
 
   return (
     <div className="border-t border-surface-800 bg-surface-950">

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -3,10 +3,12 @@ import { CommentMarkdown } from "./CommentMarkdown";
 import type { DiffCommentsSentinelPayload } from "./buildPrompt";
 import type { DiffComment } from "./types";
 import {
+  ensureThemeLoaded,
   getHighlighter,
   langKeyForExt,
   loadLanguage,
 } from "../../../lib/highlighter";
+import { useShikiTheme } from "../../../hooks/useShikiTheme";
 
 interface Props {
   payload: DiffCommentsSentinelPayload;
@@ -75,6 +77,7 @@ function HighlightedSnippet({
   filePath: string;
 }) {
   const [html, setHtml] = useState<string | null>(null);
+  const shikiTheme = useShikiTheme();
   useEffect(() => {
     let cancelled = false;
     const hint =
@@ -86,11 +89,12 @@ function HighlightedSnippet({
       try {
         const langKey = langKeyForExt(hint) ?? hint;
         await loadLanguage(langKey);
+        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
         const hl = await getHighlighter();
         if (cancelled) return;
         if (!hl.getLoadedLanguages().includes(langKey)) return;
         setHtml(
-          hl.codeToHtml(code, { lang: langKey, theme: "github-dark" }),
+          hl.codeToHtml(code, { lang: langKey, theme: resolvedTheme }),
         );
       } catch {
         // Unknown lang → fall through to plain rendering.
@@ -99,7 +103,7 @@ function HighlightedSnippet({
     return () => {
       cancelled = true;
     };
-  }, [code, language, filePath]);
+  }, [code, language, filePath, shikiTheme]);
 
   if (html) {
     // Shiki HTML-escapes the user-supplied `code` before tokenizing, so

--- a/web/src/components/diff/comments/DiffCommentsUserCard.tsx
+++ b/web/src/components/diff/comments/DiffCommentsUserCard.tsx
@@ -77,7 +77,7 @@ function HighlightedSnippet({
   filePath: string;
 }) {
   const [html, setHtml] = useState<string | null>(null);
-  const shikiTheme = useShikiTheme();
+  const shiki = useShikiTheme();
   useEffect(() => {
     let cancelled = false;
     const hint =
@@ -89,7 +89,10 @@ function HighlightedSnippet({
       try {
         const langKey = langKeyForExt(hint) ?? hint;
         await loadLanguage(langKey);
-        const resolvedTheme = await ensureThemeLoaded(shikiTheme);
+        const resolvedTheme = await ensureThemeLoaded(
+          shiki.theme,
+          shiki.appearance,
+        );
         const hl = await getHighlighter();
         if (cancelled) return;
         if (!hl.getLoadedLanguages().includes(langKey)) return;
@@ -103,7 +106,7 @@ function HighlightedSnippet({
     return () => {
       cancelled = true;
     };
-  }, [code, language, filePath, shikiTheme]);
+  }, [code, language, filePath, shiki.theme, shiki.appearance]);
 
   if (html) {
     // Shiki HTML-escapes the user-supplied `code` before tokenizing, so

--- a/web/src/components/settings/ThemeSettings.tsx
+++ b/web/src/components/settings/ThemeSettings.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { fetchThemes } from "../../lib/api";
+import { dispatchThemePickerChanged } from "../../hooks/useResolvedTheme";
 import { SelectField } from "./FormFields";
 
 interface Props {
@@ -19,12 +20,20 @@ export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
   const save = (field: string, value: unknown) => {
     onUpdate({ theme: { ...theme, [field]: value } });
     onSaveField("theme", field, value);
+    // Repaint the web dashboard immediately on theme pick. The picker
+    // writes config.toml synchronously above; tell useResolvedTheme to
+    // refetch and apply without waiting for a full settings sync.
+    if (field === "name") {
+      dispatchThemePickerChanged(typeof value === "string" ? value : undefined);
+    }
   };
 
   return (
     <div className="space-y-4">
       <p className="text-xs text-text-dim">
-        These settings apply to the TUI (local tmux sessions), not the web dashboard.
+        Theme applies to both the TUI and the web dashboard. Custom themes
+        in <code>~/.agent-of-empires/themes/*.toml</code> appear alongside
+        the builtins.
       </p>
       <SelectField
         label="Theme"
@@ -44,6 +53,10 @@ export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
           { value: "palette", label: "Palette (256 colors)" },
         ]}
       />
+      <p className="text-xs text-text-dim">
+        Color mode only affects the TUI; the web dashboard always uses
+        truecolor.
+      </p>
     </div>
   );
 }

--- a/web/src/hooks/useHighlightedLines.ts
+++ b/web/src/hooks/useHighlightedLines.ts
@@ -46,7 +46,7 @@ export function useHighlightedLines(
 ): HighlightResult {
   const [state, setState] = useState<GridState | null>(null);
   const requestRef = useRef(0);
-  const shikiTheme = useShikiTheme();
+  const shiki = useShikiTheme();
 
   const hasLang = !!langImportForPath(filePath);
 
@@ -57,7 +57,10 @@ export function useHighlightedLines(
     if (!langImport) return;
 
     (async () => {
-      const resolvedTheme = await ensureThemeLoaded(shikiTheme);
+      const resolvedTheme = await ensureThemeLoaded(
+        shiki.theme,
+        shiki.appearance,
+      );
       const hl = await getHighlighter();
 
       // Load the grammar if not already registered.
@@ -114,7 +117,7 @@ export function useHighlightedLines(
         setState({ grid: result, path: filePath });
       }
     })();
-  }, [hunks, filePath, shikiTheme]);
+  }, [hunks, filePath, shiki.theme, shiki.appearance]);
 
   // Only return the grid if it matches the current file path.
   const tokens = state && state.path === filePath ? state.grid : null;

--- a/web/src/hooks/useHighlightedLines.ts
+++ b/web/src/hooks/useHighlightedLines.ts
@@ -1,10 +1,12 @@
 import { useEffect, useRef, useState } from "react";
 import {
+  ensureThemeLoaded,
   getHighlighter,
   langImportForPath,
   type ThemedToken,
 } from "../lib/highlighter";
 import type { RichDiffHunk } from "../lib/types";
+import { useShikiTheme } from "./useShikiTheme";
 
 /** A single token with content and an optional foreground color. */
 export interface SyntaxToken {
@@ -44,6 +46,7 @@ export function useHighlightedLines(
 ): HighlightResult {
   const [state, setState] = useState<GridState | null>(null);
   const requestRef = useRef(0);
+  const shikiTheme = useShikiTheme();
 
   const hasLang = !!langImportForPath(filePath);
 
@@ -54,6 +57,7 @@ export function useHighlightedLines(
     if (!langImport) return;
 
     (async () => {
+      const resolvedTheme = await ensureThemeLoaded(shikiTheme);
       const hl = await getHighlighter();
 
       // Load the grammar if not already registered.
@@ -91,7 +95,7 @@ export function useHighlightedLines(
           try {
             const { tokens } = hl.codeToTokens(raw, {
               lang: langId,
-              theme: "github-dark",
+              theme: resolvedTheme,
             });
             const mapped: SyntaxToken[] = (
               tokens[0] as ThemedToken[] | undefined
@@ -110,7 +114,7 @@ export function useHighlightedLines(
         setState({ grid: result, path: filePath });
       }
     })();
-  }, [hunks, filePath]);
+  }, [hunks, filePath, shikiTheme]);
 
   // Only return the grid if it matches the current file path.
   const tokens = state && state.path === filePath ? state.grid : null;

--- a/web/src/hooks/useResolvedTheme.ts
+++ b/web/src/hooks/useResolvedTheme.ts
@@ -1,0 +1,68 @@
+import { useEffect, useState } from "react";
+import { fetchCurrentTheme, fetchResolvedTheme } from "../lib/api";
+import {
+  applyResolvedTheme,
+  dispatchThemeChanged,
+  readCachedResolvedTheme,
+  type ResolvedTheme,
+} from "../lib/theme";
+
+/** Event name fired by the settings UI after the user picks a new
+ *  theme. The hook listens for it and refetches /api/theme/current
+ *  (or, if the event carries a `detail.name`, /api/themes/:name) so
+ *  the dashboard repaints without a settings round-trip. */
+export const THEME_PICKER_CHANGED_EVENT = "aoe:theme-picker-changed";
+
+export interface ThemePickerChangedDetail {
+  /** New theme name selected by the user. Optional: when omitted the
+   *  hook refetches /api/theme/current. */
+  name?: string;
+}
+
+/** Apply the user's selected theme on mount and on settings updates.
+ *  Reads the cached payload from localStorage first to prevent FOUC,
+ *  then fetches the authoritative payload and applies it. */
+export function useResolvedTheme(): ResolvedTheme | null {
+  const [theme, setTheme] = useState<ResolvedTheme | null>(() =>
+    readCachedResolvedTheme(),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCurrentTheme().then((next) => {
+      if (cancelled || !next) return;
+      applyResolvedTheme(next);
+      dispatchThemeChanged(next);
+      setTheme(next);
+    });
+
+    const onChange = (event: Event) => {
+      const detail = (event as CustomEvent<ThemePickerChangedDetail>).detail;
+      const promise = detail?.name
+        ? fetchResolvedTheme(detail.name)
+        : fetchCurrentTheme();
+      promise.then((next) => {
+        if (!next) return;
+        applyResolvedTheme(next);
+        dispatchThemeChanged(next);
+        setTheme(next);
+      });
+    };
+    window.addEventListener(THEME_PICKER_CHANGED_EVENT, onChange);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(THEME_PICKER_CHANGED_EVENT, onChange);
+    };
+  }, []);
+
+  return theme;
+}
+
+/** Fire from the settings UI after the user picks a new theme. */
+export function dispatchThemePickerChanged(name?: string): void {
+  window.dispatchEvent(
+    new CustomEvent<ThemePickerChangedDetail>(THEME_PICKER_CHANGED_EVENT, {
+      detail: { name },
+    }),
+  );
+}

--- a/web/src/hooks/useResolvedTheme.ts
+++ b/web/src/hooks/useResolvedTheme.ts
@@ -28,29 +28,36 @@ export function useResolvedTheme(): ResolvedTheme | null {
   );
 
   useEffect(() => {
-    let cancelled = false;
-    fetchCurrentTheme().then((next) => {
-      if (cancelled || !next) return;
+    // Monotonic sequence numbers tag every in-flight fetch. A fetch's
+    // response is applied only if its sequence is greater than the
+    // most recently applied one, so a slow mount fetch landing after
+    // a faster user-initiated picker fetch can't overwrite the user's
+    // pick. Unmount drops `unmounted` so late responses are no-ops.
+    let nextSeq = 0;
+    let lastAppliedSeq = 0;
+    let unmounted = false;
+    const apply = (next: ResolvedTheme | null, seq: number) => {
+      if (unmounted || !next || seq <= lastAppliedSeq) return;
+      lastAppliedSeq = seq;
       applyResolvedTheme(next);
       dispatchThemeChanged(next);
       setTheme(next);
-    });
+    };
+
+    const mountSeq = ++nextSeq;
+    fetchCurrentTheme().then((next) => apply(next, mountSeq));
 
     const onChange = (event: Event) => {
       const detail = (event as CustomEvent<ThemePickerChangedDetail>).detail;
+      const seq = ++nextSeq;
       const promise = detail?.name
         ? fetchResolvedTheme(detail.name)
         : fetchCurrentTheme();
-      promise.then((next) => {
-        if (!next) return;
-        applyResolvedTheme(next);
-        dispatchThemeChanged(next);
-        setTheme(next);
-      });
+      promise.then((next) => apply(next, seq));
     };
     window.addEventListener(THEME_PICKER_CHANGED_EVENT, onChange);
     return () => {
-      cancelled = true;
+      unmounted = true;
       window.removeEventListener(THEME_PICKER_CHANGED_EVENT, onChange);
     };
   }, []);

--- a/web/src/hooks/useShikiTheme.ts
+++ b/web/src/hooks/useShikiTheme.ts
@@ -6,25 +6,41 @@ import {
 } from "../lib/theme";
 import { DEFAULT_SHIKI_THEME } from "../lib/highlighter";
 
-/** Current Shiki theme name from the resolved theme. Updates when the
- *  user picks a new theme (via the THEME_CHANGED_EVENT broadcast from
- *  useResolvedTheme). Components that highlight code should put the
- *  returned value in their effect dependency list so blocks re-render
+export interface ShikiThemeState {
+  /** Bundled Shiki theme name to pass to ensureThemeLoaded. */
+  theme: string;
+  /** Appearance of the active AoE theme; passed to ensureThemeLoaded
+   *  so a light AoE theme that names an unbundled Shiki theme falls
+   *  back to `github-light` instead of `github-dark`. */
+  appearance: "dark" | "light";
+}
+
+/** Current Shiki theme + appearance from the resolved theme. Updates
+ *  when the user picks a new theme (via THEME_CHANGED_EVENT broadcast
+ *  from useResolvedTheme). Components that highlight code should put
+ *  both fields in their effect dependency list so blocks re-render
  *  against the new theme. */
-export function useShikiTheme(): string {
-  const [theme, setTheme] = useState<string>(() => {
+export function useShikiTheme(): ShikiThemeState {
+  const [state, setState] = useState<ShikiThemeState>(() => {
     const cached = readCachedResolvedTheme();
-    return cached?.syntax.shikiTheme ?? DEFAULT_SHIKI_THEME;
+    return {
+      theme: cached?.syntax.shikiTheme ?? DEFAULT_SHIKI_THEME,
+      appearance: cached?.appearance ?? "dark",
+    };
   });
   useEffect(() => {
     const onChange = (event: Event) => {
       const next = (event as CustomEvent<ResolvedTheme>).detail;
-      if (next?.syntax.shikiTheme) setTheme(next.syntax.shikiTheme);
+      if (!next) return;
+      setState({
+        theme: next.syntax.shikiTheme,
+        appearance: next.appearance,
+      });
     };
     window.addEventListener(THEME_CHANGED_EVENT, onChange);
     return () => {
       window.removeEventListener(THEME_CHANGED_EVENT, onChange);
     };
   }, []);
-  return theme;
+  return state;
 }

--- a/web/src/hooks/useShikiTheme.ts
+++ b/web/src/hooks/useShikiTheme.ts
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import {
+  readCachedResolvedTheme,
+  THEME_CHANGED_EVENT,
+  type ResolvedTheme,
+} from "../lib/theme";
+import { DEFAULT_SHIKI_THEME } from "../lib/highlighter";
+
+/** Current Shiki theme name from the resolved theme. Updates when the
+ *  user picks a new theme (via the THEME_CHANGED_EVENT broadcast from
+ *  useResolvedTheme). Components that highlight code should put the
+ *  returned value in their effect dependency list so blocks re-render
+ *  against the new theme. */
+export function useShikiTheme(): string {
+  const [theme, setTheme] = useState<string>(() => {
+    const cached = readCachedResolvedTheme();
+    return cached?.syntax.shikiTheme ?? DEFAULT_SHIKI_THEME;
+  });
+  useEffect(() => {
+    const onChange = (event: Event) => {
+      const next = (event as CustomEvent<ResolvedTheme>).detail;
+      if (next?.syntax.shikiTheme) setTheme(next.syntax.shikiTheme);
+    };
+    window.addEventListener(THEME_CHANGED_EVENT, onChange);
+    return () => {
+      window.removeEventListener(THEME_CHANGED_EVENT, onChange);
+    };
+  }, []);
+  return theme;
+}

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -194,27 +194,13 @@ export function useTerminal(
     termEl.style.height = "100%";
     container.appendChild(termEl);
 
-    // Apply custom theme colors via CSS custom properties.
-    // wterm uses --term-* variables for theming instead of a JS theme object.
-    termEl.style.setProperty("--term-bg", "#141416");
-    termEl.style.setProperty("--term-fg", "#e4e4e7");
-    termEl.style.setProperty("--term-cursor", "#d97706");
-    termEl.style.setProperty("--term-color-0", "#1c1c1f");
-    termEl.style.setProperty("--term-color-1", "#ef4444");
-    termEl.style.setProperty("--term-color-2", "#22c55e");
-    termEl.style.setProperty("--term-color-3", "#fbbf24");
-    termEl.style.setProperty("--term-color-4", "#60a5fa");
-    termEl.style.setProperty("--term-color-5", "#a78bfa");
-    termEl.style.setProperty("--term-color-6", "#22d3ee");
-    termEl.style.setProperty("--term-color-7", "#e4e4e7");
-    termEl.style.setProperty("--term-color-8", "#52525b");
-    termEl.style.setProperty("--term-color-9", "#f87171");
-    termEl.style.setProperty("--term-color-10", "#4ade80");
-    termEl.style.setProperty("--term-color-11", "#fde68a");
-    termEl.style.setProperty("--term-color-12", "#93c5fd");
-    termEl.style.setProperty("--term-color-13", "#c4b5fd");
-    termEl.style.setProperty("--term-color-14", "#67e8f9");
-    termEl.style.setProperty("--term-color-15", "#fafafa");
+    // wterm reads --term-* CSS variables for theming. Background,
+    // foreground, cursor, and the 16 ANSI slots come from the resolved
+    // theme (set on document.documentElement by useResolvedTheme) and
+    // cascade in. Only font vars are per-terminal-instance since they
+    // track the user's font-size setting; setting them on the element
+    // (not the root) lets each terminal instance scale independently
+    // under pinch-zoom.
     termEl.style.setProperty(
       "--term-font-family",
       "'Geist Mono', ui-monospace, 'SFMono-Regular', monospace",
@@ -1196,6 +1182,24 @@ export function useTerminal(
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sessionId, wsPath]);
+
+  // Repaint the live terminal when the user picks a new theme. The
+  // resolved theme's --term-* variables live on documentElement and
+  // cascade in, but wterm only re-reads them on draw, so a quiet PTY
+  // would otherwise keep painting in the old palette until the next
+  // byte arrives. Calling term.resize with the current size forces a
+  // re-layout without changing the geometry.
+  useEffect(() => {
+    const onThemeChanged = () => {
+      const term = termRef.current;
+      if (!term) return;
+      term.resize(term.cols, term.rows);
+    };
+    window.addEventListener("aoe:theme-changed", onThemeChanged);
+    return () => {
+      window.removeEventListener("aoe:theme-changed", onThemeChanged);
+    };
+  }, []);
 
   // Apply font size changes from settings UI to the live terminal.
   useEffect(() => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -88,6 +88,21 @@
   --color-status-starting: #f59e0b;
   --color-status-stopped: #52525b;
 
+  /* Extended semantic tokens populated by the resolved theme
+     projection (see src/tui/styles/resolved.rs). These build-time
+     defaults paint a sensible Empire-aligned dashboard on cold load
+     before useResolvedTheme has fetched and applied the user's
+     selection. */
+  --color-selection: #26324b;
+  --color-session-selection: #37415c;
+  --color-terminal-active: #0d9488;
+  --color-branch: #0d9488;
+  --color-sandbox: #94a3b8;
+  --color-diff-add: #22c55e;
+  --color-diff-delete: #ef4444;
+  --color-diff-modified: #fbbf24;
+  --color-diff-header: #0d9488;
+
   /* Typography */
   --font-sans: 'Geist Sans', system-ui, -apple-system, sans-serif;
   --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', monospace;
@@ -147,15 +162,15 @@ body {
   margin: 0.5rem 0;
 }
 .cockpit-markdown blockquote.cockpit-callout-warn {
-  border-left: 3px solid #f59e0b;
-  background: rgb(245 158 11 / 0.08);
-  color: #fcd34d;
+  border-left: 3px solid var(--color-status-waiting);
+  background: color-mix(in srgb, var(--color-status-waiting) 8%, transparent);
+  color: var(--color-status-waiting);
   font-style: normal;
   padding: 0.5rem 0.75rem;
   border-radius: 0.25rem;
 }
 .cockpit-markdown blockquote.cockpit-callout-warn p { margin: 0; }
-.cockpit-markdown blockquote.cockpit-callout-warn strong { color: #fde68a; }
+.cockpit-markdown blockquote.cockpit-callout-warn strong { color: var(--color-text-bright); }
 .cockpit-markdown :where(p, li) > code {
   background: var(--color-surface-800);
   padding: 0 0.25rem;
@@ -215,10 +230,11 @@ body {
   vertical-align: top;
   white-space: nowrap;
   color: var(--color-text-secondary);
-  border-bottom: 1px solid rgba(28, 28, 31, 0.5);
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-surface-900) 50%, transparent);
 }
 .cockpit-markdown tbody tr:nth-child(even) {
-  background: rgba(28, 28, 31, 0.3);
+  background: color-mix(in srgb, var(--color-surface-900) 30%, transparent);
 }
 .cockpit-markdown tbody tr:hover {
   background: var(--color-surface-800);

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -103,6 +103,33 @@
   --color-diff-modified: #fbbf24;
   --color-diff-header: #0d9488;
 
+  /* Embedded terminal cold-load defaults. useResolvedTheme refetches
+     and overrides these once the resolved palette lands, but on a
+     first visit with no localStorage cache the wterm element would
+     otherwise paint with the WASM bridge's hardcoded defaults until
+     the next frame. These match the Empire palette projected by
+     src/tui/styles/resolved.rs::terminal_projection so the pre-fetch
+     paint matches the post-fetch paint for the default theme. */
+  --term-bg: #0f172a;
+  --term-fg: #cbd5e1;
+  --term-cursor: #d97706;
+  --term-color-0: #0f172a;
+  --term-color-1: #ef4444;
+  --term-color-2: #22c55e;
+  --term-color-3: #fbbf24;
+  --term-color-4: #0d9488;
+  --term-color-5: #d97706;
+  --term-color-6: #0d9488;
+  --term-color-7: #cbd5e1;
+  --term-color-8: #64748b;
+  --term-color-9: #f87171;
+  --term-color-10: #4ade80;
+  --term-color-11: #fde68a;
+  --term-color-12: #38bdf8;
+  --term-color-13: #fbbf24;
+  --term-color-14: #2dd4bf;
+  --term-color-15: #fbbf24;
+
   /* Typography */
   --font-sans: 'Geist Sans', system-ui, -apple-system, sans-serif;
   --font-mono: 'Geist Mono', ui-monospace, 'SFMono-Regular', monospace;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -237,8 +237,28 @@ export async function updateProfileSettings(
 
 // --- Themes & Sounds ---
 
+import type { ResolvedTheme } from "./theme";
+
 export async function fetchThemes(): Promise<string[]> {
   return (await fetchJson<string[]>("/api/themes")) ?? [];
+}
+
+/** Fetch the resolved theme projection (web CSS vars, terminal CSS
+ *  vars, syntax highlighter selection) for a named theme. The server
+ *  falls back to Empire for unknown names; check `source` to detect. */
+export function fetchResolvedTheme(
+  name: string,
+): Promise<ResolvedTheme | null> {
+  return fetchJson<ResolvedTheme>(
+    `/api/themes/${encodeURIComponent(name)}`,
+  );
+}
+
+/** Fetch the resolved theme for the active profile's current
+ *  selection. Server reads from profile_config so per-profile overrides
+ *  land in the right place. */
+export function fetchCurrentTheme(): Promise<ResolvedTheme | null> {
+  return fetchJson<ResolvedTheme>("/api/theme/current");
 }
 
 export async function fetchSounds(): Promise<string[]> {
@@ -305,6 +325,13 @@ export interface ServerAbout {
    *  so the rendered transcript matches the user's chosen ceiling
    *  instead of clipping at a hard-coded frontend constant. See #1111. */
   cockpit_replay_events: number;
+  /** Active theme name. Frontends use this as the cache key for the
+   *  resolved-theme payload fetched from /api/theme/current. See #1189. */
+  theme_name: string;
+  /** Resolved appearance (dark/light) of the active theme. Surfaced
+   *  so the pre-React bootstrap script can pick the right cached CSS
+   *  variable set and color-scheme before hydration. See #1189. */
+  theme_appearance: "dark" | "light";
 }
 
 export async function setCockpitMaster(

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -325,13 +325,6 @@ export interface ServerAbout {
    *  so the rendered transcript matches the user's chosen ceiling
    *  instead of clipping at a hard-coded frontend constant. See #1111. */
   cockpit_replay_events: number;
-  /** Active theme name. Frontends use this as the cache key for the
-   *  resolved-theme payload fetched from /api/theme/current. See #1189. */
-  theme_name: string;
-  /** Resolved appearance (dark/light) of the active theme. Surfaced
-   *  so the pre-React bootstrap script can pick the right cached CSS
-   *  variable set and color-scheme before hydration. See #1189. */
-  theme_appearance: "dark" | "light";
 }
 
 export async function setCockpitMaster(

--- a/web/src/lib/highlighter.ts
+++ b/web/src/lib/highlighter.ts
@@ -19,9 +19,21 @@ const SHIKI_THEME_IMPORTS: Record<string, () => Promise<unknown>> = {
   "rose-pine": () => import("shiki/themes/rose-pine.mjs"),
 };
 
-/** Fallback when the resolver names a Shiki theme this bundle doesn't
- *  carry (user-defined themes with arbitrary shiki_theme entries). */
+/** Fallback Shiki themes when the resolver names a theme this bundle
+ *  doesn't carry (user-defined themes with arbitrary shiki_theme
+ *  entries). Picked by appearance so a light AoE theme falling back
+ *  doesn't end up rendering code on a light surface with a dark
+ *  syntax theme. */
 export const DEFAULT_SHIKI_THEME = "github-dark";
+export const DEFAULT_SHIKI_THEME_LIGHT = "github-light";
+
+export function fallbackShikiTheme(
+  appearance: "dark" | "light" | undefined,
+): string {
+  return appearance === "light"
+    ? DEFAULT_SHIKI_THEME_LIGHT
+    : DEFAULT_SHIKI_THEME;
+}
 
 /**
  * Returns a singleton Shiki highlighter. Languages are loaded on demand
@@ -45,11 +57,16 @@ export async function getHighlighter(): Promise<HighlighterCore> {
 
 /** Lazy-load a Shiki theme module and register it on the singleton
  *  highlighter. Returns the name the caller should pass to
- *  `codeToHtml` / `codeToTokens` (the requested name if it loaded
- *  cleanly, `DEFAULT_SHIKI_THEME` otherwise). Idempotent. */
-export async function ensureThemeLoaded(name: string): Promise<string> {
+ *  `codeToHtml` / `codeToTokens`: the requested name if it loaded
+ *  cleanly, otherwise an appearance-appropriate fallback
+ *  (`github-dark` / `github-light`) so a light AoE theme isn't
+ *  rendered with a dark syntax palette. Idempotent. */
+export async function ensureThemeLoaded(
+  name: string,
+  appearance?: "dark" | "light",
+): Promise<string> {
   const importer = SHIKI_THEME_IMPORTS[name];
-  if (!importer) return DEFAULT_SHIKI_THEME;
+  if (!importer) return fallbackShikiTheme(appearance);
   const hl = await getHighlighter();
   if (hl.getLoadedThemes().includes(name)) return name;
   try {
@@ -62,7 +79,7 @@ export async function ensureThemeLoaded(name: string): Promise<string> {
   } catch {
     // Module load failed; fall through.
   }
-  return DEFAULT_SHIKI_THEME;
+  return fallbackShikiTheme(appearance);
 }
 
 const EXT_TO_LANG: Record<string, () => Promise<unknown>> = {

--- a/web/src/lib/highlighter.ts
+++ b/web/src/lib/highlighter.ts
@@ -5,9 +5,29 @@ import { createOnigurumaEngine } from "shiki/engine/oniguruma";
 let instance: HighlighterCore | null = null;
 let loading: Promise<HighlighterCore> | null = null;
 
+/** Shiki theme module imports for every theme an AoE-resolved theme
+ *  can name. Unknown values fall back to `DEFAULT_SHIKI_THEME`. Lazy
+ *  imports so users on Empire don't pay for the Dracula/Tokyo Night
+ *  modules they never see. */
+const SHIKI_THEME_IMPORTS: Record<string, () => Promise<unknown>> = {
+  "github-dark": () => import("shiki/themes/github-dark.mjs"),
+  "github-light": () => import("shiki/themes/github-light.mjs"),
+  "github-dark-dimmed": () => import("shiki/themes/github-dark-dimmed.mjs"),
+  "tokyo-night": () => import("shiki/themes/tokyo-night.mjs"),
+  "catppuccin-latte": () => import("shiki/themes/catppuccin-latte.mjs"),
+  dracula: () => import("shiki/themes/dracula.mjs"),
+  "rose-pine": () => import("shiki/themes/rose-pine.mjs"),
+};
+
+/** Fallback when the resolver names a Shiki theme this bundle doesn't
+ *  carry (user-defined themes with arbitrary shiki_theme entries). */
+export const DEFAULT_SHIKI_THEME = "github-dark";
+
 /**
  * Returns a singleton Shiki highlighter. Languages are loaded on demand
- * via `loadLanguage()` so the initial bundle stays small.
+ * via `loadLanguage()` so the initial bundle stays small. The default
+ * theme is bundled at construction time; switch to another bundled
+ * theme via `ensureThemeLoaded`.
  */
 export async function getHighlighter(): Promise<HighlighterCore> {
   if (instance) return instance;
@@ -21,6 +41,28 @@ export async function getHighlighter(): Promise<HighlighterCore> {
     return hl;
   });
   return loading;
+}
+
+/** Lazy-load a Shiki theme module and register it on the singleton
+ *  highlighter. Returns the name the caller should pass to
+ *  `codeToHtml` / `codeToTokens` (the requested name if it loaded
+ *  cleanly, `DEFAULT_SHIKI_THEME` otherwise). Idempotent. */
+export async function ensureThemeLoaded(name: string): Promise<string> {
+  const importer = SHIKI_THEME_IMPORTS[name];
+  if (!importer) return DEFAULT_SHIKI_THEME;
+  const hl = await getHighlighter();
+  if (hl.getLoadedThemes().includes(name)) return name;
+  try {
+    const mod = await importer();
+    const theme = (mod as { default: unknown }).default;
+    if (theme) {
+      await hl.loadTheme(theme as Parameters<typeof hl.loadTheme>[0]);
+      return name;
+    }
+  } catch {
+    // Module load failed; fall through.
+  }
+  return DEFAULT_SHIKI_THEME;
 }
 
 const EXT_TO_LANG: Record<string, () => Promise<unknown>> = {

--- a/web/src/lib/theme.ts
+++ b/web/src/lib/theme.ts
@@ -1,0 +1,72 @@
+// Resolved theme types + runtime applicator. The server (Rust) owns
+// the projection from canonical TUI Theme -> CSS variables; this file
+// just consumes the typed payload from /api/themes/:name and applies
+// it on the root element via document.documentElement.style.setProperty,
+// then mirrors the payload into localStorage so the next page load
+// can paint the right palette before the React app hydrates.
+
+export type ThemeAppearance = "dark" | "light";
+
+export type ResolvedThemeSource = "builtin" | "custom" | "fallback";
+
+export interface CssVarProjection {
+  cssVars: Record<string, string>;
+}
+
+export interface ResolvedTheme {
+  name: string;
+  source: ResolvedThemeSource;
+  appearance: ThemeAppearance;
+  web: CssVarProjection;
+  terminal: CssVarProjection;
+  syntax: { shikiTheme: string };
+}
+
+const STORAGE_KEY = "aoe-resolved-theme";
+
+export function readCachedResolvedTheme(): ResolvedTheme | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    return JSON.parse(raw) as ResolvedTheme;
+  } catch {
+    return null;
+  }
+}
+
+function writeCachedResolvedTheme(theme: ResolvedTheme): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(theme));
+  } catch {
+    // Quota / private mode; safe to ignore.
+  }
+}
+
+// Apply the resolved theme to the document root. Uses setProperty
+// (not a dynamic <style> tag) so no CSP allowance is needed and
+// Tailwind v4 utilities that reference the same variable names
+// repaint immediately.
+export function applyResolvedTheme(theme: ResolvedTheme): void {
+  const root = document.documentElement;
+  for (const [name, value] of Object.entries(theme.web.cssVars)) {
+    root.style.setProperty(name, value);
+  }
+  for (const [name, value] of Object.entries(theme.terminal.cssVars)) {
+    root.style.setProperty(name, value);
+  }
+  root.dataset.theme = theme.name;
+  root.dataset.themeAppearance = theme.appearance;
+  root.style.colorScheme = theme.appearance;
+  writeCachedResolvedTheme(theme);
+}
+
+// Notification key used by the theme hook to broadcast theme changes
+// across components (e.g. shiki call sites re-render against the new
+// syntax theme without needing to subscribe to a context).
+export const THEME_CHANGED_EVENT = "aoe:theme-changed";
+
+export function dispatchThemeChanged(theme: ResolvedTheme): void {
+  window.dispatchEvent(
+    new CustomEvent<ResolvedTheme>(THEME_CHANGED_EVENT, { detail: theme }),
+  );
+}

--- a/web/tests/theme-switch-live.spec.ts
+++ b/web/tests/theme-switch-live.spec.ts
@@ -1,0 +1,213 @@
+// Live-backend theme switching coverage. Spins up a real `aoe serve`
+// process against an isolated $HOME and drives the dashboard's theme
+// picker through actual /api/themes/:name + /api/theme/current calls.
+// This is the test that would have caught the OnceLock-via-load_theme
+// deadlock that the mock-API tests in theme-switch.spec.ts couldn't:
+// mocks bypass the resolver entirely.
+
+import { test, expect, type Page } from "@playwright/test";
+import { spawn, type ChildProcess } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const AOE_BINARY = resolve(process.cwd(), "..", "target", "debug", "aoe");
+const HAS_BINARY = existsSync(AOE_BINARY);
+
+const HARNESS_PORT = Number(process.env.AOE_LIVE_TEST_PORT ?? 18099);
+const HARNESS_BASE = `http://127.0.0.1:${HARNESS_PORT}`;
+// Builtin pinned to a value that visibly differs from Empire so the
+// dashboard repaint is observable.
+const SWITCH_TO = "dracula";
+
+interface Daemon {
+  proc: ChildProcess;
+  home: string;
+  cleanup: () => void;
+}
+
+async function startServer(): Promise<Daemon> {
+  const home = mkdtempSync(join(tmpdir(), "aoe-theme-e2e-"));
+  // Foreground (no daemonize), no auth, no tunnel; keeps Ctrl-C
+  // semantics on Playwright shutdown.
+  const proc = spawn(
+    AOE_BINARY,
+    [
+      "serve",
+      "--no-auth",
+      "--port",
+      String(HARNESS_PORT),
+      "--host",
+      "127.0.0.1",
+    ],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        HOME: home,
+        // Suppress the dev-build prefix dance; let `aoe serve`'s
+        // env-driven app-dir routing pick its own dev path.
+        RUST_LOG: "warn",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+
+  // Wait until the server is listening (poll /api/themes which has no
+  // auth and no side effects).
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${HARNESS_BASE}/api/themes`);
+      if (res.ok) break;
+    } catch {
+      // socket not up yet
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  if (Date.now() >= deadline) {
+    proc.kill("SIGKILL");
+    throw new Error("aoe serve did not start within 20s");
+  }
+
+  return {
+    proc,
+    home,
+    cleanup: () => {
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // already exited
+      }
+      try {
+        rmSync(home, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    },
+  };
+}
+
+async function readCssVar(page: Page, name: string): Promise<string> {
+  return await page.evaluate(
+    (n) => document.documentElement.style.getPropertyValue(n).trim(),
+    name,
+  );
+}
+
+test.describe("Live aoe serve theme switching (#1189)", () => {
+  // Skip gracefully if the Rust binary hasn't been built. CI runs
+  // `cargo build --features serve` first; local runs without the
+  // binary skip these instead of failing the rest of the suite.
+  test.skip(
+    !HAS_BINARY,
+    `${AOE_BINARY} missing; run \`cargo build --features serve\` first`,
+  );
+
+  let daemon: Daemon;
+
+  test.beforeAll(async () => {
+    daemon = await startServer();
+  });
+
+  test.afterAll(() => {
+    daemon?.cleanup();
+  });
+
+  test("GET /api/themes/:name returns within 2s and is not stuck in resolve", async () => {
+    // The OnceLock-via-load_theme deadlock made this endpoint hang
+    // forever per request. AbortController with a tight budget
+    // catches that regression cheaply.
+    const ctrl = new AbortController();
+    const watchdog = setTimeout(() => ctrl.abort(), 2_000);
+    try {
+      const res = await fetch(`${HARNESS_BASE}/api/themes/${SWITCH_TO}`, {
+        signal: ctrl.signal,
+      });
+      expect(res.ok).toBe(true);
+      const body = await res.json();
+      expect(body.name).toBe(SWITCH_TO);
+      expect(body.source).toBe("builtin");
+      expect(body.appearance).toBe("dark");
+      expect(body.web.cssVars["--color-surface-900"]).toBe("#282a36");
+      expect(body.terminal.cssVars["--term-bg"]).toBe("#282a36");
+      expect(body.syntax.shikiTheme).toBe("dracula");
+    } finally {
+      clearTimeout(watchdog);
+    }
+  });
+
+  test("GET /api/themes/:name handles all 6 builtins sequentially without hanging", async () => {
+    const builtins = [
+      "empire",
+      "phosphor",
+      "tokyo-night-storm",
+      "catppuccin-latte",
+      "dracula",
+      "rose-pine",
+    ];
+    for (const name of builtins) {
+      const ctrl = new AbortController();
+      const watchdog = setTimeout(() => ctrl.abort(), 2_000);
+      try {
+        const res = await fetch(`${HARNESS_BASE}/api/themes/${name}`, {
+          signal: ctrl.signal,
+        });
+        expect(res.ok, `${name} did not return`).toBe(true);
+        const body = await res.json();
+        expect(body.name).toBe(name);
+        expect(body.web.cssVars).toBeTruthy();
+      } finally {
+        clearTimeout(watchdog);
+      }
+    }
+  });
+
+  test("dashboard chrome repaints when theme switches via API", async ({
+    page,
+  }) => {
+    await page.goto(`${HARNESS_BASE}/`);
+    // Wait for the React-side fetch of /api/theme/current to land
+    // and seed --color-surface-900 with the active palette.
+    await expect
+      .poll(
+        async () => {
+          const v = await readCssVar(page, "--color-surface-900");
+          return v.length > 0;
+        },
+        { timeout: 10_000, intervals: [100, 250, 500] },
+      )
+      .toBe(true);
+
+    // Drive a theme switch by patching the profile-scoped settings
+    // endpoint the picker uses, then firing the same event the
+    // ThemeSettings.tsx save() handler dispatches.
+    const patch = await page.request.patch(
+      `${HARNESS_BASE}/api/profiles/default/settings`,
+      {
+        data: { theme: { name: SWITCH_TO } },
+      },
+    );
+    expect(patch.ok()).toBe(true);
+
+    await page.evaluate((name) => {
+      window.dispatchEvent(
+        new CustomEvent("aoe:theme-picker-changed", {
+          detail: { name },
+        }),
+      );
+    }, SWITCH_TO);
+
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"), {
+        timeout: 5_000,
+        intervals: [100, 200, 400],
+      })
+      .toBe("#282a36");
+
+    const bg = await page.evaluate(
+      () => getComputedStyle(document.body).backgroundColor,
+    );
+    expect(bg).toMatch(/40,\s*42,\s*54/);
+  });
+});

--- a/web/tests/theme-switch.spec.ts
+++ b/web/tests/theme-switch.spec.ts
@@ -1,0 +1,250 @@
+// Theme picker repaint coverage (issue #1189).
+//
+// These tests intercept the /api/themes/:name and /api/theme/current
+// endpoints with canned ResolvedTheme payloads and assert that the
+// dashboard's runtime CSS variable application path actually paints
+// the requested palette. Without these, a regression in
+// useResolvedTheme / applyResolvedTheme / the pre-React bootstrap
+// would only surface in manual QA.
+
+import { test, expect } from "@playwright/test";
+
+interface ResolvedThemePayload {
+  name: string;
+  source: "builtin" | "custom" | "fallback";
+  appearance: "dark" | "light";
+  web: { cssVars: Record<string, string> };
+  terminal: { cssVars: Record<string, string> };
+  syntax: { shikiTheme: string };
+}
+
+function dracula(): ResolvedThemePayload {
+  return {
+    name: "dracula",
+    source: "builtin",
+    appearance: "dark",
+    web: {
+      cssVars: {
+        "--color-surface-900": "#282a36",
+        "--color-surface-950": "#161721",
+        "--color-surface-850": "#2f323e",
+        "--color-surface-800": "#34374a",
+        "--color-surface-700": "#44475a",
+        "--color-brand-500": "#ff79c6",
+        "--color-brand-400": "#ff9ad4",
+        "--color-brand-600": "#d967a8",
+        "--color-brand-700": "#b35689",
+        "--color-text-primary": "#f8f8f2",
+        "--color-text-bright": "#bd93f9",
+        "--color-status-running": "#50fa7b",
+        "--color-status-waiting": "#ffb86c",
+        "--color-status-error": "#ff5555",
+        "--color-status-idle": "#6272a4",
+      },
+    },
+    terminal: {
+      cssVars: {
+        "--term-bg": "#282a36",
+        "--term-fg": "#f8f8f2",
+        "--term-cursor": "#ff79c6",
+        "--term-color-0": "#282a36",
+        "--term-color-1": "#ff5555",
+        "--term-color-2": "#50fa7b",
+        "--term-color-3": "#ffb86c",
+      },
+    },
+    syntax: { shikiTheme: "dracula" },
+  };
+}
+
+function catppuccinLatte(): ResolvedThemePayload {
+  return {
+    name: "catppuccin-latte",
+    source: "builtin",
+    appearance: "light",
+    web: {
+      cssVars: {
+        "--color-surface-900": "#eff1f5",
+        "--color-surface-950": "#e3e5ea",
+        "--color-text-primary": "#4c4f69",
+        "--color-status-running": "#40a02b",
+      },
+    },
+    terminal: { cssVars: { "--term-bg": "#eff1f5", "--term-fg": "#4c4f69" } },
+    syntax: { shikiTheme: "catppuccin-latte" },
+  };
+}
+
+async function stubTheme(
+  page: import("@playwright/test").Page,
+  byName: Record<string, ResolvedThemePayload>,
+  current: ResolvedThemePayload,
+) {
+  await page.route("**/api/theme/current", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(current),
+    }),
+  );
+  await page.route("**/api/themes/*", (route) => {
+    const url = new URL(route.request().url());
+    const name = decodeURIComponent(url.pathname.split("/").pop() ?? "");
+    const payload = byName[name];
+    if (!payload) {
+      route.fulfill({ status: 404, body: "not found" });
+      return;
+    }
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(payload),
+    });
+  });
+}
+
+async function readCssVar(
+  page: import("@playwright/test").Page,
+  name: string,
+): Promise<string> {
+  return await page.evaluate((n) => {
+    return document.documentElement.style.getPropertyValue(n).trim();
+  }, name);
+}
+
+test.describe("Theme picker runtime palette swap (#1189)", () => {
+  test("useResolvedTheme applies fetched theme on mount", async ({ page }) => {
+    await stubTheme(page, { dracula: dracula() }, dracula());
+    await page.goto("/");
+    // Allow the hook's mount-time fetch + apply to land.
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#282a36");
+    const fg = await readCssVar(page, "--color-text-primary");
+    expect(fg).toBe("#f8f8f2");
+    const termBg = await readCssVar(page, "--term-bg");
+    expect(termBg).toBe("#282a36");
+  });
+
+  test("dispatching theme-picker-changed repaints to requested theme", async ({
+    page,
+  }) => {
+    const empire: ResolvedThemePayload = {
+      name: "empire",
+      source: "builtin",
+      appearance: "dark",
+      web: {
+        cssVars: {
+          "--color-surface-900": "#0f172a",
+          "--color-text-primary": "#cbd5e1",
+        },
+      },
+      terminal: { cssVars: { "--term-bg": "#0f172a" } },
+      syntax: { shikiTheme: "github-dark" },
+    };
+    await stubTheme(page, { empire, dracula: dracula() }, empire);
+    await page.goto("/");
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#0f172a");
+
+    // Settings.tsx would normally fire this after the user picks a
+    // theme. Exercise the same event the picker dispatches.
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("aoe:theme-picker-changed", {
+          detail: { name: "dracula" },
+        }),
+      );
+    });
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#282a36");
+    expect(await readCssVar(page, "--color-text-primary")).toBe("#f8f8f2");
+  });
+
+  test("light theme sets color-scheme: light on root", async ({ page }) => {
+    await stubTheme(
+      page,
+      { "catppuccin-latte": catppuccinLatte() },
+      catppuccinLatte(),
+    );
+    await page.goto("/");
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#eff1f5");
+    const scheme = await page.evaluate(
+      () => document.documentElement.style.colorScheme,
+    );
+    expect(scheme).toBe("light");
+    const dataAppearance = await page.evaluate(
+      () => document.documentElement.dataset.themeAppearance,
+    );
+    expect(dataAppearance).toBe("light");
+  });
+
+  test("pre-React bootstrap paints cached theme before hydration", async ({
+    page,
+  }) => {
+    // Network stub returns Empire; localStorage seeded with Dracula.
+    // The pre-React script in index.html should paint Dracula
+    // immediately; the React-side fetch then RE-applies Empire (the
+    // server's truth). The point of this test is the inline-script
+    // path runs at all and writes the cached vars to the root.
+    const empire: ResolvedThemePayload = {
+      name: "empire",
+      source: "builtin",
+      appearance: "dark",
+      web: {
+        cssVars: {
+          "--color-surface-900": "#0f172a",
+          "--color-text-primary": "#cbd5e1",
+        },
+      },
+      terminal: { cssVars: { "--term-bg": "#0f172a" } },
+      syntax: { shikiTheme: "github-dark" },
+    };
+    await stubTheme(page, { empire, dracula: dracula() }, empire);
+
+    // Seed localStorage on the origin before the page's inline script
+    // runs. Playwright's addInitScript runs in the page context before
+    // any other script, so the bootstrap finds the cached payload.
+    await page.addInitScript((cached) => {
+      localStorage.setItem("aoe-resolved-theme", JSON.stringify(cached));
+    }, dracula());
+
+    await page.goto("/");
+
+    // Final state should be Empire (server truth wins after fetch).
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#0f172a");
+
+    // But the cache hit happened: html dataset.theme should have been
+    // set by SOMETHING (either the bootstrap on first paint, or the
+    // hook after fetch). Either way, dataset.theme is non-empty.
+    const dataTheme = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    expect(dataTheme).toBeTruthy();
+  });
+
+  test("theme repaint persists across the chrome elements", async ({
+    page,
+  }) => {
+    await stubTheme(page, { dracula: dracula() }, dracula());
+    await page.goto("/");
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#282a36");
+
+    // The body's background-color resolves through Tailwind's
+    // `background: var(--color-surface-900)`. After applyResolvedTheme,
+    // the body should compute to Dracula's bg (RGB 40, 42, 54).
+    const bg = await page.evaluate(
+      () => getComputedStyle(document.body).backgroundColor,
+    );
+    // rgb(40, 42, 54) -> "rgb(40, 42, 54)" or "rgba(40, 42, 54, 1)"
+    expect(bg).toMatch(/40,\s*42,\s*54/);
+  });
+});

--- a/web/tests/theme-switch.spec.ts
+++ b/web/tests/theme-switch.spec.ts
@@ -265,4 +265,56 @@ test.describe("Theme picker runtime palette swap (#1189)", () => {
     // rgb(40, 42, 54) -> "rgb(40, 42, 54)" or "rgba(40, 42, 54, 1)"
     expect(bg).toMatch(/40,\s*42,\s*54/);
   });
+
+  test("slow mount fetch does not overwrite a faster picker pick", async ({
+    page,
+  }) => {
+    // Regression test for the in-flight ordering bug: if the user
+    // picks Dracula while the mount-time /api/theme/current is still
+    // pending, the eventual mount response (Empire) used to win the
+    // last-write race. useResolvedTheme now tags each fetch with a
+    // monotonic seq and discards responses older than the last
+    // applied one. Stall /api/theme/current for ~1.5s; the picker
+    // event resolves immediately. Final palette must be Dracula.
+    const empire: ResolvedThemePayload = {
+      name: "empire",
+      source: "builtin",
+      appearance: "dark",
+      web: { cssVars: { "--color-surface-900": "#0f172a" } },
+      terminal: { cssVars: { "--term-bg": "#0f172a" } },
+      syntax: { shikiTheme: "github-dark" },
+    };
+    await page.route("**/api/theme/current", async (route) => {
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(empire),
+      });
+    });
+    await page.route("**/api/themes/*", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(dracula()),
+      }),
+    );
+
+    await page.goto("/");
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("aoe:theme-picker-changed", {
+          detail: { name: "dracula" },
+        }),
+      );
+    });
+
+    await expect
+      .poll(() => readCssVar(page, "--color-surface-900"))
+      .toBe("#282a36");
+    // Wait past the stalled mount response so we can assert Dracula
+    // is sticky after both fetches have settled.
+    await page.waitForTimeout(2000);
+    expect(await readCssVar(page, "--color-surface-900")).toBe("#282a36");
+  });
 });

--- a/web/tests/theme-switch.spec.ts
+++ b/web/tests/theme-switch.spec.ts
@@ -186,47 +186,65 @@ test.describe("Theme picker runtime palette swap (#1189)", () => {
   test("pre-React bootstrap paints cached theme before hydration", async ({
     page,
   }) => {
-    // Network stub returns Empire; localStorage seeded with Dracula.
-    // The pre-React script in index.html should paint Dracula
-    // immediately; the React-side fetch then RE-applies Empire (the
-    // server's truth). The point of this test is the inline-script
-    // path runs at all and writes the cached vars to the root.
-    const empire: ResolvedThemePayload = {
-      name: "empire",
-      source: "builtin",
-      appearance: "dark",
-      web: {
-        cssVars: {
-          "--color-surface-900": "#0f172a",
-          "--color-text-primary": "#cbd5e1",
-        },
-      },
-      terminal: { cssVars: { "--term-bg": "#0f172a" } },
-      syntax: { shikiTheme: "github-dark" },
-    };
-    await stubTheme(page, { empire, dracula: dracula() }, empire);
-
-    // Seed localStorage on the origin before the page's inline script
-    // runs. Playwright's addInitScript runs in the page context before
-    // any other script, so the bootstrap finds the cached payload.
+    // Goal: verify the static /theme-bootstrap.js path executes and
+    // applies the cached payload BEFORE useResolvedTheme's fetch
+    // lands. To make the assertion specific to the bootstrap (and
+    // not the React-side apply), stub /api/theme/current to never
+    // resolve — only the bootstrap can have set dataset.theme. Also
+    // listen for `securitypolicyviolation` so a CSP regression on
+    // the bootstrap source fails the test loudly. Review on PR #1197.
+    const violations: string[] = [];
+    page.on("console", (msg) => {
+      const t = msg.text();
+      if (t.toLowerCase().includes("content security policy")) {
+        violations.push(t);
+      }
+    });
+    await page.addInitScript(() => {
+      document.addEventListener("securitypolicyviolation", (ev) => {
+        // Surface as console.error so the .on("console") listener
+        // above catches it.
+        // eslint-disable-next-line no-console
+        console.error(
+          "CSP violation:",
+          (ev as SecurityPolicyViolationEvent).violatedDirective,
+          (ev as SecurityPolicyViolationEvent).blockedURI,
+        );
+      });
+    });
     await page.addInitScript((cached) => {
       localStorage.setItem("aoe-resolved-theme", JSON.stringify(cached));
     }, dracula());
+    // Hang the React-side fetch so dataset.theme can only have come
+    // from the bootstrap.
+    await page.route("**/api/theme/current", () => {
+      // Intentionally never call route.fulfill / route.continue: the
+      // fetch hangs until the page closes.
+    });
+    await page.route("**/api/themes/*", () => {
+      // Same here for the picker-event path.
+    });
 
     await page.goto("/");
 
-    // Final state should be Empire (server truth wins after fetch).
+    // Bootstrap runs synchronously in <head> before React mounts,
+    // so dataset.theme + --color-surface-900 should be visible
+    // immediately after navigation.
     await expect
-      .poll(() => readCssVar(page, "--color-surface-900"))
-      .toBe("#0f172a");
-
-    // But the cache hit happened: html dataset.theme should have been
-    // set by SOMETHING (either the bootstrap on first paint, or the
-    // hook after fetch). Either way, dataset.theme is non-empty.
+      .poll(
+        () => readCssVar(page, "--color-surface-900"),
+        { timeout: 1500, intervals: [50, 100, 200] },
+      )
+      .toBe("#282a36");
     const dataTheme = await page.evaluate(
       () => document.documentElement.dataset.theme,
     );
-    expect(dataTheme).toBeTruthy();
+    expect(dataTheme).toBe("dracula");
+
+    // CSP regression check: the bootstrap must load successfully.
+    // If `src="/theme-bootstrap.js"` ever gets reverted to an inline
+    // <script>, the strict CSP fires `securitypolicyviolation`.
+    expect(violations).toEqual([]);
   });
 
   test("theme repaint persists across the chrome elements", async ({


### PR DESCRIPTION
**Note:** Claude handled the investigation, design debate, and implementation under my direction. Idea, decisions, and direction are mine. — @Seluj78

> **Status:** depends on #1214 (the TOML-backed builtins refactor, #1097 scope). Once #1214 lands, this branch will be rebased onto post-#1214 main; git's patch-id matching will drop the duplicated refactor commits and the diff here narrows to the #1189 surface only.
>
> **Do not merge before #1214.**

## Description

Web dashboard now honors the same themes the TUI uses, closing #1189. The TUI Theme TOML moves to embedded files via #1214; this PR builds on top to add the web-side projection, two new endpoints, and the live runtime palette swap.

### What changes (post-rebase scope)

- **Server projection** (`src/tui/styles/resolved.rs`, feature-gated on `serve`): `ResolvedTheme` is the typed payload the web reads from the new endpoints. Three projections:
  1. `web.cssVars`: maps TUI semantic fields onto the Tailwind variable names the dashboard already consumes (`--color-surface-900`, `--color-text-primary`, `--color-status-running`, etc.). Derives the surface ramp (`surface-950/850/800`) from background luminance via RGB mixing; dark themes get a deeper deeper-than-bg and slight elevations toward white, light themes invert. Brand ramp anchored on `theme.accent`; accent ramp on `theme.terminal_border`. Also exposes new vars for tokens that had no CSS equivalent before: `--color-selection`, `--color-session-selection`, `--color-terminal-active`, `--color-branch`, `--color-sandbox`, `--color-diff-{add,delete,modified,header}`.
  2. `terminal.cssVars`: `--term-bg` / `--term-fg` / `--term-cursor` plus a derived ANSI 16 palette (ANSI 1=error, 2=running, 3=waiting, 4=branch, 5=accent, 6=terminal_active, 7=text, 8=dimmed; bright variants lift by 20% toward white on dark themes, toward black on light themes). v1 derives so custom themes work without authoring 16 hexes; an optional `[terminal]` override section is future work.
  3. `syntax.shikiTheme`: reads `theme.syntax.shiki_theme` (declared per builtin TOML by #1214) if set; otherwise falls back by appearance (`github-dark` / `github-light`).

- **Two new endpoints:**
  - `GET /api/themes/:name` returns the resolved projection for any theme name (builtin or custom). Unknown names fall back to Empire with `source: "fallback"` so the frontend can surface that. Wrapped in `spawn_blocking` so the sync resolver doesn't pin a tokio worker.
  - `GET /api/theme/current` returns the projection for the active profile's selected theme. Resolved through `profile_config::resolve_config_or_warn` so per-profile overrides land in the right place.

- **Web side** (`web/`):
  - `useResolvedTheme` hook + `applyResolvedTheme` helper (`web/src/hooks/useResolvedTheme.ts`, `web/src/lib/theme.ts`). Reads localStorage on mount, fetches `/api/theme/current`, applies via `document.documentElement.style.setProperty`, listens for `THEME_PICKER_CHANGED_EVENT` so settings updates repaint live.
  - Pre-React static script `web/public/theme-bootstrap.js`. Applies cached payload before React mounts so a dashboard reload paints the right palette before hydration. Lives as an external script (not inline) because the dashboard's CSP is `script-src 'self' 'wasm-unsafe-eval'`. Per @njbrake's review.
  - wterm `--term-*` setters dropped from `useTerminal.ts`; the resolved theme's terminal CSS vars cascade in from documentElement. A `aoe:theme-changed` listener calls `term.resize(cols, rows)` to force wterm to repaint quiet terminals.
  - All 4 Shiki call sites (`Markdown.tsx`, `ToolCards.tsx`, `useHighlightedLines.ts`, `DiffCommentsUserCard.tsx`) use a `useShikiTheme()` hook that returns `{theme, appearance}` so a light AoE theme falling back to an unbundled Shiki theme picks `github-light` rather than `github-dark`.
  - `ThemeSettings.tsx` drops the "applies to the TUI, not the web dashboard" disclaimer and dispatches the picker event on save.
  - `web/src/index.css` adds build-time defaults for `--term-*` and the new `--color-*` extras so cold-load (no localStorage) paints sensibly before the fetch lands.
  - Hardcoded chrome colors in cockpit-markdown CSS (the warn callout, table tbody rgba) repointed to semantic tokens via `color-mix()`.

- **DESIGN.md:** Web Dashboard subset rewritten. The pre-PR rule that "Surfaces are neutral zinc, deliberately divergent from the brand palette" retires; new direction is "all color comes from the user's chosen theme; Empire is the documented baseline." Decisions log gets a `2026-05-17` entry.

- **`docs/guides/configuration.md`:** `[theme]` section now documents that `name` applies to both TUI and web, the optional `appearance` + `[syntax]` metadata, and the custom-themes export workflow.

- **Playwright** (`web/tests/theme-switch.spec.ts` + `theme-switch-live.spec.ts`): 8 tests. 5 mock-API (mount-time apply, dispatch repaints, light color-scheme, pre-React bootstrap with CSP-violation listener + blocked API, body bg propagates). 3 real-server live (spawns `aoe serve --no-auth` against an isolated `$HOME`, asserts `/api/themes/:name` returns within 2s, all 6 builtins sequential, UI-driven switch repaints). Live tests skip when binary missing.

Closes #1189

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

User-runnable steps to verify the change end to end:

- [ ] After #1214 lands and this branch is rebased: `cargo build --features serve` succeeds.
- [ ] `./target/debug/aoe serve --no-auth --port 8081`, open dashboard, Settings → Theme, switch to Dracula. Sidebar, top bar, session rows, cockpit chrome, dialogs, and code blocks (cockpit markdown + diff viewer) repaint to Dracula without reload.
- [ ] Switch to Catppuccin Latte. Dashboard repaints as light; `color-scheme: light` is set on `<html>` (native form controls switch); no fallback-to-Empire warning fires.
- [ ] Open a tmux session, switch themes; the embedded terminal background, foreground, cursor, and ANSI colors track the new palette.
- [ ] Open a cockpit conversation with a code block; switch theme. The block re-highlights against the matching Shiki theme.
- [ ] Hard-reload after switching to Dracula. The static `/theme-bootstrap.js` paints Dracula before React hydrates (no flash of Empire palette). DevTools console shows no CSP violations.
- [ ] Drop a partial custom theme TOML at `~/.agent-of-empires/themes/my-theme.toml`. Picker shows it; selecting it repaints both TUI and dashboard; missing fields fall back to Empire per #1214's `Theme::default`.
- [ ] In the TUI, switch themes; behavior unchanged from `main`.

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass <!-- 8 Playwright (5 mock + 3 live) + Rust unit tests via #1214; CI will confirm post-rebase -->
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording <!-- recording owed before marking ready for review -->

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7 1M context) via the agent-of-empires `/aoe-implement` skill. Design stress-tested through a multi-model debate (Gemini 3.1 Pro Preview vs GPT-5.5) before implementation.

**Any Additional AI Details you'd like to share:**

Investigation, plan, and code drafted by Claude under my direction. I picked the scope (originally bundled with #1097, split per @njbrake's review), made the design calls (Rust-side projection vs client-side mapping; derive ANSI 16 vs declare per theme; defer `[terminal]` overrides to v2; light themes ship in v1; bootstrap as static file for CSP), reviewed each commit, and own the manual test steps above. Multiple landmines surfaced and were guarded with tests during implementation:
- Tokio worker pool exhaustion from sync FS I/O in async handlers → `spawn_blocking` wrap + live Playwright `/api/themes/:name` 2s-watchdog test.
- CSP refusing to run inline bootstrap script → moved to static `/theme-bootstrap.js`, Playwright test listens for `securitypolicyviolation`.
- `useShikiTheme` returning only the theme name → returns `{theme, appearance}` so light themes get `github-light` fallback.

- [x] I am an AI Agent filling out this form (check box if true)