### PR TITLE
fix(session): defense in depth for resume-fallback cascade races

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -568,13 +568,15 @@ fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
     // `agent_session_id` in memory and the TUI's reload merge would
     // otherwise resurrect a stale poller-captured value.
     //
-    // `Storage::save` is atomic per write (tempfile::persist + fsync,
-    // see `src/session/storage.rs::atomic_write`), so concurrent saves
-    // cannot corrupt the file. The residual hazard is a load-modify-save
-    // interleave (lost-update): independent of save atomicity, this
-    // requires a cross-worker mutex on the per-profile file to close
-    // durably. The post-loop reconcile in `restart_all_sessions` is the
-    // current mitigation.
+    // `Storage::save` writes are made visible via atomic rename
+    // (tempfile::persist + fsync, see `src/session/storage.rs::atomic_write`),
+    // so concurrent readers always observe either the old or new file
+    // contents, never a partial write. This guarantee covers file-level
+    // visibility only; concurrent writers can still cause lost-updates
+    // (a load-modify-save interleave), which is independent of save
+    // atomicity. Closing that durably requires a cross-worker mutex on
+    // the per-profile file. The post-loop reconcile in
+    // `restart_all_sessions` is the current mitigation.
 
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
@@ -1875,18 +1877,31 @@ impl Instance {
         // that was never passed). The debug_assert surfaces the protocol
         // violation in dev/test if a future caller forgets to tear down;
         // the tracing::warn! mirrors it in release so the race is visible
-        // in `aoe logs` for diagnosis (otherwise the cascade is silently
-        // skipped and the user sees a frozen pane with no log trail).
+        // in `aoe logs` for diagnosis. The branch on `attempting_resume`
+        // separates the dangerous case (sid was passed but no probe ran,
+        // pane could be left frozen) from the benign one (no resume was
+        // attempted, the race is just kill_clean cache staleness).
         let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
         if pane_was_preexisting {
-            tracing::warn!(
-                target: "session.store",
-                instance_id = %self.id,
-                attempting_resume,
-                "start_with_resume_fallback: tmux session still exists on entry; \
-                 cascade skipped (kill_clean race or caller protocol violation). \
-                 Returning Fresh; if pane was started with --resume <sid>, no probe runs.",
-            );
+            if attempting_resume {
+                tracing::warn!(
+                    target: "session.store",
+                    instance_id = %self.id,
+                    "start_with_resume_fallback: tmux session still exists on \
+                     entry with attempting_resume=true; cascade skipped, \
+                     returning Fresh. --resume <sid> was passed to \
+                     start_with_size_opts but no probe ran; if the agent \
+                     crashes inside the pane, it will be left frozen.",
+                );
+            } else {
+                tracing::warn!(
+                    target: "session.store",
+                    instance_id = %self.id,
+                    "start_with_resume_fallback: tmux session still exists on \
+                     entry (no resume attempted); cascade skipped, returning \
+                     Fresh. Likely a kill_clean race or caller protocol violation.",
+                );
+            }
         }
         debug_assert!(
             !pane_was_preexisting,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -568,13 +568,13 @@ fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
     // `agent_session_id` in memory and the TUI's reload merge would
     // otherwise resurrect a stale poller-captured value.
     //
-    // Storage::save is non-atomic (fs::write, not tempfile::persist), so
-    // any concurrent save would corrupt or silently lose one party's
-    // update. A future hardening is to make `Storage::save` atomic via
-    // an atomic-rename helper. Note that atomic rename does NOT close
-    // path (4)'s race: the lost-update is a load-modify-save interleave,
-    // independent of the save's atomicity. Closing (4) durably would
-    // require a cross-worker mutex on the per-profile file.
+    // `Storage::save` is atomic per write (tempfile::persist + fsync,
+    // see `src/session/storage.rs::atomic_write`), so concurrent saves
+    // cannot corrupt the file. The residual hazard is a load-modify-save
+    // interleave (lost-update): independent of save atomicity, this
+    // requires a cross-worker mutex on the per-profile file to close
+    // durably. The post-loop reconcile in `restart_all_sessions` is the
+    // current mitigation.
 
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
@@ -1873,8 +1873,21 @@ impl Instance {
         // detect, and reporting `Fresh` is the least-wrong outcome
         // (returning `Resumed` would mean lying about a `--resume <sid>`
         // that was never passed). The debug_assert surfaces the protocol
-        // violation in dev/test if a future caller forgets to tear down.
+        // violation in dev/test if a future caller forgets to tear down;
+        // the tracing::warn! mirrors it in release so the race is visible
+        // in `aoe logs` for diagnosis (otherwise the cascade is silently
+        // skipped and the user sees a frozen pane with no log trail).
         let pane_was_preexisting = self.tmux_session().is_ok_and(|s| s.exists());
+        if pane_was_preexisting {
+            tracing::warn!(
+                target: "session.store",
+                instance_id = %self.id,
+                attempting_resume,
+                "start_with_resume_fallback: tmux session still exists on entry; \
+                 cascade skipped (kill_clean race or caller protocol violation). \
+                 Returning Fresh; if pane was started with --resume <sid>, no probe runs.",
+            );
+        }
         debug_assert!(
             !pane_was_preexisting,
             "start_with_resume_fallback callers must kill_clean() first; \

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -563,6 +563,14 @@ impl HomeView {
                         .agent_session_id
                         .clone()
                         .or(inst.agent_session_id.take());
+                    // Carry the resume-fallback exclusion set across
+                    // reloads. Without this, a stale sid the cascade just
+                    // cleared would be re-imported on the next 5s reload
+                    // (the on-disk session artifact persists for ~5-10
+                    // min after the agent's crash). The set is
+                    // `#[serde(skip)]` runtime-only so disk reloads
+                    // would otherwise reset it to empty.
+                    inst.retroactive_capture_excludes = prev.retroactive_capture_excludes.clone();
                 }
             }
             // Rebuild this profile's tree from disk, preserving any collapsed

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -564,8 +564,8 @@ impl HomeView {
                         .clone()
                         .or(inst.agent_session_id.take());
                     // Carry the resume-fallback exclusion set across
-                    // reloads. Without this, a stale sid the cascade just
-                    // cleared would be re-imported on the next 5s reload
+                    // reloads. Without this, a stale sid that the cascade
+                    // just cleared would be re-imported on the next 5s reload
                     // (the on-disk session artifact persists for ~5-10
                     // min after the agent's crash). The set is
                     // `#[serde(skip)]` runtime-only so disk reloads


### PR DESCRIPTION
## Description

Two race conditions in the resume-fallback cascade (`start_with_resume_fallback`) that could fail silently after a system reboot, plus one doc-comment correction. All three are minimal defensive changes derived from a deeper investigation; they are intentionally narrow so they can land independently of any larger follow-up.

**1. `retroactive_capture_excludes` reset on every 5s disk reload (`src/tui/home/mod.rs`)**

The runtime exclusion set tracking stale session IDs that the cascade just cleared was lost on every `HomeView::reload()` because the field is `#[serde(skip)]`. The `session_id_poller` could then re-import the same bad sid from the on-disk session artifact (`~/.local/share/opencode/opencode.db`, claude project files, codex rollouts, etc., which persist ~5-10 min after the agent's crash), defeating the cascade's clear. Post-reboot this caused an oscillation: every other restart hit the cascade with the same stale sid.

Fix: carry the field across the existing in-memory merge alongside `last_start_time`, `agent_session_id`, `idle_entered_at`. The set remains process-local; daemon restart still resets it (the self-healing-within-one-cascade-cycle behavior at `src/session/instance.rs:384-390` is unchanged).

**2. `pane_was_preexisting` race silent in release (`src/session/instance.rs`)**

When `kill_clean` races the macOS tmux session cache, the cascade returns `StartOutcome::Fresh` silently with the stale `--resume <sid>` already passed to `start_with_size_opts` and no probe to detect an in-pane crash. The existing `debug_assert!` is a no-op in release, so this race was invisible to operators: the user saw a frozen pane with no log trail.

Fix: add a `tracing::warn!` mirroring the `debug_assert!` in release, with `instance_id` and `attempting_resume` context, so the race is diagnosable from `aoe logs`. Behavior is unchanged (still returns `Fresh`).

**3. `Storage::save` atomicity doc-comment correction (`src/session/instance.rs`)**

The doc-comment at `clear_session_id_on_disk` claimed `Storage::save` was non-atomic via `fs::write`. It has used `atomic_write` (`tempfile::persist` + `sync_data` + dir fsync) since `src/session/storage.rs:108`. The wrong comment risked guiding future fixes toward solving a non-bug; the comment now describes the actual remaining hazard (load-modify-save lost-update, independent of save atomicity).

## Testing

```
cargo test --lib    # 1716/1716 passed
cargo fmt --check   # clean
cargo clippy --lib  # clean
```

No new tests added: these are minimal defensive fixes (one `tracing::warn!`, one field carry, one comment correction) with no new code paths.

Manually verified by reading:
- `Session::kill()` already calls `refresh_session_cache()` (`src/tmux/session.rs:190`), so the cache is invalidated by the kill path
- `Storage::save` uses `atomic_write` (`src/session/storage.rs:108`), so the doc was wrong
- `clear_session_id_on_disk` carry-over only matters within one process lifetime; daemon restart resets is acceptable

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording (N/A, no UI changes)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:**
Claude Opus 4.7 via OpenCode

**Any Additional AI Details you'd like to share:**
The investigation that motivated these fixes was conducted by parallel sub-agents (3 explore + 2 oracle agents) cross-validating findings on the resume-fallback cascade. Two of the originally proposed fixes (cache invalidation in `Session::kill`, retry-once on `pane_was_preexisting`) were rejected after manual code reads showed the existing code already handles them correctly. Only the three changes above remained as actionable. A larger follow-up (auto-recovery at startup, gated behind a config flag) is planned as a separate PR on top of this one.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->