### PR TITLE
feat(cockpit): surface set_mode rejection, fold tall queued-prompts strip

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -445,6 +445,53 @@ transcript still replays from disk, but the model starts fresh on each
 spawn. Tracked in
 [#1005](https://github.com/njbrake/agent-of-empires/issues/1005).
 
+## Permission modes and YOLO
+
+Cockpit sessions run in one of the permission modes advertised by the
+ACP adapter. The composer's mode picker shows whatever the agent
+reports in its `NewSessionResponse.modes`; for `claude-agent-acp` the
+typical set is:
+
+| Mode id              | Meaning                                                                 |
+|----------------------|-------------------------------------------------------------------------|
+| `default`            | Every Write/Edit/Bash routes through an approval card.                  |
+| `acceptEdits`        | Edit-kind tools auto-approved; Bash and unknown tools still prompt.     |
+| `bypassPermissions`  | All tools auto-approved. The cockpit analogue of YOLO.                  |
+| `plan`               | Read-only; the agent drafts a plan but does not run side-effectful tools. |
+
+### YOLO mode maps to `bypassPermissions`
+
+When `[session] yolo_mode_default = true` (or the wizard's "Auto-approve
+actions" toggle is on), cockpit asks the adapter to start the session
+in `bypassPermissions` immediately after `session/new`. This mirrors
+what the tmux substrate does by appending
+`--dangerously-skip-permissions` to the Claude CLI argv.
+
+The wiring is best-effort: the cockpit fires `session/set_mode` after
+the handshake and continues regardless of the response. If the adapter
+accepts, the mode picker flips to `bypassPermissions` and you stop
+seeing approval cards. If it rejects (see next section), a non-blocking
+amber notice appears above the composer with the adapter's reason and
+the session keeps running in whichever mode it landed on.
+
+### `bypassPermissions` may not be available
+
+`claude-agent-acp` gates `bypassPermissions` on the `ALLOW_BYPASS`
+environment variable. If the daemon spawned the adapter without
+`ALLOW_BYPASS=1` in its env, `session/set_mode("bypassPermissions")`
+returns "Mode bypassPermissions is not available" and the session
+stays in `default`. Two ways out:
+
+1. Restart `aoe serve` with `ALLOW_BYPASS=1` so the adapter advertises
+   the mode. The cockpit then drives it automatically on every new
+   YOLO-mode session.
+2. Live with `default` and approve as you go, or pick `acceptEdits`
+   from the composer mode picker for edit-only auto-approval.
+
+The Auto-approve toggle in the wizard does not configure
+`ALLOW_BYPASS`; the env var is a daemon-process input set wherever
+`aoe serve` actually launches.
+
 ## Approvals
 
 When the agent wants to run a tool that requires approval, the cockpit

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -87,7 +87,7 @@ agent_status_hooks = true
 | Option | Default | Description |
 |--------|---------|-------------|
 | `default_tool` | (auto-detect) | Default agent for new sessions. Falls back to the first available tool if unset or unavailable. Can be set to a custom agent name. |
-| `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. |
+| `yolo_mode_default` | `false` | Enable YOLO mode by default for new sessions (skip permission prompts). Works with or without sandbox. In tmux mode this passes `--dangerously-skip-permissions` to the agent CLI; in cockpit mode it maps to ACP `bypassPermissions` (see [Cockpit: Permission modes and YOLO](../cockpit.md#permission-modes-and-yolo) for the adapter caveat). |
 | `agent_status_hooks` | `true` | Install status-detection hooks into the agent's config file. Codex uses the `[hooks]` table in `~/.codex/config.toml`; other JSON-based agents use their settings JSON. When disabled, status detection falls back to tmux pane content parsing. Codex is hook-first, but known hook gaps are reconciled from pane content. |
 | `agent_extra_args` | `{}` | Per-agent extra arguments appended after the binary (e.g., `{ opencode = "--port 8080" }`). |
 | `agent_command_override` | `{}` | Per-agent command override replacing the binary entirely (e.g., `{ claude = "my-claude-wrapper" }`). |

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -818,6 +818,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::ModeChanged { .. } => "mode_changed",
         Event::ModesAvailable { .. } => "modes_available",
         Event::CurrentModeChanged { .. } => "current_mode_changed",
+        Event::ModeSwitchFailed { .. } => "mode_switch_failed",
         Event::AvailableCommandsUpdated { .. } => "available_commands_updated",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2595,10 +2595,17 @@ async fn run_connection_task<W, R>(
                                                             .await;
                                                     }
                                                     Err(e) => {
+                                                        let reason = format!("{e}");
                                                         warn!(
                                                             target: "cockpit.acp",
-                                                            "session/set_mode failed mid-turn: {e}"
+                                                            "session/set_mode failed mid-turn: {reason}"
                                                         );
+                                                        let _ = tx
+                                                            .send(Event::ModeSwitchFailed {
+                                                                mode_id,
+                                                                reason,
+                                                            })
+                                                            .await;
                                                     }
                                                 }
                                             });
@@ -2704,7 +2711,11 @@ async fn run_connection_task<W, R>(
                                         .await;
                                 }
                                 Err(e) => {
-                                    warn!(target: "cockpit.acp", "session/set_mode failed: {e}");
+                                    let reason = format!("{e}");
+                                    warn!(target: "cockpit.acp", "session/set_mode failed: {reason}");
+                                    let _ = tx
+                                        .send(Event::ModeSwitchFailed { mode_id, reason })
+                                        .await;
                                 }
                             }
                         });

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -830,6 +830,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::ModeChanged { .. } => "mode_changed",
         Event::ModesAvailable { .. } => "modes_available",
         Event::CurrentModeChanged { .. } => "current_mode_changed",
+        Event::ModeSwitchFailed { .. } => "mode_switch_failed",
         Event::AvailableCommandsUpdated { .. } => "available_commands_updated",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -323,6 +323,17 @@ pub enum Event {
     CurrentModeChanged {
         current_mode_id: String,
     },
+    /// `session/set_mode` round-trip rejected by the adapter. Fired when
+    /// the cockpit asked for a mode the adapter does not advertise
+    /// (claude-agent-acp gates `bypassPermissions` on `ALLOW_BYPASS`, so
+    /// a YOLO-driven post-spawn `set_mode("bypassPermissions")` lands
+    /// here when the env var is unset). UI renders a non-blocking notice
+    /// so the user knows their requested mode did not take effect; the
+    /// session keeps whatever mode the adapter last reported. See #1233.
+    ModeSwitchFailed {
+        mode_id: String,
+        reason: String,
+    },
     /// Full snapshot of the slash commands the agent advertises. Comes
     /// from ACP `SessionUpdate::AvailableCommandsUpdate`. Replaces the
     /// previous list (the agent re-broadcasts the full set whenever it
@@ -500,6 +511,7 @@ impl CockpitState {
             // replay), so this is just a no-op that bumps seq.
             Event::ModesAvailable { .. } => {}
             Event::CurrentModeChanged { .. } => {}
+            Event::ModeSwitchFailed { .. } => {}
             Event::AvailableCommandsUpdated { commands } => {
                 self.available_commands = commands;
             }

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -592,6 +592,20 @@ mod tests {
     }
 
     #[test]
+    fn mode_switch_failed_bumps_seq_without_mutating_mode() {
+        let mut s = fresh_state();
+        let before_mode = s.mode;
+        let seq = s
+            .apply_event(Event::ModeSwitchFailed {
+                mode_id: "bypassPermissions".into(),
+                reason: "Mode bypassPermissions is not available.".into(),
+            })
+            .expect("apply ok");
+        assert_eq!(seq, 1);
+        assert_eq!(s.mode, before_mode);
+    }
+
+    #[test]
     fn approval_resolved_with_unknown_nonce_errors() {
         let mut s = fresh_state();
         let result = s.apply_event(Event::ApprovalResolved {

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -379,7 +379,8 @@ impl CockpitTranscript {
             | Event::UsageUpdated { .. }
             | Event::RawAgentUpdate { .. }
             | Event::WakeupScheduled { .. }
-            | Event::PromptRejected { .. } => {
+            | Event::PromptRejected { .. }
+            | Event::ModeSwitchFailed { .. } => {
                 // Surface as info notes for now; richer renderers are
                 // followup work tracked in the plan's "out of scope".
             }

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -82,6 +82,7 @@ export interface CockpitContext {
   editQueuedPrompt: (id: string, text: string) => void;
   clearQueue: () => void;
   dismissRejectedPrompt: (id: string) => void;
+  dismissModeSwitchFailed: () => void;
 }
 
 /**
@@ -155,6 +156,7 @@ export function CockpitRuntime({
         editQueuedPrompt: cockpit.editQueuedPrompt,
         clearQueue: cockpit.clearQueue,
         dismissRejectedPrompt: cockpit.dismissRejectedPrompt,
+        dismissModeSwitchFailed: cockpit.dismissModeSwitchFailed,
       })}
     </AssistantRuntimeProvider>
   );

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -40,6 +40,10 @@ import {
 import { Composer } from "./Composer";
 import { ContextPrimerBanner } from "./ContextPrimerBanner";
 import { Markdown } from "./Markdown";
+import {
+  isQueuedPromptLong,
+  queuedStripLayout,
+} from "./queuedPromptsLayout";
 import { SubagentCard, ToolCard, ToolGroupCard } from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
@@ -1609,7 +1613,22 @@ function QueuedPromptsStrip({
   onEdit,
   onClear,
 }: QueuedPromptsStripProps) {
+  // Strip-level collapse: when the queue exceeds `visibleDefault` rows,
+  // only the first N render until the user expands. State resets when
+  // the queue length drops back below the threshold (toggle disappears;
+  // `expanded` stays harmlessly true and re-arms on the next overflow).
+  // Mobile gets N=1 because a single multi-line prompt already eats
+  // half the small-viewport composer area; desktop tolerates N=2.
+  // See #1232.
+  const isMobile = useIsCoarsePointer();
+  const [expanded, setExpanded] = useState(false);
   if (queued.length === 0) return null;
+  const layout = queuedStripLayout({
+    queuedCount: queued.length,
+    isMobile,
+    expanded,
+  });
+  const visible = queued.slice(0, layout.visibleCount);
   return (
     <div className="border-t border-surface-800 bg-surface-900/60 px-4 py-2">
       <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
@@ -1629,7 +1648,7 @@ function QueuedPromptsStrip({
           )}
         </div>
         <ul className="flex flex-col gap-1.5">
-          {queued.map((q) => (
+          {visible.map((q) => (
             <QueuedPromptRow
               key={q.id}
               prompt={q}
@@ -1638,9 +1657,36 @@ function QueuedPromptsStrip({
             />
           ))}
         </ul>
+        {layout.toggleLabel && (
+          <button
+            type="button"
+            onClick={() => setExpanded((v) => !v)}
+            className="mt-1.5 w-full rounded-md border border-sky-700/20 bg-sky-950/10 px-2 py-1 text-[11px] font-medium uppercase tracking-wider text-sky-300 hover:bg-sky-950/30"
+          >
+            {layout.toggleLabel}
+          </button>
+        )}
       </div>
     </div>
   );
+}
+
+/** Tracks whether the primary pointer is coarse (touch). Used to pick
+ *  mobile vs desktop defaults that don't fit Tailwind's responsive
+ *  classes. Matches `useMobileKeyboard`'s detection. */
+function useIsCoarsePointer(): boolean {
+  const [isCoarse, setIsCoarse] = useState(() =>
+    typeof window !== "undefined" &&
+    Boolean(window.matchMedia?.("(pointer: coarse)").matches),
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setIsCoarse(mql.matches);
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
+  return isCoarse;
 }
 
 function QueuedPromptRow({
@@ -1657,6 +1703,13 @@ function QueuedPromptRow({
   // current prompt.text. This avoids a setState-in-effect to keep the
   // draft synced with external edits (lint: react-hooks/set-state-in-effect).
   const [editing, setEditing] = useState(false);
+  // Per-row clamp: long / multi-line prompts only render their first
+  // few lines in display mode. The `…` affordance lifts the clamp
+  // without entering edit mode. The clamp is undone automatically when
+  // the editor mounts, since the textarea has its own sizing logic.
+  // See #1232.
+  const [rowExpanded, setRowExpanded] = useState(false);
+  const isLong = isQueuedPromptLong(prompt.text);
 
   return (
     <li className="group flex items-start gap-2 rounded-lg border border-sky-700/30 bg-sky-950/15 px-2.5 py-1.5">
@@ -1675,14 +1728,36 @@ function QueuedPromptRow({
           }}
         />
       ) : (
-        <button
-          type="button"
-          onClick={() => setEditing(true)}
-          title="Click to edit"
-          className="min-w-0 flex-1 text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary"
-        >
-          {prompt.text}
-        </button>
+        <div className="min-w-0 flex-1">
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            title="Click to edit"
+            className={[
+              "block w-full text-left text-xs leading-5 text-text-secondary whitespace-pre-wrap break-words hover:text-text-primary",
+              isLong && !rowExpanded ? "line-clamp-3" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
+          >
+            {prompt.text}
+          </button>
+          {isLong && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setRowExpanded((v) => !v);
+              }}
+              className="mt-0.5 text-[11px] font-medium text-sky-300 hover:text-sky-200"
+              aria-label={
+                rowExpanded ? "Collapse queued prompt" : "Show full queued prompt"
+              }
+            >
+              {rowExpanded ? "Show less" : "…"}
+            </button>
+          )}
+        </div>
       )}
       <button
         type="button"

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -56,6 +56,7 @@ import {
 import { useCockpitPrefs } from "../../lib/cockpitPrefs";
 import { AgentProfileProvider } from "../../lib/agentProfileContext";
 import { useApprovalSound } from "../../hooks/useApprovalSound";
+import { useIsCoarsePointer } from "../../hooks/useIsCoarsePointer";
 import type {
   Approval,
   ApprovalDecision,
@@ -1669,24 +1670,6 @@ function QueuedPromptsStrip({
       </div>
     </div>
   );
-}
-
-/** Tracks whether the primary pointer is coarse (touch). Used to pick
- *  mobile vs desktop defaults that don't fit Tailwind's responsive
- *  classes. Matches `useMobileKeyboard`'s detection. */
-function useIsCoarsePointer(): boolean {
-  const [isCoarse, setIsCoarse] = useState(() =>
-    typeof window !== "undefined" &&
-    Boolean(window.matchMedia?.("(pointer: coarse)").matches),
-  );
-  useEffect(() => {
-    if (typeof window === "undefined" || !window.matchMedia) return;
-    const mql = window.matchMedia("(pointer: coarse)");
-    const onChange = () => setIsCoarse(mql.matches);
-    mql.addEventListener?.("change", onChange);
-    return () => mql.removeEventListener?.("change", onChange);
-  }, []);
-  return isCoarse;
 }
 
 function QueuedPromptRow({

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -24,6 +24,7 @@ import {
   Check,
   ChevronDown,
   Clock,
+  Info,
   ListChecks,
   RotateCcw,
   X,
@@ -129,6 +130,7 @@ function CockpitChrome({
   editQueuedPrompt,
   clearQueue,
   dismissRejectedPrompt,
+  dismissModeSwitchFailed,
 }: CockpitContext & {
   sessionId: string;
   cockpitWorkerState: "absent" | "resuming" | "running";
@@ -323,6 +325,11 @@ function CockpitChrome({
               state.workerStopped ||
               Boolean(state.startupError)
             }
+          />
+
+          <ModeSwitchFailedNotice
+            failure={state.modeSwitchFailed}
+            onDismiss={dismissModeSwitchFailed}
           />
 
           <ContextPrimerBanner
@@ -1452,6 +1459,54 @@ function StartupErrorBanner({
             </pre>
           </>
         )}
+      </div>
+    </div>
+  );
+}
+
+/* ── Mode-switch-failed notice ────────────────────────────────────── */
+
+interface ModeSwitchFailedNoticeProps {
+  failure: { modeId: string; reason: string; at: string } | null;
+  onDismiss: () => void;
+}
+
+/** Non-blocking notice rendered when the ACP adapter rejected a
+ *  `session/set_mode` request. The most common path: a user enabled
+ *  yolo_mode_default but the claude-agent-acp build does not expose
+ *  `bypassPermissions` (gated on the `ALLOW_BYPASS` env var), so the
+ *  session keeps running in `default` and silently prompts on every
+ *  Write/Edit/Bash. The notice gives them an explicit signal plus a
+ *  pointer to the mode picker. See #1233. */
+function ModeSwitchFailedNotice({
+  failure,
+  onDismiss,
+}: ModeSwitchFailedNoticeProps) {
+  if (!failure) return null;
+  const friendly =
+    failure.modeId === "bypassPermissions"
+      ? "YOLO mode (bypassPermissions) is not available on this adapter; the session is running in default permission mode. claude-agent-acp gates bypass on the ALLOW_BYPASS env var. Pick a different mode from the composer or restart the daemon with ALLOW_BYPASS=1."
+      : `Could not switch to mode "${failure.modeId}"; the session is staying on its previous mode. Pick a different mode from the composer.`;
+  return (
+    <div className="border-t border-amber-900/40 bg-amber-950/20 px-4 py-2">
+      <div className="mx-auto max-w-3xl xl:max-w-4xl 2xl:max-w-5xl">
+        <div className="flex items-start gap-2 rounded-lg border border-amber-700/30 bg-amber-950/15 px-2.5 py-1.5">
+          <Info className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
+          <div className="min-w-0 flex-1">
+            <p className="text-xs leading-5 text-amber-100">{friendly}</p>
+            <p className="mt-0.5 font-mono text-[10px] text-amber-400/70">
+              {failure.reason}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="inline-flex shrink-0 items-center justify-center rounded-md border border-amber-700/40 bg-amber-900/20 p-1 text-amber-200 hover:bg-amber-900/60"
+            aria-label="Dismiss mode-switch notice"
+          >
+            <X className="h-3 w-3" />
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web/src/components/cockpit/queuedPromptsLayout.test.ts
+++ b/web/src/components/cockpit/queuedPromptsLayout.test.ts
@@ -1,0 +1,121 @@
+// Layout tests for the cockpit's QueuedPromptsStrip. The pure
+// helpers in `queuedPromptsLayout.ts` let us check the
+// visible-count / toggle-label decisions across mobile / desktop /
+// expanded / collapsed states without mounting the strip + assistant-ui
+// runtime. See #1232.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  isQueuedPromptLong,
+  queuedStripLayout,
+} from "./queuedPromptsLayout";
+
+describe("queuedStripLayout (#1232)", () => {
+  describe("desktop default N=2", () => {
+    it("renders everything when queue is 1 row", () => {
+      const out = queuedStripLayout({
+        queuedCount: 1,
+        isMobile: false,
+        expanded: false,
+      });
+      expect(out.visibleCount).toBe(1);
+      expect(out.hiddenCount).toBe(0);
+      expect(out.toggleLabel).toBeNull();
+      expect(out.collapsed).toBe(false);
+    });
+
+    it("renders everything at threshold (2 rows)", () => {
+      const out = queuedStripLayout({
+        queuedCount: 2,
+        isMobile: false,
+        expanded: false,
+      });
+      expect(out.visibleCount).toBe(2);
+      expect(out.toggleLabel).toBeNull();
+    });
+
+    it("collapses to 2 + 'Show N more' once queue exceeds threshold", () => {
+      const out = queuedStripLayout({
+        queuedCount: 5,
+        isMobile: false,
+        expanded: false,
+      });
+      expect(out.visibleCount).toBe(2);
+      expect(out.hiddenCount).toBe(3);
+      expect(out.toggleLabel).toBe("Show 3 more");
+      expect(out.collapsed).toBe(true);
+    });
+
+    it("renders all rows when expanded, with 'Show less' label", () => {
+      const out = queuedStripLayout({
+        queuedCount: 5,
+        isMobile: false,
+        expanded: true,
+      });
+      expect(out.visibleCount).toBe(5);
+      expect(out.hiddenCount).toBe(0);
+      expect(out.toggleLabel).toBe("Show less");
+      expect(out.collapsed).toBe(false);
+    });
+  });
+
+  describe("mobile default N=1", () => {
+    it("renders everything when queue is 1 row", () => {
+      const out = queuedStripLayout({
+        queuedCount: 1,
+        isMobile: true,
+        expanded: false,
+      });
+      expect(out.visibleCount).toBe(1);
+      expect(out.toggleLabel).toBeNull();
+    });
+
+    it("collapses to 1 + 'Show N more' at 2+ rows", () => {
+      const out = queuedStripLayout({
+        queuedCount: 4,
+        isMobile: true,
+        expanded: false,
+      });
+      expect(out.visibleCount).toBe(1);
+      expect(out.hiddenCount).toBe(3);
+      expect(out.toggleLabel).toBe("Show 3 more");
+    });
+  });
+
+  it("returns no toggle when queue drains below threshold even with expanded=true", () => {
+    // Edge case: user expanded, then queue drained. Toggle disappears
+    // entirely; `expanded` stays harmlessly true so a future overflow
+    // doesn't surprise-collapse the rows the user just expanded.
+    const out = queuedStripLayout({
+      queuedCount: 1,
+      isMobile: false,
+      expanded: true,
+    });
+    expect(out.visibleCount).toBe(1);
+    expect(out.toggleLabel).toBeNull();
+    expect(out.collapsed).toBe(false);
+  });
+});
+
+describe("isQueuedPromptLong (#1232)", () => {
+  it("returns false for short single-line prompts", () => {
+    expect(isQueuedPromptLong("fix the spinner")).toBe(false);
+  });
+
+  it("returns false for short two-line prompts", () => {
+    expect(isQueuedPromptLong("line 1\nline 2")).toBe(false);
+  });
+
+  it("returns true for multi-line prompts with 3+ lines", () => {
+    expect(isQueuedPromptLong("line 1\nline 2\nline 3")).toBe(true);
+  });
+
+  it("returns true for a single very-long line over 160 chars", () => {
+    expect(isQueuedPromptLong("x".repeat(161))).toBe(true);
+  });
+
+  it("returns false at exactly 160 chars", () => {
+    expect(isQueuedPromptLong("x".repeat(160))).toBe(false);
+  });
+});

--- a/web/src/components/cockpit/queuedPromptsLayout.ts
+++ b/web/src/components/cockpit/queuedPromptsLayout.ts
@@ -1,0 +1,51 @@
+// Pure helpers for the cockpit's QueuedPromptsStrip. Extracted from
+// `CockpitView.tsx` so the layout decisions (visible count, "Show N
+// more" label, per-row clamp threshold) can be unit-tested without
+// mounting the strip + assistant-ui runtime. See #1232.
+
+/** Per-row clamp heuristic. Triggers on either multi-line content
+ *  (≥3 newlines, since shorter multi-line prompts fit naturally inside
+ *  line-clamp-3 without truncating) or a single very-long line that
+ *  would wrap past three rendered lines at the strip's typical width.
+ *  False positives just show an unnecessary "…" affordance, which is
+ *  cheap. */
+export function isQueuedPromptLong(text: string): boolean {
+  const lineCount = text.split("\n").length;
+  return lineCount >= 3 || text.length > 160;
+}
+
+export interface QueuedStripLayout {
+  /** Default visible row count for this viewport. */
+  visibleDefault: number;
+  /** True when collapse is active (queue exceeds default AND not user-expanded). */
+  collapsed: boolean;
+  /** How many rows render in the strip right now. */
+  visibleCount: number;
+  /** How many rows are hidden behind the toggle (0 when not collapsed). */
+  hiddenCount: number;
+  /** Label for the toggle button, or null when no toggle should render. */
+  toggleLabel: "Show less" | string | null;
+}
+
+/** Decide how many queued-prompt rows the strip should show, and the
+ *  toggle-button copy. Mobile gets a tighter default since a single
+ *  multi-line prompt already dominates the small-viewport composer
+ *  area. */
+export function queuedStripLayout(args: {
+  queuedCount: number;
+  isMobile: boolean;
+  expanded: boolean;
+}): QueuedStripLayout {
+  const { queuedCount, isMobile, expanded } = args;
+  const visibleDefault = isMobile ? 1 : 2;
+  const overflows = queuedCount > visibleDefault;
+  const collapsed = overflows && !expanded;
+  const visibleCount = collapsed ? visibleDefault : queuedCount;
+  const hiddenCount = collapsed ? queuedCount - visibleDefault : 0;
+  const toggleLabel = !overflows
+    ? null
+    : expanded
+      ? "Show less"
+      : `Show ${hiddenCount} more`;
+  return { visibleDefault, collapsed, visibleCount, hiddenCount, toggleLabel };
+}

--- a/web/src/components/cockpit/queuedPromptsLayout.ts
+++ b/web/src/components/cockpit/queuedPromptsLayout.ts
@@ -4,11 +4,11 @@
 // mounting the strip + assistant-ui runtime. See #1232.
 
 /** Per-row clamp heuristic. Triggers on either multi-line content
- *  (≥3 newlines, since shorter multi-line prompts fit naturally inside
- *  line-clamp-3 without truncating) or a single very-long line that
- *  would wrap past three rendered lines at the strip's typical width.
- *  False positives just show an unnecessary "…" affordance, which is
- *  cheap. */
+ *  (3+ lines, i.e. 2+ newlines, since shorter multi-line prompts fit
+ *  naturally inside line-clamp-3 without truncating) or a single
+ *  very-long line that would wrap past three rendered lines at the
+ *  strip's typical width. False positives just show an unnecessary
+ *  "…" affordance, which is cheap. */
 export function isQueuedPromptLong(text: string): boolean {
   const lineCount = text.split("\n").length;
   return lineCount >= 3 || text.length > 160;

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -39,7 +39,8 @@ export type Action =
   | { kind: "edit_queued_prompt"; id: string; text: string }
   | { kind: "clear_queue" }
   | { kind: "dismiss_primer" }
-  | { kind: "dismiss_rejected_prompt"; id: string };
+  | { kind: "dismiss_rejected_prompt"; id: string }
+  | { kind: "dismiss_mode_switch_failed" };
 
 // LRU-capped module cache keyed by cockpit session id. Mirrors the
 // per-session CockpitState into `localStorage` under
@@ -355,6 +356,9 @@ function reducer(state: CockpitState, action: Action): CockpitState {
         (r) => r.id !== action.id,
       ),
     };
+  }
+  if (action.kind === "dismiss_mode_switch_failed") {
+    return { ...state, modeSwitchFailed: null };
   }
   return emptyCockpitState();
 }
@@ -1025,6 +1029,10 @@ export function useCockpit(
     dispatch({ kind: "dismiss_rejected_prompt", id });
   }, []);
 
+  const dismissModeSwitchFailed = useCallback(() => {
+    dispatch({ kind: "dismiss_mode_switch_failed" });
+  }, []);
+
   // Cancels the in-flight agent turn (ACP session/cancel). Must only
   // fire on an explicit user gesture against a dedicated cancel/stop
   // affordance; never bind this to the Escape key. Claude Code CLI
@@ -1159,6 +1167,7 @@ export function useCockpit(
     editQueuedPrompt,
     clearQueue,
     dismissRejectedPrompt,
+    dismissModeSwitchFailed,
   };
 }
 

--- a/web/src/hooks/useIsCoarsePointer.ts
+++ b/web/src/hooks/useIsCoarsePointer.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+/** Tracks whether the primary pointer is coarse (touchscreen). Reactive
+ *  to `(pointer: coarse)` matchMedia changes, SSR-safe via a `typeof
+ *  window` guard on the initial read. Use when you need a coarse /
+ *  fine distinction outside Tailwind's responsive class set, e.g. to
+ *  pick mobile vs desktop defaults for component layout state.
+ *
+ *  `useMobileKeyboard` exposes an `isMobile` flag built from the same
+ *  query; consumers that need only the coarse / fine bit (without the
+ *  keyboard tracking) should prefer this hook to avoid the extra
+ *  visualViewport listeners. */
+export function useIsCoarsePointer(): boolean {
+  const [isCoarse, setIsCoarse] = useState(() =>
+    typeof window !== "undefined" &&
+    Boolean(window.matchMedia?.("(pointer: coarse)").matches),
+  );
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(pointer: coarse)");
+    const onChange = () => setIsCoarse(mql.matches);
+    mql.addEventListener?.("change", onChange);
+    return () => mql.removeEventListener?.("change", onChange);
+  }, []);
+  return isCoarse;
+}

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1100,3 +1100,59 @@ describe("cockpitHookReducer / dismiss_primer", () => {
     expect(next.contextPrimerAvailable).toBeNull();
   });
 });
+
+describe("applyEvent / ModeSwitchFailed", () => {
+  it("captures the rejected mode + reason", () => {
+    const next = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ModeSwitchFailed: {
+          mode_id: "bypassPermissions",
+          reason: "Mode bypassPermissions is not available.",
+        },
+      },
+    });
+    expect(next.modeSwitchFailed).not.toBeNull();
+    expect(next.modeSwitchFailed?.modeId).toBe("bypassPermissions");
+    expect(next.modeSwitchFailed?.reason).toBe(
+      "Mode bypassPermissions is not available.",
+    );
+  });
+
+  it("clears when a subsequent CurrentModeChanged lands", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ModeSwitchFailed: { mode_id: "bypassPermissions", reason: "denied" },
+      },
+    });
+    expect(state.modeSwitchFailed).not.toBeNull();
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { CurrentModeChanged: { current_mode_id: "acceptEdits" } },
+    });
+    expect(state.modeSwitchFailed).toBeNull();
+    expect(state.currentModeId).toBe("acceptEdits");
+  });
+});
+
+describe("cockpitHookReducer / dismiss_mode_switch_failed", () => {
+  it("clears the notice", async () => {
+    const { cockpitHookReducer } = await import("../hooks/useCockpit");
+    const seeded: CockpitState = {
+      ...emptyCockpitState(),
+      modeSwitchFailed: {
+        modeId: "bypassPermissions",
+        reason: "denied",
+        at: new Date().toISOString(),
+      },
+    };
+    const next = cockpitHookReducer(seeded, {
+      kind: "dismiss_mode_switch_failed",
+    });
+    expect(next.modeSwitchFailed).toBeNull();
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -165,6 +165,7 @@ export type CockpitEvent =
       };
     }
   | { CurrentModeChanged: { current_mode_id: string } }
+  | { ModeSwitchFailed: { mode_id: string; reason: string } }
   | { AvailableCommandsUpdated: { commands: AvailableCommand[] } }
   | { RawAgentUpdate: { payload: unknown } }
   | { AgentMessageChunk: { text: string } }
@@ -262,6 +263,14 @@ export interface CockpitState {
    *  handler to detect "no-op turn" without walking the full
    *  activity array. */
   turnHasOutput: boolean;
+  /** Latest cockpit-side `session/set_mode` rejection from the adapter.
+   *  Populated by the `ModeSwitchFailed` event so the UI can render a
+   *  non-blocking notice ("Yolo / bypassPermissions requested but the
+   *  adapter declined; session is in default mode"). Most common cause:
+   *  claude-agent-acp gates bypassPermissions on the `ALLOW_BYPASS` env
+   *  var. Cleared by the user dismissing the notice or by a successful
+   *  `CurrentModeChanged`. See #1233. */
+  modeSwitchFailed: { modeId: string; reason: string; at: string } | null;
   /** Set true when the daemon publishes `Stopped { reason: "user_stopped" }`,
    *  meaning `aoe cockpit stop|kill` (or an equivalent external
    *  teardown) terminated the runner. The composer disables itself and
@@ -407,6 +416,7 @@ export function emptyCockpitState(): CockpitState {
     contextPrimerAvailable: null,
     rejectedPrompts: [],
     agentUnresponsive: false,
+    modeSwitchFailed: null,
   };
 }
 
@@ -637,6 +647,16 @@ export function applyEvent(
   }
   if ("CurrentModeChanged" in event) {
     next.currentModeId = event.CurrentModeChanged.current_mode_id;
+    // Mode actually switched, so any prior failure notice is stale.
+    next.modeSwitchFailed = null;
+    return next;
+  }
+  if ("ModeSwitchFailed" in event) {
+    next.modeSwitchFailed = {
+      modeId: event.ModeSwitchFailed.mode_id,
+      reason: event.ModeSwitchFailed.reason,
+      at: new Date().toISOString(),
+    };
     return next;
   }
   if ("AvailableCommandsUpdated" in event) {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two cockpit polish items in one PR, both surfaced from real cockpit-polishing-9 testing on Substrate B.

### 1. YOLO mode silently downgraded when the adapter doesn't expose `bypassPermissions`

The wiring landed in #1156 already routes `yolo_mode = true` through to a post-spawn `session/set_mode("bypassPermissions")`, but the call is fire-and-forget: if the adapter rejects (`claude-agent-acp` gates `bypassPermissions` on the `ALLOW_BYPASS` env var) the failure only landed in the daemon's tracing logs. The user kept seeing approval cards while believing YOLO was on. This adds a new `Event::ModeSwitchFailed { mode_id, reason }` that both the mid-turn and idle `session/set_mode` error arms emit alongside the existing `warn!`. The frontend reducer captures it on `state.modeSwitchFailed` (cleared automatically by a subsequent `CurrentModeChanged` or by the user dismissing). The cockpit renders a non-blocking amber notice above the composer with a friendly message that names the most common cause (`ALLOW_BYPASS` unset) and the recovery path (restart the daemon with the env var, or pick a mode from the composer picker).

`docs/cockpit.md` gains a "Permission modes and YOLO" section that lists the typical four modes, explains the `yolo_mode_default` → `bypassPermissions` mapping at spawn, and documents the `ALLOW_BYPASS` adapter caveat. `docs/guides/configuration.md` cross-links from the `yolo_mode_default` row so the substrate split is discoverable from the settings reference.

### 2. Queued-prompts strip eats half the viewport when the queue grows

Queueing four medium prompts (or a single thirty-line one) used to push the strip past 200 px and crowd the conversation pane. The strip now collapses to the first **2 rows on desktop** (**1 row on coarse-pointer / mobile**) with a `Show N more` toggle that lifts the collapse in place. Per-row text clamps to 3 lines (CSS `line-clamp-3`) when the prompt is multi-line (≥ 3 lines) or single-line over 160 chars, with an inline `…` affordance that expands the row without entering edit mode. The existing click-to-edit gesture is unchanged; the editor textarea still grows naturally with its own sizing logic.

Layout decisions live in a pure helper (`queuedStripLayout`, `isQueuedPromptLong`) so the visible-count and toggle-label behaviour is unit-tested without mounting the strip plus assistant-ui runtime. Tests cover both viewport defaults, the threshold edge, the expand cycle, and the drain-below-threshold race where the user expanded then the queue shrank.

Closes #1233
Closes #1232

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

User-runnable steps for the human verifier. CI handles unit and integration tests automatically.

- [x] `cargo build --features serve`, then start `aoe serve --no-auth` with the daemon env **lacking** `ALLOW_BYPASS`. Create a Claude cockpit session with `aoe add . --cmd claude --cockpit` and `yolo_mode_default = true` (or flip the wizard toggle). Open the cockpit view: an amber notice should appear above the composer reading "YOLO mode (bypassPermissions) is not available on this adapter…". Daemon log should also carry the existing `session/set_mode failed` warn.
- [x] In the same view, dismiss the notice via the X button: it should clear and not reappear until a new failure event lands.
- [x] Restart `aoe serve` with `ALLOW_BYPASS=1` and spawn a fresh YOLO-mode cockpit session: notice should not appear; composer mode picker should read `bypassPermissions`; Write/Edit/Bash tools should run without approval cards.
- [x] Manually switch modes from the composer picker (e.g. default → bypass) on an `ALLOW_BYPASS=1` build: success path still flips the picker and emits `CurrentModeChanged`. Force a failure path by switching to an invalid mode id via the API and confirm the notice surfaces, then auto-clears when you pick a real mode.
- [x] On a desktop viewport, queue 4 short prompts via the composer while a turn is running: strip shows the first 2 rows plus a `Show 2 more` button. Click the button: all 4 rows render plus a `Show less` button. Click `Show less`: collapses back to 2.
- [x] On a mobile viewport (or DevTools emulating coarse pointer), queue 2 prompts: strip shows the first row plus `Show 1 more`. Repeat the expand cycle.
- [x] Queue a single 30-line prompt: row renders 3 lines plus a `…` affordance. Click `…`: row expands. Click `Show less`: collapses back. Click the row text itself: enters edit mode and the clamp lifts naturally as the textarea grows.
- [x] Drain the queue below the strip's threshold while expanded (e.g. cancel an in-flight prompt so the head fires and remaining rows fall under threshold): the `Show less` toggle should disappear without re-collapsing the remaining rows.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (full scope on #1233 including the new event + UI; `…` affordance for the per-row clamp on #1232; mobile / desktop default of N=1 / N=2 for the strip), and will run the manual test steps before flipping the PR to ready.

- [x] I am an AI Agent filling out this form (check box if true)