### PR TITLE
fix(tui): anchor IME candidate windows to active input cursor

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -227,6 +227,33 @@ impl App {
         Ok(())
     }
 
+    /// Draw a frame without exposing ratatui's intermediate cursor moves.
+    ///
+    /// The backend moves the real terminal cursor while flushing changed
+    /// cells. If an IME is composing text, those transient moves can pull the
+    /// candidate window toward refreshed UI such as the status list before the
+    /// frame's final cursor position is restored. Synchronized update batches
+    /// the frame, and hiding the cursor before the batch keeps the only visible
+    /// cursor transition at ratatui's final `Frame::set_cursor_position`.
+    fn draw(&mut self, terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>) -> Result<()> {
+        crossterm::execute!(
+            terminal.backend_mut(),
+            crossterm::terminal::BeginSynchronizedUpdate
+        )?;
+        let draw_result = (|| -> Result<()> {
+            crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Hide)?;
+            terminal.draw(|f| self.render(f)).map(|_| ())?;
+            Ok(())
+        })();
+        let end_result = crossterm::execute!(
+            terminal.backend_mut(),
+            crossterm::terminal::EndSynchronizedUpdate
+        );
+        draw_result?;
+        end_result?;
+        Ok(())
+    }
+
     /// Temporarily leave TUI mode, run a closure, and restore TUI mode.
     /// Drops the EventStream before the closure so child processes (tmux,
     /// editors) have exclusive access to stdin, then creates a fresh one.
