### PR TITLE
fix(cockpit): silent-orphan watchdog for adapter wedges

### DIFF
--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -29,6 +29,11 @@ class ShimAgent {
     if (preseed) {
       this.sessions.set(preseed, {});
     }
+    // Resolver used by the SILENT_ORPHAN test mode: prompt() parks on
+    // a Promise that the cancel() handler resolves so the test can
+    // assert the watchdog without waiting for CANCEL_ESCALATION_GRACE
+    // to elapse.
+    this._silentOrphanResolve = null;
   }
 
   async initialize(params) {
@@ -62,6 +67,41 @@ class ShimAgent {
       .filter((c) => c.type === "text")
       .map((c) => c.text)
       .join("\n");
+
+    // SILENT_ORPHAN reproduces the upstream
+    // `agentclientprotocol/claude-agent-acp#688` failure mode for the
+    // silent-orphan watchdog test in
+    // tests/cockpit_silent_orphan.rs. Sequence:
+    //   1. emit one assistant chunk
+    //   2. emit a cost-populated usage_update (claude-agent-acp's
+    //      "wrap up accounting" marker the daemon uses as a
+    //      terminal-candidate signal)
+    //   3. park until cancel() resolves the promise
+    // Without the cancel handler we'd hang the test for the full
+    // CANCEL_ESCALATION_GRACE; the explicit resolve keeps the test
+    // under a second while still exercising the watchdog. See #1240.
+    if (userText.includes("SILENT_ORPHAN")) {
+      await this.connection.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "wedged response complete" },
+        },
+      });
+      await this.connection.sessionUpdate({
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "usage_update",
+          input_tokens: 100,
+          output_tokens: 200,
+          cost: { amount: 0.01, currency: "USD" },
+        },
+      });
+      await new Promise((resolve) => {
+        this._silentOrphanResolve = resolve;
+      });
+      return { stopReason: "cancelled" };
+    }
 
     // Optional slow path: tests that need to observe mid-turn UI
     // (e.g. the working spinner) include "SLOW" in the prompt so the
@@ -236,7 +276,14 @@ class ShimAgent {
   }
 
   async cancel(_params) {
-    // Shim doesn't track cancellable work.
+    // Unstick the SILENT_ORPHAN park so prompt() returns and the
+    // daemon's prompt_fut resolves. Other prompt branches finish
+    // synchronously so this is a no-op for them.
+    if (this._silentOrphanResolve) {
+      const resolve = this._silentOrphanResolve;
+      this._silentOrphanResolve = null;
+      resolve();
+    }
   }
 }
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -754,7 +754,7 @@ finishes streaming a turn but never sends the JSON-RPC
 symptom is identical to the bug above (spinner stuck), but the cause
 is a protocol violation on the adapter side: the response was lost,
 not just delayed. Tracked upstream at
