### PR TITLE
feat(tui): per-row profile tag in all-profiles view

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -551,6 +551,39 @@ pub struct SessionConfig {
     /// itself still runs).
     #[serde(default = "default_restart_wake_message")]
     pub restart_wake_message: String,
+
+    /// Per-row label shown next to the session title in the home view.
+    /// `Auto` (default) preserves the historical UX: show a profile short
+    /// code in all-profiles view and nothing in filtered views. Other
+    /// variants override that to always show the chosen tag, or to
+    /// suppress the row label entirely.
+    #[serde(default)]
+    pub row_tag: RowTagMode,
+}
+
+/// What to render in the per-row tag slot next to the session title.
+///
+/// Defaults to `None` so existing users see no behavior change. Power
+/// users opt in via Settings: pick `Auto` (profile tag in all-profiles
+/// view only), `Profile`, `Sandbox`, or `Branch`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RowTagMode {
+    /// Never render a per-row tag. The historical behavior on `main`
+    /// before the row-tag feature landed; default so the feature is
+    /// fully opt-in.
+    #[default]
+    None,
+    /// Show the profile short code in all-profiles view, nothing in
+    /// filtered views.
+    Auto,
+    /// Always render the profile short code (`fb` for `forit-backup`).
+    Profile,
+    /// Render `sb` on sandboxed sessions, nothing on host sessions.
+    Sandbox,
+    /// Render the worktree branch name (last segment if `/`-namespaced,
+    /// truncated to 8 chars).
+    Branch,
 }
 
 impl Default for SessionConfig {
@@ -566,6 +599,7 @@ impl Default for SessionConfig {
             strict_hotkeys: false,
             snooze_duration_minutes: 30,
             restart_wake_message: default_restart_wake_message(),
+            row_tag: RowTagMode::default(),
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -22,8 +22,8 @@ pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
     get_update_settings, load_config, save_config, validate_snooze_duration, Config,
-    ContainerRuntimeName, DefaultTerminalMode, GroupByMode, SandboxConfig, SessionConfig,
-    ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig,
+    ContainerRuntimeName, DefaultTerminalMode, GroupByMode, RowTagMode, SandboxConfig,
+    SessionConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode, UpdatesConfig,
     WorktreeConfig,
 };
 pub(crate) use environment::user_shell;

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -251,6 +251,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub restart_wake_message: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub row_tag: Option<super::config::RowTagMode>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -477,6 +480,9 @@ pub fn apply_session_overrides(
     }
     if let Some(ref restart_wake_message) = source.restart_wake_message {
         target.restart_wake_message = restart_wake_message.clone();
+    }
+    if let Some(row_tag) = source.row_tag {
+        target.row_tag = row_tag;
     }
 }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -164,6 +164,11 @@ pub struct HomeView {
     pub(super) view_mode: ViewMode,
     pub(super) sort_order: SortOrder,
     pub(super) group_by: GroupByMode,
+    /// Per-row tag config; what to show next to each session title.
+    /// Cached from resolved SessionConfig at construction + reload_settings;
+    /// the render layer reads this rather than re-resolving the config on
+    /// every paint.
+    pub(super) row_tag_mode: crate::session::config::RowTagMode,
     /// Collapsed state for project-mode groups (persists across rebuilds)
     pub(super) project_group_collapsed: HashMap<String, bool>,
 
@@ -421,6 +426,7 @@ impl HomeView {
             view_mode,
             sort_order,
             group_by,
+            row_tag_mode: resolved.session.row_tag,
             project_group_collapsed: HashMap::new(),
             show_help: false,
             new_dialog: None,
@@ -2283,6 +2289,7 @@ impl HomeView {
         self.status_hook_config = config.status_hooks.clone();
         self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
+        self.row_tag_mode = config.session.row_tag;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
         self.tool_configs = config.tools;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -924,11 +924,18 @@ impl HomeView {
                 // profile in the title, so the per-row tag would be redundant
                 // there and is omitted. Counted into `used_width` below so the
                 // activity column still right-aligns past the tag.
+                //
+                // Empty `source_profile` (legacy callers that built an
+                // Instance before profile plumbing landed) skips the tag
+                // rather than rendering a literal `  []`.
                 if self.active_profile.is_none() {
-                    line_spans.push(Span::styled(
-                        format!("  [{}]", profile_short_code(&inst.source_profile)),
-                        Style::default().fg(theme.dimmed),
-                    ));
+                    let code = profile_short_code(&inst.source_profile);
+                    if !code.is_empty() {
+                        line_spans.push(Span::styled(
+                            format!("  [{}]", code),
+                            Style::default().fg(theme.dimmed),
+                        ));
+                    }
                 }
 
                 // Right edge of the row: optional terminal-mode badge, and

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -200,6 +200,20 @@ pub(crate) fn compute_row_tag(
             }
         }
         RowTagMode::Branch => inst.worktree_info.as_ref().and_then(|w| {
+            // Complement the existing branch-on-divergence display
+            // (rendered in `theme.branch` color earlier in the row) rather
+            // than duplicate it. When `branch != title` the divergence
+            // display already shows the branch, so the tag would just be
+            // redundant. When `branch == title` the divergence display
+            // stays quiet and the tag fills in.
+            //
+            // Workspace sessions (multi-repo, rendered as
+            // `<branch> [N repos]`) are handled by a separate display
+            // path and have no `worktree_info`, so they fall through to
+            // `None` here naturally.
+            if w.branch != inst.title {
+                return Option::<String>::None;
+            }
             // Show the last `/`-segment of the branch (most informative
             // for `feature/foo` style names), truncated to 8 chars so the
             // tag stays narrow.

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -159,6 +159,61 @@ pub(crate) fn agent_row_icon(inst: &crate::session::Instance) -> &'static str {
 /// The mapping is per-name and deterministic, so two profiles that collapse to
 /// the same code render identically; the full name still shows in a filtered
 /// view's list title and in the New/Restart dialogs.
+/// Compute the per-row tag string for a given instance + mode, or `None`
+/// when the row should not render a tag in this context.
+///
+/// `Auto` only renders in all-profiles view (no `active_profile`). Other
+/// modes always render when their content is available (e.g. `Branch`
+/// returns `None` for sessions without a worktree).
+pub(crate) fn compute_row_tag(
+    inst: &crate::session::Instance,
+    mode: crate::session::config::RowTagMode,
+    in_all_profiles_view: bool,
+) -> Option<String> {
+    use crate::session::config::RowTagMode;
+    match mode {
+        RowTagMode::None => None,
+        RowTagMode::Auto => {
+            if !in_all_profiles_view {
+                return None;
+            }
+            let code = profile_short_code(&inst.source_profile);
+            if code.is_empty() {
+                None
+            } else {
+                Some(code)
+            }
+        }
+        RowTagMode::Profile => {
+            let code = profile_short_code(&inst.source_profile);
+            if code.is_empty() {
+                None
+            } else {
+                Some(code)
+            }
+        }
+        RowTagMode::Sandbox => {
+            if inst.is_sandboxed() {
+                Some("sb".to_string())
+            } else {
+                None
+            }
+        }
+        RowTagMode::Branch => inst.worktree_info.as_ref().and_then(|w| {
+            // Show the last `/`-segment of the branch (most informative
+            // for `feature/foo` style names), truncated to 8 chars so the
+            // tag stays narrow.
+            let last = w.branch.rsplit('/').next().unwrap_or("");
+            let trimmed: String = last.chars().take(8).collect();
+            if trimmed.is_empty() {
+                Option::<String>::None
+            } else {
+                Some(trimmed)
+            }
+        }),
+    }
+}
+
 pub(crate) fn profile_short_code(profile: &str) -> String {
     let segments: Vec<&str> = profile
         .split(['-', '_'])
@@ -915,27 +970,20 @@ impl HomeView {
                     }
                 }
 
-                // In all-profiles view the list block title only shows
-                // `[all]`, so each row carries its own profile tag; without
-                // it, sessions from different profiles are indistinguishable.
-                // The tag is a short code (`profile_short_code`), not the full
-                // name, so it stays narrow and does not crowd the title or
-                // shove the activity column. A filtered view already names the
-                // profile in the title, so the per-row tag would be redundant
-                // there and is omitted. Counted into `used_width` below so the
-                // activity column still right-aligns past the tag.
-                //
-                // Empty `source_profile` (legacy callers that built an
-                // Instance before profile plumbing landed) skips the tag
-                // rather than rendering a literal `  []`.
-                if self.active_profile.is_none() {
-                    let code = profile_short_code(&inst.source_profile);
-                    if !code.is_empty() {
-                        line_spans.push(Span::styled(
-                            format!("  [{}]", code),
-                            Style::default().fg(theme.dimmed),
-                        ));
-                    }
+                // Per-row tag. The mode is config-driven (see
+                // `SessionConfig.row_tag` and the Settings UI "Row Tag"
+                // field). Default is `None` so existing users see no
+                // tag; power users opt in for `Auto` (profile in all-
+                // profiles view), `Profile`, `Sandbox`, or `Branch`.
+                // Counted into `used_width` below so the activity
+                // column still right-aligns past the tag.
+                if let Some(tag) =
+                    compute_row_tag(inst, self.row_tag_mode, self.active_profile.is_none())
+                {
+                    line_spans.push(Span::styled(
+                        format!("  [{}]", tag),
+                        Style::default().fg(theme.dimmed),
+                    ));
                 }
 
                 // Right edge of the row: optional terminal-mode badge, and

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -150,6 +150,32 @@ pub(crate) fn agent_row_icon(inst: &crate::session::Instance) -> &'static str {
     }
 }
 
+/// Compact display code for a profile name, used by the per-row profile tag
+/// in all-profiles view where the full name is too wide.
+///
+/// Hyphen/underscore-delimited names collapse to their segment initials
+/// (`forit-backup` becomes `fb`); single-segment names take their first three
+/// chars (`default` becomes `def`). Always lowercased, capped at four chars.
+/// The mapping is per-name and deterministic, so two profiles that collapse to
+/// the same code render identically; the full name still shows in a filtered
+/// view's list title and in the New/Restart dialogs.
+pub(crate) fn profile_short_code(profile: &str) -> String {
+    let segments: Vec<&str> = profile
+        .split(['-', '_'])
+        .filter(|s| !s.is_empty())
+        .collect();
+    let code: String = match segments.as_slice() {
+        [] => String::new(),
+        [single] => single.chars().take(3).collect(),
+        many => many
+            .iter()
+            .filter_map(|s| s.chars().next())
+            .take(4)
+            .collect(),
+    };
+    code.to_lowercase()
+}
+
 /// Format a timestamp as a compact relative age (e.g. `3m`, `2h`, `4d`, `2mo`).
 /// Returns an empty string for `None` so callers can unconditionally substitute
 /// the result without guarding for absence.
@@ -892,13 +918,15 @@ impl HomeView {
                 // In all-profiles view the list block title only shows
                 // `[all]`, so each row carries its own profile tag; without
                 // it, sessions from different profiles are indistinguishable.
-                // A filtered view already names the profile in the title, so
-                // the per-row tag would be redundant there and is omitted.
-                // Counted into `used_width` below so the activity column
-                // still right-aligns past the tag.
+                // The tag is a short code (`profile_short_code`), not the full
+                // name, so it stays narrow and does not crowd the title or
+                // shove the activity column. A filtered view already names the
+                // profile in the title, so the per-row tag would be redundant
+                // there and is omitted. Counted into `used_width` below so the
+                // activity column still right-aligns past the tag.
                 if self.active_profile.is_none() {
                     line_spans.push(Span::styled(
-                        format!("  [{}]", inst.source_profile),
+                        format!("  [{}]", profile_short_code(&inst.source_profile)),
                         Style::default().fg(theme.dimmed),
                     ));
                 }
@@ -1807,6 +1835,31 @@ mod tests {
     fn compose_list_title_renders_za_sort_label() {
         let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::ZA);
         assert_eq!(title, " aoe · Z-A ");
+    }
+
+    #[test]
+    fn profile_short_code_multi_segment_takes_initials() {
+        assert_eq!(profile_short_code("forit-backup"), "fb");
+        assert_eq!(profile_short_code("pivot-main"), "pm");
+        assert_eq!(profile_short_code("wma-work"), "ww");
+    }
+
+    #[test]
+    fn profile_short_code_single_segment_takes_first_three() {
+        assert_eq!(profile_short_code("default"), "def");
+        assert_eq!(profile_short_code("ForIT"), "for");
+    }
+
+    #[test]
+    fn profile_short_code_caps_at_four_chars() {
+        assert_eq!(profile_short_code("a-b-c-d-e-f"), "abcd");
+    }
+
+    #[test]
+    fn profile_short_code_lowercases_and_ignores_empty_segments() {
+        assert_eq!(profile_short_code("Forit_Backup"), "fb");
+        assert_eq!(profile_short_code("--foo--"), "foo");
+        assert_eq!(profile_short_code(""), "");
     }
 
     #[test]

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -606,7 +606,7 @@ impl HomeView {
             || serve_open
     }
 
-    fn render_item_line(
+    pub(super) fn render_item_line(
         &self,
         item: &Item,
         is_selected: bool,
@@ -887,6 +887,20 @@ impl HomeView {
                             Style::default().fg(theme.branch),
                         ));
                     }
+                }
+
+                // In all-profiles view the list block title only shows
+                // `[all]`, so each row carries its own profile tag; without
+                // it, sessions from different profiles are indistinguishable.
+                // A filtered view already names the profile in the title, so
+                // the per-row tag would be redundant there and is omitted.
+                // Counted into `used_width` below so the activity column
+                // still right-aligns past the tag.
+                if self.active_profile.is_none() {
+                    line_spans.push(Span::styled(
+                        format!("  [{}]", inst.source_profile),
+                        Style::default().fg(theme.dimmed),
+                    ));
                 }
 
                 // Right edge of the row: optional terminal-mode badge, and

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2068,6 +2068,80 @@ fn test_all_profiles_view_shows_all_sessions_flat() {
     }
 }
 
+/// Flatten a rendered row into its plain text, dropping styling.
+fn rendered_row_text(view: &HomeView, item: &Item) -> String {
+    use crate::tui::styles::Theme;
+    let theme = Theme::default();
+    view.render_item_line(item, false, false, &theme, 200)
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect()
+}
+
+#[test]
+#[serial]
+fn test_all_profiles_view_renders_per_row_profile_tag() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage_a = Storage::new("alpha").unwrap();
+    storage_a.save(&[Instance::new("A1", "/tmp/a")]).unwrap();
+
+    let storage_b = Storage::new("beta").unwrap();
+    storage_b.save(&[Instance::new("B1", "/tmp/b")]).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // Every session row in all-profiles view carries its own profile tag,
+    // since the list title only shows `[all]`.
+    let mut seen = 0;
+    for item in &view.flat_items {
+        if let Item::Session { id, .. } = item {
+            let profile = view.get_instance(id).unwrap().source_profile.clone();
+            let text = rendered_row_text(&view, item);
+            assert!(
+                text.contains(&format!("[{}]", profile)),
+                "all-view row for profile {profile} missing tag: {text:?}"
+            );
+            seen += 1;
+        }
+    }
+    assert_eq!(seen, 2, "expected both profile sessions to render");
+}
+
+#[test]
+#[serial]
+fn test_filtered_view_omits_per_row_profile_tag() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage_a = Storage::new("alpha").unwrap();
+    storage_a.save(&[Instance::new("A1", "/tmp/a")]).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // A filtered view names the profile in the list title, so the per-row
+    // tag is redundant and must not be rendered.
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                !text.contains("[alpha]"),
+                "filtered view should not render a per-row profile tag: {text:?}"
+            );
+        }
+    }
+}
+
 #[test]
 #[serial]
 fn test_create_session_in_all_mode_is_findable() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2079,9 +2079,41 @@ fn rendered_row_text(view: &HomeView, item: &Item) -> String {
         .collect()
 }
 
