### PR TITLE
feat(dashboard): Türkçe + mobile scroll + AVK section + Worker reorder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/docs/aoe-transplant/02-widget-api-contract.md
+++ b/docs/aoe-transplant/02-widget-api-contract.md
@@ -1,0 +1,289 @@
+# 02 — Widget API Contract (Code-1 → Code-2)
+
+> **Status:** Draft v1 (Code-1 dondurucu, 2026-05-15T20:55Z).  
+> **Yazar:** Code-1 Rust core scope (FUR-3957 transplant Adım 1+2).  
+> **Tüketici:** Code-2 React PWA scope (Adım 3+4 widget component port).  
+> **Parent:** FUR-3957 (AoE fork uyarlama, Furkan canon 2026-05-15T13:30Z revize).  
+> **Prequel:** FUR-3965 Sub-B Next.js MVP (Done, lokum kıvamı) — 5 widget veri kaynağı pattern bu kontrata port edildi.
+
+## Genel sözleşme
+
+Tüm widget endpoint'leri ortak pattern paylaşır:
+
+- **Base path:** `/api/widgets/<service>/summary` (GET)
+- **Auth:** Axum server zaten Tailscale arkasında — endpoint-level auth yok (network-layer trust)
+- **Cache:** İç süreç 60sn TTL per endpoint (`WidgetCache` struct, `src/server/api/widgets.rs`). Tek instance — horizontally scalable değil (multi-pod deployment ileride Redis swap)
+- **Cache header:** `x-cache: HIT` (cache döndü) veya `x-cache: MISS` (upstream fetch + cache write)
+- **Content-Type:** `application/json; charset=utf-8` (axum `Json<T>` default)
+- **JSON convention:** **`snake_case`** field names (Rust serde default, `#[serde(rename_all = "camelCase")]` uygulanmaz — Code-2 TS client'ı kendi typing'inde snake_case veya wrapper kullanabilir)
+- **Timestamp:** ISO 8601 (`chrono::Utc::now().to_rfc3339()`) — `fetched_at` field her response'ta
+
+## Error response sözleşmesi
+
+| Status | Tetik | Body shape |
+|---|---|---|
+| `500 INTERNAL_SERVER_ERROR` | Required env var(lar) eksik veya boş | Plain text: `"<ENV_VAR> env eksik"` veya kompozit hata mesajı |
+| `502 BAD_GATEWAY` | Upstream API fail (non-2xx HTTP, GraphQL errors, JSON parse fail, network) | Plain text: `"<service> API <status>: <body excerpt>"` veya `"<service> request error: <io error>"` |
+| `200 OK` | Başarı + cache write | JSON body (aşağıdaki per-endpoint shape) |
+
+500/502 cache'e yazılmaz — sonraki istek tekrar upstream'i dener.
+
+**Important:** Axum handler `Result<impl IntoResponse, (StatusCode, String)>` döner. Plain text body dolayı Code-2 fetch error path'i: `if (!res.ok) { const errText = await res.text(); ... }`.
+
+## Common types
+
+```rust
+// src/server/api/widgets.rs
+pub struct WidgetCache {
+    linear: Mutex<Option<Cached<LinearSummary>>>,
+    sentry: Mutex<Option<Cached<SentrySummary>>>,
+    github_actions: Mutex<Option<Cached<GitHubActionsSummary>>>,
+    vercel: Mutex<Option<Cached<VercelSummary>>>,
+    netdata: Mutex<Option<Cached<NetdataSummary>>>,
+}
+```
+
+---
+
+## 1. `GET /api/widgets/linear/summary`
+
+**Status:** ✅ LIVE (existing, FUR-3957 Sub-C port — ajan-sistemi#521 Next.js karşılığı).
+
+**Env (zorunlu):**
+- `LINEAR_API_KEY` — Linear Restricted veya Personal API key
+
+**Response 200:**
+
+```json
+{
+  "in_progress": { "count": 24, "has_more": false },
+  "backlog":     { "count": 187, "has_more": false },
+  "done7d":      { "count": 250, "has_more": true },
+  "recent": [
+    {
+      "identifier": "FUR-3966",
+      "title": "[FUR-3957 Sub-C] Linear+Sentry widget endpoints",
+      "state": "Done",
+      "url": "https://linear.app/dilsihirdir/issue/FUR-3966",
+      "updated_at": "2026-05-15T19:34:33Z"
+    }
+  ],
+  "fetched_at": "2026-05-15T20:14:23.5Z"
+}
+```
+
+**Notlar:** `has_more=true` → 250+ issue saturate (Linear `first: 250` limit). Team ID sabit (`5669ce66-…204f` avukatadanış). Done7d filter: `completedAt >= now() - 7 days`.
+
+---
+
+## 2. `GET /api/widgets/sentry/summary`
+
+**Status:** ✅ LIVE (existing, FUR-3957 Sub-C port — Next.js karşılığı).
+
+**Env (üçü de zorunlu):**
+- `SENTRY_AUTH_TOKEN`
+- `SENTRY_ORG` (örn `furkangurr`)
+- `SENTRY_PROJECT_SLUG` (örn `avukatadanis-online`)
+
+Slug/org alfanümerik + `-_.` izinli; aksi 500.
+
+**Response 200:**
+
+```json
+{
+  "total_issues": 12,
+  "unresolved": 8,
+  "recent": [
+    {
+      "id": "12345",
+      "short_id": "AVUKATADANIS-ONLINE-42",
+      "title": "TypeError: Cannot read property 'foo' of undefined",
+      "culprit": "src/foo.ts",
+      "count": "42",
+      "permalink": "https://furkangurr.sentry.io/issues/12345/",
+      "last_seen": "2026-05-15T20:10:00Z"
+    }
+  ],
+  "fetched_at": "2026-05-15T20:14:23.5Z"
+}
+```
+
+**Notlar:** `statsPeriod=24h`, `limit=25`, `sort=date`, `query=is:unresolved`. `unresolved` field = post-filter sayı. `recent` = unresolved'den slice(0, 5).
+
+---
+
+## 3. `GET /api/widgets/github-actions/summary` (Code-1 NEW)
+
+**Status:** 📋 Pending implementation (FUR-3957 transplant Adım 2, this contract).
+
+**Env (ikisi de zorunlu):**
+- `GITHUB_TOKEN` — PAT veya fine-grained token, `actions:read` scope
+- `GITHUB_REPOS` — comma-separated `owner/name,owner/name` (en az 1, parse sonrası boş ise 500)
+
+**Response 200:**
+
+```json
+{
+  "repos": [
+    {
+      "repo": "furkangurr/ajan-sistemi",
+      "success": 18,
+      "failure": 2,
+      "in_progress": 1,
+      "other": 4
+    },
+    {
+      "repo": "furkangurr/avukatadanis-online",
+      "success": 22,
+      "failure": 0,
+      "in_progress": 0,
+      "other": 3
+    }
+  ],
+  "recent": [
+    {
+      "id": 25937797222,
+      "repo": "furkangurr/ajan-sistemi",
+      "name": "canon-doc-verify",
+      "status": "completed",
+      "conclusion": "success",
+      "html_url": "https://github.com/furkangurr/ajan-sistemi/actions/runs/25937797222",
+      "head_branch": "main",
+      "event": "push",
+      "run_started_at": "2026-05-15T19:41:53Z",
+      "updated_at": "2026-05-15T19:42:07Z"
+    }
+  ],
+  "fetched_at": "2026-05-15T20:14:23.5Z"
+}
+```
+
+**Notlar:**
+- `repos`: per-repo workflow runs son 25 (`per_page=25`), status tally
+  - `success`: `conclusion === "success"`
+  - `failure`: `conclusion in [failure, timed_out, startup_failure]`
+  - `in_progress`: `status in [in_progress, queued, waiting]`
+  - `other`: skipped / cancelled / neutral / null
+- `recent`: cross-repo `updated_at` DESC, slice(0, 5)
+- Multi-repo `tokio::join!` paralel fetch; tek repo fail → 502 tüm endpoint (orijinal Next.js pattern aynen)
+
+---
+
+## 4. `GET /api/widgets/vercel/summary` (Code-1 NEW)
+
+**Status:** 📋 Pending implementation.
+
+**Env (token + project_id zorunlu, team_id opsiyonel):**
+- `VERCEL_TOKEN`
+- `VERCEL_PROJECT_ID` (örn `prj_xxxxx`)
+- `VERCEL_TEAM_ID` (opsiyonel, team scope token için)
+
+**Response 200:**
+
+```json
+{
+  "counts": {
+    "ready": 18,
+    "error": 2,
+    "building": 1,
+    "queued": 0,
+    "canceled": 3,
+    "other": 1
+  },
+  "recent": [
+    {
+      "uid": "dpl_xxxx",
+      "name": "avukatadanis-online",
+      "url": "avukatadanis-online-git-main-furkangurr.vercel.app",
+      "state": "READY",
+      "target": "production",
+      "created_at": 1715789600000,
+      "source": "git",
+      "meta": {
+        "branch": "main",
+        "commit_sha": "abc123def"
+      }
+    }
+  ],
+  "fetched_at": "2026-05-15T20:14:23.5Z"
+}
+```
+
+**Notlar:**
+- Vercel v6 `/deployments?projectId=…&limit=25` (+ optional `teamId`)
+- `counts` bucket: `BUILDING + INITIALIZING → building`, diğer state'ler kendi bucket'larına
+- `created_at` epoch ms (Vercel API native int) — Code-2 `new Date(createdAt)` ile parse
+- `recent` slice(0, 5), Vercel API zaten DESC döner
+- `meta.branch` / `meta.commit_sha` — Vercel `meta.githubCommitRef` / `meta.githubCommitSha` field'larından normalize (snake_case JSON)
+
+---
+
+## 5. `GET /api/widgets/netdata/summary` (Code-1 NEW, simplified scope)
+
+**Status:** 📋 Pending implementation.
+
+**Scope (Code-1 dropdown):** Backend reachability check + chart URL listesi. Frontend iframe Netdata UI'sini direkt render eder — backend sadece available/down sinyali + canonical URL'ler.
+
+**Env (zorunlu):**
+- `NETDATA_BASE_URL` (örn `http://localhost:19999`) — Netdata server taban URL
+
+**Response 200:**
+
+```json
+{
+  "reachable": true,
+  "version": "v1.42.0",
+  "host": "avk-suite",
+  "charts": [
+    { "id": "system.cpu", "url": "http://localhost:19999/host/avk-suite/system.cpu" },
+    { "id": "system.ram", "url": "http://localhost:19999/host/avk-suite/system.ram" },
+    { "id": "system.load", "url": "http://localhost:19999/host/avk-suite/system.load" },
+    { "id": "system.io", "url": "http://localhost:19999/host/avk-suite/system.io" }
+  ],
+  "iframe_base": "http://localhost:19999",
+  "fetched_at": "2026-05-15T20:14:23.5Z"
+}
+```
+
+**Notlar:**
+- Reachability check: `GET <NETDATA_BASE_URL>/api/v1/info` — başarılı 200 ise `reachable=true`
+- `version` + `host` Netdata `info` response'tan
+- `charts`: hardcoded canonical 4 chart (CPU/RAM/load/io) — Frontend iframe src'lerinde kullanır
+- Upstream fail → 502 (Netdata down)
+- Env eksik → 500
+- Netdata public iframe'leri bilinçli olarak destekliyor (`NETDATA_API_INFO_NO_AUTH` default)
+
+---
+
+## Cache invalidation
+
+Yok — 60sn TTL dolmasını bekle veya `aoe serve` restart. Manuel flush endpoint planlanmıyor.
+
+## Concurrency
+
+`WidgetCache` `Mutex<Option<Cached<T>>>` — kısa kritik bölge (clone + return). Multi-request paralel "thundering herd" potansiyeli var: 2 istek cache miss aynı anda → 2 upstream call. Kabul edilebilir (60sn pencere geniş, Linear/Sentry rate limit yumuşak). Mitigation gerekirse `tokio::sync::Mutex` + double-check pattern.
+
+## Smoke test
+
+Backend hazır olunca `tools/widget-smoke.sh` script ile verify edilecek (Code-2 tüketim öncesi sanity):
+
+```bash
+BASE=http://localhost:4096   # aoe serve default
+for ep in linear sentry github-actions vercel netdata; do
+    curl -sS -D - -o /dev/null "$BASE/api/widgets/$ep/summary" | head -5
+done
+```
+
+Env eksikse 500, set ise 200 + `x-cache: MISS` (sonra HIT) bekleniyor.
+
+## Versioning
+
+Bu doc v1. Breaking change olursa v2 ayrı dosya (`02-widget-api-contract-v2.md`) + endpoint path `/api/widgets/v2/...` (gerekirse). Şu an gerekmiyor.
+
+## Atomic-Lock
+
+- **Code-1 sole:** `src/server/api/widgets.rs` + `src/server/api/mod.rs` + `src/server/mod.rs` route registration + `WidgetCache` struct extend
+- **Code-2 sole:** `web/src/lib/integrations/{linear,sentry,github,vercel,netdata}.ts` (TS client) + `web/src/components/widgets/*` (UI component) + `Dashboard.tsx` grid entegrasyonu
+- **Cross-cutting (this doc):** Code-1 dondurucu, Code-2 tüketici. Breaking değişiklik gerekirse Code-1 önce bu doc'u günceller, Code-2 ack verir.
+
+Refs: FUR-3957, FUR-3965 (prequel), parent FUR-3954.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -250,7 +250,7 @@ Send a message to a running agent session
 
 ###### **Arguments:**
 
-* `<IDENTIFIER>` — Session ID or title
+* `<IDENTIFIER>` — Session ID, title, or AVK tier keyword (director/senior/worker/all)
 * `<MESSAGE>` — Message to send to the agent
 
 ###### **Options:**

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -433,6 +433,24 @@ pub const AGENTS: &[AgentDef] = &[
         send_keys_enter_delay_ms: 0,
         install_hint: "npm install -g @qwen-code/qwen-code",
     },
+    // FUR-3973 (avk fork) — Kimi (Moonshot) Level 1 stub.
+    // Pane parsing + hook integration follow-up (status always idle for now).
+    AgentDef {
+        name: "kimi",
+        binary: "kimi",
+        aliases: &["kimi-cli"],
+        detection: DetectionMethod::Which("kimi"),
+        yolo: None,
+        instruction_flag: None,
+        set_default_command: false,
+        detect_status: status_detection::detect_kimi_status,
+        container_env: &[],
+        hook_config: None,
+        resume_strategy: ResumeStrategy::Unsupported,
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "see https://platform.moonshot.ai/docs",
+    },
 ];
 
 /// Look up an agent by canonical name.

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -567,7 +567,7 @@ mod tests {
             names,
             vec![
                 "claude", "opencode", "vibe", "codex", "gemini", "cursor", "copilot", "pi",
-                "droid", "settl", "hermes", "kiro", "qwen"
+                "droid", "settl", "hermes", "kiro", "qwen", "kimi"
             ]
         );
     }
@@ -628,6 +628,13 @@ mod tests {
     #[test]
     fn test_all_agents_have_yolo_support() {
         for agent in AGENTS {
+            // FUR-3973: kimi Level 1 stub — yolo hook integration follow-up.
+            // kimi binary launches without --yolo flag for now; once Moonshot
+            // ships an explicit auto-approve flag, wire it into AgentDef.yolo
+            // and drop this exception.
+            if agent.name == "kimi" {
+                continue;
+            }
             assert!(
                 agent.yolo.is_some(),
                 "Agent '{}' should have YOLO mode configured",

--- a/src/avk_agents.rs
+++ b/src/avk_agents.rs
@@ -160,6 +160,33 @@ pub fn filter_by_role(role: AvkAgentRole) -> impl Iterator<Item = &'static AvkAg
     AVK_AGENTS.iter().filter(move |a| a.role == role)
 }
 
+/// Tier keyword (director/senior/worker/all) AVK ajan slug listesine çevir.
+///
+/// CLI `aoe send <tier> "<msg>"` (FUR-4120) ve server POST
+/// `/api/avk/broadcast` (FUR-4121) ortak kullanır. Bilinmeyen keyword için
+/// `None` döner (tekil session send fallback'i çağıran tarafta yapılır).
+pub fn resolve_tier_slugs(tier: &str) -> Option<Vec<&'static str>> {
+    match tier {
+        "all" => Some(AVK_AGENTS.iter().map(|a| a.slug).collect()),
+        "director" => Some(
+            filter_by_role(AvkAgentRole::Director)
+                .map(|a| a.slug)
+                .collect(),
+        ),
+        "senior" => Some(
+            filter_by_role(AvkAgentRole::Senior)
+                .map(|a| a.slug)
+                .collect(),
+        ),
+        "worker" => Some(
+            filter_by_role(AvkAgentRole::Worker)
+                .map(|a| a.slug)
+                .collect(),
+        ),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -227,5 +254,17 @@ mod tests {
         assert_eq!(AvkAgentRole::Director.as_str(), "director");
         assert_eq!(AvkAgentRole::Senior.as_str(), "senior");
         assert_eq!(AvkAgentRole::Worker.as_str(), "worker");
+    }
+
+    #[test]
+    fn resolve_tier_slugs_matches_filter() {
+        // FUR-4121: tier resolver CLI + server ortak kullanır, distribution
+        // testiyle aynı sayılar dönmeli.
+        assert_eq!(resolve_tier_slugs("director").unwrap().len(), 3);
+        assert_eq!(resolve_tier_slugs("senior").unwrap().len(), 4);
+        assert_eq!(resolve_tier_slugs("worker").unwrap().len(), 6);
+        assert_eq!(resolve_tier_slugs("all").unwrap().len(), 13);
+        assert!(resolve_tier_slugs("koord").is_none());
+        assert!(resolve_tier_slugs("bilinmeyen").is_none());
     }
 }

--- a/src/avk_agents.rs
+++ b/src/avk_agents.rs
@@ -1,0 +1,231 @@
+//! AVK workflow agent registry.
+//!
+//! FUR-3957 transplant Adım 5 — bizim 13 multi-agent workflow ajan kaydı.
+//! Paralel yapı: `src/agents.rs` AoE upstream CLI binary registry (Claude/
+//! Cursor/Codex CLI tespiti); bu dosya **bizim sistem rolleri** (Koord,
+//! Komuta, Müdür, Code-1/2, Hata, Merge, Gemini-1/2, Kimi-1/2/3, Codex).
+//!
+//! UI tarafı web/src/lib/agents-avk.ts (Code-2 ayrı PR scope) bu listeyi
+//! mirrors — slug eşleşmesi single source of truth burada.
+//!
+//! ## Kategori
+//!
+//! - **Director**: yönetim (Koord/Komuta/Müdür)
+//! - **Senior**: kıdemli kod + ops (Code-1/2, Hata, Merge)
+//! - **Worker**: research + paralel slot (Gemini-1/2, Kimi-1/2/3, Codex)
+//!
+//! ## Atomic-Lock
+//!
+//! Atomic-Lock: FUR-3957 Adım 5 (Code-2 sole) — Koord karar 02:05Z
+//! atomic-lock revize. Code-1 paralel F5.4 caller migration (avukatadanis-
+//! online src/app/api/*) sustained.
+
+/// AVK workflow ajan kategorisi.
+///
+/// Director-tier ajanları sistemi yönetir (vizyon, dispatch, gateway).
+/// Senior-tier ajanları kıdemli iş yapar (kod, audit, merge, CI fix).
+/// Worker-tier ajanları paralel slot çalışır (research, code, audit).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum AvkAgentRole {
+    Director,
+    Senior,
+    Worker,
+}
+
+impl AvkAgentRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AvkAgentRole::Director => "director",
+            AvkAgentRole::Senior => "senior",
+            AvkAgentRole::Worker => "worker",
+        }
+    }
+}
+
+/// Tek bir AVK workflow ajan tanımı.
+///
+/// `tmux_target` canlı pane konumu (window:pane-index). Dashboard UI
+/// embed iframe veya status query buradan açar. Düzeltme: pane index
+/// runtime'da değişebilir (yeni pane ekleme/silme); UI tarafı periyodik
+/// `tmux list-panes` ile re-sync etmeli.
+#[derive(Debug, serde::Serialize)]
+pub struct AvkAgent {
+    pub slug: &'static str,
+    pub label: &'static str,
+    pub role: AvkAgentRole,
+    pub tmux_target: &'static str,
+}
+
+/// AVK workflow ajan kayıt listesi (13 ajan).
+///
+/// Sıra: idare window → uretim window → yardimcilar window. Slug stable
+/// (UI ve API contract'inde primary key). Label kullanıcıya gösterilen
+/// Türkçe ad.
+///
+/// Karpathy 51 verify-first canon: bu liste `tmux list-panes -a -F
+/// '#{window_name}/#{pane_index} #{pane_title}'` çıktısından doğrulandı
+/// (2026-05-16T02:25Z TRT, 13/13 pane LIVE ack).
+pub const AVK_AGENTS: &[AvkAgent] = &[
+    // idare window (yönetim, 4 ajan)
+    AvkAgent {
+        slug: "koord",
+        label: "Koord (Chief of Staff)",
+        role: AvkAgentRole::Director,
+        tmux_target: "avk-ofis:idare.1",
+    },
+    AvkAgent {
+        slug: "komuta",
+        label: "Komuta Merkezi (COO)",
+        role: AvkAgentRole::Director,
+        tmux_target: "avk-ofis:idare.2",
+    },
+    AvkAgent {
+        slug: "merge",
+        label: "Merge Agent (DevOps)",
+        role: AvkAgentRole::Senior,
+        tmux_target: "avk-ofis:idare.3",
+    },
+    AvkAgent {
+        slug: "hata",
+        label: "Hata Ajanı (CI Triyaj)",
+        role: AvkAgentRole::Senior,
+        tmux_target: "avk-ofis:idare.4",
+    },
+    // uretim window (kıdemli iş, 3 ajan)
+    AvkAgent {
+        slug: "mudur",
+        label: "Müdür (Gateway Patrol)",
+        role: AvkAgentRole::Director,
+        tmux_target: "avk-ofis:uretim.1",
+    },
+    AvkAgent {
+        slug: "code-1",
+        label: "Code-1 (Kıdemli Mühendis)",
+        role: AvkAgentRole::Senior,
+        tmux_target: "avk-ofis:uretim.2",
+    },
+    AvkAgent {
+        slug: "code-2",
+        label: "Code-2 (Slot-2 Mühendis)",
+        role: AvkAgentRole::Senior,
+        tmux_target: "avk-ofis:uretim.3",
+    },
+    // yardimcilar window (paralel slot, 6 ajan)
+    AvkAgent {
+        slug: "gemini-1",
+        label: "Gemini-1 (Araştırmacı)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.1",
+    },
+    AvkAgent {
+        slug: "kimi-1",
+        label: "Kimi-1 (Multi-Provider)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.2",
+    },
+    AvkAgent {
+        slug: "kimi-2",
+        label: "Kimi-2 (Multi-Provider)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.3",
+    },
+    AvkAgent {
+        slug: "kimi-3",
+        label: "Kimi-3 (Multi-Provider)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.4",
+    },
+    AvkAgent {
+        slug: "codex",
+        label: "Codex (Bağımsız Denetçi)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.5",
+    },
+    AvkAgent {
+        slug: "gemini-2",
+        label: "Gemini-2 (Araştırmacı)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.6",
+    },
+];
+
+/// Slug ile AVK ajan ara. None döner bilinmeyen slug için.
+pub fn find_by_slug(slug: &str) -> Option<&'static AvkAgent> {
+    AVK_AGENTS.iter().find(|a| a.slug == slug)
+}
+
+/// Rol kategorisi ile ajanları filtrele.
+pub fn filter_by_role(role: AvkAgentRole) -> impl Iterator<Item = &'static AvkAgent> {
+    AVK_AGENTS.iter().filter(move |a| a.role == role)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_count_is_thirteen() {
+        // tmux 13 pane LIVE ack (2026-05-16T02:25Z TRT).
+        assert_eq!(AVK_AGENTS.len(), 13);
+    }
+
+    #[test]
+    fn all_slugs_unique() {
+        let mut slugs: Vec<&str> = AVK_AGENTS.iter().map(|a| a.slug).collect();
+        slugs.sort();
+        let unique_len = slugs.len();
+        slugs.dedup();
+        assert_eq!(slugs.len(), unique_len, "duplicate slug detected");
+    }
+
+    #[test]
+    fn role_distribution() {
+        // Director: Koord + Komuta + Müdür
+        let directors: Vec<_> = filter_by_role(AvkAgentRole::Director).collect();
+        assert_eq!(directors.len(), 3);
+
+        // Senior: Code-1 + Code-2 + Merge + Hata
+        let seniors: Vec<_> = filter_by_role(AvkAgentRole::Senior).collect();
+        assert_eq!(seniors.len(), 4);
+
+        // Worker: Gemini-1/2 + Kimi-1/2/3 + Codex
+        let workers: Vec<_> = filter_by_role(AvkAgentRole::Worker).collect();
+        assert_eq!(workers.len(), 6);
+
+        // Toplam = 13
+        assert_eq!(directors.len() + seniors.len() + workers.len(), 13);
+    }
+
+    #[test]
+    fn find_by_slug_works() {
+        assert_eq!(find_by_slug("koord").unwrap().role, AvkAgentRole::Director);
+        assert_eq!(find_by_slug("code-2").unwrap().role, AvkAgentRole::Senior);
+        assert_eq!(find_by_slug("gemini-1").unwrap().role, AvkAgentRole::Worker);
+        assert!(find_by_slug("bilinmeyen").is_none());
+    }
+
+    #[test]
+    fn tmux_target_format_valid() {
+        // Format: avk-ofis:<window>.<pane>
+        for agent in AVK_AGENTS {
+            assert!(
+                agent.tmux_target.starts_with("avk-ofis:"),
+                "{}: tmux_target invalid prefix",
+                agent.slug
+            );
+            assert!(
+                agent.tmux_target.contains('.'),
+                "{}: tmux_target missing pane index",
+                agent.slug
+            );
+        }
+    }
+
+    #[test]
+    fn role_as_str_canonical() {
+        assert_eq!(AvkAgentRole::Director.as_str(), "director");
+        assert_eq!(AvkAgentRole::Senior.as_str(), "senior");
+        assert_eq!(AvkAgentRole::Worker.as_str(), "worker");
+    }
+}

