### PR TITLE
fix(server): respect state.shutdown in background cleanup loops

### DIFF
--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -334,13 +334,17 @@ impl LoginManager {
     }
 
     /// Spawn periodic cleanup (piggybacks on the rate limiter's interval).
-    pub fn spawn_cleanup_task(self: &Arc<Self>) {
+    /// Exits cleanly on shutdown so `aoe serve --stop` drains within one
+    /// tick instead of waiting for the 5 s force exit safety net.
+    pub fn spawn_cleanup_task(self: &Arc<Self>, shutdown: tokio_util::sync::CancellationToken) {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
             loop {
-                interval.tick().await;
-                manager.cleanup_expired().await;
+                tokio::select! {
+                    _ = interval.tick() => manager.cleanup_expired().await,
+                    _ = shutdown.cancelled() => break,
+                }
             }
         });
     }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -808,8 +808,8 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // (feature disabled via web.notifications_enabled=false).
     push::spawn_consumer(state.clone());
 
-    rate_limiter.spawn_cleanup_task();
-    login_manager.spawn_cleanup_task();
+    rate_limiter.spawn_cleanup_task(state.shutdown.clone());
+    login_manager.spawn_cleanup_task(state.shutdown.clone());
 
     if remote {
         // Inline the rotation loop here rather than calling
@@ -818,6 +818,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         // rotation. Behavior otherwise matches the original: wait one
         // lifetime, rotate, wait 300s grace, clear previous.
         let rot_state = state.clone();
+        let rot_shutdown = state.shutdown.clone();
         // The tunnel URL is stable across the daemon's lifetime (Tailscale
         // and named CF tunnels are stable; quick CF rotates only on
         // restart, which is outside this task's scope). Capture once so
@@ -826,7 +827,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
         tokio::spawn(async move {
             loop {
                 let lifetime = rot_state.token_manager.lifetime_secs().await;
-                tokio::time::sleep(std::time::Duration::from_secs(lifetime)).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(lifetime)) => {}
+                    _ = rot_shutdown.cancelled() => break,
+                }
 
                 // Capture the hashes of the current and (about-to-be)
                 // previous tokens BEFORE rotating, so we know which
@@ -879,7 +883,10 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
                 // After grace period, the previous token becomes invalid.
                 // Clear it AND drop any subscriptions that were bound
                 // only to the old hash (retain_owners with only the new).
-                tokio::time::sleep(std::time::Duration::from_secs(300)).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(std::time::Duration::from_secs(300)) => {}
+                    _ = rot_shutdown.cancelled() => break,
+                }
                 // Clear previous token inside TokenManager. Reuse its
                 // internal state access via a tiny helper on the manager.
                 rot_state.token_manager.clear_previous().await;

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -461,6 +461,10 @@ pub fn spawn_consumer(state: std::sync::Arc<super::AppState>) {
                 _ = tick.tick() => {
                     fire_due_pushes(state.clone(), &client, &semaphore, &mut dwell, &mut last_suppress_reason).await;
                 }
+                _ = state.shutdown.cancelled() => {
+                    tracing::info!(target: "http.middleware", "push: shutdown signaled, consumer exiting");
+                    return;
+                }
             }
         }
     });

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 const MAX_FAILURES: u32 = 5;
 const LOCKOUT_DURATION: std::time::Duration = std::time::Duration::from_secs(15 * 60);
@@ -146,25 +147,32 @@ impl RateLimiter {
         failures.remove(&ip);
     }
 
-    /// Spawn periodic cleanup task to evict expired entries.
-    pub fn spawn_cleanup_task(self: &Arc<Self>) {
+    /// Spawn periodic cleanup task to evict expired entries. The task
+    /// exits cleanly when `shutdown` is cancelled, so `aoe serve --stop`
+    /// drains the loop within one tick instead of waiting for the
+    /// 5 s force exit safety net.
+    pub fn spawn_cleanup_task(self: &Arc<Self>, shutdown: CancellationToken) {
         let limiter = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(CLEANUP_INTERVAL);
             loop {
-                interval.tick().await;
-                let mut failures = limiter.failures.write().await;
-                let now = Instant::now();
-                failures.retain(|_, record| {
-                    // Keep entries that are still locked
-                    if let Some(locked_until) = record.locked_until {
-                        if now < locked_until {
-                            return true;
-                        }
+                tokio::select! {
+                    _ = interval.tick() => {
+                        let mut failures = limiter.failures.write().await;
+                        let now = Instant::now();
+                        failures.retain(|_, record| {
+                            // Keep entries that are still locked
+                            if let Some(locked_until) = record.locked_until {
+                                if now < locked_until {
+                                    return true;
+                                }
+                            }
+                            // Keep entries with recent failures (within window)
+                            now.duration_since(record.first_failure) < WINDOW_DURATION
+                        });
                     }
-                    // Keep entries with recent failures (within window)
-                    now.duration_since(record.first_failure) < WINDOW_DURATION
-                });
+                    _ = shutdown.cancelled() => break,
+                }
             }
         });
     }


