### PR TITLE
refactor(cockpit): drop Mutex<AcpClient> in WorkerHandle, fix lock broadening

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -118,7 +118,15 @@ enum WorkerKind {
 }
 
 struct WorkerHandle {
-    client: Arc<Mutex<AcpClient>>,
+    /// Shared with all callers that need to issue an ACP request to
+    /// this worker. Stored as `Arc<AcpClient>` (no surrounding Mutex)
+    /// because every method on `AcpClient` takes `&self` and forwards
+    /// to an `mpsc::Sender<ClientCmd>` whose consumer is the
+    /// connection task. Ordering across multiple senders is whatever
+    /// the channel scheduler picks; the agent serialises within a
+    /// turn anyway. The single writer (respawn) replaces the whole
+    /// `Arc` rather than mutating the inner client.
+    client: Arc<AcpClient>,
     /// Background task draining events from the client. Aborted on
     /// shutdown.
     drain_task: JoinHandle<()>,
@@ -663,7 +671,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         let inbound = client
             .take_inbound()
             .expect("freshly spawned AcpClient always has inbound receiver");
-        let client = Arc::new(Mutex::new(client));
+        let client = Arc::new(client);
 
         let mut workers = self.workers.lock().await;
         // Belt-and-braces: even with the pending_spawns reservation,
@@ -721,8 +729,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         // failure, and adapters that don't advertise bypass mode stay in
         // default. See #1142.
         if let Some(client) = client_for_yolo {
-            let client_guard = client.lock().await;
-            if let Err(e) = client_guard.set_mode("bypassPermissions").await {
+            if let Err(e) = client.set_mode("bypassPermissions").await {
                 warn!(
                     target: "cockpit.supervisor",
                     session = %session_id,
@@ -1054,7 +1061,7 @@ impl<S: BroadcastSink> Supervisor<S> {
                     let Some(handle) = guard.get_mut(&session_id) else {
                         return;
                     };
-                    handle.client = Arc::new(Mutex::new(new_client));
+                    handle.client = Arc::new(new_client);
                 }
 
                 info!(
@@ -1101,11 +1108,13 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn send_prompt(&self, session_id: &str, text: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let workers = self.workers.lock().await;
-        let handle = workers
-            .get(session_id)
-            .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))?;
-        let client = handle.client.lock().await;
+        let client = {
+            let workers = self.workers.lock().await;
+            workers
+                .get(session_id)
+                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
+                .map(|h| Arc::clone(&h.client))?
+        };
         client.send_prompt(text).await?;
         Ok(())
     }
@@ -1115,11 +1124,13 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn cancel_prompt(&self, session_id: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let workers = self.workers.lock().await;
-        let handle = workers
-            .get(session_id)
-            .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))?;
-        let client = handle.client.lock().await;
+        let client = {
+            let workers = self.workers.lock().await;
+            workers
+                .get(session_id)
+                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
+                .map(|h| Arc::clone(&h.client))?
+        };
         client.cancel_prompt().await?;
         Ok(())
     }
@@ -1142,9 +1153,11 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
         // Best-effort cancel; ignore UnknownSession because the headline
         // intent is "free the UI", which the publish above already did.
-        let workers = self.workers.lock().await;
-        if let Some(handle) = workers.get(session_id) {
-            let client = handle.client.lock().await;
+        let client = {
+            let workers = self.workers.lock().await;
+            workers.get(session_id).map(|h| Arc::clone(&h.client))
+        };
+        if let Some(client) = client {
             let _ = client.cancel_prompt().await;
         }
     }
@@ -1153,11 +1166,13 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn set_mode(&self, session_id: &str, mode_id: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let workers = self.workers.lock().await;
-        let handle = workers
-            .get(session_id)
-            .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))?;
-        let client = handle.client.lock().await;
+        let client = {
+            let workers = self.workers.lock().await;
+            workers
+                .get(session_id)
+                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
+                .map(|h| Arc::clone(&h.client))?
+        };
         client.set_mode(mode_id).await?;
         Ok(())
     }
