### PR TITLE
fix: kill terminal and container terminal tmux sessions on removal

### DIFF
--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -61,10 +61,7 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                 .is_some_and(|wt| wt.managed_by_aoe)
                 && (args.delete_branch
                     || (delete_worktree && config.worktree.delete_branch_on_cleanup));
-            let delete_sandbox = inst
-                .sandbox_info
-                .as_ref()
-                .is_some_and(|s| s.enabled)
+            let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
                 && !args.keep_container
                 && config.sandbox.auto_cleanup;
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -3,11 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::containers;
-use crate::git::cleanup::remove_managed_worktree;
-use crate::git::GitWorktree;
 use crate::session::{GroupTree, Instance, Storage};
-use std::path::PathBuf;
 
 #[derive(Args)]
 pub struct RemoveArgs {
@@ -58,175 +54,59 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
                 std::path::Path::new(&inst.project_path),
             );
 
-            // Run on_destroy hooks before cleanup so resources are still available.
-            // Global/profile hooks are implicitly trusted; repo hooks require trust.
-            {
-                let project_path = std::path::Path::new(&inst.project_path);
-                let mut on_destroy = config.hooks.on_destroy.clone();
-
-                // If the resolved config included repo hooks, verify they're still trusted.
-                // Re-check trust to avoid running hooks that changed since approval.
-                match crate::session::repo_config::check_hook_trust(project_path) {
-                    Ok(crate::session::repo_config::HookTrustStatus::Trusted(hooks))
-                        if !hooks.on_destroy.is_empty() =>
-                    {
-                        on_destroy = hooks.on_destroy.clone();
-                    }
-                    Ok(crate::session::repo_config::HookTrustStatus::NeedsTrust { .. }) => {
-                        // Repo hooks changed; fall back to global/profile only.
-                        on_destroy =
-                            crate::session::profile_config::resolve_config_or_warn(profile)
-                                .hooks
-                                .on_destroy;
-                    }
-                    _ => {}
-                }
-
-                if !on_destroy.is_empty() {
-                    let is_sandboxed = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled);
-
-                    // CLI context: leave the terminal attached so a hook that
-                    // legitimately needs user input can still be answered.
-                    let errors = if is_sandboxed {
-                        if let Some(ref sandbox) = inst.sandbox_info {
-                            let workdir = inst.container_workdir();
-                            crate::session::repo_config::execute_hooks_in_container_best_effort(
-                                &on_destroy,
-                                &sandbox.container_name,
-                                &workdir,
-                                false,
-                            )
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        crate::session::repo_config::execute_hooks_best_effort(
-                            &on_destroy,
-                            project_path,
-                            false,
-                        )
-                    };
-
-                    for err in &errors {
-                        eprintln!("Warning: on_destroy hook: {}", err);
-                    }
-                }
-            }
-
-            let will_cleanup_worktree = needs_worktree_cleanup(&inst, &args);
-            // Delete branch if explicitly requested, or if worktree is being
-            // deleted and config says to also delete the branch.
-            let will_delete_branch = inst
+            let delete_worktree = needs_worktree_cleanup(&inst, &args);
+            let delete_branch = inst
                 .worktree_info
                 .as_ref()
                 .is_some_and(|wt| wt.managed_by_aoe)
                 && (args.delete_branch
-                    || (will_cleanup_worktree && config.worktree.delete_branch_on_cleanup));
+                    || (delete_worktree && config.worktree.delete_branch_on_cleanup));
+            let delete_sandbox = inst
+                .sandbox_info
+                .as_ref()
+                .is_some_and(|s| s.enabled)
+                && !args.keep_container
+                && config.sandbox.auto_cleanup;
 
-            // Track whether worktree removal succeeded (needed for branch deletion)
-            let mut worktree_removed = false;
+            let result = crate::session::deletion::perform_deletion(
+                &crate::session::deletion::DeletionRequest {
+                    session_id: inst.id.clone(),
+                    instance: inst.clone(),
+                    delete_worktree,
+                    delete_branch,
+                    delete_sandbox,
+                    force_delete: args.force,
+                    detach_hooks: false,
+                },
+            );
 
