### PR TITLE
feat(tui): surface current sort in list title; drop noisy [all] tag

### DIFF
--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1371,8 +1371,11 @@ impl HomeView {
         flatten_tree(&tree, &grouped, self.sort_order)
     }
 
-    pub fn active_profile_display(&self) -> &str {
-        self.active_profile.as_deref().unwrap_or("all")
+    /// The active profile filter name, or `None` when no filter is applied.
+    /// Returning `None` lets callers (e.g. the list-pane title) omit the
+    /// `[<profile>]` segment entirely instead of rendering a noisy `[all]`.
+    pub fn active_profile_display(&self) -> Option<&str> {
+        self.active_profile.as_deref()
     }
 
     /// Switch the active profile filter in-place without destroying the view.

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -11,7 +11,7 @@ use super::{
     get_indent, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING, ICON_ERROR,
     ICON_EXPANDED, ICON_IDLE, ICON_STOPPED, ICON_UNKNOWN,
 };
-use crate::session::config::GroupByMode;
+use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
 use crate::tui::components::{set_prefixed_input_cursor_position, HelpOverlay, Preview};
 use crate::tui::responsive;
@@ -22,6 +22,39 @@ use crate::update::UpdateInfo;
 /// sessions started at different times show visually distinct spinner positions.
 fn session_offset(created_at: &DateTime<Utc>) -> usize {
     created_at.timestamp_millis() as usize
+}
+
+/// Build the list-pane title.
+///
+/// `prefix` is the leading label ("aoe", "Terminals", "Tool: <name>").
+/// `profile` is `Some(name)` only when a real filter is active; when `None`,
+/// the `[<profile>]` segment is omitted so the default all-profiles state
+/// stays uncluttered.
+/// The `(by project)` and `sort: <label>` suffixes are merged into a single
+/// parenthesized hint, and each piece is dropped when it matches the default.
+fn compose_list_title(
+    prefix: &str,
+    profile: Option<&str>,
+    group_by: GroupByMode,
+    sort_order: SortOrder,
+) -> String {
+    let mut parts: Vec<String> = Vec::with_capacity(2);
+    if group_by == GroupByMode::Project {
+        parts.push("by project".to_string());
+    }
+    if sort_order != SortOrder::default() {
+        parts.push(format!("sort: {}", sort_order.label()));
+    }
+    let suffix = if parts.is_empty() {
+        String::new()
+    } else {
+        format!(" ({})", parts.join(", "))
+    };
+    let profile_tag = match profile {
+        Some(name) => format!(" [{}]", name),
+        None => String::new(),
+    };
+    format!(" {}{}{} ", prefix, profile_tag, suffix)
 }
 
 /// Extra rows captured beyond the visible window so moderate scrolls don't
@@ -337,23 +370,17 @@ impl HomeView {
     }
 
     fn render_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let group_suffix = if self.group_by == GroupByMode::Project {
-            " (by project)"
-        } else {
-            ""
-        };
+        let profile = self.active_profile_display();
         let title = match &self.view_mode {
-            ViewMode::Agent => format!(" aoe [{}]{} ", self.active_profile_display(), group_suffix),
-            ViewMode::Terminal => format!(
-                " Terminals [{}]{} ",
-                self.active_profile_display(),
-                group_suffix
-            ),
-            ViewMode::Tool(name) => format!(
-                " Tool: {} [{}]{} ",
-                name,
-                self.active_profile_display(),
-                group_suffix
+            ViewMode::Agent => compose_list_title("aoe", profile, self.group_by, self.sort_order),
+            ViewMode::Terminal => {
+                compose_list_title("Terminals", profile, self.group_by, self.sort_order)
+            }
+            ViewMode::Tool(name) => compose_list_title(
+                &format!("Tool: {}", name),
+                profile,
+                self.group_by,
+                self.sort_order,
             ),
         };
         let (border_color, title_color) = match self.view_mode {
@@ -1440,6 +1467,62 @@ impl HomeView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn compose_list_title_omits_profile_and_suffix_at_defaults() {
+        // Default group/sort and no profile filter: title is just the prefix,
+        // no `[all]` tag, no parenthesized suffix.
+        let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::Newest);
+        assert_eq!(title, " aoe ");
+    }
+
+    #[test]
+    fn compose_list_title_includes_profile_when_filter_active() {
+        let title = compose_list_title(
+            "aoe",
+            Some("my-profile"),
+            GroupByMode::Manual,
+            SortOrder::Newest,
+        );
+        assert_eq!(title, " aoe [my-profile] ");
+    }
+
+    #[test]
+    fn compose_list_title_shows_by_project_only() {
+        let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::Newest);
+        assert_eq!(title, " aoe (by project) ");
+    }
+
+    #[test]
+    fn compose_list_title_shows_sort_only_when_non_default() {
+        let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::LastActivity);
+        assert_eq!(title, " aoe (sort: Recent) ");
+    }
+
+    #[test]
+    fn compose_list_title_merges_group_and_sort_suffixes() {
+        let title = compose_list_title(
+            "aoe",
+            Some("alpha"),
+            GroupByMode::Project,
+            SortOrder::LastActivity,
+        );
+        assert_eq!(title, " aoe [alpha] (by project, sort: Recent) ");
+    }
+
+    #[test]
+    fn compose_list_title_default_sort_drops_suffix_segment() {
+        // Newest is the default; it must not appear in the title even when
+        // group mode contributes its own suffix piece.
+        let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::Newest);
+        assert_eq!(title, " aoe (by project) ");
+    }
+
+    #[test]
+    fn compose_list_title_supports_tool_prefix() {
+        let title = compose_list_title("Tool: foo", None, GroupByMode::Manual, SortOrder::AZ);
+        assert_eq!(title, " Tool: foo (sort: A-Z) ");
+    }
 
     #[test]
     fn format_relative_age_none_returns_empty() {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1525,6 +1525,62 @@ mod tests {
     }
 
     #[test]
+    fn compose_list_title_supports_terminal_prefix() {
+        // Terminal view mode uses the "Terminals" prefix; verify it flows
+        // through the helper just like the Agent and Tool prefixes do.
+        let title = compose_list_title(
+            "Terminals",
+            Some("work"),
+            GroupByMode::Project,
+            SortOrder::Newest,
+        );
+        assert_eq!(title, " Terminals [work] (by project) ");
+    }
+
+    #[test]
+    fn compose_list_title_default_sort_with_project_and_profile() {
+        // Matrix cell: default sort + project group + active profile.
+        let title = compose_list_title(
+            "aoe",
+            Some("alpha"),
+            GroupByMode::Project,
+            SortOrder::Newest,
+        );
+        assert_eq!(title, " aoe [alpha] (by project) ");
+    }
+
+    #[test]
+    fn compose_list_title_non_default_sort_with_profile_only() {
+        // Matrix cell: non-default sort + manual group + active profile.
+        let title = compose_list_title(
+            "aoe",
+            Some("alpha"),
+            GroupByMode::Manual,
+            SortOrder::LastActivity,
+        );
+        assert_eq!(title, " aoe [alpha] (sort: Recent) ");
+    }
+
+    #[test]
+    fn compose_list_title_non_default_sort_with_project_no_profile() {
+        // Matrix cell: non-default sort + project group + no profile.
+        let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::LastActivity);
+        assert_eq!(title, " aoe (by project, sort: Recent) ");
+    }
+
+    #[test]
+    fn compose_list_title_renders_oldest_sort_label() {
+        let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::Oldest);
+        assert_eq!(title, " aoe (sort: Oldest) ");
+    }
+
+    #[test]
+    fn compose_list_title_renders_za_sort_label() {
+        let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::ZA);
+        assert_eq!(title, " aoe (sort: Z-A) ");
+    }
+
+    #[test]
     fn format_relative_age_none_returns_empty() {
         assert_eq!(format_relative_age(None), "");
     }

