### PR TITLE
fix(sandbox): silence false-positive env warnings for terminal defaults

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -280,6 +280,12 @@ pub(crate) fn resolve_env_value(val: &str) -> Option<String> {
 /// Mirrors what `collect_environment` will silently drop at container
 /// create or docker exec time, so callers can surface the same warnings
 /// to the user via toast or stderr before the failure becomes invisible.
+///
+/// `DEFAULT_TERMINAL_ENV_VARS` are pass-through-if-set toggles (FORCE_COLOR
+/// and NO_COLOR in particular are mutually exclusive and intentionally
+/// unset on most hosts), so we skip them. Without this skip, every new
+/// sandboxed session pops a warning dialog for env vars the user never
+/// set on purpose.
 pub fn validate_env_entries<I, S>(entries: I) -> Vec<String>
 where
     I: IntoIterator<Item = S>,
@@ -287,7 +293,15 @@ where
 {
     entries
         .into_iter()
-        .filter_map(|e| validate_env_entry(e.as_ref()))
+        .filter_map(|e| {
+            let s = e.as_ref();
+            let key = s.split_once('=').map(|(k, _)| k).unwrap_or(s);
+            if DEFAULT_TERMINAL_ENV_VARS.contains(&key) {
+                None
+            } else {
+                validate_env_entry(s)
+            }
+        })
         .collect()
 }
 
@@ -1051,6 +1065,23 @@ environment = ["GH_TOKEN=write_token"]
     #[test]
     fn test_validate_env_entries_empty_list() {
         assert!(validate_env_entries(Vec::<String>::new()).is_empty());
+    }
+
+    #[test]
+    fn test_validate_env_entries_skips_default_terminal_vars_when_unset() {
+        for key in DEFAULT_TERMINAL_ENV_VARS {
+            std::env::remove_var(key);
+        }
+        let entries: Vec<String> = DEFAULT_TERMINAL_ENV_VARS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let warnings = validate_env_entries(&entries);
+        assert!(
+            warnings.is_empty(),
+            "expected no warnings for default terminal vars even when unset, got: {:?}",
+            warnings
+        );
     }
 
     #[test]

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -1068,15 +1068,33 @@ environment = ["GH_TOKEN=write_token"]
     }
 
     #[test]