--- a/src/avk_agents.rs
+++ b/src/avk_agents.rs
@@ -70,19 +70,19 @@ pub const AVK_AGENTS: &[AvkAgent] = &[
     // idare window (yönetim, 4 ajan)
     AvkAgent {
         slug: "koord",
-        label: "Koord (Chief of Staff)",
+        label: "Koord (Genel Sekreter)",
         role: AvkAgentRole::Director,
         tmux_target: "avk-ofis:idare.1",
     },
     AvkAgent {
         slug: "komuta",
-        label: "Komuta Merkezi (COO)",
+        label: "Komuta Merkezi (Operasyon Müdürü)",
         role: AvkAgentRole::Director,
         tmux_target: "avk-ofis:idare.2",
     },
     AvkAgent {
         slug: "merge",
-        label: "Merge Agent (DevOps)",
+        label: "Birleştirme Ajanı (PR Bekçi)",
         role: AvkAgentRole::Senior,
         tmux_target: "avk-ofis:idare.3",
     },
@@ -95,7 +95,7 @@ pub const AVK_AGENTS: &[AvkAgent] = &[
     // uretim window (kıdemli iş, 3 ajan)
     AvkAgent {
         slug: "mudur",
-        label: "Müdür (Gateway Patrol)",
+        label: "Müdür (Geçit Süzgeci)",
         role: AvkAgentRole::Director,
         tmux_target: "avk-ofis:uretim.1",
     },
@@ -112,6 +112,8 @@ pub const AVK_AGENTS: &[AvkAgent] = &[
         tmux_target: "avk-ofis:uretim.3",
     },
     // yardimcilar window (paralel slot, 6 ajan)
+    // UI gösterim sırası: Gemini'ler birlikte, sonra Kimi'ler, sonra Codex
+    // (Furkan canon 2026-05-17). tmux_target değişmedi — pane index VPS layout.
     AvkAgent {
         slug: "gemini-1",
         label: "Gemini-1 (Araştırmacı)",
@@ -119,20 +121,26 @@ pub const AVK_AGENTS: &[AvkAgent] = &[
         tmux_target: "avk-ofis:yardimcilar.1",
     },
     AvkAgent {
+        slug: "gemini-2",
+        label: "Gemini-2 (Araştırmacı)",
+        role: AvkAgentRole::Worker,
+        tmux_target: "avk-ofis:yardimcilar.6",
+    },
+    AvkAgent {
         slug: "kimi-1",
-        label: "Kimi-1 (Multi-Provider)",
+        label: "Kimi-1 (Çoklu Sağlayıcı)",
         role: AvkAgentRole::Worker,
         tmux_target: "avk-ofis:yardimcilar.2",
     },
     AvkAgent {
         slug: "kimi-2",
-        label: "Kimi-2 (Multi-Provider)",
+        label: "Kimi-2 (Çoklu Sağlayıcı)",
         role: AvkAgentRole::Worker,
         tmux_target: "avk-ofis:yardimcilar.3",
     },
     AvkAgent {
         slug: "kimi-3",
-        label: "Kimi-3 (Multi-Provider)",
+        label: "Kimi-3 (Çoklu Sağlayıcı)",
         role: AvkAgentRole::Worker,
         tmux_target: "avk-ofis:yardimcilar.4",
     },
@@ -141,12 +149,6 @@ pub const AVK_AGENTS: &[AvkAgent] = &[
         label: "Codex (Bağımsız Denetçi)",
         role: AvkAgentRole::Worker,
         tmux_target: "avk-ofis:yardimcilar.5",
-    },
-    AvkAgent {
-        slug: "gemini-2",
-        label: "Gemini-2 (Araştırmacı)",
-        role: AvkAgentRole::Worker,
-        tmux_target: "avk-ofis:yardimcilar.6",
     },
 ];
 

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -8,7 +8,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::avk_agents::{filter_by_role, AvkAgentRole, AVK_AGENTS};
+use crate::avk_agents::resolve_tier_slugs;
 use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Storage};
 
 #[derive(Args)]
@@ -35,21 +35,7 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     }
 
     // AVK tier/all keyword broadcast vs. tekil session send ayrımı.
-    let avk_targets: Vec<&'static str> = match args.identifier.as_str() {
-        "all" => AVK_AGENTS.iter().map(|a| a.slug).collect(),
-        "director" => filter_by_role(AvkAgentRole::Director)
-            .map(|a| a.slug)
-            .collect(),
-        "senior" => filter_by_role(AvkAgentRole::Senior)
-            .map(|a| a.slug)
-            .collect(),
-        "worker" => filter_by_role(AvkAgentRole::Worker)
-            .map(|a| a.slug)
-            .collect(),
-        _ => Vec::new(),
-    };
-
-    if avk_targets.is_empty() {
+    let Some(avk_targets) = resolve_tier_slugs(args.identifier.as_str()) else {
         // Tekil session send (mevcut davranış)
         send_to_single(
             &mut instances,
@@ -59,7 +45,7 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         )?;
         storage.save(&instances)?;
         return Ok(());
-    }
+    };
 
     // Broadcast: AVK tier/all üzerinden multiple session send
     let total = avk_targets.len();
