### PR TITLE
test(web): token-mode auth coverage (Playwright + test-only rotation override)

### DIFF
--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -66,6 +66,7 @@ Fixtures:
 
 - `serve` : `aoe serve --no-auth`. Default for backend round-trip flows.
 - `servePassphrase` : `aoe serve --passphrase aoe-e2e-fixed-passphrase`. The harness mints a session cookie via `POST /api/login` and exposes it as `handle.sessionCookie`. Specs that drive auth from the browser side use `seedAuth(page, handle)` to inject cookie + binding secret before the first navigation.
+- `serveToken` : `aoe serve --auth=token`. The harness reads the daemon-written `serve.token` from the isolated app dir and exposes the value as `handle.authToken` plus its on-disk path as `handle.tokenFile`. Rotation-aware specs call `spawnAoeServe` directly with `tokenLifetimeSecs` / `tokenGraceSecs` overrides; both env vars are debug-build only (`AOE_TEST_TOKEN_LIFETIME_SECS`, `AOE_TEST_TOKEN_GRACE_SECS`) and ignored in release.
 - `serveReadOnly` : `aoe serve --no-auth --read-only`.
 - `serveCockpit` : like `serve` but the fake-ACP agent (see below) is on `$PATH` as both `claude` and `aoe-agent`, and `PATCH /api/cockpit/master` is called after startup.
 
@@ -160,7 +161,7 @@ Report-only in this PR. Phase-2 threshold floor and phase-3 ratchet upward are t
 
 ## Gotchas
 
-- `--no-auth` and `--passphrase` are the only auth modes the harness supports today. Token mode coverage is queued in #1226.
+- `--no-auth`, `--passphrase`, and `--auth=token` are the supported auth modes. Token-mode specs need a debug-build `aoe` because `AOE_TEST_TOKEN_LIFETIME_SECS` and `AOE_TEST_TOKEN_GRACE_SECS` are gated behind `cfg!(debug_assertions)`; release builds keep the production 24h/4h lifetimes and 300s grace.
 - The fake-ACP agent does not delegate FS or terminal calls back to the supervisor. If a scripted turn emits `tool_call_started` for a tool that would normally call `fs/write`, the supervisor will not actually write anything (and the test should not assume it does).
 - Cockpit replay uses the in-memory broadcast channel plus the SQLite event store. If a test asserts a specific event in the replay, give the supervisor up to a few hundred ms to flush (the included tracer specs poll for up to 6 seconds).
 - Synthetic touchmove events for mobile specs fire back-to-back with Δt≈1ms. Cap velocity and per-frame emit counts in production code, or a real device will look sane while the e2e produces runaway momentum (and vice versa).
@@ -169,7 +170,7 @@ Report-only in this PR. Phase-2 threshold floor and phase-3 ratchet upward are t
 
 1. Create `web/tests/live/<surface>.spec.ts`.
 2. Import from `../helpers/liveTest`.
-3. Pick a fixture (`serve`, `servePassphrase`, `serveReadOnly`, `serveCockpit`) or call `spawnAoeServe()` directly if you need custom options.
+3. Pick a fixture (`serve`, `servePassphrase`, `serveToken`, `serveReadOnly`, `serveCockpit`) or call `spawnAoeServe()` directly if you need custom options.
 4. Add (or update) the matching surface entry in `web/tests/coverage-matrix.json`. Make sure every component the spec touches is in its `components[]` (or already in another surface or the exempt list).
 5. Run `node web/tests/validate-coverage-matrix.mjs` locally. CI runs the same script.
 6. Run `npx playwright test --config=playwright.live.config.ts <your spec>` to confirm it passes. Live specs require tmux installed and `cargo build --features serve --release` to have run at least once.

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -69,6 +69,7 @@ struct TokenState {
     previous: Option<String>,
     grace_expires: Option<tokio::time::Instant>,
     lifetime: Duration,
+    grace: Duration,
 }
 
 /// Manages auth tokens with rotation and grace periods.
@@ -76,14 +77,21 @@ pub struct TokenManager {
     state: RwLock<TokenState>,
 }
 
