### PR TITLE
fix: pi install hint → @earendil-works package + correct Pi/Hermes confusion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ Thumbs.db
 
 # AI coding tools
 .opencode/
+.omo/
 .sisyphus/
 
 # Per-repo config (created by `aoe init`, should be committed per-repo by users)

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -109,7 +109,7 @@ Configured agents:
     install: npm install -g @google/gemini-cli  (then `gemini --acp`)
 [!! ] opencode  (OpenCode (SST); native ACP via `opencode acp`)
     install: curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)
-[!! ] pi  (Hermes coding agent (`pi`) via the pi-acp adapter …)
+[!! ] pi  (Pi coding agent (`pi`) via the pi-acp adapter …)
     install: npm install -g pi-acp  (also requires `npm i -g @earendil-works/pi-coding-agent`)
 [!! ] vibe  (Mistral Vibe; native ACP via the bundled `vibe-acp` binary)
     install: follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -110,7 +110,7 @@ Configured agents:
 [!! ] opencode  (OpenCode (SST); native ACP via `opencode acp`)
     install: curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)
 [!! ] pi  (Pi coding agent (`pi`) via the pi-acp adapter …)
-    install: npm install -g pi-acp  (also requires `npm i -g @earendil-works/pi-coding-agent`)
+    install: npm install -g pi-acp (also requires `npm install -g @earendil-works/pi-coding-agent`)
 [!! ] vibe  (Mistral Vibe; native ACP via the bundled `vibe-acp` binary)
     install: follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -38,7 +38,7 @@ The wizard greys out the cockpit option for tools not in this set.
 | `gemini`   | `gemini --acp` (native, Google)                            | `GEMINI_API_KEY` env var, OAuth via `gemini auth`, or Vertex `GOOGLE_API_KEY` |
 | `codex`    | `codex-acp` (Zed adapter, npm `@zed-industries/codex-acp`) | `OPENAI_API_KEY` env var, or ChatGPT login (local-only) |
 | `vibe`     | `vibe-acp` (native, Mistral)                               | Mistral API key; set up via `vibe` first |
-| `pi`       | `pi-acp` (adapter, requires `@mariozechner/pi-coding-agent`) | `pi-acp --terminal-login` for OAuth, or env vars per provider |
+| `pi`       | `pi-acp` (adapter, requires `@earendil-works/pi-coding-agent`) | `pi-acp --terminal-login` for OAuth, or env vars per provider |
 | `aoe-agent`| Bundled multi-provider agent (Vercel AI SDK 6)             | Whatever provider env vars Vercel AI SDK expects |
 | *aider, cursor, copilot, droid, settl, hermes* | not yet wired into the cockpit registry; fall back to terminal mode |
 
@@ -110,7 +110,7 @@ Configured agents:
 [!! ] opencode  (OpenCode (SST); native ACP via `opencode acp`)
     install: curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)
 [!! ] pi  (Hermes coding agent (`pi`) via the pi-acp adapter …)
-    install: npm install -g pi-acp  (also requires `npm i -g @mariozechner/pi-coding-agent`)
+    install: npm install -g pi-acp  (also requires `npm i -g @earendil-works/pi-coding-agent`)
 [!! ] vibe  (Mistral Vibe; native ACP via the bundled `vibe-acp` binary)
     install: follow https://github.com/mistralai/mistral-vibe (ships the `vibe-acp` binary)
 

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -14,7 +14,7 @@ are first-class but lighter on per-tool polish.
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |
 | Vibe (Mistral) | `vibe-acp` (native) | See https://github.com/mistralai/mistral-vibe |
-| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
+| Pi | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
 | aoe-agent | bundled | shipped with `aoe` |
 
 Adding a new ACP-capable agent: see `docs/development/adding-agents.md`,

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -14,7 +14,7 @@ are first-class but lighter on per-tool polish.
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |
 | Vibe (Mistral) | `vibe-acp` (native) | See https://github.com/mistralai/mistral-vibe |
-| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@mariozechner/pi-coding-agent`) |
+| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
 | aoe-agent | bundled | shipped with `aoe` |
 
 Adding a new ACP-capable agent: see `docs/development/adding-agents.md`,

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -368,7 +368,7 @@ pub const AGENTS: &[AgentDef] = &[
         resume_strategy: ResumeStrategy::Flag("--session"),
         host_only: false,
         send_keys_enter_delay_ms: 0,
-        install_hint: "npm install -g @mariozechner/pi-coding-agent",
+        install_hint: "npm install -g @earendil-works/pi-coding-agent",
     },
     AgentDef {
         name: "droid",
@@ -689,7 +689,7 @@ mod tests {
         // Pi is distributed via npm, not pip (issue #818).
         assert_eq!(
             install_hint("pi"),
-            Some("npm install -g @mariozechner/pi-coding-agent")
+            Some("npm install -g @earendil-works/pi-coding-agent")
         );
         // Mistral Vibe's PyPI package is `mistral-vibe`, not `vibe-tool`.
         assert_eq!(install_hint("vibe"), Some("pip install mistral-vibe"));

--- a/src/cockpit/agent_profiles.rs
+++ b/src/cockpit/agent_profiles.rs
@@ -139,7 +139,7 @@ pub const VIBE: AgentProfile = AgentProfile {
     supports_wakeup_tools: false,
 };
 
-/// Hermes coding agent via `pi-acp`. Defaults until verified.
+/// Pi coding agent via `pi-acp`. Defaults until verified.
 pub const PI: AgentProfile = AgentProfile {
     key: "pi",
     parent_meta_namespaces: &[],

--- a/src/cockpit/agent_registry.rs
+++ b/src/cockpit/agent_registry.rs
@@ -45,7 +45,7 @@ impl AgentRegistry {
     ///   gemini   → `gemini --acp`       (native, Google)
     ///   codex    → codex-acp            (Zed adapter, OpenAI Codex CLI)
     ///   vibe     → vibe-acp             (native, Mistral)
-    ///   pi       → pi-acp               (adapter, Hermes coding agent)
+    ///   pi       → pi-acp               (adapter, Pi coding agent)
     ///
     /// We deliberately don't use `npx -y` for these. First-run
     /// downloads can hang for tens of seconds with no output, which
@@ -120,7 +120,7 @@ impl AgentRegistry {
             AgentSpec {
                 command: "pi-acp".into(),
                 args: vec![],
-                description: "Hermes coding agent (`pi`) via the pi-acp adapter (npm i -g pi-acp)"
+                description: "Pi coding agent (`pi`) via the pi-acp adapter (npm i -g pi-acp)"
                     .into(),
                 env_allowlist: None,
             },

--- a/src/cockpit/install_hints.rs
+++ b/src/cockpit/install_hints.rs
@@ -11,7 +11,7 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
         "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp",
         "codex-acp" => "npm install -g @zed-industries/codex-acp",
         "pi-acp" => {
-            "npm install -g pi-acp  (also requires `npm i -g @earendil-works/pi-coding-agent`)"
+            "npm install -g pi-acp (also requires `npm install -g @earendil-works/pi-coding-agent`)"
         }
         "opencode" => "curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)",
         "gemini" => "npm install -g @google/gemini-cli  (then `gemini --acp`)",

--- a/src/cockpit/install_hints.rs
+++ b/src/cockpit/install_hints.rs
@@ -11,7 +11,7 @@ pub fn install_hint_for(binary: &str) -> Option<&'static str> {
         "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp",
         "codex-acp" => "npm install -g @zed-industries/codex-acp",
         "pi-acp" => {
-            "npm install -g pi-acp  (also requires `npm i -g @mariozechner/pi-coding-agent`)"
+            "npm install -g pi-acp  (also requires `npm i -g @earendil-works/pi-coding-agent`)"
         }
         "opencode" => "curl -fsSL https://opencode.ai/install | bash  (then `opencode acp`)",
         "gemini" => "npm install -g @google/gemini-cli  (then `gemini --acp`)",

--- a/website/src/pages/docs/cockpit/multi-agent.md
+++ b/website/src/pages/docs/cockpit/multi-agent.md
@@ -18,7 +18,7 @@ are first-class but lighter on per-tool polish.
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |
 | Vibe (Mistral) | `vibe-acp` (native) | See https://github.com/mistralai/mistral-vibe |
-| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
+| Pi | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
 | aoe-agent | bundled | shipped with `aoe` |
 
 Adding a new ACP-capable agent: see `docs/development/adding-agents.md`,

--- a/website/src/pages/docs/cockpit/multi-agent.md
+++ b/website/src/pages/docs/cockpit/multi-agent.md
@@ -18,7 +18,7 @@ are first-class but lighter on per-tool polish.
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |
 | Vibe (Mistral) | `vibe-acp` (native) | See https://github.com/mistralai/mistral-vibe |
-| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@mariozechner/pi-coding-agent`) |
+| Pi (Hermes) | `pi-acp` (adapter) | `npm install -g pi-acp` (plus `@earendil-works/pi-coding-agent`) |
 | aoe-agent | bundled | shipped with `aoe` |
 
 Adding a new ACP-capable agent: see `docs/development/adding-agents.md`,