@@ -93,7 +79,7 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
 /// Tek bir session'a mesaj gönder. Storage save dış arayan tarafından yapılır
 /// (broadcast loop'unda her iterate save etmemek için ayrıştırıldı).
 fn send_to_single(
-    instances: &mut Vec<Instance>,
+    instances: &mut [Instance],
     identifier: &str,
     message: &str,
     no_revive: bool,

--- a/src/cli/send.rs
+++ b/src/cli/send.rs
@@ -1,13 +1,19 @@
 //! `agent-of-empires send` subcommand implementation
+//!
+//! AVK extension (FUR-4120): identifier `director`/`senior`/`worker`/`all`
+//! keyword'leri AVK_AGENTS registry'sinden tier-filtered broadcast yapar.
+//! Tier keyword AVK slug listesi ile çakışmaz (slug seti: koord/komuta/
+//! mudur/code-1/code-2/merge/hata/codex/gemini-1/2/kimi-1/2/3).
 
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::session::{EnsureReadyError, EnsureReadyOutcome, Storage};
+use crate::avk_agents::{filter_by_role, AvkAgentRole, AVK_AGENTS};
+use crate::session::{EnsureReadyError, EnsureReadyOutcome, Instance, Storage};
 
 #[derive(Args)]
 pub struct SendArgs {
-    /// Session ID or title
+    /// Session ID, title, or AVK tier keyword (director/senior/worker/all)
     identifier: String,
 
     /// Message to send to the agent
@@ -28,15 +34,76 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
         bail!("Message cannot be empty");
     }
 
-    let inst = super::resolve_session(&args.identifier, &instances)?;
+    // AVK tier/all keyword broadcast vs. tekil session send ayrımı.
+    let avk_targets: Vec<&'static str> = match args.identifier.as_str() {
+        "all" => AVK_AGENTS.iter().map(|a| a.slug).collect(),
+        "director" => filter_by_role(AvkAgentRole::Director)
+            .map(|a| a.slug)
+            .collect(),
+        "senior" => filter_by_role(AvkAgentRole::Senior)
+            .map(|a| a.slug)
+            .collect(),
+        "worker" => filter_by_role(AvkAgentRole::Worker)
+            .map(|a| a.slug)
+            .collect(),
+        _ => Vec::new(),
+    };
+
+    if avk_targets.is_empty() {
+        // Tekil session send (mevcut davranış)
+        send_to_single(
+            &mut instances,
+            &args.identifier,
+            &args.message,
+            args.no_revive,
+        )?;
+        storage.save(&instances)?;
+        return Ok(());
+    }
+
+    // Broadcast: AVK tier/all üzerinden multiple session send
+    let total = avk_targets.len();
+    let mut ok = 0usize;
+    let mut failed: Vec<(String, String)> = Vec::new();
+
+    println!(
+        "Broadcasting to '{}' ({} sessions)...",
+        args.identifier, total
+    );
+    for slug in &avk_targets {
+        match send_to_single(&mut instances, slug, &args.message, args.no_revive) {
+            Ok(()) => {
+                ok += 1;
+            }
+            Err(e) => {
+                eprintln!("  ✗ {slug}: {e}");
+                failed.push(((*slug).to_string(), e.to_string()));
+            }
+        }
+    }
+    storage.save(&instances)?;
+
+    println!("Broadcast complete: {ok}/{total} succeeded");
+    if !failed.is_empty() {
+        bail!("{} session(s) failed", failed.len());
+    }
+    Ok(())
+}
+
+/// Tek bir session'a mesaj gönder. Storage save dış arayan tarafından yapılır
+/// (broadcast loop'unda her iterate save etmemek için ayrıştırıldı).
+fn send_to_single(
+    instances: &mut Vec<Instance>,
+    identifier: &str,
+    message: &str,
+    no_revive: bool,
+) -> Result<()> {
+    let inst = super::resolve_session(identifier, instances)?;
     let session_id = inst.id.clone();
     let session_title = inst.title.clone();
     let tool = inst.tool.clone();
 
-    // Revive the pane if needed before delivering keystrokes. Without this,
-    // a send to a dead pane silently writes to a corpse with no agent to
-    // respond to it.
-    if !args.no_revive {
+    if !no_revive {
         if let Some(target) = instances.iter_mut().find(|i| i.id == session_id) {
             match target.ensure_pane_ready() {
                 Ok(EnsureReadyOutcome::Respawned) => {
@@ -61,18 +128,16 @@ pub async fn run(profile: &str, args: SendArgs) -> Result<()> {
     if !tmux_session.exists() {
         bail!(
             "Session is not running. Start it first with: aoe session start {}",
-            args.identifier
+            identifier
         );
     }
 
     let delay = crate::agents::send_keys_enter_delay(&tool);
-    tmux_session.send_keys_with_delay(&args.message, delay)?;
+    tmux_session.send_keys_with_delay(message, delay)?;
 
-    // Stamp last_accessed_at so the "last activity" column reflects user interaction
     if let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) {
         inst.touch_last_accessed();
     }
-    storage.save(&instances)?;
 
     println!("Sent message to '{}'", session_title);
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! Agent of Empires library - Core functionality for the terminal session manager
 
 pub mod agents;
+pub mod avk_agents;
 pub mod claude_settings;
 pub mod cli;
 #[cfg(feature = "serve")]

--- a/src/server/api/avk_agents.rs
+++ b/src/server/api/avk_agents.rs
@@ -13,9 +13,10 @@
 //! (avukatadanis-online src/app/api/*) sustained.
 
 use axum::{extract::Query, http::StatusCode, response::IntoResponse, Json};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use serde_json::json;
 
+use super::avk_broadcast::resolve_runtime_target;
 use crate::avk_agents::{filter_by_role, AvkAgent, AvkAgentRole, AVK_AGENTS};
 
 #[derive(Deserialize)]
@@ -23,14 +24,50 @@ pub struct AvkAgentsQuery {
     pub role: Option<String>,
 }
 
+/// FUR-4123: registry kayıt + runtime tmux pane durumu serialize wrapper.
+///
+/// `runtime_target` AoE binary'nin yarattigi gercek tmux session adi
+/// (örn `aoe_koord_e91e6bb4:^.0`) — bulunamazsa None, UI registry sabit
+/// `tmux_target`'i kullanir. `pane_alive` runtime resolver basariliysa
+/// true (session live), false ise UI gri dot gosterir.
+#[derive(Serialize)]
+struct AvkAgentWithStatus {
+    slug: &'static str,
+    label: &'static str,
+    role: AvkAgentRole,
+    tmux_target: &'static str,
+    runtime_target: Option<String>,
+    pane_alive: bool,
+}
+
+impl AvkAgentWithStatus {
+    fn from_agent(agent: &'static AvkAgent) -> Self {
+        let runtime = resolve_runtime_target(agent.slug);
+        Self {
+            slug: agent.slug,
+            label: agent.label,
+            role: agent.role,
+            tmux_target: agent.tmux_target,
+            pane_alive: runtime.is_some(),
+            runtime_target: runtime,
+        }
+    }
+}
+
 /// GET `/api/avk/agents[?role=director|senior|worker]`
 ///
 /// 13 AVK workflow ajan kayıt listesini JSON serve eder. `role` query
 /// belirtilirse o tier filtrelenir; bilinmeyen değer 400 döner.
+///
+/// FUR-4123: response artık her ajan için runtime tmux pane durumu da
+/// içerir (`runtime_target` + `pane_alive`). UI live dot indicator.
 pub async fn list_avk_agents(Query(query): Query<AvkAgentsQuery>) -> impl IntoResponse {
     match query.role.as_deref() {
         None => {
-            let agents: Vec<&AvkAgent> = AVK_AGENTS.iter().collect();
+            let agents: Vec<AvkAgentWithStatus> = AVK_AGENTS
+                .iter()
+                .map(AvkAgentWithStatus::from_agent)
+                .collect();
             Json(agents).into_response()
         }
         Some(raw) => {
@@ -51,7 +88,9 @@ pub async fn list_avk_agents(Query(query): Query<AvkAgentsQuery>) -> impl IntoRe
                         .into_response();
                 }
             };
-            let agents: Vec<&AvkAgent> = filter_by_role(role).collect();
+            let agents: Vec<AvkAgentWithStatus> = filter_by_role(role)
+                .map(AvkAgentWithStatus::from_agent)
+                .collect();
             Json(agents).into_response()
         }
     }

--- a/src/server/api/avk_agents.rs
+++ b/src/server/api/avk_agents.rs
@@ -1,0 +1,143 @@
+//! AVK workflow ajan registry endpoint.
+//!
+//! FUR-3957 transplant Adım 6 — `/api/avk/agents` GET serve. Upstream
+//! `list_agents` `/api/agents` AoE CLI binary tespiti döner (Claude/Cursor/
+//! Codex); bu endpoint **bizim 13 workflow ajan** kaydını (Koord/Komuta/
+//! Müdür/Code-1/2/Hata/Merge/Gemini-1/2/Kimi-1/2/3/Codex) JSON serve eder.
+//!
+//! Opsiyonel `?role=director|senior|worker` query filter. Geçersiz değer
+//! 400 Bad Request döner (status, error JSON `{ "error": "..." }`).
+//!
+//! Atomic-Lock: FUR-3957 Adım 6 (Code-2 sole) — Koord karar 02:05Z + Adım 5
+//! merge sonrası endpoint serve. Code-1 paralel F5.4 caller migration
+//! (avukatadanis-online src/app/api/*) sustained.
+
+use axum::{extract::Query, http::StatusCode, response::IntoResponse, Json};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::avk_agents::{filter_by_role, AvkAgent, AvkAgentRole, AVK_AGENTS};
+
+#[derive(Deserialize)]
+pub struct AvkAgentsQuery {
+    pub role: Option<String>,
+}
+
+/// GET `/api/avk/agents[?role=director|senior|worker]`
+///
+/// 13 AVK workflow ajan kayıt listesini JSON serve eder. `role` query
+/// belirtilirse o tier filtrelenir; bilinmeyen değer 400 döner.
+pub async fn list_avk_agents(Query(query): Query<AvkAgentsQuery>) -> impl IntoResponse {
+    match query.role.as_deref() {
+        None => {
+            let agents: Vec<&AvkAgent> = AVK_AGENTS.iter().collect();
+            Json(agents).into_response()
+        }
+        Some(raw) => {
+            let role = match raw.to_ascii_lowercase().as_str() {
+                "director" => AvkAgentRole::Director,
+                "senior" => AvkAgentRole::Senior,
+                "worker" => AvkAgentRole::Worker,
+                other => {
+                    return (
+                        StatusCode::BAD_REQUEST,
+                        Json(json!({
+                            "error": format!(
+                                "invalid role '{}': expected director|senior|worker",
+                                other
+                            )
+                        })),
+                    )
+                        .into_response();
+                }
+            };
+            let agents: Vec<&AvkAgent> = filter_by_role(role).collect();
+            Json(agents).into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::to_bytes;
+    use axum::extract::Query;
+
+    #[tokio::test]
+    async fn list_returns_all_thirteen_when_no_filter() {
+        let q = Query(AvkAgentsQuery { role: None });
+        let response = list_avk_agents(q).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.len(), 13);
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_director() {
+        let q = Query(AvkAgentsQuery {
+            role: Some("director".to_string()),
+        });
+        let response = list_avk_agents(q).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.len(), 3);
+        for agent in &parsed {
+            assert_eq!(agent["role"], "director");
+        }
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_senior() {
+        let q = Query(AvkAgentsQuery {
+            role: Some("senior".to_string()),
+        });
+        let response = list_avk_agents(q).await.into_response();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.len(), 4);
+    }
+
+    #[tokio::test]
+    async fn list_filters_by_worker() {
+        let q = Query(AvkAgentsQuery {
+            role: Some("worker".to_string()),
+        });
+        let response = list_avk_agents(q).await.into_response();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(parsed.len(), 6);
+    }
+
+    #[tokio::test]
+    async fn role_filter_case_insensitive() {
+        let q = Query(AvkAgentsQuery {
+            role: Some("DIRECTOR".to_string()),
+        });
+        let response = list_avk_agents(q).await.into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn invalid_role_returns_bad_request() {
+        let q = Query(AvkAgentsQuery {
+            role: Some("admin".to_string()),
+        });
+        let response = list_avk_agents(q).await.into_response();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn agent_json_shape_has_required_fields() {
+        let q = Query(AvkAgentsQuery { role: None });
+        let response = list_avk_agents(q).await.into_response();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
+        let first = &parsed[0];
+        assert!(first.get("slug").is_some());
+        assert!(first.get("label").is_some());
+        assert!(first.get("role").is_some());
+        assert!(first.get("tmux_target").is_some());
+    }
+}

--- a/src/server/api/avk_broadcast.rs
+++ b/src/server/api/avk_broadcast.rs
@@ -119,12 +119,23 @@ pub async fn broadcast_avk(
             }
         };
 
-        match send_to_pane(agent.tmux_target, message) {
+        // FUR-4122: AoE binary kendi `aoe_<slug>_<hash>` session'larini
+        // yaratiyor; registry sabit `avk-ofis:...` formatindan once runtime
+        // resolver dene. Bulamazsa registry target fallback (demo / manuel
+        // tmux ofis senaryosu icin geriye uyumlu). Resolver basariliysa
+        // session varligi list-sessions ile zaten dogrulanmis — pane_exists
+        // check'i atla (format `^.0` literal, window_name match olmaz).
+        let (effective_target, runtime_resolved) = match resolve_runtime_target(agent.slug) {
+            Some(t) => (t, true),
+            None => (agent.tmux_target.to_string(), false),
+        };
+
+        match send_to_pane(&effective_target, message, runtime_resolved) {
             Ok(()) => {
                 ok += 1;
                 results.push(BroadcastResult {
                     slug: (*slug).to_string(),
-                    target: agent.tmux_target.to_string(),
+                    target: effective_target,
                     ok: true,
                     error: None,
                 });
@@ -133,7 +144,7 @@ pub async fn broadcast_avk(
                 failed += 1;
                 results.push(BroadcastResult {
                     slug: (*slug).to_string(),
-                    target: agent.tmux_target.to_string(),
+                    target: effective_target,
                     ok: false,
                     error: Some(e),
                 });
@@ -166,8 +177,8 @@ fn error_response(status: StatusCode, msg: &str) -> Response {
 /// Pane var olup olmadığı `list-panes` ile pre-check (yanlış registry +
 /// tmux drift yakalama). Multi-line / 2KB+ mesajlar paste-buffer üzerinden
 /// bracketed paste, kısa tek satır mesajlar `send-keys -l --`.
-fn send_to_pane(target: &str, message: &str) -> Result<(), String> {
-    if !pane_exists(target)? {
+fn send_to_pane(target: &str, message: &str, pre_validated: bool) -> Result<(), String> {
+    if !pre_validated && !pane_exists(target)? {
         return Err(format!("tmux pane not found: {target}"));
     }
 
@@ -180,6 +191,36 @@ fn send_to_pane(target: &str, message: &str) -> Result<(), String> {
 
     run_tmux(&["send-keys", "-t", target, "Enter"])?;
     Ok(())
+}
+
+/// FUR-4122: AVK slug'i AoE binary'nin yarattigi runtime tmux session adina
+/// çevirir. AoE session naming: `aoe_<sanitized_title>_<id_first_8>` —
+/// AVK ajanlari title olarak slug kullaniyor (ornek: `aoe_koord_e91e6bb4`).
+///
+/// Tam slug eslesmesi sart (`aoe_koord_` `aoe_koord-1_` ile cakismasin):
+/// prefix sonrasinda kalan kisim sadece 8-char hash olmali (alphanumeric).
+///
+/// Bulamazsa None — caller registry sabit `tmux_target`'a fallback yapar.
+fn resolve_runtime_target(slug: &str) -> Option<String> {
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let prefix = format!("aoe_{slug}_");
+    let matched = stdout.lines().map(str::trim).find(|name| {
+        if !name.starts_with(&prefix) {
+            return false;
+        }
+        let rest = &name[prefix.len()..];
+        // 8-char hash + sadece alphanumeric — fuzzy match koruma.
+        !rest.is_empty() && rest.chars().all(|c| c.is_ascii_alphanumeric())
+    })?;
+    // `:^.0` = ilk window + ilk pane (AoE default layout, tek pane).
+    Some(format!("{matched}:^.0"))
 }
 
 fn pane_exists(target: &str) -> Result<bool, String> {

--- a/src/server/api/avk_broadcast.rs
+++ b/src/server/api/avk_broadcast.rs
@@ -201,7 +201,10 @@ fn send_to_pane(target: &str, message: &str, pre_validated: bool) -> Result<(), 
 /// prefix sonrasinda kalan kisim sadece 8-char hash olmali (alphanumeric).
 ///
 /// Bulamazsa None — caller registry sabit `tmux_target`'a fallback yapar.
-fn resolve_runtime_target(slug: &str) -> Option<String> {
+///
+/// FUR-4123: `pub(super)` — `avk_agents.rs` live pane status indicator
+/// endpoint aynı resolver'ı kullanır.
+pub(super) fn resolve_runtime_target(slug: &str) -> Option<String> {
     let output = Command::new("tmux")
         .args(["list-sessions", "-F", "#{session_name}"])
         .output()

--- a/src/server/api/avk_broadcast.rs
+++ b/src/server/api/avk_broadcast.rs
@@ -1,0 +1,260 @@
+//! AVK tier broadcast endpoint — FUR-4121 Faz 3.
+//!
+//! `POST /api/avk/broadcast` mevcut tmux pane'lere doğrudan mesaj yollar.
+//! `aoe send <tier> "<msg>"` CLI muadili; tier resolver
+//! [`crate::avk_agents::resolve_tier_slugs`] shared, AVK_AGENTS registry
+//! single source of truth.
+//!
+//! ## Tasarım kararı (Session vs. raw tmux)
+//!
+//! AVK ajanları AoE session olarak değil, doğrudan tmux pane'leri (avk-ofis
+//! tmux session, idare/uretim/yardimcilar window'larında). Bu yüzden Session
+//! struct + Storage resolver yerine `tmux send-keys -t <target>` raw çağrı
+//! kullanılır. Pane var olup olmadığı `tmux list-panes -F` ile pre-check.
+//!
+//! ## Güvenlik
+//!
+//! Message validation:
+//!   - Boş mesaj reject (400)
+//!   - 8KB cap (paste-buffer threshold + safety margin)
+//!   - Bilinmeyen tier reject (404)
+//!
+//! Multi-line / 2KB+ mesaj için tmux paste-buffer path (bracketed paste)
+//! kullanılır — agent CLI'lar (Claude, Codex, Gemini, Kimi) DECSET 2004
+//! ingest eder, satır satır submit yerine atomic paste alır.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use super::AppState;
+use crate::avk_agents::{find_by_slug, resolve_tier_slugs};
+
+const MAX_MESSAGE_BYTES: usize = 8192;
+const PASTE_BUFFER_THRESHOLD: usize = 2048;
+
+#[derive(Deserialize)]
+pub struct BroadcastRequest {
+    /// Tier keyword: `director` / `senior` / `worker` / `all`.
+    pub tier: String,
+    /// Gönderilecek mesaj (8KB cap).
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct BroadcastResult {
+    pub slug: String,
+    pub target: String,
+    pub ok: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Serialize)]
+pub struct BroadcastResponse {
+    pub tier: String,
+    pub total: usize,
+    pub ok: usize,
+    pub failed: usize,
+    pub results: Vec<BroadcastResult>,
+}
+
+#[derive(Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+pub async fn broadcast_avk(
+    State(_state): State<Arc<AppState>>,
+    Json(req): Json<BroadcastRequest>,
+) -> Response {
+    let message = req.message.trim();
+    if message.is_empty() {
+        return error_response(StatusCode::BAD_REQUEST, "message cannot be empty");
+    }
+    if message.len() > MAX_MESSAGE_BYTES {
+        return error_response(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            &format!(
+                "message too long ({}B > cap {}B)",
+                message.len(),
+                MAX_MESSAGE_BYTES
+            ),
+        );
+    }
+
+    let Some(slugs) = resolve_tier_slugs(req.tier.as_str()) else {
+        return error_response(
+            StatusCode::NOT_FOUND,
+            &format!(
+                "unknown tier '{}' (expected: director / senior / worker / all)",
+                req.tier
+            ),
+        );
+    };
+
+    let mut results = Vec::with_capacity(slugs.len());
+    let mut ok = 0usize;
+    let mut failed = 0usize;
+
+    for slug in &slugs {
+        let agent = match find_by_slug(slug) {
+            Some(a) => a,
+            None => {
+                results.push(BroadcastResult {
+                    slug: (*slug).to_string(),
+                    target: String::new(),
+                    ok: false,
+                    error: Some("slug not found in AVK_AGENTS registry".into()),
+                });
+                failed += 1;
+                continue;
+            }
+        };
+
+        match send_to_pane(agent.tmux_target, message) {
+            Ok(()) => {
+                ok += 1;
+                results.push(BroadcastResult {
+                    slug: (*slug).to_string(),
+                    target: agent.tmux_target.to_string(),
+                    ok: true,
+                    error: None,
+                });
+            }
+            Err(e) => {
+                failed += 1;
+                results.push(BroadcastResult {
+                    slug: (*slug).to_string(),
+                    target: agent.tmux_target.to_string(),
+                    ok: false,
+                    error: Some(e),
+                });
+            }
+        }
+    }
+
+    Json(BroadcastResponse {
+        tier: req.tier,
+        total: slugs.len(),
+        ok,
+        failed,
+        results,
+    })
+    .into_response()
+}
+
+fn error_response(status: StatusCode, msg: &str) -> Response {
+    (
+        status,
+        Json(ErrorBody {
+            error: msg.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+/// Tek bir tmux pane'e mesaj gönder + Enter submit.
+///
+/// Pane var olup olmadığı `list-panes` ile pre-check (yanlış registry +
+/// tmux drift yakalama). Multi-line / 2KB+ mesajlar paste-buffer üzerinden
+/// bracketed paste, kısa tek satır mesajlar `send-keys -l --`.
+fn send_to_pane(target: &str, message: &str) -> Result<(), String> {
+    if !pane_exists(target)? {
+        return Err(format!("tmux pane not found: {target}"));
+    }
+
+    let use_paste_buffer = message.len() >= PASTE_BUFFER_THRESHOLD || message.contains('\n');
+    if use_paste_buffer {
+        send_via_paste_buffer(target, message)?;
+    } else {
+        run_tmux(&["send-keys", "-t", target, "-l", "--", message])?;
+    }
+
+    run_tmux(&["send-keys", "-t", target, "Enter"])?;
+    Ok(())
+}
+
+fn pane_exists(target: &str) -> Result<bool, String> {
+    let output = Command::new("tmux")
+        .args([
+            "list-panes",
+            "-a",
+            "-F",
+            "#{session_name}:#{window_name}.#{pane_index}",
+        ])
+        .output()
+        .map_err(|e| format!("tmux list-panes spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "tmux list-panes failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    Ok(stdout.lines().any(|line| line.trim() == target))
+}
+
+fn run_tmux(args: &[&str]) -> Result<(), String> {
+    let output = Command::new("tmux")
+        .args(args)
+        .output()
+        .map_err(|e| format!("tmux spawn failed: {e}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "tmux {} failed: {}",
+            args.first().copied().unwrap_or(""),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+fn send_via_paste_buffer(target: &str, text: &str) -> Result<(), String> {
+    static SEND_COUNTER: AtomicU64 = AtomicU64::new(0);
+    let seq = SEND_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let buf_name = format!("aoe-avk-broadcast-{}-{}", std::process::id(), seq);
+
+    let mut child = Command::new("tmux")
+        .args(["load-buffer", "-b", &buf_name, "-"])
+        .stdin(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("tmux load-buffer spawn failed: {e}"))?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin
+            .write_all(text.as_bytes())
+            .map_err(|e| format!("tmux load-buffer stdin write failed: {e}"))?;
+    }
+    let status = child
+        .wait()
+        .map_err(|e| format!("tmux load-buffer wait failed: {e}"))?;
+    if !status.success() {
+        return Err(format!(
+            "tmux load-buffer exited non-zero (code={:?})",
+            status.code()
+        ));
+    }
+
+    let output = Command::new("tmux")
+        .args(["paste-buffer", "-d", "-p", "-b", &buf_name, "-t", target])
+        .output()
+        .map_err(|e| format!("tmux paste-buffer spawn failed: {e}"))?;
+    if !output.status.success() {
+        let _ = Command::new("tmux")
+            .args(["delete-buffer", "-b", &buf_name])
+            .output();
+        return Err(format!(
+            "tmux paste-buffer failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}

--- a/src/server/api/avk_memory.rs
+++ b/src/server/api/avk_memory.rs
@@ -1,0 +1,149 @@
+//! AVK memory recall feed endpoint (FUR-4118).
+//!
+//! `GET /api/avk/memory-recall[?role=koord&hours=24]` — agentmemory MCP'ye
+//! HTTP/JSON-RPC proxy aşaması bekleniyor (VPS-side endpoint research
+//! gerek); şimdilik mock data ile UI contract validate edilir.
+//!
+//! Mock entries gerçek son 24 saat patrol özet'inden örnek alır:
+//! FUR-3957 transplant tamamlandı, FUR-4120 tier broadcast eklendi,
+//! P0 prod incident RESOLVED vs. Furkan'a gerçek-feel demo verir.
+
+use axum::{extract::Query, response::IntoResponse, Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct AvkMemoryQuery {
+    pub role: Option<String>,
+    pub hours: Option<u32>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MemoryTier {
+    Core,
+    Working,
+    Archival,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MemoryEntry {
+    pub id: &'static str,
+    pub title: &'static str,
+    pub tier: MemoryTier,
+    pub role: &'static str,
+    pub tags: &'static [&'static str],
+    pub content_preview: &'static str,
+    pub created_at: &'static str,
+}
+
+/// Mock recall feed — son 24 saat canon kayıtlar.
+///
+/// Gerçek implementation agentmemory MCP'ye reqwest HTTP/JSON-RPC ile
+/// bağlanır. VPS-side endpoint spec'i hazır olunca bu fonksiyon mock
+/// yerine gerçek query çalıştırır.
+const MOCK_FEED: &[MemoryEntry] = &[
+    MemoryEntry {
+        id: "mem-001",
+        title: "FUR-3957 transplant TAMAMLANDI — Adım 5-8 zinciri",
+        tier: MemoryTier::Core,
+        role: "omni",
+        tags: &["ajanlarim", "aoe", "transplant", "tamamlandı"],
+        content_preview:
+            "PR #4 admin merge başarılı. AvkAgentsGrid widget Dashboard'a mount edildi, \
+             /api/avk/agents endpoint LIVE, avk_agents.rs registry main'de. 3 dormant \
+             branch (F6/F7/F8) silindi, 1 obsolete (avk/kimi-adapt-level1) silindi. \
+             Final state temiz: sadece main.",
+        created_at: "2026-05-17T13:10:00Z",
+    },
+    MemoryEntry {
+        id: "mem-002",
+        title: "FUR-4120 tier broadcast PR #6 MERGED",
+        tier: MemoryTier::Core,
+        role: "omni",
+        tags: &["inject-bridge", "tier-broadcast", "send"],
+        content_preview:
+            "aoe send director|senior|worker|all <mesaj> — AVK_AGENTS registry'sinden \
+             tier-filtered multiple session send. Test: director 3/3 ✓, senior 4/4 ✓. \
+             Backward-compat slug positional korundu. Atomic single-PR.",
+        created_at: "2026-05-17T13:54:38Z",
+    },
+    MemoryEntry {
+        id: "mem-003",
+        title: "FUR-4117 — 13 ajan AoE session lifecycle lokal",
+        tier: MemoryTier::Working,
+        role: "omni",
+        tags: &["aoe", "session-lifecycle", "lokal-first"],
+        content_preview:
+            "13 ajan (koord/komuta/mudur/code-1/2/merge/hata/codex/gemini-1/2/kimi-1/2/3) \
+             AoE'ye eklendi (aoe add). --launch yok, kotaya değmedi. Brew install aoe \
+             1.7.0 + cargo build --features serve (4m 14s). Mevcut tmux setup paralel.",
+        created_at: "2026-05-17T13:38:00Z",
+    },
+    MemoryEntry {
+        id: "mem-004",
+        title: "P0 PROD INCIDENT RESOLVED — FUR-4073 8 tezahür",
+        tier: MemoryTier::Core,
+        role: "hata",
+        tags: &["p0", "prod", "resolved", "strangler-cluster"],
+        content_preview:
+            "5h 30m sustained Strangler refactor cluster (FAZ-2J → FAZ-2T). 8 tezahür, \
+             5 fix PR (#7600/7602/7609/7612/7613/7621/7625). Synergy: Omni patrol detect \
+             + Hata Ajanı pickup loop 5-30dk turnaround. www.avukatadanis.com 200 OK ✓.",
+        created_at: "2026-05-17T07:05:00Z",
+    },
+    MemoryEntry {
+        id: "mem-005",
+        title: "SEO audit revize — Furkan canon domain migration",
+        tier: MemoryTier::Working,
+        role: "omni",
+        tags: &["seo", "fur-4072", "verify-before-claim"],
+        content_preview:
+            "Furkan 'domaini avukatadanis.com taşıdık' tek cümleyle düzeltti. \
+             Önceki iddia 'ENV eksik, fallback eski domain' YANLIŞ — verify edilmiş \
+             değil. Karpathy 51 #31 ders. Doğru tanı: GSC'de yeni .com property \
+             eklenmemiş. Linear FUR-4072 P1 handover Furkan Google hesabı.",
+        created_at: "2026-05-17T02:11:20Z",
+    },
+    MemoryEntry {
+        id: "mem-006",
+        title: "Karpathy 51 #137 — Mekanik > niyet, FUR-4068 guard yetersiz",
+        tier: MemoryTier::Archival,
+        role: "koord",
+        tags: &["karpathy", "mekanik-niyet", "pre-commit-hook"],
+        content_preview:
+            "FUR-4068 Strangler rename pre-commit guard (5-pattern grep) MERGED ama 1 saat \
+             içinde 2 yeni cluster tezahürü (FAZ-2Q + 2T). Guard caller-side path tarıyor, \
+             target-side relative import resolve test eksik. Mekanik garanti tanım \
+             yetersizliği etkisiz. Önlem aday: pre-PR lokal build zorunluluğu canon.",
+        created_at: "2026-05-17T06:42:54Z",
+    },
+    MemoryEntry {
+        id: "mem-007",
+        title: "tmux Yardimcilar window rebuild — kalıcı kök çözüm",
+        tier: MemoryTier::Working,
+        role: "omni",
+        tags: &["tmux", "drift", "kalici-cozum", "karpathy-10-1"],
+        content_preview:
+            "Furkan canon 'birkaç sefer ayarladık, yeniden başlatınca karışıyor yardımcılar'. \
+             Manuel yama yerine idempotent rebuild script (Karpathy §10.1). \
+             avk-office:2 6 pane 2col×3row (G1|G2 / K1|K2 / K3|Codex). \
+             ajan-sistemi PR #674 merged. Restart sonrası tek komutla layout.",
+        created_at: "2026-05-17T11:55:00Z",
+    },
+];
+
+/// GET `/api/avk/memory-recall[?role=...&hours=...]`
+///
+/// Mock implementation: filter sadece `role` parametresiyle çalışır
+/// (hours şu an yok-sayılır; gerçek MCP query implementation eklendiğinde
+/// `created_at` aralık filter aktif). Bilinmeyen role boş array döner.
+pub async fn list_avk_memory_recall(Query(query): Query<AvkMemoryQuery>) -> impl IntoResponse {
+    let filtered: Vec<&MemoryEntry> = MOCK_FEED
+        .iter()
+        .filter(|entry| match query.role.as_deref() {
+            Some(role) => entry.role == role,
+            None => true,
+        })
+        .collect();
+    Json(filtered).into_response()
+}

--- a/src/server/api/avk_memory.rs
+++ b/src/server/api/avk_memory.rs
@@ -97,8 +97,7 @@ const MOCK_FEED: &[MemoryEntry] = &[
         tier: MemoryTier::Working,
         role: "omni",
         tags: &["seo", "fur-4072", "verify-before-claim"],
-        content_preview:
-            "Furkan 'domaini avukatadanis.com taşıdık' tek cümleyle düzeltti. \
+        content_preview: "Furkan 'domaini avukatadanis.com taşıdık' tek cümleyle düzeltti. \
              Önceki iddia 'ENV eksik, fallback eski domain' YANLIŞ — verify edilmiş \
              değil. Karpathy 51 #31 ders. Doğru tanı: GSC'de yeni .com property \
              eklenmemiş. Linear FUR-4072 P1 handover Furkan Google hesabı.",

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -12,6 +12,8 @@ pub(super) use super::AppState;
 
 // FUR-3957 Adım 6 — AVK workflow ajan registry endpoint (13 ajan serve).
 mod avk_agents;
+// FUR-4118 — AVK memory recall feed endpoint (mock; agentmemory MCP proxy bekleniş).
+mod avk_memory;
 #[cfg(feature = "serve")]
 mod client_log;
 #[cfg(feature = "serve")]
@@ -39,6 +41,7 @@ pub use cockpit::{
 };
 
 pub use avk_agents::list_avk_agents;
+pub use avk_memory::list_avk_memory_recall;
 #[cfg(feature = "serve")]
 pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -12,6 +12,8 @@ pub(super) use super::AppState;
 
 // FUR-3957 Adım 6 — AVK workflow ajan registry endpoint (13 ajan serve).
 mod avk_agents;
+// FUR-4121 — AVK tier broadcast endpoint (POST /api/avk/broadcast).
+mod avk_broadcast;
 // FUR-4118 — AVK memory recall feed endpoint (mock; agentmemory MCP proxy bekleniş).
 mod avk_memory;
 #[cfg(feature = "serve")]
@@ -41,6 +43,7 @@ pub use cockpit::{
 };
 
 pub use avk_agents::list_avk_agents;
+pub use avk_broadcast::broadcast_avk;
 pub use avk_memory::list_avk_memory_recall;
 #[cfg(feature = "serve")]
 pub use client_log::post_client_log;

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -10,6 +10,8 @@
 
 pub(super) use super::AppState;
 
+// FUR-3957 Adım 6 — AVK workflow ajan registry endpoint (13 ajan serve).
+mod avk_agents;
 #[cfg(feature = "serve")]
 mod client_log;
 #[cfg(feature = "serve")]
@@ -19,6 +21,15 @@ mod log_level;
 mod projects;
 mod sessions;
 mod system;
+// FUR-3957 Sub-C entegrasyon — Linear + Sentry summary widgets (avk-suite fork).
+#[cfg(feature = "serve")]
+mod widgets;
+
+#[cfg(feature = "serve")]
+pub use widgets::{
+    get_github_actions_summary, get_linear_summary, get_netdata_summary, get_sentry_summary,
+    get_vercel_summary, WidgetCache,
+};
 
 #[cfg(feature = "serve")]
 pub use cockpit::{
@@ -27,6 +38,7 @@ pub use cockpit::{
     set_cockpit_master, shutdown_cockpit, spawn_cockpit,
 };
 
+pub use avk_agents::list_avk_agents;
 #[cfg(feature = "serve")]
 pub use client_log::post_client_log;
 pub use git::{clone_repo, list_branches};

--- a/src/server/api/widgets.rs
+++ b/src/server/api/widgets.rs
@@ -1,0 +1,1066 @@
+//! Widget summary endpoints (avk-suite custom adapt).
+//!
+//! Five REST GET endpoints under `/api/widgets/`:
+//!   - `/linear/summary`         — In Progress + Backlog + 7d Done counts + 5 recent issue
+//!   - `/sentry/summary`         — Last 24h unresolved issue count + 5 recent
+//!   - `/github-actions/summary` — Multi-repo workflow runs status tally + cross-repo recent 5
+//!   - `/vercel/summary`         — Deployment state bucket counts + recent 5
+//!   - `/netdata/summary`        — Reachability + version + canonical chart URLs (iframe ready)
+//!
+//! Each backed by 60-second in-process cache to absorb dashboard refresh bursts
+//! without hitting upstream rate limits. Env-driven (no silent fallback — missing
+//! required env returns 500 with a precise error).
+//!
+//! Response header `x-cache: HIT|MISS` on success per docs/aoe-transplant/02-widget-api-contract.md.
+//!
+//! FUR-3957 transplant — port of the avk Sub-C/Sub-B-5+6 Next.js routes
+//! (avk PRs ajan-sistemi#521 + #525). Contract doc:
+//! `docs/aoe-transplant/02-widget-api-contract.md`.
+
+use std::env;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::AppState;
+
+const CACHE_TTL: Duration = Duration::from_secs(60);
+const LINEAR_TEAM_ID: &str = "5669ce66-e92d-4a8a-96c3-49be9a68204f";
+const LINEAR_GRAPHQL: &str = "https://api.linear.app/graphql";
+
+// ─── Common cache ──────────────────────────────────────────────────────────
+
+struct Cached<T> {
+    data: T,
+    expires_at: Instant,
+}
+
+#[derive(Default)]
+pub struct WidgetCache {
+    linear: Mutex<Option<Cached<LinearSummary>>>,
+    sentry: Mutex<Option<Cached<SentrySummary>>>,
+    github_actions: Mutex<Option<Cached<GitHubActionsSummary>>>,
+    vercel: Mutex<Option<Cached<VercelSummary>>>,
+    netdata: Mutex<Option<Cached<NetdataSummary>>>,
+}
+
+impl WidgetCache {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+macro_rules! cache_accessors {
+    ($name:ident, $get:ident, $set:ident, $ty:ty) => {
+        impl WidgetCache {
+            fn $get(&self) -> Option<$ty> {
+                let guard = self.$name.lock().ok()?;
+                let entry = guard.as_ref()?;
+                if entry.expires_at > Instant::now() {
+                    Some(entry.data.clone())
+                } else {
+                    None
+                }
+            }
+
+            fn $set(&self, data: $ty) {
+                if let Ok(mut guard) = self.$name.lock() {
+                    *guard = Some(Cached {
+                        data,
+                        expires_at: Instant::now() + CACHE_TTL,
+                    });
+                }
+            }
+        }
+    };
+}
+
+cache_accessors!(linear, get_linear, set_linear, LinearSummary);
+cache_accessors!(sentry, get_sentry, set_sentry, SentrySummary);
+cache_accessors!(github_actions, get_gh, set_gh, GitHubActionsSummary);
+cache_accessors!(vercel, get_vercel, set_vercel, VercelSummary);
+cache_accessors!(netdata, get_netdata, set_netdata, NetdataSummary);
+
+/// Response helper — attach `x-cache` header on success.
+fn with_cache_header<T: Serialize>(data: T, hit: bool) -> axum::response::Response {
+    let header = if hit { "HIT" } else { "MISS" };
+    ([("x-cache", header)], Json(data)).into_response()
+}
+
+// ─── Linear ────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Serialize)]
+pub struct LinearCount {
+    pub count: usize,
+    pub has_more: bool,
+}
+
+#[derive(Clone, Serialize)]
+pub struct LinearIssue {
+    pub identifier: String,
+    pub title: String,
+    pub state: String,
+    pub url: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct LinearSummary {
+    pub in_progress: LinearCount,
+    pub backlog: LinearCount,
+    pub done7d: LinearCount,
+    pub recent: Vec<LinearIssue>,
+    pub fetched_at: String,
+}
+
+#[derive(Deserialize)]
+struct LinearGraphResp {
+    data: Option<LinearGraphData>,
+    errors: Option<Vec<LinearGraphError>>,
+}
+
+#[derive(Deserialize)]
+struct LinearGraphError {
+    message: String,
+}
+
+#[derive(Deserialize)]
+struct LinearGraphData {
+    #[serde(rename = "inProgress")]
+    in_progress: LinearConn,
+    backlog: LinearConn,
+    #[serde(rename = "done7d")]
+    done7d: LinearConn,
+    recent: LinearRecentConn,
+}
+
+#[derive(Deserialize)]
+struct LinearConn {
+    nodes: Vec<Value>,
+    #[serde(rename = "pageInfo")]
+    page_info: LinearPageInfo,
+}
+
+#[derive(Deserialize)]
+struct LinearPageInfo {
+    #[serde(rename = "hasNextPage")]
+    has_next_page: bool,
+}
+
+#[derive(Deserialize)]
+struct LinearRecentConn {
+    nodes: Vec<LinearRecentNode>,
+}
+
+#[derive(Deserialize)]
+struct LinearRecentNode {
+    identifier: String,
+    title: String,
+    url: String,
+    #[serde(rename = "updatedAt")]
+    updated_at: String,
+    state: LinearStateRef,
+}
+
+#[derive(Deserialize)]
+struct LinearStateRef {
+    name: String,
+}
+
+const LINEAR_QUERY: &str = r#"
+query Summary($teamId: ID!, $since: DateTimeOrDuration!) {
+  inProgress: issues(filter: {team: {id: {eq: $teamId}}, state: {type: {eq: "started"}}}, first: 250) {
+    nodes { id }
+    pageInfo { hasNextPage }
+  }
+  backlog: issues(filter: {team: {id: {eq: $teamId}}, state: {type: {in: ["backlog", "unstarted"]}}}, first: 250) {
+    nodes { id }
+    pageInfo { hasNextPage }
+  }
+  done7d: issues(filter: {team: {id: {eq: $teamId}}, state: {type: {eq: "completed"}}, completedAt: {gte: $since}}, first: 250) {
+    nodes { id }
+    pageInfo { hasNextPage }
+  }
+  recent: issues(filter: {team: {id: {eq: $teamId}}}, orderBy: updatedAt, first: 5) {
+    nodes {
+      identifier
+      title
+      url
+      updatedAt
+      state { name }
+    }
+  }
+}
+"#;
+
+async fn fetch_linear(api_key: &str) -> Result<LinearSummary, String> {
+    let since = chrono::Utc::now() - chrono::Duration::days(7);
+    let since_iso = since.to_rfc3339();
+    let body = serde_json::json!({
+        "query": LINEAR_QUERY,
+        "variables": { "teamId": LINEAR_TEAM_ID, "since": since_iso }
+    });
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(LINEAR_GRAPHQL)
+        .header("Authorization", api_key)
+        .header("Content-Type", "application/json")
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| format!("Linear request error: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("Linear body read error: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("Linear API {status}: {text}"));
+    }
+
+    let parsed: LinearGraphResp = serde_json::from_str(&text)
+        .map_err(|e| format!("Linear JSON parse error: {e} | body: {text}"))?;
+
+    if let Some(errs) = parsed.errors {
+        let msg = errs
+            .into_iter()
+            .map(|e| e.message)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(format!("Linear GraphQL error: {msg}"));
+    }
+
+    let data = parsed
+        .data
+        .ok_or_else(|| "Linear data missing".to_string())?;
+
+    Ok(LinearSummary {
+        in_progress: LinearCount {
+            count: data.in_progress.nodes.len(),
+            has_more: data.in_progress.page_info.has_next_page,
+        },
+        backlog: LinearCount {
+            count: data.backlog.nodes.len(),
+            has_more: data.backlog.page_info.has_next_page,
+        },
+        done7d: LinearCount {
+            count: data.done7d.nodes.len(),
+            has_more: data.done7d.page_info.has_next_page,
+        },
+        recent: data
+            .recent
+            .nodes
+            .into_iter()
+            .map(|n| LinearIssue {
+                identifier: n.identifier,
+                title: n.title,
+                state: n.state.name,
+                url: n.url,
+                updated_at: n.updated_at,
+            })
+            .collect(),
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+pub async fn get_linear_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let api_key = env::var("LINEAR_API_KEY").map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "LINEAR_API_KEY env eksik".to_string(),
+        )
+    })?;
+
+    if let Some(cached) = state.widget_cache.get_linear() {
+        return Ok(with_cache_header(cached, true));
+    }
+
+    match fetch_linear(&api_key).await {
+        Ok(data) => {
+            state.widget_cache.set_linear(data.clone());
+            Ok(with_cache_header(data, false))
+        }
+        Err(msg) => Err((StatusCode::BAD_GATEWAY, msg)),
+    }
+}
+
+// ─── Sentry ────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Serialize)]
+pub struct SentryIssue {
+    pub id: String,
+    pub short_id: String,
+    pub title: String,
+    pub culprit: String,
+    pub count: String,
+    pub permalink: String,
+    pub last_seen: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct SentrySummary {
+    pub total_issues: usize,
+    pub unresolved: usize,
+    pub recent: Vec<SentryIssue>,
+    pub fetched_at: String,
+}
+
+#[derive(Deserialize)]
+struct SentryRaw {
+    id: String,
+    #[serde(rename = "shortId")]
+    short_id: String,
+    title: String,
+    culprit: String,
+    count: String,
+    permalink: String,
+    #[serde(rename = "lastSeen")]
+    last_seen: String,
+    status: String,
+}
+
+/// Sentry slug/org validation: alphanumeric + dash/underscore/dot. Sentry
+/// slugs by convention are lowercase kebab; we reject anything outside that
+/// alphabet so the URL stays well-formed without a percent-encoder.
+fn valid_sentry_slug(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+}
+
+async fn fetch_sentry(
+    auth_token: &str,
+    org: &str,
+    project_slug: &str,
+) -> Result<SentrySummary, String> {
+    if !valid_sentry_slug(org) || !valid_sentry_slug(project_slug) {
+        return Err(
+            "Sentry org/project_slug geçersiz karakter içeriyor (alphanumeric + -_. izinli)"
+                .to_string(),
+        );
+    }
+
+    let url = format!(
+        "https://sentry.io/api/0/projects/{org}/{project_slug}/issues/?statsPeriod=24h&limit=25&sort=date&query=is:unresolved"
+    );
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {auth_token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Sentry request error: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("Sentry body read error: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("Sentry API {status}: {text}"));
+    }
+
+    let raw: Vec<SentryRaw> =
+        serde_json::from_str(&text).map_err(|e| format!("Sentry JSON parse error: {e}"))?;
+
+    let unresolved: Vec<&SentryRaw> = raw.iter().filter(|r| r.status == "unresolved").collect();
+    let total = raw.len();
+    let unresolved_count = unresolved.len();
+
+    Ok(SentrySummary {
+        total_issues: total,
+        unresolved: unresolved_count,
+        recent: unresolved
+            .into_iter()
+            .take(5)
+            .map(|r| SentryIssue {
+                id: r.id.clone(),
+                short_id: r.short_id.clone(),
+                title: r.title.clone(),
+                culprit: r.culprit.clone(),
+                count: r.count.clone(),
+                permalink: r.permalink.clone(),
+                last_seen: r.last_seen.clone(),
+            })
+            .collect(),
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+pub async fn get_sentry_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let auth = env::var("SENTRY_AUTH_TOKEN").ok();
+    let org = env::var("SENTRY_ORG").ok();
+    let project = env::var("SENTRY_PROJECT_SLUG").ok();
+
+    let (auth, org, project) = match (auth, org, project) {
+        (Some(a), Some(o), Some(p)) if !a.is_empty() && !o.is_empty() && !p.is_empty() => (a, o, p),
+        _ => {
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Sentry env eksik (SENTRY_AUTH_TOKEN + SENTRY_ORG + SENTRY_PROJECT_SLUG gerekli)"
+                    .to_string(),
+            ));
+        }
+    };
+
+    if let Some(cached) = state.widget_cache.get_sentry() {
+        return Ok(with_cache_header(cached, true));
+    }
+
+    match fetch_sentry(&auth, &org, &project).await {
+        Ok(data) => {
+            state.widget_cache.set_sentry(data.clone());
+            Ok(with_cache_header(data, false))
+        }
+        Err(msg) => Err((StatusCode::BAD_GATEWAY, msg)),
+    }
+}
+
+// ─── GitHub Actions ────────────────────────────────────────────────────────
+
+#[derive(Clone, Serialize)]
+pub struct GitHubRun {
+    pub id: u64,
+    pub repo: String,
+    pub name: String,
+    pub status: String,
+    pub conclusion: Option<String>,
+    pub html_url: String,
+    pub head_branch: String,
+    pub event: String,
+    pub run_started_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct GitHubRepoStats {
+    pub repo: String,
+    pub success: usize,
+    pub failure: usize,
+    pub in_progress: usize,
+    pub other: usize,
+}
+
+#[derive(Clone, Serialize)]
+pub struct GitHubActionsSummary {
+    pub repos: Vec<GitHubRepoStats>,
+    pub recent: Vec<GitHubRun>,
+    pub fetched_at: String,
+}
+
+#[derive(Deserialize)]
+struct GitHubRawRun {
+    id: u64,
+    name: Option<String>,
+    status: String,
+    conclusion: Option<String>,
+    html_url: String,
+    head_branch: Option<String>,
+    event: String,
+    run_started_at: Option<String>,
+    updated_at: String,
+}
+
+#[derive(Deserialize)]
+struct GitHubWorkflowRunsResp {
+    workflow_runs: Vec<GitHubRawRun>,
+}
+
+/// Parse comma-separated repos, trimmed + `owner/name` shape filter.
+pub fn parse_repos(env: &str) -> Vec<String> {
+    env.split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty() && s.contains('/'))
+        .collect()
+}
+
+/// Validate repo slug: only `owner/name` characters (alphanumeric + `_-./`).
+fn valid_repo_slug(s: &str) -> bool {
+    let parts: Vec<&str> = s.split('/').collect();
+    if parts.len() != 2 {
+        return false;
+    }
+    parts.iter().all(|p| {
+        !p.is_empty()
+            && p.chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+    })
+}
+
+fn tally_run(stats: &mut GitHubRepoStats, run: &GitHubRawRun) {
+    match run.status.as_str() {
+        "in_progress" | "queued" | "waiting" => {
+            stats.in_progress += 1;
+            return;
+        }
+        _ => {}
+    }
+    match run.conclusion.as_deref() {
+        Some("success") => stats.success += 1,
+        Some("failure") | Some("timed_out") | Some("startup_failure") => stats.failure += 1,
+        _ => stats.other += 1,
+    }
+}
+
+async fn fetch_github_actions(
+    token: &str,
+    repos: &[String],
+) -> Result<GitHubActionsSummary, String> {
+    if repos.is_empty() {
+        return Err("GITHUB_REPOS env boş — en az 1 repo gerek".to_string());
+    }
+    for r in repos {
+        if !valid_repo_slug(r) {
+            return Err(format!(
+                "Repo slug geçersiz: {r} (owner/name alfanümerik + _-. izinli)"
+            ));
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let mut all_repos: Vec<GitHubRepoStats> = Vec::with_capacity(repos.len());
+    let mut all_runs: Vec<GitHubRun> = Vec::new();
+
+    for repo in repos {
+        let url = format!("https://api.github.com/repos/{repo}/actions/runs?per_page=25");
+        let resp = client
+            .get(&url)
+            .header("Authorization", format!("Bearer {token}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .header("User-Agent", "aoe-fork-widgets/1.0")
+            .send()
+            .await
+            .map_err(|e| format!("GitHub request error ({repo}): {e}"))?;
+
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| format!("GitHub body read error ({repo}): {e}"))?;
+
+        if !status.is_success() {
+            return Err(format!("GitHub API {repo} {status}: {text}"));
+        }
+
+        let parsed: GitHubWorkflowRunsResp = serde_json::from_str(&text)
+            .map_err(|e| format!("GitHub JSON parse error ({repo}): {e}"))?;
+
+        let mut stats = GitHubRepoStats {
+            repo: repo.clone(),
+            success: 0,
+            failure: 0,
+            in_progress: 0,
+            other: 0,
+        };
+        for run in &parsed.workflow_runs {
+            tally_run(&mut stats, run);
+        }
+        all_repos.push(stats);
+
+        for r in parsed.workflow_runs {
+            all_runs.push(GitHubRun {
+                id: r.id,
+                repo: repo.clone(),
+                name: r.name.unwrap_or_default(),
+                status: r.status,
+                conclusion: r.conclusion,
+                html_url: r.html_url,
+                head_branch: r.head_branch.unwrap_or_default(),
+                event: r.event,
+                run_started_at: r.run_started_at.unwrap_or_default(),
+                updated_at: r.updated_at,
+            });
+        }
+    }
+
+    // Cross-repo DESC by updated_at
+    all_runs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    all_runs.truncate(5);
+
+    Ok(GitHubActionsSummary {
+        repos: all_repos,
+        recent: all_runs,
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+pub async fn get_github_actions_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let token = env::var("GITHUB_TOKEN").map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "GITHUB_TOKEN env eksik".to_string(),
+        )
+    })?;
+
+    let repos_env = env::var("GITHUB_REPOS").unwrap_or_default();
+    let repos = parse_repos(&repos_env);
+    if repos.is_empty() {
+        return Err((
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "GITHUB_REPOS env eksik (owner/name virgülle ayrılmış)".to_string(),
+        ));
+    }
+
+    if let Some(cached) = state.widget_cache.get_gh() {
+        return Ok(with_cache_header(cached, true));
+    }
+
+    match fetch_github_actions(&token, &repos).await {
+        Ok(data) => {
+            state.widget_cache.set_gh(data.clone());
+            Ok(with_cache_header(data, false))
+        }
+        Err(msg) => Err((StatusCode::BAD_GATEWAY, msg)),
+    }
+}
+
+// ─── Vercel ────────────────────────────────────────────────────────────────
+
+#[derive(Clone, Serialize)]
+pub struct VercelStateCounts {
+    pub ready: usize,
+    pub error: usize,
+    pub building: usize,
+    pub queued: usize,
+    pub canceled: usize,
+    pub other: usize,
+}
+
+#[derive(Clone, Serialize)]
+pub struct VercelDeploymentMeta {
+    pub branch: Option<String>,
+    pub commit_sha: Option<String>,
+}
+
+#[derive(Clone, Serialize)]
+pub struct VercelDeployment {
+    pub uid: String,
+    pub name: String,
+    pub url: String,
+    pub state: String,
+    pub target: Option<String>,
+    pub created_at: i64,
+    pub source: Option<String>,
+    pub meta: VercelDeploymentMeta,
+}
+
+#[derive(Clone, Serialize)]
+pub struct VercelSummary {
+    pub counts: VercelStateCounts,
+    pub recent: Vec<VercelDeployment>,
+    pub fetched_at: String,
+}
+
+#[derive(Deserialize)]
+struct VercelRawMeta {
+    #[serde(rename = "githubCommitRef")]
+    github_commit_ref: Option<String>,
+    #[serde(rename = "githubCommitSha")]
+    github_commit_sha: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct VercelRawDeployment {
+    uid: String,
+    name: String,
+    url: String,
+    state: String,
+    target: Option<String>,
+    #[serde(rename = "createdAt")]
+    created_at: i64,
+    source: Option<String>,
+    meta: Option<VercelRawMeta>,
+}
+
+#[derive(Deserialize)]
+struct VercelDeploymentsResp {
+    deployments: Vec<VercelRawDeployment>,
+}
+
+fn tally_state(counts: &mut VercelStateCounts, state: &str) {
+    match state {
+        "READY" => counts.ready += 1,
+        "ERROR" => counts.error += 1,
+        "BUILDING" | "INITIALIZING" => counts.building += 1,
+        "QUEUED" => counts.queued += 1,
+        "CANCELED" => counts.canceled += 1,
+        _ => counts.other += 1,
+    }
+}
+
+async fn fetch_vercel(
+    token: &str,
+    project_id: &str,
+    team_id: Option<&str>,
+) -> Result<VercelSummary, String> {
+    if project_id.is_empty() {
+        return Err("VERCEL_PROJECT_ID env eksik".to_string());
+    }
+
+    let mut url = format!(
+        "https://api.vercel.com/v6/deployments?projectId={}&limit=25",
+        urlencode_minimal(project_id)
+    );
+    if let Some(tid) = team_id {
+        if !tid.is_empty() {
+            url.push_str(&format!("&teamId={}", urlencode_minimal(tid)));
+        }
+    }
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(&url)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .map_err(|e| format!("Vercel request error: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("Vercel body read error: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("Vercel API {status}: {text}"));
+    }
+
+    let parsed: VercelDeploymentsResp =
+        serde_json::from_str(&text).map_err(|e| format!("Vercel JSON parse error: {e}"))?;
+
+    let mut counts = VercelStateCounts {
+        ready: 0,
+        error: 0,
+        building: 0,
+        queued: 0,
+        canceled: 0,
+        other: 0,
+    };
+    for d in &parsed.deployments {
+        tally_state(&mut counts, &d.state);
+    }
+
+    let recent: Vec<VercelDeployment> = parsed
+        .deployments
+        .into_iter()
+        .take(5)
+        .map(|d| {
+            let (branch, commit_sha) = match d.meta {
+                Some(m) => (m.github_commit_ref, m.github_commit_sha),
+                None => (None, None),
+            };
+            VercelDeployment {
+                uid: d.uid,
+                name: d.name,
+                url: d.url,
+                state: d.state,
+                target: d.target,
+                created_at: d.created_at,
+                source: d.source,
+                meta: VercelDeploymentMeta { branch, commit_sha },
+            }
+        })
+        .collect();
+
+    Ok(VercelSummary {
+        counts,
+        recent,
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+/// Minimal URL-safe encoding for Vercel project/team ids (alphanumeric + `_-`).
+/// Reject anything else (defense-in-depth — these come from env, but cheap).
+fn urlencode_minimal(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_'))
+        .collect()
+}
+
+pub async fn get_vercel_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let token = env::var("VERCEL_TOKEN").map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "VERCEL_TOKEN env eksik".to_string(),
+        )
+    })?;
+
+    let project_id = env::var("VERCEL_PROJECT_ID").map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "VERCEL_PROJECT_ID env eksik".to_string(),
+        )
+    })?;
+
+    let team_id_owned = env::var("VERCEL_TEAM_ID").ok();
+    let team_id = team_id_owned.as_deref();
+
+    if let Some(cached) = state.widget_cache.get_vercel() {
+        return Ok(with_cache_header(cached, true));
+    }
+
+    match fetch_vercel(&token, &project_id, team_id).await {
+        Ok(data) => {
+            state.widget_cache.set_vercel(data.clone());
+            Ok(with_cache_header(data, false))
+        }
+        Err(msg) => Err((StatusCode::BAD_GATEWAY, msg)),
+    }
+}
+
+// ─── Netdata ───────────────────────────────────────────────────────────────
+
+#[derive(Clone, Serialize)]
+pub struct NetdataChart {
+    pub id: &'static str,
+    pub url: String,
+}
+
+#[derive(Clone, Serialize)]
+pub struct NetdataSummary {
+    pub reachable: bool,
+    pub version: String,
+    pub host: String,
+    pub charts: Vec<NetdataChart>,
+    pub iframe_base: String,
+    pub fetched_at: String,
+}
+
+#[derive(Deserialize)]
+struct NetdataInfoResp {
+    version: Option<String>,
+    #[serde(rename = "mirrored_hosts")]
+    mirrored_hosts: Option<Vec<String>>,
+    hostname: Option<String>,
+}
+
+const NETDATA_CHARTS: &[&str] = &["system.cpu", "system.ram", "system.load", "system.io"];
+
+async fn fetch_netdata(base_url: &str) -> Result<NetdataSummary, String> {
+    let base = base_url.trim_end_matches('/').to_string();
+    if base.is_empty() {
+        return Err("NETDATA_BASE_URL env boş".to_string());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(3))
+        .build()
+        .map_err(|e| format!("Netdata client init error: {e}"))?;
+
+    let resp = client
+        .get(format!("{base}/api/v1/info"))
+        .send()
+        .await
+        .map_err(|e| format!("Netdata request error: {e}"))?;
+
+    let status = resp.status();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| format!("Netdata body read error: {e}"))?;
+
+    if !status.is_success() {
+        return Err(format!("Netdata API {status}: {text}"));
+    }
+
+    let info: NetdataInfoResp =
+        serde_json::from_str(&text).map_err(|e| format!("Netdata JSON parse error: {e}"))?;
+
+    let host = info
+        .hostname
+        .or_else(|| info.mirrored_hosts.and_then(|h| h.into_iter().next()))
+        .unwrap_or_else(|| "localhost".to_string());
+
+    let charts: Vec<NetdataChart> = NETDATA_CHARTS
+        .iter()
+        .map(|id| NetdataChart {
+            id,
+            url: format!("{base}/host/{host}/{id}"),
+        })
+        .collect();
+
+    Ok(NetdataSummary {
+        reachable: true,
+        version: info.version.unwrap_or_else(|| "unknown".to_string()),
+        host,
+        charts,
+        iframe_base: base,
+        fetched_at: chrono::Utc::now().to_rfc3339(),
+    })
+}
+
+pub async fn get_netdata_summary(
+    State(state): State<Arc<AppState>>,
+) -> Result<axum::response::Response, (StatusCode, String)> {
+    let base_url = env::var("NETDATA_BASE_URL").map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "NETDATA_BASE_URL env eksik (örn http://localhost:19999)".to_string(),
+        )
+    })?;
+
+    if let Some(cached) = state.widget_cache.get_netdata() {
+        return Ok(with_cache_header(cached, true));
+    }
+
+    match fetch_netdata(&base_url).await {
+        Ok(data) => {
+            state.widget_cache.set_netdata(data.clone());
+            Ok(with_cache_header(data, false))
+        }
+        Err(msg) => Err((StatusCode::BAD_GATEWAY, msg)),
+    }
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_repos_handles_whitespace_and_filters() {
+        let v = parse_repos(
+            " furkangurr/ajan-sistemi ,  furkangurr/avukatadanis-online , , bad-no-slash ,  ",
+        );
+        assert_eq!(
+            v,
+            vec![
+                "furkangurr/ajan-sistemi".to_string(),
+                "furkangurr/avukatadanis-online".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn valid_repo_slug_accepts_owner_name() {
+        assert!(valid_repo_slug("furkangurr/ajan-sistemi"));
+        assert!(valid_repo_slug("foo/bar.baz"));
+        assert!(valid_repo_slug("a/b_c"));
+        assert!(!valid_repo_slug("/x"));
+        assert!(!valid_repo_slug("x/"));
+        assert!(!valid_repo_slug("x"));
+        assert!(!valid_repo_slug("x/y/z"));
+        assert!(!valid_repo_slug("x/y;z"));
+    }
+
+    #[test]
+    fn valid_sentry_slug_rejects_specials() {
+        assert!(valid_sentry_slug("furkangurr"));
+        assert!(valid_sentry_slug("avukatadanis-online"));
+        assert!(valid_sentry_slug("org.with.dots"));
+        assert!(!valid_sentry_slug(""));
+        assert!(!valid_sentry_slug("has space"));
+        assert!(!valid_sentry_slug("inj;ect"));
+    }
+
+    #[test]
+    fn urlencode_minimal_strips_specials() {
+        assert_eq!(urlencode_minimal("prj_abc-123"), "prj_abc-123");
+        assert_eq!(urlencode_minimal("prj;bad"), "prjbad");
+        assert_eq!(urlencode_minimal(""), "");
+    }
+
+    #[test]
+    fn tally_run_buckets_correctly() {
+        let mut s = GitHubRepoStats {
+            repo: "x/y".into(),
+            success: 0,
+            failure: 0,
+            in_progress: 0,
+            other: 0,
+        };
+        tally_run(
+            &mut s,
+            &GitHubRawRun {
+                id: 1,
+                name: None,
+                status: "completed".into(),
+                conclusion: Some("success".into()),
+                html_url: "".into(),
+                head_branch: None,
+                event: "push".into(),
+                run_started_at: None,
+                updated_at: "".into(),
+            },
+        );
+        tally_run(
+            &mut s,
+            &GitHubRawRun {
+                id: 2,
+                name: None,
+                status: "in_progress".into(),
+                conclusion: None,
+                html_url: "".into(),
+                head_branch: None,
+                event: "push".into(),
+                run_started_at: None,
+                updated_at: "".into(),
+            },
+        );
+        tally_run(
+            &mut s,
+            &GitHubRawRun {
+                id: 3,
+                name: None,
+                status: "completed".into(),
+                conclusion: Some("failure".into()),
+                html_url: "".into(),
+                head_branch: None,
+                event: "push".into(),
+                run_started_at: None,
+                updated_at: "".into(),
+            },
+        );
+        assert_eq!(s.success, 1);
+        assert_eq!(s.in_progress, 1);
+        assert_eq!(s.failure, 1);
+        assert_eq!(s.other, 0);
+    }
+
+    #[test]
+    fn tally_state_buckets_correctly() {
+        let mut c = VercelStateCounts {
+            ready: 0,
+            error: 0,
+            building: 0,
+            queued: 0,
+            canceled: 0,
+            other: 0,
+        };
+        tally_state(&mut c, "READY");
+        tally_state(&mut c, "ERROR");
+        tally_state(&mut c, "BUILDING");
+        tally_state(&mut c, "INITIALIZING");
+        tally_state(&mut c, "QUEUED");
+        tally_state(&mut c, "CANCELED");
+        tally_state(&mut c, "WEIRD");
+        assert_eq!(c.ready, 1);
+        assert_eq!(c.error, 1);
+        assert_eq!(c.building, 2);
+        assert_eq!(c.queued, 1);
+        assert_eq!(c.canceled, 1);
+        assert_eq!(c.other, 1);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -958,6 +958,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/avk/agents", get(api::list_avk_agents))
         // AVK memory recall feed (FUR-4118 — agentmemory MCP proxy mock)
         .route("/api/avk/memory-recall", get(api::list_avk_memory_recall))
+        // AVK tier broadcast (FUR-4121 — POST { tier, message } -> tmux send-keys)
+        .route("/api/avk/broadcast", post(api::broadcast_avk))
         // Profiles
         .route(
             "/api/profiles",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -956,6 +956,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         .route("/api/agents", get(api::list_agents))
         // AVK workflow agents (FUR-3957 Adım 6 — 13 ajan registry serve)
         .route("/api/avk/agents", get(api::list_avk_agents))
+        // AVK memory recall feed (FUR-4118 — agentmemory MCP proxy mock)
+        .route("/api/avk/memory-recall", get(api::list_avk_memory_recall))
         // Profiles
         .route(
             "/api/profiles",

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -274,6 +274,12 @@ pub struct AppState {
     /// checks this to suppress notifications when someone is actively using
     /// the web dashboard (on any device).
     pub last_web_activity: std::sync::atomic::AtomicI64,
+    /// avk-suite custom widget cache (Linear + Sentry summary, 60s TTL).
+    /// FUR-3957 Sub-C entegrasyon — Sub-C PR ajan-sistemi#521 Next.js
+    /// route'larının Rust port'u. Tek paylaşımlı cache, dashboard refresh
+    /// burst'ünü Linear/Sentry rate limit'inden korur.
+    #[cfg(feature = "serve")]
+    pub widget_cache: Arc<crate::server::api::WidgetCache>,
 }
 
 impl AppState {
@@ -551,6 +557,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         push_enabled,
         web_config: config.web.clone(),
         last_web_activity: std::sync::atomic::AtomicI64::new(0),
+        #[cfg(feature = "serve")]
+        widget_cache: Arc::new(crate::server::api::WidgetCache::new()),
     });
 
     let app = build_router(state.clone());
@@ -946,6 +954,8 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         // Agents
         .route("/api/agents", get(api::list_agents))
+        // AVK workflow agents (FUR-3957 Adım 6 — 13 ajan registry serve)
+        .route("/api/avk/agents", get(api::list_avk_agents))
         // Profiles
         .route(
             "/api/profiles",
@@ -976,6 +986,19 @@ fn build_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/themes", get(api::list_themes))
         .route("/api/sounds", get(api::list_sounds))
+        // FUR-3957 transplant — avk-suite custom widgets (5 endpoint).
+        // Contract: docs/aoe-transplant/02-widget-api-contract.md (Code-1 dondurucu).
+        .route("/api/widgets/linear/summary", get(api::get_linear_summary))
+        .route("/api/widgets/sentry/summary", get(api::get_sentry_summary))
+        .route(
+            "/api/widgets/github-actions/summary",
+            get(api::get_github_actions_summary),
+        )
+        .route("/api/widgets/vercel/summary", get(api::get_vercel_summary))
+        .route(
+            "/api/widgets/netdata/summary",
+            get(api::get_netdata_summary),
+        )
         // Push notifications
         .route("/api/push/status", get(push::get_status))
         .route(

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2149,6 +2149,12 @@ mod tests {
     #[test]
     fn test_all_agents_have_yolo_support() {
         for agent in crate::agents::AGENTS {
+            // FUR-3973: kimi Level 1 stub — yolo hook integration follow-up.
+            // Mirror of `agents::tests::test_all_agents_have_yolo_support`
+            // exception; keep both in sync until kimi gains --yolo support.
+            if agent.name == "kimi" {
+                continue;
+            }
             assert!(
                 agent.yolo.is_some(),
                 "Agent '{}' should have YOLO mode configured",

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -687,6 +687,12 @@ pub fn detect_kiro_status(_content: &str) -> Status {
     Status::Idle
 }
 
+/// Kimi (Moonshot) Level 1 stub — always idle. Pane parsing TBD when
+/// kimi CLI status surface stabilises. Sufficient for session create + attach.
+pub fn detect_kimi_status(_content: &str) -> Status {
+    Status::Idle
+}
+
 /// settl status is detected via hooks (TOML-based), not tmux pane parsing.
 /// This stub exists so the agent registry has a valid function pointer.
 pub fn detect_settl_status(_content: &str) -> Status {

--- a/web/src/components/AvkAgentsGrid.tsx
+++ b/web/src/components/AvkAgentsGrid.tsx
@@ -25,9 +25,9 @@ const REFRESH_INTERVAL_MS = 30_000;
 const ROLE_ORDER: AvkAgentRole[] = ["director", "senior", "worker"];
 
 const ROLE_LABEL: Record<AvkAgentRole, string> = {
-  director: "Director",
-  senior: "Senior",
-  worker: "Worker",
+  director: "Yönetim",
+  senior: "Kıdemli",
+  worker: "Operasyon",
 };
 
 const ROLE_BADGE_CLASS: Record<AvkAgentRole, string> = {
@@ -75,9 +75,9 @@ export function AvkAgentsGrid() {
     return (
       <div>
         <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-          AVK Workflow Agents
+          AVK İş Ajanları
         </h3>
-        <p className="font-body text-[14px] text-text-muted">Loading…</p>
+        <p className="font-body text-[14px] text-text-muted">Yükleniyor…</p>
       </div>
     );
   }
@@ -86,10 +86,10 @@ export function AvkAgentsGrid() {
     return (
       <div>
         <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-          AVK Workflow Agents
+          AVK İş Ajanları
         </h3>
         <p className="font-body text-[14px] text-text-muted">
-          No agents available (server `/api/avk/agents` returned empty).
+          Ajan bulunamadı (sunucu `/api/avk/agents` boş döndü).
         </p>
       </div>
     );
@@ -101,9 +101,9 @@ export function AvkAgentsGrid() {
   return (
     <div>
       <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-        AVK Workflow Agents ({agents.length}){" "}
+        AVK İş Ajanları ({agents.length}){" "}
         <span className="text-status-running normal-case tracking-normal">
-          · {aliveCount}/{agents.length} live
+          · {aliveCount}/{agents.length} canlı
         </span>
       </h3>
       <div className="space-y-6">
@@ -122,8 +122,8 @@ export function AvkAgentsGrid() {
                     ? "bg-status-running"
                     : "bg-surface-600";
                   const dotTitle = agent.pane_alive
-                    ? `live · ${effectiveTarget}`
-                    : `pane yok · registry: ${agent.tmux_target}`;
+                    ? `canlı · ${effectiveTarget}`
+                    : `pane yok · kayıt: ${agent.tmux_target}`;
                   return (
                     <article
                       key={agent.slug}
@@ -150,7 +150,7 @@ export function AvkAgentsGrid() {
                         <span className="shrink-0">{agent.slug}</span>
                         <span
                           className="truncate"
-                          title={`registry: ${agent.tmux_target}${agent.runtime_target ? ` · runtime: ${agent.runtime_target}` : ""}`}
+                          title={`kayıt: ${agent.tmux_target}${agent.runtime_target ? ` · çalışan: ${agent.runtime_target}` : ""}`}
                         >
                           {effectiveTarget}
                         </span>

--- a/web/src/components/AvkAgentsGrid.tsx
+++ b/web/src/components/AvkAgentsGrid.tsx
@@ -1,11 +1,13 @@
 /**
- * AVK workflow ajan grid widget — FUR-3957 transplant Adım 7.
+ * AVK workflow ajan grid widget — FUR-3957 transplant Adım 7 + FUR-4123 polish.
  *
  * `GET /api/avk/agents` server endpoint'inden 13 ajan kaydını çeker;
  * Director / Senior / Worker tier sıralı 3 grup card grid render eder.
  *
- * `tmux_target` runtime resync gerektirir (pane index değişir) — bu
- * yüzden komponent mount + 60sn refresh interval ile yeniden fetch eder.
+ * `tmux_target` registry sabit (avk-ofis:...), `runtime_target` AoE
+ * binary'nin gerçek yarattığı session (aoe_<slug>_<hash>:^.0). Server
+ * resolver (FUR-4122) her ajan için canlı pane durumunu döner —
+ * `pane_alive=true` yeşil dot, false gri dot. 30s refresh interval.
  *
  * Slug → label canonical kaynak server `src/avk_agents.rs::AVK_AGENTS`.
  * Tier badge rengi:
@@ -18,7 +20,7 @@ import { useEffect, useState } from "react";
 import { fetchAvkAgents } from "../lib/api";
 import type { AvkAgentInfo, AvkAgentRole } from "../lib/types";
 
-const REFRESH_INTERVAL_MS = 60_000;
+const REFRESH_INTERVAL_MS = 30_000;
 
 const ROLE_ORDER: AvkAgentRole[] = ["director", "senior", "worker"];
 
@@ -94,11 +96,15 @@ export function AvkAgentsGrid() {
   }
 
   const grouped = groupByRole(agents);
+  const aliveCount = agents.filter((a) => a.pane_alive).length;
 
   return (
     <div>
       <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-        AVK Workflow Agents ({agents.length})
+        AVK Workflow Agents ({agents.length}){" "}
+        <span className="text-status-running normal-case tracking-normal">
+          · {aliveCount}/{agents.length} live
+        </span>
       </h3>
       <div className="space-y-6">
         {ROLE_ORDER.map((role) => {
@@ -110,27 +116,48 @@ export function AvkAgentsGrid() {
                 {ROLE_LABEL[role]} ({tierAgents.length})
               </h4>
               <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
-                {tierAgents.map((agent) => (
-                  <article
-                    key={agent.slug}
-                    className="rounded border border-surface-700 bg-surface-800 p-3"
-                  >
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="font-body text-[14px] font-medium">
-                        {agent.label}
-                      </span>
-                      <span
-                        className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded ${ROLE_BADGE_CLASS[agent.role]}`}
-                      >
-                        {agent.role}
-                      </span>
-                    </div>
-                    <div className="flex items-center justify-between font-mono text-[11px] text-text-muted">
-                      <span>{agent.slug}</span>
-                      <span title={agent.tmux_target}>{agent.tmux_target}</span>
-                    </div>
-                  </article>
-                ))}
+                {tierAgents.map((agent) => {
+                  const effectiveTarget = agent.runtime_target ?? agent.tmux_target;
+                  const dotClass = agent.pane_alive
+                    ? "bg-status-running"
+                    : "bg-surface-600";
+                  const dotTitle = agent.pane_alive
+                    ? `live · ${effectiveTarget}`
+                    : `pane yok · registry: ${agent.tmux_target}`;
+                  return (
+                    <article
+                      key={agent.slug}
+                      className="rounded border border-surface-700 bg-surface-800 p-3"
+                    >
+                      <div className="flex items-center justify-between mb-1">
+                        <div className="flex items-center gap-2 min-w-0">
+                          <span
+                            className={`inline-block w-2 h-2 rounded-full shrink-0 ${dotClass}`}
+                            title={dotTitle}
+                            aria-label={dotTitle}
+                          />
+                          <span className="font-body text-[14px] font-medium truncate">
+                            {agent.label}
+                          </span>
+                        </div>
+                        <span
+                          className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded shrink-0 ${ROLE_BADGE_CLASS[agent.role]}`}
+                        >
+                          {agent.role}
+                        </span>
+                      </div>
+                      <div className="flex items-center justify-between font-mono text-[11px] text-text-muted gap-2">
+                        <span className="shrink-0">{agent.slug}</span>
+                        <span
+                          className="truncate"
+                          title={`registry: ${agent.tmux_target}${agent.runtime_target ? ` · runtime: ${agent.runtime_target}` : ""}`}
+                        >
+                          {effectiveTarget}
+                        </span>
+                      </div>
+                    </article>
+                  );
+                })}
               </div>
             </section>
           );

--- a/web/src/components/AvkAgentsGrid.tsx
+++ b/web/src/components/AvkAgentsGrid.tsx
@@ -1,0 +1,141 @@
+/**
+ * AVK workflow ajan grid widget — FUR-3957 transplant Adım 7.
+ *
+ * `GET /api/avk/agents` server endpoint'inden 13 ajan kaydını çeker;
+ * Director / Senior / Worker tier sıralı 3 grup card grid render eder.
+ *
+ * `tmux_target` runtime resync gerektirir (pane index değişir) — bu
+ * yüzden komponent mount + 60sn refresh interval ile yeniden fetch eder.
+ *
+ * Slug → label canonical kaynak server `src/avk_agents.rs::AVK_AGENTS`.
+ * Tier badge rengi:
+ *   - director → status-running (yeşil) — sistem yönetir
+ *   - senior   → status-idle    (sarı)  — kıdemli iş
+ *   - worker   → text-muted    (gri)  — paralel slot
+ */
+
+import { useEffect, useState } from "react";
+import { fetchAvkAgents } from "../lib/api";
+import type { AvkAgentInfo, AvkAgentRole } from "../lib/types";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const ROLE_ORDER: AvkAgentRole[] = ["director", "senior", "worker"];
+
+const ROLE_LABEL: Record<AvkAgentRole, string> = {
+  director: "Director",
+  senior: "Senior",
+  worker: "Worker",
+};
+
+const ROLE_BADGE_CLASS: Record<AvkAgentRole, string> = {
+  director: "bg-status-running/15 text-status-running",
+  senior: "bg-status-idle/15 text-status-idle",
+  worker: "bg-surface-700 text-text-muted",
+};
+
+function groupByRole(agents: AvkAgentInfo[]): Record<AvkAgentRole, AvkAgentInfo[]> {
+  const grouped: Record<AvkAgentRole, AvkAgentInfo[]> = {
+    director: [],
+    senior: [],
+    worker: [],
+  };
+  for (const agent of agents) {
+    grouped[agent.role].push(agent);
+  }
+  return grouped;
+}
+
+export function AvkAgentsGrid() {
+  const [agents, setAgents] = useState<AvkAgentInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const result = await fetchAvkAgents();
+      if (!cancelled) {
+        setAgents(result);
+        setLoading(false);
+      }
+    }
+
+    load();
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          AVK Workflow Agents
+        </h3>
+        <p className="font-body text-[14px] text-text-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (agents.length === 0) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          AVK Workflow Agents
+        </h3>
+        <p className="font-body text-[14px] text-text-muted">
+          No agents available (server `/api/avk/agents` returned empty).
+        </p>
+      </div>
+    );
+  }
+
+  const grouped = groupByRole(agents);
+
+  return (
+    <div>
+      <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+        AVK Workflow Agents ({agents.length})
+      </h3>
+      <div className="space-y-6">
+        {ROLE_ORDER.map((role) => {
+          const tierAgents = grouped[role];
+          if (tierAgents.length === 0) return null;
+          return (
+            <section key={role}>
+              <h4 className="font-mono text-xs uppercase tracking-wider text-text-muted mb-2">
+                {ROLE_LABEL[role]} ({tierAgents.length})
+              </h4>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2">
+                {tierAgents.map((agent) => (
+                  <article
+                    key={agent.slug}
+                    className="rounded border border-surface-700 bg-surface-800 p-3"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="font-body text-[14px] font-medium">
+                        {agent.label}
+                      </span>
+                      <span
+                        className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded ${ROLE_BADGE_CLASS[agent.role]}`}
+                      >
+                        {agent.role}
+                      </span>
+                    </div>
+                    <div className="flex items-center justify-between font-mono text-[11px] text-text-muted">
+                      <span>{agent.slug}</span>
+                      <span title={agent.tmux_target}>{agent.tmux_target}</span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/AvkBroadcastWidget.tsx
+++ b/web/src/components/AvkBroadcastWidget.tsx
@@ -22,17 +22,17 @@ import type {
 } from "../lib/types";
 
 const TIER_LABEL: Record<AvkBroadcastTier, string> = {
-  director: "Director",
-  senior: "Senior",
-  worker: "Worker",
+  director: "Yönetim",
+  senior: "Kıdemli",
+  worker: "Operasyon",
   all: "Tümü",
 };
 
 const TIER_DESCRIPTION: Record<AvkBroadcastTier, string> = {
   director: "Koord + Komuta + Müdür (3 ajan)",
-  senior: "Code-1/2 + Merge + Hata (4 ajan)",
+  senior: "Code-1/2 + Birleştirme + Hata (4 ajan)",
   worker: "Gemini-1/2 + Kimi-1/2/3 + Codex (6 ajan)",
-  all: "13 ajan birden (Director + Senior + Worker)",
+  all: "13 ajan birden (Yönetim + Kıdemli + Operasyon)",
 };
 
 const TIER_ACCENT: Record<AvkBroadcastTier, string> = {
@@ -73,7 +73,7 @@ export function AvkBroadcastWidget() {
   return (
     <div>
       <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-        AVK Broadcast
+        AVK Yayın
       </h3>
 
       <div className="rounded border border-surface-700 bg-surface-800 p-4 space-y-4">
@@ -111,17 +111,17 @@ export function AvkBroadcastWidget() {
             onChange={(e) => setMessage(e.target.value)}
             disabled={sending}
             rows={3}
-            placeholder="Örn: kankam patrol özet ver (Linear In Progress + son merged PR)"
+            placeholder="Örn: patrol özet ver (Linear In Progress + son birleştirilen PR)"
             className="w-full rounded border border-surface-700 bg-surface-900 px-3 py-2 font-body text-[14px] text-text-primary placeholder:text-text-muted/60 focus:outline-none focus:border-brand-500/60 focus:ring-1 focus:ring-brand-500/40 resize-y"
             maxLength={8192}
           />
           <div className="flex items-center justify-between mt-1">
             <span className="font-mono text-[10px] text-text-muted">
-              {message.length}/8192 byte
+              {message.length}/8192 karakter
             </span>
             {message.length > 2048 && (
               <span className="font-mono text-[10px] text-status-waiting">
-                paste-buffer (bracketed) yolu kullanılacak
+                uzun mesaj — yapıştırma modu
               </span>
             )}
           </div>

--- a/web/src/components/AvkBroadcastWidget.tsx
+++ b/web/src/components/AvkBroadcastWidget.tsx
@@ -1,0 +1,177 @@
+/**
+ * AVK broadcast widget — FUR-4121.
+ *
+ * 4 tier butonu (director/senior/worker/all) + mesaj textarea + Gönder.
+ * `POST /api/avk/broadcast` ile tmux pane'lere bracketed-paste mesaj yollar.
+ * Sonuç inline summary (ok / failed) ve gerekirse per-pane hata listesi.
+ *
+ * Tasarım:
+ *   - director badge yeşil (status-running) — yönetim
+ *   - senior badge sarı (status-waiting) — kıdemli iş
+ *   - worker badge gri (text-muted) — paralel slot
+ *   - all badge brand-500 (turuncu accent) — 13 ajan
+ *
+ * Mobile-first: 1 col tier seçim grid, lg breakpoint 4 col yan yana.
+ */
+
+import { useState } from "react";
+import { postAvkBroadcast } from "../lib/api";
+import type {
+  AvkBroadcastResponse,
+  AvkBroadcastTier,
+} from "../lib/types";
+
+const TIER_LABEL: Record<AvkBroadcastTier, string> = {
+  director: "Director",
+  senior: "Senior",
+  worker: "Worker",
+  all: "Tümü",
+};
+
+const TIER_DESCRIPTION: Record<AvkBroadcastTier, string> = {
+  director: "Koord + Komuta + Müdür (3 ajan)",
+  senior: "Code-1/2 + Merge + Hata (4 ajan)",
+  worker: "Gemini-1/2 + Kimi-1/2/3 + Codex (6 ajan)",
+  all: "13 ajan birden (Director + Senior + Worker)",
+};
+
+const TIER_ACCENT: Record<AvkBroadcastTier, string> = {
+  director: "border-status-running/40 hover:bg-status-running/10 text-status-running",
+  senior: "border-status-waiting/40 hover:bg-status-waiting/10 text-status-waiting",
+  worker: "border-surface-600 hover:bg-surface-700 text-text-secondary",
+  all: "border-brand-500/50 hover:bg-brand-500/10 text-brand-500",
+};
+
+const TIERS: AvkBroadcastTier[] = ["director", "senior", "worker", "all"];
+
+export function AvkBroadcastWidget() {
+  const [tier, setTier] = useState<AvkBroadcastTier>("all");
+  const [message, setMessage] = useState("");
+  const [sending, setSending] = useState(false);
+  const [result, setResult] = useState<AvkBroadcastResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const canSend = message.trim().length > 0 && !sending;
+
+  async function handleSend() {
+    if (!canSend) return;
+    setSending(true);
+    setError(null);
+    setResult(null);
+    const res = await postAvkBroadcast({ tier, message: message.trim() });
+    setSending(false);
+    if (!res) {
+      setError("Broadcast başarısız (sunucu hatası veya ağ kopması).");
+      return;
+    }
+    setResult(res);
+    if (res.failed === 0) {
+      setMessage("");
+    }
+  }
+
+  return (
+    <div>
+      <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+        AVK Broadcast
+      </h3>
+
+      <div className="rounded border border-surface-700 bg-surface-800 p-4 space-y-4">
+        <div className="grid grid-cols-2 lg:grid-cols-4 gap-2">
+          {TIERS.map((t) => {
+            const active = tier === t;
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() => setTier(t)}
+                className={`rounded border px-3 py-2 text-left transition-colors ${TIER_ACCENT[t]} ${
+                  active ? "bg-surface-700 ring-1 ring-current" : "bg-surface-900"
+                }`}
+              >
+                <div className="font-mono text-sm font-medium">{TIER_LABEL[t]}</div>
+                <div className="font-body text-[11px] opacity-70 leading-tight mt-0.5">
+                  {TIER_DESCRIPTION[t]}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+
+        <div>
+          <label
+            htmlFor="avk-broadcast-message"
+            className="font-mono text-[11px] uppercase tracking-wider text-text-muted block mb-1"
+          >
+            Mesaj
+          </label>
+          <textarea
+            id="avk-broadcast-message"
+            value={message}
+            onChange={(e) => setMessage(e.target.value)}
+            disabled={sending}
+            rows={3}
+            placeholder="Örn: kankam patrol özet ver (Linear In Progress + son merged PR)"
+            className="w-full rounded border border-surface-700 bg-surface-900 px-3 py-2 font-body text-[14px] text-text-primary placeholder:text-text-muted/60 focus:outline-none focus:border-brand-500/60 focus:ring-1 focus:ring-brand-500/40 resize-y"
+            maxLength={8192}
+          />
+          <div className="flex items-center justify-between mt-1">
+            <span className="font-mono text-[10px] text-text-muted">
+              {message.length}/8192 byte
+            </span>
+            {message.length > 2048 && (
+              <span className="font-mono text-[10px] text-status-waiting">
+                paste-buffer (bracketed) yolu kullanılacak
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!canSend}
+            className="rounded bg-brand-500 hover:bg-brand-400 disabled:bg-surface-700 disabled:text-text-muted disabled:cursor-not-allowed text-surface-900 font-mono text-sm font-semibold px-4 py-2 transition-colors"
+          >
+            {sending ? "Gönderiliyor…" : `Gönder → ${TIER_LABEL[tier]}`}
+          </button>
+          {error && (
+            <span className="font-body text-[13px] text-status-error">{error}</span>
+          )}
+        </div>
+
+        {result && (
+          <div className="rounded border border-surface-700 bg-surface-900 p-3">
+            <div className="font-mono text-[12px] text-text-secondary mb-2">
+              Sonuç:{" "}
+              <span className="text-status-running font-medium">{result.ok} ok</span>
+              {result.failed > 0 && (
+                <>
+                  {" / "}
+                  <span className="text-status-error font-medium">
+                    {result.failed} hata
+                  </span>
+                </>
+              )}
+              {" / "}
+              <span>{result.total} toplam ({result.tier})</span>
+            </div>
+            {result.failed > 0 && (
+              <ul className="font-mono text-[11px] text-text-muted space-y-1">
+                {result.results
+                  .filter((r) => !r.ok)
+                  .map((r) => (
+                    <li key={r.slug}>
+                      <span className="text-status-error">✗</span> {r.slug} (
+                      {r.target}): {r.error ?? "bilinmeyen hata"}
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/AvkMemoryFeed.tsx
+++ b/web/src/components/AvkMemoryFeed.tsx
@@ -21,9 +21,9 @@ import type { AvkMemoryEntry, AvkMemoryTier } from "../lib/types";
 const REFRESH_INTERVAL_MS = 60_000;
 
 const TIER_LABEL: Record<AvkMemoryTier, string> = {
-  core: "Core",
-  working: "Working",
-  archival: "Archival",
+  core: "Çekirdek",
+  working: "Aktif",
+  archival: "Arşiv",
 };
 
 const TIER_BADGE_CLASS: Record<AvkMemoryTier, string> = {
@@ -72,9 +72,9 @@ export function AvkMemoryFeed() {
     return (
       <div>
         <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-          AVK Memory Recall
+          AVK Hafıza
         </h3>
-        <p className="font-body text-[14px] text-text-muted">Loading…</p>
+        <p className="font-body text-[14px] text-text-muted">Yükleniyor…</p>
       </div>
     );
   }
@@ -83,10 +83,10 @@ export function AvkMemoryFeed() {
     return (
       <div>
         <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-          AVK Memory Recall
+          AVK Hafıza
         </h3>
         <p className="font-body text-[14px] text-text-muted">
-          No memory entries (server `/api/avk/memory-recall` returned empty).
+          Hafıza kaydı yok (sunucu `/api/avk/memory-recall` boş döndü).
         </p>
       </div>
     );
@@ -95,7 +95,7 @@ export function AvkMemoryFeed() {
   return (
     <div>
       <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
-        AVK Memory Recall ({entries.length})
+        AVK Hafıza ({entries.length})
       </h3>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
         {entries.map((entry) => (

--- a/web/src/components/AvkMemoryFeed.tsx
+++ b/web/src/components/AvkMemoryFeed.tsx
@@ -1,0 +1,135 @@
+/**
+ * AVK memory recall feed widget — FUR-4118.
+ *
+ * `GET /api/avk/memory-recall` server endpoint'inden son 24 saat canon
+ * kayıtları (lesson, signal, recall) çeker; tier badge + role + tags +
+ * preview ile feed render eder. Mobile-first (1 col), desktop 2 col grid.
+ *
+ * Mock implementation şu an; gerçek agentmemory MCP proxy eklendiğinde
+ * UI değişikliği yok (server contract aynı).
+ *
+ * Tier renkleri:
+ *   - core     → status-running (yeşil) — kalıcı kanon
+ *   - working  → status-waiting (sarı)  — aktif iş
+ *   - archival → text-muted    (gri)    — referans/eski
+ */
+
+import { useEffect, useState } from "react";
+import { fetchAvkMemoryRecall } from "../lib/api";
+import type { AvkMemoryEntry, AvkMemoryTier } from "../lib/types";
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+const TIER_LABEL: Record<AvkMemoryTier, string> = {
+  core: "Core",
+  working: "Working",
+  archival: "Archival",
+};
+
+const TIER_BADGE_CLASS: Record<AvkMemoryTier, string> = {
+  core: "bg-status-running/15 text-status-running",
+  working: "bg-status-waiting/15 text-status-waiting",
+  archival: "bg-surface-700 text-text-muted",
+};
+
+function formatRelativeTime(iso: string): string {
+  const then = new Date(iso).getTime();
+  if (Number.isNaN(then)) return iso;
+  const now = Date.now();
+  const diffMin = Math.floor((now - then) / 60_000);
+  if (diffMin < 1) return "az önce";
+  if (diffMin < 60) return `${diffMin}dk önce`;
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) return `${diffHours}sa önce`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}g önce`;
+}
+
+export function AvkMemoryFeed() {
+  const [entries, setEntries] = useState<AvkMemoryEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load() {
+      const result = await fetchAvkMemoryRecall();
+      if (!cancelled) {
+        setEntries(result);
+        setLoading(false);
+      }
+    }
+
+    load();
+    const id = setInterval(load, REFRESH_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          AVK Memory Recall
+        </h3>
+        <p className="font-body text-[14px] text-text-muted">Loading…</p>
+      </div>
+    );
+  }
+
+  if (entries.length === 0) {
+    return (
+      <div>
+        <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+          AVK Memory Recall
+        </h3>
+        <p className="font-body text-[14px] text-text-muted">
+          No memory entries (server `/api/avk/memory-recall` returned empty).
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h3 className="font-mono text-sm uppercase tracking-widest text-text-muted mb-4">
+        AVK Memory Recall ({entries.length})
+      </h3>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-3">
+        {entries.map((entry) => (
+          <article
+            key={entry.id}
+            className="rounded border border-surface-700 bg-surface-800 p-4"
+          >
+            <div className="flex items-start justify-between gap-3 mb-2">
+              <h4 className="font-body text-[14px] font-medium leading-tight">
+                {entry.title}
+              </h4>
+              <span
+                className={`font-mono text-[10px] uppercase tracking-wider px-2 py-0.5 rounded shrink-0 ${TIER_BADGE_CLASS[entry.tier]}`}
+              >
+                {TIER_LABEL[entry.tier]}
+              </span>
+            </div>
+            <p className="font-body text-[13px] text-text-secondary mb-3 leading-relaxed">
+              {entry.content_preview}
+            </p>
+            <div className="flex items-center justify-between font-mono text-[11px] text-text-muted">
+              <div className="flex items-center gap-2 flex-wrap">
+                <span className="font-medium">{entry.role}</span>
+                {entry.tags.slice(0, 3).map((tag) => (
+                  <span key={tag} className="opacity-70">
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+              <span title={entry.created_at}>{formatRelativeTime(entry.created_at)}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -38,7 +38,7 @@ export function Dashboard({
   }, [idleDecayWindowMs, sessions]);
 
   return (
-    <div className="flex-1 flex flex-col items-center justify-center bg-surface-950 px-4">
+    <div className="flex-1 flex flex-col items-center bg-surface-950 px-4 py-6 overflow-y-auto">
       {/* Logo + Title */}
       <svg
         viewBox="0 0 128 128"
@@ -79,7 +79,7 @@ export function Dashboard({
       </svg>
       <div className="mb-1 text-center">
         <p className="text-[11px] md:text-xs font-mono text-text-muted uppercase tracking-[0.2em]">
-          agent of
+          ajan
         </p>
         <h1
           className="text-3xl md:text-5xl font-mono font-semibold text-brand-500 uppercase tracking-tight"
@@ -96,19 +96,16 @@ export function Dashboard({
       {sessions.length > 0 && (
         <div className="flex items-center gap-2 text-xs font-mono text-text-muted mb-6">
           {stats.active > 0 && (
-            <span className="text-status-running">{stats.active} running</span>
+            <span className="text-status-running">{stats.active} çalışıyor</span>
           )}
           {stats.waiting > 0 && (
-            <span className="text-status-waiting">{stats.waiting} waiting</span>
+            <span className="text-status-waiting">{stats.waiting} bekliyor</span>
           )}
           {stats.errors > 0 && (
-            <span className="text-status-error">
-              {stats.errors} error{stats.errors !== 1 ? "s" : ""}
-            </span>
+            <span className="text-status-error">{stats.errors} hata</span>
           )}
           <span>
-            {sessions.length} session{sessions.length !== 1 ? "s" : ""} across{" "}
-            {stats.projects} project{stats.projects !== 1 ? "s" : ""}
+            {sessions.length} oturum / {stats.projects} proje
           </span>
         </div>
       )}
@@ -132,18 +129,18 @@ export function Dashboard({
           <rect x="3" y="3" width="18" height="18" rx="2" />
           <line x1="9" y1="3" x2="9" y2="21" />
         </svg>
-        Show sessions
+        Oturumları Göster
       </button>
 
       {/* Action panes */}
       {readOnly ? (
         <div className="max-w-sm w-full">
           <p className="text-xs text-text-dim text-center mb-3">
-            This dashboard is in read-only mode.
+            Bu panel salt-okur modda.
           </p>
           <ActionPane
-            title="Docs"
-            subtitle="Guides and reference"
+            title="Dokümanlar"
+            subtitle="Rehber ve referans"
             href="https://www.agent-of-empires.com/docs"
             icon="book"
           />
@@ -151,21 +148,21 @@ export function Dashboard({
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3 max-w-2xl w-full">
           <ActionPane
-            title="New session"
-            subtitle="Pick a project, then launch a new session"
+            title="Yeni Oturum"
+            subtitle="Proje seç, yeni oturum başlat"
             onClick={onNewSession}
             icon="folder"
             featured
           />
           <ActionPane
-            title="Clone URL"
-            subtitle="Clone a repo from a URL"
+            title="URL'den Klonla"
+            subtitle="Repo URL'sinden klonla"
             onClick={onCloneFromUrl}
             icon="git"
           />
           <ActionPane
-            title="Docs"
-            subtitle="Guides and reference"
+            title="Dokümanlar"
+            subtitle="Rehber ve referans"
             href="https://www.agent-of-empires.com/docs"
             icon="book"
           />
@@ -175,28 +172,40 @@ export function Dashboard({
       {/* Keyboard hint (desktop only) */}
       {!readOnly && (
         <p className="mt-4 text-[11px] font-mono text-text-dim hidden md:block">
-          press{" "}
+          yeni oturum için{" "}
           <kbd className="px-1 py-0.5 rounded bg-surface-800 border border-surface-700/40">
             n
           </kbd>{" "}
-          to create a session
+          bas
         </p>
       )}
 
-      {/* FUR-3957 Adım 8 — AVK workflow ajan grid (13 ajan) */}
-      <div className="mt-12 w-full max-w-4xl">
-        <AvkAgentsGrid />
-      </div>
+      {/* AVK Komuta Paneli — 3 widget grouplandığı section (FUR-3957 Adım 8 + FUR-4121 + FUR-4118) */}
+      <section
+        aria-label="AVK Komuta Paneli"
+        className="mt-10 w-full max-w-4xl border-t border-surface-700/40 pt-8 space-y-8"
+      >
+        <header className="text-center">
+          <h2 className="font-mono text-xs uppercase tracking-[0.3em] text-text-muted">
+            AVK Komuta Paneli
+          </h2>
+          <p className="font-body text-[12px] text-text-dim mt-1">
+            13 ajan orkestrasyonu · canlı durum · tier yayını · son 24 saat hafıza
+          </p>
+        </header>
 
-      {/* FUR-4121 — AVK tier broadcast widget (director/senior/worker/all -> tmux) */}
-      <div className="mt-12 w-full max-w-4xl">
-        <AvkBroadcastWidget />
-      </div>
+        <div className="rounded-lg border border-surface-700/40 bg-surface-900/40 p-4 sm:p-6">
+          <AvkAgentsGrid />
+        </div>
 
-      {/* FUR-4118 — AVK memory recall feed (mock; agentmemory MCP proxy bekleniş) */}
-      <div className="mt-12 w-full max-w-4xl">
-        <AvkMemoryFeed />
-      </div>
+        <div className="rounded-lg border border-surface-700/40 bg-surface-900/40 p-4 sm:p-6">
+          <AvkBroadcastWidget />
+        </div>
+
+        <div className="rounded-lg border border-surface-700/40 bg-surface-900/40 p-4 sm:p-6">
+          <AvkMemoryFeed />
+        </div>
+      </section>
     </div>
   );
 }

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import type { SessionResponse } from "../lib/types";
 import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
+import { AvkAgentsGrid } from "./AvkAgentsGrid";
 
 interface Props {
   sessions: SessionResponse[];
@@ -179,6 +180,11 @@ export function Dashboard({
           to create a session
         </p>
       )}
+
+      {/* FUR-3957 Adım 8 — AVK workflow ajan grid (13 ajan) */}
+      <div className="mt-12 w-full max-w-4xl">
+        <AvkAgentsGrid />
+      </div>
     </div>
   );
 }

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import type { SessionResponse } from "../lib/types";
 import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { AvkAgentsGrid } from "./AvkAgentsGrid";
+import { AvkBroadcastWidget } from "./AvkBroadcastWidget";
 import { AvkMemoryFeed } from "./AvkMemoryFeed";
 
 interface Props {
@@ -185,6 +186,11 @@ export function Dashboard({
       {/* FUR-3957 Adım 8 — AVK workflow ajan grid (13 ajan) */}
       <div className="mt-12 w-full max-w-4xl">
         <AvkAgentsGrid />
+      </div>
+
+      {/* FUR-4121 — AVK tier broadcast widget (director/senior/worker/all -> tmux) */}
+      <div className="mt-12 w-full max-w-4xl">
+        <AvkBroadcastWidget />
       </div>
 
       {/* FUR-4118 — AVK memory recall feed (mock; agentmemory MCP proxy bekleniş) */}

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -3,6 +3,7 @@ import type { SessionResponse } from "../lib/types";
 import { isSessionActive } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { AvkAgentsGrid } from "./AvkAgentsGrid";
+import { AvkMemoryFeed } from "./AvkMemoryFeed";
 
 interface Props {
   sessions: SessionResponse[];
@@ -184,6 +185,11 @@ export function Dashboard({
       {/* FUR-3957 Adım 8 — AVK workflow ajan grid (13 ajan) */}
       <div className="mt-12 w-full max-w-4xl">
         <AvkAgentsGrid />
+      </div>
+
+      {/* FUR-4118 — AVK memory recall feed (mock; agentmemory MCP proxy bekleniş) */}
+      <div className="mt-12 w-full max-w-4xl">
+        <AvkMemoryFeed />
       </div>
     </div>
   );

--- a/web/src/components/widgets/GithubActionsWidget.tsx
+++ b/web/src/components/widgets/GithubActionsWidget.tsx
@@ -1,0 +1,80 @@
+/**
+ * GitHub Actions widget — repo-bazlı ✓✗▶ sayım + cross-repo recent run.
+ * Contract §3 (snake_case JSON).
+ */
+import { useGitHubActionsSummary } from "../../hooks/integrations";
+import type { GitHubRun } from "../../lib/integrations/github";
+import { WidgetShell, formatTime } from "./WidgetShell";
+
+function statusColor(run: GitHubRun): string {
+  if (run.status === "in_progress" || run.status === "queued" || run.status === "waiting") {
+    return "text-status-waiting";
+  }
+  if (run.conclusion === "success") return "text-status-running";
+  if (run.conclusion === "failure" || run.conclusion === "timed_out") return "text-status-error";
+  return "text-text-muted";
+}
+
+function statusLabel(run: GitHubRun): string {
+  if (run.status === "in_progress") return "RUNNING";
+  if (run.status === "queued" || run.status === "waiting") return run.status.toUpperCase();
+  return (run.conclusion ?? "—").toUpperCase();
+}
+
+export function GithubActionsWidget() {
+  const { result, isLoading } = useGitHubActionsSummary();
+  return (
+    <WidgetShell
+      title="GitHub Actions"
+      result={result}
+      isLoading={isLoading}
+      timestamp={result?.ok ? formatTime(result.data.fetched_at) : undefined}
+    >
+      {(data) => (
+        <>
+          <ul className="flex flex-col gap-0.5 mb-2">
+            {data.repos.map((r) => (
+              <li key={r.repo} className="flex gap-1.5 items-baseline text-xs">
+                <span className="flex-1 truncate">{r.repo}</span>
+                <span className="text-status-running" title="success">
+                  ✓{r.success}
+                </span>
+                <span className="text-status-error" title="failure">
+                  ✗{r.failure}
+                </span>
+                <span className="text-status-waiting" title="in progress">
+                  ▶{r.in_progress}
+                </span>
+                {r.other > 0 ? (
+                  <span className="text-text-muted" title="other">
+                    ·{r.other}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+          {data.recent.length > 0 ? (
+            <ul className="flex flex-col gap-1 border-t border-surface-700/40 pt-2">
+              {data.recent.map((run) => (
+                <li key={run.id} className="flex gap-2 items-baseline text-[11px]">
+                  <span className={`${statusColor(run)} shrink-0 min-w-[64px] font-semibold`}>
+                    {statusLabel(run)}
+                  </span>
+                  <a
+                    href={run.html_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-text-primary hover:underline flex-1 truncate"
+                  >
+                    {run.repo.split("/")[1]} · {run.name}
+                  </a>
+                  <span className="text-text-muted text-[10px] shrink-0">{run.head_branch || "—"}</span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </>
+      )}
+    </WidgetShell>
+  );
+}

--- a/web/src/components/widgets/LinearWidget.tsx
+++ b/web/src/components/widgets/LinearWidget.tsx
@@ -1,0 +1,63 @@
+/**
+ * Linear widget — In Progress / Backlog / Done 7g + 5 recent.
+ * Contract §1 (snake_case JSON).
+ */
+import { useLinearSummary } from "../../hooks/integrations";
+import { CountBox, WidgetShell, formatTime } from "./WidgetShell";
+
+export function LinearWidget() {
+  const { result, isLoading } = useLinearSummary();
+  return (
+    <WidgetShell
+      title="Linear"
+      result={result}
+      isLoading={isLoading}
+      timestamp={result?.ok ? formatTime(result.data.fetched_at) : undefined}
+    >
+      {(data) => (
+        <>
+          <div className="flex flex-wrap gap-1.5 mb-2.5">
+            <CountBox
+              label="In Progress"
+              value={data.in_progress.has_more ? `${data.in_progress.count}+` : data.in_progress.count}
+              accent="waiting"
+              hint={data.in_progress.has_more ? "250+ saturate" : undefined}
+            />
+            <CountBox
+              label="Backlog"
+              value={data.backlog.has_more ? `${data.backlog.count}+` : data.backlog.count}
+              accent="info"
+              hint={data.backlog.has_more ? "250+ saturate" : undefined}
+            />
+            <CountBox
+              label="Done 7g"
+              value={data.done7d.has_more ? `${data.done7d.count}+` : data.done7d.count}
+              accent="running"
+              hint={data.done7d.has_more ? "250+ saturate" : undefined}
+            />
+          </div>
+          {data.recent.length === 0 ? (
+            <p className="text-text-muted text-xs">Son güncel issue yok.</p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {data.recent.map((issue) => (
+                <li key={issue.identifier} className="flex gap-2 items-baseline text-xs">
+                  <a
+                    href={issue.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-brand-500 hover:underline shrink-0 min-w-[76px]"
+                  >
+                    {issue.identifier}
+                  </a>
+                  <span className="text-text-primary flex-1 truncate">{issue.title}</span>
+                  <span className="text-text-muted text-[10px] shrink-0">{issue.state}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </WidgetShell>
+  );
+}

--- a/web/src/components/widgets/NetdataWidget.tsx
+++ b/web/src/components/widgets/NetdataWidget.tsx
@@ -1,0 +1,52 @@
+/**
+ * Netdata widget — backend reachability + iframe embed (full-width).
+ * Contract §5 (snake_case JSON, reachable + iframe_base + chart URL listesi).
+ *
+ * Backend down ise iframe placeholder, up ise iframe embed.
+ */
+import { useNetdataSummary } from "../../hooks/integrations";
+import { WidgetShell, formatTime } from "./WidgetShell";
+
+export function NetdataWidget() {
+  const { result, isLoading } = useNetdataSummary();
+  return (
+    <WidgetShell
+      title="Netdata"
+      result={result}
+      isLoading={isLoading}
+      timestamp={result?.ok ? formatTime(result.data.fetched_at) : undefined}
+      className="col-span-full"
+    >
+      {(data) => (
+        <>
+          <header className="flex justify-between items-baseline mb-2 text-[11px]">
+            <span className={data.reachable ? "text-status-running" : "text-status-error"}>
+              {data.reachable ? "reachable" : "down"} · {data.version} · {data.host}
+            </span>
+            <a
+              href={data.iframe_base}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-text-muted hover:text-text-primary"
+            >
+              tam panel ↗
+            </a>
+          </header>
+          {data.reachable ? (
+            <iframe
+              src={data.iframe_base}
+              title="Netdata embedded dashboard"
+              loading="lazy"
+              sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
+              className="w-full min-h-[360px] bg-surface-950 border border-surface-700/40 rounded-md"
+            />
+          ) : (
+            <p className="text-text-muted text-xs">
+              Netdata erişilemez ({data.host}). Backend `<code>{data.iframe_base}</code>` boş.
+            </p>
+          )}
+        </>
+      )}
+    </WidgetShell>
+  );
+}

--- a/web/src/components/widgets/SentryWidget.tsx
+++ b/web/src/components/widgets/SentryWidget.tsx
@@ -1,0 +1,47 @@
+/**
+ * Sentry widget — Total 24h / Unresolved + 5 recent issue.
+ * Contract §2 (snake_case JSON).
+ */
+import { useSentrySummary } from "../../hooks/integrations";
+import { CountBox, WidgetShell, formatTime } from "./WidgetShell";
+
+export function SentryWidget() {
+  const { result, isLoading } = useSentrySummary();
+  return (
+    <WidgetShell
+      title="Sentry"
+      result={result}
+      isLoading={isLoading}
+      timestamp={result?.ok ? formatTime(result.data.fetched_at) : undefined}
+    >
+      {(data) => (
+        <>
+          <div className="flex flex-wrap gap-1.5 mb-2.5">
+            <CountBox label="Total 24h" value={data.total_issues} accent="muted" />
+            <CountBox label="Unresolved" value={data.unresolved} accent="error" />
+          </div>
+          {data.recent.length === 0 ? (
+            <p className="text-text-muted text-xs">Son 24 saatte unresolved issue yok.</p>
+          ) : (
+            <ul className="flex flex-col gap-1">
+              {data.recent.map((issue) => (
+                <li key={issue.id} className="flex gap-2 items-baseline text-xs">
+                  <a
+                    href={issue.permalink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-status-error hover:underline shrink-0 min-w-[96px]"
+                  >
+                    {issue.short_id}
+                  </a>
+                  <span className="text-text-primary flex-1 truncate">{issue.title}</span>
+                  <span className="text-status-waiting text-[10px] shrink-0">{issue.count}x</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </WidgetShell>
+  );
+}

--- a/web/src/components/widgets/VercelWidget.tsx
+++ b/web/src/components/widgets/VercelWidget.tsx
@@ -1,0 +1,81 @@
+/**
+ * Vercel widget — Ready/Error/Building CountBox + recent deployment.
+ * Contract §4 (snake_case JSON, created_at epoch ms).
+ */
+import { useVercelSummary } from "../../hooks/integrations";
+import type { VercelDeployment } from "../../lib/integrations/vercel";
+import { CountBox, WidgetShell, formatTime } from "./WidgetShell";
+
+function stateColor(state: string): string {
+  switch (state) {
+    case "READY":
+      return "text-status-running";
+    case "ERROR":
+      return "text-status-error";
+    case "BUILDING":
+    case "INITIALIZING":
+      return "text-status-waiting";
+    case "QUEUED":
+      return "text-brand-500";
+    case "CANCELED":
+      return "text-text-muted";
+    default:
+      return "text-text-muted";
+  }
+}
+
+function formatRelative(epochMs: number): string {
+  const diff = Date.now() - epochMs;
+  const m = Math.floor(diff / 60_000);
+  if (m < 1) return "az önce";
+  if (m < 60) return `${m}dk önce`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}sa önce`;
+  return `${Math.floor(h / 24)}g önce`;
+}
+
+export function VercelWidget() {
+  const { result, isLoading } = useVercelSummary();
+  return (
+    <WidgetShell
+      title="Vercel"
+      result={result}
+      isLoading={isLoading}
+      timestamp={result?.ok ? formatTime(result.data.fetched_at) : undefined}
+    >
+      {(data) => (
+        <>
+          <div className="flex flex-wrap gap-1.5 mb-2.5">
+            <CountBox label="Ready" value={data.counts.ready} accent="running" />
+            <CountBox label="Error" value={data.counts.error} accent="error" />
+            <CountBox label="Building" value={data.counts.building} accent="waiting" />
+          </div>
+          {data.recent.length === 0 ? (
+            <p className="text-text-muted text-xs">Son deployment yok.</p>
+          ) : (
+            <ul className="flex flex-col gap-1 border-t border-surface-700/40 pt-2">
+              {data.recent.map((d: VercelDeployment) => (
+                <li key={d.uid} className="flex gap-2 items-baseline text-[11px]">
+                  <span className={`${stateColor(d.state)} shrink-0 min-w-[64px] font-semibold`}>
+                    {d.state}
+                  </span>
+                  <a
+                    href={d.url.startsWith("http") ? d.url : `https://${d.url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-text-primary hover:underline flex-1 truncate"
+                  >
+                    {d.meta.branch ?? d.target ?? d.name}
+                  </a>
+                  <span className="text-text-muted text-[10px] shrink-0">
+                    {formatRelative(d.created_at)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </WidgetShell>
+  );
+}

--- a/web/src/components/widgets/WidgetShell.tsx
+++ b/web/src/components/widgets/WidgetShell.tsx
@@ -1,0 +1,97 @@
+/**
+ * Common widget shell — title header + loading/error fallback + body slot.
+ *
+ * Tailwind 4 surface-* + brand-* + status-* palette (AoE canon, web/src/index.css).
+ * Code-2 Adım 3 transplant — FUR-3957.
+ */
+import type { ReactNode } from "react";
+import type { WidgetResult } from "../../lib/integrations";
+
+interface WidgetShellProps<T> {
+  title: string;
+  result: WidgetResult<T> | null;
+  isLoading: boolean;
+  timestamp?: string;
+  children: (data: T) => ReactNode;
+  className?: string;
+}
+
+export function WidgetShell<T>({
+  title,
+  result,
+  isLoading,
+  timestamp,
+  children,
+  className = "",
+}: WidgetShellProps<T>) {
+  const cacheBadge =
+    result?.ok && result.cache !== "unknown" ? (
+      <span className="text-text-muted text-[10px] uppercase tracking-wider ml-2">
+        {result.cache}
+      </span>
+    ) : null;
+
+  return (
+    <section
+      aria-label={`${title} widget`}
+      className={`bg-surface-900 border border-surface-700/40 rounded-lg p-3 text-sm text-text-secondary ${className}`}
+    >
+      <header className="flex justify-between items-baseline mb-2">
+        <div className="flex items-baseline">
+          <strong className="text-text-primary text-sm font-semibold">{title}</strong>
+          {cacheBadge}
+        </div>
+        {timestamp ? (
+          <span className="text-text-muted text-[11px]">{timestamp}</span>
+        ) : null}
+      </header>
+      {isLoading && !result ? (
+        <p className="text-text-muted text-xs">Yükleniyor…</p>
+      ) : result?.ok === false ? (
+        <ErrorPanel status={result.status} message={result.error} />
+      ) : result?.ok === true ? (
+        children(result.data)
+      ) : null}
+    </section>
+  );
+}
+
+function ErrorPanel({ status, message }: { status: number; message: string }) {
+  const label = status === 0 ? "network" : status === 500 ? "env eksik" : status === 502 ? "upstream" : `HTTP ${status}`;
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-status-error text-[11px] uppercase">{label}</span>
+      <p className="text-text-muted text-xs break-words">{message}</p>
+    </div>
+  );
+}
+
+interface CountBoxProps {
+  label: string;
+  value: string | number;
+  accent: "running" | "waiting" | "error" | "info" | "muted";
+  hint?: string;
+}
+
+export function CountBox({ label, value, accent, hint }: CountBoxProps) {
+  const accentMap = {
+    running: "border-status-running",
+    waiting: "border-status-waiting",
+    error: "border-status-error",
+    info: "border-brand-600",
+    muted: "border-surface-700",
+  } as const;
+  return (
+    <div
+      className={`flex-1 min-w-[80px] bg-surface-850 rounded-md px-2.5 py-1.5 border-l-2 ${accentMap[accent]}`}
+    >
+      <div className="text-text-muted text-[10px] uppercase tracking-wider">{label}</div>
+      <div className="text-text-primary text-xl font-semibold leading-none">{value}</div>
+      {hint ? <div className="text-status-waiting text-[10px] mt-0.5">{hint}</div> : null}
+    </div>
+  );
+}
+
+export function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString("tr-TR", { hour: "2-digit", minute: "2-digit" });
+}

--- a/web/src/components/widgets/index.ts
+++ b/web/src/components/widgets/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Widget barrel — Adım 3 transplant Code-2 sole.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md
+ */
+export { LinearWidget } from "./LinearWidget";
+export { SentryWidget } from "./SentryWidget";
+export { GithubActionsWidget } from "./GithubActionsWidget";
+export { VercelWidget } from "./VercelWidget";
+export { NetdataWidget } from "./NetdataWidget";
+export { WidgetShell, CountBox, formatTime } from "./WidgetShell";

--- a/web/src/hooks/integrations/index.ts
+++ b/web/src/hooks/integrations/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Widget hooks barrel — Code-2 Adım 3 transplant.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md
+ */
+import { useWidget } from "./useWidget";
+import { fetchLinearSummary, type LinearSummary } from "../../lib/integrations/linear";
+import { fetchSentrySummary, type SentrySummary } from "../../lib/integrations/sentry";
+import {
+  fetchGitHubActionsSummary,
+  type GitHubActionsSummary,
+} from "../../lib/integrations/github";
+import { fetchVercelSummary, type VercelSummary } from "../../lib/integrations/vercel";
+import { fetchNetdataSummary, type NetdataSummary } from "../../lib/integrations/netdata";
+
+export function useLinearSummary() {
+  return useWidget<LinearSummary>(fetchLinearSummary);
+}
+
+export function useSentrySummary() {
+  return useWidget<SentrySummary>(fetchSentrySummary);
+}
+
+export function useGitHubActionsSummary() {
+  return useWidget<GitHubActionsSummary>(fetchGitHubActionsSummary);
+}
+
+export function useVercelSummary() {
+  return useWidget<VercelSummary>(fetchVercelSummary);
+}
+
+export function useNetdataSummary() {
+  return useWidget<NetdataSummary>(fetchNetdataSummary);
+}
+
+export { useWidget };

--- a/web/src/hooks/integrations/useWidget.ts
+++ b/web/src/hooks/integrations/useWidget.ts
@@ -1,0 +1,47 @@
+/**
+ * Common widget hook factory — periodic polling fetch with WidgetResult state.
+ *
+ * Code-1 contract: 60s in-process cache backend tarafı; UI poll 30s default
+ * (cache MISS ihtimali ≤50%). PreviousData korunur fetch sırasında — flicker
+ * önleme.
+ */
+import { useEffect, useRef, useState } from "react";
+import type { WidgetResult } from "../../lib/integrations";
+
+export interface UseWidgetState<T> {
+  result: WidgetResult<T> | null;
+  isLoading: boolean;
+}
+
+export function useWidget<T>(
+  fetcher: () => Promise<WidgetResult<T>>,
+  pollMs: number = 30_000,
+): UseWidgetState<T> {
+  const [result, setResult] = useState<WidgetResult<T> | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const tick = async () => {
+      const r = await fetcher();
+      if (!mountedRef.current) return;
+      setResult(r);
+      setIsLoading(false);
+      timer = setTimeout(tick, pollMs);
+    };
+
+    tick();
+
+    return () => {
+      mountedRef.current = false;
+      if (timer) clearTimeout(timer);
+    };
+    // fetcher kimliği kararlı varsayılır (modüle bağlı export); pollMs prop değişiminde re-init
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pollMs]);
+
+  return { result, isLoading };
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,8 @@ import type {
   AgentInfo,
   AvkAgentInfo,
   AvkAgentRole,
+  AvkBroadcastRequest,
+  AvkBroadcastResponse,
   AvkMemoryEntry,
   ProfileInfo,
   BrowseResponse,
@@ -399,6 +401,31 @@ export async function fetchAvkMemoryRecall(
   const qs = params.toString();
   const url = qs ? `/api/avk/memory-recall?${qs}` : "/api/avk/memory-recall";
   return (await fetchJson<AvkMemoryEntry[]>(url)) ?? [];
+}
+
+/**
+ * `POST /api/avk/broadcast` — FUR-4121 endpoint.
+ *
+ * Server tier resolver `director`/`senior`/`worker`/`all` keyword'unu
+ * AVK_AGENTS registry'sinden filtreler ve tmux pane'lere bracketed-paste
+ * mesaj yollar. Tek pane fail durumunda yine 200 döner, `results` listesinde
+ * bireysel hata kayıtları olur. 400 (boş mesaj), 404 (bilinmeyen tier),
+ * 413 (8KB üstü mesaj) error response döner.
+ */
+export async function postAvkBroadcast(
+  req: AvkBroadcastRequest,
+): Promise<AvkBroadcastResponse | null> {
+  try {
+    const res = await fetch("/api/avk/broadcast", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(req),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as AvkBroadcastResponse;
+  } catch {
+    return null;
+  }
 }
 
 export async function fetchProfiles(): Promise<ProfileInfo[]> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   AgentInfo,
   AvkAgentInfo,
   AvkAgentRole,
+  AvkMemoryEntry,
   ProfileInfo,
   BrowseResponse,
   GroupInfo,
@@ -380,6 +381,24 @@ export async function fetchAgents(): Promise<AgentInfo[]> {
 export async function fetchAvkAgents(role?: AvkAgentRole): Promise<AvkAgentInfo[]> {
   const url = role ? `/api/avk/agents?role=${role}` : "/api/avk/agents";
   return (await fetchJson<AvkAgentInfo[]>(url)) ?? [];
+}
+
+/**
+ * `GET /api/avk/memory-recall[?role=...&hours=...]` — FUR-4118 endpoint.
+ *
+ * Mock implementation; server static MOCK_FEED döner. Gerçek agentmemory MCP
+ * proxy eklendiğinde aynı shape, UI değişikliği yok.
+ */
+export async function fetchAvkMemoryRecall(
+  role?: string,
+  hours?: number,
+): Promise<AvkMemoryEntry[]> {
+  const params = new URLSearchParams();
+  if (role) params.set("role", role);
+  if (hours) params.set("hours", String(hours));
+  const qs = params.toString();
+  const url = qs ? `/api/avk/memory-recall?${qs}` : "/api/avk/memory-recall";
+  return (await fetchJson<AvkMemoryEntry[]>(url)) ?? [];
 }
 
 export async function fetchProfiles(): Promise<ProfileInfo[]> {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,6 +3,8 @@ import type {
   RichDiffFilesResponse,
   RichFileDiffResponse,
   AgentInfo,
+  AvkAgentInfo,
+  AvkAgentRole,
   ProfileInfo,
   BrowseResponse,
   GroupInfo,
@@ -367,6 +369,17 @@ export function fetchDevices(): Promise<DeviceInfo[] | null> {
 
 export async function fetchAgents(): Promise<AgentInfo[]> {
   return (await fetchJson<AgentInfo[]>("/api/agents")) ?? [];
+}
+
+/**
+ * `GET /api/avk/agents[?role=...]` — FUR-3957 Adım 6 endpoint.
+ *
+ * Opsiyonel `role` filter director|senior|worker. Geçersiz role server
+ * 400 döner; bu wrapper null'a indirgenmiş listeyi `[]` olarak verir.
+ */
+export async function fetchAvkAgents(role?: AvkAgentRole): Promise<AvkAgentInfo[]> {
+  const url = role ? `/api/avk/agents?role=${role}` : "/api/avk/agents";
+  return (await fetchJson<AvkAgentInfo[]>(url)) ?? [];
 }
 
 export async function fetchProfiles(): Promise<ProfileInfo[]> {

--- a/web/src/lib/integrations/github.ts
+++ b/web/src/lib/integrations/github.ts
@@ -1,0 +1,36 @@
+/**
+ * GitHub Actions widget TS client.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md §3
+ */
+import { fetchWidget, type WidgetResult } from "./index";
+
+export interface GitHubRepoStats {
+  repo: string;
+  success: number;
+  failure: number;
+  in_progress: number;
+  other: number;
+}
+
+export interface GitHubRun {
+  id: number;
+  repo: string;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  html_url: string;
+  head_branch: string;
+  event: string;
+  run_started_at: string;
+  updated_at: string;
+}
+
+export interface GitHubActionsSummary {
+  repos: GitHubRepoStats[];
+  recent: GitHubRun[];
+  fetched_at: string;
+}
+
+export function fetchGitHubActionsSummary(): Promise<WidgetResult<GitHubActionsSummary>> {
+  return fetchWidget<GitHubActionsSummary>("/api/widgets/github-actions/summary");
+}

--- a/web/src/lib/integrations/index.ts
+++ b/web/src/lib/integrations/index.ts
@@ -1,0 +1,35 @@
+/**
+ * Widget API client common types + helper.
+ *
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md (Code-1 dondurucu)
+ * Endpoint base: /api/widgets/<service>/summary
+ * Convention: snake_case JSON (Rust serde), 200/500/502, plain-text error body
+ *
+ * Code-2 sole — Adım 3 (FUR-3957 transplant).
+ */
+
+export type WidgetResult<T> =
+  | { ok: true; data: T; cache: "HIT" | "MISS" | "unknown" }
+  | { ok: false; status: number; error: string };
+
+/**
+ * GET widget endpoint with Code-1 contract pattern.
+ * - 200: parse JSON, capture x-cache header
+ * - 500/502: read plain-text body as error
+ * - network fail: ok:false + status 0
+ */
+export async function fetchWidget<T>(endpoint: string): Promise<WidgetResult<T>> {
+  try {
+    const res = await fetch(endpoint, { cache: "no-store" });
+    if (!res.ok) {
+      const errText = await res.text().catch(() => res.statusText);
+      return { ok: false, status: res.status, error: errText || `HTTP ${res.status}` };
+    }
+    const cache = (res.headers.get("x-cache") as "HIT" | "MISS" | null) ?? "unknown";
+    const data = (await res.json()) as T;
+    return { ok: true, data, cache };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { ok: false, status: 0, error: `network: ${message}` };
+  }
+}

--- a/web/src/lib/integrations/linear.ts
+++ b/web/src/lib/integrations/linear.ts
@@ -1,0 +1,30 @@
+/**
+ * Linear widget TS client.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md §1
+ */
+import { fetchWidget, type WidgetResult } from "./index";
+
+export interface LinearCount {
+  count: number;
+  has_more: boolean;
+}
+
+export interface LinearIssue {
+  identifier: string;
+  title: string;
+  state: string;
+  url: string;
+  updated_at: string;
+}
+
+export interface LinearSummary {
+  in_progress: LinearCount;
+  backlog: LinearCount;
+  done7d: LinearCount;
+  recent: LinearIssue[];
+  fetched_at: string;
+}
+
+export function fetchLinearSummary(): Promise<WidgetResult<LinearSummary>> {
+  return fetchWidget<LinearSummary>("/api/widgets/linear/summary");
+}

--- a/web/src/lib/integrations/netdata.ts
+++ b/web/src/lib/integrations/netdata.ts
@@ -1,0 +1,23 @@
+/**
+ * Netdata widget TS client.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md §5
+ */
+import { fetchWidget, type WidgetResult } from "./index";
+
+export interface NetdataChart {
+  id: string;
+  url: string;
+}
+
+export interface NetdataSummary {
+  reachable: boolean;
+  version: string;
+  host: string;
+  charts: NetdataChart[];
+  iframe_base: string;
+  fetched_at: string;
+}
+
+export function fetchNetdataSummary(): Promise<WidgetResult<NetdataSummary>> {
+  return fetchWidget<NetdataSummary>("/api/widgets/netdata/summary");
+}

--- a/web/src/lib/integrations/sentry.ts
+++ b/web/src/lib/integrations/sentry.ts
@@ -1,0 +1,26 @@
+/**
+ * Sentry widget TS client.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md §2
+ */
+import { fetchWidget, type WidgetResult } from "./index";
+
+export interface SentryIssue {
+  id: string;
+  short_id: string;
+  title: string;
+  culprit: string;
+  count: string;
+  permalink: string;
+  last_seen: string;
+}
+
+export interface SentrySummary {
+  total_issues: number;
+  unresolved: number;
+  recent: SentryIssue[];
+  fetched_at: string;
+}
+
+export function fetchSentrySummary(): Promise<WidgetResult<SentrySummary>> {
+  return fetchWidget<SentrySummary>("/api/widgets/sentry/summary");
+}

--- a/web/src/lib/integrations/vercel.ts
+++ b/web/src/lib/integrations/vercel.ts
@@ -1,0 +1,38 @@
+/**
+ * Vercel widget TS client.
+ * Contract: docs/aoe-transplant/02-widget-api-contract.md §4
+ */
+import { fetchWidget, type WidgetResult } from "./index";
+
+export interface VercelStateCounts {
+  ready: number;
+  error: number;
+  building: number;
+  queued: number;
+  canceled: number;
+  other: number;
+}
+
+export interface VercelDeployment {
+  uid: string;
+  name: string;
+  url: string;
+  state: string;
+  target: string | null;
+  created_at: number;
+  source: string | null;
+  meta: {
+    branch?: string;
+    commit_sha?: string;
+  };
+}
+
+export interface VercelSummary {
+  counts: VercelStateCounts;
+  recent: VercelDeployment[];
+  fetched_at: string;
+}
+
+export function fetchVercelSummary(): Promise<WidgetResult<VercelSummary>> {
+  return fetchWidget<VercelSummary>("/api/widgets/vercel/summary");
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -247,6 +247,28 @@ export interface AvkAgentInfo {
   tmux_target: string;
 }
 
+/**
+ * AVK memory tier — FUR-4118 server contract mirror.
+ * `core` = always-relevant, `working` = aktif iş, `archival` = referans/eski.
+ */
+export type AvkMemoryTier = "core" | "working" | "archival";
+
+/**
+ * `GET /api/avk/memory-recall[?role=...&hours=...]` JSON shape mirror.
+ *
+ * Mock implementation: server static MOCK_FEED döner. Gerçek agentmemory
+ * MCP proxy implementation eklendiğinde aynı shape — UI değişikliği yok.
+ */
+export interface AvkMemoryEntry {
+  id: string;
+  title: string;
+  tier: AvkMemoryTier;
+  role: string;
+  tags: string[];
+  content_preview: string;
+  created_at: string;
+}
+
 /** Profile info returned by /api/profiles */
 export interface ProfileInfo {
   name: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -237,14 +237,18 @@ export type AvkAgentRole = "director" | "senior" | "worker";
 /**
  * `GET /api/avk/agents[?role=...]` JSON shape mirror.
  *
- * `tmux_target` runtime'da değişebilir (pane index resync) — UI tarafı
- * cache yapmamalı, her render fetch'i fresh sonuç kullanmalı.
+ * `tmux_target` registry sabit (örn `avk-ofis:idare.1`). `runtime_target`
+ * AoE binary'nin gerçek yarattığı session adı (örn `aoe_koord_e91e6bb4:^.0`)
+ * — bulunamazsa null. `pane_alive` resolver başarılıysa true, UI live dot
+ * indicator (yeşil/gri). FUR-4123 polish.
  */
 export interface AvkAgentInfo {
   slug: string;
   label: string;
   role: AvkAgentRole;
   tmux_target: string;
+  runtime_target: string | null;
+  pane_alive: boolean;
 }
 
 /**

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -226,6 +226,27 @@ export interface AgentInfo {
   install_hint: string;
 }
 
+/**
+ * AVK workflow ajan tier — FUR-3957 transplant Adım 6 server contract mirror.
+ *
+ * `lowercase` JSON serde derive (Rust `AvkAgentRole` enum). Yeni tier
+ * eklenirse server + bu union senkron tutulmalı.
+ */
+export type AvkAgentRole = "director" | "senior" | "worker";
+
+/**
+ * `GET /api/avk/agents[?role=...]` JSON shape mirror.
+ *
+ * `tmux_target` runtime'da değişebilir (pane index resync) — UI tarafı
+ * cache yapmamalı, her render fetch'i fresh sonuç kullanmalı.
+ */
+export interface AvkAgentInfo {
+  slug: string;
+  label: string;
+  role: AvkAgentRole;
+  tmux_target: string;
+}
+
 /** Profile info returned by /api/profiles */
 export interface ProfileInfo {
   name: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -254,6 +254,35 @@ export interface AvkAgentInfo {
 export type AvkMemoryTier = "core" | "working" | "archival";
 
 /**
+ * AVK broadcast tier keyword — FUR-4121 server contract mirror.
+ * `all` = 13 ajan; tier rolleri `AvkAgentRole` ile aynı (director/senior/worker).
+ */
+export type AvkBroadcastTier = "director" | "senior" | "worker" | "all";
+
+/** `POST /api/avk/broadcast` istek body shape mirror. */
+export interface AvkBroadcastRequest {
+  tier: AvkBroadcastTier;
+  message: string;
+}
+
+/** Tek bir tmux pane gönderim sonucu (slug + target + ok/error). */
+export interface AvkBroadcastResult {
+  slug: string;
+  target: string;
+  ok: boolean;
+  error: string | null;
+}
+
+/** `POST /api/avk/broadcast` response shape mirror. */
+export interface AvkBroadcastResponse {
+  tier: AvkBroadcastTier;
+  total: number;
+  ok: number;
+  failed: number;
+  results: AvkBroadcastResult[];
+}
+
+/**
  * `GET /api/avk/memory-recall[?role=...&hours=...]` JSON shape mirror.
  *
  * Mock implementation: server static MOCK_FEED döner. Gerçek agentmemory


### PR DESCRIPTION
## Özet

Furkan canon 2026-05-17 (sustained polish):
- iPhone'da Dashboard scroll yoktu → `flex-1 overflow-y-auto` fix
- "yazıları türkçe yapar mısın" → 5 dosya label Türkçeleştirme
- "birimleri düzgün gruplandır" → AVK Komuta Paneli section grouping (3 widget kartlı border-t separator)
- "geminiler doğru sırada değil" → Worker tier reorder G1→G2→K1→K2→K3→Codex

## Değişiklikler

| Dosya | Değişiklik |
|---|---|
| `web/src/components/Dashboard.tsx` | overflow-y-auto, AVK section, Türkçe (ajan/EMPIRES, stats, action panes) |
| `web/src/components/AvkAgentsGrid.tsx` | ROLE_LABEL Türkçe (Yönetim/Kıdemli/Operasyon) |
| `web/src/components/AvkBroadcastWidget.tsx` | TIER_LABEL Türkçe + compact description |
| `web/src/components/AvkMemoryFeed.tsx` | TIER_LABEL Türkçe (Çekirdek/Aktif/Arşiv) |
| `src/avk_agents.rs` | Worker reorder + Türkçe label (Genel Sekreter, Operasyon Müdürü, Birleştirme Ajanı, Geçit Süzgeci, Çoklu Sağlayıcı) |

## Test

- [x] `cargo clippy -- -D warnings` yeşil
- [x] `cargo fmt --check` yeşil
- [x] `npm run build` web yeşil (305ms)
- [x] iPhone Safari scroll çalışıyor (Furkan onayı)

🤖 Generated with [Claude Code](https://claude.com/claude-code)