@@ -1169,11 +1184,13 @@ impl<S: BroadcastSink> Supervisor<S> {
         nonce: Nonce,
         decision: ApprovalDecision,
     ) -> Result<(), SupervisorError> {
-        let workers = self.workers.lock().await;
-        let handle = workers
-            .get(session_id)
-            .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))?;
-        let client = handle.client.lock().await;
+        let client = {
+            let workers = self.workers.lock().await;
+            workers
+                .get(session_id)
+                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
+                .map(|h| Arc::clone(&h.client))?
+        };
         client.resolve_permission(nonce, decision).await?;
         Ok(())
     }
@@ -1189,10 +1206,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         if let Some(handle) = workers.remove(session_id) {
             // Worker is alive — tear it down.
             drop(workers);
-            {
-                let client = handle.client.lock().await;
-                let _ = client.shutdown().await;
-            }
+            let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             // SIGTERM the runner (if there is one) so the agent
             // subprocess dies; the runner cleans up its own files but
@@ -1267,16 +1281,15 @@ impl<S: BroadcastSink> Supervisor<S> {
             .map(|r| (r.session_id, r.pid))
             .collect();
 
-        let mut workers = self.workers.lock().await;
-        for (id, handle) in workers.drain() {
+        let drained: Vec<(String, WorkerHandle)> = {
+            let mut workers = self.workers.lock().await;
+            workers.drain().collect()
+        };
+        for (id, handle) in drained {
             debug!(target: "cockpit.supervisor", session = %id, "shutting down");
-            {
-                let client = handle.client.lock().await;
-                let _ = client.shutdown().await;
-            }
+            let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
         }
-        drop(workers);
 
         // SIGTERM every runner we knew about, so detached agents that
         // outlived a previous daemon are also taken down by an explicit
@@ -1302,20 +1315,20 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// registry entry. The runner observes EOF on its socket read,
     /// clears its active outbound, and goes back to accepting.
     pub async fn detach_all(&self) {
-        let mut workers = self.workers.lock().await;
-        let ids: Vec<String> = workers.keys().cloned().collect();
-        info!(
-            target: "cockpit.supervisor",
-            count = ids.len(),
-            "detaching cockpit workers; they continue running. \
-             Use `aoe cockpit stop` to terminate."
-        );
-        for (id, handle) in workers.drain() {
+        let drained: Vec<(String, WorkerHandle)> = {
+            let mut workers = self.workers.lock().await;
+            let drained: Vec<(String, WorkerHandle)> = workers.drain().collect();
+            info!(
+                target: "cockpit.supervisor",
+                count = drained.len(),
+                "detaching cockpit workers; they continue running. \
+                 Use `aoe cockpit stop` to terminate."
+            );
+            drained
+        };
+        for (id, handle) in drained {
             debug!(target: "cockpit.supervisor", session = %id, "detaching");
-            {
-                let client = handle.client.lock().await;
-                let _ = client.shutdown().await;
-            }
+            let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             super::worker_registry::mark_detached(&id);
         }
@@ -1431,7 +1444,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         let inbound = client
             .take_inbound()
             .expect("freshly attached AcpClient always has inbound receiver");
-        let client = Arc::new(Mutex::new(client));
+        let client = Arc::new(client);
         let mut workers = self.workers.lock().await;
         if workers.contains_key(&session_id) {
             drop(workers);
@@ -1611,10 +1624,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             // Send ACP Shutdown so the connection task's closure breaks
             // out of its cmd_rx loop and the underlying transport closes
             // cleanly (avoids a leaked socket fd until the daemon dies).
-            {
-                let client = handle.client.lock().await;
-                let _ = client.shutdown().await;
-            }
+            let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             if is_restart {
                 restart_pending.push(id);
@@ -1880,7 +1890,7 @@ mod tests {
         workers.insert(
             "s-1".into(),
             WorkerHandle {
-                client: Arc::new(Mutex::new(client)),
+                client: Arc::new(client),
                 drain_task: drain,
                 restart_history: vec![Instant::now()],
                 kind: WorkerKind::Stdio,
@@ -1976,7 +1986,7 @@ mod tests {
             workers.insert(
                 "s-1".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Runner {
@@ -2049,7 +2059,7 @@ mod tests {
             workers.insert(
                 "s-stop".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Runner {
@@ -2121,7 +2131,7 @@ mod tests {
             workers.insert(
                 "s-reap".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Runner {
@@ -2193,7 +2203,7 @@ mod tests {
             workers.insert(
                 "s-restart".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Runner {
@@ -2262,7 +2272,7 @@ mod tests {
             workers.insert(
                 "s-stdio".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Stdio,
@@ -2319,7 +2329,7 @@ mod tests {
             workers.insert(
                 "s-stop".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Runner {
@@ -2360,7 +2370,7 @@ mod tests {
             workers.insert(
                 "s-stdio".into(),
                 WorkerHandle {
-                    client: Arc::new(Mutex::new(client)),
+                    client: Arc::new(client),
                     drain_task: drain,
                     restart_history: vec![],
                     kind: WorkerKind::Stdio,
@@ -2699,7 +2709,7 @@ mod tests {
         workers.insert(
             "s-1".into(),
             WorkerHandle {
-                client: Arc::new(Mutex::new(client)),
+                client: Arc::new(client),
                 drain_task: drain,
                 restart_history: vec![],
                 kind: WorkerKind::Stdio,


### PR DESCRIPTION
## Description

Drop the `Mutex` from `WorkerHandle.client: Arc<Mutex<AcpClient>>` and fix the lock broadening pattern in the five prompt forwarding methods of `Supervisor`.

### Why drop the `Mutex<AcpClient>`

Every method on `AcpClient` takes `&self` and forwards to an internal `mpsc::Sender<ClientCmd>`:

```rust
pub async fn send_prompt(&self, text: &str) -> Result<(), AcpError> {
    let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
    cmd_tx.send(ClientCmd::Prompt(text.to_string())).await
        .map_err(|_| AcpError::AgentExited)
}
```

(same shape for `cancel_prompt`, `set_mode`, `resolve_permission`, `shutdown`)

The supervisor never needs to mutate the `AcpClient` value: the single writer in the respawn path replaces the whole `Arc` rather than mutating the inner client. The `Mutex` was decorative on every read path. `Arc<AcpClient>` is `Send + Sync` and supports concurrent calls correctly because the underlying `mpsc::Sender` is itself `Send + Sync` and serialises commands at the channel boundary.

### Why this fixes the lock broadening bug

The five prompt forwarding methods (`send_prompt`, `cancel_prompt`, `force_end_turn`, `set_mode`, `resolve_permission`) used to look like:

```rust
let workers = self.workers.lock().await;
let handle = workers.get(session_id).ok_or(...)?;
let client = handle.client.lock().await;        // inner Mutex
client.send_prompt(text).await?;                // workers guard STILL HELD
```

The `workers` guard was held across `client.send_prompt(text).await`, which serialises every cockpit method (`send_prompt`, `cancel_prompt`, `set_mode`, `resolve_permission`, `shutdown`, `worker_states_snapshot`, etc.) on every cockpit session behind one session's ACP round trip. Identified as the only `HIGH` severity finding in the audit (the other was the pipe drain deadlock fixed in #1283).

After the change:

```rust
let client = {
    let workers = self.workers.lock().await;
    workers.get(session_id)
        .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
        .map(|h| Arc::clone(&h.client))?
};                              // workers guard dropped here
client.send_prompt(text).await?;
```

`shutdown_all` and `detach_all` previously held `workers` across N sequential `client.shutdown().await` calls. Same fix: drain the map into a local `Vec` under the guard, drop the guard, then iterate. Sequential awaits remain in place; parallelisation via `JoinSet` is a follow up.

### What changed

- `src/cockpit/supervisor.rs`:
  - `WorkerHandle.client: Arc<Mutex<AcpClient>>` becomes `Arc<AcpClient>`. Field documentation explains the invariant (no `Mutex` because methods take `&self` and the single writer replaces the whole `Arc`).
  - 11 construction sites updated from `Arc::new(Mutex::new(client))` to `Arc::new(client)`.
  - The single writer in the respawn path: `handle.client = Arc::new(Mutex::new(new_client))` becomes `handle.client = Arc::new(new_client)`.
  - Five prompt forwarding methods snapshot `Arc<AcpClient>` under the `workers` guard, drop the guard, then await.
  - `shutdown_all` and `detach_all` drain into a local `Vec`, drop the guard, then iterate sequentially.
  - `shutdown` (single session), the post spawn yolo path, and the watchdog cleanup site already had the `workers` guard dropped or owned the removed handle, so they only needed the inner `.lock().await` removed.

### Behavior change to be aware of

Two concurrent `POST /api/cockpit/sessions/:id/prompts` arriving simultaneously on the same session no longer share the `workers` Mutex serialisation; they both call `cmd_tx.send(ClientCmd::Prompt)` on the same `Arc<AcpClient>`. Tokio's `mpsc::Sender` is fair per sender clone but ordering across multiple clones is whatever the scheduler picks. The agent itself serialises within a turn (the second `Prompt` waits behind the first inside the connection task), so this is functionally equivalent to the previous behavior except the second call no longer blocks every other supervisor method on every other session.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::supervisor` 30/30 pass
- `cargo test --features serve --lib cockpit::` 202/202 pass

The compiler is the regression test: with `Arc<AcpClient>` (no `Mutex`), there is no `.lock()` to call, so no future code can accidentally hold a guard across `.await`. The structural property is enforced by type, not by lint or convention.

The integration tests `cockpit_acp_smoke` and `cockpit_midturn_resume` have pre existing environmental failures on this machine (Node ACP shim handshake timeout, identical on `main`); not introduced by this PR.

No e2e or web changes. No public API change. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 3/12 in a series resulting from a cross validated tokio integration audit. This addresses the only `HIGH` severity supervisor side finding in the audit (the other `HIGH`, the cockpit terminal pipe drain deadlock, shipped in #1283). Subsequent PRs in this series cover cleanup loop shutdown tokens, EventStore offload, fs_handler offload, tunnel guard release, and a generic spawn supervised helper for `JoinError` observability + span propagation.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

This PR simplifies the internal architecture of the session worker system by removing an unnecessary locking mechanism around the ACP client, enabling better concurrent handling of multiple sessions.

### What Changed
The WorkerHandle now stores the ACP client as a simple shared reference (`Arc<AcpClient>`) instead of a wrapped, locked reference (`Arc<Mutex<AcpClient>>`). This change removes the need to acquire locks when communicating with the client.

### What Was Removed
- Mutex wrapper around the AcpClient in WorkerHandle storage
- Lock acquisition calls (`.lock().await`) on the client across 11 call sites
- Lock-holding across async await points that caused serialization

### What Was Updated
- All methods that interact with the client (prompt sending, cancellation, mode setting, etc.) now call directly on the Arc reference
- Five Supervisor methods that forward prompts now avoid holding locks across async operations
- Eleven code locations that construct AcpClient instances were updated to wrap them in Arc without the Mutex
- Test fixtures were updated to match the new WorkerHandle structure

## Benefits
- **Improved Concurrency**: Multiple sessions can now process requests concurrently without blocking each other at the supervisor level
- **Reduced Lock Contention**: Removes unnecessary serialization that previously made all cockpit sessions wait for one session's ACP round trip to complete
- **Simpler Code**: Eliminates the complexity of managing mutex guards, making the code easier to understand and maintain

## Technical Details

The underlying AcpClient uses internal `mpsc::Sender<ClientCmd>` channels for thread-safe communication and only replaces the entire Arc reference during respawns (rather than mutating the inner value), making the outer Mutex redundant. The fix addresses lock-broadening issues by:

- Snapshotting the Arc<AcpClient> under the workers guard, then dropping the guard before awaiting operations
- Draining the workers map into a local Vec in `shutdown_all` and `detach_all` before dropping the guard and iterating

Concurrent POST requests to `/api/cockpit/sessions/:id/prompts` on the same session now rely on the internal mpsc sender for ordering rather than supervisor-level serialization.

All existing tests pass (202/202 cockpit tests, 30/30 supervisor unit tests); no public API changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1285?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->