### PR TITLE
fix(test): de-flake live ensure-session-restart status check

### DIFF
--- a/web/tests/live/ensure-session-restart.spec.ts
+++ b/web/tests/live/ensure-session-restart.spec.ts
@@ -43,7 +43,16 @@ base.describe("ensure_session restart flow", () => {
       const sessionId: string = sessions[0]!.id;
       const tmuxName = `${serve.tmuxPrefix}${title}_${sessionId.slice(0, 8)}`;
 
-      expect(sessions[0]!.status).toBe("Error");
+      // The server's status_poll_loop runs every 2s and reconciles the
+      // on-disk session record (initial status: Idle) against tmux. There
+      // is no tmux session for this seed, so it eventually flips to Error,
+      // but a freshly booted server may not have polled yet.
+      await expect
+        .poll(
+          async () => (await listSessions(serve.baseUrl))[0]?.status,
+          { timeout: 10_000 },
+        )
+        .toBe("Error");
       expect(tmuxHasSession(serve.home, tmuxName)).toBe(false);
 
       const r1 = await fetch(

--- a/web/tests/live/ensure-session-restart.spec.ts
+++ b/web/tests/live/ensure-session-restart.spec.ts
@@ -115,6 +115,7 @@ base.describe("ensure_session restart flow", () => {
 
     try {
       const sessions = await listSessions(serve.baseUrl);
+      expect(sessions.length).toBeGreaterThan(0);
       const sessionId: string = sessions[0]!.id;
       const tmuxName = `${serve.tmuxPrefix}${title}_${sessionId.slice(0, 8)}`;
 


### PR DESCRIPTION
> AI disclosure: drafted with Claude Opus 4.7 (1M context).

## Description

Live Playwright run on main failed in https://github.com/njbrake/agent-of-empires/actions/runs/26089516852/job/76711231346:

\`\`\`
1) [chromium] › tests/live/ensure-session-restart.spec.ts:31:3 › ensure_session restart flow › dead session is restarted by /ensure, live session stays alive

    Expected: \"Error\"
    Received: \"Idle\"
\`\`\`

Race between server boot and the first \`status_poll_loop\` tick (2s interval):

- \`seedSessionViaAoeAdd\` writes a session record to disk before \`aoe serve\` spawns.
- Server loads the instance with default \`Status::Idle\` (see \`src/session/instance.rs:635\`).
- \`status_poll_loop\` probes tmux every 2s and only then flips status to \`Error\` (\`src/server/mod.rs:1439\`, \`src/session/instance.rs:2186\`).
- Harness's \`waitForServer\` returns as soon as \`/api/about\` is 200, which can land before the first poll tick.

Test was sampling \`/api/sessions\` once and asserting \`Error\`, so on a fast-booting server it saw the stale \`Idle\`.

Fix: wrap the status assertion in \`expect.poll\` with a 10s timeout so the assertion converges instead of sampling once. No backend change needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Local verification:

\`\`\`
AOE_E2E_BINARY=.../target/debug/aoe \\
  npx playwright test --config=playwright.live.config.ts \\
  -g \"dead session is restarted\" tests/live/ensure-session-restart.spec.ts
# 1 passed (3.6s)
\`\`\`

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code.

**Any Additional AI Details you'd like to share:**

Investigation and patch authored by AI; reviewed by Jules before pushing.

- [ ] I am an AI Agent filling out this form (check box if true)