### PR TITLE
feat(web): confirm session delete with Enter key

### DIFF
--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -27,6 +27,7 @@ export function DeleteSessionDialog({
   const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed && cleanupDefaults.delete_sandbox);
   const [deleting, setDeleting] = useState(false);
   const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
 
   const hasOptions = hasManagedWorktree || isSandboxed;
 
@@ -44,8 +45,15 @@ export function DeleteSessionDialog({
     }
   }, [onConfirm, deleteWorktree, deleteBranch, deleteSandbox, forceDelete]);
 
+  // Capture the previously focused element on mount and restore focus on
+  // unmount so keyboard users return to the trigger (the sidebar row /
+  // context-menu item) instead of losing focus to document.body.
   useEffect(() => {
+    previousFocusRef.current = document.activeElement as HTMLElement | null;
     confirmButtonRef.current?.focus();
+    return () => {
+      previousFocusRef.current?.focus?.();
+    };
   }, []);
 
   useEffect(() => {
@@ -80,6 +88,7 @@ export function DeleteSessionDialog({
     <div
       role="dialog"
       aria-modal="true"
+      aria-labelledby="delete-session-dialog-title"
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
       onClick={onCancel}
     >
@@ -89,7 +98,10 @@ export function DeleteSessionDialog({
       >
         {/* Header */}
         <div className="px-5 py-4 border-b border-surface-700">
-          <h2 className="text-sm font-semibold text-status-error">
+          <h2
+            id="delete-session-dialog-title"
+            className="text-sm font-semibold text-status-error"
+          >
             Delete Session
           </h2>
         </div>

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type { DeleteSessionOptions } from "../lib/api";
 import type { CleanupDefaults } from "../lib/types";
 
@@ -26,16 +26,9 @@ export function DeleteSessionDialog({
   const [deleteBranch, setDeleteBranch] = useState(hasManagedWorktree && cleanupDefaults.delete_branch);
   const [deleteSandbox, setDeleteSandbox] = useState(isSandboxed && cleanupDefaults.delete_sandbox);
   const [deleting, setDeleting] = useState(false);
+  const confirmButtonRef = useRef<HTMLButtonElement | null>(null);
 
   const hasOptions = hasManagedWorktree || isSandboxed;
-
-  useEffect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onCancel();
-    };
-    document.addEventListener("keydown", onKey);
-    return () => document.removeEventListener("keydown", onKey);
-  }, [onCancel]);
 
   const handleConfirm = useCallback(async () => {
     setDeleting(true);
@@ -50,6 +43,39 @@ export function DeleteSessionDialog({
       setDeleting(false);
     }
   }, [onConfirm, deleteWorktree, deleteBranch, deleteSandbox, forceDelete]);
+
+  useEffect(() => {
+    confirmButtonRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+        return;
+      }
+      if (e.key === "Enter") {
+        // Skip when focus is on an element that has its own Enter semantics
+        // (Cancel button, native input/textarea), so the user can still
+        // tab to Cancel and press Enter to dismiss without confirming.
+        const target = e.target as HTMLElement | null;
+        if (target) {
+          const tag = target.tagName;
+          if (tag === "INPUT" || tag === "TEXTAREA") return;
+          if (
+            tag === "BUTTON" &&
+            target !== confirmButtonRef.current
+          )
+            return;
+        }
+        if (deleting) return;
+        e.preventDefault();
+        void handleConfirm();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel, handleConfirm, deleting]);
 
   return (
     <div
@@ -126,6 +152,7 @@ export function DeleteSessionDialog({
             Cancel
           </button>
           <button
+            ref={confirmButtonRef}
             onClick={handleConfirm}
             disabled={deleting}
             className="px-3 py-1.5 text-sm text-white bg-status-error/90 hover:bg-status-error rounded-md cursor-pointer transition-colors disabled:opacity-50 flex items-center gap-2"

--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -55,17 +55,16 @@ export function DeleteSessionDialog({
         return;
       }
       if (e.key === "Enter") {
-        // Skip when focus is on an element that has its own Enter semantics
-        // (Cancel button, native input/textarea), so the user can still
-        // tab to Cancel and press Enter to dismiss without confirming.
+        // Skip when focus is on an element that has its own Enter
+        // semantics so we don't double-fire or override defaults:
+        //   - native input/textarea: leave their own behavior alone
+        //   - any button (including the Delete button itself): the
+        //     browser already activates the focused button on Enter,
+        //     so handling it here would call handleConfirm twice.
         const target = e.target as HTMLElement | null;
         if (target) {
           const tag = target.tagName;
-          if (tag === "INPUT" || tag === "TEXTAREA") return;
-          if (
-            tag === "BUTTON" &&
-            target !== confirmButtonRef.current
-          )
+          if (tag === "INPUT" || tag === "TEXTAREA" || tag === "BUTTON")
             return;
         }
         if (deleting) return;

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -126,4 +126,33 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(onConfirm).not.toHaveBeenCalled();
     expect(onCancel).toHaveBeenCalledTimes(1);
   });
+
+  it("dialog has role=dialog, aria-modal, and aria-labelledby pointing at the title", () => {
+    const { container } = setup();
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).toBeTruthy();
+    expect(dialog?.getAttribute("aria-modal")).toBe("true");
+    const labelId = dialog?.getAttribute("aria-labelledby");
+    expect(labelId).toBeTruthy();
+    const titleEl = container.querySelector(`#${labelId}`);
+    expect(titleEl?.textContent).toMatch(/Delete Session/);
+  });
+
+  it("restores focus to the previously focused element when the dialog unmounts", () => {
+    // Create a trigger button outside the dialog and focus it before mount,
+    // mirroring how the sidebar context-menu item is focused when the user
+    // chooses Delete. After the dialog unmounts, focus should return there.
+    const trigger = document.createElement("button");
+    trigger.textContent = "trigger";
+    document.body.appendChild(trigger);
+    trigger.focus();
+    expect(document.activeElement).toBe(trigger);
+
+    const { unmount } = setup();
+    // Dialog mount steals focus to the Delete button.
+    expect(document.activeElement).not.toBe(trigger);
+    unmount();
+    expect(document.activeElement).toBe(trigger);
+    trigger.remove();
+  });
 });

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -91,6 +91,24 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     resolveConfirm?.();
   });
 
+  it("Enter while focus is on the Delete button does not double-fire onConfirm", () => {
+    // When the Delete button is focused (the default on mount), the
+    // browser already activates the button on Enter via a synthetic
+    // click. The document-level keydown handler must skip Enter when
+    // the event target is a button, or onConfirm would be called twice.
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({ onConfirm });
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Delete") && !b.textContent.includes("Deleting"),
+    )!;
+    expect(document.activeElement).toBe(deleteBtn);
+    // Dispatch keydown from the focused button (bubbles up to document)
+    // and the native button activation (click) that the browser would emit.
+    fireEvent.keyDown(deleteBtn, { key: "Enter" });
+    fireEvent.click(deleteBtn);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
   it("Enter while focus is on the Cancel button cancels rather than confirms", () => {
     const onConfirm = vi.fn().mockResolvedValue(undefined);
     const onCancel = vi.fn();

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// Keyboard-affordance tests for DeleteSessionDialog. The dialog opens from
+// the workspace sidebar right-click menu; pressing Enter inside it should
+// confirm the delete without forcing the user to mouse over to the button
+// (issue #1260). Escape continues to cancel, and Enter should not fire a
+// second confirm while one is already in flight.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+
+import { DeleteSessionDialog } from "../DeleteSessionDialog";
+import type { CleanupDefaults } from "../../lib/types";
+
+const cleanupDefaults: CleanupDefaults = {
+  delete_worktree: true,
+  delete_branch: false,
+  delete_sandbox: false,
+};
+
+function setup(overrides?: {
+  onConfirm?: () => Promise<void>;
+  onCancel?: () => void;
+  hasManagedWorktree?: boolean;
+  isSandboxed?: boolean;
+}) {
+  const onConfirm = overrides?.onConfirm ?? vi.fn().mockResolvedValue(undefined);
+  const onCancel = overrides?.onCancel ?? vi.fn();
+  const utils = render(
+    <DeleteSessionDialog
+      sessionTitle="my-session"
+      branchName="feature/foo"
+      hasManagedWorktree={overrides?.hasManagedWorktree ?? true}
+      isSandboxed={overrides?.isSandboxed ?? false}
+      cleanupDefaults={cleanupDefaults}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />,
+  );
+  return { ...utils, onConfirm, onCancel };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("DeleteSessionDialog keyboard affordances", () => {
+  it("focuses the Delete button on mount so Enter activates it natively", () => {
+    const { container } = setup();
+    const deleteBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.includes("Delete") && !b.textContent.includes("Deleting"),
+    );
+    expect(deleteBtn).toBeTruthy();
+    expect(document.activeElement).toBe(deleteBtn);
+  });
+
+  it("Enter pressed inside the dialog calls onConfirm", async () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    setup({ onConfirm });
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: true,
+      delete_branch: false,
+      delete_sandbox: false,
+      force_delete: false,
+    });
+  });
+
+  it("Escape pressed inside the dialog calls onCancel", () => {
+    const onCancel = vi.fn();
+    setup({ onCancel });
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("Enter does not fire onConfirm a second time while delete is in flight", async () => {
+    // Keep the first confirm promise pending so the component stays in the
+    // "deleting" state; a second Enter should be ignored.
+    let resolveConfirm: (() => void) | null = null;
+    const onConfirm = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveConfirm = () => resolve();
+        }),
+    );
+    setup({ onConfirm });
+    fireEvent.keyDown(document, { key: "Enter" });
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    resolveConfirm?.();
+  });
+
+  it("Enter while focus is on the Cancel button cancels rather than confirms", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const onCancel = vi.fn();
+    const { container } = setup({ onConfirm, onCancel });
+    const cancelBtn = Array.from(container.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === "Cancel",
+    );
+    expect(cancelBtn).toBeTruthy();
+    cancelBtn!.focus();
+    // The keydown handler should skip Enter when focus is on a non-confirm
+    // button, leaving the browser's native button-Enter behavior to drive
+    // the Cancel click. Simulate that click here.
+    fireEvent.keyDown(cancelBtn!, { key: "Enter" });
+    fireEvent.click(cancelBtn!);
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -173,6 +173,13 @@
       ]
     },
     {
+      "id": "session.delete-dialog-keyboard",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": ["src/components/__tests__/DeleteSessionDialog.test.tsx"],
+      "components": ["web/src/components/DeleteSessionDialog.tsx"]
+    },
+    {
       "id": "right-panel.diff",
       "kind": "deferred",
       "issue": "https://github.com/njbrake/agent-of-empires/issues/1221",


### PR DESCRIPTION
## Description

In the web dashboard, the session-delete confirmation popup is launched from the workspace sidebar right-click menu, so the user's hand is already on the mouse and they have to drag it across to click Delete. Pressing Enter now confirms the delete without that mouse travel.

Two layered affordances:

1. The dialog focuses its Delete button on mount, so native button-Enter activates it.
2. A document-level Enter handler also confirms when focus has moved onto a checkbox row (e.g., the user toggled "Delete branch" and never tabbed back). The handler is a no-op when focus is on the Cancel button or a native input, so those keep their usual semantics, and it's gated on the in-flight `deleting` flag so Enter cannot double-fire.

Escape continues to cancel.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No screenshot; visual surface unchanged, only keyboard behavior. Verified via Vitest: Enter confirms with the expected payload, Escape cancels, focus lands on Delete on mount, Enter is suppressed while a delete is in flight, and Enter while focus is on Cancel does not confirm.)

How I tested:

- `cd web && npx vitest run src/components/__tests__/DeleteSessionDialog.test.tsx` (5/5 pass)
- `cd web && npx vitest run` (431/431 pass)
- `cd web && npm run build`
- `cargo build --features serve`
- `node web/tests/validate-coverage-matrix.mjs`

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Implementation and tests drafted by Claude via the /fix-github-issue skill, then reviewed and run locally by @njbrake. The reasoning and decisions are his; the prose is Claude's.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1260

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

Improves keyboard accessibility for the session delete confirmation dialog. The Delete (confirm) button is focused when the dialog opens so pressing Enter confirms the deletion, and Escape still cancels. A document-level Enter handler also confirms when focus is on non-input dialog elements (e.g., after toggling a checkbox), but it preserves native semantics for inputs/buttons and is disabled while a delete is in progress to prevent double-submission. Focus is restored to the trigger element on close and the dialog gains proper aria-labelledby for screen readers.

## What changed

- Modified component: web/src/components/DeleteSessionDialog.tsx
  - Focuses the Delete button on mount and restores prior focus on unmount.
  - Adds aria-labelledby linking the dialog title for improved screen-reader announcement.
  - Replaces prior Escape-only listener with a document-level keydown handler that:
    - Confirms on Enter when the event target is not INPUT, TEXTAREA, or BUTTON.
    - Skips handling when Cancel is focused or when native button behavior should apply.
    - Cancels on Escape.
    - Guards against double-confirmation via an in-flight `deleting` flag.
- Tests added/updated: web/src/components/__tests__/DeleteSessionDialog.test.tsx
  - Covers focus behavior, Enter/Escape handling, in-flight protection, ARIA labeling, and focus restoration.
- Test surface added: web/tests/coverage-matrix.json
  - Registers the new keyboard-affordance test surface.

## Benefits

- Enables confirming deletion with Enter after invoking the dialog from a context menu (reduces mouse travel).
- Preserves expected behavior for inputs/buttons and prevents accidental double-deletes.
- Accessibility improvements for screen readers and keyboard users.
- Changes are covered by tests to reduce regressions.

## Technical details (concise)

- Uses a ref (confirmButtonRef) to focus the Delete button and stores document.activeElement to restore focus on unmount.
- Installs a document-level keydown handler that inspects e.key and event.target.tagName to decide behavior; ignores INPUT, TEXTAREA, and BUTTON.
- The Enter flow calls onConfirm with current options; a local `deleting` flag prevents re-entry until the confirm promise resolves.
- Tests simulate keydown/click interactions and assert single-confirm semantics, cancel semantics, ARIA attributes, and focus restoration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->