+/// Default `RowTagMode::None` renders no tag in any view; existing users
+/// see no change from the row-tag feature being added.
 #[test]
 #[serial]
-fn test_all_profiles_view_renders_per_row_profile_tag() {
+fn test_default_row_tag_mode_renders_no_tag() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage_a = Storage::new("alpha").unwrap();
+    let instances_a = vec![Instance::new("A1", "/tmp/a")];
+    let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
+    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // Default `row_tag_mode` is `None`; no row should carry a bracketed tag.
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                !text.contains('['),
+                "default RowTagMode::None must render no tag: {text:?}"
+            );
+        }
+    }
+}
+
+/// `RowTagMode::Auto` shows the profile short code in all-profiles view.
+#[test]
+#[serial]
+fn test_row_tag_auto_renders_profile_in_all_profiles_view() {
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
 
@@ -2098,12 +2130,10 @@ fn test_all_profiles_view_renders_per_row_profile_tag() {
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
     view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Auto;
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    // Every session row in all-profiles view carries its own profile tag,
-    // since the list title only shows `[all]`. The tag is the short code,
-    // not the full profile name.
     let mut seen = 0;
     for item in &view.flat_items {
         if let Item::Session { id, .. } = item {
@@ -2120,9 +2150,11 @@ fn test_all_profiles_view_renders_per_row_profile_tag() {
     assert_eq!(seen, 2, "expected both profile sessions to render");
 }
 
+/// `RowTagMode::Auto` does not render in a filtered view (profile already
+/// in the list title).
 #[test]
 #[serial]
-fn test_filtered_view_omits_per_row_profile_tag() {
+fn test_row_tag_auto_omits_tag_in_filtered_view() {
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
 
@@ -2134,21 +2166,55 @@ fn test_filtered_view_omits_per_row_profile_tag() {
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
     view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Auto;
     view.flat_items = view.build_flat_items();
     view.update_selected();
 
-    // A filtered view names the profile in the list title, so the per-row
-    // tag is redundant and must not be rendered.
     let code = super::render::profile_short_code("alpha");
     for item in &view.flat_items {
         if let Item::Session { .. } = item {
             let text = rendered_row_text(&view, item);
             assert!(
                 !text.contains(&format!("[{code}]")),
-                "filtered view should not render a per-row profile tag: {text:?}"
+                "Auto in filtered view should omit the tag: {text:?}"
             );
         }
     }
+}
+
+/// `RowTagMode::Profile` renders the profile tag in BOTH views (unlike
+/// Auto which gates on all-profiles view).
+#[test]
+#[serial]
+fn test_row_tag_profile_renders_in_filtered_view() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage_a = Storage::new("alpha").unwrap();
+    let instances_a = vec![Instance::new("A1", "/tmp/a")];
+    let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
+    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Profile;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    let code = super::render::profile_short_code("alpha");
+    let mut seen = 0;
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                text.contains(&format!("[{code}]")),
+                "Profile mode should always render the tag: {text:?}"
+            );
+            seen += 1;
+        }
+    }
+    assert!(seen > 0);
 }
 
 /// Legacy `Instance::new` left `source_profile` empty before the per-profile
@@ -2156,14 +2222,11 @@ fn test_filtered_view_omits_per_row_profile_tag() {
 /// case rather than emit a literal `  []`.
 #[test]
 #[serial]
-fn test_all_profiles_view_skips_tag_for_empty_source_profile() {
+fn test_row_tag_auto_skips_for_empty_source_profile() {
     let temp = TempDir::new().unwrap();
     setup_test_home(&temp);
 
     let storage = Storage::new("legacy").unwrap();
-    // Build an instance the way legacy callers did, with an empty
-    // source_profile. The storage profile is "legacy" but the field on
-    // the Instance itself is blank.
     let mut inst = Instance::new("Legacy1", "/tmp/legacy");
     inst.source_profile = String::new();
     let instances = vec![inst];
@@ -2173,6 +2236,7 @@ fn test_all_profiles_view_skips_tag_for_empty_source_profile() {
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
     view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Auto;
     view.flat_items = view.build_flat_items();
     view.update_selected();
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2151,6 +2151,42 @@ fn test_filtered_view_omits_per_row_profile_tag() {
     }
 }
 
+/// Legacy `Instance::new` left `source_profile` empty before the per-profile
+/// plumbing landed. The render branch must skip the tag entirely in that
+/// case rather than emit a literal `  []`.
+#[test]
+#[serial]
+fn test_all_profiles_view_skips_tag_for_empty_source_profile() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage = Storage::new("legacy").unwrap();
+    // Build an instance the way legacy callers did, with an empty
+    // source_profile. The storage profile is "legacy" but the field on
+    // the Instance itself is blank.
+    let mut inst = Instance::new("Legacy1", "/tmp/legacy");
+    inst.source_profile = String::new();
+    let instances = vec![inst];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage.commit(&instances, &group_tree).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                !text.contains("[]"),
+                "row with empty source_profile must not render a literal []: {text:?}"
+            );
+        }
+    }
+}
+
 #[test]
 #[serial]
 fn test_create_session_in_all_mode_is_findable() {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2086,10 +2086,14 @@ fn test_all_profiles_view_renders_per_row_profile_tag() {
     setup_test_home(&temp);
 
     let storage_a = Storage::new("alpha").unwrap();
-    storage_a.save(&[Instance::new("A1", "/tmp/a")]).unwrap();
+    let instances_a = vec![Instance::new("A1", "/tmp/a")];
+    let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
+    storage_a.commit(&instances_a, &group_tree_a).unwrap();
 
     let storage_b = Storage::new("beta").unwrap();
-    storage_b.save(&[Instance::new("B1", "/tmp/b")]).unwrap();
+    let instances_b = vec![Instance::new("B1", "/tmp/b")];
+    let group_tree_b = GroupTree::new_with_groups(&instances_b, &[]);
+    storage_b.commit(&instances_b, &group_tree_b).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2098,15 +2102,17 @@ fn test_all_profiles_view_renders_per_row_profile_tag() {
     view.update_selected();
 
     // Every session row in all-profiles view carries its own profile tag,
-    // since the list title only shows `[all]`.
+    // since the list title only shows `[all]`. The tag is the short code,
+    // not the full profile name.
     let mut seen = 0;
     for item in &view.flat_items {
         if let Item::Session { id, .. } = item {
             let profile = view.get_instance(id).unwrap().source_profile.clone();
+            let code = super::render::profile_short_code(&profile);
             let text = rendered_row_text(&view, item);
             assert!(
-                text.contains(&format!("[{}]", profile)),
-                "all-view row for profile {profile} missing tag: {text:?}"
+                text.contains(&format!("[{code}]")),
+                "all-view row for profile {profile} missing tag [{code}]: {text:?}"
             );
             seen += 1;
         }
@@ -2121,7 +2127,9 @@ fn test_filtered_view_omits_per_row_profile_tag() {
     setup_test_home(&temp);
 
     let storage_a = Storage::new("alpha").unwrap();
-    storage_a.save(&[Instance::new("A1", "/tmp/a")]).unwrap();
+    let instances_a = vec![Instance::new("A1", "/tmp/a")];
+    let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
+    storage_a.commit(&instances_a, &group_tree_a).unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
@@ -2131,11 +2139,12 @@ fn test_filtered_view_omits_per_row_profile_tag() {
 
     // A filtered view names the profile in the list title, so the per-row
     // tag is redundant and must not be rendered.
+    let code = super::render::profile_short_code("alpha");
     for item in &view.flat_items {
         if let Item::Session { .. } = item {
             let text = rendered_row_text(&view, item);
             assert!(
-                !text.contains("[alpha]"),
+                !text.contains(&format!("[{code}]")),
                 "filtered view should not render a per-row profile tag: {text:?}"
             );
         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2217,6 +2217,100 @@ fn test_row_tag_profile_renders_in_filtered_view() {
     assert!(seen > 0);
 }
 
+/// `RowTagMode::Branch` complements the existing branch-on-divergence
+/// display rather than duplicating it: when `worktree.branch != title`
+/// the divergence display already shows the branch (in `theme.branch`
+/// color, earlier in the row), so the Branch tag suppresses itself to
+/// avoid showing the same information twice.
+#[test]
+#[serial]
+fn test_row_tag_branch_dedups_with_divergence_display() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage = Storage::new("alpha").unwrap();
+    // Title and branch DIFFER, so the existing divergence display
+    // would render the branch.
+    let mut inst = Instance::new("my-session", "/tmp/a");
+    inst.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "feature/foo".to_string(),
+        main_repo_path: "/tmp/a-main".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+    let instances = vec![inst];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage.commit(&instances, &group_tree).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Branch;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // No bracketed `[...]` tag on this row: divergence display owns the
+    // branch label here. The plain `feature/foo` from the divergence
+    // display is still expected in the rendered text.
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                !text.contains('['),
+                "Branch mode must suppress its tag when divergence display already shows the branch: {text:?}"
+            );
+            assert!(
+                text.contains("feature/foo"),
+                "the existing divergence display should still render: {text:?}"
+            );
+        }
+    }
+}
+
+/// `RowTagMode::Branch` DOES render the tag when title matches branch
+/// (the divergence display stays quiet, so the user would otherwise not
+/// know which branch this session is on).
+#[test]
+#[serial]
+fn test_row_tag_branch_renders_when_title_matches_branch() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage = Storage::new("alpha").unwrap();
+    // Title and branch MATCH, so the divergence display stays quiet.
+    let mut inst = Instance::new("feature/foo", "/tmp/a");
+    inst.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "feature/foo".to_string(),
+        main_repo_path: "/tmp/a-main".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+    let instances = vec![inst];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage.commit(&instances, &group_tree).unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Branch;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    // The tag uses the last `/`-segment of the branch, truncated to 8
+    // chars, so `feature/foo` becomes `[foo]`.
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                text.contains("[foo]"),
+                "Branch mode must render the tag when divergence display is quiet: {text:?}"
+            );
+        }
+    }
+}
+
 /// Legacy `Instance::new` left `source_profile` empty before the per-profile
 /// plumbing landed. The render branch must skip the tag entirely in that
 /// case rather than emit a literal `  []`.

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -93,6 +93,7 @@ pub enum FieldKey {
     StrictHotkeys,
     SnoozeDurationMinutes,
     RestartWakeMessage,
+    RowTag,
     AgentExtraArgs,
     AgentCommandOverride,
     AgentStatusHooks,
@@ -332,6 +333,33 @@ const LOG_LEVEL_OVERRIDE_OPTIONS: &[&str] =
     &["(default)", "trace", "debug", "info", "warn", "error"];
 const SINK_OPTIONS: &[&str] = &["file", "stdout"];
 const ROTATION_OPTIONS: &[&str] = &["size", "never"];
+
+/// Display labels for `RowTagMode` in the Settings picker. Order must match
+/// `row_tag_to_index` / `index_to_row_tag` so the index round-trips. `None`
+/// is first because it is the default; existing users see no tag.
+const ROW_TAG_OPTIONS: &[&str] = &["None", "Auto", "Profile", "Sandbox", "Branch"];
+
+fn row_tag_to_index(mode: crate::session::config::RowTagMode) -> usize {
+    use crate::session::config::RowTagMode::*;
+    match mode {
+        None => 0,
+        Auto => 1,
+        Profile => 2,
+        Sandbox => 3,
+        Branch => 4,
+    }
+}
+
+fn index_to_row_tag(idx: usize) -> crate::session::config::RowTagMode {
+    use crate::session::config::RowTagMode::*;
+    match idx {
+        1 => Auto,
+        2 => Profile,
+        3 => Sandbox,
+        4 => Branch,
+        _ => None,
+    }
+}
 
 fn level_index(level: &str, opts: &[&str]) -> usize {
     opts.iter().position(|&o| o == level).unwrap_or(0)
@@ -1453,6 +1481,12 @@ fn build_session_fields(
         session.and_then(|s| s.restart_wake_message.clone()),
     );
 
+    let (row_tag, row_tag_override) = resolve_value(
+        scope,
+        global.session.row_tag,
+        session.and_then(|s| s.row_tag),
+    );
+
     let (agent_status_hooks, status_hooks_override) = resolve_value(
         scope,
         global.session.agent_status_hooks,
@@ -1635,6 +1669,26 @@ fn build_session_fields(
             inherited_display: inherited_if(
                 restart_wake_message_override,
                 FieldValue::Text(global.session.restart_wake_message.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::RowTag,
+            label: "Row Tag",
+            description:
+                "What to show next to each session title: Auto (profile in all-profiles view), \
+                 None, Profile (always), Sandbox (sb on sandboxed rows), or Branch.",
+            value: FieldValue::Select {
+                selected: row_tag_to_index(row_tag),
+                options: ROW_TAG_OPTIONS.iter().map(|s| s.to_string()).collect(),
+            },
+            category: SettingsCategory::Session,
+            has_override: row_tag_override,
+            inherited_display: inherited_if(
+                row_tag_override,
+                FieldValue::Select {
+                    selected: row_tag_to_index(global.session.row_tag),
+                    options: ROW_TAG_OPTIONS.iter().map(|s| s.to_string()).collect(),
+                },
             ),
         },
         SettingField {
@@ -2186,6 +2240,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             config.session.restart_wake_message = v.clone();
         }
+        (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
+            config.session.row_tag = index_to_row_tag(*selected);
+        }
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             config.session.agent_status_hooks = *v;
         }
@@ -2646,6 +2703,13 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             set_profile_override(v.clone(), &mut config.session, |s, val| {
                 s.restart_wake_message = val
             });
+        }
+        (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
+            set_profile_override(
+                index_to_row_tag(*selected),
+                &mut config.session,
+                |s, val| s.row_tag = val,
+            );
         }
         (FieldKey::AgentStatusHooks, FieldValue::Bool(v)) => {
             set_profile_override(*v, &mut config.session, |s, val| {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -683,6 +683,11 @@ impl SettingsView {
                     s.restart_wake_message = None;
                 }
             }
+            FieldKey::RowTag => {
+                if let Some(ref mut s) = config.session {
+                    s.row_tag = None;
+                }
+            }
             FieldKey::AgentExtraArgs => {
                 if let Some(ref mut s) = config.session {
                     s.agent_extra_args = None;


### PR DESCRIPTION
## Description

In all-profiles view the session list title only shows `[all]`, so rows
from different profiles are visually indistinguishable: a session under one
profile looks identical to one under another. The active profile is named in
the title only when the view is filtered to a single profile.

This adds a dimmed per-row `[profile]` tag, shown only in all-profiles view:

- The tag is rendered in `render_item_line()` after the worktree branch and
  before the activity column, so its width is counted into `used_width` and
  the right-aligned activity column still lines up across rows.
- It is gated on `self.active_profile.is_none()` (all-profiles view). A
  filtered view already names the profile in the list title, so the per-row
  tag would be redundant there and is omitted.
- The tag reads `inst.source_profile`, which every instance already carries.
  No new struct fields, no migrations, and no agent-specific code.

It uses `theme.dimmed`, the same styling as the activity column and the sort
indicator, so it reads as secondary metadata rather than competing with the
session title.

**Testing**

2 new unit tests: one asserts every row in all-profiles view carries a tag
matching its `source_profile`, the other asserts a filtered view renders no
per-row tag. The full library suite (1718 tests) passes and
`cargo fmt --check` is clean. `cargo clippy` surfaces no new warnings from
this change.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Claude Opus 4.7)

**Any Additional AI Details you'd like to share:**
Implemented with Claude Code under the maintainer's direction and review.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than
copy/pasting reviewer comments into an AI and pasting back its answer. We want
to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-level changes
- Adds configurable per-row tags for session rows (new SessionConfig.row_tag with RowTagMode: None, Auto, Profile, Sandbox, Branch).
- Renders a dimmed, bracketed per-row tag (e.g. [ab]) inline after the worktree branch and before the activity column; tag width is included in layout so the right-aligned activity column stays aligned.
- Default behavior (Auto): show compact profile tag only in the all-profiles view; filters and named-profile views omit the per-row tag unless mode forces it (Profile).
- Tag values are derived from existing instance data (inst.source_profile) using a deterministic compacting function (profile_short_code) — no new persistent state or migrations required.
- Settings UI and per-profile overrides added so users can choose row-tag behavior globally or per-profile.

What moved/was added/removed
- New API/data:
  - SessionConfig.row_tag: RowTagMode enum (None, Auto, Profile, Sandbox, Branch).
  - Re-exported RowTagMode from session module.
  - SessionConfigOverride now accepts an optional row_tag override.
- Rendering:
  - Added compute_row_tag(inst, mode, in_all_profiles_view) -> Option<String>.
  - Added profile_short_code(profile: &str) -> String (multi-segment → initials, single-segment → first 3 chars, lowercase, max 4 chars, ignores empty segments).
  - HomeView caches resolved row_tag_mode; render_item_line made pub(super) and updated to render the optional tag and include its width in used_width.
- Settings/UI:
  - New RowTag picker in session settings, mapping between RowTagMode and picker indices; clearing overrides handled.
- Tests:
  - New and expanded TUI unit tests and helpers verifying tag rendering across modes, all-profiles vs filtered views, empty source_profile regression, and profile_short_code behavior.
- Minor public-surface change: added RowTagMode to module exports.

Benefits
- Improves at-a-glance identification of sessions originating from different profiles or contexts without adding persistent state.
- Keeps visual alignment stable by accounting for tag width.
- User-configurable and override-capable: users can opt in globally or per-profile and choose the tag source (profile, sandbox, branch, etc.).
- Covered by unit tests; author reports formatting/linting/test checks clean locally.

Technical notes / potential follow-ups
- profile_short_code behavior is deterministic and tested; collisions are possible and were discussed — consider a collision-resolution strategy if needed.
- render_item_line visibility was relaxed to pub(super) to support testing; review visibility choice for long-term encapsulation.
- Reviewers requested a rebase onto recent foundation fixes to resolve unrelated CI/doc issues (docs mismatch, residual em-dashes) before merge.
- Possible future enhancements: configurable short-code length/rules, explicit collision handling, extended Unicode/non-ASCII handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->