### PR DESCRIPTION
## Description

Pi [moved from `@mariozechner` to `@earendil-works` on 2026-05-07](https://pi.dev/news/2026/5/7/pi-has-a-new-home). The old npm package `@mariozechner/pi-coding-agent` is deprecated at `0.73.1`; new releases (`>= 0.74.0`, latest `0.75.3`) live under `@earendil-works/pi-coding-agent`.

This PR updates every install hint AoE surfaces to users so doctor output, the agent registry, and the cockpit docs point at the maintained package. While auditing the cockpit registry strings, I also noticed an unrelated factual error in the same lines: `pi-acp` was described as wrapping the "Hermes coding agent". Pi is its own agent (see [pi.dev](https://pi.dev)); Hermes is a separate agent already listed alongside Pi in the supported-agents matrix (`docs/index.md`, `docs/development/adding-agents.md`). Fixed in the same files since they are the same touchpoints.

### Files updated (8)

Package rename (`@mariozechner` → `@earendil-works`):

- `src/agents.rs`: `AgentDef` for `pi` install hint + matching unit-test assertion.
- `src/cockpit/install_hints.rs`: `pi-acp` branch of the cockpit doctor's hint catalog.
- `docs/cockpit.md`: agent matrix row + sample `aoe cockpit doctor` output.
- `docs/cockpit/multi-agent.md`: per-agent install matrix.
- `website/src/pages/docs/cockpit/multi-agent.md`: regenerated by `node website/scripts/sync-docs.mjs` from the canonical `docs/` source.

Pi/Hermes description fix (same touchpoints):

- `src/cockpit/agent_registry.rs`: `description` string emitted by the doctor + ASCII map comment.
- `src/cockpit/agent_profiles.rs`: docstring on `pub const PI`.
- `docs/cockpit.md`: sample doctor output line for `pi`.

### Explicitly NOT changed (false positives, verified against the upstream migration notes)

- The `pi` binary name, the `PI_CODING_AGENT_DIR` env var, and the `~/.pi/agent` config/sessions path are unchanged. The pi.dev announcement guarantees existing configurations stay where they are.
- The `pi-acp` ACP adapter is maintained separately by `svkozak` and was not renamed (`@earendil-works/pi-acp` 404s on the npm registry; latest `pi-acp` is `0.0.27`).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --lib`: 1716 passed, 0 failed; `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` shows only a pre-existing `ThemeAppearance` warning unrelated to this PR, present on `main` already)
- [x] Documentation was updated where necessary (`docs/cockpit.md`, `docs/cockpit/multi-agent.md`, regenerated website mirror)
- [ ] For UI changes: included screenshot or recording (N/A: no UI change, only string updates in install hints and agent descriptions)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (`anthropic/claude-opus-4-7`) driven by OpenCode/Sisyphus.

**Any Additional AI Details you'd like to share:**

The agent grepped the workspace for `@mariozechner`, `badlogic`, `pi-mono`, `earendil`, and `Hermes coding`/`Pi (Hermes)` to enumerate every reference, cross-checked the npm registry to confirm which packages were actually renamed (`@mariozechner/pi-coding-agent` → `@earendil-works/pi-coding-agent`) and which were not (`pi-acp`, separate maintainer, deliberately left untouched), and verified post-edit that zero `@mariozechner` and zero `Hermes coding` references remain. The Pi/Hermes fix was prompted by a maintainer-style review by the human operator pointing out that pi.dev describes Pi as its own harness and never mentions Hermes; the website mirror was regenerated via `node website/scripts/sync-docs.mjs` rather than hand-edited, per `AGENTS.md`.

- [x] I am an AI Agent filling out this form (check box if true)