--- a/tests/e2e/command_palette.rs
+++ b/tests/e2e/command_palette.rs
@@ -11,7 +11,7 @@ fn test_command_palette_opens_with_ctrl_k() {
     let mut h = TuiTestHarness::new("palette_open");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("C-k");
     h.wait_for("Commands");
     // Both assertions target entries in the top "Actions" group so they're
@@ -29,7 +29,7 @@ fn test_command_palette_esc_closes() {
     let mut h = TuiTestHarness::new("palette_close");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("C-k");
     h.wait_for("Commands");
 
@@ -45,7 +45,7 @@ fn test_command_palette_fuzzy_search_settings() {
     let mut h = TuiTestHarness::new("palette_fuzzy");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("C-k");
     h.wait_for("Commands");
 
@@ -68,7 +68,7 @@ fn test_status_bar_shows_palette_hint() {
     let mut h = TuiTestHarness::new("palette_hint");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     // The footer should mention the Ctrl+K shortcut so users discover it.
     h.assert_screen_contains("^K");
 }

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -11,7 +11,7 @@ fn test_new_session_dialog_opens() {
     let mut h = TuiTestHarness::new("new_dialog");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.send_keys("n");
     h.wait_for("Title");
     h.assert_screen_contains("Path");
@@ -25,7 +25,7 @@ fn test_new_session_dialog_escape_cancels() {
     let mut h = TuiTestHarness::new("new_esc");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.send_keys("n");
     h.wait_for("Title");
 
@@ -112,7 +112,7 @@ fn test_creating_stub_appears_during_hook_execution() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
 
     // Open new session dialog and fill in the path.
     h.send_keys("n");
@@ -138,7 +138,7 @@ fn test_creating_stub_cancelled_with_ctrl_c() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
 
     // Create a session with a slow hook.
     h.send_keys("n");
@@ -167,7 +167,7 @@ fn test_creating_blocks_second_session_creation() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
 
     // Start creating a session.
     h.send_keys("n");
@@ -201,7 +201,7 @@ fn test_quit_during_creation_shows_confirm() {
     let project = h.project_path();
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
 
     // Start creating a session.
     h.send_keys("n");

--- a/tests/e2e/profile_picker.rs
+++ b/tests/e2e/profile_picker.rs
@@ -18,7 +18,7 @@ fn test_profile_picker_opens_and_closes() {
     h.spawn_tui();
 
     // Default launch is now all-profiles mode
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
     h.assert_screen_contains("default");
@@ -39,7 +39,7 @@ fn test_profile_picker_shows_multiple_profiles() {
     create_profile(&h, "personal");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
     h.assert_screen_contains("default");
@@ -55,7 +55,7 @@ fn test_profile_picker_create_new_profile() {
     let mut h = TuiTestHarness::new("picker_create");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
 
@@ -80,7 +80,7 @@ fn test_profile_picker_create_esc_returns_to_list() {
     let mut h = TuiTestHarness::new("picker_create_esc");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
 
@@ -102,7 +102,7 @@ fn test_profile_picker_delete_flow() {
     create_profile(&h, "deleteme");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
     h.assert_screen_contains("deleteme");
@@ -135,7 +135,7 @@ fn test_profile_picker_delete_cancel() {
     create_profile(&h, "keepme");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
 
@@ -163,7 +163,7 @@ fn test_profile_picker_switch_profile() {
     create_profile(&h, "other");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("P");
     h.wait_for("Profiles");
 

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -69,7 +69,7 @@ fn tui_serve_dialog_opens_to_mode_picker() {
     let mut h = TuiTestHarness::new("serve_mode_picker");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.send_keys("R");
 
     h.wait_for("How should this be reachable?");
@@ -92,7 +92,7 @@ fn tui_serve_dialog_escape_returns_home() {
     let mut h = TuiTestHarness::new("serve_mode_picker_esc");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.send_keys("R");
     h.wait_for("How should this be reachable?");
 

--- a/tests/e2e/tool_sessions.rs
+++ b/tests/e2e/tool_sessions.rs
@@ -68,7 +68,7 @@ command = "yazi"
     );
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("\\;");
     h.wait_for("Tool Sessions");
     h.assert_screen_contains("lazygit");
@@ -90,7 +90,7 @@ fn test_tool_picker_does_not_open_with_no_tools_configured() {
     let mut h = TuiTestHarness::new("tool_picker_empty");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("\\;");
     // With zero [tools.*] entries the picker is suppressed; the screen
     // should still be on the home view.
@@ -114,7 +114,7 @@ hotkey = "Alt+g"
     );
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
     h.send_keys("C-k");
     h.wait_for("Commands");
     h.type_text("lazyg");

--- a/tests/e2e/tui_launch.rs
+++ b/tests/e2e/tui_launch.rs
@@ -11,7 +11,7 @@ fn test_tui_launches_and_shows_home_screen() {
     let mut h = TuiTestHarness::new("launch");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.assert_screen_contains("No sessions yet");
     // Status bar should be visible. Use the j/k key hint (which has no
     // accompanying description in the compact footer).
@@ -26,7 +26,7 @@ fn test_tui_quit_with_q() {
     let mut h = TuiTestHarness::new("quit");
     h.spawn_tui();
 
-    h.wait_for(" aoe [");
+    h.wait_for(" aoe ");
     h.send_keys("q");
     h.wait_for_exit(Duration::from_secs(5));
     assert!(!h.session_alive(), "session should have exited after 'q'");

--- a/tests/e2e/unified_view.rs
+++ b/tests/e2e/unified_view.rs
@@ -25,7 +25,11 @@ fn test_default_view_shows_all_profiles() {
     create_profile_with_session(&h, "beta", "Beta Session");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
+    // Default all-profiles mode has no `[profile]` tag in the title;
+    // the absence of the bracketed segment is the new "unfiltered" tell.
+    h.assert_screen_not_contains("[alpha]");
+    h.assert_screen_not_contains("[beta]");
     h.assert_screen_contains("Alpha Session");
     h.assert_screen_contains("Beta Session");
 }
@@ -40,7 +44,7 @@ fn test_profile_filter_via_picker() {
     create_profile_with_session(&h, "beta", "Beta Session");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
 
     // Open picker and select "alpha"
     h.send_keys("P");
@@ -64,7 +68,7 @@ fn test_return_to_all_view_via_picker() {
     create_profile_with_session(&h, "beta", "Beta Session");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
 
     // Filter to alpha
     h.send_keys("P");
@@ -84,7 +88,8 @@ fn test_return_to_all_view_via_picker() {
     std::thread::sleep(Duration::from_millis(50));
     h.send_keys("Enter");
 
-    h.wait_for("[all]");
+    // Returning to all-profiles mode drops the `[alpha]` tag from the title.
+    h.wait_for_absent("[alpha]", Duration::from_secs(5));
     h.assert_screen_contains("Alpha Session");
     h.assert_screen_contains("Beta Session");
 }
@@ -101,7 +106,7 @@ fn test_all_profiles_flat_view() {
     create_profile_with_session(&h, "beta", "Beta Session");
     h.spawn_tui();
 
-    h.wait_for("[all]");
+    h.wait_for(" aoe ");
 
     // Both sessions visible simultaneously with no headers to collapse
     h.assert_screen_contains("Alpha Session");


### PR DESCRIPTION
## Description

The home view's list-pane title now reflects the active sort mode when it is non-default, alongside the existing project-grouping suffix, e.g. ` aoe [my-profile] (by project, sort: Recent) `. Default sort (`Newest`) omits the segment so the quiescent state stays uncluttered.

The `[all]` profile tag is dropped entirely: `[<profile>]` only renders when an explicit profile filter is active, so the brackets double as a visual indicator that a filter is on.

Implementation notes:
- `active_profile_display()` now returns `Option<&str>` (None when no filter) so the title-construction site can suppress the bracketed segment instead of stringly checking for a `"all"` sentinel.
- Title composition is extracted into a pure `compose_list_title()` helper so the suffix logic is unit-testable without spinning up a `HomeView`. The two parenthesized hints (`by project`, `sort: <label>`) are joined with a comma when both are active so the title doesn't sprout twin parens.
- Profile picker and `:profile` switching continue to update the title in real time (they mutate `active_profile`, which is what the helper reads).

Fixes #873

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Minor UX polish; technically a feature for the sort surfacing piece and a refactor for the profile-display return type, leaning refactor.)

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Note on the screenshot box: this is a title-bar copy tweak whose behavior is verified by deterministic unit tests on the pure `compose_list_title()` helper, covering every relevant combination (default state, profile-only, group-only, sort-only, both suffixes, default-sort drops cleanly, tool prefix). Happy to attach a terminal grab if a reviewer wants one.

### How I tested

- `cargo fmt --check` clean.
- `cargo clippy --all-targets` clean for the touched files (one pre-existing `themes::ThemeAppearance` unused-import warning on `src/tui/styles/mod.rs` is unrelated and present on `main`).
- `cargo test` green: 1745 lib tests + all integration suites pass. Seven new unit tests cover the title composer:
  - default state collapses to ` aoe `
  - profile-only renders ` aoe [my-profile] `
  - group-only renders ` aoe (by project) `
  - sort-only renders ` aoe (sort: Recent) `
  - both suffixes merge: ` aoe [alpha] (by project, sort: Recent) `
  - default sort drops cleanly when group is on
  - tool-mode prefix flows through

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Opus 4.7, 1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Implementation and tests drafted by Claude under my direction; I reviewed the diff and confirmed acceptance criteria.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR cleans up the TUI home view list-pane title: it shows the active non-default sort inline and removes the noisy default `[all]` profile tag, making the title clearer and more informative.

## What changed (user-facing)
- When a non-default sort is active, the title appends "sort: <label>" alongside the existing "(by project)" hint, e.g. `aoe [my-profile] (by project, sort: Recent)`.
- The profile bracket is no longer shown as `[all]` when no profile filter is active; a bracketed `[<profile>]` appears only when an explicit profile filter is set.
- Profile picker and `:profile` switching still update the title in real time.

## What changed (code-level)
- active_profile_display() now returns Option<&str> (None when no profile filter) instead of returning the sentinel "all".
- Added compose_list_title(mode_prefix, active_profile: Option<&str>, group_by: GroupByMode, sort: SortOrder): a pure helper that centralizes title composition and suffix merging.
- render_list now calls compose_list_title() for Agent/Terminal/Tool modes (removed duplicated per-mode suffix logic).
- Unit tests added/expanded (seven new unit tests covering default, profile-only, group-only, sort-only, merged suffixes, default-sort suppression, and tool-mode prefix).
- E2E tests updated to synchronize on a broader startup sentinel (" aoe ") instead of expecting "[all]".
- CI checks (cargo fmt, clippy) and cargo test pass.
- Fixes issue `#873`.

## Benefits
- Users can see the active sort without opening help, improving discoverability.
- UI is less noisy by eliminating the unnecessary `[all]` tag.
- Title logic is now unit-testable and centralized, improving maintainability and reducing duplication.
- Additional tests reduce risk of regressions.

## Technical notes (brief)
- compose_list_title omits the profile segment when active_profile is None and omits the sort segment when sort == default (Newest). It merges group and sort hints into a single parenthesized suffix when applicable.
- Small test/e2e changes adjust readiness markers to the new default title format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->