### PR TITLE
fix(cockpit): keep Escape from cancelling the active turn

### DIFF
--- a/web/src/components/cockpit/Composer.escape.test.tsx
+++ b/web/src/components/cockpit/Composer.escape.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// Contract guard for the cockpit composer's "Escape does not cancel an
+// active turn" behaviour. The cockpit Composer passes
+// `cancelOnEscape={false}` to assistant-ui's ComposerPrimitive.Input so
+// that pressing Escape inside the textarea does not run
+// runtime.cancelRun and abort the in-flight turn. Claude Code CLI also
+// binds Escape to cancel in its TUI, so a stray press is easy to make.
+//
+// This test renders the real ComposerPrimitive.Input inside a minimal
+// AssistantRuntimeProvider where the external store's `onCancel` is a
+// vi.fn(). It documents the contract via two cases:
+//   1. With cancelOnEscape={false}, Escape does NOT invoke onCancel.
+//   2. Without that prop (the SDK default), Escape DOES invoke onCancel.
+// The second case is the control that makes the first case meaningful:
+// if assistant-ui ever changes the prop semantics, both will move and
+// the regression surfaces here.
+
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  useExternalStoreRuntime,
+  type ThreadMessageLike,
+} from "@assistant-ui/react";
+
+afterEach(() => {
+  cleanup();
+});
+
+function Harness({
+  onCancel,
+  cancelOnEscape,
+}: {
+  onCancel: () => void | Promise<void>;
+  cancelOnEscape?: boolean;
+}) {
+  const runtime = useExternalStoreRuntime<ThreadMessageLike>({
+    messages: [],
+    isRunning: true,
+    convertMessage: (m) => m,
+    onNew: async () => {},
+    onCancel,
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ComposerPrimitive.Root>
+        <ComposerPrimitive.Input
+          data-testid="composer-input"
+          cancelOnEscape={cancelOnEscape}
+        />
+      </ComposerPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+}
+
+function pressEscape(target: HTMLElement) {
+  // assistant-ui registers its Escape listener on document via
+  // @radix-ui/react-use-escape-keydown, which uses a capture-phase
+  // document listener. Dispatch from the textarea so the listener's
+  // `textareaRef.current.contains(e.target)` guard passes.
+  target.dispatchEvent(
+    new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+  );
+}
+
+describe("ComposerPrimitive.Input + cancelOnEscape contract", () => {
+  it("does not invoke onCancel when cancelOnEscape={false}", async () => {
+    const onCancel = vi.fn();
+    const { getByTestId } = render(
+      <Harness onCancel={onCancel} cancelOnEscape={false} />,
+    );
+    const input = getByTestId("composer-input");
+    input.focus();
+    pressEscape(input);
+    // Give microtasks a tick in case the SDK queues the cancel.
+    await Promise.resolve();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("invokes onCancel when cancelOnEscape is left at its default", async () => {
+    const onCancel = vi.fn();
+    const { getByTestId } = render(<Harness onCancel={onCancel} />);
+    const input = getByTestId("composer-input");
+    input.focus();
+    pressEscape(input);
+    await Promise.resolve();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -430,6 +430,13 @@ export function Composer({
             <ComposerPrimitive.Input
               ref={taRef}
               rows={2}
+              // assistant-ui's default Escape binding cancels the active
+              // run (see ComposerPrimitive.Input's `cancelOnEscape`
+              // default). The cockpit deliberately keeps cancel behind
+              // an explicit gesture, the Stop button, because Claude
+              // Code CLI also hijacks Escape for cancel and a stray
+              // press would lose work the user did not mean to abort.
+              cancelOnEscape={false}
               placeholder={
                 turnActive
                   ? "Queue a follow-up… (sent when current turn ends)"
@@ -990,7 +997,7 @@ function StopButton() {
     <button
       type="button"
       aria-label="Stop"
-      title="Stop the agent · Esc"
+      title="Stop the agent"
       onClick={() => runtime.cancelRun()}
       className={[
         "inline-flex items-center justify-center gap-1.5",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -241,6 +241,20 @@
       "components": ["web/src/components/cockpit/ApprovalCard.tsx"]
     },
     {
+      "id": "cockpit.escape-no-cancel",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/cockpit-escape-no-cancel.spec.ts"],
+      "components": []
+    },
+    {
+      "id": "cockpit.escape-no-cancel-contract",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/cockpit/Composer.escape.test.tsx"],
+      "components": []
+    },
+    {
       "id": "cockpit.mode-switch",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/cockpit-escape-no-cancel.spec.ts
+++ b/web/tests/live/cockpit-escape-no-cancel.spec.ts
@@ -1,0 +1,88 @@
+// Cockpit Escape does not cancel the active turn.
+//
+// Regression guard for the cockpit composer's `cancelOnEscape={false}`
+// wiring on ComposerPrimitive.Input. assistant-ui's default Escape
+// binding calls runtime.cancelRun, which in the cockpit funnels through
+// onCancel into POST /api/sessions/:id/cockpit/cancel. We disabled that
+// binding so accidental Escape presses cannot abort an in-flight turn
+// while the user is typing the next prompt.
+//
+// Skipped pending #1237: the supervisor's ACP handshake against the
+// fake agent fails with "Authentication required" before a turn can
+// start, so we cannot reach the turn-active branch of the composer
+// from the browser. Unskip alongside the sibling cockpit specs
+// (cockpit-spawn-prompt, cockpit-mode-switch, cockpit-approval) once
+// the harness installs a working `claude-agent-acp` shim.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.skip("Escape inside the cockpit composer does not POST /cockpit/cancel", async ({
+  page,
+}, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "escape-no-cancel" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const sessionId: string = sessions[0]!.id;
+
+    const enableRes = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+      { method: "POST" },
+    );
+    expect(enableRes.ok).toBeTruthy();
+    // Allow the supervisor to come up.
+    await new Promise((r) => setTimeout(r, 2_000));
+
+    // Send a prompt so the agent enters turn-active.
+    const promptRes = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: "stay in the turn" }),
+      },
+    );
+    expect(promptRes.ok).toBeTruthy();
+
+    // Track any POST to /cockpit/cancel emitted by the page after this
+    // point. If the regression returns, our keypress below produces
+    // exactly one such request.
+    let cancelCount = 0;
+    page.on("request", (req) => {
+      if (
+        req.method() === "POST" &&
+        req.url().includes(`/api/sessions/${sessionId}/cockpit/cancel`)
+      ) {
+        cancelCount += 1;
+      }
+    });
+
+    await page.goto(`${serve.baseUrl}/sessions/${sessionId}`);
+
+    // Focus the composer textarea and press Escape. The composer
+    // mounts the assistant-ui ComposerPrimitive.Input with
+    // cancelOnEscape={false}; the keystroke should be a no-op.
+    const composer = page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    });
+    await composer.focus();
+    await page.keyboard.press("Escape");
+    // Hold for a tick so any cancel fetch has time to fire.
+    await page.waitForTimeout(500);
+
+    expect(cancelCount).toBe(0);
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Pressing Escape inside the cockpit composer while a turn was in flight cancelled the turn. assistant-ui's `ComposerPrimitive.Input` defaults `cancelOnEscape` to true, which binds Escape to `runtime.cancelRun`. In the cockpit that funnels through `onCancel` into `useCockpit.cancelPrompt` and `POST /api/sessions/:id/cockpit/cancel`, aborting the in-flight turn. Claude Code CLI already hijacks Escape for cancel in its TUI, so muscle memory plus a focused composer made accidental cancels easy.

The fix passes `cancelOnEscape={false}` so the keystroke is a no-op inside the composer; cancel stays behind the explicit Stop button click. The Stop button tooltip also drops the stale "· Esc" hint.

Two layers of regression coverage are added:

- A Vitest contract test that mounts the real `ComposerPrimitive.Input` inside a minimal `AssistantRuntimeProvider` and asserts the prop's semantics in both directions (with and without `cancelOnEscape={false}`). If assistant-ui ever changes the prop, the control case moves with it and surfaces the regression.
- A Live Playwright spec that drives the cockpit end-to-end and asserts no POST to `/cockpit/cancel` after an Escape press. Skipped via `base.skip` pending #1237, matching the sibling cockpit live specs that need the same fake-ACP-agent unblocking work.

`web/tests/coverage-matrix.json` gets two new entries pointing at the new specs.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] `cd web && npx vitest run src/components/cockpit/Composer.escape.test.tsx` passes both cases.
- [x] `cd web && node tests/validate-coverage-matrix.mjs` reports validation passed.
- [x] Open the web dashboard, enable cockpit on a session, send a prompt, and while the agent is mid-turn press Escape with the composer textarea focused. Expect the turn to keep running and the Stop button to remain the only way to cancel.
- [x] In the same state, click Stop. Expect the turn to cancel as before.
- [x] Hover the Stop button. Tooltip reads "Stop the agent" without the trailing "· Esc".

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes an issue where pressing the Escape key while a turn is actively running in the cockpit composer would cancel the agent turn. The fix prevents Escape from triggering the cancellation while keeping the explicit Stop button as the only way to cancel a running turn.

## What Changed

**Files Modified:**
- **Composer.tsx** - Updated the composer textarea to disable the default Escape-to-cancel behavior and simplified the Stop button tooltip
- **coverage-matrix.json** - Added entries for two new regression test suites

**Files Added:**
- **Composer.escape.test.tsx** - New Vitest contract test that validates Escape behavior with and without the cancellation flag
- **cockpit-escape-no-cancel.spec.ts** - New Playwright end-to-end test verifying Escape doesn't send a cancel request to the backend (currently skipped pending resolution of issue `#1237`)

## Benefits

- **Improved user experience** - Users can now use Escape to close modals or perform other common actions without accidentally cancelling their agent turn
- **Clearer cancellation flow** - Only the explicit Stop button cancels turns, making the behavior more predictable
- **Regression test coverage** - Two complementary test suites ensure this behavior is maintained (contract test at the component level, e2e test at the user interaction level)

## Technical Details

The root cause was that assistant-ui's `ComposerPrimitive.Input` component defaults `cancelOnEscape` to `true`, which automatically binds the Escape key to the `onCancel` callback. In the cockpit, this callback propagated through to `useCockpit.cancelPrompt()`, which sent a POST request to `/api/sessions/:id/cockpit/cancel`, aborting the turn.

The fix sets `cancelOnEscape={false}` on the composer input, making Escape a no-op there. The Stop button tooltip was also updated to remove the stale "· Esc" hint that no longer applies.

The Vitest test mounts the real `ComposerPrimitive.Input` inside an `AssistantRuntimeProvider` and verifies that with `cancelOnEscape={false}`, pressing Escape does not trigger `onCancel`, while the default behavior still does. The Playwright spec drives the full cockpit workflow to verify no `/cockpit/cancel` POST occurs when Escape is pressed during an active turn.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->