### PR TITLE
fix(cockpit): drain stdout, stderr, and wait concurrently in terminal_handler

### DIFF
--- a/src/cockpit/terminal_handler.rs
+++ b/src/cockpit/terminal_handler.rs
@@ -15,7 +15,6 @@ use std::process::Stdio;
 use std::sync::Arc;
 
 use thiserror::Error;
-use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::Mutex;
 use tracing::info;
@@ -127,7 +126,7 @@ impl TerminalManager {
             "terminal/create"
         );
 
-        let mut child = match sandbox {
+        let child = match sandbox {
             Some(s) => {
                 let runtime = crate::containers::get_container_runtime();
                 let binary = runtime.base.binary;
@@ -151,19 +150,18 @@ impl TerminalManager {
                 .spawn()?,
         };
 
-        let mut stdout_buf = String::new();
-        let mut stderr_buf = String::new();
-        if let Some(mut stdout) = child.stdout.take() {
-            stdout.read_to_string(&mut stdout_buf).await?;
-        }
-        if let Some(mut stderr) = child.stderr.take() {
-            stderr.read_to_string(&mut stderr_buf).await?;
-        }
-        let status = child.wait().await?;
+        // Drain stdout, stderr, and wait() concurrently. Reading
+        // stdout to EOF before stderr deadlocks when the child fills
+        // its stderr pipe buffer first (~64 KiB Linux, ~16 KiB macOS):
+        // the child blocks on the next stderr write, stdout never
+        // closes, this task hangs forever holding the child. Reachable
+        // via the agent-exposed ACP `terminal/create`. `from_utf8_lossy`
+        // keeps non-UTF8 output from failing the whole capture.
+        let raw = child.wait_with_output().await?;
         let output = TerminalOutput {
-            stdout: stdout_buf,
-            stderr: stderr_buf,
-            exit_code: status.code(),
+            stdout: String::from_utf8_lossy(&raw.stdout).into_owned(),
+            stderr: String::from_utf8_lossy(&raw.stderr).into_owned(),
+            exit_code: raw.status.code(),
         };
 
         self.inner.lock().await.outputs.insert(id.clone(), output);
@@ -220,6 +218,56 @@ mod tests {
         mgr.release(&id).await.unwrap();
         let result = mgr.output(&id).await;
         assert!(matches!(result, Err(TerminalError::UnknownTerminal(_))));
+    }
+
+    // Regression: pipe-buffer deadlock when stderr exceeds the
+    // OS pipe buffer (~64 KiB Linux, ~16 KiB macOS) before stdout
+    // closes. 200 KiB on stderr clears both thresholds. Pre-fix
+    // this test hangs forever; the outer timeout makes a regression
+    // surface as a fast failure instead of a stalled CI job.
+    #[tokio::test]
+    async fn large_stderr_does_not_deadlock() {
+        let mgr = TerminalManager::new();
+        let cwd = std::env::temp_dir();
+        let script = "head -c 204800 /dev/zero | tr '\\0' 'x' >&2; echo done";
+        let run = mgr.create_and_run(
+            "s-large-stderr",
+            "sh",
+            vec!["-c".into(), script.into()],
+            cwd,
+            None,
+        );
+        let id = tokio::time::timeout(std::time::Duration::from_secs(5), run)
+            .await
+            .expect("create_and_run hung; pipe deadlock regressed")
+            .expect("create_and_run failed");
+        let out = mgr.output(&id).await.unwrap();
+        assert_eq!(out.stderr.len(), 204_800);
+        assert!(out.stdout.contains("done"));
+        assert_eq!(out.exit_code, Some(0));
+    }
+
+    #[tokio::test]
+    async fn large_stdout_and_stderr_drain_concurrently() {
+        let mgr = TerminalManager::new();
+        let cwd = std::env::temp_dir();
+        let script = "head -c 204800 /dev/zero | tr '\\0' 'o' \
+                      & head -c 204800 /dev/zero | tr '\\0' 'e' >&2 \
+                      & wait";
+        let run = mgr.create_and_run(
+            "s-both-pipes",
+            "sh",
+            vec!["-c".into(), script.into()],
+            cwd,
+            None,
+        );
+        let id = tokio::time::timeout(std::time::Duration::from_secs(5), run)
+            .await
+            .expect("create_and_run hung; pipe deadlock regressed")
+            .expect("create_and_run failed");
+        let out = mgr.output(&id).await.unwrap();
+        assert_eq!(out.stdout.len(), 204_800);
+        assert_eq!(out.stderr.len(), 204_800);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Fix a pipe-buffer deadlock in the cockpit ACP `terminal/create` handler. When a spawned child writes more bytes to stderr than the OS pipe buffer (~64 KiB on Linux, ~16 KiB on macOS) before stdout closes, the child blocks on its next stderr write, stdout never reaches EOF, and the task hangs forever holding the child process.

The path is reachable via the agent-exposed `terminal/create` request, so any verbose tool invocation an agent triggers (`cargo build 2>&1 | tee`, large test output, etc.) could hang a cockpit session.

### What changed

- `src/cockpit/terminal_handler.rs`: replace the sequential `read_to_string` of stdout then stderr with `child.wait_with_output()`, which drains both pipes and the wait future concurrently. This is the canonical tokio primitive for capturing a one shot child's output.
- Decode bytes with `from_utf8_lossy` instead of `read_to_string`. The previous shape would fail the entire capture on non UTF 8 stderr (e.g. raw bytes from a misbehaving tool); `from_utf8_lossy` substitutes replacement chars and matches the permissiveness used by the tmux ACP path.
- Removed the now unused `tokio::io::AsyncReadExt` import.

### Why

Found via a cross validated tokio integration audit (3 independent reviews). This was rated `HIGH` severity because the trigger is fully under agent control: an agent that runs a verbose tool can wedge the cockpit session indefinitely. Fix is mechanical and surgical (1 file, 1 function).

### Tests

Two new regression tests in the existing `#[cfg(test)]` block:

- `large_stderr_does_not_deadlock`: spawns a child that writes 200 KiB to stderr (clears both 64 KiB Linux and 16 KiB macOS pipe buffer thresholds) followed by a small stdout marker. Wrapped in a 5 s `tokio::time::timeout`. Pre fix this test hangs forever; post fix it returns within milliseconds and asserts the full 200 KiB is captured.
- `large_stdout_and_stderr_drain_concurrently`: writes 200 KiB to both pipes in parallel, asserts both are fully captured.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::terminal_handler` 6/6 pass
- `cargo test --features serve --lib cockpit::` 202/202 pass

No e2e or web changes. Backend only fix; not a user facing dashboard flow, so no `web/tests/coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

First PR in a 12 PR series resulting from a cross validated tokio integration audit. Three independent oracle reviews identified two HIGH severity bugs and several MEDIUM hygiene issues; this PR addresses one of the two HIGH findings. Subsequent PRs (lock broadening in supervisor, std::sync::Mutex migration, cleanup loop shutdown tokens, etc.) will land iteratively, each scoped to remain reviewable in under an hour.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes a deadlock issue in the cockpit terminal handler that occurred when child processes generated large amounts of output to standard error before closing standard output. The sequential read approach could cause the process to hang if one pipe buffer filled before being drained.

### What Changed

**Modified:** `src/cockpit/terminal_handler.rs`
- Replaced sequential reading of stdout followed by stderr with concurrent draining of both pipes
- Changed from manual pipe reading to using `wait_with_output()` for simultaneous pipe handling
- Updated output decoding to use `from_utf8_lossy` instead of `read_to_string`, which is more resilient to non-UTF-8 content
- Removed an unused import (`tokio::io::AsyncReadExt`)

**Added:** Two regression test cases
- `large_stderr_does_not_deadlock`: Validates that large stderr output (200 KiB) doesn't cause hanging
- `large_stdout_and_stderr_drain_concurrently`: Ensures both pipes are drained concurrently without deadlock

### Benefits

- **Eliminates deadlock risk**: Child processes can now safely generate large amounts of output to either pipe without risk of blocking
- **More resilient output handling**: Non-UTF-8 output in stderr is now handled gracefully instead of causing capture failures
- **Aligned behavior**: Matches the approach used in the tmux ACP path for consistency
- **Comprehensive testing**: New regression tests ensure the fix is maintained and catches similar issues in the future

### Technical Details

The core issue was a pipe-buffer deadlock: if a child process wrote more data to stderr (>64 KiB on Linux, >16 KiB on macOS) before stdout closed, the write to stderr could block while the handler was still waiting for stdout to close. Using `wait_with_output()` ensures both pipes are drained concurrently, preventing either from filling up. The `from_utf8_lossy` decoder also prevents capture failures when stderr contains non-UTF-8 sequences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->