### PR TITLE
fix(recovery): skip startup recovery on tmux probe failure

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1524,7 +1524,7 @@ async fn status_poll_loop(state: Arc<AppState>) {
             let mut instances = load_all_instances().unwrap_or_default();
 
             crate::tmux::refresh_session_cache();
-            let pane_metadata = crate::tmux::batch_pane_metadata();
+            let pane_metadata = crate::tmux::batch_pane_metadata().unwrap_or_default();
 
             for inst in &mut instances {
                 if suppressed_ids.contains(&inst.id) {
@@ -1694,7 +1694,7 @@ async fn daemon_startup_recovery_mark(
 
     crate::session::recovery::warm_tmux_server();
     crate::tmux::refresh_session_cache();
-    let pane_meta = crate::tmux::batch_pane_metadata();
+    let pane_meta = crate::tmux::batch_pane_metadata().unwrap_or_default();
 
     let candidates: Vec<crate::session::Instance> = {
         let instances = state.instances.read().await;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1694,7 +1694,21 @@ async fn daemon_startup_recovery_mark(
 
     crate::session::recovery::warm_tmux_server();
     crate::tmux::refresh_session_cache();
-    let pane_meta = crate::tmux::batch_pane_metadata().unwrap_or_default();
+    // On probe failure we cannot distinguish "all panes dead" from "tmux
+    // unreachable", and treating the latter as the former would trigger
+    // spurious recovery cascades that kill possibly-alive panes. Skip
+    // the entire pass on Err; the next daemon launch will retry.
+    let pane_meta = match crate::tmux::batch_pane_metadata() {
+        Ok(map) => map,
+        Err(e) => {
+            tracing::warn!(
+                target: "session.startup_recovery",
+                error = %e,
+                "tmux probe failed at daemon startup; skipping recovery this launch",
+            );
+            return None;
+        }
+    };
 
     let candidates: Vec<crate::session::Instance> = {
         let instances = state.instances.read().await;
@@ -1759,14 +1773,39 @@ async fn daemon_startup_recovery_cascade(
             // tmux re-check, recovery would `kill_clean` a freshly-started
             // pane the user just attached to. The lock + this re-check
             // serialise against any other AoE writer.
+            //
+            // Use the fallible `batch_pane_metadata()` here so a transient
+            // tmux probe failure does NOT collapse to "pane dead" and
+            // wrongly proceed with the cascade: skip + unmark instead.
+            // Mirrors Phase A's pattern at the mark site.
+            let pane_meta = match crate::tmux::batch_pane_metadata() {
+                Ok(map) => map,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "session.startup_recovery",
+                        instance_id = %id,
+                        error = %e,
+                        "tmux probe failed during recovery re-check; skipping cascade",
+                    );
+                    crate::session::recovery::unmark_recently_restarted(
+                        &inst_state.recently_restarted,
+                        &id,
+                    );
+                    return;
+                }
+            };
             let still_candidate = {
                 let instances = inst_state.instances.read().await;
                 instances
                     .iter()
                     .find(|i| i.id == id)
                     .map(|i| {
-                        !i.has_live_tmux_pane()
-                            && crate::session::recovery::is_recovery_candidate(i)
+                        let session_name = crate::tmux::Session::generate_name(&i.id, &i.title);
+                        let has_live_tmux = pane_meta
+                            .get(&session_name)
+                            .map(|m| !m.pane_dead)
+                            .unwrap_or(false);
+                        !has_live_tmux && crate::session::recovery::is_recovery_candidate(i)
                     })
                     .unwrap_or(false)
             };

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -130,7 +130,14 @@ pub fn refresh_session_cache() {
 
 /// Batch-fetch pane metadata for all aoe sessions in a single tmux subprocess call.
 /// Returns a map from session name to metadata for the first window's first pane.
-pub fn batch_pane_metadata() -> HashMap<String, PaneMetadata> {
+///
+/// Returns `Err` when the underlying `tmux list-panes` call fails to spawn or
+/// exits non-zero. Callers MUST distinguish this from `Ok(map)` where a missing
+/// key means the session is genuinely absent: `Err` means we don't know.
+/// Startup recovery treats `Err` as "skip this pass" to avoid killing a
+/// possibly-live pane on a transient tmux glitch; status pollers treat it as
+/// `unwrap_or_default()` because their semantics are unchanged by an empty map.
+pub fn batch_pane_metadata() -> anyhow::Result<HashMap<String, PaneMetadata>> {
     let start = Instant::now();
     let output = Command::new("tmux")
         .args([
@@ -141,10 +148,10 @@ pub fn batch_pane_metadata() -> HashMap<String, PaneMetadata> {
         ])
         .output();
 
-    let result = match output {
+    let result: anyhow::Result<HashMap<String, PaneMetadata>> = match output {
         Ok(out) if out.status.success() => {
             let stdout = String::from_utf8_lossy(&out.stdout);
-            parse_pane_metadata(&stdout)
+            Ok(parse_pane_metadata(&stdout))
         }
         Ok(out) => {
             tracing::warn!(
@@ -153,11 +160,14 @@ pub fn batch_pane_metadata() -> HashMap<String, PaneMetadata> {
                 stderr_bytes = out.stderr.len(),
                 "list-panes returned non-zero",
             );
-            HashMap::new()
+            Err(anyhow::anyhow!(
+                "tmux list-panes returned non-zero status: {:?}",
+                out.status
+            ))
         }
         Err(e) => {
             tracing::warn!(target: "tmux.pane", error = %e, "list-panes spawn failed");
-            HashMap::new()
+            Err(anyhow::anyhow!("tmux list-panes spawn failed: {}", e))
         }
     };
 
@@ -166,7 +176,7 @@ pub fn batch_pane_metadata() -> HashMap<String, PaneMetadata> {
     // idle log.
     tracing::trace!(
         target: "tmux.pane",
-        sessions = result.len(),
+        sessions = result.as_ref().map(|m| m.len()).unwrap_or(0),
         duration_ms = start.elapsed().as_millis() as u64,
         "batch pane metadata fetched",
     );

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1039,8 +1039,29 @@ impl HomeView {
         };
 
         let mut candidates: Vec<crate::session::Instance> = Vec::new();
+        // Single fallible tmux probe instead of per-instance
+        // `inst.has_live_tmux_pane()` calls. On Err: skip recovery this
+        // launch (a transient tmux glitch must NOT collapse to "all panes
+        // dead" and trigger phantom cascades). Bonus: one subprocess call
+        // regardless of instance count (was 1-2 per instance).
+        let pane_meta = match crate::tmux::batch_pane_metadata() {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::warn!(
+                    target: "session.startup_recovery",
+                    error = %e,
+                    "tmux probe failed; TUI skipping startup recovery this launch",
+                );
+                drop(lock);
+                return;
+            }
+        };
         for inst in &mut self.instances {
-            let has_live_tmux = inst.has_live_tmux_pane();
+            let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let has_live_tmux = pane_meta
+                .get(&session_name)
+                .map(|m| !m.pane_dead)
+                .unwrap_or(false);
             if has_live_tmux {
                 continue;
             }

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -105,7 +105,7 @@ impl StatusPoller {
 
             let pane_metadata = if any_pollable {
                 crate::tmux::refresh_session_cache();
-                crate::tmux::batch_pane_metadata()
+                crate::tmux::batch_pane_metadata().unwrap_or_default()
             } else {
                 HashMap::new()
             };


### PR DESCRIPTION
## Description

Follow-up to merged [PR #1251](https://github.com/njbrake/agent-of-empires/pull/1251). A new CodeRabbit review comment landed shortly before that PR was merged but the fix commits were pushed too late to be included in the merge. This PR ports those two commits onto the post-merge `main`.

### CodeRabbit's finding (PR #1251 [discussion](https://github.com/njbrake/agent-of-empires/pull/1251#discussion_r3269355280))

> `has_live_tmux_pane()` collapses tmux lookup failures to `false`, so this re-check treats probe errors the same as a dead pane and can start the recovery cascade for a session that is merely unprobeable. That can turn a transient tmux failure into an unnecessary restart or spurious `Error`. Thread a fallible liveness probe through this path and skip/unmark on probe failure instead.

### Root cause

Two independent collapse points conflated "tmux probe failed" with "session genuinely dead":

1. `tmux::batch_pane_metadata()` returned `HashMap::new()` on any probe failure (spawn error, non-zero exit). Phase A's `pane_meta.get(name).map(|m| !m.pane_dead).unwrap_or(false)` treated a missing key (probe failed) as "session absent → recovery candidate". A whole-server tmux outage caused all sessions to be queued for recovery simultaneously.

2. `Instance::has_live_tmux_pane()` (used by Phase B re-check + TUI candidate loop) returned `false` when `Session::exists()` failed via `tmux has-session`, identical to a confirmed-dead pane. A transient tmux glitch (server restart, IPC hiccup) at the moment of the re-check caused `still_candidate=true` and ran the cascade against possibly-live panes, `kill_clean`-ing them.

### Fix

Two atomic commits:

#### `refactor(tmux): make batch_pane_metadata fallible` (`ab091bd`)

Pure no-op refactor. Change `tmux::batch_pane_metadata()` from `HashMap<String, PaneMetadata>` to `anyhow::Result<HashMap<String, PaneMetadata>>`. The two best-effort callers (`status_poll_loop` in the daemon and `StatusPoller` worker thread in the TUI) migrate to `.unwrap_or_default()`, preserving exact prior behaviour. The internal failure arms keep `tracing::warn!(target: "tmux.pane", ...)` for operator visibility; callers do not need to log on Err.

This matches the existing tmux-module convention: action functions return `anyhow::Result` (`session.rs`, `env.rs`, `terminal_session.rs`); pure probe functions return `bool`/`Option`. `batch_pane_metadata` straddles both, and the migration here puts it on the action-function side because its callers genuinely need to distinguish probe failure.

#### `fix(recovery): skip startup recovery on tmux probe failure` (`fa23cd2`)

Three-site migration:

1. **Phase A** (`daemon_startup_recovery_mark`, `src/server/mod.rs`): on `Err`, log warn + `return None`. The whole recovery flow short-circuits this launch; the cross-process recovery lock is dropped on the early return. The caller in `start_server` only spawns Phase B when `Some(...)` is returned.

2. **Phase B re-check** (`daemon_startup_recovery_cascade`, the line CodeRabbit flagged): replace `i.has_live_tmux_pane()` with a fresh `batch_pane_metadata()` call inside the lock-held window. On `Err`: log warn + `unmark_recently_restarted` + return early. Mirrors Phase A's pattern symmetrically. Net cost: one `tmux list-panes -a` per worker instead of 1-2 `has-session` + `display-message` calls — neutral to negative.

3. **TUI** (`HomeView::maybe_start_startup_recovery`): single `batch_pane_metadata()` before the candidate loop instead of per-instance `inst.has_live_tmux_pane()`. On `Err`: log warn + `drop(lock)` + return. Bonus: 1 subprocess call regardless of instance count (was 1-2 per instance, so 3-20 calls saved at TUI startup for typical session counts).

The `has_live_tmux_pane()` helper itself is unchanged and still used by the session-ID poller init (`tui/home/mod.rs:538`); a probe failure there is self-healing (poller retry on next reload, no restart side-effect), so the boolean signature is fine for that low-blast-radius caller.

### Failure-mode analysis

| Scenario | Old behaviour | New behaviour |
|---|---|---|
| **tmux fully broken** | Cascades trigger, all fail → `Status::Error` with cascade error string. | Skip cascade; next status_poll surfaces "tmux session is gone". Both converge on `Error` for the user; new path is honest about cause. |
| **tmux flickers (succeeds then fails)** | Old path killed a healthy pane on the wrong second of the flicker. | New path correctly recognises the live pane on the second probe. |
| **tmux healthy, sessions genuinely dead** | Recovery cascade fires (correct). | Recovery cascade fires (unchanged). |

Net: cascade workers are MORE resilient to tmux instability with this fix, not less.

### Cross-validation

The fix design was produced via the same adversarial methodology used for PR #1251:

- 1 explore agent: validated the bug at 3 call sites with file:line evidence (Phase A, Phase B, TUI), traced `is_pane_dead`/`Session::exists` collapse points.
- 1 oracle agent: scoped Option A design with adversarial self-review across 9 questions (signature choice, lock-order, blast radius, failure-mode flip, compile matrix). Initial verdict was DEFER (blast radius bounded by `is_recovery_candidate`'s resume-capable filter); explicit user override → re-engaged for the implement design.
- 1 explore agent: mapped existing tmux error-handling conventions (`anyhow::Result` for action functions, `tracing::warn!(target: "session.startup_recovery")` for log-and-skip patterns, error-type uniformity).
- Both agents converged on identical design; implementation matches the design exactly.

### Testing

```
cargo fmt --check       # clean
cargo clippy --lib                       -- -D warnings   # clean
cargo clippy --lib --features serve     -- -D warnings   # clean
cargo test  --lib --features serve                       # 2247/2247 pass
```

Manual verification (covered by `cargo test`):

- `batch_pane_metadata`'s subprocess success path is exercised by every existing recovery / status-poll test.
- The `Err` arm is reachable only on a tmux-broken environment; matches the existing convention (no other tmux probe in `src/tmux/` mocks subprocess failure either).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (inline rustdoc on `batch_pane_metadata` documents the `Err` semantic for callers)
- [x] For UI changes: N/A — no visual changes

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:**
Claude Opus 4.7 via OpenCode

**Any Additional AI Details you'd like to share:**

Same adversarial methodology as PR #1251: parallel sub-agents (explore for codebase pattern matching + oracle for design review with adversarial self-review). Each design choice (signature, error type, log target, caller migration strategy) was justified against existing codebase conventions before implementation.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This fix improves how the application handles temporary tmux connectivity issues during startup recovery. Previously, when tmux commands failed, the system would treat these failures as if all sessions were dead, causing unnecessary automatic restarts or recovery cascades. This PR separates "tmux is unavailable" from "sessions are actually dead," making the recovery process more resilient to transient glitches.

## What Changed

**Core change:** The `batch_pane_metadata()` function in the tmux module now explicitly returns success or failure, rather than silently returning an empty result on errors.

**Updated to handle failures:**
1. **Daemon startup recovery marker** - When checking which instances need recovery, if tmux is unavailable, the process logs a warning and skips that recovery pass entirely instead of assuming all sessions are dead.

2. **Daemon recovery cascade workers** - When re-checking which instances are still recovery candidates, if tmux becomes unavailable mid-check, the worker logs a warning, cleans up its previous recovery markers, and stops processing that instance.

3. **TUI home view recovery** - The startup recovery check in the user interface now probes tmux once upfront. If it fails, the system logs a warning and skips startup recovery for that launch.

4. **Status polling loop** - The periodic status check continues to work by falling back to an empty metadata set when tmux is unavailable (minimal impact on polling).

## Benefits
- **Prevents false alarms**: Transient tmux issues no longer trigger unnecessary restarts or kills
- **Preserves correctness**: Actual dead sessions are still detected and handled properly
- **More resilient**: The system gracefully handles temporary tmux unavailability instead of cascading failures
- **Better diagnostics**: Warnings are logged when probe failures occur, helping diagnose actual issues

## Technical Details

**Signature change:**
- `batch_pane_metadata()` now returns `anyhow::Result<HashMap<String, PaneMetadata>>` instead of `HashMap<String, PaneMetadata>`

**Error handling patterns introduced:**
- Recovery paths use explicit error handling with logging and early returns
- Polling paths use `.unwrap_or_default()` to maintain non-blocking behavior
- Error cases log warnings to maintain observability

**Files modified:**
- `src/tmux/mod.rs` - Changed function signature and error propagation
- `src/server/mod.rs` - Updated recovery and polling logic for error handling
- `src/tui/home/mod.rs` - Updated startup recovery to handle probe failures
- `src/tui/status_poller.rs` - Added fallback for polling robustness

**Testing:** All existing tests pass (2246-2247 tests), code formatting and linting checks pass.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->