+const DEFAULT_TOKEN_GRACE: Duration = Duration::from_secs(300);
+
 impl TokenManager {
     pub fn new(initial_token: Option<String>, lifetime: Duration) -> Self {
+        Self::with_grace(initial_token, lifetime, DEFAULT_TOKEN_GRACE)
+    }
+
+    pub fn with_grace(initial_token: Option<String>, lifetime: Duration, grace: Duration) -> Self {
         Self {
             state: RwLock::new(TokenState {
                 current: initial_token,
                 previous: None,
                 grace_expires: None,
                 lifetime,
+                grace,
             }),
         }
     }
@@ -139,10 +147,11 @@ impl TokenManager {
     pub async fn rotate(&self) {
         let mut state = self.state.write().await;
         let new_token = generate_token();
+        let grace = state.grace;
 
         state.previous = state.current.take();
         state.current = Some(new_token.clone());
-        state.grace_expires = Some(tokio::time::Instant::now() + Duration::from_secs(300));
+        state.grace_expires = Some(tokio::time::Instant::now() + grace);
 
         // Persist to disk
         if let Ok(app_dir) = crate::session::get_app_dir() {
@@ -151,22 +160,28 @@ impl TokenManager {
 
         info!(
             target: "auth.token",
-            grace_secs = 300,
+            grace_secs = grace.as_secs(),
             "auth token rotated"
         );
     }
 
-    /// Spawn a background rotation task (only in remote mode).
+    /// Spawn a background rotation task. Production paths only call this
+    /// from the `--remote` branch; debug builds also call it when the
+    /// `AOE_TEST_TOKEN_LIFETIME_SECS` env override is set, so live e2e
+    /// specs can observe the grace window without waiting hours.
     pub fn spawn_rotation_task(self: &Arc<Self>) {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
             loop {
-                let lifetime = manager.state.read().await.lifetime;
+                let (lifetime, grace) = {
+                    let state = manager.state.read().await;
+                    (state.lifetime, state.grace)
+                };
                 tokio::time::sleep(lifetime).await;
                 manager.rotate().await;
 
                 // After grace period, clear previous
-                tokio::time::sleep(Duration::from_secs(300)).await;
+                tokio::time::sleep(grace).await;
                 {
                     let mut state = manager.state.write().await;
                     state.previous = None;
@@ -175,6 +190,38 @@ impl TokenManager {
             }
         });
     }
+}
+
+/// Read `AOE_TEST_TOKEN_LIFETIME_SECS`. Debug builds only; ignored in
+/// release so production cannot be forced into a short rotation cycle
+/// by a stray env var.
+#[cfg(debug_assertions)]
+fn test_token_lifetime_override() -> Option<Duration> {
+    std::env::var("AOE_TEST_TOKEN_LIFETIME_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .map(Duration::from_secs)
+}
+
+#[cfg(not(debug_assertions))]
+fn test_token_lifetime_override() -> Option<Duration> {
+    None
+}
+
+/// Read `AOE_TEST_TOKEN_GRACE_SECS`. Debug builds only.
+#[cfg(debug_assertions)]
+fn test_token_grace_override() -> Option<Duration> {
+    std::env::var("AOE_TEST_TOKEN_GRACE_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .map(Duration::from_secs)
+}
+
+#[cfg(not(debug_assertions))]
+fn test_token_grace_override() -> Option<Duration> {
+    None
 }
 
 // ── AppState ────────────────────────────────────────────────────────────────
@@ -427,13 +474,20 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         Some(load_or_generate_token().await?)
     };
 
-    let token_lifetime = if remote {
-        Duration::from_secs(4 * 60 * 60) // 4 hours
-    } else {
-        Duration::from_secs(24 * 60 * 60) // 24 hours (existing behavior)
-    };
+    let token_lifetime = test_token_lifetime_override().unwrap_or_else(|| {
+        if remote {
+            Duration::from_secs(4 * 60 * 60) // 4 hours
+        } else {
+            Duration::from_secs(24 * 60 * 60) // 24 hours (existing behavior)
+        }
+    });
+    let token_grace = test_token_grace_override().unwrap_or(DEFAULT_TOKEN_GRACE);
 
-    let token_manager = Arc::new(TokenManager::new(auth_token.clone(), token_lifetime));
+    let token_manager = Arc::new(TokenManager::with_grace(
+        auth_token.clone(),
+        token_lifetime,
+        token_grace,
+    ));
     let login_manager = Arc::new(login::LoginManager::new(passphrase));
     let rate_limiter = Arc::new(RateLimiter::new());
 
@@ -896,6 +950,13 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 }
             }
         });
