### PR TITLE
docs: link to public roadmap from README and website footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,10 @@ In the TUI, press `?` for help. The bottom information bar shows all available k
 - **[HTTP API Reference](https://www.agent-of-empires.com/docs/api/)**: REST endpoints for external orchestrators
 - **[Development](https://www.agent-of-empires.com/docs/development/)**: contributing and local setup
 
+## Roadmap
+
+The AoE roadmap is public: see the [project board](https://github.com/users/njbrake/projects/1) for what's planned, in progress, and recently shipped. Issues and PRs welcome.
+
 ## FAQ
 
 ### What happens when I close aoe?

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -40,6 +40,7 @@
         <ul class="space-y-2 text-sm">
           <li><a href="https://github.com/njbrake/agent-of-empires" class="text-gray-400 hover:text-white transition-colors">GitHub</a></li>
           <li><a href="https://github.com/njbrake/agent-of-empires/issues" class="text-gray-400 hover:text-white transition-colors">Issues</a></li>
+          <li><a href="https://github.com/users/njbrake/projects/1" target="_blank" rel="noopener" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
           <li><a href="https://github.com/njbrake/agent-of-empires/blob/main/LICENSE" class="text-gray-400 hover:text-white transition-colors">MIT License</a></li>
         </ul>
       </div>

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -40,7 +40,7 @@
         <ul class="space-y-2 text-sm">
           <li><a href="https://github.com/njbrake/agent-of-empires" class="text-gray-400 hover:text-white transition-colors">GitHub</a></li>
           <li><a href="https://github.com/njbrake/agent-of-empires/issues" class="text-gray-400 hover:text-white transition-colors">Issues</a></li>
-          <li><a href="https://github.com/users/njbrake/projects/1" target="_blank" rel="noopener" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
+          <li><a href="https://github.com/users/njbrake/projects/1" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
           <li><a href="https://github.com/njbrake/agent-of-empires/blob/main/LICENSE" class="text-gray-400 hover:text-white transition-colors">MIT License</a></li>
         </ul>
       </div>


### PR DESCRIPTION
## Description

Adds a "Roadmap" section to the README pointing at the public GitHub project board (https://github.com/users/njbrake/projects/1), and adds a "Roadmap" entry to the website footer's Community column so visitors can find the project direction from any page.

The issue also asked about designing a system to keep the project board automatically up to date with new issue labeling. That half is deferred: this PR only does the link-sharing portion, so leaving #1262 open with Refs (not Closes) so the auto-labeling / board-hygiene work can be tracked separately.

Refs #1262

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Docs-only change: no code paths or tests touched. Footer markup edit is a single new `<li>`, matched to existing styling.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**

Drafted by Claude via back-and-forth with @njbrake. Scope decision (link-sharing only, defer auto-labeling) and the chosen surfaces (README "Roadmap" section + website Footer Community column) are his; prose is mine.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR improves discoverability of the project's public roadmap by adding links in two prominent locations: the repository README and the website footer.

## What Changed

- README: Added a new "Roadmap" section linking to the public GitHub project board (https://github.com/users/njbrake/projects/1).
- Website footer: Added a "Roadmap" entry to the Community column so the roadmap is reachable from every site page.
- Footer link behavior: The new Roadmap link opens in the same tab (removed target="_blank") to match existing Community links.
- Commit metadata: The commit includes a Co-Authored-By line noting AI assistance in drafting the prose.

## Benefits

- Improves discoverability for users and contributors by surfacing the public roadmap in both the repo and site UI.
- Provides a single, consistent place to view project direction and planned work.
- Maintains consistent UX with existing footer links and styling.
- Keeps this change small and documentation-only, deferring automation of board synchronization to tracked issue `#1262`.

## Technical Details

- Documentation-only changes: no runtime logic or public API changes.
- Scope: small — ~4 lines added to README, 1 line added to Footer component; no deletions.
- Tests: author reports new and existing tests pass.
- Prose: AI-assisted drafting (Claude Opus 4.7) and author-reviewed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->