### PR TITLE
feat(kiro): document upstream gap blocking waiting-status mapping

### DIFF
--- a/src/agents.rs
+++ b/src/agents.rs
@@ -443,6 +443,12 @@ pub const AGENTS: &[AgentDef] = &[
         // by Claude/Cursor/Gemini, so hook_config: None and install is
         // special-cased like hermes/settl. Status comes from the hook sidecar
         // file written by install_kiro_hooks; the pane stub is unused.
+        //
+        // Kiro CLI does not currently emit a tool-approval / permission-request
+        // hook event (only agentSpawn, userPromptSubmit, preToolUse,
+        // postToolUse, stop), so we cannot surface a distinct `waiting` status
+        // for Kiro sessions blocked on tool approval. See KIRO_HOOKS in
+        // src/hooks/mod.rs and AoE issue #961.
         hook_config: None,
         resume_strategy: ResumeStrategy::Flag("--resume-id"),
         host_only: false,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -860,6 +860,16 @@ fn render_hermes_allowlist(config_dir: &Path) -> Result<(std::path::PathBuf, Str
 
 /// Kiro CLI hook events. Kiro uses lowercase camelCase event names and a flat
 /// `[{"command": "..."}]` structure in its agent config JSON.
+///
+/// Kiro CLI currently exposes only five hook events: `agentSpawn`,
+/// `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop`. There is no
+/// equivalent of Claude's `Notification` (with `permission_prompt` matcher),
+/// Codex's `PermissionRequest`, or Hermes's `pre_approval_request` that fires
+/// when the agent pauses waiting for the user to approve a tool. Until Kiro
+/// adds such an event, a Kiro session blocked on tool approval will continue
+/// to show as `running` rather than flipping to `waiting`. Tracked upstream
+/// at <https://github.com/kirodotdev/Kiro/issues> (see AoE issue #961 for the
+/// AoE-side follow-up).
 const KIRO_HOOKS: &[(&str, &str)] = &[
     ("preToolUse", "running"),
     ("userPromptSubmit", "running"),

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -864,12 +864,13 @@ fn render_hermes_allowlist(config_dir: &Path) -> Result<(std::path::PathBuf, Str
 /// Kiro CLI currently exposes only five hook events: `agentSpawn`,
 /// `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop`. There is no
 /// equivalent of Claude's `Notification` (with `permission_prompt` matcher),
-/// Codex's `PermissionRequest`, or Hermes's `pre_approval_request` that fires
-/// when the agent pauses waiting for the user to approve a tool. Until Kiro
-/// adds such an event, a Kiro session blocked on tool approval will continue
-/// to show as `running` rather than flipping to `waiting`. Tracked upstream
-/// at <https://github.com/kirodotdev/Kiro/issues> (see AoE issue #961 for the
-/// AoE-side follow-up).
+/// Gemini's `Notification` (with `ToolPermission` matcher), Codex's
+/// `PermissionRequest`, or Hermes's `pre_approval_request` that fires when
+/// the agent pauses waiting for the user to approve a tool. Until Kiro adds
+/// such an event, a Kiro session blocked on tool approval will continue to
+/// show as `running` rather than flipping to `waiting`. Feature request to
+/// be filed against <https://github.com/kirodotdev/Kiro>; see AoE issue
+/// #961 for the AoE-side follow-up.
 const KIRO_HOOKS: &[(&str, &str)] = &[
     ("preToolUse", "running"),
     ("userPromptSubmit", "running"),


### PR DESCRIPTION
## Description

Investigation follow-up for #961.

The issue asked us to map a Kiro CLI tool-approval / pre-approval hook event to the `waiting` status, matching what Claude, Cursor, Codex, Gemini, Qwen, and Hermes already do. Per the issue, first step was to confirm whether Kiro emits such an event.

**Finding: Kiro CLI does not currently emit a tool-approval hook event.**

The full list of Kiro CLI hook events per the docs at https://kiro.dev/docs/cli/hooks/ and https://kiro.dev/docs/cli/custom-agents/configuration-reference/ is:

1. `agentSpawn`
2. `userPromptSubmit`
3. `preToolUse` (fires before tool execution; can validate / block, but does not signal "blocked on approval")
4. `postToolUse`
5. `stop`

There is no equivalent of Claude's `Notification` (`permission_prompt` matcher), Codex's `PermissionRequest`, Gemini's `Notification` (`ToolPermission` matcher), or Hermes's `pre_approval_request`. Kiro does have a runtime approval flow (Yes / Trust / No dropdown, see https://kiro.dev/docs/cli/chat/permissions/) but no hook callback for it.

**Conclusion: there is nothing for us to wire up on the AoE side right now.** Until upstream adds the event, a Kiro session blocked on tool approval will continue to show as `running` rather than `waiting`.

## What this PR does

No behavior change. Two inline comments only, to make sure the next person who looks at this sees the constraint:

- `KIRO_HOOKS` in `src/hooks/mod.rs`: documents the five available Kiro events, names the missing one, and points at the upstream gap and AoE issue #961.
- The Kiro `AgentDef` entry in `src/agents.rs`: cross-references `KIRO_HOOKS` so anyone editing the agent registry sees the same context.

## Next steps

Two things to land before this PR can move out of draft / be closed:

1. **File the upstream feature request with `kirodotdev/Kiro`.** I tried to file it from the agent token but creating issues on third-party repos is not in scope for the fine-grained PAT. Drafted body below; @njbrake to file from your account when convenient.
2. **Decide what to do with this PR.** Two reasonable options:
   - **Close this PR** and update the comments to link the upstream issue number once filed; reopen / re-do the implementation when upstream lands the event.
   - **Land the comments now** so the constraint is documented in-tree, and track the upstream/implementation work via #961 + the upstream issue. (Slight preference here since the comments are net useful even before upstream moves.)

## Drafted upstream issue body (for `kirodotdev/Kiro`)

Title: `Feature Request: hook event for tool-approval / permission-request prompts`

````
_Note: this issue was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Summary

Kiro CLI currently exposes five hook events: `agentSpawn`, `userPromptSubmit`, `preToolUse`, `postToolUse`, and `stop`. There is no hook event that fires when Kiro pauses to ask the user to approve a tool (the "Yes / Trust / No" panel-based dropdown).

Could Kiro add a hook event that fires at the moment the agent is blocked waiting on user approval, plus a matching event when that approval resolves? Proposed names (matching existing camelCase convention): `permissionRequest` (fires when the approval prompt appears) and `permissionResolved` (fires when the user picks Yes/Trust/No). Either of those, or an extension of an existing event with a discriminator field that distinguishes "pre-execute" from "blocked-on-approval", would also work.

## Motivation

We are building Agent of Empires (https://github.com/njbrake/agent-of-empires), a multi-agent orchestrator that runs several CLI coding agents in parallel and surfaces their status (`running` / `waiting` / `idle`) in a TUI and web dashboard. We support Kiro CLI as a first-class agent today via the existing hooks.

Other agents in our matrix (Claude Code, Cursor CLI, Gemini CLI, Codex, Qwen Code, Hermes) all emit a hook event when the agent is blocked on a tool-approval prompt:

- Claude Code / Cursor CLI: `Notification` with `permission_prompt` matcher
- Codex: `PermissionRequest`
- Gemini CLI: `Notification` with `ToolPermission` matcher
- Hermes: `pre_approval_request`

We map all of these to a distinct `waiting` status so users can triage at a glance: "this session is making progress" vs. "this session is blocked on me". With Kiro, we cannot distinguish those two cases today, so a Kiro session sitting on a tool-approval prompt shows up the same as one that is actively executing a tool. For a user juggling 6+ agents that gap is significant.

## Expected behavior

When Kiro pauses to show the approval dropdown for a tool that does not have a pre-granted permission, a hook configured for the new event fires before the user picks an option. The event payload would naturally include at least the tool name and the current session UUID (matching the existing `preToolUse` shape). A corresponding event after the user resolves the prompt (with the choice and tool result) is ideal but not strictly required; we can clear the waiting state from `postToolUse`.

## Repro / impact

In any Kiro CLI session, run a tool that does not have an existing permission grant (e.g. a fresh session that asks for `execute_bash` approval). External tooling watching hook events sees no signal between `userPromptSubmit` and `preToolUse`; the session is functionally paused but indistinguishable from an actively-running session.

## References

- Kiro hooks docs: https://kiro.dev/docs/cli/hooks/
- Kiro permissions docs: https://kiro.dev/docs/cli/chat/permissions/
- AoE follow-up issue: https://github.com/njbrake/agent-of-empires/issues/961
````

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --lib hooks::`, all 56 hook tests green; no behavior change so existing coverage suffices)
- [x] Documentation was updated where necessary (the change *is* documentation)
- [ ] For UI changes: included screenshot or recording (n/a)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (via Claude Code agent harness, invoked through the `fix-github-issue` skill).

**Any Additional AI Details you'd like to share:**

This PR is intentionally docs-only. Investigation surfaced an upstream gap that blocks the requested mapping, so the agent did not invent a workaround; instead it added two anchor comments so a future contributor lands on the upstream constraint immediately, and drafted the upstream issue body for @njbrake to file under his own account.

- [x] I am an AI Agent filling out this form (check box if true)

Refs #961