@@ -334,7 +361,7 @@ impl App {
     ) -> Result<()> {
         // Initial render
         terminal.clear()?;
-        terminal.draw(|f| self.render(f))?;
+        self.draw(terminal)?;
 
         // Refresh tmux session cache
         crate::tmux::refresh_session_cache();
@@ -512,7 +539,7 @@ impl App {
                                 // non-burst Event::Key arm below.
                                 self.sync_mouse_capture(terminal)?;
                                 if !self.needs_redraw {
-                                    terminal.draw(|f| self.render(f))?;
+                                    self.draw(terminal)?;
                                 }
                                 if self.should_quit {
                                     break;
@@ -528,7 +555,7 @@ impl App {
                             // on the next iteration; drawing before that drain
                             // wastes a frame and can flicker.
                             if !self.needs_redraw {
-                                terminal.draw(|f| self.render(f))?;
+                                self.draw(terminal)?;
                             }
 
                             if self.should_quit {
@@ -550,14 +577,14 @@ impl App {
                                 _ => false,
                             };
                             if handled {
-                                terminal.draw(|f| self.render(f))?;
+                                self.draw(terminal)?;
                             }
                             continue;
                         }
                         Some(Ok(Event::Paste(text))) => {
                             self.home.handle_paste(&text);
 
-                            terminal.draw(|f| self.render(f))?;
+                            self.draw(terminal)?;
 
                             continue;
                         }
@@ -570,7 +597,7 @@ impl App {
                             // (responsive::dialog_width, STACKED_BREAKPOINT,
                             // etc.) re-evaluates; ratatui's draw() autoresizes
                             // internally before rendering.
-                            terminal.draw(|f| self.render(f))?;
+                            self.draw(terminal)?;
                             continue;
                         }
                         Some(Ok(_)) => {}
@@ -680,7 +707,7 @@ impl App {
             }
 
             if refresh_needed {
-                terminal.draw(|f| self.render(f))?;
+                self.draw(terminal)?;
             }
 
             if self.should_quit {
@@ -1000,7 +1027,7 @@ impl App {
                 self.home
                     .set_instance_status(&id, crate::session::Status::Starting);
                 self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
-                terminal.draw(|f| self.render(f))?;
+                self.draw(terminal)?;
                 self.home.execute_send_message(&id, &message);
                 self.update_status = None;
             }

--- a/src/tui/cockpit_view/render.rs
+++ b/src/tui/cockpit_view/render.rs
@@ -164,6 +164,14 @@ fn render_composer(frame: &mut Frame, area: Rect, theme: &Theme, state: &Cockpit
     let inner = block.inner(area);
     frame.render_widget(block, area);
     frame.render_widget(&state.composer, inner);
+    if matches!(state.focus, Focus::Composer) && inner.width > 0 && inner.height > 0 {
+        let cursor = state.composer.screen_cursor();
+        let max_x = inner.x.saturating_add(inner.width.saturating_sub(1));
+        let max_y = inner.y.saturating_add(inner.height.saturating_sub(1));
+        let cursor_x = inner.x.saturating_add(cursor.col as u16).min(max_x);
+        let cursor_y = inner.y.saturating_add(cursor.row as u16).min(max_y);
+        frame.set_cursor_position((cursor_x, cursor_y));
+    }
 }
 
 fn transcript_lines<'a>(

--- a/src/tui/components/dir_picker.rs
+++ b/src/tui/components/dir_picker.rs
@@ -8,6 +8,7 @@ use ratatui::widgets::*;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
+use super::text_input::set_prefixed_input_cursor_position;
 use crate::tui::styles::Theme;
 
 pub enum DirPickerResult {
@@ -289,6 +290,7 @@ impl DirPicker {
             Span::styled("_", Style::default().fg(theme.accent)),
         ]);
         frame.render_widget(Paragraph::new(filter_line), chunks[0]);
+        set_prefixed_input_cursor_position(frame, chunks[0], "Filter: ", &self.filter);
 
         let visible_height = chunks[2].height as usize;
         let scroll = super::scroll::calculate_scroll(filtered.len(), self.selected, visible_height);

--- a/src/tui/components/list_picker.rs
+++ b/src/tui/components/list_picker.rs
@@ -6,6 +6,7 @@ use ratatui::widgets::*;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
+use super::text_input::set_prefixed_input_cursor_position;
 use crate::tui::styles::Theme;
 
 pub enum ListPickerResult {
@@ -138,6 +139,7 @@ impl ListPicker {
             Span::styled("_", Style::default().fg(theme.accent)),
         ]);
         frame.render_widget(Paragraph::new(filter_line), chunks[0]);
+        set_prefixed_input_cursor_position(frame, chunks[0], "Filter: ", &self.filter);
 
         // Item list with scrolling
         let visible_height = chunks[2].height as usize;

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -14,5 +14,6 @@ pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
 pub use preview::Preview;
 pub use text_input::{
-    longest_common_prefix, render_text_field, render_text_field_with_ghost, GroupGhostCompletion,
+    longest_common_prefix, render_text_field, render_text_field_with_ghost,
+    set_input_cursor_position, set_prefixed_input_cursor_position, GroupGhostCompletion,
 };

--- a/src/tui/components/text_input.rs
+++ b/src/tui/components/text_input.rs
@@ -3,6 +3,7 @@
 use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 use tui_input::Input;
+use unicode_width::UnicodeWidthStr;
 
 use crate::tui::styles::Theme;
 
@@ -51,7 +52,7 @@ impl GroupGhostCompletion {
         }
 
         let char_len = value.chars().count();
-        let cursor_char = input.visual_cursor().min(char_len);
+        let cursor_char = input.cursor().min(char_len);
 
         // Only show ghost when cursor is at end of input
         if cursor_char < char_len {
@@ -95,7 +96,7 @@ impl GroupGhostCompletion {
     /// if the ghost was still valid (not stale), or `None` if stale.
     pub fn accept(self, input: &Input) -> Option<String> {
         let value = input.value().to_string();
-        let cursor_char = input.visual_cursor().min(value.chars().count());
+        let cursor_char = input.cursor().min(value.chars().count());
 
         // Staleness check
         if self.input_snapshot != value || self.cursor_snapshot != cursor_char {
@@ -170,7 +171,7 @@ pub fn render_text_field_with_ghost(
             spans.push(Span::styled(placeholder_text, value_style));
         }
     } else if is_focused {
-        let cursor_pos = input.visual_cursor();
+        let cursor_pos = input.cursor();
         let cursor_style = Style::default().fg(theme.background).bg(theme.accent);
 
         // Split value into: before cursor, char at cursor, after cursor
@@ -197,6 +198,36 @@ pub fn render_text_field_with_ghost(
     }
 
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+
+    if is_focused {
+        let prefix = format!("{label} ");
+        set_prefixed_input_cursor_position(frame, area, &prefix, input);
+    }
+}
+
+pub fn set_prefixed_input_cursor_position(
+    frame: &mut Frame,
+    area: Rect,
+    prefix: &str,
+    input: &Input,
+) {
+    set_input_cursor_position(frame, area, prefix.width(), input);
+}
+
+pub fn set_input_cursor_position(
+    frame: &mut Frame,
+    area: Rect,
+    prefix_width: usize,
+    input: &Input,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let cursor_col = prefix_width.saturating_add(input.visual_cursor());
+    let max_col = area.width.saturating_sub(1) as usize;
+    let x = area.x.saturating_add(cursor_col.min(max_col) as u16);
+    frame.set_cursor_position(Position::new(x, area.y));
 }
 
 #[cfg(test)]
@@ -332,5 +363,63 @@ mod tests {
         // Input changed after computing ghost
         let changed_input = Input::new("pers".to_string());
         assert!(ghost.accept(&changed_input).is_none());
+    }
+
+    #[test]
+    fn focused_text_field_sets_terminal_cursor() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let input = Input::new("hi".to_string());
+        let theme = Theme::empire();
+
+        terminal
+            .draw(|f| {
+                render_text_field(
+                    f,
+                    Rect::new(2, 1, 30, 1),
+                    "Name:",
+                    &input,
+                    true,
+                    None,
+                    &theme,
+                );
+            })
+            .unwrap();
+
+        terminal
+            .backend_mut()
+            .assert_cursor_position(Position::new(10, 1));
+    }
+
+    #[test]
+    fn focused_text_field_uses_display_columns_for_wide_chars() {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(40, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let input = Input::new("你".to_string());
+        let theme = Theme::empire();
+
+        terminal
+            .draw(|f| {
+                render_text_field(
+                    f,
+                    Rect::new(2, 1, 30, 1),
+                    "Name:",
+                    &input,
+                    true,
+                    None,
+                    &theme,
+                );
+            })
+            .unwrap();
+
+        terminal
+            .backend_mut()
+            .assert_cursor_position(Position::new(10, 1));
     }
 }

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -14,6 +14,7 @@ use tui_input::Input;
 use unicode_width::UnicodeWidthStr;
 
 use super::DialogResult;
+use crate::tui::components::set_prefixed_input_cursor_position;
 use crate::tui::styles::Theme;
 
 /// Group buckets, rendered in this order. Mirrors `web/src/components/command-palette/groups.ts`.
@@ -386,6 +387,7 @@ impl CommandPaletteDialog {
             Span::styled("_", Style::default().fg(theme.accent)),
         ]);
         frame.render_widget(Paragraph::new(input_line), chunks[0]);
+        set_prefixed_input_cursor_position(frame, chunks[0], "> ", &self.input);
 
         // Separator
         let sep = "─".repeat(chunks[1].width as usize);

--- a/src/tui/dialogs/custom_instruction.rs
+++ b/src/tui/dialogs/custom_instruction.rs
@@ -122,6 +122,7 @@ impl CustomInstructionDialog {
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
             .border_style(Style::default().fg(textarea_border_color));
+        let textarea_inner = textarea_block.inner(chunks[0]);
 
         let mut text_area_clone = self.text_area.clone();
         text_area_clone.set_block(textarea_block);
@@ -134,6 +135,24 @@ impl CustomInstructionDialog {
         }
 
         frame.render_widget(&text_area_clone, chunks[0]);
+        if self.focused_zone == 0 && textarea_inner.width > 0 && textarea_inner.height > 0 {
+            let cursor = text_area_clone.screen_cursor();
+            let max_x = textarea_inner
+                .x
+                .saturating_add(textarea_inner.width.saturating_sub(1));
+            let max_y = textarea_inner
+                .y
+                .saturating_add(textarea_inner.height.saturating_sub(1));
+            let cursor_x = textarea_inner
+                .x
+                .saturating_add(cursor.col as u16)
+                .min(max_x);
+            let cursor_y = textarea_inner
+                .y
+                .saturating_add(cursor.row as u16)
+                .min(max_y);
+            frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+        }
 
         // Button row
         let button_area = chunks[1];

--- a/src/tui/dialogs/new_session/group_input.rs
+++ b/src/tui/dialogs/new_session/group_input.rs
@@ -12,7 +12,7 @@ impl NewSessionDialog {
 
         // Right arrow at end of input with ghost: accept ghost text
         if key.code == KeyCode::Right && key.modifiers == KeyModifiers::NONE {
-            let cursor = self.group.visual_cursor();
+            let cursor = self.group.cursor();
             let char_len = self.group.value().chars().count();
             if cursor >= char_len && self.group_ghost.is_some() {
                 self.accept_group_ghost();
@@ -23,7 +23,7 @@ impl NewSessionDialog {
 
         // End key at end of input with ghost: accept ghost text
         if key.code == KeyCode::End && key.modifiers == KeyModifiers::NONE {
-            let cursor = self.group.visual_cursor();
+            let cursor = self.group.cursor();
             let char_len = self.group.value().chars().count();
             if cursor >= char_len && self.group_ghost.is_some() {
                 self.accept_group_ghost();

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -1403,13 +1403,13 @@ impl NewSessionDialog {
                 && key.modifiers == KeyModifiers::NONE
             {
                 if let Some(ref input) = self.workspace_repo_editing_input {
-                    let cursor = input.visual_cursor();
+                    let cursor = input.cursor();
                     let char_len = input.value().chars().count();
                     if cursor >= char_len {
                         if let Some(ghost) = self.workspace_repo_ghost.take() {
                             if let Some(ref mut input) = self.workspace_repo_editing_input {
                                 let value = input.value().to_string();
-                                let cursor_char = input.visual_cursor().min(value.chars().count());
+                                let cursor_char = input.cursor().min(value.chars().count());
                                 if ghost.input_snapshot == value
                                     && ghost.cursor_snapshot == cursor_char
                                 {

--- a/src/tui/dialogs/new_session/path_input.rs
+++ b/src/tui/dialogs/new_session/path_input.rs
@@ -80,7 +80,7 @@ fn path_completion_base(parent_prefix: &str) -> Option<PathBuf> {
 pub(super) fn compute_path_ghost(input: &Input) -> Option<PathGhostCompletion> {
     let value = input.value().to_string();
     let char_len = value.chars().count();
-    let cursor_char = input.visual_cursor().min(char_len);
+    let cursor_char = input.cursor().min(char_len);
 
     if cursor_char < char_len {
         return None;
@@ -149,7 +149,7 @@ impl NewSessionDialog {
 
         // Right arrow at end of input with ghost: accept ghost text
         if key.code == KeyCode::Right && key.modifiers == KeyModifiers::NONE {
-            let cursor = self.path.visual_cursor();
+            let cursor = self.path.cursor();
             let char_len = self.path.value().chars().count();
             if cursor >= char_len && self.path_ghost.is_some() {
                 self.accept_path_ghost();
@@ -160,7 +160,7 @@ impl NewSessionDialog {
 
         // End key at end of input with ghost: accept ghost text
         if key.code == KeyCode::End && key.modifiers == KeyModifiers::NONE {
-            let cursor = self.path.visual_cursor();
+            let cursor = self.path.cursor();
             let char_len = self.path.value().chars().count();
             if cursor >= char_len && self.path_ghost.is_some() {
                 self.accept_path_ghost();
@@ -195,7 +195,7 @@ impl NewSessionDialog {
     fn move_path_cursor_to(&mut self, target_char_idx: usize) {
         let char_len = self.path.value().chars().count();
         let target = target_char_idx.min(char_len);
-        let current = self.path.visual_cursor().min(char_len);
+        let current = self.path.cursor().min(char_len);
 
         if target < current {
             for _ in 0..(current - target) {
@@ -218,7 +218,7 @@ impl NewSessionDialog {
 
     fn move_path_cursor_to_previous_segment(&mut self) {
         let chars: Vec<char> = self.path.value().chars().collect();
-        let mut cursor = self.path.visual_cursor().min(chars.len());
+        let mut cursor = self.path.cursor().min(chars.len());
         if cursor == 0 {
             return;
         }
@@ -259,7 +259,7 @@ impl NewSessionDialog {
         };
 
         let value = self.path.value().to_string();
-        let cursor_char = self.path.visual_cursor().min(value.chars().count());
+        let cursor_char = self.path.cursor().min(value.chars().count());
 
         // Staleness check
         if ghost.input_snapshot != value || ghost.cursor_snapshot != cursor_char {

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -2,11 +2,14 @@
 
 use ratatui::prelude::*;
 use ratatui::widgets::*;
+use tui_input::Input;
 
 use rattles::presets::prelude as spinners;
 
 use super::{NewSessionDialog, FIELD_HELP, HELP_DIALOG_WIDTH};
-use crate::tui::components::{render_text_field, render_text_field_with_ghost};
+use crate::tui::components::{
+    render_text_field, render_text_field_with_ghost, set_prefixed_input_cursor_position,
+};
 use crate::tui::styles::Theme;
 
 impl NewSessionDialog {
@@ -554,7 +557,7 @@ impl NewSessionDialog {
                 spans.push(Span::styled(placeholder_text, value_style));
             }
         } else if is_focused {
-            let cursor_pos = self.path.visual_cursor();
+            let cursor_pos = self.path.cursor();
             let cursor_style = if flashing_invalid {
                 Style::default().fg(theme.background).bg(theme.error)
             } else {
@@ -584,6 +587,29 @@ impl NewSessionDialog {
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
+
+        if is_focused {
+            set_prefixed_input_cursor_position(frame, area, "Path: ", &self.path);
+        }
+    }
+
+    fn set_input_cursor_on_row(
+        frame: &mut Frame,
+        area: Rect,
+        row: usize,
+        prefix: &str,
+        input: &Input,
+    ) {
+        if row >= area.height as usize {
+            return;
+        }
+        let row_area = Rect {
+            x: area.x,
+            y: area.y.saturating_add(row as u16),
+            width: area.width,
+            height: 1,
+        };
+        set_prefixed_input_cursor_position(frame, row_area, prefix, input);
     }
 
     fn render_sandbox_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -965,6 +991,7 @@ impl NewSessionDialog {
         } else {
             // Expanded view with list
             let mut lines: Vec<Line> = Vec::new();
+            let mut cursor_row: Option<(usize, &'static str, &Input)> = None;
 
             // Header with controls hint
             let header = Line::from(vec![
@@ -998,6 +1025,7 @@ impl NewSessionDialog {
                         Span::styled("_", Style::default().fg(theme.accent)),
                     ]);
                     lines.push(input_line);
+                    cursor_row = Some((lines.len() - 1, "  + ", input));
                 } else {
                     // Editing existing item
                     for (i, entry) in self.extra_env.iter().enumerate() {
@@ -1012,6 +1040,7 @@ impl NewSessionDialog {
                                 Span::styled("_", Style::default().fg(theme.accent)),
                             ]);
                             lines.push(input_line);
+                            cursor_row = Some((lines.len() - 1, "  > ", input));
                         } else {
                             let prefix = "    ";
                             lines.push(Line::from(Span::styled(
@@ -1046,6 +1075,9 @@ impl NewSessionDialog {
             }
 
             frame.render_widget(Paragraph::new(lines), area);
+            if let Some((row, prefix, input)) = cursor_row {
+                Self::set_input_cursor_on_row(frame, area, row, prefix, input);
+            }
         }
     }
 
@@ -1085,6 +1117,7 @@ impl NewSessionDialog {
         } else {
             // Expanded view with list
             let mut lines: Vec<Line> = Vec::new();
+            let mut cursor_row: Option<(usize, &'static str, &Input)> = None;
 
             let header = Line::from(vec![
                 Span::styled("Extra Repos:", label_style),
@@ -1130,10 +1163,12 @@ impl NewSessionDialog {
                         )));
                     }
                     lines.push(make_input_line("  + ", input.value(), &ghost_text, theme));
+                    cursor_row = Some((lines.len() - 1, "  + ", input));
                 } else {
                     for (i, entry) in self.workspace_repos.iter().enumerate() {
                         if i == self.workspace_repo_selected_index {
                             lines.push(make_input_line("  > ", input.value(), &ghost_text, theme));
+                            cursor_row = Some((lines.len() - 1, "  > ", input));
                         } else {
                             let prefix = "    ";
                             lines.push(Line::from(Span::styled(
@@ -1168,6 +1203,9 @@ impl NewSessionDialog {
             }
 
             frame.render_widget(Paragraph::new(lines), area);
+            if let Some((row, prefix, input)) = cursor_row {
+                Self::set_input_cursor_on_row(frame, area, row, prefix, input);
+            }
         }
     }
 

--- a/src/tui/dialogs/profile_picker.rs
+++ b/src/tui/dialogs/profile_picker.rs
@@ -7,6 +7,7 @@ use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
 use super::DialogResult;
+use crate::tui::components::set_prefixed_input_cursor_position;
 use crate::tui::styles::Theme;
 
 /// Result when profile picker submits
@@ -357,6 +358,7 @@ impl ProfilePickerDialog {
             Span::styled("_", Style::default().fg(theme.accent)),
         ]);
         frame.render_widget(Paragraph::new(input_line), chunks[0]);
+        set_prefixed_input_cursor_position(frame, chunks[0], "Name: ", &self.name_input);
 
         let mut chunk_idx = 2;
 

--- a/src/tui/dialogs/projects.rs
+++ b/src/tui/dialogs/projects.rs
@@ -9,6 +9,7 @@ use tui_input::Input;
 use super::DialogResult;
 use crate::session::projects;
 use crate::session::{Project, ProjectScope};
+use crate::tui::components::set_prefixed_input_cursor_position;
 use crate::tui::styles::Theme;
 
 #[derive(Copy, Clone, PartialEq, Eq)]
@@ -338,6 +339,9 @@ impl ProjectsDialog {
                     )));
                 }
                 frame.render_widget(Paragraph::new(lines), chunks[2]);
+                if self.add_focused == 0 {
+                    set_prefixed_input_cursor_position(frame, chunks[2], "Path: ", &self.add_input);
+                }
             }
         }
 

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -204,7 +204,7 @@ impl RenameDialog {
             && key.modifiers == KeyModifiers::NONE
             && self.group_ghost.is_some()
         {
-            let cursor = self.new_group.visual_cursor();
+            let cursor = self.new_group.cursor();
             let char_len = self.new_group.value().chars().count();
             if cursor >= char_len {
                 self.accept_group_ghost();

--- a/src/tui/dialogs/send_message.rs
+++ b/src/tui/dialogs/send_message.rs
@@ -171,6 +171,15 @@ impl SendMessageDialog {
         text_area_clone.set_cursor_style(Style::default().fg(theme.background).bg(theme.accent));
 
         frame.render_widget(&text_area_clone, inner);
+
+        if inner.width > 0 && inner.height > 0 {
+            let cursor = text_area_clone.screen_cursor();
+            let max_x = inner.x.saturating_add(inner.width.saturating_sub(1));
+            let max_y = inner.y.saturating_add(inner.height.saturating_sub(1));
+            let cursor_x = inner.x.saturating_add(cursor.col as u16).min(max_x);
+            let cursor_y = inner.y.saturating_add(cursor.row as u16).min(max_y);
+            frame.set_cursor_position(Position::new(cursor_x, cursor_y));
+        }
     }
 }
 
@@ -192,6 +201,23 @@ mod tests {
 
     fn ctrl_key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::CONTROL)
+    }
+
+    fn render_cursor_position(dialog: &SendMessageDialog, width: u16, height: u16) -> Position {
+        use crate::tui::styles::Theme;
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = Theme::empire();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                dialog.render(f, area, &theme);
+            })
+            .unwrap();
+        terminal.backend_mut().get_cursor_position().unwrap()
     }
 
     #[test]
@@ -222,6 +248,33 @@ mod tests {
         let mut dialog = SendMessageDialog::new("Test Session");
         let result = dialog.handle_key(key(KeyCode::Char('a')));
         assert!(matches!(result, DialogResult::Continue));
+    }
+
+    #[test]
+    fn render_places_terminal_cursor_at_textarea_cursor() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_key(key(KeyCode::Char('h')));
+        dialog.handle_key(key(KeyCode::Char('i')));
+
+        // 80-col viewport -> 64-col dialog centered at x=8, inner x=9.
+        // 3-row dialog centered at y=10, inner y=11. Cursor is after "hi".
+        assert_eq!(
+            render_cursor_position(&dialog, 80, 24),
+            Position::new(11, 11)
+        );
+    }
+
+    #[test]
+    fn render_cursor_uses_display_columns_for_wide_chars() {
+        let mut dialog = SendMessageDialog::new("Test Session");
+        dialog.handle_key(key(KeyCode::Char('你')));
+
+        // The visual cursor should move two cells for an East Asian wide char,
+        // not one Unicode scalar position.
+        assert_eq!(
+            render_cursor_position(&dialog, 80, 24),
+            Position::new(11, 11)
+        );
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::session::config::GroupByMode;
 use crate::session::{Item, Status};
-use crate::tui::components::{HelpOverlay, Preview};
+use crate::tui::components::{set_prefixed_input_cursor_position, HelpOverlay, Preview};
 use crate::tui::responsive;
 use crate::tui::styles::Theme;
 use crate::update::UpdateInfo;
@@ -440,7 +440,7 @@ impl HomeView {
             };
 
             let value = self.search_query.value();
-            let cursor_pos = self.search_query.visual_cursor();
+            let cursor_pos = self.search_query.cursor();
             let cursor_style = Style::default().fg(theme.background).bg(theme.search);
             let text_style = Style::default().fg(theme.search);
 
@@ -474,7 +474,36 @@ impl HomeView {
             }
 
             frame.render_widget(Paragraph::new(Line::from(spans)), search_area);
+            if !self.has_overlay_above_search() {
+                set_prefixed_input_cursor_position(frame, search_area, "/", &self.search_query);
+            }
         }
+    }
+
+    fn has_overlay_above_search(&self) -> bool {
+        #[cfg(feature = "serve")]
+        let serve_open = self.serve_view.is_some();
+        #[cfg(not(feature = "serve"))]
+        let serve_open = false;
+
+        self.show_help
+            || self.new_dialog.is_some()
+            || self.confirm_dialog.is_some()
+            || self.unified_delete_dialog.is_some()
+            || self.group_delete_options_dialog.is_some()
+            || self.rename_dialog.is_some()
+            || self.hook_trust_dialog.is_some()
+            || self.hooks_install_dialog.is_some()
+            || self.welcome_dialog.is_some()
+            || self.no_agents_dialog.is_some()
+            || self.changelog_dialog.is_some()
+            || self.info_dialog.is_some()
+            || self.profile_picker_dialog.is_some()
+            || self.projects_dialog.is_some()
+            || self.command_palette.is_some()
+            || self.send_message_dialog.is_some()
+            || self.update_confirm_dialog.is_some()
+            || serve_open
     }
 
     fn render_item_line(

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -11,8 +11,10 @@ use ratatui::{
     Frame,
 };
 use tui_input::Input;
+use unicode_width::UnicodeWidthStr;
 
 use super::{FieldValue, SettingsCategory, SettingsFocus, SettingsScope, SettingsView};
+use crate::tui::components::set_input_cursor_position;
 use crate::tui::styles::Theme;
 
 /// Detect if we're running over SSH
@@ -527,8 +529,11 @@ impl SettingsView {
         input: &Input,
         theme: &Theme,
     ) {
-        let spans = Self::build_cursor_spans(input.value(), input.visual_cursor(), theme);
+        let spans = Self::build_cursor_spans(input.value(), input.cursor(), theme);
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        if self.editing_cursor_visible() {
+            set_input_cursor_position(frame, area, 0, input);
+        }
     }
 
     /// Render a list item with prefix and inverse-video cursor
@@ -544,10 +549,17 @@ impl SettingsView {
         let mut spans = vec![Span::styled(prefix.to_string(), value_style)];
         spans.extend(Self::build_cursor_spans(
             input.value(),
-            input.visual_cursor(),
+            input.cursor(),
             theme,
         ));
         frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        if self.editing_cursor_visible() {
+            set_input_cursor_position(frame, area, prefix.width(), input);
+        }
+    }
+
+    fn editing_cursor_visible(&self) -> bool {
+        self.custom_instruction_dialog.is_none() && !self.show_help
     }
 
     fn render_number_field(


### PR DESCRIPTION
## Description

Fix IME candidate window drift in TUI text inputs.

The TUI previously rendered styled "fake" cursors in several input widgets, but did not consistently move the real terminal cursor to the active input position. During periodic UI/status refreshes, ratatui can temporarily move the real terminal cursor while flushing changed cells, which makes IME candidate windows drift toward refreshed UI areas instead of staying near the text cursor.

Changes included:

- Anchor the real terminal cursor for the `m` send-message dialog.
- Add shared cursor-position helpers for `tui_input::Input` fields.
- Apply real cursor positioning to home search, command palette, list/dir pickers, settings inputs, new-session fields, rename/group/path inputs, profile/project dialogs, custom instruction editor, and cockpit composer.
- Use display-column-aware cursor placement for wide characters.
- Use character cursor positions for string slicing/autocomplete logic where `visual_cursor()` was incorrectly used as a character index.
- Wrap TUI redraws in synchronized terminal updates and hide the cursor during frame flushing to avoid exposing intermediate cursor moves to IMEs.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [ ] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Testing performed:

```bash
cargo fmt --check --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml
cargo check -q --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml
cargo clippy -- -D warnings
cargo test -q --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml tui::components::text_input
cargo test -q --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml tui::dialogs::send_message
cargo test -q --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml tui::dialogs::new_session
cargo build -q --release --manifest-path /home/aiscuser/hwq/agent-of-empires/Cargo.toml --bin aoe
```

Full `cargo test` was also run locally. It reported `1623 passed` and `4 failed`; the failures were existing/environment-related hook execution tests in `src/session/repo_config.rs` with `No such file or directory`, not in the TUI cursor path.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Codex helped inspect the TUI rendering paths, implement cursor anchoring across input widgets, and run local verification commands. I reviewed the changes and test results before submitting.

- [x] I am an AI Agent filling out this form