+    #[serial_test::serial(shell_env)]
     fn test_validate_env_entries_skips_default_terminal_vars_when_unset() {
+        // Stash + remove the defaults so the test catches all four keys even
+        // on CI hosts where TERM/COLORTERM are set. `serial(shell_env)` matches
+        // the pattern used by other tests in this file that mutate globally-
+        // shared env vars.
+        let originals: Vec<(&&str, Option<String>)> = DEFAULT_TERMINAL_ENV_VARS
+            .iter()
+            .map(|k| (k, std::env::var(*k).ok()))
+            .collect();
         for key in DEFAULT_TERMINAL_ENV_VARS {
             std::env::remove_var(key);
         }
+
         let entries: Vec<String> = DEFAULT_TERMINAL_ENV_VARS
             .iter()
             .map(|s| s.to_string())
             .collect();
         let warnings = validate_env_entries(&entries);
+
+        for (key, original) in originals {
+            match original {
+                Some(v) => std::env::set_var(*key, v),
+                None => std::env::remove_var(*key),
+            }
+        }
+
         assert!(
             warnings.is_empty(),
             "expected no warnings for default terminal vars even when unset, got: {:?}",

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1026,13 +1026,29 @@ impl HomeView {
 
                 if !warnings.is_empty() {
                     let body = warnings.join("\n\n");
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Worktree warnings",
-                        &format!(
-                            "Session was created, but the following warnings were emitted during worktree setup:\n\n{}",
-                            body
-                        ),
-                    ));
+                    let message = format!(
+                        "Session was created, but the following warnings were emitted during worktree setup:\n\n{}",
+                        body
+                    );
+                    // Size to fit content. The default 50x9 truncates everything
+                    // past the prefix sentence, so the user only sees the prefix
+                    // and a blank line. Mirrors the math in app.rs:show_startup_warning.
+                    const WIDTH: u16 = 96;
+                    let inner_width = WIDTH.saturating_sub(4) as usize;
+                    let visual_lines: usize = message
+                        .lines()
+                        .map(|l| {
+                            if l.is_empty() {
+                                1
+                            } else {
+                                l.len().div_ceil(inner_width)
+                            }
+                        })
+                        .sum();
+                    let height = ((visual_lines as u16).saturating_add(7)).clamp(9, 35);
+                    self.info_dialog = Some(
+                        InfoDialog::new("Worktree warnings", &message).with_size(WIDTH, height),
+                    );
                 }
 
                 Some(session_id)


### PR DESCRIPTION
## Description

PR #1253 added env-validation warnings at session-create. It runs on the default sandbox env list `[TERM, COLORTERM, FORCE_COLOR, NO_COLOR]`. `FORCE_COLOR` and `NO_COLOR` are mutually exclusive optional terminal toggles, intentionally unset on most hosts, so every new sandboxed session was firing a "Worktree warnings" popup with two noise warnings about vars the user never set on purpose.

The popup also looked empty: `InfoDialog`'s default `50x9` size leaves roughly 3 visible message rows. The prefix sentence wraps to 2 rows, the blank line from `\n\n` is row 3, and the actual warning content gets clipped. Users see prefix + blank.

### Changes

- `src/session/environment.rs`: `validate_env_entries` skips entries whose key matches `DEFAULT_TERMINAL_ENV_VARS`. Those are pass-through-if-set defaults; unset is the normal state. User-added bare keys (e.g. a typo'd `GH_TOKEN`) still warn as intended.
- `src/tui/home/mod.rs`: size the worktree-warnings dialog to its content using the same math as `src/tui/app.rs:show_startup_warning` (96 cols wide, height clamped to `9..=35`) so a real warning, when it does fire, is actually readable.

### Why both fixes

The validator skip is the root-cause fix. The dialog sizing is the latent symptom that masked the bug; without it, future real warnings would still be invisible.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- `cargo test --lib` (1727 pass)
- New regression test `test_validate_env_entries_skips_default_terminal_vars_when_unset` verified to FAIL without the filter and PASS with it
- `cargo fmt`, `cargo clippy` clean

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code, /investigate skill

**Any Additional AI Details you'd like to share:**
Root-cause investigation surfaced both bugs; the user picked the fix scope (skip defaults + autosize) from a presented option list. Implementation and test written by Claude with my review and direction.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes false-positive environment warnings and improves the visibility of worktree warning dialogs.

Changes:
- Environment validation filtering (src/session/environment.rs)
  - validate_env_entries now treats TERM, COLORTERM, FORCE_COLOR, and NO_COLOR as default terminal vars: unset values are ignored so they no longer produce spurious warnings.
  - Adds a regression test that stashes/restores these host env vars and asserts no warnings are produced for the default-terminal-only entries.

- Warning dialog sizing (src/tui/home/mod.rs)
  - The worktree-warnings InfoDialog is now auto-sized to its content (uses the same sizing math as the startup warning dialog: target width 96, height clamped 9..=35) so warning text is not clipped and is more readable.
  - The message text is prefixed and wrapped to improve clarity.

Benefits:
- Eliminates noisy "Worktree warnings" for unset optional terminal toggles that most hosts intentionally leave unset.
- Makes real warnings readable by preventing dialog clipping.
- Preserves warnings for user-added environment entries.

Technical details (brief):
- DEFAULT_TERMINAL_ENV_VARS constant is used to skip validation for those keys when unset.
- New serial regression test saves/restores TERM/COLORTERM/FORCE_COLOR/NO_COLOR to avoid test races.
- Dialog sizing reuses existing startup dialog sizing logic (96 cols, height clamped 9..=35).
- All existing tests pass; new test included; code formatted and lint-clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->