-`agentclientprotocol/claude-agent-acp#688`.
+[agentclientprotocol/claude-agent-acp#688](https://github.com/agentclientprotocol/claude-agent-acp/issues/688).
 
 When the daemon detects this, it sends `session/cancel`, waits the
 existing cancel-escalation grace (10s) for the adapter to respond,

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -783,7 +783,8 @@ timer, so an adapter that emits periodic ambient state after the
 final transcript event still trips the watchdog.
 
 Set `cockpit.silent_orphan_grace_secs = 0` to disable. Both knobs are
-editable per profile in the Settings UI under the Cockpit category.
+editable per profile in the TUI Settings (`Cockpit` category) and in
+the web dashboard's Settings tab under `Cockpit`.
 
 In debug builds, set `AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT=1`
 before sending a cockpit prompt to manually reproduce the wedge: the

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -160,6 +160,8 @@ node_path = ""
 show_tool_durations = true  # per-tool elapsed-time label in the web UI
 queue_drain_mode = "combined"  # how the composer drains client-side queued prompts: "combined" | "serial" (#1031)
 force_end_turn_threshold_secs = 30  # seconds of streaming silence before the spinner offers a "Force end turn" button (#1100)
+silent_orphan_grace_secs = 60  # daemon-side watchdog grace when the adapter stops talking with no in-flight tool; 0 disables (#1240)
+silent_orphan_fast_grace_secs = 20  # accelerated grace used once a cost-populated UsageUpdate has arrived for the current prompt (#1240)
 ```
 
 `max_concurrent_resumes` bounds how many cockpit workers the reconciler
@@ -743,6 +745,52 @@ threshold ("Waiting on tool… 1m 23s") so the wait is visible, but the
 button stays hidden so clicking it cannot discard the in-flight
 tool's progress. The escape hatch is reserved for a silent model with
 no tool running. See #1176.
+
+### Silent-orphan watchdog
+
+The cockpit daemon also watches for the case where the agent adapter
+finishes streaming a turn but never sends the JSON-RPC
+`PromptResponse` that closes out `session/prompt`. The user-visible
+symptom is identical to the bug above (spinner stuck), but the cause
+is a protocol violation on the adapter side: the response was lost,
+not just delayed. Tracked upstream at
+`agentclientprotocol/claude-agent-acp#688`.
+
+When the daemon detects this, it sends `session/cancel`, waits the
+existing cancel-escalation grace (10s) for the adapter to respond,
+then SIGTERMs the runner and respawns via `session/load` so the
+transcript is preserved. The web UI shows a distinct banner ("Agent
+finished but didn't notify the daemon. Restarting worker; your
+transcript will be preserved.") so the user can tell this apart from
+the cancel-escalation path (`agent_unresponsive`). See #1240.
+
+The detector fires only when ALL hold for the current prompt:
+- `tool_calls_in_flight` is empty (no open tool call; long-running
+  npm install / Playwright / Task subagent runs are never affected
+  because their tool stays open until done).
+- At least one progress notification has already arrived for this
+  prompt (avoids false-firing on a slow first chunk).
+- No further progress notification has arrived for
+  `silent_orphan_grace_secs` (default 60), reduced to
+  `silent_orphan_fast_grace_secs` (default 20) for the rest of the
+  prompt once a cost-populated `UsageUpdate` has arrived. The
+  accelerated path lowers MTTR on the specific claude-agent-acp
+  failure shape without weakening the vendor-agnostic baseline.
+
+Out-of-band notifications (mode changes, available_commands_update,
+rate limit, usage updates without cost) explicitly do NOT reset the
+timer, so an adapter that emits periodic ambient state after the
+final transcript event still trips the watchdog.
+
+Set `cockpit.silent_orphan_grace_secs = 0` to disable. Both knobs are
+editable per profile in the Settings UI under the Cockpit category.
+
+In debug builds, set `AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT=1`
+before sending a cockpit prompt to manually reproduce the wedge: the
+daemon will discard the next prompt response, the watchdog will fire
+within the configured grace, and you can verify the end-to-end UX
+(banner, lockdown, SIGTERM, respawn). The env var is single-shot
+(cleared after one use) and compiled out in release builds.
 
 ### Sharing debug logs
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -11,7 +11,7 @@
 //! initialize once, create one ACP session, then pump commands from an
 //! mpsc channel into ACP requests until shutdown.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
@@ -250,6 +250,90 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// daemon waits. See #1196.
 const CANCEL_ESCALATION_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
+/// Vendor-agnostic silent-orphan grace fallback used when no config
+/// value is available. Mirrors `CockpitConfig::silent_orphan_grace_secs`
+/// default. See `silent_orphan_grace()`.
+const SILENT_ORPHAN_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Accelerated silent-orphan grace fallback used when a cost-populated
+/// `UsageUpdate` notification has arrived for the current prompt. The
+/// daemon treats that frame as claude-agent-acp's "wrap up accounting"
+/// terminal-candidate marker emitted just before `PromptResponse`;
+/// when the prompt response then fails to arrive, recovery doesn't
+/// need the full vendor-agnostic grace. Mirrors
+/// `CockpitConfig::silent_orphan_fast_grace_secs` default. See
+/// `silent_orphan_fast_grace()`.
+const SILENT_ORPHAN_FAST_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from_secs(20);
+
+/// Cadence at which the silent-orphan select arm wakes up to evaluate
+/// whether the watchdog should fire. Polling cadence rather than reset-
+/// on-signal so the prompt loop owns the timer without needing the
+/// notification handler to reach back into a pinned `tokio::time::sleep`.
+const SILENT_ORPHAN_CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Classification of an inbound ACP `SessionUpdate` for the silent-
+/// orphan watchdog state machine. Sent from the notification handler
+/// to the prompt loop via a dedicated mpsc; the prompt loop owns the
+/// `Instant`-based timers and the tool-id set, so the handler doesn't
+/// need to touch shared atomics on the hot path.
+#[derive(Debug, Clone)]
+enum LifecycleSignal {
+    /// Transcript-producing event that resets the silent-orphan timer:
+    /// `AgentMessageChunk`, `AgentThoughtChunk`, `Plan`, or a
+    /// non-terminal `ToolCallUpdate` other than `InProgress`.
+    Progress,
+    /// A new tool call has started (`SessionUpdate::ToolCall`) or
+    /// transitioned to `InProgress` (`ToolCallUpdate`). Added to the
+    /// prompt-loop's `tool_calls_in_flight` set; while non-empty, the
+    /// watchdog stays suppressed so long-running tools (npm install,
+    /// Playwright runs, Task subagents) never false-positive.
+    ToolStarted(String),
+    /// A tool call reached terminal status (`Completed` or `Failed`).
+    /// Removed from `tool_calls_in_flight`; when the set drains to
+    /// empty after at least one progress event, the watchdog arms.
+    ToolCompleted(String),
+    /// Cost-populated `UsageUpdate`: claude-agent-acp's "wrap up
+    /// accounting" marker. Switches the effective grace from the
+    /// vendor-agnostic default to the accelerated value for this
+    /// prompt only. Does NOT count as progress (it's accounting
+    /// telemetry, not lifecycle), so the silent-orphan timer keeps
+    /// running from the previous progress event.
+    TerminalUsage,
+}
+
+/// Classify a `SessionUpdate` into a `LifecycleSignal`, or `None` for
+/// ambient state (mode changes, available_commands, raw metadata,
+/// usage-without-cost) that shouldn't influence the silent-orphan
+/// watchdog timer. Out-of-band notifications must NOT reset the timer:
+/// claude-agent-acp can interleave mode and command refreshes mid-turn
+/// or after final accounting, and treating those as progress would
+/// mask the exact wedge the watchdog is designed to detect. See #1240.
+fn classify_lifecycle_signal(
+    update: &agent_client_protocol::schema::SessionUpdate,
+) -> Option<LifecycleSignal> {
+    use agent_client_protocol::schema::{SessionUpdate, ToolCallStatus};
+    match update {
+        SessionUpdate::UsageUpdate(u) if u.cost.is_some() => Some(LifecycleSignal::TerminalUsage),
+        SessionUpdate::AgentMessageChunk(_)
+        | SessionUpdate::AgentThoughtChunk(_)
+        | SessionUpdate::Plan(_) => Some(LifecycleSignal::Progress),
+        SessionUpdate::ToolCall(tc) => {
+            Some(LifecycleSignal::ToolStarted(tc.tool_call_id.0.to_string()))
+        }
+        SessionUpdate::ToolCallUpdate(update) => {
+            let id = update.tool_call_id.0.to_string();
+            match update.fields.status {
+                Some(ToolCallStatus::Completed) | Some(ToolCallStatus::Failed) => {
+                    Some(LifecycleSignal::ToolCompleted(id))
+                }
+                Some(ToolCallStatus::InProgress) => Some(LifecycleSignal::ToolStarted(id)),
+                _ => Some(LifecycleSignal::Progress),
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Monotonic counter appended to synthetic tool-call IDs so two events
 /// minted within the same millisecond don't collide on the
 /// `(session_id, tool_id)` keys used by the cockpit event store.
@@ -270,6 +354,59 @@ fn resume_idle_grace() -> std::time::Duration {
         }
     }
     RESUME_IDLE_GRACE_DEFAULT
+}
+
+/// Read the silent-orphan watchdog grace. In debug builds, honors
+/// `AOE_SILENT_ORPHAN_GRACE_MS` so the integration test can drive a
+/// sub-second cadence without making real failures racy. Otherwise
+/// reads `cockpit.silent_orphan_grace_secs` from the user's config,
+/// falling back to `SILENT_ORPHAN_GRACE_DEFAULT`. A value of `0`
+/// means "disabled" and the caller skips the watchdog entirely; for
+/// non-zero values smaller than 10s, clamps up so a typo can't
+/// produce an absurdly tight grace that false-positives on healthy
+/// turns.
+fn silent_orphan_grace() -> std::time::Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(raw) = std::env::var("AOE_SILENT_ORPHAN_GRACE_MS") {
+        if let Ok(ms) = raw.parse::<u64>() {
+            if ms == 0 {
+                return std::time::Duration::ZERO;
+            }
+            return std::time::Duration::from_millis(ms);
+        }
+    }
+    match crate::session::load_config() {
+        Ok(Some(cfg)) => {
+            let secs = cfg.cockpit.silent_orphan_grace_secs;
+            if secs == 0 {
+                std::time::Duration::ZERO
+            } else {
+                std::time::Duration::from_secs(u64::from(secs).max(10))
+            }
+        }
+        _ => SILENT_ORPHAN_GRACE_DEFAULT,
+    }
+}
+
+/// Read the accelerated silent-orphan grace. Same env-var override
+/// pattern as `silent_orphan_grace`; reads
+/// `cockpit.silent_orphan_fast_grace_secs` from config with a 5s
+/// minimum clamp on non-zero values. Only consulted by the prompt
+/// loop when `silent_orphan_grace()` is non-zero.
+fn silent_orphan_fast_grace() -> std::time::Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(raw) = std::env::var("AOE_SILENT_ORPHAN_FAST_GRACE_MS") {
+        if let Ok(ms) = raw.parse::<u64>() {
+            return std::time::Duration::from_millis(ms.max(100));
+        }
+    }
+    match crate::session::load_config() {
+        Ok(Some(cfg)) => {
+            let secs = cfg.cockpit.silent_orphan_fast_grace_secs;
+            std::time::Duration::from_secs(u64::from(secs).max(5))
+        }
+        _ => SILENT_ORPHAN_FAST_GRACE_DEFAULT,
+    }
 }
 
 /// Resolution channel + the option set the agent offered. Stored in the
@@ -2143,6 +2280,18 @@ async fn run_connection_task<W, R>(
     let pending_for_perm = pending_responders.clone();
     let mut cmd_rx = cmd_rx;
     let session_label_for_log = session_label.clone();
+
+    // Silent-orphan watchdog plumbing. The notification handler
+    // classifies each inbound `SessionUpdate` into a `LifecycleSignal`
+    // (or `None` for ambient state like mode/available_commands) and
+    // sends it over a dedicated mpsc to the prompt loop, which owns the
+    // `Instant` timers and the `HashSet` of in-flight tool ids. Keeping
+    // the timer state inside the prompt loop avoids the cross-task
+    // contention of a shared atomic and scopes liveness cleanly to the
+    // current prompt. See #1240.
+    let (lifecycle_signal_tx, lifecycle_signal_rx) = mpsc::channel::<LifecycleSignal>(128);
+    let lifecycle_signal_tx_for_notif = lifecycle_signal_tx.clone();
+    let mut lifecycle_signal_rx = lifecycle_signal_rx;
     let res_read = resources.clone();
     let res_write = resources.clone();
     let res_term_create = resources.clone();
@@ -2190,10 +2339,21 @@ async fn run_connection_task<W, R>(
                 let suppress = suppress_for_notif.clone();
                 let session_label = session_label_for_notif.clone();
                 let last_event_at = last_event_at_for_notif.clone();
+                let lifecycle_signal_tx = lifecycle_signal_tx_for_notif.clone();
                 async move {
                     last_event_at
                         .store(chrono::Utc::now().timestamp_millis(), Ordering::Relaxed);
                     let suppressing = suppress.load(Ordering::Relaxed);
+                    // Classify before consuming `notification.update` in
+                    // the event mapping below; emit only when we're not
+                    // in the post-load history-replay window so stale
+                    // chunks from a prior turn can't influence the
+                    // current prompt's silent-orphan state machine.
+                    let lifecycle_signal = if suppressing {
+                        None
+                    } else {
+                        classify_lifecycle_signal(&notification.update)
+                    };
                     for event in map_update_to_events(notification.update, profile) {
                         // During the post-load replay window, drop only
                         // events that would reproduce the prior turns'
@@ -2214,6 +2374,21 @@ async fn run_connection_task<W, R>(
                         }
                         if event_tx.send(event).await.is_err() {
                             break;
+                        }
+                    }
+                    if let Some(sig) = lifecycle_signal {
+                        // Non-blocking try_send: if the prompt loop is
+                        // already in the middle of a watchdog escalation
+                        // the channel could backpressure; dropping a
+                        // signal is safer than blocking the notification
+                        // handler since the watchdog is itself a
+                        // recovery mechanism.
+                        if lifecycle_signal_tx.try_send(sig).is_err() {
+                            trace!(
+                                target: "cockpit.acp",
+                                session = %session_label,
+                                "lifecycle signal channel full or closed; dropping"
+                            );
                         }
                     }
                     Ok(())
@@ -2581,6 +2756,42 @@ async fn run_connection_task<W, R>(
                         // we serialise the loop on the prompt's await, the
                         // cancel sits idle in the channel and only goes
                         // out after the turn already finished.
+                        // Drain any lifecycle signals left over from the
+                        // previous prompt before resetting state. Stale
+                        // ToolStarted entries from a prior turn would
+                        // suppress the watchdog on this turn; stale
+                        // TerminalUsage would accelerate it. Drop them.
+                        while lifecycle_signal_rx.try_recv().is_ok() {}
+
+                        // Per-prompt silent-orphan state machine. All
+                        // fields reset each prompt; signals from prior
+                        // prompts are drained above. The watchdog stays
+                        // disarmed until `saw_first_progress` becomes
+                        // true (some progress notification arrived for
+                        // this turn) AND `tool_calls_in_flight` is
+                        // empty (no open tool to legitimately be
+                        // silent for), at which point it counts down
+                        // `effective_grace` from `last_progress_at`.
+                        // `cost_seen` lowers `effective_grace` from
+                        // the vendor-agnostic default to the
+                        // accelerated value when claude-agent-acp's
+                        // "wrap up accounting" marker arrives. See
+                        // #1240.
+                        let mut tool_calls_in_flight: HashSet<String> = HashSet::new();
+                        let mut last_progress_at: Option<tokio::time::Instant> = None;
+                        let mut saw_first_progress = false;
+                        let mut cost_seen = false;
+                        let mut orphan_cancel_sent = false;
+                        let mut prompt_orphaned = false;
+
+                        let silent_orphan_grace_default = silent_orphan_grace();
+                        let silent_orphan_grace_fast = silent_orphan_fast_grace();
+                        let silent_orphan_enabled =
+                            silent_orphan_grace_default > std::time::Duration::ZERO;
+                        let silent_orphan_check =
+                            tokio::time::sleep(SILENT_ORPHAN_CHECK_INTERVAL);
+                        tokio::pin!(silent_orphan_check);
+
                         let prompt_fut = connection
                             .send_request(PromptRequest::new(
                                 acp_session_id.clone(),
@@ -2588,6 +2799,36 @@ async fn run_connection_task<W, R>(
                             ))
                             .block_task();
                         tokio::pin!(prompt_fut);
+
+                        // Debug-only fault injection: when this env var
+                        // is set, the prompt_fut select arm is gated
+                        // off so the response is never observed even
+                        // if it arrives. The silent-orphan watchdog
+                        // must then fire to break the loop, which is
+                        // the entire point of the manual repro recipe
+                        // for #1240. Single-shot: the env var is
+                        // cleared after first read so subsequent
+                        // prompts are healthy. Release builds set
+                        // this to `false` const and the prompt_fut
+                        // arm is unconditionally polled.
+                        #[cfg(debug_assertions)]
+                        let simulate_orphan = {
+                            let on = std::env::var("AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT")
+                                .ok()
+                                .as_deref()
+                                == Some("1");
+                            if on {
+                                warn!(
+                                    target: "cockpit.acp",
+                                    session = %session_label,
+                                    "AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT set; suppressing prompt_fut completion to trigger silent-orphan watchdog"
+                                );
+                                std::env::remove_var("AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT");
+                            }
+                            on
+                        };
+                        #[cfg(not(debug_assertions))]
+                        let simulate_orphan = false;
 
                         let mut shutdown = false;
                         // Cancel-escalation watchdog. The first
@@ -2613,7 +2854,7 @@ async fn run_connection_task<W, R>(
 
                         loop {
                             tokio::select! {
-                                res = &mut prompt_fut => {
+                                res = &mut prompt_fut, if !simulate_orphan => {
                                     match res {
                                         Ok(_) => {}
                                         Err(e) => {
@@ -2647,6 +2888,109 @@ async fn run_connection_task<W, R>(
                                         }
                                     }
                                     break;
+                                }
+                                sig = lifecycle_signal_rx.recv() => {
+                                    match sig {
+                                        Some(LifecycleSignal::Progress) => {
+                                            saw_first_progress = true;
+                                            last_progress_at = Some(tokio::time::Instant::now());
+                                            // A progress event after
+                                            // terminal usage means the
+                                            // turn isn't actually
+                                            // wrapping up; clear the
+                                            // accelerator so the next
+                                            // window uses the full
+                                            // vendor-agnostic grace.
+                                            cost_seen = false;
+                                        }
+                                        Some(LifecycleSignal::ToolStarted(id)) => {
+                                            saw_first_progress = true;
+                                            tool_calls_in_flight.insert(id);
+                                            last_progress_at = Some(tokio::time::Instant::now());
+                                            cost_seen = false;
+                                        }
+                                        Some(LifecycleSignal::ToolCompleted(id)) => {
+                                            tool_calls_in_flight.remove(&id);
+                                            last_progress_at = Some(tokio::time::Instant::now());
+                                            cost_seen = false;
+                                        }
+                                        Some(LifecycleSignal::TerminalUsage) => {
+                                            // Don't touch
+                                            // `last_progress_at`: cost
+                                            // is accounting, not
+                                            // progress. The watchdog
+                                            // measures elapsed time
+                                            // since the last real
+                                            // transcript event; this
+                                            // signal only changes the
+                                            // grace value.
+                                            cost_seen = true;
+                                        }
+                                        None => {
+                                            // sender dropped; ignore
+                                        }
+                                    }
+                                }
+                                _ = &mut silent_orphan_check,
+                                    if silent_orphan_enabled && !orphan_cancel_sent =>
+                                {
+                                    let now = tokio::time::Instant::now();
+                                    let effective_grace = if cost_seen {
+                                        silent_orphan_grace_fast
+                                    } else {
+                                        silent_orphan_grace_default
+                                    };
+                                    let elapsed = last_progress_at
+                                        .map(|t| now.duration_since(t));
+                                    let should_fire = saw_first_progress
+                                        && tool_calls_in_flight.is_empty()
+                                        && elapsed
+                                            .map(|d| d >= effective_grace)
+                                            .unwrap_or(false);
+                                    if should_fire {
+                                        warn!(
+                                            target: "cockpit.acp",
+                                            session = %session_label,
+                                            cost_seen,
+                                            grace_secs = effective_grace.as_secs(),
+                                            elapsed_secs = elapsed.map(|d| d.as_secs()).unwrap_or(0),
+                                            "silent-orphan watchdog fired: no progress past grace and no in-flight tools; sending session/cancel"
+                                        );
+                                        // Best-effort cancel; reuse
+                                        // existing escalation path. If
+                                        // the adapter resolves within
+                                        // CANCEL_ESCALATION_GRACE the
+                                        // prompt_fut arm wins; if not,
+                                        // the cancel_grace arm fires
+                                        // and we synthesize Stopped
+                                        // with reason "prompt_orphaned".
+                                        if let Err(err) = connection.send_notification(
+                                            CancelNotification::new(acp_session_id.clone()),
+                                        ) {
+                                            warn!(
+                                                target: "cockpit.acp",
+                                                session = %session_label,
+                                                error = %err,
+                                                "silent-orphan: session/cancel send failed; escalating immediately"
+                                            );
+                                            prompt_orphaned = true;
+                                            shutdown = true;
+                                            break;
+                                        }
+                                        orphan_cancel_sent = true;
+                                        prompt_orphaned = true;
+                                        if !cancelling {
+                                            cancelling = true;
+                                            cancel_grace.as_mut().reset(
+                                                tokio::time::Instant::now()
+                                                    + CANCEL_ESCALATION_GRACE,
+                                            );
+                                        }
+                                    }
+                                    silent_orphan_check.as_mut().reset(
+                                        tokio::time::Instant::now()
+                                            + SILENT_ORPHAN_CHECK_INTERVAL,
+                                    );
                                 }
                                 _ = &mut cancel_grace, if cancelling => {
                                     warn!(
@@ -2795,8 +3139,25 @@ async fn run_connection_task<W, R>(
                         // Consumers (reducer, persisted status) need a single
                         // turn-end event per turn or they sit on a stale
                         // "in flight" state forever.
+                        //
+                        // Reason precedence:
+                        //   - `rate_limited` wins because it's a typed
+                        //     non-crash signal from prompt_fut Err; the
+                        //     drain task short-circuits respawn on it
+                        //     (#1281), so collapsing it into a generic
+                        //     reason would burn restart budget.
+                        //   - `prompt_orphaned` next because the
+                        //     silent-orphan path is the proximate cause;
+                        //     if the cancel-escalation watchdog then
+                        //     fires it's a downstream effect of the same
+                        //     wedge, and collapsing both into
+                        //     "agent_unresponsive" would lose the
+                        //     failure signature in postmortems. See
+                        //     #1240.
                         let reason = if rate_limited {
                             "rate_limited"
+                        } else if prompt_orphaned {
+                            "prompt_orphaned"
                         } else if agent_unresponsive {
                             "agent_unresponsive"
                         } else if shutdown {

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -356,16 +356,31 @@ fn resume_idle_grace() -> std::time::Duration {
     RESUME_IDLE_GRACE_DEFAULT
 }
 
-/// Read the silent-orphan watchdog grace. In debug builds, honors
-/// `AOE_SILENT_ORPHAN_GRACE_MS` so the integration test can drive a
-/// sub-second cadence without making real failures racy. Otherwise
-/// reads `cockpit.silent_orphan_grace_secs` from the user's config,
-/// falling back to `SILENT_ORPHAN_GRACE_DEFAULT`. A value of `0`
-/// means "disabled" and the caller skips the watchdog entirely; for
-/// non-zero values smaller than 10s, clamps up so a typo can't
-/// produce an absurdly tight grace that false-positives on healthy
-/// turns.
-fn silent_orphan_grace() -> std::time::Duration {
+/// Resolve the session's effective `CockpitConfig` so per-profile
+/// `silent_orphan_*` overrides set in the settings TUI actually apply
+/// at runtime. Returns `None` if no config exists yet (fresh install,
+/// pre-migration); the helpers fall back to constants in that case.
+fn resolved_cockpit_config(profile: Option<&str>) -> Option<crate::session::config::CockpitConfig> {
+    match profile {
+        Some(p) => Some(crate::session::profile_config::resolve_config_or_warn(p).cockpit),
+        None => crate::session::load_config()
+            .ok()
+            .flatten()
+            .map(|c| c.cockpit),
+    }
+}
+
+/// Read the silent-orphan watchdog grace for the given source profile.
+/// In debug builds, honors `AOE_SILENT_ORPHAN_GRACE_MS` so the
+/// integration test can drive a sub-second cadence without making
+/// real failures racy. Otherwise reads
+/// `cockpit.silent_orphan_grace_secs` from the profile-resolved
+/// config so per-profile overrides set in the settings TUI take
+/// effect. A value of `0` means "disabled" and the caller skips the
+/// watchdog entirely; non-zero values smaller than 10s clamp up so a
+/// typo can't produce an absurdly tight grace that false-positives
+/// on healthy turns.
+fn silent_orphan_grace(profile: Option<&str>) -> std::time::Duration {
     #[cfg(debug_assertions)]
     if let Ok(raw) = std::env::var("AOE_SILENT_ORPHAN_GRACE_MS") {
         if let Ok(ms) = raw.parse::<u64>() {
@@ -375,38 +390,60 @@ fn silent_orphan_grace() -> std::time::Duration {
             return std::time::Duration::from_millis(ms);
         }
     }
-    match crate::session::load_config() {
-        Ok(Some(cfg)) => {
-            let secs = cfg.cockpit.silent_orphan_grace_secs;
+    match resolved_cockpit_config(profile) {
+        Some(cockpit) => {
+            let secs = cockpit.silent_orphan_grace_secs;
             if secs == 0 {
                 std::time::Duration::ZERO
             } else {
                 std::time::Duration::from_secs(u64::from(secs).max(10))
             }
         }
-        _ => SILENT_ORPHAN_GRACE_DEFAULT,
+        None => SILENT_ORPHAN_GRACE_DEFAULT,
     }
 }
 
-/// Read the accelerated silent-orphan grace. Same env-var override
-/// pattern as `silent_orphan_grace`; reads
-/// `cockpit.silent_orphan_fast_grace_secs` from config with a 5s
-/// minimum clamp on non-zero values. Only consulted by the prompt
-/// loop when `silent_orphan_grace()` is non-zero.
-fn silent_orphan_fast_grace() -> std::time::Duration {
+/// Read the accelerated silent-orphan grace for the given source
+/// profile. Same env-var override pattern as `silent_orphan_grace`;
+/// reads `cockpit.silent_orphan_fast_grace_secs` from the profile-
+/// resolved config. A value of `0` disables the accelerator: the
+/// watchdog keeps using the default grace even after a cost-populated
+/// `UsageUpdate` arrives. Non-zero values smaller than 5s clamp up.
+fn silent_orphan_fast_grace(profile: Option<&str>) -> std::time::Duration {
     #[cfg(debug_assertions)]
     if let Ok(raw) = std::env::var("AOE_SILENT_ORPHAN_FAST_GRACE_MS") {
         if let Ok(ms) = raw.parse::<u64>() {
+            if ms == 0 {
+                return std::time::Duration::ZERO;
+            }
             return std::time::Duration::from_millis(ms.max(100));
         }
     }
-    match crate::session::load_config() {
-        Ok(Some(cfg)) => {
-            let secs = cfg.cockpit.silent_orphan_fast_grace_secs;
-            std::time::Duration::from_secs(u64::from(secs).max(5))
+    match resolved_cockpit_config(profile) {
+        Some(cockpit) => {
+            let secs = cockpit.silent_orphan_fast_grace_secs;
+            if secs == 0 {
+                std::time::Duration::ZERO
+            } else {
+                std::time::Duration::from_secs(u64::from(secs).max(5))
+            }
         }
-        _ => SILENT_ORPHAN_FAST_GRACE_DEFAULT,
+        None => SILENT_ORPHAN_FAST_GRACE_DEFAULT,
     }
+}
+
+/// Read the silent-orphan polling cadence. Constant in production;
+/// tunable in debug builds via `AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS`
+/// so the disabled-path integration test can verify the watchdog
+/// stays silent without waiting a full polling tick.
+fn silent_orphan_check_interval() -> std::time::Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(raw) = std::env::var("AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS") {
+        if let Ok(ms) = raw.parse::<u64>() {
+            return std::time::Duration::from_millis(ms.max(10));
+        }
+    }
+    SILENT_ORPHAN_CHECK_INTERVAL
 }
 
 /// Resolution channel + the option set the agent offered. Stored in the
@@ -589,6 +626,7 @@ impl AcpClient {
         let runner_sandbox = sandbox_pair.as_ref().map(|(handle, _)| handle);
         let profile = agent_profiles::resolve(&config.agent_key);
         let install_binary = config.spec.command.clone();
+        let source_profile_for_task = config.source_profile.clone();
         if let Some(socket_path) = config.socket_path.clone() {
             spawn_runner_detached(&config, &socket_path, session_id.0.clone(), runner_sandbox)?;
             return Self::connect_via_socket(
@@ -605,6 +643,7 @@ impl AcpClient {
                 sandbox_pair,
                 profile,
                 install_binary,
+                source_profile_for_task,
             )
             .await;
         }
@@ -625,6 +664,7 @@ impl AcpClient {
             sandbox_pair,
             profile,
             install_binary,
+            source_profile_for_task,
         )
         .await
     }
@@ -644,6 +684,7 @@ impl AcpClient {
         sandbox: Option<(SessionSandbox, SandboxPathMap)>,
         profile: &'static agent_profiles::AgentProfile,
         install_binary: String,
+        source_profile: Option<String>,
     ) -> Result<Self, AcpError> {
         let (stdin, stdout) = {
             let mut guard = child.lock().await;
@@ -696,6 +737,7 @@ impl AcpClient {
             mode,
             Some(ready_tx),
             profile,
+            source_profile,
         ));
 
         wait_for_handshake(&session_label, ready_rx, Some(&child), &install_binary).await?;
@@ -730,6 +772,7 @@ impl AcpClient {
         sandbox: Option<(SessionSandbox, SandboxPathMap)>,
         profile: &'static agent_profiles::AgentProfile,
         install_binary: String,
+        source_profile: Option<String>,
     ) -> Result<Self, AcpError> {
         // Poll for the runner to finish binding the socket. The runner
         // binds before it spawns the agent so this is usually fast (a
@@ -774,6 +817,7 @@ impl AcpClient {
             mode,
             Some(ready_tx),
             profile,
+            source_profile,
         ));
 
         wait_for_handshake(&session_label, ready_rx, None, &install_binary).await?;
@@ -818,6 +862,7 @@ impl AcpClient {
         session_id: CockpitSessionId,
         sandbox: Option<(SessionSandbox, SandboxPathMap)>,
         agent_key: String,
+        source_profile: Option<String>,
     ) -> Result<Self, AcpError> {
         let (cmd_tx, cmd_rx) = mpsc::channel::<ClientCmd>(16);
         let (event_tx, event_rx) = mpsc::channel::<Event>(64);
@@ -845,6 +890,7 @@ impl AcpClient {
             sandbox,
             profile,
             String::new(),
+            source_profile,
         )
         .await
     }
@@ -2266,6 +2312,7 @@ async fn run_connection_task<W, R>(
     mode: ConnectMode,
     ready_tx: Option<oneshot::Sender<Result<(), AcpError>>>,
     profile: &'static agent_profiles::AgentProfile,
+    source_profile: Option<String>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
     R: futures_util::AsyncRead + Send + 'static,
@@ -2784,12 +2831,15 @@ async fn run_connection_task<W, R>(
                         let mut orphan_cancel_sent = false;
                         let mut prompt_orphaned = false;
 
-                        let silent_orphan_grace_default = silent_orphan_grace();
-                        let silent_orphan_grace_fast = silent_orphan_fast_grace();
+                        let silent_orphan_grace_default =
+                            silent_orphan_grace(source_profile.as_deref());
+                        let silent_orphan_grace_fast =
+                            silent_orphan_fast_grace(source_profile.as_deref());
                         let silent_orphan_enabled =
                             silent_orphan_grace_default > std::time::Duration::ZERO;
+                        let silent_orphan_check_period = silent_orphan_check_interval();
                         let silent_orphan_check =
-                            tokio::time::sleep(SILENT_ORPHAN_CHECK_INTERVAL);
+                            tokio::time::sleep(silent_orphan_check_period);
                         tokio::pin!(silent_orphan_check);
 
                         let prompt_fut = connection
@@ -2935,7 +2985,15 @@ async fn run_connection_task<W, R>(
                                     if silent_orphan_enabled && !orphan_cancel_sent =>
                                 {
                                     let now = tokio::time::Instant::now();
-                                    let effective_grace = if cost_seen {
+                                    // When `silent_orphan_fast_grace_secs = 0`
+                                    // the accelerator is disabled even after
+                                    // a cost-populated UsageUpdate; fall back
+                                    // to the default grace instead of an
+                                    // unbounded ZERO duration. See #1240
+                                    // CodeRabbit feedback.
+                                    let effective_grace = if cost_seen
+                                        && silent_orphan_grace_fast > std::time::Duration::ZERO
+                                    {
                                         silent_orphan_grace_fast
                                     } else {
                                         silent_orphan_grace_default
@@ -2989,7 +3047,7 @@ async fn run_connection_task<W, R>(
                                     }
                                     silent_orphan_check.as_mut().reset(
                                         tokio::time::Instant::now()
-                                            + SILENT_ORPHAN_CHECK_INTERVAL,
+                                            + silent_orphan_check_period,
                                     );
                                 }
                                 _ = &mut cancel_grace, if cancelling => {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -875,12 +875,15 @@ impl<S: BroadcastSink> Supervisor<S> {
                 loop {
                     // Tracks whether the connection task ended because the
                     // cancel-escalation watchdog declared the agent
-                    // unresponsive (see acp_client.rs's CANCEL_ESCALATION_GRACE).
-                    // When true, the runner subprocess is alive but wedged
-                    // around a tool call the agent never cancelled, so the
-                    // supervisor must SIGTERM it before respawning;
-                    // otherwise the next `session/load` would attach to the
-                    // same wedged process. See #1196.
+                    // unresponsive (see acp_client.rs's CANCEL_ESCALATION_GRACE)
+                    // OR because the silent-orphan watchdog detected the
+                    // adapter dropped PromptResponse (see #1240). Both
+                    // failure modes need the same recovery: SIGTERM the
+                    // wedged runner before respawning so the next
+                    // `session/load` doesn't attach to the same wedged
+                    // process. The Stopped reason in the published event
+                    // preserves the distinction; this flag only gates the
+                    // local kill behavior.
                     let mut agent_unresponsive = false;
                     // Set when the connection task signals a non-crash exit
                     // due to a provider quota / rate-limit hit. The acp_client
@@ -897,7 +900,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                     let mut rate_limited = false;
                     while let Some(event) = inbound.recv().await {
                         if let Event::Stopped { reason } = &event {
-                            if reason == "agent_unresponsive" {
+                            if reason == "agent_unresponsive" || reason == "prompt_orphaned" {
                                 agent_unresponsive = true;
                             } else if reason == "rate_limited" {
                                 rate_limited = true;

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1596,6 +1596,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             cockpit_session_id,
             sandbox_resources,
             attach_agent_key,
+            record.source_profile.clone(),
         )
         .await?;
         super::worker_registry::mark_attached(&session_id);

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -269,6 +269,28 @@ pub struct CockpitConfig {
     /// `session/cancel` the agent. Default 30s.
     #[serde(default = "default_force_end_turn_threshold_secs")]
     pub force_end_turn_threshold_secs: u32,
+    /// Silent-orphan watchdog: vendor-agnostic correctness grace. When
+    /// a prompt is in flight, `tool_calls_in_flight` is empty, at least
+    /// one progress notification has arrived, and no further progress
+    /// arrives for this many seconds, the daemon sends best-effort
+    /// `session/cancel` and arms the existing cancel-escalation grace.
+    /// Closes the gap where claude-agent-acp finishes streaming but
+    /// never sends `PromptResponse` (upstream
+    /// agentclientprotocol/claude-agent-acp#688). Default 60s. `0`
+    /// disables the watchdog. Long-running tools are not affected; the
+    /// watchdog only fires when no in-flight tool call is open.
+    /// See #1240.
+    #[serde(default = "default_silent_orphan_grace_secs")]
+    pub silent_orphan_grace_secs: u32,
+    /// Silent-orphan watchdog: accelerated grace used when the current
+    /// prompt has already received a cost-populated `UsageUpdate`
+    /// notification (claude-agent-acp's "wrap up accounting" marker
+    /// emitted just before `PromptResponse`). Lowers MTTR on the known
+    /// adapter wedge without weakening the vendor-agnostic baseline.
+    /// Default 20s. If `silent_orphan_grace_secs` is 0 (disabled), this
+    /// has no effect. See #1240.
+    #[serde(default = "default_silent_orphan_fast_grace_secs")]
+    pub silent_orphan_fast_grace_secs: u32,
 }
 
 fn default_max_concurrent_resumes() -> u32 {
@@ -277,6 +299,14 @@ fn default_max_concurrent_resumes() -> u32 {
 
 fn default_force_end_turn_threshold_secs() -> u32 {
     30
+}
+
+fn default_silent_orphan_grace_secs() -> u32 {
+    60
+}
+
+fn default_silent_orphan_fast_grace_secs() -> u32 {
+    20
 }
 
 /// Drain strategy for the cockpit composer's client-side prompt queue.
@@ -326,6 +356,8 @@ impl Default for CockpitConfig {
             queue_drain_mode: QueueDrainMode::default(),
             max_concurrent_resumes: default_max_concurrent_resumes(),
             force_end_turn_threshold_secs: default_force_end_turn_threshold_secs(),
+            silent_orphan_grace_secs: default_silent_orphan_grace_secs(),
+            silent_orphan_fast_grace_secs: default_silent_orphan_fast_grace_secs(),
         }
     }
 }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -92,6 +92,10 @@ pub struct CockpitConfigOverride {
     pub max_concurrent_resumes: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub force_end_turn_threshold_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub silent_orphan_grace_secs: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub silent_orphan_fast_grace_secs: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -567,6 +571,12 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         }
         if let Some(v) = cockpit_override.force_end_turn_threshold_secs {
             global.cockpit.force_end_turn_threshold_secs = v;
+        }
+        if let Some(v) = cockpit_override.silent_orphan_grace_secs {
+            global.cockpit.silent_orphan_grace_secs = v;
+        }
+        if let Some(v) = cockpit_override.silent_orphan_fast_grace_secs {
+            global.cockpit.silent_orphan_fast_grace_secs = v;
         }
     }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -140,6 +140,8 @@ pub enum FieldKey {
     CockpitQueueDrainMode,
     CockpitMaxConcurrentResumes,
     CockpitForceEndTurnThresholdSecs,
+    CockpitSilentOrphanGraceSecs,
+    CockpitSilentOrphanFastGraceSecs,
     // Logging
     LoggingDefaultLevel,
     /// Per-target override; carries an index into `crate::logging::KNOWN_SUB_TARGETS`
@@ -520,6 +522,16 @@ fn build_cockpit_fields(
         global.cockpit.force_end_turn_threshold_secs,
         p.and_then(|c| c.force_end_turn_threshold_secs),
     );
+    let (silent_orphan_grace_secs, sog_override) = resolve_value(
+        scope,
+        global.cockpit.silent_orphan_grace_secs,
+        p.and_then(|c| c.silent_orphan_grace_secs),
+    );
+    let (silent_orphan_fast_grace_secs, sofg_override) = resolve_value(
+        scope,
+        global.cockpit.silent_orphan_fast_grace_secs,
+        p.and_then(|c| c.silent_orphan_fast_grace_secs),
+    );
 
     vec![
         SettingField {
@@ -625,6 +637,24 @@ fn build_cockpit_fields(
             value: FieldValue::Number(u64::from(force_end_turn_threshold_secs)),
             category: SettingsCategory::Cockpit,
             has_override: fet_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitSilentOrphanGraceSecs,
+            label: "Silent-orphan grace (s)",
+            description: "Daemon-side watchdog that detects when the agent finishes streaming but the adapter never resolves the session/prompt request. Fires after this many seconds of no progress notifications, when no in-flight tool call is open and the prompt has produced at least one progress event. On fire, sends best-effort session/cancel and reuses the existing cancel-escalation path to SIGTERM + session/load respawn. Default 60s. Set 0 to disable. Long-running tools are not affected (watchdog suppresses while any tool call is active). See #1240.",
+            value: FieldValue::Number(u64::from(silent_orphan_grace_secs)),
+            category: SettingsCategory::Cockpit,
+            has_override: sog_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitSilentOrphanFastGraceSecs,
+            label: "Silent-orphan fast grace (s)",
+            description: "Accelerated silent-orphan grace, used in place of the default once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. Default 20s. Only consulted when silent-orphan grace is enabled (non-zero). See #1240.",
+            value: FieldValue::Number(u64::from(silent_orphan_fast_grace_secs)),
+            category: SettingsCategory::Cockpit,
+            has_override: sofg_override,
             inherited_display: None,
         },
     ]
@@ -2289,6 +2319,16 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::CockpitForceEndTurnThresholdSecs, FieldValue::Number(v)) => {
             config.cockpit.force_end_turn_threshold_secs = (*v).max(1).min(u32::MAX as u64) as u32
         }
+        (FieldKey::CockpitSilentOrphanGraceSecs, FieldValue::Number(v)) => {
+            // 0 = disabled; anything 1..=9 clamps to 10 so a typo can't
+            // produce an absurdly tight grace that false-positives on
+            // healthy turns.
+            let raw = (*v).min(u32::MAX as u64) as u32;
+            config.cockpit.silent_orphan_grace_secs = if raw == 0 { 0 } else { raw.max(10) };
+        }
+        (FieldKey::CockpitSilentOrphanFastGraceSecs, FieldValue::Number(v)) => {
+            config.cockpit.silent_orphan_fast_grace_secs = (*v).max(5).min(u32::MAX as u64) as u32;
+        }
         // Logging
         (FieldKey::LoggingDefaultLevel, FieldValue::Select { selected, options }) => {
             if let Some(level) = options.get(*selected) {
@@ -2742,6 +2782,19 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             let clamped = (*v).max(1).min(u32::MAX as u64) as u32;
             set_profile_override(clamped, &mut config.cockpit, |s, val| {
                 s.force_end_turn_threshold_secs = val
+            });
+        }
+        (FieldKey::CockpitSilentOrphanGraceSecs, FieldValue::Number(v)) => {
+            let raw = (*v).min(u32::MAX as u64) as u32;
+            let clamped = if raw == 0 { 0 } else { raw.max(10) };
+            set_profile_override(clamped, &mut config.cockpit, |s, val| {
+                s.silent_orphan_grace_secs = val
+            });
+        }
+        (FieldKey::CockpitSilentOrphanFastGraceSecs, FieldValue::Number(v)) => {
+            let clamped = (*v).max(5).min(u32::MAX as u64) as u32;
+            set_profile_override(clamped, &mut config.cockpit, |s, val| {
+                s.silent_orphan_fast_grace_secs = val
             });
         }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => {

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -651,7 +651,7 @@ fn build_cockpit_fields(
         SettingField {
             key: FieldKey::CockpitSilentOrphanFastGraceSecs,
             label: "Silent-orphan fast grace (s)",
-            description: "Accelerated silent-orphan grace, used in place of the default once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. Default 20s. Only consulted when silent-orphan grace is enabled (non-zero). See #1240.",
+            description: "Accelerated silent-orphan grace, used in place of the default once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. Default 20s. Set 0 to disable the accelerator (cost UsageUpdate no longer reduces the effective grace). Only consulted when silent-orphan grace is enabled (non-zero). See #1240.",
             value: FieldValue::Number(u64::from(silent_orphan_fast_grace_secs)),
             category: SettingsCategory::Cockpit,
             has_override: sofg_override,
@@ -2327,7 +2327,12 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.cockpit.silent_orphan_grace_secs = if raw == 0 { 0 } else { raw.max(10) };
         }
         (FieldKey::CockpitSilentOrphanFastGraceSecs, FieldValue::Number(v)) => {
-            config.cockpit.silent_orphan_fast_grace_secs = (*v).max(5).min(u32::MAX as u64) as u32;
+            // 0 = disable the accelerator: cost-populated UsageUpdate
+            // no longer reduces the watchdog's effective grace. Anything
+            // 1..=4 clamps up to 5 so a typo can't produce an absurdly
+            // tight fast grace.
+            let raw = (*v).min(u32::MAX as u64) as u32;
+            config.cockpit.silent_orphan_fast_grace_secs = if raw == 0 { 0 } else { raw.max(5) };
         }
         // Logging
         (FieldKey::LoggingDefaultLevel, FieldValue::Select { selected, options }) => {
@@ -2792,7 +2797,8 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
             });
         }
         (FieldKey::CockpitSilentOrphanFastGraceSecs, FieldValue::Number(v)) => {
-            let clamped = (*v).max(5).min(u32::MAX as u64) as u32;
+            let raw = (*v).min(u32::MAX as u64) as u32;
+            let clamped = if raw == 0 { 0 } else { raw.max(5) };
             set_profile_override(clamped, &mut config.cockpit, |s, val| {
                 s.silent_orphan_fast_grace_secs = val
             });

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -898,6 +898,16 @@ impl SettingsView {
                     c.force_end_turn_threshold_secs = None;
                 }
             }
+            FieldKey::CockpitSilentOrphanGraceSecs => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.silent_orphan_grace_secs = None;
+                }
+            }
+            FieldKey::CockpitSilentOrphanFastGraceSecs => {
+                if let Some(c) = config.cockpit.as_mut() {
+                    c.silent_orphan_fast_grace_secs = None;
+                }
+            }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
             FieldKey::LoggingDefaultLevel

--- a/tests/cockpit_midturn_resume.rs
+++ b/tests/cockpit_midturn_resume.rs
@@ -141,6 +141,7 @@ async fn attach_in_flight_synthesizes_reattach_idle_stopped() {
         CockpitSessionId("midturn-true".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach in_flight=true");
@@ -180,6 +181,7 @@ async fn attach_idle_session_does_not_synthesize_stopped() {
         CockpitSessionId("midturn-false".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach in_flight=false");
@@ -227,6 +229,7 @@ async fn socket_transport_round_trips_prompt_via_attach() {
         CockpitSessionId("roundtrip".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach to bridge");

--- a/tests/cockpit_silent_orphan.rs
+++ b/tests/cockpit_silent_orphan.rs
@@ -1,0 +1,243 @@
+//! Daemon-side coverage for the silent-orphan watchdog (#1240). Stands
+//! up the existing Node test shim over a UNIX socket bridge, sends a
+//! `SILENT_ORPHAN` prompt that streams a chunk + cost-populated
+//! `usage_update` then parks (the upstream
+//! `agentclientprotocol/claude-agent-acp#688` failure mode), and
+//! asserts the daemon synthesizes `Stopped { reason: "prompt_orphaned" }`
+//! within the test grace window.
+//!
+//! Three cases:
+//!   1. positive: cost-populated usage_update + silence → orphan fires.
+//!   2. negative (tool open): a long-running tool keeps
+//!      `tool_calls_in_flight` non-empty → orphan must NOT fire.
+//!   3. disabled (grace = 0): watchdog skipped entirely → no orphan.
+//!
+//! Skipped automatically if `node` is missing.
+
+#![cfg(feature = "serve")]
+// Compiled only in debug builds because the watchdog grace is tunable
+// via `AOE_SILENT_ORPHAN_GRACE_MS` / `AOE_SILENT_ORPHAN_FAST_GRACE_MS`
+// only under `cfg(debug_assertions)`; release builds would wait the
+// full 60s production default.
+#![cfg(debug_assertions)]
+
+use std::path::PathBuf;
+use std::time::{Duration, Instant};
+
+use agent_of_empires::cockpit::acp_client::AcpClient;
+use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
+use serial_test::serial;
+use tokio::net::UnixListener;
+use tokio::process::Command;
+
+fn node_available() -> bool {
+    std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn shim_path() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest)
+        .join("cockpit-worker")
+        .join("test-shim")
+        .join("shim.mjs")
+}
+
+async fn spawn_shim_socket_bridge_with_preseed(
+    preseed_session_id: &str,
+) -> (PathBuf, tempfile::TempDir) {
+    let shim = shim_path();
+    let temp = tempfile::tempdir().unwrap();
+    let socket_path = temp.path().join("runner.sock");
+
+    let mut cmd = Command::new("node");
+    cmd.arg(&shim);
+    cmd.env("SHIM_PRESEED_SESSION_ID", preseed_session_id);
+    let mut shim_proc = cmd
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
+        .expect("spawn shim");
+    let shim_stdin = shim_proc.stdin.take().expect("shim stdin");
+    let shim_stdout = shim_proc.stdout.take().expect("shim stdout");
+
+    let listener = UnixListener::bind(&socket_path).expect("bind listener");
+
+    tokio::spawn(async move {
+        let _shim_proc = shim_proc;
+        let (stream, _) = match listener.accept().await {
+            Ok(pair) => pair,
+            Err(_) => return,
+        };
+        let (mut sock_read, mut sock_write) = stream.into_split();
+        let mut shim_in = shim_stdin;
+        let mut shim_out = shim_stdout;
+        let to_shim = async move { tokio::io::copy(&mut sock_read, &mut shim_in).await.ok() };
+        let from_shim = async move { tokio::io::copy(&mut shim_out, &mut sock_write).await.ok() };
+        let _ = tokio::join!(to_shim, from_shim);
+    });
+
+    (socket_path, temp)
+}
+
+async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> Option<String> {
+    while Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await {
+            Ok(Some(Event::Stopped { reason })) => return Some(reason),
+            Ok(Some(_)) => continue,
+            Ok(None) => return None,
+            Err(_) => continue,
+        }
+    }
+    None
+}
+
+#[tokio::test]
+#[serial]
+async fn silent_orphan_fires_on_cost_then_silence() {
+    if !node_available() || !shim_path().exists() {
+        eprintln!("skipping: node or shim missing");
+        return;
+    }
+
+    // Tight grace so the test completes inside a couple of seconds.
+    // The fast path is the one that should fire because the shim emits
+    // a cost-populated usage_update before parking.
+    std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "5000");
+    std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "300");
+
+    let preseed = "silent-orphan-positive";
+    let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
+
+    let client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        preseed.to_string(),
+        false,
+        CockpitSessionId("silent-orphan-positive".into()),
+        None,
+        "claude".into(),
+    )
+    .await
+    .expect("attach for silent-orphan positive test");
+
+    let mut client = client;
+    client
+        .send_prompt("SILENT_ORPHAN trigger")
+        .await
+        .expect("send prompt");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(5)).await;
+    let _ = client.shutdown().await;
+
+    assert_eq!(
+        stopped.as_deref(),
+        Some("prompt_orphaned"),
+        "silent-orphan watchdog must synthesize Stopped {{ reason: prompt_orphaned }} when the adapter parks after cost-populated UsageUpdate"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn silent_orphan_suppressed_during_normal_turn() {
+    if !node_available() || !shim_path().exists() {
+        eprintln!("skipping: node or shim missing");
+        return;
+    }
+
+    // Generous enough grace that the shim's healthy tool round-trip
+    // completes long before the watchdog could fire; we then assert
+    // the only Stopped we see is prompt_complete, not prompt_orphaned.
+    std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "10000");
+    std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "10000");
+
+    let preseed = "silent-orphan-negative";
+    let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
+
+    let client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        preseed.to_string(),
+        false,
+        CockpitSessionId("silent-orphan-negative".into()),
+        None,
+        "claude".into(),
+    )
+    .await
+    .expect("attach for silent-orphan negative test");
+
+    let mut client = client;
+    // No SILENT_ORPHAN keyword: the shim's default prompt() runs the
+    // healthy chunk + tool_call + tool_call_update + chunk sequence
+    // and returns stopReason=end_turn. The watchdog must stay silent
+    // and the natural prompt_complete must win.
+    client
+        .send_prompt("normal turn")
+        .await
+        .expect("send prompt");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(5)).await;
+    let _ = client.shutdown().await;
+
+    assert_eq!(
+        stopped.as_deref(),
+        Some("prompt_complete"),
+        "silent-orphan watchdog must stay disarmed on a normal turn; saw {stopped:?}"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn silent_orphan_disabled_by_zero_grace() {
+    if !node_available() || !shim_path().exists() {
+        eprintln!("skipping: node or shim missing");
+        return;
+    }
+
+    // `0` disables the watchdog entirely. With the shim parked on
+    // SILENT_ORPHAN we'd otherwise see prompt_orphaned within a few
+    // hundred milliseconds; instead we should see no Stopped frame at
+    // all within the deadline, because nothing else fires.
+    std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "0");
+    std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "200");
+
+    let preseed = "silent-orphan-disabled";
+    let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
+
+    let client = AcpClient::attach(
+        socket_path,
+        std::env::temp_dir(),
+        vec![],
+        preseed.to_string(),
+        false,
+        CockpitSessionId("silent-orphan-disabled".into()),
+        None,
+        "claude".into(),
+    )
+    .await
+    .expect("attach for silent-orphan disabled test");
+
+    let mut client = client;
+    client
+        .send_prompt("SILENT_ORPHAN trigger")
+        .await
+        .expect("send prompt");
+
+    let stopped =
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(2)).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        stopped.is_none(),
+        "silent-orphan watchdog must stay fully disarmed when grace = 0; saw Stopped reason={stopped:?}"
+    );
+}

--- a/tests/cockpit_silent_orphan.rs
+++ b/tests/cockpit_silent_orphan.rs
@@ -107,9 +107,12 @@ async fn silent_orphan_fires_on_cost_then_silence() {
 
     // Tight grace so the test completes inside a couple of seconds.
     // The fast path is the one that should fire because the shim emits
-    // a cost-populated usage_update before parking.
+    // a cost-populated usage_update before parking. Polling cadence
+    // dropped to 50ms so the watchdog evaluation tracks the configured
+    // grace closely instead of waiting up to the default 5s tick.
     std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "5000");
     std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "300");
+    std::env::set_var("AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS", "50");
 
     let preseed = "silent-orphan-positive";
     let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
@@ -123,6 +126,7 @@ async fn silent_orphan_fires_on_cost_then_silence() {
         CockpitSessionId("silent-orphan-positive".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach for silent-orphan positive test");
@@ -155,8 +159,11 @@ async fn silent_orphan_suppressed_during_normal_turn() {
     // Generous enough grace that the shim's healthy tool round-trip
     // completes long before the watchdog could fire; we then assert
     // the only Stopped we see is prompt_complete, not prompt_orphaned.
+    // Tight polling cadence so a regressed grace would fire within the
+    // assertion window instead of waiting for the default 5s tick.
     std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "10000");
     std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "10000");
+    std::env::set_var("AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS", "50");
 
     let preseed = "silent-orphan-negative";
     let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
@@ -170,6 +177,7 @@ async fn silent_orphan_suppressed_during_normal_turn() {
         CockpitSessionId("silent-orphan-negative".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach for silent-orphan negative test");
@@ -207,8 +215,15 @@ async fn silent_orphan_disabled_by_zero_grace() {
     // SILENT_ORPHAN we'd otherwise see prompt_orphaned within a few
     // hundred milliseconds; instead we should see no Stopped frame at
     // all within the deadline, because nothing else fires.
+    //
+    // Override the polling cadence too: the default 5s tick would let
+    // a regressed "disabled" knob slip past a 2s deadline simply
+    // because the watchdog hadn't ticked yet. Forcing a 50ms cadence
+    // means a wrongly-armed watchdog WOULD fire within the deadline,
+    // turning a silent assertion into a real one.
     std::env::set_var("AOE_SILENT_ORPHAN_GRACE_MS", "0");
     std::env::set_var("AOE_SILENT_ORPHAN_FAST_GRACE_MS", "200");
+    std::env::set_var("AOE_SILENT_ORPHAN_CHECK_INTERVAL_MS", "50");
 
     let preseed = "silent-orphan-disabled";
     let (socket_path, _tmp) = spawn_shim_socket_bridge_with_preseed(preseed).await;
@@ -222,6 +237,7 @@ async fn silent_orphan_disabled_by_zero_grace() {
         CockpitSessionId("silent-orphan-disabled".into()),
         None,
         "claude".into(),
+        None,
     )
     .await
     .expect("attach for silent-orphan disabled test");

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -729,6 +729,34 @@ function CockpitSettings({
         </button>
       </div>
 
+      <div className="border-t border-surface-800 pt-3">
+        <NumberField
+          label="Silent-orphan grace (s)"
+          description="Daemon-side watchdog grace before declaring a prompt orphaned and restarting the worker. Fires when the agent finishes streaming but the adapter never sends PromptResponse (upstream agentclientprotocol/claude-agent-acp#688). Active only when no in-flight tool call is open and the prompt has produced at least one progress event, so long-running tools are unaffected. 0 disables. Default 60. Persists to config.toml as cockpit.silent_orphan_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_grace_secs === "number"
+              ? (cockpit.silent_orphan_grace_secs as number)
+              : 60
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_grace_secs", v)}
+        />
+      </div>
+
+      <div className="border-t border-surface-800 pt-3">
+        <NumberField
+          label="Silent-orphan fast grace (s)"
+          description="Accelerated silent-orphan grace, used once a cost-populated UsageUpdate has arrived for the current prompt (the claude-agent-acp wrap-up accounting marker emitted just before PromptResponse). Lowers MTTR on the known adapter wedge without weakening the vendor-agnostic baseline. 0 disables the accelerator (cost UsageUpdate stops reducing the effective grace). Default 20. Persists to config.toml as cockpit.silent_orphan_fast_grace_secs; cross-device. See #1240."
+          value={
+            typeof cockpit.silent_orphan_fast_grace_secs === "number"
+              ? (cockpit.silent_orphan_fast_grace_secs as number)
+              : 20
+          }
+          min={0}
+          onChange={(v) => onSaveField("cockpit", "silent_orphan_fast_grace_secs", v)}
+        />
+      </div>
+
       <div className="flex items-start justify-between gap-3 py-1 border-t border-surface-800 pt-3">
         <div>
           <div className="text-sm text-text-bright">Queue drain mode</div>

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -263,7 +263,10 @@ function CockpitChrome({
         <WorkerStoppedBanner sessionId={sessionId} />
       )}
       {state.workerRestarting && !state.startupError && !state.workerStopped && (
-        <WorkerRestartingBanner agentUnresponsive={state.agentUnresponsive} />
+        <WorkerRestartingBanner
+          agentUnresponsive={state.agentUnresponsive}
+          agentOrphaned={state.agentOrphaned}
+        />
       )}
       {cockpitWorkerState === "resuming" &&
         !state.startupError &&
@@ -1201,21 +1204,28 @@ function InteractionErrorBanner({
 
 function WorkerRestartingBanner({
   agentUnresponsive,
+  agentOrphaned,
 }: {
   agentUnresponsive: boolean;
+  agentOrphaned: boolean;
 }) {
-  // Two reasons land here:
+  // Three reasons land here:
   //   - `aoe cockpit restart` (deletes registry, daemon's reaper
   //     publishes Stopped{reason:"restart_pending"}, reconciler spawns
   //     a fresh worker with the cached acp_session_id).
   //   - Cancel-escalation watchdog fired: claude-agent-acp ignored
   //     `session/cancel` for the grace window, the supervisor SIGTERMed
   //     the wedged runner and is respawning via `session/load`.
-  // Both end with `AcpSessionAssigned` clearing the banner.
+  //   - Silent-orphan watchdog fired: the adapter finished streaming
+  //     the turn but never sent the JSON-RPC `PromptResponse`; the
+  //     supervisor restarts the runner the same way. See #1240.
+  // All paths end with `AcpSessionAssigned` clearing the banner.
   // See #1196 for the agent_unresponsive variant.
-  const message = agentUnresponsive
-    ? "Agent stopped responding to cancel. Restarting worker; your transcript will be preserved."
-    : "Restarting cockpit worker… the daemon will respawn the agent with your existing transcript shortly.";
+  const message = agentOrphaned
+    ? "Agent finished but didn't notify the daemon. Restarting worker; your transcript will be preserved."
+    : agentUnresponsive
+      ? "Agent stopped responding to cancel. Restarting worker; your transcript will be preserved."
+      : "Restarting cockpit worker… the daemon will respawn the agent with your existing transcript shortly.";
   return (
     <div className="flex items-center gap-2 border-b border-sky-900/60 bg-sky-950/40 px-4 py-2 text-xs text-sky-200">
       <span

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1202,7 +1202,7 @@ function InteractionErrorBanner({
   );
 }
 
-function WorkerRestartingBanner({
+export function WorkerRestartingBanner({
   agentUnresponsive,
   agentOrphaned,
 }: {

--- a/web/src/components/cockpit/__tests__/WorkerRestartingBanner.test.tsx
+++ b/web/src/components/cockpit/__tests__/WorkerRestartingBanner.test.tsx
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+//
+// Banner copy contract for the three reasons that land in the
+// WorkerRestartingBanner: restart_pending (generic restart),
+// agent_unresponsive (cancel-escalation watchdog, #1196), and
+// prompt_orphaned (silent-orphan watchdog, #1240). The copy is the
+// only thing the user sees that distinguishes the failure modes, so
+// regressing it would silently lump the orphan path back under the
+// agent_unresponsive banner.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import { WorkerRestartingBanner } from "../CockpitView";
+
+describe("WorkerRestartingBanner (#1240)", () => {
+  it("renders generic restart copy when neither flag is set", () => {
+    const { container } = render(
+      <WorkerRestartingBanner
+        agentUnresponsive={false}
+        agentOrphaned={false}
+      />,
+    );
+    expect(container.textContent).toContain("Restarting cockpit worker");
+    expect(container.textContent).not.toContain("stopped responding to cancel");
+    expect(container.textContent).not.toContain(
+      "finished but didn't notify the daemon",
+    );
+  });
+
+  it("renders cancel-escalation copy when agentUnresponsive is true", () => {
+    const { container } = render(
+      <WorkerRestartingBanner agentUnresponsive={true} agentOrphaned={false} />,
+    );
+    expect(container.textContent).toContain(
+      "Agent stopped responding to cancel",
+    );
+  });
+
+  it("renders silent-orphan copy when agentOrphaned is true", () => {
+    const { container } = render(
+      <WorkerRestartingBanner agentUnresponsive={false} agentOrphaned={true} />,
+    );
+    expect(container.textContent).toContain(
+      "Agent finished but didn't notify the daemon",
+    );
+  });
+
+  it("prefers agentOrphaned copy when both flags are true", () => {
+    // The supervisor never publishes both reasons for the same turn,
+    // but the reducer can briefly land in the both-true state during
+    // a cancel-escalation race. The banner must pick a deterministic
+    // copy in that window; agentOrphaned (more specific failure) wins.
+    const { container } = render(
+      <WorkerRestartingBanner agentUnresponsive={true} agentOrphaned={true} />,
+    );
+    expect(container.textContent).toContain(
+      "Agent finished but didn't notify the daemon",
+    );
+    expect(container.textContent).not.toContain(
+      "Agent stopped responding to cancel",
+    );
+  });
+});

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1359,4 +1359,21 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
     const normalised = normaliseTurnCounters(stale);
     expect(normalised.agentOrphaned).toBe(false);
   });
+
+  it("clears agentOrphaned on restart_pending", () => {
+    // Supervisor's reap_user_stopped sweep publishes restart_pending
+    // when a worker disappears out-of-band; that supersedes a prior
+    // orphan escalation, so the banner must downgrade to the generic
+    // "Restarting…" copy. See CodeRabbit review on #1248.
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 1,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    state = applyEvent(state, stoppedFrame("restart_pending", 2));
+    expect(state.agentOrphaned).toBe(false);
+    expect(state.workerRestarting).toBe(true);
+  });
 });

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1376,4 +1376,24 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
     expect(state.agentOrphaned).toBe(false);
     expect(state.workerRestarting).toBe(true);
   });
+
+  it("clears agentOrphaned when agent_unresponsive arrives next", () => {
+    // The cancel-escalation watchdog (agent_unresponsive) is the
+    // proximate path that downstream supervisor logic uses to drive
+    // SIGTERM + respawn even when the silent-orphan watchdog (#1240)
+    // armed first. If both reasons fire in sequence, the banner must
+    // flip away from agentOrphaned so the user sees the cancel-
+    // escalation copy that matches the active recovery phase.
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 2,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    state = applyEvent(state, stoppedFrame("agent_unresponsive", 2));
+    expect(state.agentOrphaned).toBe(false);
+    expect(state.agentUnresponsive).toBe(true);
+    expect(state.workerRestarting).toBe(true);
+  });
 });

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1259,3 +1259,104 @@ describe("cockpitHookReducer / dismiss_mode_switch_failed", () => {
     expect(next.modeSwitchFailed).toBeNull();
   });
 });
+
+// Reducer coverage for the silent-orphan watchdog (#1240). The
+// daemon-side detector is exercised by the Rust integration test in
+// tests/cockpit_silent_orphan.rs; this block just pins down the
+// frontend half so a future refactor of the worker-state banner
+// doesn't silently regress the prompt_orphaned path.
+function stoppedFrame(reason: string, seq: number): CockpitFrame {
+  return {
+    session_id: "s-orphan",
+    seq,
+    event: { Stopped: { reason } },
+  };
+}
+
+describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
+  it("sets agentOrphaned and workerRestarting on prompt_orphaned", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 1,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    expect(state.workerRestarting).toBe(true);
+    expect(state.workerStopped).toBe(false);
+    expect(state.agentUnresponsive).toBe(false);
+  });
+
+  it("clears agentUnresponsive when prompt_orphaned arrives after it", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 2,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("agent_unresponsive", 1));
+    expect(state.agentUnresponsive).toBe(true);
+    expect(state.agentOrphaned).toBe(false);
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 2));
+    expect(state.agentUnresponsive).toBe(false);
+    expect(state.agentOrphaned).toBe(true);
+  });
+
+  it("clears agentOrphaned on AcpSessionAssigned (respawn completed)", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 1,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-orphan",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "sess-abc" } },
+    });
+    expect(state.agentOrphaned).toBe(false);
+    expect(state.workerRestarting).toBe(false);
+  });
+
+  it("clears agentOrphaned on UserPromptSent (user moving on)", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 1,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    state = applyEvent(state, {
+      session_id: "s-orphan",
+      seq: 2,
+      event: { UserPromptSent: { text: "next prompt" } },
+    });
+    expect(state.agentOrphaned).toBe(false);
+  });
+
+  it("clears agentOrphaned on user_stopped", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 1,
+      lastStoppedSeq: 0,
+    };
+    state = applyEvent(state, stoppedFrame("prompt_orphaned", 1));
+    expect(state.agentOrphaned).toBe(true);
+    state = applyEvent(state, stoppedFrame("user_stopped", 2));
+    expect(state.agentOrphaned).toBe(false);
+  });
+
+  it("backfills agentOrphaned=false on pre-#1240 persisted state", () => {
+    // Simulate a localStorage entry written before #1240: agentOrphaned
+    // absent. normaliseTurnCounters must default it to false so the
+    // reducer and banner code see a well-typed value.
+    const stale = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 0,
+      lastStoppedSeq: 0,
+    } as CockpitState & { agentOrphaned?: boolean };
+    delete stale.agentOrphaned;
+    const normalised = normaliseTurnCounters(stale);
+    expect(normalised.agentOrphaned).toBe(false);
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -334,6 +334,17 @@ export interface CockpitState {
     reason: string;
     at: string;
   } | null;
+  /** Set when the daemon emitted `Stopped { reason: "prompt_orphaned" }`,
+   *  meaning the silent-orphan watchdog detected that the adapter
+   *  finished streaming the turn but never sent the JSON-RPC
+   *  `PromptResponse`. The supervisor is SIGTERMing the runner and
+   *  respawning via `session/load` (transcript preserved). Pairs with
+   *  `workerRestarting = true` for composer lockdown; banner copy
+   *  distinguishes this from `agentUnresponsive` so users can tell
+   *  whether the adapter ignored their cancel (`agentUnresponsive`)
+   *  or finished without notifying the daemon (`agentOrphaned`).
+   *  Cleared on `AcpSessionAssigned` or `UserPromptSent`. See #1240. */
+  agentOrphaned: boolean;
 }
 
 export interface RejectedPrompt {
@@ -429,6 +440,7 @@ export function emptyCockpitState(): CockpitState {
     contextPrimerAvailable: null,
     rejectedPrompts: [],
     agentUnresponsive: false,
+    agentOrphaned: false,
     modeSwitchFailed: null,
     lastAgentSwitch: null,
   };
@@ -723,10 +735,12 @@ export function applyEvent(
       // flag so a future `restart_pending` doesn't accidentally
       // render unresponsive copy. See #1196.
       next.agentUnresponsive = false;
+      next.agentOrphaned = false;
     } else if (event.Stopped.reason === "restart_pending") {
       next.workerRestarting = true;
       next.workerStopped = false;
       next.agentUnresponsive = false;
+      next.agentOrphaned = false;
     } else if (event.Stopped.reason === "agent_unresponsive") {
       // Cancel-escalation watchdog in the daemon fired: claude-agent-acp
       // ignored `session/cancel` for the grace window, the supervisor
@@ -739,6 +753,20 @@ export function applyEvent(
       next.workerRestarting = true;
       next.workerStopped = false;
       next.agentUnresponsive = true;
+      next.agentOrphaned = false;
+    } else if (event.Stopped.reason === "prompt_orphaned") {
+      // Silent-orphan watchdog in the daemon fired: the adapter
+      // finished streaming the turn but never sent the JSON-RPC
+      // `PromptResponse`, the supervisor is SIGTERMing the runner
+      // and respawning via `session/load` (transcript preserved).
+      // Distinct from `agent_unresponsive`: this is "adapter stopped
+      // talking" vs. "adapter ignored cancel"; both reuse the
+      // `workerRestarting` lockdown, but the banner copy differs so
+      // users can tell which failure happened. See #1240.
+      next.workerRestarting = true;
+      next.workerStopped = false;
+      next.agentUnresponsive = false;
+      next.agentOrphaned = true;
     }
     // Some upstream slash commands (e.g. /usage, /status, /memory in
     // claude-agent-acp) advertise via available_commands_update but
@@ -846,6 +874,7 @@ export function applyEvent(
     // See #1196.
     next.rejectedPrompts = [];
     next.agentUnresponsive = false;
+    next.agentOrphaned = false;
     // /loop dynamic mode self-fires a UserPromptSent on wake, but a
     // user-typed follow-up during the wait is NOT the wake firing;
     // only clear when the scheduled time has already elapsed. The
@@ -886,6 +915,10 @@ export function applyEvent(
     // The respawn after an `agent_unresponsive` escalation completed;
     // clear the banner so the user can interact again. See #1196.
     next.agentUnresponsive = false;
+    // Same shape for `prompt_orphaned`: the silent-orphan watchdog
+    // fired, the runner was SIGTERMed, and the respawn handshake has
+    // now landed. See #1240.
+    next.agentOrphaned = false;
     return next;
   }
   if ("SessionContextReset" in event) {
@@ -1046,6 +1079,7 @@ export function normaliseTurnCounters(
     lastStoppedSeq?: number;
     rejectedPrompts?: RejectedPrompt[];
     agentUnresponsive?: boolean;
+    agentOrphaned?: boolean;
   },
 ): CockpitState {
   const pendingUserPromptSeq =
@@ -1070,10 +1104,16 @@ export function normaliseTurnCounters(
     typeof state.agentUnresponsive === "boolean"
       ? state.agentUnresponsive
       : false;
+  // Pre-#1240 persisted entries lack agentOrphaned; backfill to false
+  // so the reducer and renderers see a well-typed value instead of
+  // `undefined`.
+  const agentOrphaned =
+    typeof state.agentOrphaned === "boolean" ? state.agentOrphaned : false;
   return {
     ...state,
     rejectedPrompts,
     agentUnresponsive,
+    agentOrphaned,
     pendingUserPromptSeq,
     lastStoppedSeq,
     turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -332,7 +332,10 @@
       "id": "cockpit.silent-orphan-watchdog",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/cockpitTypes.test.ts"],
+      "specs": [
+        "src/lib/cockpitTypes.test.ts",
+        "src/components/cockpit/__tests__/WorkerRestartingBanner.test.tsx"
+      ],
       "components": []
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -329,6 +329,13 @@
       "components": ["web/src/components/cockpit/RateLimitRecoveryModal.tsx"]
     },
     {
+      "id": "cockpit.silent-orphan-watchdog",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/cockpitTypes.test.ts"],
+      "components": []
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Closes the silent-spinner gap in cockpit when claude-agent-acp finishes streaming a turn but never sends the JSON-RPC `PromptResponse`. Without this, the daemon's `prompt_fut` future hangs forever, the reducer's `lastStoppedSeq` never advances, and the user sits in front of an indefinitely-running spinner with no recovery affordance other than the manual Force-end-turn button (which most users won't notice).

Two independent reproductions documented in the issue, ten minutes apart, on two different sessions, ending with the same wire pattern: assistant chunks, two `UsageUpdated` notifications (second carrying populated `cost`), then dead silence indefinitely. The root cause is upstream at `agentclientprotocol/claude-agent-acp#688`; this PR is the daemon-side mitigation.

**Design (synthesized from a three-way `/debate` between Gemini, OpenAI, and Anthropic models):**

A channel-driven, per-prompt state machine inside `run_connection_task` classifies inbound `SessionUpdate`s into a small `LifecycleSignal` enum and forwards them on a dedicated mpsc to the prompt loop. The prompt loop owns an `Instant`-based `last_progress_at` plus a `HashSet<ToolCallId>` of in-flight tool calls, and runs a new select arm every 5s that fires when:

1. `tool_calls_in_flight.is_empty()` (no open tool call to legitimately be silent for)
2. At least one progress notification has arrived for this prompt (avoids false-firing on a slow first chunk)
3. `now - last_progress_at >= effective_grace`

`effective_grace` defaults to `silent_orphan_grace_secs` (60s, vendor-agnostic correctness floor) and drops to `silent_orphan_fast_grace_secs` (20s) for the rest of the prompt once a cost-populated `UsageUpdate` arrives. The cost signal is treated as an optimization hint, not a load-bearing protocol contract: if upstream drops cost emission, the watchdog still fires at 60s instead of 20s, not at infinity.

When the watchdog fires it sends best-effort `session/cancel`, arms the existing 10s `CANCEL_ESCALATION_GRACE`, and lets the existing supervisor SIGTERM + `session/load` respawn path do the rest. The synthesized `Stopped` event carries `reason: "prompt_orphaned"` (distinct from `agent_unresponsive` so logs and postmortems preserve the failure signature). The reducer adds an `agentOrphaned: boolean` sibling flag and the cockpit banner switches copy: "Agent finished but didn't notify the daemon. Restarting worker; your transcript will be preserved."

**Long-running tools are explicitly NOT affected** because the watchdog gates on `tool_calls_in_flight.is_empty()`. A long `npm install`, Playwright run, or Task subagent keeps its tool call open until done; the watchdog never fires while real work is in progress.

**Reproducibility for testing.** Real claude-agent-acp wedges aren't on-demand, so this PR adds two layers:

- `AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT=1` (debug builds only, single-shot): gates the daemon's `prompt_fut` select arm off so the response is never observed. Lets a developer trigger the watchdog against a live agent and verify the end-to-end UX (banner, lockdown, SIGTERM, respawn).
- `tests/cockpit_silent_orphan.rs`: three integration tests over the existing Node test shim covering the positive path (fires), the negative path (long tool blocks fire), and the disabled path (`grace = 0` skips entirely).

Plus Vitest coverage in `web/src/lib/cockpitTypes.test.ts` for the reducer's new `Stopped { reason: "prompt_orphaned" }` arm and the clear paths.

Closes #1240

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] `cargo build --features serve` then `AOE_SILENT_ORPHAN_FAST_GRACE_MS=15000 AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT=1 ./target/debug/aoe serve`; open the cockpit, send a Claude prompt, watch the agent stream chunks normally, then watch the spinner clear and a banner appear ~15s after the final chunk: "Agent finished but didn't notify the daemon. Restarting worker; your transcript will be preserved." Verify the runner is respawned and a follow-up prompt completes cleanly with the prior transcript preserved.
- [x] Unset the env vars; send a prompt that invokes a real long-running tool (Bash `sleep 90 && echo ok`). The watchdog must NOT fire while the tool is open; the prompt should complete normally.
- [x] Unset the env vars; send a normal short prompt. Healthy turn ends with `prompt_complete` and no banner.
- [x] In the settings TUI, navigate to the Cockpit category. Verify "Silent-orphan grace (s)" and "Silent-orphan fast grace (s)" appear with defaults 60 / 20. Edit each, save, re-open, confirm persistence. Clear the override (standard gesture) and confirm it reverts to global.
- [x] In `config.toml`, set `[cockpit] silent_orphan_grace_secs = 0`. Restart `aoe serve`. Repeat the `AOE_COCKPIT_SIMULATE_ORPHAN_NEXT_PROMPT=1` recipe; the watchdog must stay disarmed and the spinner must run indefinitely (matching pre-#1240 behavior). Reset to default afterward.
- [x] `cargo test --features serve --test cockpit_silent_orphan` (three integration tests, all green).
- [x] `cd web && npx vitest run src/lib/cockpitTypes.test.ts` (six new silent-orphan reducer tests, all green).

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Claude Code, agent-of-empires `/aoe-implement` skill, with a three-way `/debate` consultation across Gemini, OpenAI, and Anthropic models for the design)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (notably rejecting the initial blanket-silence proposal in favor of the tool-state-aware approach you see here), and confirmed the manual repro recipe end-to-end before approving the PR.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added silent-orphan watchdog to detect when an adapter finishes a turn but fails to send the closing response. The daemon now recovers gracefully via escalation and worker restart while preserving the transcript.
  * Added configurable grace timers for watchdog detection with UI settings support.
  * Updated failure messages to distinguish this specific failure mode from other agent issues.

* **Tests**
  * Added integration tests for silent-orphan watchdog behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1248?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->