### PR TITLE
feat: add configurable tool sessions

### DIFF
--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -236,6 +236,22 @@ web_poll_interval_minutes = 60
 | `notify_in_cli` | `true` | Show update notifications in CLI output |
 | `web_poll_interval_minutes` | `60` | How often the web dashboard re-polls `/api/system/update-status` while open (min 5) |
 
+## Tools
+
+The `[tools.*]` block configures persistent dev tool sessions (lazygit, yazi, tig, etc.) tied to each agent session's working directory. Each entry has a required `command` and an optional `hotkey` in `Alt+<single-char>` format.
+
+```toml
+[tools.lazygit]
+command = "lazygit"
+hotkey = "Alt+g"
+
+[tools.yazi]
+command = "yazi"
+hotkey = "Alt+f"
+```
+
+See [Tool Sessions](tool-sessions.md) for the full reference, hotkey rules, and lifecycle.
+
 ## Profiles
 
 Profiles provide separate workspaces with their own sessions and groups. Each profile can override any of the settings above.

--- a/docs/guides/tool-sessions.md
+++ b/docs/guides/tool-sessions.md
@@ -1,0 +1,190 @@
+# Tool Sessions
+
+Tool sessions let you keep dev tools like `lazygit`, `yazi`, `tig`, or
+`gitui` running alongside each agent session, scoped to that session's
+working directory. Each tool runs in its own persistent tmux session, so
+re-attaching is instant and state (cursor position, staged hunks, browsed
+path) survives across detaches.
+
+The UX mirrors the built-in terminal preview: press a hotkey to preview
+the tool in the home view, `Enter` to attach to it full-screen, and
+`Esc` to come back to the home view with the tool still running in the
+background.
+
+## Configuring tools
+
+Tool sessions are defined in your global `config.toml` under
+`[tools.<name>]`. The path follows the usual config conventions:
+
+- **Linux**: `$XDG_CONFIG_HOME/agent-of-empires/config.toml`
+  (defaults to `~/.config/agent-of-empires/config.toml`)
+- **macOS / Windows**: `~/.agent-of-empires/config.toml`
+
+Each entry has a required `command` and an optional `hotkey`:
+
+```toml
+[tools.lazygit]
+command = "lazygit"
+hotkey = "Alt+g"
+
+[tools.yazi]
+command = "yazi"
+hotkey = "Alt+f"
+
+[tools.tig]
+command = "tig --all"
+# no hotkey, reachable from the picker and palette only
+```
+
+### Field reference
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `command` | yes | Shell command to run inside the tmux session. The string is passed to `tmux new-session`, so pipes and `&&` work. |
+| `hotkey` | no | Hotkey binding in `Alt+<single-char>` format (case-insensitive on the modifier, normalized to lowercase on the letter). Examples: `"Alt+g"`, `"Alt+1"`, `"Alt+/"`. |
+
+Tool sessions are intentionally a config-file feature today; they are
+not editable from the settings TUI. Edit `config.toml` and reload from
+the settings dialog (or restart `aoe`) to pick up changes.
+
+### Hotkey rules
+
+Tool hotkeys are limited to `Alt+<single-char>`:
+
+- Modifier is case-insensitive: `Alt+g`, `ALT+g`, and `alt+g` all work.
+- ASCII letter is normalized to lowercase: `Alt+G` becomes `Alt+g`.
+  Non-ASCII characters are matched as-is (case-sensitive) and depend on
+  your terminal sending them with the Alt modifier; ASCII bindings are
+  recommended for portability.
+- Multi-character keys (`Alt+gg`, `Alt+F1`) are rejected.
+- Other modifiers (`Ctrl+g`, `Shift+g`) are not supported.
+
+If a hotkey fails to parse, AoE shows an info dialog on startup (and on
+settings reload) listing each invalid entry. The corresponding tool is
+still reachable from the picker and command palette; only the dead
+binding is dropped.
+
+If two tools claim the same hotkey, the alphabetically-first tool name
+wins.
+
+Tool hotkeys are checked **before** the built-in normal-mode keybindings
+on the home screen, so a tool hotkey will shadow any future built-in
+binding that uses the same combination.
+
+## Using tools
+
+Three ways to open a tool, in roughly the order you'll grow into them:
+
+1. **Hotkey**. Select an agent session, press the configured hotkey
+   (e.g. `Alt+g`). The home view switches to a live preview of that
+   tool's tmux pane. Press `Enter` to attach.
+2. **Picker**. Press `;` on the home view. A modal lists every
+   configured tool with its command and hotkey. Pick one with arrow
+   keys (or `j`/`k`) and `Enter`. `;` or `Esc` closes the picker.
+3. **Command palette**. Press `Ctrl+K`. Tool sessions appear as
+   "Open tool: \<name\>" entries you can fuzzy-search.
+
+Once you're in tool preview mode:
+
+- `Enter` attaches you to the tool full-screen.
+- The hotkey **toggles** preview off and back to the agent view.
+- `Esc`, `;`, or `t` returns to the agent view.
+
+Once you're attached:
+
+- The tool's own keybindings apply (it owns the screen).
+- To detach: use the tool's quit/detach behavior. Most quit on `q`. For
+  long-running tools, detach the underlying tmux session
+  (`Ctrl+B d` by default) to keep state across reattaches.
+
+## Lifecycle and cleanup
+
+Each tool session is tied to one agent session's working directory.
+Switching to a different agent session and pressing the same hotkey
+opens a **separate** tmux session running the same tool against that
+worktree, with its own independent state.
+
+Tool sessions are automatically killed when their parent agent session
+is removed, including:
+
+- `aoe remove <id>`
+- "Remove session" from the TUI
+- Delete via the web dashboard
+
+Removal sweeps every `aoe_tool_*_<id>` tmux session (or `aoe_dev_tool_*`
+under a debug build) regardless of whether the corresponding `[tools.*]`
+entry still exists in your config. This means you can rename or delete
+a tool from your config without leaving orphaned tmux sessions behind
+on the next session removal.
+
+## Where the tool runs
+
+Tools always run on the **host**, in the working directory of the agent
+session. For a sandboxed (Docker) agent session, the tool does not run
+inside the container; it runs on the host against the worktree path
+that the container has mounted. For most tools (lazygit, yazi, tig,
+gitui) that is the right default: they read files via the same
+worktree path the container sees, so file state stays consistent, and
+host launches avoid `docker exec` overhead on every attach.
+
+If your dev environment lives entirely inside the container (your
+`$PATH`, `git config`, or tool binaries differ host vs. container),
+keep that in mind: tool sessions reflect the host environment. A
+config-only workaround is to define the tool's `command` as a
+`docker exec` wrapper that runs the binary inside the container, e.g.
+`command = "docker exec -it my-container lazygit"`.
+
+## Examples
+
+### lazygit per worktree
+
+```toml
+[tools.lazygit]
+command = "lazygit"
+hotkey = "Alt+g"
+```
+
+Now `Alt+g` on any agent session previews lazygit running against that
+session's worktree; pressing `Alt+g` a second time toggles back to the
+agent view. Each worktree has its own staged hunks.
+
+### File browser with a custom config
+
+```toml
+[tools.yazi]
+command = "yazi --config-dir ~/.config/yazi"
+hotkey = "Alt+f"
+```
+
+### Composite commands
+
+The `command` is shelled out, so multi-step launches work:
+
+```toml
+[tools.dbshell]
+command = "psql $DATABASE_URL || sleep 5"
+hotkey = "Alt+d"
+```
+
+### Hotkey-less tool
+
+```toml
+[tools.bench]
+command = "btm"
+# Reachable via `;` or `Ctrl+K`. No global hotkey.
+```
+
+## tmux session naming
+
+Tool sessions follow a deterministic naming scheme so you can find them
+manually if you ever need to:
+
+- Release builds: `aoe_tool_<tool>_<title>_<id8>`
+- Debug builds:   `aoe_dev_tool_<tool>_<title>_<id8>`
+
+Where `<id8>` is the first 8 characters of the agent session ID. Tool
+and title strings are sanitized (colons, dots, and spaces stripped) to
+satisfy tmux's session-name constraints.
+
+You can attach manually with `tmux attach -t <name>`, but you'll
+normally never need to: AoE's three access paths are faster.

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -65,6 +65,27 @@ pub struct Config {
         deserialize_with = "super::serde_helpers::string_or_vec"
     )]
     pub environment: Vec<String>,
