### PR TITLE
feat(profile): add optional description field surfaced in pickers

### DIFF
--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -62,7 +62,13 @@ pub(super) fn validate_no_shell_injection(value: &str, field_name: &str) -> Resu
 }
 
 pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
-    "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
+    "theme",
+    "session",
+    "tmux",
+    "updates",
+    "sound",
+    "sandbox",
+    "worktree",
     // web: audited 2026-04-24, contains only boolean notification toggles
     // (notifications_enabled, notify_on_waiting, notify_on_idle, notify_on_error).
     // No shell commands, no binary paths, no RCE surface.
@@ -71,6 +77,10 @@ pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
     // No shell commands, no binary paths. Values are validated against the
     // EnvFilter parser before being written back to disk.
     "logging",
+    // description: top-level profile field (Option<String>) surfaced as
+    // helper text in the wizard profile picker (#949). Plain text only,
+    // no shell metacharacters or binary paths.
+    "description",
 ];
 
 pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
@@ -309,7 +319,13 @@ mod tests {
         // section in particular must NOT be API-writable because global
         // hooks bypass the trust prompt that gates repo hooks.
         let expected: &[&str] = &[
-            "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
+            "theme",
+            "session",
+            "tmux",
+            "updates",
+            "sound",
+            "sandbox",
+            "worktree",
             // web: audited 2026-04-24. WebConfig has 4 boolean fields
             // (notifications_enabled, notify_on_waiting, notify_on_idle,
             // notify_on_error). No shell commands, no binary paths.
@@ -317,6 +333,9 @@ mod tests {
             // logging: persistent tracing filter. EnvFilter parser
             // validates every value before save_config writes it back.
             "logging",
+            // description: optional string surfaced in the wizard profile
+            // picker (#949). Plain text, no shell metacharacters.
+            "description",
         ];
         assert_eq!(
             ALLOWED_SETTINGS_SECTIONS.len(),

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -61,14 +61,14 @@ pub(super) fn validate_no_shell_injection(value: &str, field_name: &str) -> Resu
     Ok(())
 }
 
-pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
-    "theme",
-    "session",
-    "tmux",
-    "updates",
-    "sound",
-    "sandbox",
-    "worktree",
+/// Sections that PATCH /api/settings (global config) may write.
+///
+/// Keep this list narrower than the profile-write list: anything here lands
+/// in the process-global Config and is shared by every profile, so the bar
+/// for inclusion is higher. `description` is intentionally absent because
+/// it is a per-profile field (#949).
+pub(super) const ALLOWED_GLOBAL_SETTINGS_SECTIONS: &[&str] = &[
+    "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
     // web: audited 2026-04-24, contains only boolean notification toggles
     // (notifications_enabled, notify_on_waiting, notify_on_idle, notify_on_error).
     // No shell commands, no binary paths, no RCE surface.
@@ -77,9 +77,24 @@ pub(super) const ALLOWED_SETTINGS_SECTIONS: &[&str] = &[
     // No shell commands, no binary paths. Values are validated against the
     // EnvFilter parser before being written back to disk.
     "logging",
-    // description: top-level profile field (Option<String>) surfaced as
-    // helper text in the wizard profile picker (#949). Plain text only,
-    // no shell metacharacters or binary paths.
+];
+
+/// Sections that PATCH /api/settings/profile/:name may write.
+///
+/// Superset of the global list; adds `description`, which is a top-level
+/// per-profile string field (Option<String>) surfaced as helper text in
+/// the wizard profile picker (#949). Plain text only, no shell
+/// metacharacters or binary paths.
+pub(super) const ALLOWED_PROFILE_SETTINGS_SECTIONS: &[&str] = &[
+    "theme",
+    "session",
+    "tmux",
+    "updates",
+    "sound",
+    "sandbox",
+    "worktree",
+    "web",
+    "logging",
     "description",
 ];
 
@@ -312,12 +327,61 @@ mod tests {
     }
 
     #[test]
-    fn allowed_settings_sections_are_pinned() {
+    fn allowed_global_settings_sections_are_pinned() {
         // If you're adding a new top-level settings section, add it here AND
         // confirm the schema deserializes user input safely (no shell
         // commands that run on launch, no binary overrides). The `hooks`
         // section in particular must NOT be API-writable because global
         // hooks bypass the trust prompt that gates repo hooks.
+        //
+        // Global allowlist is intentionally narrower than the profile
+        // allowlist: profile-only fields (e.g., `description`) must not be
+        // accepted by PATCH /api/settings, only by the per-profile endpoint.
+        let expected: &[&str] = &[
+            "theme", "session", "tmux", "updates", "sound", "sandbox", "worktree",
+            // web: audited 2026-04-24. WebConfig has 4 boolean fields
+            // (notifications_enabled, notify_on_waiting, notify_on_idle,
+            // notify_on_error). No shell commands, no binary paths.
+            "web",
+            // logging: persistent tracing filter. EnvFilter parser
+            // validates every value before save_config writes it back.
+            "logging",
+        ];
+        assert_eq!(
+            ALLOWED_GLOBAL_SETTINGS_SECTIONS.len(),
+            expected.len(),
+            "ALLOWED_GLOBAL_SETTINGS_SECTIONS size changed — adding a section widens \
+             the API write surface and must be reviewed as a security change. \
+             In particular, do NOT add 'hooks' without auditing the RCE surface."
+        );
+        for section in expected {
+            assert!(
+                ALLOWED_GLOBAL_SETTINGS_SECTIONS.contains(section),
+                "ALLOWED_GLOBAL_SETTINGS_SECTIONS lost section {:?}",
+                section
+            );
+        }
+        // Explicitly guard against accidental hooks re-addition.
+        assert!(
+            !ALLOWED_GLOBAL_SETTINGS_SECTIONS.contains(&"hooks"),
+            "hooks must not be API-writable: global/profile hooks bypass the \
+             repo-hook trust prompt and run arbitrary shell commands on session \
+             start (local RCE)"
+        );
+        // `description` is a per-profile field and must not appear on the
+        // global endpoint, even though it is plain text and safe in itself.
+        assert!(
+            !ALLOWED_GLOBAL_SETTINGS_SECTIONS.contains(&"description"),
+            "description is a per-profile field and must only be writable via \
+             PATCH /api/settings/profile/:name, not the global endpoint"
+        );
+    }
+
+    #[test]
+    fn allowed_profile_settings_sections_are_pinned() {
+        // Profile allowlist is the global list plus `description`. Anything
+        // global can also be set per-profile (overrides); profile-only fields
+        // (`description` today) are the additions.
         let expected: &[&str] = &[
             "theme",
             "session",
@@ -326,38 +390,37 @@ mod tests {
             "sound",
             "sandbox",
             "worktree",
-            // web: audited 2026-04-24. WebConfig has 4 boolean fields
-            // (notifications_enabled, notify_on_waiting, notify_on_idle,
-            // notify_on_error). No shell commands, no binary paths.
             "web",
-            // logging: persistent tracing filter. EnvFilter parser
-            // validates every value before save_config writes it back.
             "logging",
             // description: optional string surfaced in the wizard profile
             // picker (#949). Plain text, no shell metacharacters.
             "description",
         ];
         assert_eq!(
-            ALLOWED_SETTINGS_SECTIONS.len(),
+            ALLOWED_PROFILE_SETTINGS_SECTIONS.len(),
             expected.len(),
-            "ALLOWED_SETTINGS_SECTIONS size changed — adding a section widens \
-             the API write surface and must be reviewed as a security change. \
-             In particular, do NOT add 'hooks' without auditing the RCE surface."
+            "ALLOWED_PROFILE_SETTINGS_SECTIONS size changed — adding a section \
+             widens the API write surface and must be reviewed as a security change."
         );
         for section in expected {
             assert!(
-                ALLOWED_SETTINGS_SECTIONS.contains(section),
-                "ALLOWED_SETTINGS_SECTIONS lost section {:?}",
+                ALLOWED_PROFILE_SETTINGS_SECTIONS.contains(section),
+                "ALLOWED_PROFILE_SETTINGS_SECTIONS lost section {:?}",
                 section
             );
         }
-        // Explicitly guard against accidental hooks re-addition.
         assert!(
-            !ALLOWED_SETTINGS_SECTIONS.contains(&"hooks"),
-            "hooks must not be API-writable: global/profile hooks bypass the \
-             repo-hook trust prompt and run arbitrary shell commands on session \
-             start (local RCE)"
+            !ALLOWED_PROFILE_SETTINGS_SECTIONS.contains(&"hooks"),
+            "hooks must not be API-writable on any endpoint"
         );
+        // Every global section must also be writable per-profile (overrides).
+        for section in ALLOWED_GLOBAL_SETTINGS_SECTIONS {
+            assert!(
+                ALLOWED_PROFILE_SETTINGS_SECTIONS.contains(section),
+                "global section {:?} must also be accepted by the per-profile endpoint",
+                section
+            );
+        }
     }
 
     #[test]

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -8,7 +8,10 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
 
 use super::AppState;
-use super::{validate_profile_name, ALLOWED_SETTINGS_SECTIONS, SESSION_BLOCKED_FIELDS};
+use super::{
+    validate_profile_name, ALLOWED_GLOBAL_SETTINGS_SECTIONS, ALLOWED_PROFILE_SETTINGS_SECTIONS,
+    SESSION_BLOCKED_FIELDS,
+};
 
 // --- Agents ---
 
@@ -124,10 +127,11 @@ pub async fn update_settings(
         )
             .into_response();
     }
-    // Validate that only allowed sections are being updated
+    // Validate that only allowed sections are being updated. Use the
+    // narrower global allowlist here (no `description`, which is profile-only).
     if let Some(obj) = body.as_object() {
         for key in obj.keys() {
-            if !ALLOWED_SETTINGS_SECTIONS.contains(&key.as_str()) {
+            if !ALLOWED_GLOBAL_SETTINGS_SECTIONS.contains(&key.as_str()) {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({
@@ -304,40 +308,50 @@ pub struct ProfileInfo {
 }
 
 pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<ProfileInfo>> {
-    let profiles = crate::session::list_profiles().unwrap_or_default();
-    // Treat empty profile (server launched without --profile) as "default"
-    let active = if state.profile.is_empty() {
-        "default"
-    } else {
-        &state.profile
-    };
-    let mut result: Vec<ProfileInfo> = profiles
-        .into_iter()
-        .map(|name| {
-            let is_default = name == active;
-            let description = crate::session::load_profile_config(&name)
-                .ok()
-                .and_then(|c| c.description);
-            ProfileInfo {
-                name,
-                is_default,
-                description,
-            }
-        })
-        .collect();
-    // Ensure the active profile appears even if list_profiles missed it
-    if !active.is_empty() && !result.iter().any(|p| p.name == active) {
-        result.insert(
-            0,
-            ProfileInfo {
-                name: active.to_string(),
-                is_default: true,
-                description: crate::session::load_profile_config(active)
+    // Profile enumeration plus per-profile description lookups all hit disk;
+    // do that off the async runtime so a slow filesystem (network home, fuse,
+    // etc.) cannot stall Tokio workers for every API client. See CodeRabbit
+    // feedback on #1274.
+    let active_profile = state.profile.clone();
+    let result = tokio::task::spawn_blocking(move || {
+        let profiles = crate::session::list_profiles().unwrap_or_default();
+        // Treat empty profile (server launched without --profile) as "default"
+        let active: &str = if active_profile.is_empty() {
+            "default"
+        } else {
+            &active_profile
+        };
+        let mut result: Vec<ProfileInfo> = profiles
+            .into_iter()
+            .map(|name| {
+                let is_default = name == active;
+                let description = crate::session::load_profile_config(&name)
                     .ok()
-                    .and_then(|c| c.description),
-            },
-        );
-    }
+                    .and_then(|c| c.description);
+                ProfileInfo {
+                    name,
+                    is_default,
+                    description,
+                }
+            })
+            .collect();
+        // Ensure the active profile appears even if list_profiles missed it
+        if !active.is_empty() && !result.iter().any(|p| p.name == active) {
+            result.insert(
+                0,
+                ProfileInfo {
+                    name: active.to_string(),
+                    is_default: true,
+                    description: crate::session::load_profile_config(active)
+                        .ok()
+                        .and_then(|c| c.description),
+                },
+            );
+        }
+        result
+    })
+    .await
+    .unwrap_or_default();
     Json(result)
 }
 
@@ -897,10 +911,11 @@ pub async fn update_profile_settings(
         )
             .into_response();
     }
-    // Validate allowed sections
+    // Validate allowed sections. Use the per-profile allowlist here, which
+    // is the global list plus `description` (a profile-only field).
     if let Some(obj) = body.as_object() {
         for key in obj.keys() {
-            if !ALLOWED_SETTINGS_SECTIONS.contains(&key.as_str()) {
+            if !ALLOWED_PROFILE_SETTINGS_SECTIONS.contains(&key.as_str()) {
                 return (
                     StatusCode::BAD_REQUEST,
                     Json(serde_json::json!({

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -296,6 +296,11 @@ pub async fn get_current_theme(
 pub struct ProfileInfo {
     pub name: String,
     pub is_default: bool,
+    /// Optional short description, surfaced as helper text in the wizard
+    /// profile picker. `None` (and therefore omitted from JSON) when the
+    /// profile has no description configured. See #949.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<ProfileInfo>> {
@@ -310,7 +315,14 @@ pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<Profi
         .into_iter()
         .map(|name| {
             let is_default = name == active;
-            ProfileInfo { name, is_default }
+            let description = crate::session::load_profile_config(&name)
+                .ok()
+                .and_then(|c| c.description);
+            ProfileInfo {
+                name,
+                is_default,
+                description,
+            }
         })
         .collect();
     // Ensure the active profile appears even if list_profiles missed it
@@ -320,6 +332,9 @@ pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<Profi
             ProfileInfo {
                 name: active.to_string(),
                 is_default: true,
+                description: crate::session::load_profile_config(active)
+                    .ok()
+                    .and_then(|c| c.description),
             },
         );
     }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -17,6 +17,12 @@ use super::get_profile_dir;
 /// Profile-specific settings. All fields are Option<T> - None means "inherit from global"
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ProfileConfig {
+    /// Short, human-readable description of what this profile does.
+    /// Surfaced as helper text in the new-session profile picker (TUI + web).
+    /// Profile-only: there is no global counterpart to inherit from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub theme: Option<ThemeConfigOverride>,
 
@@ -287,7 +293,8 @@ pub fn get_profile_config_path(profile: &str) -> Result<std::path::PathBuf> {
 
 /// Check if a profile has any overrides set
 pub fn profile_has_overrides(config: &ProfileConfig) -> bool {
-    config.theme.is_some()
+    config.description.is_some()
+        || config.theme.is_some()
         || config.updates.is_some()
         || config.worktree.is_some()
         || config.sandbox.is_some()
@@ -1007,6 +1014,37 @@ mod tests {
         let merged = merge_configs(global, &profile);
         // Profile env replaces (matches sandbox.environment semantics).
         assert_eq!(merged.environment, vec!["FROM_PROFILE=2".to_string()]);
+    }
+
+    #[test]
+    fn test_description_round_trips() {
+        let toml_in = r#"description = "Read-only review profile""#;
+        let config: ProfileConfig = toml::from_str(toml_in).unwrap();
+        assert_eq!(
+            config.description.as_deref(),
+            Some("Read-only review profile"),
+        );
+
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        assert!(serialized.contains("Read-only review profile"));
+    }
+
+    #[test]
+    fn test_description_default_is_none() {
+        let config = ProfileConfig::default();
+        assert!(config.description.is_none());
+        // Default empty config must still serialize empty so untouched profiles
+        // don't grow a description line on first save.
+        let serialized = toml::to_string(&config).unwrap();
+        assert!(serialized.trim().is_empty());
+    }
+
+    #[test]
+    fn test_description_promotes_profile_has_overrides() {
+        let mut profile = ProfileConfig::default();
+        assert!(!profile_has_overrides(&profile));
+        profile.description = Some("My profile".to_string());
+        assert!(profile_has_overrides(&profile));
     }
 
     #[test]

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -108,6 +108,11 @@ pub struct NewSessionData {
 pub struct NewSessionDialog {
     pub(super) profile: String,
     pub(super) available_profiles: Vec<String>,
+    /// Per-profile short descriptions, indexed in lockstep with
+    /// `available_profiles`. `None` when a profile has no description
+    /// configured. Surfaced as helper text under the profile name in the
+    /// picker when one is set.
+    pub(super) profile_descriptions: Vec<Option<String>>,
     pub(super) profile_index: usize,
     pub(super) title: Input,
     pub(super) path: Input,
@@ -379,9 +384,22 @@ impl NewSessionDialog {
             .position(|p| p == profile)
             .unwrap_or(0);
 
+        // Resolve each profile's description from its on-disk config. Failures
+        // fall through to None so a corrupted profile config does not break
+        // the new-session picker.
+        let profile_descriptions = available_profiles
+            .iter()
+            .map(|name| {
+                crate::session::load_profile_config(name)
+                    .ok()
+                    .and_then(|c| c.description)
+            })
+            .collect();
+
         Self {
             profile: profile.to_string(),
             available_profiles,
+            profile_descriptions,
             profile_index,
             title: Input::default(),
             path: Input::new(current_dir),
@@ -520,6 +538,16 @@ impl NewSessionDialog {
         &self.available_profiles[self.profile_index]
     }
 
+    /// Description for the currently selected profile, if one was configured.
+    /// Indexed in lockstep with `available_profiles`; an out-of-bounds index
+    /// (shouldn't happen in practice) yields `None` so the picker degrades
+    /// gracefully instead of panicking.
+    pub(super) fn selected_profile_description(&self) -> Option<&str> {
+        self.profile_descriptions
+            .get(self.profile_index)
+            .and_then(|d| d.as_deref())
+    }
+
     pub(super) fn has_profile_selection(&self) -> bool {
         self.available_profiles.len() > 1
     }
@@ -637,6 +665,7 @@ impl NewSessionDialog {
         Self {
             profile: "default".to_string(),
             available_profiles: vec!["default".to_string()],
+            profile_descriptions: vec![None],
             profile_index: 0,
             title: Input::default(),
             path: Input::new(path),
@@ -700,6 +729,7 @@ impl NewSessionDialog {
         Self {
             profile: "default".to_string(),
             available_profiles: vec!["default".to_string()],
+            profile_descriptions: vec![None],
             profile_index: 0,
             title: Input::default(),
             path: Input::new(path),

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -44,11 +44,20 @@ impl NewSessionDialog {
         let has_sandbox = self.docker_available && !is_host_only;
         let has_yolo = !self.selected_tool_always_yolo();
         let dialog_width = 80;
+        // When the selected profile has a description, the profile row needs
+        // an extra line to render it beneath the name. We compute this once
+        // here so the layout constraint and the renderer agree on height.
+        let profile_field_height: u16 =
+            if has_profile_selection && self.selected_profile_description().is_some() {
+                3
+            } else {
+                2
+            };
 
         // Build constraints dynamically based on visible fields only
         let mut constraints = Vec::new();
         if has_profile_selection {
-            constraints.push(Constraint::Length(2)); // Profile
+            constraints.push(Constraint::Length(profile_field_height)); // Profile
         }
         constraints.extend([
             Constraint::Length(2), // Title
@@ -514,7 +523,18 @@ impl NewSessionDialog {
             spans.push(Span::styled(selected, profile_style));
         }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+        let mut lines = vec![Line::from(spans)];
+        // Show the selected profile's description on the line below when one
+        // is set, so users can tell what each profile is for without leaving
+        // the dialog. (#949)
+        if let Some(desc) = self.selected_profile_description() {
+            lines.push(Line::from(Span::styled(
+                format!("  {}", desc),
+                Style::default().fg(theme.dimmed),
+            )));
+        }
+
+        frame.render_widget(Paragraph::new(lines), area);
     }
 
     fn render_path_field(

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1103,6 +1103,7 @@ fn test_profile_cycling() {
         "work".to_string(),
         "personal".to_string(),
     ];
+    dialog.profile_descriptions = vec![None, None, None];
     dialog.profile_index = 0;
     dialog.focused_field = 0; // profile field
 
@@ -1126,6 +1127,7 @@ fn test_profile_cycling() {
 fn test_profile_single_profile_no_cycle() {
     let mut dialog = single_tool_dialog();
     dialog.available_profiles = vec!["default".to_string()];
+    dialog.profile_descriptions = vec![None];
     dialog.profile_index = 0;
     dialog.focused_field = 0;
 
@@ -1138,6 +1140,7 @@ fn test_profile_single_profile_no_cycle() {
 fn test_profile_included_in_submit() {
     let mut dialog = single_tool_dialog();
     dialog.available_profiles = vec!["default".to_string(), "work".to_string()];
+    dialog.profile_descriptions = vec![None, None];
     dialog.focused_field = 0;
 
     dialog.handle_key(key(KeyCode::Right)); // switch to "work"

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -48,6 +48,8 @@ impl SettingsCategory {
 /// Type-safe field identifiers (prevents typos in string matching)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FieldKey {
+    // Profile (only relevant when the Profile scope is active)
+    ProfileDescription,
     // Theme
     ThemeName,
     ThemeColorMode,
@@ -731,7 +733,25 @@ fn build_theme_fields(
         theme.and_then(|t| t.idle_decay_minutes),
     );
 
-    vec![
+    let mut fields = Vec::with_capacity(4);
+    // The profile description is a profile-only field (no global counterpart),
+    // so we surface it only when the user is editing the Profile scope. It
+    // sits at the top of the Theme category so it is the first thing they
+    // see when looking at a profile's settings.
+    if scope == SettingsScope::Profile {
+        fields.push(SettingField {
+            key: FieldKey::ProfileDescription,
+            label: "Description",
+            description:
+                "Short, human-readable description of what this profile does. Shown as helper \
+                 text under the profile name in the new-session picker (TUI + web).",
+            value: FieldValue::OptionalText(profile.description.clone()),
+            category: SettingsCategory::Theme,
+            has_override: profile.description.is_some(),
+            inherited_display: None,
+        });
+    }
+    fields.extend([
         SettingField {
             key: FieldKey::ThemeName,
             label: "Theme",
@@ -765,7 +785,8 @@ fn build_theme_fields(
                 FieldValue::Number(global.theme.idle_decay_minutes),
             ),
         },
-    ]
+    ]);
+    fields
 }
 
 fn build_updates_fields(
@@ -1876,6 +1897,9 @@ pub fn apply_field_to_config(
 
 fn apply_field_to_global(field: &SettingField, config: &mut Config) {
     match (&field.key, &field.value) {
+        // ProfileDescription is profile-only; the field never appears in
+        // Global scope, but match it so the fallthrough doesn't have to.
+        (FieldKey::ProfileDescription, _) => {}
         // Theme
         (FieldKey::ThemeName, FieldValue::Select { selected, options }) => {
             config.theme.name = options.get(*selected).cloned().unwrap_or_default();
@@ -2134,6 +2158,15 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
 /// Always stores the value as an override; use 'r' key to clear overrides.
 fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut ProfileConfig) {
     match (&field.key, &field.value) {
+        // Profile description: empty input clears the field, otherwise we
+        // store the trimmed string so a stray space doesn't promote the
+        // profile to "has overrides".
+        (FieldKey::ProfileDescription, FieldValue::OptionalText(v)) => {
+            config.description = v
+                .as_ref()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+        }
         // Theme
         (FieldKey::ThemeName, FieldValue::Select { selected, options }) => {
             let name = options.get(*selected).cloned().unwrap_or_default();

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -530,6 +530,11 @@ impl SettingsView {
         };
 
         match key {
+            // Profile description: clears straight to None since there is no
+            // global counterpart to inherit from.
+            FieldKey::ProfileDescription => {
+                config.description = None;
+            }
             // Theme
             FieldKey::ThemeName => {
                 if let Some(ref mut t) = config.theme {

--- a/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
+++ b/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
@@ -132,6 +132,53 @@ describe("AgentStep custom-agent selection (#1252)", () => {
   });
 });
 
+describe("AgentStep profile description (#949)", () => {
+  function renderWithProfiles(profiles: ProfileInfo[]) {
+    const onChange = vi.fn();
+    const utils = render(
+      <AgentStep
+        data={{ ...initialData, tool: "claude" }}
+        onChange={onChange}
+        agents={[builtin]}
+        profiles={profiles}
+        dockerAvailable={false}
+        onApplyProfileDefaults={() => {}}
+        cockpitMasterEnabled={false}
+      />,
+    );
+    return { onChange, ...utils };
+  }
+
+  it("renders each profile's description as helper text under its name", () => {
+    const { getByText } = renderWithProfiles([
+      { name: "default", is_default: true, description: "Stock setup, no overrides" },
+      { name: "yolo-sandbox", is_default: false, description: "Auto-approve in a container" },
+    ]);
+    expect(getByText("Stock setup, no overrides")).toBeTruthy();
+    expect(getByText("Auto-approve in a container")).toBeTruthy();
+  });
+
+  it("omits the helper text line when a profile has no description", () => {
+    const { queryByText, getByRole } = renderWithProfiles([
+      { name: "default", is_default: true },
+      { name: "other", is_default: false },
+    ]);
+    // The card itself is still rendered ...
+    expect(getByRole("radio", { name: /other/ })).toBeTruthy();
+    // ... but no description text leaks through with a stray "undefined".
+    expect(queryByText(/undefined/)).toBeNull();
+  });
+
+  it("clicking a profile card calls onChange with the profile name", () => {
+    const { onChange, getByRole } = renderWithProfiles([
+      { name: "default", is_default: true },
+      { name: "work", is_default: false, description: "Work setup" },
+    ]);
+    fireEvent.click(getByRole("radio", { name: /work/ }));
+    expect(onChange).toHaveBeenCalledWith("profile", "work");
+  });
+});
+
 describe("ReviewStep agent row (#1252)", () => {
   function renderReviewStep(overrides: {
     tool: string;

--- a/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
+++ b/web/src/components/session-wizard/__tests__/AgentStep.customAgent.test.tsx
@@ -133,20 +133,24 @@ describe("AgentStep custom-agent selection (#1252)", () => {
 });
 
 describe("AgentStep profile description (#949)", () => {
-  function renderWithProfiles(profiles: ProfileInfo[]) {
+  function renderWithProfiles(
+    profiles: ProfileInfo[],
+    dataOverrides: Partial<typeof initialData> = {},
+  ) {
     const onChange = vi.fn();
+    const onApplyProfileDefaults = vi.fn();
     const utils = render(
       <AgentStep
-        data={{ ...initialData, tool: "claude" }}
+        data={{ ...initialData, tool: "claude", ...dataOverrides }}
         onChange={onChange}
         agents={[builtin]}
         profiles={profiles}
         dockerAvailable={false}
-        onApplyProfileDefaults={() => {}}
+        onApplyProfileDefaults={onApplyProfileDefaults}
         cockpitMasterEnabled={false}
       />,
     );
-    return { onChange, ...utils };
+    return { onChange, onApplyProfileDefaults, ...utils };
   }
 
   it("renders each profile's description as helper text under its name", () => {
@@ -176,6 +180,85 @@ describe("AgentStep profile description (#949)", () => {
     ]);
     fireEvent.click(getByRole("radio", { name: /work/ }));
     expect(onChange).toHaveBeenCalledWith("profile", "work");
+  });
+
+  it("renders the Active badge on the profile flagged is_default", () => {
+    // is_default true is rendered as an "Active" pill; checks that the
+    // conditional badge branch is exercised in coverage.
+    const { getAllByText } = renderWithProfiles([
+      { name: "default", is_default: true, description: "Stock setup" },
+      { name: "work", is_default: false, description: "Work setup" },
+    ]);
+    expect(getAllByText("Active").length).toBe(1);
+  });
+
+  it("marks the currently selected profile with aria-checked=true", () => {
+    // data.profile === p.name takes the selected styling/aria branch.
+    const { getByRole } = renderWithProfiles(
+      [
+        { name: "default", is_default: true },
+        { name: "work", is_default: false, description: "Work setup" },
+      ],
+      { profile: "work" },
+    );
+    const selected = getByRole("radio", { name: /work/ });
+    expect(selected.getAttribute("aria-checked")).toBe("true");
+    const unselected = getByRole("radio", { name: /^Server default/ });
+    expect(unselected.getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("clicking Server default with a profile selected calls onChange with empty string", () => {
+    // The "Server default" card uses handleProfileChange("") and bails
+    // before fetchSettings, so it must not call onApplyProfileDefaults.
+    const { onChange, onApplyProfileDefaults, getByRole } = renderWithProfiles(
+      [
+        { name: "default", is_default: true },
+        { name: "work", is_default: false },
+      ],
+      { profile: "work" },
+    );
+    fireEvent.click(getByRole("radio", { name: /Server default/ }));
+    expect(onChange).toHaveBeenCalledWith("profile", "");
+    expect(onApplyProfileDefaults).not.toHaveBeenCalled();
+  });
+
+  it("shows the (Custom) marker when the selected profile has been edited", () => {
+    const { getByText } = renderWithProfiles(
+      [
+        { name: "default", is_default: true },
+        { name: "work", is_default: false },
+      ],
+      { profile: "work", profileDirty: true },
+    );
+    expect(getByText(/\(Custom\) Settings differ from preset defaults/)).toBeTruthy();
+  });
+
+  it("confirms before switching profiles when settings are dirty (canceled)", () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    try {
+      const { onChange, getByRole } = renderWithProfiles(
+        [
+          { name: "default", is_default: true },
+          { name: "work", is_default: false },
+        ],
+        { profile: "default", profileDirty: true },
+      );
+      fireEvent.click(getByRole("radio", { name: /work/ }));
+      expect(confirmSpy).toHaveBeenCalled();
+      // User cancelled, so no profile change should fire.
+      expect(onChange).not.toHaveBeenCalledWith("profile", "work");
+    } finally {
+      confirmSpy.mockRestore();
+    }
+  });
+
+  it("hides the profile picker when only a single profile exists", () => {
+    // Guard the showProfilePicker branch: list of length <= 1 hides the
+    // picker entirely so the Workflow preset section is not rendered.
+    const { queryByText } = renderWithProfiles([
+      { name: "default", is_default: true, description: "Stock setup" },
+    ]);
+    expect(queryByText("Workflow preset")).toBeNull();
   });
 });
 

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -206,25 +206,60 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
         />
       )}
 
-      {/* Profile selector */}
+      {/* Profile selector. We render a card list (rather than a native
+          <select>) so each profile can carry a short description beneath
+          its name. The card list also makes the active selection more
+          obvious on touch devices. See #949. */}
       {showProfilePicker && (
         <div className="mb-5">
           <label className="block text-sm text-text-dim mb-1.5">Workflow preset</label>
           <p className="text-xs text-text-dim mb-2">
             Profiles preload tool, sandbox, auto-approve, and env defaults for common workflows.
           </p>
-          <select
-            value={data.profile}
-            onChange={(e) => handleProfileChange(e.target.value)}
-            className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm text-text-primary focus:border-brand-600 focus:outline-none cursor-pointer"
-          >
-            <option value="">Server default</option>
+          <div role="radiogroup" aria-label="Workflow preset" className="space-y-1.5">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={data.profile === ""}
+              onClick={() => handleProfileChange("")}
+              className={`w-full min-h-[44px] text-left p-3 rounded-lg border transition-colors cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
+                data.profile === ""
+                  ? "border-brand-600 bg-surface-900"
+                  : "border-surface-700 bg-surface-950 hover:border-surface-600"
+              }`}
+            >
+              <div className="text-sm font-semibold text-text-primary">Server default</div>
+              <div className="mt-0.5 text-xs text-text-dim leading-snug">
+                Use the active profile on the server with no client-side preset.
+              </div>
+            </button>
             {profiles.map((p) => (
-              <option key={p.name} value={p.name}>
-                {p.name}{p.is_default ? " (active)" : ""}
-              </option>
+              <button
+                type="button"
+                role="radio"
+                aria-checked={data.profile === p.name}
+                key={p.name}
+                onClick={() => handleProfileChange(p.name)}
+                className={`w-full min-h-[44px] text-left p-3 rounded-lg border transition-colors cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 ${
+                  data.profile === p.name
+                    ? "border-brand-600 bg-surface-900"
+                    : "border-surface-700 bg-surface-950 hover:border-surface-600"
+                }`}
+              >
+                <div className="flex flex-wrap items-baseline gap-2">
+                  <span className="text-sm font-semibold text-text-primary">{p.name}</span>
+                  {p.is_default && (
+                    <span className="rounded px-1.5 py-px text-[10px] font-mono uppercase tracking-wide bg-surface-700 text-text-dim">
+                      Active
+                    </span>
+                  )}
+                </div>
+                {p.description && (
+                  <div className="mt-0.5 text-xs text-text-dim leading-snug">{p.description}</div>
+                )}
+              </button>
             ))}
-          </select>
+          </div>
           {data.profile && data.profileDirty && (
             <p className="text-xs text-brand-500 mt-1">(Custom) Settings differ from preset defaults</p>
           )}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -236,6 +236,10 @@ export interface AgentInfo {
 export interface ProfileInfo {
   name: string;
   is_default: boolean;
+  /** Optional short description of what this profile does, surfaced as
+   *  helper text in the wizard profile picker (#949). Omitted from the
+   *  server payload when the profile has no description configured. */
+  description?: string;
 }
 
 /** Directory entry returned by /api/filesystem/browse */

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -163,6 +163,13 @@
       ]
     },
     {
+      "id": "wizard.profile-description",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/wizard-agent-step.spec.ts"],
+      "components": ["web/src/components/session-wizard/steps/AgentStep.tsx"]
+    },
+    {
       "id": "directory-browser",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/wizard-agent-step.spec.ts
+++ b/web/tests/wizard-agent-step.spec.ts
@@ -16,7 +16,7 @@ interface MockOptions {
     installed?: boolean;
     install_hint?: string;
   }>;
-  profiles?: Array<{ name: string; is_default: boolean }>;
+  profiles?: Array<{ name: string; is_default: boolean; description?: string }>;
   docker?: boolean;
   profileSettings?: Record<string, unknown>;
 }
@@ -167,14 +167,47 @@ test.describe("Wizard agent step (#1219)", () => {
     await page.goto("/");
     await openAgentStep(page);
     await expect(page.getByText("Workflow preset")).toBeVisible();
-    const select = page.locator("select");
-    await select.selectOption("yolo-sandbox");
+    // Profile picker is now a radiogroup of cards (#949) so each profile
+    // can show a short description; clicking the row is equivalent to the
+    // old <select>.selectOption call.
+    await page.getByRole("radio", { name: /yolo-sandbox/ }).click();
     // Both toggles flip on because APPLY_PROFILE_DEFAULTS dispatched.
     const sandboxToggle = page.locator("label", { hasText: "Run in a safe container" }).locator("role=switch");
     const yoloToggle = page.locator("label", { hasText: "Auto-approve actions" }).locator("role=switch");
     await expect(sandboxToggle).toHaveAttribute("aria-checked", "true");
     await expect(yoloToggle).toHaveAttribute("aria-checked", "true");
     expect(settingsCalls).toContain("yolo-sandbox");
+  });
+
+  test("profile picker renders description as helper text under each option (#949)", async ({
+    page,
+  }) => {
+    await mockApis(page, {
+      profiles: [
+        {
+          name: "default",
+          is_default: true,
+          description: "Stock setup with no overrides",
+        },
+        {
+          name: "yolo-sandbox",
+          is_default: false,
+          description: "Auto-approve in a container",
+        },
+        // Profiles without a description should still render (just without
+        // helper text), so a mixed list does not silently drop them.
+        { name: "no-desc", is_default: false },
+      ],
+    });
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openAgentStep(page);
+    await expect(page.getByText("Workflow preset")).toBeVisible();
+    // Descriptions render beneath the profile name.
+    await expect(page.getByText("Stock setup with no overrides")).toBeVisible();
+    await expect(page.getByText("Auto-approve in a container")).toBeVisible();
+    // Profiles without a description still appear in the picker.
+    await expect(page.getByRole("radio", { name: /no-desc/ })).toBeVisible();
   });
 
   test("sandbox toggle is disabled when Docker is not running", async ({ page }) => {


### PR DESCRIPTION
## Description

Adds an optional `description` field on `ProfileConfig` so each profile can carry a one-line description, then surfaces it everywhere the user picks a profile so they can tell presets apart without leaving the dialog. Fixes #949.

Surfaces wired:

- **TOML config**: new top-level `description` field on `ProfileConfig` (profile-only, no global counterpart). Round-trip and `profile_has_overrides` coverage added.
- **Settings TUI**: new `FieldKey::ProfileDescription` rendered at the top of the Theme category when the Profile scope is active, with `apply_field_to_profile`, `apply_field_to_global` (no-op), and `clear_profile_override` wiring per AGENTS.md's settings-field mandate.
- **New-session TUI dialog**: parallel `profile_descriptions` vec loaded from each profile's config; the picker reserves a second line under the profile name to show the active selection's description.
- **Web SessionWizard / AgentStep**: switched the workflow-preset `<select>` to a radiogroup of cards so each profile can show its description as helper text. `ProfileInfo` TS type and `/api/profiles` response gain an optional `description`; settings PATCH allow-list adds the new field.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

### How I tested

- `cargo fmt --check` clean.
- `cargo clippy --features serve` clean.
- `cargo test --features serve --lib` passes (2249 tests).
- `cd web && npx vitest run` passes (429 tests, includes 3 new AgentStep description cases).
- `cd web && npx tsc --noEmit` clean.
- `node web/tests/validate-coverage-matrix.mjs` passes; matrix gains a `wizard.profile-description` entry.
- Playwright browsers aren't installed in this sandbox; the new mocked spec is exercised under the existing `wizard-agent-step.spec.ts` test file which CI runs.

Did not capture a screenshot; the rendering change is small (description text below the profile row in TUI, helper text under each profile card in the wizard) and the new vitest + playwright specs assert the visible text.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**

Claude drafted the patch via the `fix-github-issue` skill against the issue body. I reviewed the diff, the tests, and the commit message before pushing.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds an optional one-line description to profile configs and surfaces that description in all profile pickers (web and TUI). Users can now distinguish presets inline in pickers without opening config files or leaving the picker UI.

## What was added
- Optional description field on ProfileConfig (TOML) and ProfileInfo (server + TypeScript).
- TUI: description shown on a second, dimmed line under the selected profile in the new-session dialog; settings UI gains a profile-scoped "Description" field to edit/clear the profile description.
- Web: profile picker replaced the old <select> with a card-style radiogroup so each profile can show helper text (the description) and badges (e.g., Active).
- API: /api/profiles now returns optional profile descriptions; settings PATCH endpoints updated to allow profile-only keys.
- Tests: Rust unit tests (TOML round-trip, override detection, allowlist pinning), Vitest cases for AgentStep, and updated Playwright spec mapping.

## What changed
- Settings allowlist split into separate pinned allowlists: GLOBAL and PROFILE. The profile-only `description` key is explicitly allowed only in the per-profile allowlist; global PATCH endpoints no longer accept it.
- Profile listing I/O moved into spawn_blocking to avoid synchronous disk reads on the async runtime.
- Web profile picker UI changed from a native dropdown to card/radio UI to support description display and richer state badges.
- New-session dialog layout adjusted to reserve extra row height when a description exists.

## What was removed
- The native HTML <select> for workflow-preset/profile selection in the web SessionWizard was removed (replaced by the card radiogroup).

## Benefits
- Improved discoverability: users can read short descriptions inline and pick the right profile faster.
- Backward compatible: description is optional and omitted when unset.
- Security/clarity: allowlists are tightened and explicitly document which settings are global vs. profile-scoped.
- Performance-safe I/O: profile reads moved off the async runtime to prevent blocking as profile counts grow.

## Technical details (concise)
- Rust: added Option<String> description to ProfileConfig and ProfileInfo; ProfileConfig uses serde(default, skip_serializing_if).
- New settings enum variant: FieldKey::ProfileDescription; apply/clear logic implemented for profile scope; global-scope updates ignore it.
- API changes: update_settings uses ALLOWED_GLOBAL_SETTINGS_SECTIONS; update_profile_settings uses ALLOWED_PROFILE_SETTINGS_SECTIONS (includes "description"); tests split to assert both lists.
- TUI: NewSessionDialog now stores profile_descriptions: Vec<Option<String>> and provides selected_profile_description(); render adapts row height.
- Web: ProfileInfo TS type includes description?; AgentStep renders a radiogroup of profile cards with description helper text; tests (vitest + mocked Playwright) updated.
- Misc: profile listing moved to spawn_blocking; allowlist tests enforce size and membership to catch accidental changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1274?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->