### PR TITLE
feat(tui): add lock_sort_order setting to pin sort order

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -458,6 +458,10 @@ pub struct SessionConfig {
     /// Off by default; existing users keep the legacy single-letter UX.
     #[serde(default)]
     pub strict_hotkeys: bool,
+
+    /// Lock the sort order to a specific value, disabling the O / Ctrl+O cycling hotkeys.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock_sort_order: Option<SortOrder>,
 }
 
 impl SessionConfig {

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use std::fs;
 
 use super::config::{
-    ColorMode, Config, ContainerRuntimeName, DefaultTerminalMode, TmuxClipboardMode, TmuxMouseMode,
-    TmuxStatusBarMode,
+    ColorMode, Config, ContainerRuntimeName, DefaultTerminalMode, SortOrder, TmuxClipboardMode,
+    TmuxMouseMode, TmuxStatusBarMode,
 };
 use super::get_profile_dir;
 
@@ -232,6 +232,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub strict_hotkeys: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lock_sort_order: Option<SortOrder>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -442,6 +445,9 @@ pub fn apply_session_overrides(
     }
     if let Some(strict_hotkeys) = source.strict_hotkeys {
         target.strict_hotkeys = strict_hotkeys;
+    }
+    if source.lock_sort_order.is_some() {
+        target.lock_sort_order = source.lock_sort_order;
     }
 }
 

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -162,6 +162,7 @@ impl HelpOverlay {
         theme: &Theme,
         sort_order: SortOrder,
         strict_hotkeys: bool,
+        lock_sort_order: Option<SortOrder>,
     ) {
         let x = area.x + (area.width.saturating_sub(DIALOG_WIDTH)) / 2;
         let y = area.y + (area.height.saturating_sub(DIALOG_HEIGHT)) / 2;
@@ -191,7 +192,11 @@ impl HelpOverlay {
         frame.render_widget(block, dialog_area);
 
         let mut lines: Vec<Line> = Vec::new();
-        let sort_label = format!("(current sort: {})", sort_order.label());
+        let sort_label = if lock_sort_order.is_some() {
+            format!("(sort locked: {})", sort_order.label())
+        } else {
+            format!("(current sort: {})", sort_order.label())
+        };
 
         let sections = shortcuts(strict_hotkeys);
         let last_idx = sections.len().saturating_sub(1);
@@ -201,9 +206,13 @@ impl HelpOverlay {
                 Style::default().fg(theme.accent).bold(),
             )));
             for (key, desc) in keys {
+                let is_locked_sort = lock_sort_order.is_some()
+                    && (*key == "O" || *key == "Ctrl+O" || *key == "o" || *key == "Ctrl+o");
+                let key_color = if is_locked_sort { theme.dimmed } else { theme.waiting };
+                let desc_color = if is_locked_sort { theme.dimmed } else { theme.text };
                 lines.push(Line::from(vec![
-                    Span::styled(format!("  {:11}", key), Style::default().fg(theme.waiting)),
-                    Span::styled(*desc, Style::default().fg(theme.text)),
+                    Span::styled(format!("  {:11}", key), Style::default().fg(key_color)),
+                    Span::styled(*desc, Style::default().fg(desc_color)),
                 ]));
             }
 

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -85,7 +85,7 @@ fn hotkey_label(non_strict: &'static str, strict: &'static str, strict_mode: boo
 /// PageUp/PageDown, h/l for collapse) since those don't belong in a palette.
 /// `strict_hotkeys` controls only the displayed hotkey label; the synthesized
 /// payload bypasses strict-mode normalization either way.
-pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<PaletteCommand> {
+pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool, lock_sort_order: bool) -> Vec<PaletteCommand> {
     let mut cmds = vec![
         PaletteCommand {
             id: "new-session",
@@ -168,14 +168,6 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
             payload: PaletteAction::Key(key('t')),
         },
         PaletteCommand {
-            id: "cycle-sort",
-            title: "Cycle sort order".to_string(),
-            group: PaletteGroup::Views,
-            keywords: vec!["order", "sort"],
-            hotkey: hotkey_label("o", "O", strict_hotkeys),
-            payload: PaletteAction::Key(key('o')),
-        },
-        PaletteCommand {
             id: "cycle-group-by",
             title: "Cycle group by".to_string(),
             group: PaletteGroup::Views,
@@ -224,6 +216,17 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
             payload: PaletteAction::Key(key('?')),
         },
     ];
+
+    if !lock_sort_order {
+        cmds.push(PaletteCommand {
+            id: "cycle-sort",
+            title: "Cycle sort order".to_string(),
+            group: PaletteGroup::Views,
+            keywords: vec!["order", "sort"],
+            hotkey: hotkey_label("o", "O", strict_hotkeys),
+            payload: PaletteAction::Key(key('o')),
+        });
+    }
 
     if serve_enabled {
         cmds.push(PaletteCommand {
@@ -534,7 +537,7 @@ mod tests {
     }
 
     fn make_dialog() -> CommandPaletteDialog {
-        CommandPaletteDialog::new(builtin_commands(false, false))
+        CommandPaletteDialog::new(builtin_commands(false, false, false))
     }
 
     #[test]
@@ -639,8 +642,8 @@ mod tests {
 
     #[test]
     fn serve_command_only_with_feature() {
-        let with = builtin_commands(true, false);
-        let without = builtin_commands(false, false);
+        let with = builtin_commands(true, false, false);
+        let without = builtin_commands(false, false, false);
         assert!(with.iter().any(|c| c.id == "serve"));
         assert!(!without.iter().any(|c| c.id == "serve"));
     }
@@ -650,8 +653,8 @@ mod tests {
         // Picks one entry whose label moves under strict mode and one whose
         // binding gets relocated to Ctrl. Catches regressions where strict
         // mode was forgotten when adding a new entry.
-        let normal = builtin_commands(false, false);
-        let strict = builtin_commands(false, true);
+        let normal = builtin_commands(false, false, false);
+        let strict = builtin_commands(false, true, false);
 
         let new_normal = normal.iter().find(|c| c.id == "new-session").unwrap();
         let new_strict = strict.iter().find(|c| c.id == "new-session").unwrap();

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1047,10 +1047,14 @@ impl HomeView {
                 self.open_send_message_dialog();
             }
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
-                self.apply_sort_order(self.sort_order.cycle_reverse());
+                if self.lock_sort_order.is_none() {
+                    self.apply_sort_order(self.sort_order.cycle_reverse());
+                }
             }
             KeyCode::Char('o') => {
-                self.apply_sort_order(self.sort_order.cycle());
+                if self.lock_sort_order.is_none() {
+                    self.apply_sort_order(self.sort_order.cycle());
+                }
             }
             // iPad-friendly ±10 aliases for PageUp/PageDown. iPads have no
             // PageUp/PageDown keys, and Cmd combos are typically stripped by
@@ -1176,7 +1180,7 @@ impl HomeView {
     /// current `flat_items`.
     fn open_command_palette(&mut self) {
         let serve_enabled = cfg!(feature = "serve");
-        let mut entries: Vec<PaletteCommand> = builtin_commands(serve_enabled, self.strict_hotkeys);
+        let mut entries: Vec<PaletteCommand> = builtin_commands(serve_enabled, self.strict_hotkeys, self.lock_sort_order.is_some());
 
         // Quit command (separate so the lifetime mapping is clear and we
         // can keep it out of `builtin_commands` to avoid pulling KeyCode

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -249,6 +249,8 @@ pub struct HomeView {
     // dictation / stray keystrokes triggering destructive actions).
     pub(super) strict_hotkeys: bool,
 
+    pub(super) lock_sort_order: Option<SortOrder>,
+
     // Settings view
     pub(super) settings_view: Option<SettingsView>,
     /// Flag to indicate we're confirming settings close (unsaved changes)
@@ -303,13 +305,16 @@ impl HomeView {
         };
         let sound_config = resolved.sound.clone();
         let strict_hotkeys = resolved.session.strict_hotkeys;
+        let lock_sort_order = resolved.session.lock_sort_order;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
         let user_config = load_config().ok().flatten();
-        let sort_order = user_config
-            .as_ref()
-            .and_then(|c| c.app_state.sort_order)
-            .unwrap_or_default();
+        let sort_order = lock_sort_order.unwrap_or_else(|| {
+            user_config
+                .as_ref()
+                .and_then(|c| c.app_state.sort_order)
+                .unwrap_or_default()
+        });
         // New users (haven't dismissed the welcome screen) default to Project
         // grouping so they see the same layout as the web dashboard. Existing
         // users keep Manual (the existing behavior) unless they explicitly
@@ -392,6 +397,7 @@ impl HomeView {
             default_terminal_mode,
             sound_config,
             strict_hotkeys,
+            lock_sort_order,
             idle_decay_window,
             settings_view: None,
             settings_close_confirm: false,
@@ -1592,6 +1598,15 @@ impl HomeView {
         };
         self.sound_config = config.sound.clone();
         self.strict_hotkeys = config.session.strict_hotkeys;
+        self.lock_sort_order = config.session.lock_sort_order;
+        if let Some(locked) = self.lock_sort_order {
+            if self.sort_order != locked {
+                self.sort_order = locked;
+                self.flat_items = self.build_flat_items();
+                self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
+                self.update_selected();
+            }
+        }
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
     }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -269,7 +269,7 @@ impl HomeView {
 
         // Render dialogs on top
         if self.show_help {
-            HelpOverlay::render(frame, area, theme, self.sort_order, self.strict_hotkeys);
+            HelpOverlay::render(frame, area, theme, self.sort_order, self.strict_hotkeys, self.lock_sort_order);
         }
 
         // Each Option<Dialog> field on HomeView gets the same render dispatch:

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -1,8 +1,8 @@
 //! Setting field definitions and config mapping
 
 use crate::session::{
-    validate_check_interval, Config, ContainerRuntimeName, DefaultTerminalMode, ProfileConfig,
-    TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
+    config::SortOrder, validate_check_interval, Config, ContainerRuntimeName,
+    DefaultTerminalMode, ProfileConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
 };
 use crate::sound::{
     validate_sound_exists, volume_from_option, volume_options, volume_to_index, SoundMode,
@@ -87,6 +87,7 @@ pub enum FieldKey {
     // Session
     DefaultTool,
     StrictHotkeys,
+    LockSortOrder,
     AgentExtraArgs,
     AgentCommandOverride,
     AgentStatusHooks,
@@ -217,6 +218,17 @@ fn parse_key_value_list(items: &[String]) -> std::collections::HashMap<String, S
             Some((k.to_string(), v.to_string()))
         })
         .collect()
+}
+
+fn sort_order_from_select_index(index: usize) -> Option<SortOrder> {
+    match index {
+        1 => Some(SortOrder::Newest),
+        2 => Some(SortOrder::LastActivity),
+        3 => Some(SortOrder::Oldest),
+        4 => Some(SortOrder::AZ),
+        5 => Some(SortOrder::ZA),
+        _ => None,
+    }
 }
 
 /// Value types for settings fields
@@ -1354,6 +1366,38 @@ fn build_session_fields(
         session.and_then(|s| s.strict_hotkeys),
     );
 
+    let (lock_sort_order, lock_sort_override) = resolve_optional(
+        scope,
+        global.session.lock_sort_order,
+        session.and_then(|s| s.lock_sort_order),
+        session.map(|s| s.lock_sort_order.is_some()).unwrap_or(false),
+    );
+
+    let lock_sort_options = vec![
+        "Off".to_string(),
+        "Newest".to_string(),
+        "Recent".to_string(),
+        "Oldest".to_string(),
+        "A-Z".to_string(),
+        "Z-A".to_string(),
+    ];
+    let lock_sort_selected = match lock_sort_order {
+        None => 0,
+        Some(SortOrder::Newest) => 1,
+        Some(SortOrder::LastActivity) => 2,
+        Some(SortOrder::Oldest) => 3,
+        Some(SortOrder::AZ) => 4,
+        Some(SortOrder::ZA) => 5,
+    };
+    let global_lock_sort_selected = match global.session.lock_sort_order {
+        None => 0,
+        Some(SortOrder::Newest) => 1,
+        Some(SortOrder::LastActivity) => 2,
+        Some(SortOrder::Oldest) => 3,
+        Some(SortOrder::AZ) => 4,
+        Some(SortOrder::ZA) => 5,
+    };
+
     let (agent_status_hooks, status_hooks_override) = resolve_value(
         scope,
         global.session.agent_status_hooks,
@@ -1512,6 +1556,24 @@ fn build_session_fields(
             inherited_display: inherited_if(
                 strict_hotkeys_override,
                 FieldValue::Bool(global.session.strict_hotkeys),
+            ),
+        },
+        SettingField {
+            key: FieldKey::LockSortOrder,
+            label: "Lock Sort Order",
+            description: "Lock to a specific sort order and disable the O / Ctrl+O cycling hotkeys",
+            value: FieldValue::Select {
+                selected: lock_sort_selected,
+                options: lock_sort_options.clone(),
+            },
+            category: SettingsCategory::Session,
+            has_override: lock_sort_override,
+            inherited_display: inherited_if(
+                lock_sort_override,
+                FieldValue::Select {
+                    selected: global_lock_sort_selected,
+                    options: lock_sort_options,
+                },
             ),
         },
         SettingField {
@@ -1884,6 +1946,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::YoloModeDefault, FieldValue::Bool(v)) => config.session.yolo_mode_default = *v,
         (FieldKey::StrictHotkeys, FieldValue::Bool(v)) => config.session.strict_hotkeys = *v,
+        (FieldKey::LockSortOrder, FieldValue::Select { selected, .. }) => {
+            config.session.lock_sort_order = sort_order_from_select_index(*selected);
+        }
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             config.session.agent_status_hooks = *v;
         }
@@ -2279,6 +2344,14 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         }
         (FieldKey::StrictHotkeys, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.session, |s, val| s.strict_hotkeys = val);
+        }
+        (FieldKey::LockSortOrder, FieldValue::Select { selected, .. }) => {
+            let value = sort_order_from_select_index(*selected);
+            use crate::session::SessionConfigOverride;
+            let session = config
+                .session
+                .get_or_insert_with(SessionConfigOverride::default);
+            session.lock_sort_order = value;
         }
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.session, |s, val| {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -656,6 +656,11 @@ impl SettingsView {
                     s.strict_hotkeys = None;
                 }
             }
+            FieldKey::LockSortOrder => {
+                if let Some(ref mut s) = config.session {
+                    s.lock_sort_order = None;
+                }
+            }
             FieldKey::AgentExtraArgs => {
                 if let Some(ref mut s) = config.session {
                     s.agent_extra_args = None;


### PR DESCRIPTION
## Description

Closes #1205.

Adds a `lock_sort_order` session setting (`Option<SortOrder>`) that locks the session list to a specific sort order and disables the `O` / `Ctrl+O` cycling hotkeys. Follows the same pattern as `strict_hotkeys`: config field on `SessionConfig`, profile override on `SessionConfigOverride` with merge logic, settings TUI field with global/profile apply and clear, and runtime state on `HomeView` loaded at startup and refreshed on config change.

When set, the sort order is forced to the configured value on startup and on config refresh. The help overlay shows `(sort locked: Newest)` and dims the disabled hotkey entries. The command palette hides the "Cycle sort order" entry. The settings TUI exposes a select dropdown (Off / Newest / Recent / Oldest / A-Z / Z-A).

Configurable via Settings > Session or `lock_sort_order = "newest"` under `[session]` in config.toml. Supports per-profile overrides.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

How tested:
- `cargo build --release` from the worktree, launched the binary, toggled Lock Sort Order in Settings > Session, confirmed `O` / `Ctrl+O` are no-ops and help overlay shows `(sort locked: ...)` with dimmed hotkeys.
- `cargo clippy`: zero warnings.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.6 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)