+
+    /// User-defined tool sessions: name -> config.
+    /// Tools are launched in the selected session's working directory and
+    /// persist as independent tmux sessions until the parent agent session
+    /// is deleted. Access via hotkey, the tool picker (`;`), or command
+    /// palette (Ctrl+K).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub tools: HashMap<String, ToolSessionConfig>,
+}
+
+/// Configuration for a user-defined tool session (lazygit, yazi, tig, etc.)
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolSessionConfig {
+    /// Shell command to run (e.g. "lazygit", "yazi", "tig --all").
+    /// The string is passed to the shell, so pipes and `&&` work.
+    #[serde(default)]
+    pub command: String,
+    /// Optional hotkey binding in `Alt+<letter>` format (e.g. "Alt+g", "Alt+f").
+    /// Only Alt+ single-character bindings are supported.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hotkey: Option<String>,
 }
 
 /// Persistent logging configuration. Drives the default tracing

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -64,6 +64,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     let _ = request.instance.kill();
     let _ = request.instance.kill_terminal();
     let _ = request.instance.kill_container_terminal();
+    crate::tmux::kill_all_tool_sessions_for_id(&request.session_id);
 
     let is_sandboxed = request
         .instance

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -5,12 +5,14 @@ mod session;
 pub mod status_bar;
 pub(crate) mod status_detection;
 mod terminal_session;
+mod tool_session;
 pub(crate) mod utils;
 
 pub use session::Session;
 pub use status_bar::{get_session_info_for_current, get_status_for_current_session};
 pub use status_detection::detect_status_from_content;
 pub use terminal_session::{ContainerTerminalSession, TerminalSession};
+pub use tool_session::{kill_all_tool_sessions_for_id, ToolSession};
 pub use utils::tmux_prefix_display;
 
 #[cfg(any(test, feature = "test-support"))]
@@ -44,6 +46,11 @@ pub const CONTAINER_TERMINAL_PREFIX: &str = if cfg!(debug_assertions) {
     "aoe_dev_cterm_"
 } else {
     "aoe_cterm_"
+};
+pub const TOOL_PREFIX: &str = if cfg!(debug_assertions) {
+    "aoe_dev_tool_"
+} else {
+    "aoe_tool_"
 };
 
 /// Pre-fetched pane metadata from a single `tmux list-panes -a` call.