### PR DESCRIPTION
## Description

Four background `tokio::spawn` loops kept running across the 5 s `SHUTDOWN_GRACE` window instead of draining cleanly when the daemon receives `SIGINT` or `aoe serve --stop`:

- `src/server/rate_limit.rs` `spawn_cleanup_task`: 60 s tick to GC rate limit failures.
- `src/server/login.rs` `spawn_cleanup_task`: 60 s tick to expire login attempts.
- `src/server/mod.rs` token rotation loop: lifetime second sleep, rotate, then 300 s grace sleep before clearing the previous token.
- `src/server/push.rs` `spawn_consumer`: the `select!` on `rx + tick` already exited on broadcast `Closed`, but it did not respect `state.shutdown` when the daemon was tearing down. Force exit could leave an in-flight `spawn_blocking` call leaking a thread.

### Why

Found via a cross validated tokio integration audit. All three oracles flagged this; the canonical shape already exists in the same file at `src/server/mod.rs:765-777` (the `recently_restarted` GC task). Audit rated `MEDIUM` because the 5 s force exit safety net at `mod.rs:947-962` runs `std::process::exit(0)` regardless, so the consequence in practice is "tasks die abruptly with whatever transient state they have, rather than draining cleanly".

### What changed

Each loop now uses the canonical pattern:

```rust
loop {
    tokio::select! {
        _ = work => { ... }
        _ = shutdown.cancelled() => break,
    }
}
```

- `RateLimiter::spawn_cleanup_task(self: &Arc<Self>, shutdown: CancellationToken)`: signature gains a `CancellationToken` parameter; caller in `server/mod.rs:811` passes `state.shutdown.clone()`.
- `LoginManager::spawn_cleanup_task(self: &Arc<Self>, shutdown: CancellationToken)`: same.
- The inline rotation loop in `server/mod.rs:826` captures `let rot_shutdown = state.shutdown.clone();` and wraps both sleeps (`lifetime` and the 300 s grace) in `tokio::select!`.
- The push consumer's existing `select!` gains a third arm: `_ = state.shutdown.cancelled() => return`.

### Breaking change call out

`spawn_cleanup_task` on both `RateLimiter` and `LoginManager` is `pub fn` and now requires a `CancellationToken` argument. Both methods are only called inside this crate from `server::mod::run`, so the only update needed is at the two call sites in `mod.rs`.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib server::rate_limit` 7/7 pass
- `cargo test --features serve --lib server::login` 31/31 pass

The pattern itself is small and structural; the existing canonical example at `mod.rs:765-777` shows the same shape, so a reviewer can compare side by side.

No e2e or web changes. No public API change visible outside the crate. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 4/12 in a series resulting from a cross validated tokio integration audit. All three oracles independently flagged this finding (server side cleanup loops do not observe `state.shutdown`); the canonical shape already exists at `mod.rs:765-777` so this PR just propagates it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

Four background cleanup and maintenance loops in the server code were not properly responding to shutdown signals. When the daemon received a stop request (via SIGINT or `aoe serve --stop`), these loops would keep running until a forced 5-second timeout expired, rather than draining gracefully.

## The Fix

All four loops were updated to listen for shutdown signals:

1. **Rate limiter cleanup** (`src/server/rate_limit.rs`) - The IP rate limiter's garbage collection loop now exits when shutdown is triggered
2. **Login manager cleanup** (`src/server/login.rs`) - The expired session cleanup loop now exits when shutdown is triggered
3. **Token rotation** (`src/server/mod.rs`) - The token refresh loop now stops waiting for rotation timers when shutdown begins
4. **Push consumer** (`src/server/push.rs`) - The event processing loop now exits when shutdown is triggered

## Technical Implementation

Each loop was updated to use `tokio::select!` with a shutdown cancellation token, following the existing canonical shutdown pattern already used elsewhere in the codebase. Two public functions (`RateLimiter::spawn_cleanup_task` and `LoginManager::spawn_cleanup_task`) now accept a `CancellationToken` parameter that callers pass when spawning the background tasks.

## Benefits

- **Cleaner shutdown**: Daemon stops more gracefully without waiting for the forced 5-second timeout
- **Faster service restarts**: Background tasks terminate promptly instead of lingering
- **Better reliability**: Fixes a MEDIUM-severity issue identified in the tokio integration audit
- **Consistent pattern**: All shutdown logic now follows the same standard pattern throughout the codebase

## Breaking Changes

The two `spawn_cleanup_task` functions are public APIs that now require a shutdown token parameter. No external callers are known, and all internal calls have been updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->