+    } else if test_token_lifetime_override().is_some() && auth_token.is_some() {
+        // Debug-build test path: live Playwright specs set
+        // AOE_TEST_TOKEN_LIFETIME_SECS (and optionally AOE_TEST_TOKEN_GRACE_SECS)
+        // so they can observe the rotation grace window without waiting hours.
+        // Skips the remote-only serve.url rewrite and push retain steps because
+        // neither exists in the local test setup.
+        token_manager.spawn_rotation_task();
     }
 
     // Graceful shutdown: SIGINT (Ctrl-C), SIGTERM (`aoe serve --stop`),

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -29,10 +29,17 @@
     },
     {
       "id": "auth.token-entry",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1226",
+      "kind": "live-playwright",
       "risk": "medium",
-      "components": ["web/src/components/TokenEntryPage.tsx"]
+      "specs": ["tests/live/auth-token-entry.spec.ts"],
+      "components": ["web/src/components/TokenEntryPage.tsx", "web/src/lib/token.ts"]
+    },
+    {
+      "id": "auth.token-rotation",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/auth-token-rotation.spec.ts"],
+      "components": ["src/server/mod.rs"]
     },
     {
       "id": "settings.theme-persistence",

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -33,7 +33,7 @@ const __dirname = dirname(__filename);
 
 const DEFAULT_PASSPHRASE = "aoe-e2e-fixed-passphrase";
 
-export type AuthMode = "none" | "passphrase";
+export type AuthMode = "none" | "passphrase" | "token";
 
 export interface SpawnOptions {
   authMode?: AuthMode;
@@ -45,6 +45,19 @@ export interface SpawnOptions {
   extraArgs?: string[];
   /** Override the spawn timeout (default 10s). */
   spawnTimeoutMs?: number;
+  /**
+   * Token mode only. Sets `AOE_TEST_TOKEN_LIFETIME_SECS` on the server
+   * subprocess; in debug builds the daemon enables the rotation task
+   * even outside `--remote` and uses this lifetime. Ignored when
+   * authMode !== "token".
+   */
+  tokenLifetimeSecs?: number;
+  /**
+   * Token mode only. Sets `AOE_TEST_TOKEN_GRACE_SECS`. Defaults to the
+   * production 300s; specs that assert "old rejected past grace" pass a
+   * small value (e.g. 2) so the assertion lands inside a Playwright run.
+   */
+  tokenGraceSecs?: number;
   /**
    * When true, install `fakeAcpAgent.mjs` as the `claude` / `aoe-agent`
    * shim instead of the tail-f-dev-null stub, and flip the cockpit
@@ -83,6 +96,18 @@ export interface ServeHandle {
   proc: ChildProcess;
   authMode: AuthMode;
   passphrase?: string;
+  /**
+   * Token-mode only: the 64-char hex token the daemon wrote to
+   * `serve.token` after boot. Specs append it as `?token=<value>` on
+   * navigation or attach it as a Bearer header for direct fetches.
+   */
+  authToken?: string;
+  /**
+   * Token-mode only: filesystem path to `serve.token` under the
+   * isolated HOME. Specs that need to read the rotated token re-read
+   * this file; the daemon rewrites it on every rotation.
+   */
+  tokenFile?: string;
   /**
    * Set when `authMode === "passphrase"` and the harness has minted a
    * session via POST /api/login. Callers (typically the Playwright fixture)
@@ -196,6 +221,46 @@ export function tmuxPrefixFor(binaryPath: string): "aoe_" | "aoe_dev_" {
   return binaryPath.includes("/target/debug/") ? "aoe_dev_" : "aoe_";
 }
 
+/**
+ * Resolve where the daemon will write `serve.token` (and other serve.*
+ * state files) under the test's isolated filesystem tree. Mirrors the
+ * Rust `get_app_dir_path` logic at `src/session/mod.rs:83`: Linux uses
+ * `$XDG_CONFIG_HOME/agent-of-empires[-dev]`, macOS/Windows uses
+ * `$HOME/.agent-of-empires[-dev]`. Debug builds carry the `-dev`
+ * suffix, derived from the binary path the same way as `tmuxPrefixFor`.
+ */
+export function appDirFor(home: string, xdg: string, binaryPath: string): string {
+  const suffix = binaryPath.includes("/target/debug/") ? "-dev" : "";
+  if (process.platform === "linux") {
+    return join(xdg, `agent-of-empires${suffix}`);
+  }
+  return join(home, `.agent-of-empires${suffix}`);
+}
+
+/**
+ * Wait for `serve.token` to appear in the daemon's app dir, then read
+ * it. The daemon writes the token early in startup, so by the time
+ * `waitForServer` resolves it is on disk; the loop is a small safety
+ * net for systems where fs writes lag the listen socket by a few ms.
+ */
+async function readTokenFile(tokenPath: string, deadlineMs: number): Promise<string> {
+  const { readFile } = await import("node:fs/promises");
+  const deadline = Date.now() + deadlineMs;
+  let lastErr: unknown = "no attempts made";
+  while (Date.now() < deadline) {
+    try {
+      const raw = await readFile(tokenPath, "utf8");
+      const token = raw.trim();
+      if (token.length > 0) return token;
+      lastErr = "empty";
+    } catch (err) {
+      lastErr = err;
+    }
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(`token file ${tokenPath} not readable: ${lastErr}`);
+}
+
 function portFor(workerIndex: number, parallelIndex: number, attempt: number): number {
   // 5200 + worker*100 + parallel + attempt*7 covers ~14 retries per
   // (worker, parallel) slot before colliding with the next slot.
@@ -224,7 +289,10 @@ async function waitForServer(
       // the harness latch onto stale token-auth servers that other test
       // runs left running on the same port. Be precise per authMode.
       if (authMode === "none" && res.status === 200) return;
-      if (authMode === "passphrase" && (res.status === 200 || res.status === 401))
+      if (
+        (authMode === "passphrase" || authMode === "token") &&
+        (res.status === 200 || res.status === 401)
+      )
         return;
       lastErr = `status ${res.status}`;
     } catch (err) {
@@ -338,7 +406,9 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     writeFakeClaudeShim(shimBin);
   }
 
-  const seedEnv = {
+  const authMode: AuthMode = opts.authMode ?? "none";
+
+  const seedEnv: NodeJS.ProcessEnv = {
     ...process.env,
     HOME: home,
     XDG_CONFIG_HOME: xdg,
@@ -347,11 +417,19 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     PATH: `${shimBin}:${process.env.PATH ?? ""}`,
   };
 
+  if (authMode === "token") {
+    if (typeof opts.tokenLifetimeSecs === "number") {
+      seedEnv.AOE_TEST_TOKEN_LIFETIME_SECS = String(opts.tokenLifetimeSecs);
+    }
+    if (typeof opts.tokenGraceSecs === "number") {
+      seedEnv.AOE_TEST_TOKEN_GRACE_SECS = String(opts.tokenGraceSecs);
+    }
+  }
+
   if (opts.seedFn) {
     await opts.seedFn({ home, shimBin, xdg, tmp, tmuxTmp, env: seedEnv });
   }
 
-  const authMode: AuthMode = opts.authMode ?? "none";
   const passphrase = authMode === "passphrase" ? opts.passphrase ?? DEFAULT_PASSPHRASE : undefined;
 
   const spawnTimeoutMs = opts.spawnTimeoutMs ?? 10_000;
@@ -364,6 +442,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     baseUrl = `http://127.0.0.1:${port}`;
     const args = ["serve", "--host", "127.0.0.1", "--port", String(port)];
     if (authMode === "none") args.push("--no-auth");
+    if (authMode === "token") args.push("--auth", "token");
     if (passphrase) args.push("--passphrase", passphrase);
     if (opts.readOnly) args.push("--read-only");
     if (opts.extraArgs) args.push(...opts.extraArgs);
@@ -413,6 +492,13 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     throw new Error("aoe serve failed to bind on every attempted port");
   }
 
+  let authToken: string | undefined;
+  let tokenFile: string | undefined;
+  if (authMode === "token") {
+    tokenFile = join(appDirFor(home, xdg, aoeBinary), "serve.token");
+    authToken = await readTokenFile(tokenFile, spawnTimeoutMs);
+  }
+
   const handle: ServeHandle = {
     baseUrl,
     port,
@@ -421,6 +507,8 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     proc,
     authMode,
     passphrase,
+    authToken,
+    tokenFile,
     tmuxPrefix: tmuxPrefixFor(aoeBinary),
     async stop() {
       try {

--- a/web/tests/helpers/liveTest.ts
+++ b/web/tests/helpers/liveTest.ts
@@ -29,11 +29,19 @@ type LiveFixtures = {
   servePassphrase: ServeHandle;
   serveReadOnly: ServeHandle;
   /**
+   * Token-mode fixture: spawns `aoe serve --auth=token` and resolves
+   * `handle.authToken` from the daemon-written `serve.token` file.
+   * Specs typically navigate to `${baseUrl}/?token=${handle.authToken}`
+   * and let `web/src/lib/token.ts` capture it into localStorage.
+   * Rotation-aware specs call `spawnAoeServe` directly with
+   * `tokenLifetimeSecs` / `tokenGraceSecs` overrides.
+   */
+  serveToken: ServeHandle;
+  /**
    * Cockpit fixture. Only supported with `authMode: "none"` today; the
    * harness calls `PATCH /api/cockpit/master` without a session cookie.
-   * Token-mode cockpit coverage is queued in #1226. If you need
-   * passphrase + cockpit, call `spawnAoeServe` directly and pass the
-   * `sessionCookie` through to the master-enable request.
+   * If you need passphrase + cockpit, call `spawnAoeServe` directly and
+   * pass the `sessionCookie` through to the master-enable request.
    */
   serveCockpit: ServeHandle;
 };
@@ -84,6 +92,15 @@ export const test = base.extend<LiveFixtures>({
   servePassphrase: async ({}, use, testInfo) => {
     const h = await spawnAoeServe({
       authMode: "passphrase",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+    });
+    await use(h);
+    await h.stop();
+  },
+  serveToken: async ({}, use, testInfo) => {
+    const h = await spawnAoeServe({
+      authMode: "token",
       workerIndex: testInfo.workerIndex,
       parallelIndex: testInfo.parallelIndex,
     });

--- a/web/tests/live/auth-token-entry.spec.ts
+++ b/web/tests/live/auth-token-entry.spec.ts
@@ -1,0 +1,73 @@
+// Token-mode entry flow: a stale or bad token in the URL puts the SPA on
+// `TokenEntryPage`; pasting the valid token replaces it and routes to the
+// dashboard. Covers `web/src/components/TokenEntryPage.tsx`, the localStorage
+// capture in `web/src/lib/token.ts`, and the 401 handler in
+// `web/src/lib/fetchInterceptor.ts`.
+
+import { test, expect } from "../helpers/liveTest";
+
+const BAD_TOKEN = "a".repeat(64);
+
+test("bad token in URL routes to TokenEntryPage; valid token routes to dashboard", async ({
+  serveToken,
+  page,
+}) => {
+  expect(serveToken.authToken, "harness must expose serve.token").toBeTruthy();
+  const validToken = serveToken.authToken!;
+
+  // Drop the bad token into localStorage via the URL capture path that
+  // token.ts runs on module load. The SPA then strips ?token from the URL
+  // and starts firing token-gated requests with the bad value.
+  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`);
+
+  // First auth-gated request 401s; fetchInterceptor dispatches
+  // TOKEN_EXPIRED_EVENT and App.tsx swaps in TokenEntryPage.
+  await expect(page.locator("#token")).toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.getByText(/session token has expired or is missing/i),
+  ).toBeVisible();
+
+  // Sanity: localStorage was cleared by the interceptor on 401.
+  const storedAfterReject = await page.evaluate(() =>
+    window.localStorage.getItem("aoe_auth_token"),
+  );
+  expect(storedAfterReject).toBeNull();
+
+  // Submitting another bad token surfaces the inline error.
+  await page.locator("#token").fill(BAD_TOKEN);
+  await page.getByRole("button", { name: /connect/i }).click();
+  await expect(page.getByText(/invalid token/i)).toBeVisible({
+    timeout: 5_000,
+  });
+
+  // Paste the real token; verifyToken hits /api/login/status (login-exempt
+  // but token-gated), the 200 unsticks tokenExpired, App re-renders the
+  // dashboard. We assert on a stable dashboard locator rather than the
+  // absence of TokenEntryPage so the test fails loudly if routing breaks.
+  await page.locator("#token").fill(validToken);
+  await page.getByRole("button", { name: /connect/i }).click();
+
+  await expect(page.locator("#token")).toBeHidden({ timeout: 10_000 });
+
+  // Token was persisted to localStorage by saveToken.
+  const storedAfterAccept = await page.evaluate(() =>
+    window.localStorage.getItem("aoe_auth_token"),
+  );
+  expect(storedAfterAccept).toBe(validToken);
+});
+
+test("URL form (?token=...) and raw-token form both unlock TokenEntryPage", async ({
+  serveToken,
+  page,
+}) => {
+  const validToken = serveToken.authToken!;
+
+  // Start with a bad token to land on TokenEntryPage.
+  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`);
+  await expect(page.locator("#token")).toBeVisible({ timeout: 10_000 });
+
+  // Submit the full URL form (extractToken in TokenEntryPage.tsx parses it).
+  await page.locator("#token").fill(`${serveToken.baseUrl}/?token=${validToken}`);
+  await page.getByRole("button", { name: /connect/i }).click();
+  await expect(page.locator("#token")).toBeHidden({ timeout: 10_000 });
+});

--- a/web/tests/live/auth-token-entry.spec.ts
+++ b/web/tests/live/auth-token-entry.spec.ts
@@ -18,11 +18,15 @@ test("bad token in URL routes to TokenEntryPage; valid token routes to dashboard
   // Drop the bad token into localStorage via the URL capture path that
   // token.ts runs on module load. The SPA then strips ?token from the URL
   // and starts firing token-gated requests with the bad value.
-  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`);
+  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`, {
+    waitUntil: "domcontentloaded",
+  });
 
   // First auth-gated request 401s; fetchInterceptor dispatches
-  // TOKEN_EXPIRED_EVENT and App.tsx swaps in TokenEntryPage.
-  await expect(page.locator("#token")).toBeVisible({ timeout: 10_000 });
+  // TOKEN_EXPIRED_EVENT and App.tsx swaps in TokenEntryPage. Bump the
+  // timeout above the harness's spawn slack so a cold-cache Vite serve
+  // doesn't race the assertion.
+  await expect(page.locator("#token")).toBeVisible({ timeout: 15_000 });
   await expect(
     page.getByText(/session token has expired or is missing/i),
   ).toBeVisible();
@@ -63,8 +67,10 @@ test("URL form (?token=...) and raw-token form both unlock TokenEntryPage", asyn
   const validToken = serveToken.authToken!;
 
   // Start with a bad token to land on TokenEntryPage.
-  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`);
-  await expect(page.locator("#token")).toBeVisible({ timeout: 10_000 });
+  await page.goto(`${serveToken.baseUrl}/?token=${BAD_TOKEN}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await expect(page.locator("#token")).toBeVisible({ timeout: 15_000 });
 
   // Submit the full URL form (extractToken in TokenEntryPage.tsx parses it).
   await page.locator("#token").fill(`${serveToken.baseUrl}/?token=${validToken}`);

--- a/web/tests/live/auth-token-rotation.spec.ts
+++ b/web/tests/live/auth-token-rotation.spec.ts
@@ -1,0 +1,101 @@
+// Token rotation grace window: after the daemon rotates, the previous
+// token must keep working for the grace period, the new token must work
+// immediately, and the previous token must be rejected once grace
+// expires. Covers `src/server/mod.rs` TokenManager rotate + validate.
+//
+// Driven by debug-build env overrides AOE_TEST_TOKEN_LIFETIME_SECS and
+// AOE_TEST_TOKEN_GRACE_SECS. The harness sets these via the
+// `tokenLifetimeSecs` / `tokenGraceSecs` options on spawnAoeServe. In
+// release builds the override is ignored (token lifetime stays at 24h);
+// this spec relies on debug-build behavior so the CI matrix that runs
+// live specs must build aoe in debug or pass --features serve with
+// `cfg!(debug_assertions)` on (current `playwright-live` job does both).
+
+import { readFile } from "node:fs/promises";
+
+import { test, expect } from "../helpers/liveTest";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+const LIFETIME_SECS = 6;
+const GRACE_SECS = 3;
+const POLL_INTERVAL_MS = 200;
+
+/** Probe a token via Bearer header against an unauthenticated GET. */
+async function probeToken(baseUrl: string, token: string): Promise<number> {
+  const res = await fetch(`${baseUrl}/api/about`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  // Drain body so the connection releases promptly.
+  await res.text().catch(() => "");
+  return res.status;
+}
+
+/**
+ * Poll the daemon's `serve.token` file until its content differs from
+ * `previous`. Returns the new token. Times out after `deadlineMs`.
+ */
+async function waitForRotation(
+  tokenFile: string,
+  previous: string,
+  deadlineMs: number,
+): Promise<string> {
+  const deadline = Date.now() + deadlineMs;
+  while (Date.now() < deadline) {
+    try {
+      const raw = (await readFile(tokenFile, "utf8")).trim();
+      if (raw.length > 0 && raw !== previous) return raw;
+    } catch {
+      // file may be momentarily unlinked during write; retry
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+  throw new Error(`token file did not rotate within ${deadlineMs}ms`);
+}
+
+test("rotated token: old accepted in grace, new accepted, old rejected past grace", async ({}, testInfo) => {
+  test.setTimeout(60_000);
+
+  const handle = await spawnAoeServe({
+    authMode: "token",
+    tokenLifetimeSecs: LIFETIME_SECS,
+    tokenGraceSecs: GRACE_SECS,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    const tokenA = handle.authToken!;
+    expect(tokenA).toMatch(/^[0-9a-f]{64}$/);
+
+    // Pre-rotation: tokenA works, garbage does not.
+    expect(await probeToken(handle.baseUrl, tokenA)).toBe(200);
+    expect(await probeToken(handle.baseUrl, "z".repeat(64))).toBe(401);
+
+    // Wait for the daemon to rotate; lifetime is LIFETIME_SECS, so allow
+    // an extra grace+slack to avoid a flake on slow CI.
+    const tokenB = await waitForRotation(
+      handle.tokenFile!,
+      tokenA,
+      (LIFETIME_SECS + GRACE_SECS + 5) * 1000,
+    );
+    expect(tokenB).toMatch(/^[0-9a-f]{64}$/);
+    expect(tokenB).not.toBe(tokenA);
+
+    // In-grace window: both tokens valid.
+    expect(await probeToken(handle.baseUrl, tokenA)).toBe(200);
+    expect(await probeToken(handle.baseUrl, tokenB)).toBe(200);
+
+    // Wait past the grace expiry. Add a small fudge factor because the
+    // rotation task's `sleep(grace)` is the bound; the validate-side
+    // grace_expires comparison is the actual gate.
+    await new Promise((r) => setTimeout(r, (GRACE_SECS + 1) * 1000));
+
+    // After grace: tokenA rejected. tokenB still current. (A second
+    // rotation could fire at t = LIFETIME_SECS*2, which is still > the
+    // current elapsed time given LIFETIME_SECS=6 and GRACE_SECS=3.)
+    expect(await probeToken(handle.baseUrl, tokenA)).toBe(401);
+    expect(await probeToken(handle.baseUrl, tokenB)).toBe(200);
+  } finally {
+    await handle.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Follow-up to foundation PR #1228 for the #986 coverage push. Adds live-Playwright coverage for the token-auth dashboard flows that the foundation PR explicitly left deferred:

- A `serveToken` fixture (and an updated `AuthMode` on `aoeServe.ts`) that spawns `aoe serve --auth=token`, reads the daemon-written `serve.token` out of the isolated app dir, and exposes the value as `handle.authToken` / `handle.tokenFile`.
- `auth-token-entry.spec.ts` covers `TokenEntryPage.tsx`, the `?token=...` localStorage capture in `web/src/lib/token.ts`, and the 401 → `TOKEN_EXPIRED_EVENT` path in `web/src/lib/fetchInterceptor.ts`. Two cases: raw-token submission and full-URL form.
- `auth-token-rotation.spec.ts` covers the `TokenManager` grace window: pre-rotation token works, both tokens work during grace, old token rejected post-grace while the new one keeps working.

The rotation spec needs the daemon to rotate within seconds rather than the production 24h/4h cadence, so a tiny test-only knob lands in `src/server/mod.rs`: `AOE_TEST_TOKEN_LIFETIME_SECS` and `AOE_TEST_TOKEN_GRACE_SECS` env overrides, both gated on `cfg!(debug_assertions)` so release builds ignore them. When the lifetime override is set in a non-remote start, the lean `TokenManager::spawn_rotation_task` runs (the remote path's inline rotation loop is unchanged). The grace field is plumbed through `TokenManager` so `rotate()` and the task read from state instead of the previous hard-coded 300s; the existing unit tests keep using the 2-arg `new()` shim which defaults to 300s.

Matrix entries flip: `auth.token-entry` moves from `deferred` to `live-playwright`, and a fresh `auth.token-rotation` entry is added pointing at the new spec. `docs/development/playwright.md` documents the new fixture and the two env knobs.

Closes #1226

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

User-runnable behavioral steps to verify before flipping to ready-for-review:

- [ ] `cargo fmt --all -- --check && cargo clippy --features serve --all-targets -- -D warnings && cargo test --features serve` all green.
- [ ] `cd web && node tests/validate-coverage-matrix.mjs` prints `Coverage matrix validation passed.`
- [ ] `cargo build --features serve` (debug build, needed for the env override).
- [ ] `cd web && AOE_E2E_BINARY=$PWD/../target/debug/aoe npx playwright test --config=playwright.live.config.ts auth-token-entry auth-token-rotation` reports 3 passed.
- [ ] In a separate shell, run the binary manually: `./target/debug/aoe serve --auth=token`. Confirm the printed URL has `?token=<value>` and that the dashboard loads.
- [ ] With the same daemon up, paste a deliberately wrong token into the URL: `http://127.0.0.1:8081/?token=aaaaaaaa...` (64 a's). Confirm `TokenEntryPage` renders, the inline error appears on a second bad submit, and pasting the real token from `~/.agent-of-empires-dev/serve.token` returns you to the dashboard.
- [ ] Confirm `AOE_TEST_TOKEN_LIFETIME_SECS=5 AOE_TEST_TOKEN_GRACE_SECS=3 ./target/debug/aoe serve --auth=token` rotates `~/.agent-of-empires-dev/serve.token` every five seconds (`watch -n1 'cat ~/.agent-of-empires-dev/serve.token'`).
- [ ] Confirm a release build ignores both env vars: `cargo build --features serve --release && AOE_TEST_TOKEN_LIFETIME_SECS=5 ./target/release/aoe serve --auth=token`, then check the token file does not rotate within a minute.
- [ ] CI's `playwright-live` job exercises the new specs against `target/debug/aoe`; confirm both specs land in the green column on the PR's CI tab.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, agent-of-empires `/aoe-implement` skill.

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. I picked the rotation mechanism (env override over a debug-only admin endpoint or a restart-only flow that loses grace semantics), confirmed the issue's grace-period wording inversion against `verify_token` in `src/server/mod.rs`, reviewed each commit, and ran the manual test steps locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds live Playwright test coverage for token-mode authentication in the dashboard, fulfilling issue `#1226`. The changes enable comprehensive testing of token entry flows, token rotation behavior, and grace-window semantics.

### What Was Added
- **New test fixture**: `serveToken` in the live test harness that spawns an `aoe serve` instance with token authentication enabled
- **Two new live test specs**: 
  - `auth-token-entry.spec.ts` validates token entry UI behavior, error handling, and localStorage token persistence
  - `auth-token-rotation.spec.ts` verifies token rotation behavior including grace-window acceptance and rejection timing
- **Test-only token lifecycle controls**: Environment variables (`AOE_TEST_TOKEN_LIFETIME_SECS`, `AOE_TEST_TOKEN_GRACE_SECS`) allow tests to control token rotation timing without affecting production code
- **Token file reading capability**: Helper functions to locate and poll for the token file from the isolated app directory

### What Changed
- **Test harness** (`aoeServe.ts`): Extended to support token auth mode, reading token values from the daemon-written `serve.token` file, and propagating test-only timing overrides to the server
- **Token management** (`TokenManager`): Now accepts configurable grace duration via `with_grace()` constructor, replacing fixed 300s values, with conditional rotation task spawning for test scenarios
- **Server startup** (`src/server/mod.rs`): Integrated debug-only token lifetime/grace overrides and rotational task support
- **Coverage matrix**: Migrated token-entry from deferred to live-playwright coverage and added new token-rotation entry
- **Documentation** (`playwright.md`): Added details on token fixture usage and test-only configuration knobs

### Benefits
- Closes the gap on live test coverage for token authentication flows (previously deferred)
- Enables testing of complex token rotation and grace-window timing without production impact
- Provides a reusable `serveToken` fixture for future token-auth test scenarios
- Maintains backward compatibility: existing tests and code continue to use default 300s grace; test-only overrides are debug-build only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1286?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->