--- a/src/tmux/tool_session.rs
+++ b/src/tmux/tool_session.rs
@@ -1,0 +1,256 @@
+//! Tool sessions: user-configured dev tools (lazygit, yazi, tig, etc.) that
+//! run in persistent tmux sessions tied to an agent session's working directory.
+
+use anyhow::{bail, Result};
+use std::process::Command;
+
+use super::utils::{
+    append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
+    append_remain_on_exit_args, append_window_size_args, is_pane_dead, sanitize_session_name,
+};
+use super::{refresh_session_cache, session_exists_from_cache, TOOL_PREFIX};
+use crate::cli::truncate_id;
+use crate::process;
+use crate::session::config::should_apply_tmux_clipboard;
+
+pub struct ToolSession {
+    name: String,
+}
+
+impl ToolSession {
+    pub fn new(session_id: &str, session_title: &str, tool_name: &str) -> Self {
+        let safe_title = sanitize_session_name(session_title);
+        let safe_tool = sanitize_session_name(tool_name);
+        let name = format!(
+            "{}{}_{}_{}",
+            TOOL_PREFIX,
+            safe_tool,
+            safe_title,
+            truncate_id(session_id, 8)
+        );
+        Self { name }
+    }
+
+    pub fn session_name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn exists(&self) -> bool {
+        if let Some(exists) = session_exists_from_cache(&self.name) {
+            return exists;
+        }
+
+        Command::new("tmux")
+            .args(["has-session", "-t", &self.name])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    pub fn is_pane_dead(&self) -> bool {
+        is_pane_dead(&self.name)
+    }
+
+    pub fn create_with_size(
+        &self,
+        working_dir: &str,
+        command: &str,
+        size: Option<(u16, u16)>,
+    ) -> Result<()> {
+        if self.exists() {
+            return Ok(());
+        }
+
+        let mut args = vec![
+            "new-session".to_string(),
+            "-d".to_string(),
+            "-s".to_string(),
+            self.name.clone(),
+            "-c".to_string(),
+            working_dir.to_string(),
+        ];
+
+        if let Some((width, height)) = size {
+            args.push("-x".to_string());
+            args.push(width.to_string());
+            args.push("-y".to_string());
+            args.push(height.to_string());
+        }
+
+        args.push(command.to_string());
+
+        append_remain_on_exit_args(&mut args, &self.name);
+        append_pane_base_index_args(&mut args, &self.name);
+        append_mouse_on_args(&mut args, &self.name);
+        append_window_size_args(&mut args, &self.name);
+        if should_apply_tmux_clipboard() {
+            append_clipboard_passthrough_args(&mut args, &self.name);
+        }
+
+        let output = Command::new("tmux").args(&args).output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("duplicate session") {
+                refresh_session_cache();
+                return Ok(());
+            }
+            bail!("Failed to create tool session '{}': {}", self.name, stderr);
+        }
+
+        refresh_session_cache();
+        Ok(())
+    }
+
+    pub fn kill(&self) -> Result<()> {
+        if !self.exists() {
+            return Ok(());
+        }
+
+        if let Some(pane_pid) = self.get_pane_pid() {
+            process::kill_process_tree(pane_pid);
+        }
+
+        let output = Command::new("tmux")
+            .args(["kill-session", "-t", &self.name])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("Failed to kill tool session '{}': {}", self.name, stderr);
+        }
+
+        refresh_session_cache();
+        Ok(())
+    }
+
+    pub fn attach(&self) -> Result<()> {
+        if !self.exists() {
+            bail!("Tool session does not exist: {}", self.name);
+        }
+
+        if std::env::var("TMUX").is_ok() {
+            let status = Command::new("tmux")
+                .args(["switch-client", "-t", &self.name])
+                .status()?;
+
+            if !status.success() {
+                let status = Command::new("tmux")
+                    .args(["attach-session", "-t", &self.name])
+                    .status()?;
+
+                if !status.success() {
+                    bail!("Failed to attach to tool session '{}'", self.name);
+                }
+            }
+        } else {
+            let status = Command::new("tmux")
+                .args(["attach-session", "-t", &self.name])
+                .status()?;
+
+            if !status.success() {
+                bail!("Failed to attach to tool session '{}'", self.name);
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn capture_pane(&self, lines: usize) -> Result<String> {
+        if !self.exists() {
+            return Ok(String::new());
+        }
+
+        let target = format!("{}:^.0", self.name);
+        let output = Command::new("tmux")
+            .args([
+                "capture-pane",
+                "-t",
+                &target,
+                "-p",
+                "-e",
+                "-S",
+                &format!("-{}", lines),
+            ])
+            .output()?;
+
+        if output.status.success() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Ok(String::new())
+        }
+    }
+
+    fn get_pane_pid(&self) -> Option<u32> {
+        process::get_pane_pid(&self.name)
+    }
+}
+
+/// Kill all tool sessions associated with a given agent session ID.
+/// Uses tmux list-sessions to find matches by ID suffix, so it works
+/// even if tools have been removed from the config since creation.
+pub fn kill_all_tool_sessions_for_id(session_id: &str) {
+    let id_suffix = format!("_{}", truncate_id(session_id, 8));
+
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output();
+
+    if let Ok(out) = output {
+        if out.status.success() {
+            let stdout = String::from_utf8_lossy(&out.stdout);
+            for line in stdout.lines() {
+                if line.starts_with(TOOL_PREFIX) && line.ends_with(&id_suffix) {
+                    if let Some(pid) = process::get_pane_pid(line) {
+                        process::kill_process_tree(pid);
+                    }
+                    let _ = Command::new("tmux")
+                        .args(["kill-session", "-t", line])
+                        .output();
+                }
+            }
+        }
+    }
+
+    refresh_session_cache();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new_name_includes_prefix_tool_title_and_truncated_id() {
+        let s = ToolSession::new("0123456789abcdef", "my-session", "lazygit");
+        let name = s.session_name();
+        assert!(name.starts_with(TOOL_PREFIX), "name was {}", name);
+        assert!(name.contains("lazygit"));
+        assert!(name.contains("my-session"));
+        assert!(name.ends_with("_01234567"), "name was {}", name);
+    }
+
+    #[test]
+    fn new_name_sanitizes_unsafe_characters() {
+        // tmux session names can't contain ':' or '.'
+        let s = ToolSession::new("abc12345", "feature/foo:bar", "my tool.v2");
+        let name = s.session_name();
+        assert!(!name.contains(':'), "name was {}", name);
+        assert!(!name.contains('.'), "name was {}", name);
+        assert!(!name.contains(' '), "name was {}", name);
+    }
+
+    #[test]
+    fn distinct_tools_on_same_session_have_distinct_names() {
+        let id = "0123456789abcdef";
+        let lazygit = ToolSession::new(id, "x", "lazygit");
+        let yazi = ToolSession::new(id, "x", "yazi");
+        assert_ne!(lazygit.session_name(), yazi.session_name());
+    }
+
+    #[test]
+    fn distinct_sessions_for_same_tool_have_distinct_names() {
+        let a = ToolSession::new("aaaaaaaa1111", "x", "lazygit");
+        let b = ToolSession::new("bbbbbbbb2222", "x", "lazygit");
+        assert_ne!(a.session_name(), b.session_name());
+    }
+}

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1031,6 +1031,9 @@ impl App {
                 self.home.execute_send_message(&id, &message);
                 self.update_status = None;
             }
+            Action::AttachToolSession(id, tool_name) => {
+                self.attach_tool_session(&id, &tool_name, terminal)?;
+            }
             #[cfg(feature = "serve")]
             Action::OpenCockpit(id) => {
                 // Stash for the async main loop. The cockpit view needs
@@ -1248,6 +1251,77 @@ impl App {
         Ok(())
     }
 
+    fn attach_tool_session(
+        &mut self,
+        session_id: &str,
+        tool_name: &str,
+        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    ) -> Result<()> {
+        let instance = match self.home.get_instance(session_id) {
+            Some(inst) => inst.clone(),
+            None => return Ok(()),
+        };
+
+        let tool_config = match self.home.tool_configs.get(tool_name) {
+            Some(tc) => tc.clone(),
+            None => return Ok(()),
+        };
+
+        if tool_config.command.is_empty() {
+            self.home.set_instance_error(
+                session_id,
+                Some(format!("Tool '{}' has no command configured", tool_name)),
+            );
+            return Ok(());
+        }
+
+        let size = crate::terminal::get_size();
+        let tool_session = crate::tmux::ToolSession::new(&instance.id, &instance.title, tool_name);
+
+        if !tool_session.exists() || tool_session.is_pane_dead() {
+            if tool_session.exists() {
+                let _ = tool_session.kill();
+            }
+            if let Err(e) =
+                tool_session.create_with_size(&instance.project_path, &tool_config.command, size)
+            {
+                self.home
+                    .set_instance_error(session_id, Some(e.to_string()));
+                return Ok(());
+            }
+        }
+
+        let branch = instance
+            .worktree_info
+            .as_ref()
+            .map(|w| w.branch.as_str())
+            .or_else(|| instance.workspace_info.as_ref().map(|w| w.branch.as_str()));
+        crate::tmux::status_bar::apply_all_tmux_options(
+            tool_session.session_name(),
+            &format!("{} ({})", instance.title, tool_name),
+            branch,
+            None,
+        );
+
+        let attach_fn: Box<dyn FnOnce() -> Result<()>> = Box::new(move || tool_session.attach());
+        let attach_result = self.with_raw_mode_disabled(terminal, attach_fn)?;
+
+        self.needs_redraw = true;
+        crate::tmux::refresh_session_cache();
+        self.home.reload()?;
+        self.home.select_session_by_id(session_id);
+
+        if let Err(e) = attach_result {
+            tracing::warn!(
+                "tmux tool session '{}' attach returned error: {}",
+                tool_name,
+                e
+            );
+        }
+
+        Ok(())
+    }
+
     fn edit_file(
         &mut self,
         path: &std::path::Path,
@@ -1321,6 +1395,9 @@ pub enum Action {
     /// can render a "Reviving..." status before the potentially-slow
     /// ensure_pane_ready call.
     SendMessage(String, String),
+    /// Attach to a tool session (lazygit, yazi, etc.) for the given agent
+    /// session. The tool_name indexes into Config.tools.
+    AttachToolSession(String, String),
     /// Open the native cockpit view for `session_id`. The action handler
     /// stashes the id in `pending_cockpit_open`; the main loop drains it
     /// after `execute_action` returns and runs the async cockpit loop

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 44;
+const DIALOG_HEIGHT: u16 = 45;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -35,6 +35,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                 vec![
                     ("Enter", "Attach to session"),
                     ("Ctrl+T", "Attach to terminal"),
+                    (";", "Open tool session"),
                     ("N", "New session"),
                     ("Ctrl+N", "New from selection"),
                     ("X", "Stop session"),
@@ -91,6 +92,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                 vec![
                     ("Enter", "Attach to session"),
                     ("T", "Attach to terminal"),
+                    (";", "Open tool session"),
                     ("n", "New session"),
                     ("N", "New from selection"),
                     ("x", "Stop session"),

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -57,6 +57,8 @@ pub enum PaletteAction {
     Key(KeyEvent),
     /// Move the cursor to a position in `flat_items` (used for session/group jump items).
     JumpToCursor(usize),
+    /// Open a tool session by name (lazygit, yazi, etc.)
+    ToolSession(String),
 }
 
 /// One entry in the palette. `payload` is what gets returned when the user picks it.

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -17,6 +17,7 @@ mod rename;
 mod send_message;
 #[cfg(feature = "serve")]
 mod serve;
+mod tool_picker;
 mod update_confirm;
 mod welcome;
 
@@ -39,6 +40,7 @@ pub use rename::{RenameData, RenameDialog, RenameMode};
 pub use send_message::SendMessageDialog;
 #[cfg(feature = "serve")]
 pub use serve::{ServeAction, ServeView};
+pub use tool_picker::ToolPickerDialog;
 pub use update_confirm::UpdateConfirmDialog;
 pub use welcome::WelcomeDialog;
 

--- a/src/tui/dialogs/tool_picker.rs
+++ b/src/tui/dialogs/tool_picker.rs
@@ -1,0 +1,144 @@
+//! Tool picker dialog: quick list of configured tool sessions.
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use super::{centered_rect, DialogResult};
+use crate::session::config::ToolSessionConfig;
+use crate::tui::styles::Theme;
+
+pub struct ToolPickerDialog {
+    items: Vec<ToolPickerEntry>,
+    cursor: usize,
+}
+
+struct ToolPickerEntry {
+    name: String,
+    command: String,
+    hotkey: String,
+}
+
+impl ToolPickerDialog {
+    pub fn new(tools: &std::collections::HashMap<String, ToolSessionConfig>) -> Self {
+        let mut items: Vec<ToolPickerEntry> = tools
+            .iter()
+            .map(|(name, config)| ToolPickerEntry {
+                name: name.clone(),
+                command: config.command.clone(),
+                hotkey: config.hotkey.clone().unwrap_or_default(),
+            })
+            .collect();
+        items.sort_by(|a, b| a.name.cmp(&b.name));
+        Self { items, cursor: 0 }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<String> {
+        match key.code {
+            KeyCode::Esc | KeyCode::Char(';') => DialogResult::Cancel,
+            KeyCode::Enter => {
+                if let Some(entry) = self.items.get(self.cursor) {
+                    DialogResult::Submit(entry.name.clone())
+                } else {
+                    DialogResult::Cancel
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.cursor > 0 {
+                    self.cursor -= 1;
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if self.cursor + 1 < self.items.len() {
+                    self.cursor += 1;
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Home => {
+                self.cursor = 0;
+                DialogResult::Continue
+            }
+            KeyCode::End => {
+                self.cursor = self.items.len().saturating_sub(1);
+                DialogResult::Continue
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let width = 50u16.min(area.width.saturating_sub(4));
+        // +2 for borders, +1 for the footer hint row.
+        let height = (self.items.len() as u16 + 3).min(area.height.saturating_sub(4));
+        let dialog_area = centered_rect(area, width, height);
+
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .title(" Tool Sessions ")
+            .title_style(Style::default().fg(theme.title))
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme.accent))
+            .style(Style::default().bg(theme.background));
+
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let chunks = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(1)])
+            .split(inner);
+        let list_area = chunks[0];
+        let footer_area = chunks[1];
+
+        let items: Vec<ListItem> = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                let hotkey_part = if entry.hotkey.is_empty() {
+                    String::new()
+                } else {
+                    format!("  [{}]", entry.hotkey)
+                };
+                let line = Line::from(vec![
+                    Span::styled(
+                        &entry.name,
+                        Style::default().fg(if i == self.cursor {
+                            theme.accent
+                        } else {
+                            theme.text
+                        }),
+                    ),
+                    Span::styled(
+                        format!("  {}", entry.command),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                    Span::styled(hotkey_part, Style::default().fg(theme.hint)),
+                ]);
+                ListItem::new(line)
+            })
+            .collect();
+
+        let list = List::new(items).highlight_style(
+            Style::default()
+                .bg(theme.selection)
+                .add_modifier(Modifier::BOLD),
+        );
+
+        let mut state = ListState::default();
+        state.select(Some(self.cursor));
+        frame.render_stateful_widget(list, list_area, &mut state);
+
+        let footer = Line::from(vec![
+            Span::styled("↑↓", Style::default().fg(theme.hint)),
+            Span::raw(" navigate  "),
+            Span::styled("Enter", Style::default().fg(theme.hint)),
+            Span::raw(" open  "),
+            Span::styled("Esc", Style::default().fg(theme.hint)),
+            Span::raw(" close"),
+        ]);
+        frame.render_widget(Paragraph::new(footer), footer_area);
+    }
+}

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -21,6 +21,62 @@ use crate::tui::dialogs::{
 use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::settings::{SettingsAction, SettingsView};
 
+pub(super) fn parse_hotkey(s: &str) -> Option<(KeyCode, KeyModifiers)> {
+    let (modifier, key) = s.split_once('+')?;
+    if !modifier.eq_ignore_ascii_case("alt") {
+        return None;
+    }
+    let mut chars = key.chars();
+    let ch = chars.next()?;
+    if chars.next().is_some() {
+        return None;
+    }
+    Some((KeyCode::Char(ch.to_ascii_lowercase()), KeyModifiers::ALT))
+}
+
+/// Validate tool hotkey strings, returning a list of human-readable warning
+/// lines for any that fail to parse. Tool hotkeys must match the
+/// `Alt+<single-char>` shape; everything else is rejected so the user gets
+/// a clear error rather than a silently dead binding.
+pub(super) fn validate_tool_hotkeys(
+    tools: &std::collections::HashMap<String, crate::session::config::ToolSessionConfig>,
+) -> Vec<String> {
+    let mut warnings = Vec::new();
+    for (name, config) in tools {
+        if let Some(ref hotkey) = config.hotkey {
+            if parse_hotkey(hotkey).is_none() {
+                let msg = format!(
+                    "Tool '{}': invalid hotkey '{}' (expected format: Alt+<letter>)",
+                    name, hotkey
+                );
+                tracing::warn!("{}", msg);
+                warnings.push(msg);
+            }
+        }
+    }
+    warnings
+}
+
+/// Build a sorted lookup list of `(tool_name, KeyCode, KeyModifiers)` for
+/// every tool whose `hotkey` parses. Sorted by tool name so the
+/// alphabetically-first tool wins on duplicate hotkeys. Built once at
+/// startup and on settings reload, then iterated on every keystroke;
+/// keep it cheap.
+pub(super) fn build_tool_hotkey_cache(
+    tools: &std::collections::HashMap<String, crate::session::config::ToolSessionConfig>,
+) -> Vec<(String, KeyCode, KeyModifiers)> {
+    let mut sorted: Vec<_> = tools.iter().collect();
+    sorted.sort_by_key(|(name, _)| name.to_owned());
+    sorted
+        .into_iter()
+        .filter_map(|(name, config)| {
+            let hotkey_str = config.hotkey.as_deref()?;
+            let (code, modifiers) = parse_hotkey(hotkey_str)?;
+            Some((name.clone(), code, modifiers))
+        })
+        .collect()
+}
+
 impl HomeView {
     pub fn is_diff_open(&self) -> bool {
         self.diff_view.is_some()
@@ -36,6 +92,24 @@ impl HomeView {
 
     pub fn hit_diff(&self, col: u16, row: u16) -> bool {
         self.diff_area.contains(Position::from((col, row)))
+    }
+
+    fn open_tool_picker(&mut self) {
+        self.tool_picker_dialog = Some(crate::tui::dialogs::ToolPickerDialog::new(
+            &self.tool_configs,
+        ));
+    }
+
+    /// Check if the key event matches any configured tool session hotkey.
+    /// On duplicate hotkeys, the alphabetically-first tool name wins
+    /// (the cache is built sorted by tool name).
+    fn match_tool_hotkey(&self, key: &KeyEvent) -> Option<String> {
+        for (name, code, modifiers) in &self.tool_hotkey_cache {
+            if key.code == *code && key.modifiers == *modifiers {
+                return Some(name.clone());
+            }
+        }
+        None
     }
 
     pub fn handle_key(
@@ -204,6 +278,24 @@ impl HomeView {
                 DialogResult::Submit(action) => {
                     self.command_palette = None;
                     return self.dispatch_palette_action(action, update_info);
+                }
+            }
+        }
+
+        // Handle tool picker dialog
+        if let Some(picker) = &mut self.tool_picker_dialog {
+            match picker.handle_key(key) {
+                DialogResult::Continue => return None,
+                DialogResult::Cancel => {
+                    self.tool_picker_dialog = None;
+                    return None;
+                }
+                DialogResult::Submit(tool_name) => {
+                    self.tool_picker_dialog = None;
+                    self.view_mode = ViewMode::Tool(tool_name);
+                    self.preview_scroll_offset = 0;
+                    self.tool_preview_cache = super::PreviewCache::default();
+                    return None;
                 }
             }
         }
@@ -609,12 +701,27 @@ impl HomeView {
         key: KeyEvent,
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
+        // Dynamic tool session hotkeys (checked before static match block)
+        if let Some(tool_name) = self.match_tool_hotkey(&key) {
+            if matches!(&self.view_mode, ViewMode::Tool(current) if current == &tool_name) {
+                self.view_mode = ViewMode::Agent;
+            } else {
+                self.view_mode = ViewMode::Tool(tool_name);
+                self.preview_scroll_offset = 0;
+                self.tool_preview_cache = super::PreviewCache::default();
+            }
+            return None;
+        }
+
         // Normal mode keybindings
         match key.code {
             KeyCode::Esc if !self.search_matches.is_empty() => {
                 self.search_matches.clear();
                 self.search_match_index = 0;
                 self.search_query = Input::default();
+            }
+            KeyCode::Esc if matches!(self.view_mode, ViewMode::Tool(_)) => {
+                self.view_mode = ViewMode::Agent;
             }
             KeyCode::Char('q') => return Some(Action::Quit),
             KeyCode::Char('?') => {
@@ -649,7 +756,7 @@ impl HomeView {
             KeyCode::Char('t') => {
                 self.view_mode = match self.view_mode {
                     ViewMode::Agent => ViewMode::Terminal,
-                    ViewMode::Terminal => ViewMode::Agent,
+                    ViewMode::Terminal | ViewMode::Tool(_) => ViewMode::Agent,
                 };
             }
             KeyCode::Char('T') => {
@@ -685,6 +792,13 @@ impl HomeView {
                             ));
                         }
                     }
+                }
+            }
+            KeyCode::Char(';') => {
+                if matches!(self.view_mode, ViewMode::Tool(_)) {
+                    self.view_mode = ViewMode::Agent;
+                } else if !self.tool_configs.is_empty() {
+                    self.open_tool_picker();
                 }
             }
             KeyCode::Char('/') => {
@@ -1128,6 +1242,9 @@ impl HomeView {
                             };
                             Some(Action::AttachTerminal(id.clone(), terminal_mode))
                         }
+                        ViewMode::Tool(ref tool_name) => {
+                            Some(Action::AttachToolSession(id.clone(), tool_name.clone()))
+                        }
                     };
                 } else if let Some(Item::Group { path, .. }) = self.flat_items.get(self.cursor) {
                     let path = path.clone();
@@ -1242,6 +1359,26 @@ impl HomeView {
             }
         }
 
+        // Tool session entries, sorted by name for stable palette ordering
+        // (matches the tool picker dialog's alphabetical order).
+        let mut tools_sorted: Vec<_> = self.tool_configs.iter().collect();
+        tools_sorted.sort_by_key(|(name, _)| name.to_owned());
+        for (name, config) in tools_sorted {
+            let hotkey_label = config
+                .hotkey
+                .as_deref()
+                .map(|h| format!(" [{}]", h))
+                .unwrap_or_default();
+            entries.push(PaletteCommand {
+                id: "tool-session",
+                title: format!("Open tool: {}{}", name, hotkey_label),
+                group: PaletteGroup::Actions,
+                keywords: vec!["tool", "session"],
+                hotkey: "",
+                payload: PaletteAction::ToolSession(name.clone()),
+            });
+        }
+
         self.command_palette = Some(CommandPaletteDialog::new(entries));
     }
 
@@ -1272,6 +1409,12 @@ impl HomeView {
                     self.cursor = idx.min(self.flat_items.len() - 1);
                     self.update_selected();
                 }
+                None
+            }
+            PaletteAction::ToolSession(tool_name) => {
+                self.view_mode = ViewMode::Tool(tool_name);
+                self.preview_scroll_offset = 0;
+                self.tool_preview_cache = super::PreviewCache::default();
                 None
             }
         }
@@ -1480,6 +1623,7 @@ impl HomeView {
                     TerminalMode::Host => &self.terminal_preview_cache,
                 }
             }
+            ViewMode::Tool(_) => &self.tool_preview_cache,
         };
 
         let visible_height = active_cache.dimensions.1.saturating_sub(1) as usize;
@@ -1844,5 +1988,181 @@ impl HomeView {
             // Everything else passes through unchanged (navigation, ?, /, Enter, etc.)
             _ => Some(key),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::session::config::ToolSessionConfig;
+
+    #[test]
+    fn parse_hotkey_accepts_alt_letter() {
+        let (code, mods) = parse_hotkey("Alt+g").expect("valid");
+        assert_eq!(code, KeyCode::Char('g'));
+        assert_eq!(mods, KeyModifiers::ALT);
+    }
+
+    #[test]
+    fn parse_hotkey_is_case_insensitive_on_modifier() {
+        assert!(parse_hotkey("alt+g").is_some());
+        assert!(parse_hotkey("ALT+g").is_some());
+        assert!(parse_hotkey("aLt+g").is_some());
+    }
+
+    #[test]
+    fn parse_hotkey_normalizes_letter_to_lowercase() {
+        let (code, _) = parse_hotkey("Alt+G").expect("valid");
+        assert_eq!(code, KeyCode::Char('g'));
+    }
+
+    #[test]
+    fn parse_hotkey_accepts_digit() {
+        let (code, mods) = parse_hotkey("Alt+1").expect("valid");
+        assert_eq!(code, KeyCode::Char('1'));
+        assert_eq!(mods, KeyModifiers::ALT);
+    }
+
+    #[test]
+    fn parse_hotkey_rejects_non_alt_modifier() {
+        assert!(parse_hotkey("Ctrl+g").is_none());
+        assert!(parse_hotkey("Shift+g").is_none());
+        assert!(parse_hotkey("Cmd+g").is_none());
+    }
+
+    #[test]
+    fn parse_hotkey_rejects_multi_char_key() {
+        assert!(parse_hotkey("Alt+gg").is_none());
+        assert!(parse_hotkey("Alt+F1").is_none());
+    }
+
+    #[test]
+    fn parse_hotkey_rejects_missing_modifier() {
+        assert!(parse_hotkey("g").is_none());
+        assert!(parse_hotkey("Alt").is_none());
+        assert!(parse_hotkey("").is_none());
+    }
+
+    #[test]
+    fn parse_hotkey_rejects_wrong_separator() {
+        assert!(parse_hotkey("Alt-g").is_none());
+        assert!(parse_hotkey("Alt g").is_none());
+    }
+
+    #[test]
+    fn validate_tool_hotkeys_reports_each_invalid_entry() {
+        let mut tools = std::collections::HashMap::new();
+        tools.insert(
+            "lazygit".to_string(),
+            ToolSessionConfig {
+                command: "lazygit".into(),
+                hotkey: Some("Alt+g".into()),
+            },
+        );
+        tools.insert(
+            "yazi".to_string(),
+            ToolSessionConfig {
+                command: "yazi".into(),
+                hotkey: Some("Ctrl+f".into()),
+            },
+        );
+        tools.insert(
+            "tig".to_string(),
+            ToolSessionConfig {
+                command: "tig".into(),
+                hotkey: Some("Alt+too-long".into()),
+            },
+        );
+        let warnings = validate_tool_hotkeys(&tools);
+        assert_eq!(warnings.len(), 2);
+        let joined = warnings.join("|");
+        assert!(joined.contains("yazi"));
+        assert!(joined.contains("tig"));
+        assert!(!joined.contains("lazygit"));
+    }
+
+    #[test]
+    fn validate_tool_hotkeys_empty_when_all_valid_or_unset() {
+        let mut tools = std::collections::HashMap::new();
+        tools.insert(
+            "lazygit".to_string(),
+            ToolSessionConfig {
+                command: "lazygit".into(),
+                hotkey: Some("Alt+g".into()),
+            },
+        );
+        tools.insert(
+            "rg".to_string(),
+            ToolSessionConfig {
+                command: "rg --files".into(),
+                hotkey: None,
+            },
+        );
+        assert!(validate_tool_hotkeys(&tools).is_empty());
+    }
+
+    #[test]
+    fn build_tool_hotkey_cache_sorts_by_name_and_skips_invalid() {
+        let mut tools = std::collections::HashMap::new();
+        tools.insert(
+            "zoxide".to_string(),
+            ToolSessionConfig {
+                command: "z".into(),
+                hotkey: Some("Alt+z".into()),
+            },
+        );
+        tools.insert(
+            "lazygit".to_string(),
+            ToolSessionConfig {
+                command: "lazygit".into(),
+                hotkey: Some("Alt+g".into()),
+            },
+        );
+        tools.insert(
+            "broken".to_string(),
+            ToolSessionConfig {
+                command: "x".into(),
+                hotkey: Some("Ctrl+x".into()),
+            },
+        );
+        tools.insert(
+            "no-hotkey".to_string(),
+            ToolSessionConfig {
+                command: "y".into(),
+                hotkey: None,
+            },
+        );
+
+        let cache = build_tool_hotkey_cache(&tools);
+        // Two valid entries, sorted by name.
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache[0].0, "lazygit");
+        assert_eq!(cache[0].1, KeyCode::Char('g'));
+        assert_eq!(cache[0].2, KeyModifiers::ALT);
+        assert_eq!(cache[1].0, "zoxide");
+        assert_eq!(cache[1].1, KeyCode::Char('z'));
+    }
+
+    #[test]
+    fn build_tool_hotkey_cache_tie_break_favors_alphabetically_first_name() {
+        let mut tools = std::collections::HashMap::new();
+        // Both bind Alt+g; alphabetical winner is "alpha".
+        tools.insert(
+            "beta".to_string(),
+            ToolSessionConfig {
+                command: "b".into(),
+                hotkey: Some("Alt+g".into()),
+            },
+        );
+        tools.insert(
+            "alpha".to_string(),
+            ToolSessionConfig {
+                command: "a".into(),
+                hotkey: Some("Alt+g".into()),
+            },
+        );
+        let cache = build_tool_hotkey_cache(&tools);
+        assert_eq!(cache[0].0, "alpha");
+        assert_eq!(cache[1].0, "beta");
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -63,11 +63,13 @@ pub(super) struct GroupRenameContext {
 }
 
 /// View mode for the home screen
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub enum ViewMode {
     #[default]
     Agent,
     Terminal,
+    /// Previewing a tool session (lazygit, yazi, etc.)
+    Tool(String),
 }
 
 /// Terminal mode for sandboxed sessions (container vs host)
@@ -224,6 +226,7 @@ pub struct HomeView {
     pub(super) preview_cache: PreviewCache,
     pub(super) terminal_preview_cache: PreviewCache,
     pub(super) container_terminal_preview_cache: PreviewCache,
+    pub(super) tool_preview_cache: PreviewCache,
 
     /// Mouse wheel offset for the preview pane, in lines back from the bottom.
     /// Reset to 0 whenever the selected session changes.
@@ -259,6 +262,19 @@ pub struct HomeView {
 
     // Resizable list column width (percentage-like units)
     pub(super) list_width: u16,
+
+    // Tool sessions config (lazygit, yazi, etc.)
+    pub(super) tool_configs: HashMap<String, crate::session::config::ToolSessionConfig>,
+    /// Pre-parsed and sorted view of valid tool hotkeys: (name, KeyCode, KeyModifiers).
+    /// Built once at construction and on settings reload, then iterated on every
+    /// keystroke to look up matching tools. Sorted by name so the alphabetically-first
+    /// tool wins on duplicate hotkeys.
+    pub(super) tool_hotkey_cache: Vec<(
+        String,
+        crossterm::event::KeyCode,
+        crossterm::event::KeyModifiers,
+    )>,
+    pub(super) tool_picker_dialog: Option<super::dialogs::ToolPickerDialog>,
 }
 
 impl HomeView {
@@ -385,6 +401,7 @@ impl HomeView {
             preview_cache: PreviewCache::default(),
             terminal_preview_cache: PreviewCache::default(),
             container_terminal_preview_cache: PreviewCache::default(),
+            tool_preview_cache: PreviewCache::default(),
             preview_scroll_offset: 0,
             preview_area: Rect::default(),
             diff_area: Rect::default(),
@@ -397,9 +414,25 @@ impl HomeView {
             settings_close_confirm: false,
             diff_view: None,
             list_width: user_config
+                .as_ref()
                 .and_then(|c| c.app_state.home_list_width)
                 .unwrap_or(35),
+            tool_configs: user_config
+                .as_ref()
+                .map(|c| c.tools.clone())
+                .unwrap_or_default(),
+            tool_hotkey_cache: Vec::new(),
+            tool_picker_dialog: None,
         };
+
+        view.tool_hotkey_cache = input::build_tool_hotkey_cache(&view.tool_configs);
+        let hotkey_warnings = input::validate_tool_hotkeys(&view.tool_configs);
+        if !hotkey_warnings.is_empty() && view.info_dialog.is_none() {
+            view.info_dialog = Some(InfoDialog::new(
+                "Tool hotkey config errors",
+                &hotkey_warnings.join("\n"),
+            ));
+        }
 
         // Clean up orphaned Creating instances from a prior crash
         let orphan_ids: Vec<String> = view
@@ -1159,6 +1192,7 @@ impl HomeView {
             || self.profile_picker_dialog.is_some()
             || self.projects_dialog.is_some()
             || self.command_palette.is_some()
+            || self.tool_picker_dialog.is_some()
             || self.send_message_dialog.is_some()
             || self.update_confirm_dialog.is_some()
             || serve_open
@@ -1322,6 +1356,7 @@ impl HomeView {
         self.preview_cache = PreviewCache::default();
         self.terminal_preview_cache = PreviewCache::default();
         self.container_terminal_preview_cache = PreviewCache::default();
+        self.tool_preview_cache = PreviewCache::default();
         self.preview_scroll_offset = 0;
         // Clear search since match indices are invalid with new flat_items
         if self.search_active {
@@ -1598,6 +1633,15 @@ impl HomeView {
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
+        self.tool_configs = config.tools;
+        self.tool_hotkey_cache = input::build_tool_hotkey_cache(&self.tool_configs);
+        let hotkey_warnings = input::validate_tool_hotkeys(&self.tool_configs);
+        if !hotkey_warnings.is_empty() && self.info_dialog.is_none() {
+            self.info_dialog = Some(InfoDialog::new(
+                "Tool hotkey config errors",
+                &hotkey_warnings.join("\n"),
+            ));
+        }
     }
 
     /// Toggle terminal mode between Container and Host for a session

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -302,6 +302,7 @@ impl HomeView {
             profile_picker_dialog,
             projects_dialog,
             command_palette,
+            tool_picker_dialog,
             send_message_dialog,
             update_confirm_dialog,
         );
@@ -341,17 +342,25 @@ impl HomeView {
         } else {
             ""
         };
-        let title = match self.view_mode {
+        let title = match &self.view_mode {
             ViewMode::Agent => format!(" aoe [{}]{} ", self.active_profile_display(), group_suffix),
             ViewMode::Terminal => format!(
                 " Terminals [{}]{} ",
                 self.active_profile_display(),
                 group_suffix
             ),
+            ViewMode::Tool(name) => format!(
+                " Tool: {} [{}]{} ",
+                name,
+                self.active_profile_display(),
+                group_suffix
+            ),
         };
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Agent => (theme.border, theme.title),
-            ViewMode::Terminal => (theme.terminal_border, theme.terminal_border),
+            ViewMode::Terminal | ViewMode::Tool(_) => {
+                (theme.terminal_border, theme.terminal_border)
+            }
         };
         let block = Block::default()
             .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
@@ -597,6 +606,19 @@ impl HomeView {
                                     .unwrap_or(false),
                             };
                             let (icon, color) = if terminal_running {
+                                (spinner_running(&inst.created_at), theme.terminal_active)
+                            } else {
+                                (ICON_IDLE, theme.dimmed)
+                            };
+                            let style = Style::default().fg(color);
+                            (icon, Cow::Owned(inst.title.clone()), style)
+                        }
+                        ViewMode::Tool(ref tool_name) => {
+                            let tool_session =
+                                crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+                            let tool_running =
+                                tool_session.exists() && !tool_session.is_pane_dead();
+                            let (icon, color) = if tool_running {
                                 (spinner_running(&inst.created_at), theme.terminal_active)
                             } else {
                                 (ICON_IDLE, theme.dimmed)
@@ -866,11 +888,54 @@ impl HomeView {
         }
     }
 
+    fn refresh_tool_preview_cache_if_needed(&mut self, width: u16, height: u16, tool_name: &str) {
+        const PREVIEW_REFRESH_MS: u128 = 250;
+
+        let scroll_offset = self.preview_scroll_offset;
+        let needs_refresh = match &self.selected_session {
+            Some(id) => {
+                self.tool_preview_cache.session_id.as_ref() != Some(id)
+                    || self.tool_preview_cache.dimensions != (width, height)
+                    || scroll_exceeds_cache(
+                        self.tool_preview_cache.captured_lines,
+                        height,
+                        scroll_offset,
+                    )
+                    || self.tool_preview_cache.last_refresh.elapsed().as_millis()
+                        > PREVIEW_REFRESH_MS
+            }
+            None => false,
+        };
+
+        if needs_refresh {
+            if let Some(id) = &self.selected_session {
+                if let Some(inst) = self.get_instance(id) {
+                    let capture_lines = capture_lines_for(height, scroll_offset);
+                    let tool_session =
+                        crate::tmux::ToolSession::new(&inst.id, &inst.title, tool_name);
+                    let content = tool_session.capture_pane(capture_lines).unwrap_or_default();
+                    self.tool_preview_cache.captured_lines = content.lines().count();
+                    self.tool_preview_cache.content = content;
+                    self.tool_preview_cache.session_id = Some(id.clone());
+                    self.tool_preview_cache.dimensions = (width, height);
+                    self.tool_preview_cache.last_refresh = Instant::now();
+                    self.preview_scroll_offset = clamp_scroll_to_capture(
+                        self.preview_scroll_offset,
+                        self.tool_preview_cache.captured_lines,
+                        height,
+                    );
+                }
+            }
+        }
+    }
+
     fn render_preview(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let compact = area.width < responsive::STACKED_BREAKPOINT;
         let (border_color, title_color) = match self.view_mode {
             ViewMode::Agent => (theme.border, theme.title),
-            ViewMode::Terminal => (theme.terminal_border, theme.terminal_border),
+            ViewMode::Terminal | ViewMode::Tool(_) => {
+                (theme.terminal_border, theme.terminal_border)
+            }
         };
 
         let mut block = Block::default()
@@ -922,9 +987,10 @@ impl HomeView {
         if let Some(line) = compact_title {
             block = block.title(line);
         } else {
-            let title = match self.view_mode {
-                ViewMode::Agent => " Preview ",
-                ViewMode::Terminal => " Terminal Preview ",
+            let title = match &self.view_mode {
+                ViewMode::Agent => " Preview ".to_string(),
+                ViewMode::Terminal => " Terminal Preview ".to_string(),
+                ViewMode::Tool(name) => format!(" {} Preview ", name),
             };
             block = block
                 .title(title)
@@ -1036,6 +1102,40 @@ impl HomeView {
                     }
                 } else {
                     let hint = Paragraph::new("Select a session to preview terminal")
+                        .style(Style::default().fg(theme.dimmed))
+                        .alignment(Alignment::Center);
+                    frame.render_widget(hint, inner);
+                }
+            }
+            ViewMode::Tool(ref tool_name) => {
+                let tool_name = tool_name.clone();
+                let selected_id = self.selected_session.clone();
+
+                if let Some(id) = selected_id {
+                    self.refresh_tool_preview_cache_if_needed(
+                        inner.width,
+                        inner.height,
+                        &tool_name,
+                    );
+
+                    if let Some(inst) = self.get_instance(&id) {
+                        let tool_session =
+                            crate::tmux::ToolSession::new(&inst.id, &inst.title, &tool_name);
+                        let tool_running = tool_session.exists() && !tool_session.is_pane_dead();
+
+                        Preview::render_terminal_preview(
+                            frame,
+                            inner,
+                            inst,
+                            tool_running,
+                            &self.tool_preview_cache.content,
+                            self.preview_scroll_offset,
+                            theme,
+                            compact,
+                        );
+                    }
+                } else {
+                    let hint = Paragraph::new("Select a session to preview tool")
                         .style(Style::default().fg(theme.dimmed))
                         .alignment(Alignment::Center);
                     frame.render_widget(hint, inner);
@@ -1235,6 +1335,11 @@ impl HomeView {
         }
 
         groups.push((2, mk(if strict { "T" } else { "t" }, "View")));
+        if matches!(self.view_mode, ViewMode::Tool(_)) {
+            groups.push((1, mk(";", "Back")));
+        } else if !self.tool_configs.is_empty() {
+            groups.push((2, mk(";", "Tools")));
+        }
         groups.push((3, mk(if strict { "^G" } else { "g" }, "Group")));
 
         // c: container/host toggle hint for sandboxed sessions in Terminal view

--- a/tests/e2e/main.rs
+++ b/tests/e2e/main.rs
@@ -26,6 +26,7 @@ mod profile_picker;
 mod project_registry;
 mod sandbox;
 mod serve;
+mod tool_sessions;
 mod tui_launch;
 mod unified_view;
 mod update_command;

--- a/tests/e2e/tool_sessions.rs
+++ b/tests/e2e/tool_sessions.rs
@@ -1,0 +1,284 @@
+//! E2E coverage for the [tools.*] feature: picker dialog, command-palette
+//! integration, the invalid-hotkey info dialog, and the full attach +
+//! cleanup roundtrip against a real agent session.
+
+use serial_test::serial;
+use std::fs;
+use std::process::Command;
+use std::time::Duration;
+
+use crate::harness::{app_dir_in, require_tmux, TuiTestHarness};
+
+/// Append a `[tools.*]` block to the harness's pre-seeded config.toml.
+fn append_tools_config(h: &TuiTestHarness, body: &str) {
+    let path = app_dir_in(h.home_path()).join("config.toml");
+    let existing = fs::read_to_string(&path).expect("read pre-seeded config.toml");
+    fs::write(&path, format!("{existing}\n{body}\n")).expect("write tools config");
+}
+
+/// List tmux session names on a specific socket. Tool sessions spawned by
+/// `aoe` while running inside the harness's tmux land on the harness's
+/// per-test socket (because `TMUX` env points there), so callers pass
+/// the harness's socket here to verify creation and sweep.
+fn list_tmux_sessions_on(socket: &std::path::Path) -> Vec<String> {
+    let output = Command::new("tmux")
+        .arg("-S")
+        .arg(socket)
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output();
+    match output {
+        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .lines()
+            .map(String::from)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Defensive teardown for any tool tmux session that survived a test
+/// (e.g., when the test panics before the cleanup assertion).
+fn kill_lingering_tool_sessions_on(socket: &std::path::Path, prefix_marker: &str) {
+    for name in list_tmux_sessions_on(socket) {
+        if name.starts_with("aoe_dev_tool_") && name.contains(prefix_marker) {
+            let _ = Command::new("tmux")
+                .arg("-S")
+                .arg(socket)
+                .args(["kill-session", "-t", &name])
+                .output();
+        }
+    }
+}
+
+#[test]
+#[serial]
+fn test_tool_picker_lists_configured_tools() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tool_picker_list");
+    append_tools_config(
+        &h,
+        r#"
+[tools.lazygit]
+command = "lazygit"
+hotkey = "Alt+g"
+
+[tools.yazi]
+command = "yazi"
+"#,
+    );
+    h.spawn_tui();
+
+    h.wait_for("[all]");
+    h.send_keys("\\;");
+    h.wait_for("Tool Sessions");
+    h.assert_screen_contains("lazygit");
+    h.assert_screen_contains("yazi");
+    // Footer hint added in this PR.
+    h.assert_screen_contains("Enter");
+    h.assert_screen_contains("Esc");
+
+    // Re-press ; to close (toggle behavior added in this PR).
+    h.send_keys("\\;");
+    h.wait_for_absent("Tool Sessions", Duration::from_secs(5));
+}
+
+#[test]
+#[serial]
+fn test_tool_picker_does_not_open_with_no_tools_configured() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tool_picker_empty");
+    h.spawn_tui();
+
+    h.wait_for("[all]");
+    h.send_keys("\\;");
+    // With zero [tools.*] entries the picker is suppressed; the screen
+    // should still be on the home view.
+    std::thread::sleep(Duration::from_millis(200));
+    h.assert_screen_not_contains("Tool Sessions");
+}
+
+#[test]
+#[serial]
+fn test_command_palette_includes_tool_entries() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tool_palette_entry");
+    append_tools_config(
+        &h,
+        r#"
+[tools.lazygit]
+command = "lazygit"
+hotkey = "Alt+g"
+"#,
+    );
+    h.spawn_tui();
+
+    h.wait_for("[all]");
+    h.send_keys("C-k");
+    h.wait_for("Commands");
+    h.type_text("lazyg");
+    std::thread::sleep(Duration::from_millis(150));
+    h.assert_screen_contains("Open tool: lazygit");
+}
+
+#[test]
+#[serial]
+fn test_invalid_hotkey_surfaces_info_dialog() {
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("tool_invalid_hotkey");
+    append_tools_config(
+        &h,
+        r#"
+[tools.bad]
+command = "echo hi"
+hotkey = "Ctrl+x"
+"#,
+    );
+    h.spawn_tui();
+
+    // The startup info dialog should mention the broken entry.
+    h.wait_for("Tool hotkey config errors");
+    h.assert_screen_contains("bad");
+    h.assert_screen_contains("Ctrl+x");
+}
+
+#[test]
+#[serial]
+fn test_tool_session_full_attach_and_cleanup_roundtrip() {
+    require_tmux!();
+
+    // Marker we'll grep for in the preview pane to prove the tool ran in
+    // the right working directory and the preview cache captured it.
+    const MARKER: &str = "TOOL_OUTPUT_ROUNDTRIP_MARKER";
+
+    let mut h = TuiTestHarness::new("tool_roundtrip");
+    append_tools_config(
+        &h,
+        &format!(
+            r#"
+[tools.echotool]
+command = "while true; do echo {MARKER}; sleep 0.5; done"
+hotkey = "Alt+t"
+"#
+        ),
+    );
+
+    // Create an agent session for the tool to attach to. The harness's
+    // claude stub exits immediately, but the session row stays in the
+    // list (Idle status). That's all we need to drive the tool flow.
+    let project = h.project_path();
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "RoundtripSession"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    // Find the session ID for the later remove + cleanup-sweep assertion.
+    let sessions_path = app_dir_in(h.home_path()).join("profiles/default/sessions.json");
+    let sessions_str = fs::read_to_string(&sessions_path).expect("read sessions.json");
+    let sessions: serde_json::Value =
+        serde_json::from_str(&sessions_str).expect("parse sessions.json");
+    let session_id = sessions[0]["id"]
+        .as_str()
+        .expect("session id present in sessions.json")
+        .to_string();
+    let id_suffix = &session_id[..session_id.len().min(8)];
+
+    // The harness's tmux server uses a per-test socket. Tool tmux sessions
+    // spawned by aoe (running inside the harness's tmux) inherit `TMUX` and
+    // land on the *same* socket, not the system default. We inspect and
+    // clean up on that socket.
+    let harness_sock = h.home_path().join("tmux.sock");
+
+    // Defensive: kill any stale tool sessions from a previous aborted run.
+    kill_lingering_tool_sessions_on(&harness_sock, id_suffix);
+
+    h.spawn_tui();
+    h.wait_for("RoundtripSession");
+
+    // Press the configured hotkey (Alt+t). tmux's send-keys grammar
+    // names Alt-modified keys as `M-<key>`.
+    h.send_keys("M-t");
+
+    // Title flips to the new "Tool: <name>" prefix added in this PR.
+    h.wait_for("Tool: echotool");
+
+    // Pressing Enter triggers AttachToolSession, which (a) creates the
+    // tool tmux session via `tmux new-session` running our command, then
+    // (b) tries to switch-client / attach-session. Both attach paths
+    // return errors when invoked from inside the harness's existing
+    // tmux session ("sessions should be nested with care"), but that
+    // error is swallowed and the tool tmux session itself is created.
+    // After the failed attach, the TUI redraws and the preview cache
+    // picks up the tool's stdout on its next 250ms refresh.
+    h.send_keys("Enter");
+
+    // Wait for the preview cache to pick up the tool's output. The cache
+    // refreshes only when the TUI redraws (every 120ms when there's an
+    // animated spinner, every 5s on disk refresh, or on any key event).
+    h.wait_for(MARKER);
+
+    // Esc returns to the agent view.
+    h.send_keys("Escape");
+    h.wait_for_absent("Tool: echotool", Duration::from_secs(5));
+
+    // The tool tmux session should still exist on the harness socket
+    // until we remove the parent agent session.
+    let pre_remove = list_tmux_sessions_on(&harness_sock);
+    assert!(
+        pre_remove
+            .iter()
+            .any(|s| s.starts_with("aoe_dev_tool_") && s.contains(id_suffix)),
+        "expected a live aoe_dev_tool_* session matching id suffix {} before removal. \
+         sessions seen: {:?}",
+        id_suffix,
+        pre_remove
+    );
+
+    // Quit the TUI so the removal CLI can write sessions.json without
+    // racing the TUI's poller.
+    h.send_keys("q");
+    h.wait_for_exit(Duration::from_secs(5));
+
+    // Remove the agent session. `perform_deletion` invokes
+    // `kill_all_tool_sessions_for_id`, which runs `tmux list-sessions` /
+    // `kill-session` against the tmux socket that the calling process
+    // sees. To exercise the sweep on the harness's per-test socket we
+    // point `TMUX` at it so the subprocess routes its tmux commands
+    // there instead of the system default.
+    let tmux_env = format!("{},0,0", harness_sock.display());
+    let aoe_binary = env!("CARGO_BIN_EXE_aoe");
+    let remove = Command::new(aoe_binary)
+        .args(["remove", &session_id, "--force"])
+        .env("HOME", h.home_path())
+        .env("XDG_CONFIG_HOME", h.home_path().join(".config"))
+        .env("TMUX", tmux_env)
+        .env_remove("AGENT_OF_EMPIRES_DEBUG")
+        .env_remove("AOE_LOG_LEVEL")
+        .output()
+        .expect("run aoe remove");
+    assert!(
+        remove.status.success(),
+        "aoe remove failed: {}",
+        String::from_utf8_lossy(&remove.stderr)
+    );
+
+    // Verify the sweep landed.
+    let post_remove = list_tmux_sessions_on(&harness_sock);
+    let leaked: Vec<_> = post_remove
+        .iter()
+        .filter(|s| s.starts_with("aoe_dev_tool_") && s.contains(id_suffix))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "tool sessions leaked after `aoe remove`: {:?}",
+        leaked
+    );
+
+    // Belt-and-suspenders: clean up anything else we created, in case
+    // the assertion above passes but other state hangs around.
+    kill_lingering_tool_sessions_on(&harness_sock, id_suffix);
+}

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -161,6 +161,13 @@ const PAGES = [
       "Mobile-first native rendering of AI agent state via the Agent Client Protocol (ACP). Plan panels, tool-call cards, swipe-to-approve, multi-provider support.",
   },
   {
+    source: "docs/guides/tool-sessions.md",
+    dest: "guides/tool-sessions.md",
+    title: "Tool Sessions",
+    description:
+      "Configure persistent dev-tool sessions (lazygit, yazi, tig, etc.) tied to each agent session's working directory, with hotkey, picker, and command-palette access.",
+  },
+  {
     source: "docs/api.md",
     dest: "docs/api.md",
     title: "HTTP API Reference",
@@ -194,6 +201,7 @@ const URL_MAP = {
   "docs/guides/agent-override.md": "/guides/agent-override/",
   "docs/guides/session-resume.md": "/guides/session-resume/",
   "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
+  "docs/guides/tool-sessions.md": "/guides/tool-sessions/",
 };
 
 const GITHUB_BASE =

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -30,6 +30,7 @@ export const docsNav: NavSection[] = [
       { title: "Diff View", href: "/guides/diff-view/" },
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/" },
       { title: "Agent Command Overrides", href: "/guides/agent-override/" },
+      { title: "Tool Sessions", href: "/guides/tool-sessions/" },
       { title: "Session Resume (Claude)", href: "/guides/session-resume/" },
       { title: "Sound Effects", href: "/docs/sounds/" },
     ],


### PR DESCRIPTION
## Description

Add user-configured tool sessions (lazygit, yazi, tig, etc.) that run in persistent tmux sessions tied to each agent session's working directory. Closes #1203.

Tools are defined in `config.toml` with optional per-tool hotkeys:

```toml
[tools.lazygit]
command = "lazygit"
hotkey = "Alt+g"

[tools.yazi]
command = "yazi"
hotkey = "Alt+f"
```

UX mirrors terminal mode: hotkey/picker switches to tool preview, Enter attaches, Esc/`;`/`t` goes back. Three access methods: per-tool hotkeys, tool picker (`;`), and command palette (`Ctrl+K`). Tool sessions get AoE-themed tmux status bar and are cleaned up on parent session deletion.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus)

**Any Additional AI Details you'd like to share:** Implementation was drafted with AI assistance, reviewed and tested manually across 5 review passes.

- [x] I am an AI Agent filling out this form (check box if true)