### PR TITLE
test(web): live spec for git-clone wizard happy + failure paths

### DIFF
--- a/src/server/api/git.rs
+++ b/src/server/api/git.rs
@@ -17,6 +17,19 @@ pub struct CloneRepoBody {
     pub shallow: bool,
 }
 
+/// Returns true if `url` looks like a git clone URL accepted by this
+/// endpoint. Recognised forms: https, http, git, ssh, file schemes, and
+/// scp-style (`user@host:path`). Anything else is rejected with a 400
+/// before reaching `git clone`.
+fn looks_like_git_url(url: &str) -> bool {
+    url.starts_with("https://")
+        || url.starts_with("http://")
+        || url.starts_with("git://")
+        || url.starts_with("ssh://")
+        || url.starts_with("file://")
+        || (url.contains('@') && url.contains(':') && !url.contains(' '))
+}
+
 /// Extract a repository name from a git URL.
 ///
 /// Handles HTTPS, SSH, and scp-style URLs:
@@ -68,13 +81,7 @@ pub async fn clone_repo(
             .into_response();
     }
 
-    // Basic URL scheme validation
-    let looks_like_url = url.starts_with("https://")
-        || url.starts_with("http://")
-        || url.starts_with("git://")
-        || url.starts_with("ssh://")
-        || (url.contains('@') && url.contains(':') && !url.contains(' '));
-    if !looks_like_url {
+    if !looks_like_git_url(&url) {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({"error": "validation_failed", "message": "URL does not look like a git repository URL"})),
@@ -306,5 +313,52 @@ mod tests {
             repo_name_from_url("ssh://git@host:2222/user/my-repo.git"),
             Some("my-repo".to_string())
         );
+    }
+
+    // ── looks_like_git_url tests ──────────────────────────────────────────────
+
+    #[test]
+    fn looks_like_git_url_accepts_https() {
+        assert!(looks_like_git_url("https://github.com/u/r.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_accepts_http() {
+        assert!(looks_like_git_url("http://example.com/r.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_accepts_git_protocol() {
+        assert!(looks_like_git_url("git://example.com/u/r.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_accepts_ssh() {
+        assert!(looks_like_git_url("ssh://git@github.com/u/r.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_accepts_scp_style() {
+        assert!(looks_like_git_url("git@github.com:u/r.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_accepts_file_scheme() {
+        assert!(looks_like_git_url("file:///tmp/bare.git"));
+    }
+
+    #[test]
+    fn looks_like_git_url_rejects_bare_word() {
+        assert!(!looks_like_git_url("not-a-url"));
+    }
+
+    #[test]
+    fn looks_like_git_url_rejects_empty() {
+        assert!(!looks_like_git_url(""));
+    }
+
+    #[test]
+    fn looks_like_git_url_rejects_scp_style_with_space() {
+        assert!(!looks_like_git_url("git@host: /path"));
     }
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -214,10 +214,10 @@
     },
     {
       "id": "git-clone",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1223",
+      "kind": "live-playwright",
       "risk": "medium",
-      "components": []
+      "specs": ["tests/live/git-clone.spec.ts"],
+      "components": ["web/src/components/session-wizard/steps/ProjectStep.tsx"]
     },
     {
       "id": "cockpit.spawn-prompt",

--- a/web/tests/helpers/gitFixture.ts
+++ b/web/tests/helpers/gitFixture.ts
@@ -1,0 +1,48 @@
+// Git fixture helpers for live Playwright specs.
+//
+// Used by `tests/live/git-clone.spec.ts` (and any future spec exercising
+// the `POST /api/git/clone` endpoint) to spin up a throwaway bare repo
+// the wizard can clone from via `file://`. Keeping the source repo on
+// the local filesystem keeps the test deterministic, hermetic, and free
+// from any network dependency.
+//
+// The matching server-side validator accepts `file://` URLs by design.
+// See `src/server/api/git.rs::looks_like_git_url` for the allowlist.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+export interface BareRepoFixture {
+  /** Absolute path of the bare repo on disk. */
+  path: string;
+  /** `file://` URL pointing at `path`, ready to feed into the wizard input. */
+  url: string;
+}
+
+/**
+ * Create a throwaway local bare git repo so a live `aoe serve` can clone
+ * from `file://...`. Parent dir must already exist (the harness home tree
+ * is created before this helper runs).
+ *
+ * Returns the absolute path and the `file://` URL.
+ */
+export function createBareRepo(parentDir: string, name = "bare.git"): BareRepoFixture {
+  const path = join(parentDir, name);
+  mkdirSync(parentDir, { recursive: true });
+  const res = spawnSync("git", ["init", "--bare", "--quiet", path], {
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "t",
+      GIT_AUTHOR_EMAIL: "t@t",
+      GIT_COMMITTER_NAME: "t",
+      GIT_COMMITTER_EMAIL: "t@t",
+    },
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `git init --bare failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+    );
+  }
+  return { path, url: `file://${path}` };
+}

--- a/web/tests/live/git-clone.spec.ts
+++ b/web/tests/live/git-clone.spec.ts
@@ -1,0 +1,99 @@
+// Live-backend spec: wizard `Clone URL` tab end-to-end against a real
+// `aoe serve`. Covers the happy path (file:// clone of a throwaway bare
+// repo into the isolated HOME) and the validation-failure path
+// (unrecognised URL scheme surfaces the server's error banner).
+//
+// Pairs with the matching matrix entry `git-clone` in
+// `web/tests/coverage-matrix.json`. Wizard interaction patterns mirror
+// the directory-browser live spec.
+
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+import { createBareRepo } from "../helpers/gitFixture";
+
+base("clone happy path: file:// URL clones into HOME and the wizard advances", async (
+  { page },
+  testInfo,
+) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    const bare = createBareRepo(serve.home);
+
+    await page.goto(serve.baseUrl);
+    await page.locator("body").click();
+    await page.keyboard.press("n");
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: "Clone URL", exact: true }).click();
+
+    const cloneBtn = page.getByRole("button", { name: "Clone repository" });
+    await expect(cloneBtn).toBeDisabled();
+
+    const urlInput = page.locator("#clone-url");
+    await urlInput.fill(bare.url);
+    await expect(cloneBtn).toBeEnabled();
+
+    // Pin the destination to a known path under the isolated HOME so the
+    // assertion isn't sensitive to the repo-name derivation in the server.
+    await page.getByRole("button", { name: /Advanced/ }).click();
+    const destInput = page.locator("#clone-dest");
+    const dest = join(serve.home, "cloned-repo");
+    await destInput.fill(dest);
+
+    await cloneBtn.click();
+
+    // The wizard switches back to the Recent tab and renders the selected
+    // path block; the cloned dir exists on disk; the wizard `Next`
+    // button becomes enabled now that `data.path` is set.
+    await expect(page.getByText("Selected project")).toBeVisible({ timeout: 30_000 });
+    await expect(page.getByText(dest, { exact: false })).toBeVisible();
+    expect(existsSync(join(dest, ".git"))).toBe(true);
+    await expect(page.getByRole("button", { name: "Next" })).toBeEnabled();
+  } finally {
+    await serve.stop();
+  }
+});
+
+base("clone failure path: unrecognised URL scheme surfaces a server error", async (
+  { page },
+  testInfo,
+) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.locator("body").click();
+    await page.keyboard.press("n");
+    await expect(page.getByRole("heading", { name: "New session" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: "Clone URL", exact: true }).click();
+    await page.locator("#clone-url").fill("not-a-url");
+    await page.getByRole("button", { name: "Clone repository" }).click();
+
+    // The server's `validation_failed` message reaches the UI banner.
+    await expect(
+      page.getByText("URL does not look like a git repository URL"),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // No path got selected, so the wizard can't advance.
+    await expect(page.getByText("Selected project")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Next" })).toBeDisabled();
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds live Playwright coverage for the wizard's Clone URL tab against a real `aoe serve`, closing the gap left by the foundation PR #1228. The new spec exercises both the happy path (a throwaway local bare repo is cloned into the isolated `HOME` and the wizard advances) and the validation-failure path (an unrecognised URL scheme surfaces the server's error banner).

Two layers of change:

1. **Server**: extract the inlined URL scheme allowlist in `clone_repo` into a `looks_like_git_url` helper and add `file://` to the recognised schemes. `file://` is a legitimate git URL form for local network mounts and split-mirror setups, and it lets the live spec drive a real clone without standing up an HTTP server. Destination is still gated to within `HOME` by the existing check, so the change does not widen what an authenticated caller can write to. Unit tests cover each accepted scheme and the rejection cases.

2. **Web tests**: add `gitFixture.ts` exposing `createBareRepo(parentDir)` for any future spec that needs a local source repo, and `web/tests/live/git-clone.spec.ts` with the happy and failure cases. The coverage matrix entry for `git-clone` flips from `deferred` to `live-playwright`, pointing at the new spec and listing `ProjectStep.tsx` under components.

Closes #1223

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design call to add `file://` to the validator allowlist (versus standing up an HTTP server in the harness), and ran the validation sweep locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## How to test

- [ ] `cd web && npx playwright test --config=playwright.live.config.ts tests/live/git-clone.spec.ts` reports 2 passed.
- [ ] Start `aoe serve --no-auth`, open the wizard, switch to the `Clone URL` tab, enter `file:///tmp/some-existing-bare-repo.git`, expand `Advanced`, set a destination under `$HOME`, click `Clone repository`; the wizard switches back to `Recent`, shows the cloned path under `Selected project`, and `Next` becomes enabled.
- [ ] In the same wizard, enter `not-a-url`, click `Clone repository`; a red error banner reads `URL does not look like a git repository URL` and the `Next` button stays disabled.
- [ ] `cargo test --features serve --lib server::api::git::tests::looks_like_git_url` reports 9 passed (one per scheme + rejection cases).
- [ ] `cd web && node tests/validate-coverage-matrix.mjs` passes (matrix is internally consistent, `git-clone` is no longer `deferred`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Backend (Server)**
- Refactored URL validation logic for git cloning into a reusable helper function (`looks_like_git_url`)
- Extended support to allow `file://` URLs for local repository cloning
- Added unit tests to ensure the validation works correctly for both accepted and rejected URL formats

**Frontend (Web Tests)**
- Added a new test fixture helper (`gitFixture.ts`) that creates temporary local git repositories for testing purposes
- Updated test coverage configuration to activate live Playwright testing for the git-clone feature
- Added `ProjectStep.tsx` component to the coverage tracking
- Created a comprehensive Playwright test spec (`git-clone.spec.ts`) with two test scenarios:
  - **Happy path**: Successfully clones a repository from a local `file://` URL and verifies the wizard progresses correctly
  - **Failure path**: Validates that invalid URLs are caught and error messages are properly displayed to the user

## Benefits

1. **Improved Testing Coverage**: The PR shifts git-clone testing from "deferred" (not yet tested) to "live-playwright" (actively tested with real infrastructure), providing confidence that the feature works end-to-end
2. **Local Development Support**: By adding `file://` URL support, developers can now test and use the clone feature locally without requiring remote repositories
3. **Better Error Handling Validation**: The new tests verify that user-facing errors are properly handled and displayed, improving user experience
4. **Reusable Test Infrastructure**: The `gitFixture` helper can be reused across other git-related tests in the future
5. **Refactored Validation Logic**: The extracted `looks_like_git_url` helper makes the URL validation logic testable and maintainable, with clear test coverage for edge cases

## Technical Details

**Server changes:**
- New `looks_like_git_url()` function validates against schemes: `https`, `http`, `git`, `ssh`, `file`, plus SCP-style `user@host:path` patterns
- Destination writes remain restricted to `$HOME` for security
- Unit tests cover accepted schemes, rejected schemes, empty strings, and malformed URLs

**Web test changes:**
- `BareRepoFixture` interface provides both file path and URL
- `createBareRepo()` initializes bare repos with deterministic git author/committer environment
- Playwright tests run against real `aoe serve` instance for true end-to-end validation
- Tests verify both successful clone (200 response, new session appears, `.git` directory created) and error scenarios (validation failure surfaces error banner)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->