-            // Handle worktree cleanup
-            if will_cleanup_worktree {
-                let wt_info = inst.worktree_info.as_ref().unwrap();
-                let worktree_path = PathBuf::from(&inst.project_path);
-                let main_repo = PathBuf::from(&wt_info.main_repo_path);
-
-                match GitWorktree::new(main_repo.clone()) {
-                    Ok(git_wt) => {
-                        // --keep-container means the sandbox fallback
-                        // must not surprise-tear-down the container to
-                        // free a permission-bound worktree.
-                        let allow_container_removal = !args.keep_container;
-                        match remove_managed_worktree(
-                            &git_wt,
-                            &worktree_path,
-                            &main_repo,
-                            &inst,
-                            args.force,
-                            allow_container_removal,
-                        ) {
-                            Ok(()) => {
-                                worktree_removed = true;
-                                println!("  Worktree removed");
-                            }
-                            Err(errs) => {
-                                for e in &errs {
-                                    eprintln!("Warning: {}", e);
-                                }
-                                eprintln!(
-                                    "You may need to remove it manually with: git worktree remove {}",
-                                    inst.project_path
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        eprintln!("Warning: failed to access git repository: {}", e);
-                    }
-                }
-            } else if let Some(wt_info) = &inst.worktree_info {
-                if wt_info.managed_by_aoe {
-                    println!(
-                        "Worktree preserved at: {} (use --delete-worktree to remove)",
-                        inst.project_path
-                    );
-                }
+            for msg in &result.messages {
+                println!("  {}", msg);
+            }
+            for err in &result.errors {
+                eprintln!("Warning: {}", err);
             }
 
-            // Handle branch cleanup (only if worktree was removed or wasn't requested)
-            if will_delete_branch {
-                let worktree_ok = !will_cleanup_worktree || worktree_removed;
-                if worktree_ok {
-                    let wt_info = inst.worktree_info.as_ref().unwrap();
-                    let main_repo = PathBuf::from(&wt_info.main_repo_path);
-                    match GitWorktree::new(main_repo) {
-                        Ok(git_wt) => {
-                            if let Err(e) = git_wt.delete_branch(&wt_info.branch) {
-                                eprintln!("Warning: failed to delete branch: {}", e);
-                            } else {
-                                println!("  Branch '{}' deleted", wt_info.branch);
-                            }
-                        }
-                        Err(e) => {
-                            eprintln!("Warning: failed to access git repository: {}", e);
-                        }
-                    }
-                }
-            }
-
-            // Kill tmux session if it exists
-            if let Ok(tmux_session) = crate::tmux::Session::new(&inst.id, &inst.title) {
-                if tmux_session.exists() {
-                    if let Err(e) = tmux_session.kill() {
-                        eprintln!("Warning: failed to kill tmux session: {}", e);
-                        eprintln!(
-                            "Session removed from Agent of Empires but may still be running in tmux"
+            if !delete_worktree {
+                if let Some(wt_info) = &inst.worktree_info {
+                    if wt_info.managed_by_aoe {
+                        println!(
+                            "Worktree preserved at: {} (use --delete-worktree to remove)",
+                            inst.project_path
                         );
                     }
                 }
             }
-
-            // Container cleanup (if config allows and user didn't request --keep-container)
             if let Some(sandbox) = &inst.sandbox_info {
-                if sandbox.enabled && !args.keep_container {
-                    if config.sandbox.auto_cleanup {
-                        let container = containers::DockerContainer::from_session_id(&inst.id);
-                        if container.exists().unwrap_or(false) {
-                            if let Err(e) = container.remove(true) {
-                                eprintln!("Warning: failed to remove container: {}", e);
-                            } else {
-                                println!("  Container removed");
-                            }
-                        }
-                    } else {
+                if sandbox.enabled {
+                    if args.keep_container {
+                        println!("Container preserved: {}", sandbox.container_name);
+                    } else if !config.sandbox.auto_cleanup {
                         println!(
                             "Container preserved: {} (auto_cleanup disabled in config)",
                             sandbox.container_name
                         );
                     }
-                } else if args.keep_container {
-                    println!("Container preserved: {}", sandbox.container_name);
                 }
             }
         } else {

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -695,6 +695,7 @@ pub async fn delete_session(
             delete_branch: body.delete_branch,
             delete_sandbox: body.delete_sandbox,
             force_delete: body.force_delete,
+            detach_hooks: true,
         })
     })
     .await;
@@ -726,7 +727,11 @@ pub async fn delete_session(
         }
         Ok(result) => {
             // Deletion had errors; set status to Error
-            let error_msg = result.error.unwrap_or_else(|| "Unknown error".to_string());
+            let error_msg = if result.errors.is_empty() {
+                "Unknown error".to_string()
+            } else {
+                result.errors.join("; ")
+            };
             {
                 let mut instances = state.instances.write().await;
                 if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -1,4 +1,4 @@
-//! Shared session deletion logic used by both TUI and web server.
+//! Shared session deletion logic used by CLI, TUI, and web server.
 
 use std::path::{Path, PathBuf};
 
@@ -15,17 +15,23 @@ pub struct DeletionRequest {
     pub delete_branch: bool,
     pub delete_sandbox: bool,
     pub force_delete: bool,
+    /// When `true`, on_destroy hooks run detached from the controlling
+    /// terminal (TUI/web). When `false`, hooks inherit stdin/stdout so
+    /// interactive prompts work (CLI).
+    pub detach_hooks: bool,
 }
 
 #[derive(Debug)]
 pub struct DeletionResult {
     pub session_id: String,
     pub success: bool,
-    pub error: Option<String>,
+    pub messages: Vec<String>,
+    pub errors: Vec<String>,
 }
 
 pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     let mut errors = Vec::new();
+    let mut messages = Vec::new();
 
     tracing::debug!(
         session_id = %request.session_id,
@@ -44,7 +50,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     // Stage 1: on_destroy hooks. The container and worktree are still
     // alive here so teardown commands have full access.
     tracing::debug!(session_id = %request.session_id, stage = "on_destroy_hooks", "perform_deletion: stage");
-    run_on_destroy_hooks(&request.instance);
+    run_on_destroy_hooks(&request.instance, request.detach_hooks);
 
     // Stage 2: sever the live agent BEFORE we touch the working tree it
     // may be writing to. Killing the tmux session terminates the user's
@@ -57,6 +63,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     tracing::debug!(session_id = %request.session_id, stage = "tmux_kill", "perform_deletion: stage");
     let _ = request.instance.kill();
     let _ = request.instance.kill_terminal();
+    let _ = request.instance.kill_container_terminal();
 
     let is_sandboxed = request
         .instance
@@ -137,6 +144,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         if container.exists().unwrap_or(false) {
             if let Err(e) = container.remove(true) {
                 errors.push(format!("Container: {}", e));
+            } else {
+                messages.push("Container removed".to_string());
             }
         }
     }
@@ -178,6 +187,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                 request.delete_sandbox,
                             ) {
                                 errors.extend(errs);
+                            } else {
+                                messages.push("Worktree removed".to_string());
                             }
                         }
                         Err(e) => {
@@ -215,6 +226,11 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                                         errs.into_iter()
                                             .map(|e| format!("Workspace ({}): {}", repo.name, e)),
                                     );
+                                } else {
+                                    messages.push(format!(
+                                        "Workspace ({}) worktree removed",
+                                        repo.name
+                                    ));
                                 }
                             }
                             Err(e) => {
@@ -231,6 +247,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                     if ws_path.exists() {
                         if let Err(e) = std::fs::remove_dir_all(&ws_path) {
                             errors.push(format!("Workspace dir: {}", e));
+                        } else {
+                            messages.push("Workspace directory removed".to_string());
                         }
                     }
                 }
@@ -251,6 +269,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                     if let Err(e) = git_wt.delete_branch(&branch) {
                         tracing::debug!(branch = %branch, error = %e, "perform_deletion: delete_branch returned error");
                         errors.push(format!("Branch: {}", e));
+                    } else {
+                        messages.push(format!("Branch '{}' deleted", branch));
                     }
                 }
                 Err(e) => {
@@ -277,6 +297,11 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
                         if let Ok(git_wt) = GitWorktree::new(main_repo) {
                             if let Err(e) = git_wt.delete_branch(&repo.branch) {
                                 errors.push(format!("Branch ({}): {}", repo.name, e));
+                            } else {
+                                messages.push(format!(
+                                    "Branch '{}' ({}) deleted",
+                                    repo.branch, repo.name
+                                ));
                             }
                         }
                     }
@@ -303,11 +328,8 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
     DeletionResult {
         session_id: request.session_id.clone(),
         success: errors.is_empty(),
-        error: if errors.is_empty() {
-            None
-        } else {
-            Some(errors.join("; "))
-        },
+        messages,
+        errors,
     }
 }
 
@@ -318,7 +340,7 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
 /// Global/profile hooks are implicitly trusted. Repo-level hooks go through
 /// the same trust verification as on_launch: if the hooks hash has changed
 /// since the user last approved, repo hooks are silently skipped.
-fn run_on_destroy_hooks(instance: &Instance) {
+fn run_on_destroy_hooks(instance: &Instance, detach: bool) {
     let profile = if instance.source_profile.is_empty() {
         "default"
     } else {
@@ -353,9 +375,9 @@ fn run_on_destroy_hooks(instance: &Instance) {
 
     let is_sandboxed = instance.sandbox_info.as_ref().is_some_and(|s| s.enabled);
 
-    // perform_deletion is the shared path used by the TUI and web server, so
-    // detach the hook child from the controlling terminal: a credential prompt
-    // would otherwise corrupt the rendered UI (see issue #901).
+    // The caller controls detachment: TUI/web pass detach=true to avoid
+    // corrupting the rendered UI (see issue #901); CLI passes detach=false
+    // so interactive prompts work.
     let errors = if is_sandboxed {
         if let Some(ref sandbox) = instance.sandbox_info {
             let workdir = instance.container_workdir();
@@ -363,13 +385,13 @@ fn run_on_destroy_hooks(instance: &Instance) {
                 &resolved_on_destroy,
                 &sandbox.container_name,
                 &workdir,
-                true,
+                detach,
             )
         } else {
             vec![]
         }
     } else {
-        repo_config::execute_hooks_best_effort(&resolved_on_destroy, project_path, true)
+        repo_config::execute_hooks_best_effort(&resolved_on_destroy, project_path, detach)
     };
 
     if !errors.is_empty() {
@@ -399,12 +421,13 @@ mod tests {
             delete_branch: false,
             delete_sandbox: false,
             force_delete: false,
+            detach_hooks: true,
         };
 
         let result = perform_deletion(&request);
 
         assert!(result.success);
-        assert!(result.error.is_none());
+        assert!(result.errors.is_empty());
         assert_eq!(result.session_id, request.session_id);
     }
 
@@ -418,12 +441,13 @@ mod tests {
             delete_branch: false,
             delete_sandbox: false,
             force_delete: false,
+            detach_hooks: true,
         };
 
         let result = perform_deletion(&request);
 
         assert!(result.success);
-        assert!(result.error.is_none());
+        assert!(result.errors.is_empty());
     }
 
     #[test]
@@ -438,6 +462,7 @@ mod tests {
             delete_branch: false,
             delete_sandbox: false,
             force_delete: false,
+            detach_hooks: true,
         };
 
         let result = perform_deletion(&request);
@@ -583,6 +608,7 @@ mod tests {
                 delete_branch: false,
                 delete_sandbox: true,
                 force_delete: false,
+                detach_hooks: true,
             };
 
             let stages = run_with_capture(|| {
@@ -689,13 +715,14 @@ mod tests {
                 delete_branch: true,
                 delete_sandbox: false,
                 force_delete: false,
+                detach_hooks: true,
             };
 
             let result = perform_deletion(&request);
             assert!(
                 result.success,
                 "perform_deletion failed: {:?}",
-                result.error
+                result.errors
             );
 
             // worktree directory and its admin entry must be gone
@@ -782,6 +809,7 @@ mod tests {
                 delete_branch: false,
                 delete_sandbox: false,
                 force_delete: false,
+                detach_hooks: true,
             };
             let result = perform_deletion(&req_no_force);
             assert!(
@@ -801,12 +829,13 @@ mod tests {
                 delete_branch: true,
                 delete_sandbox: false,
                 force_delete: true,
+                detach_hooks: true,
             };
             let result = perform_deletion(&req_force);
             assert!(
                 result.success,
                 "force delete should succeed: {:?}",
-                result.error
+                result.errors
             );
             assert!(!worktree_path.exists());
             assert!(!main_repo.join(".git/worktrees/worktree").exists());
@@ -897,6 +926,7 @@ mod tests {
                 delete_branch: true,
                 delete_sandbox: true,
                 force_delete: false,
+                detach_hooks: true,
             };
 
             // Stage assertions: preclean must not run when dirty.
@@ -917,9 +947,11 @@ mod tests {
                 !result.success,
                 "dirty worktree must not be deleted without --force"
             );
-            let err = result
-                .error
-                .expect("dirty deletion should surface an error");
+            assert!(
+                !result.errors.is_empty(),
+                "dirty deletion should surface errors"
+            );
+            let err = result.errors.join("; ");
             assert!(
                 err.contains("modified or untracked"),
                 "error should describe dirty state: {}",
@@ -964,6 +996,7 @@ mod tests {
                 delete_branch: true,
                 delete_sandbox: false,
                 force_delete: true,
+                detach_hooks: true,
             };
 
             let stages = run_with_capture(|| {
@@ -1000,6 +1033,7 @@ mod tests {
                 delete_branch: false,
                 delete_sandbox: false,
                 force_delete: false,
+                detach_hooks: true,
             };
 
             let stages = run_with_capture(|| {

--- a/src/tui/deletion_poller.rs
+++ b/src/tui/deletion_poller.rs
@@ -78,6 +78,7 @@ mod tests {
             delete_branch: false,
             delete_sandbox: false,
             force_delete: false,
+            detach_hooks: true,
         });
 
         let mut result = None;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -685,7 +685,11 @@ impl HomeView {
                     tracing::warn!("Failed to reload session state: {e}");
                 }
             } else {
-                let error = result.error;
+                let error = if result.errors.is_empty() {
+                    None
+                } else {
+                    Some(result.errors.join("; "))
+                };
                 self.mutate_instance(&result.session_id, |inst| {
                     inst.status = Status::Error;
                     inst.last_error = error;

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -87,6 +87,7 @@ impl HomeView {
                     delete_branch: options.delete_branch,
                     delete_sandbox: options.delete_sandbox,
                     force_delete: options.force_delete,
+                    detach_hooks: true,
                 };
                 self.deletion_poller.request_deletion(request);
             }
@@ -185,6 +186,7 @@ impl HomeView {
                         delete_branch,
                         delete_sandbox,
                         force_delete: options.force_delete_worktrees,
+                        detach_hooks: true,
                     };
                     self.deletion_poller.request_deletion(request);
                 }


### PR DESCRIPTION
## Description

Fixes #1209.

Session removal leaked subsidiary tmux sessions (`aoe_term_*`, `aoe_cterm_*`) because only the primary session was killed. The CLI path (`aoe remove`) also duplicated ~120 lines of cleanup logic that had drifted from the shared `perform_deletion()`, including running the tmux kill after worktree cleanup instead of before it.

Replace the hand-rolled cleanup in `cli/remove.rs` with a single `perform_deletion()` call so CLI, TUI, and web API all follow the same deletion stages in the same order. This eliminates the duplication and prevents the two paths from drifting apart again.

In `session/deletion.rs`, add the missing `kill_container_terminal()` call alongside the existing `kill()` and `kill_terminal()`. Add a `detach_hooks` field to `DeletionRequest` so CLI hooks can remain interactive (inheriting stdin/stdout) while TUI/web hooks run detached to avoid corrupting the rendered UI. Change `DeletionResult` from a single joined error string to structured `messages`/`errors` vecs so callers can format feedback appropriately.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Test plan:
- `cargo check` clean.
- `cargo test --lib session::deletion` — 9 tests pass (all existing ordering and dirty-worktree tests).
- Verified against a live `aoe serve` instance: removed a session with an open terminal pane, confirmed `tmux list-sessions | grep aoe_term_` shows no orphan.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus via Claude Code

**Any Additional AI Details you'd like to share:**
- [x] I am an AI Agent filling out this form (check box if true)