### PR TITLE
chore: reduce PR bot noise from CodeRabbit and Codecov

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,7 +36,10 @@ reviews:
   auto_title_instructions: "Generate a short, action-oriented PR title. Start with a verb in the imperative form. Focus only on what changed, not why. Keep it concise and specific"
 
   review_status: true
-  commit_status: true
+  # Off to stop CodeRabbit from posting a separate per-commit status check.
+  # The walkthrough comment on the PR is enough signal; CI already gates
+  # merges via clippy, eslint, tests, and codecov.
+  commit_status: false
   # Fails the GitHub commit check when CodeRabbit cannot complete a review
   # (errors, timeouts, service unavailable). It does NOT fail based on review
   # findings; those are surfaced as comments.
@@ -78,7 +81,11 @@ reviews:
 
   auto_review:
     enabled: true
-    auto_incremental_review: true
+    # Off to stop CodeRabbit from re-reviewing on every push, which edited
+    # its walkthrough comment and pinged subscribers each time. CodeRabbit
+    # still reviews once when a PR opens; ask for a re-review explicitly
+    # with `@coderabbitai review` after a meaningful change.
+    auto_incremental_review: false
     ignore_title_keywords:
       - "Dependencies"
       - "update dependency"

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,7 +17,11 @@ comment:
   after_n_builds: 1
   layout: "header, diff, files, components, sunburst, uncovered, footer"
   behavior: default
-  require_changes: false
+  # Only post (or update) the PR comment when patch / project coverage
+  # actually moves. Reduces noise from comment edits on every push when
+  # the underlying numbers are unchanged. The `codecov/patch` and
+  # `codecov/project` status checks still gate merges either way.
+  require_changes: true
   require_base: false
   require_head: false
   hide_project_coverage: false


### PR DESCRIPTION
## Description

Recent PRs were generating a lot of subscriber notifications because both CodeRabbit and Codecov edit their PR comments (and CodeRabbit posts a separate commit status) on every push. Each edit pings everyone subscribed to the PR, which made it hard to keep up with what actually needed attention.

This PR turns off three sources of repeated pings while keeping the parts that actually gate merges:

- `.coderabbit.yaml`: set `reviews.auto_review.auto_incremental_review` to `false`. CodeRabbit still reviews once when a PR opens; re-reviews are now explicit via `@coderabbitai review`.
- `.coderabbit.yaml`: set `reviews.commit_status` to `false`. Removes the separate per-commit status check; the walkthrough comment on the PR is enough signal, and CI already gates merges via clippy, eslint, tests, and codecov.
- `codecov.yml`: set `comment.require_changes` to `true`. Codecov only posts or edits its PR comment when patch / project coverage actually moves. The `codecov/patch` and `codecov/project` status checks are unchanged and still gate merges.

If this is still too noisy after a week or two, the next lever is dropping the Codecov PR comment entirely (`comment: false`) and relying purely on the merge-box statuses.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

No code paths change; this only adjusts the bot configurations. Pre-commit hook ran clippy + fmt cleanly.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (via Claude Code)

**Any Additional AI Details you'd like to share:**

Claude reviewed the comment volume across recent PRs (1270 to 1276), inspected the existing `.coderabbit.yaml` and `codecov.yml` configs, proposed knobs ordered by impact, and drafted this change after I picked the conservative set. The reasoning and decisions are mine; the prose and the YAML edits are Claude's.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR reduces repetitive notifications from CodeRabbit and Codecov by adjusting their configuration settings, while maintaining all merge-gating quality checks.

## What Changed

**CodeRabbit Configuration (`.coderabbit.yaml`)**
- Disabled automatic incremental reviews on every push — CodeRabbit will now review once when a PR is opened, and require explicit `@coderabbitai review` command for re-reviews after changes
- Disabled per-commit status checks — removes granular commit-level status signals, though the PR walkthrough comment is preserved

**Codecov Configuration (`codecov.yml`)**
- Enabled conditional PR comments — Codecov will now post or update its PR comment only when patch or project coverage actually changes, rather than on every run

## Benefits

- **Reduced PR notification fatigue**: Fewer repetitive bot comments and status checks cluttering the review experience
- **Maintained quality gates**: All merge-blocking checks remain active — Codecov `patch` and `project` status checks, plus existing CI (clippy, eslint, tests, codecov) continue to enforce standards
- **Intentional code review**: CodeRabbit reviews are now deliberate rather than automatic on every commit, allowing developers to batch meaningful changes before requesting fresh analysis

## Technical Details

- Codecov will still gate merges on coverage thresholds; the comment filtering only reduces noise on unchanged coverage metrics
- CodeRabbit's walkthrough feedback and PR analysis functionality remain fully operational and merge-blocking
- Configuration changes are non-breaking: developers can still trigger CodeRabbit reviews manually when needed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1277?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->