### PR TITLE
fix(server): drop tunnel child guard before restart_tunnel + select on cancel

### DIFF
--- a/src/server/tunnel.rs
+++ b/src/server/tunnel.rs
@@ -433,43 +433,65 @@ impl TunnelHandle {
                     _ = tokio::time::sleep(std::time::Duration::from_secs(10)) => {}
                 }
 
-                let mut child_guard = child.lock().await;
-                match child_guard.try_wait() {
-                    Ok(Some(status)) => {
-                        if has_restarted {
-                            error!(
-                                "Cloudflare tunnel exited again ({}). \
-                                 Remote access is unavailable. \
-                                 Restart with `aoe serve --remote`.",
-                                status
-                            );
-                            return;
-                        }
-
-                        warn!(
-                            "Cloudflare tunnel exited unexpectedly ({}). Attempting restart...",
-                            status
-                        );
-
-                        match restart_tunnel(&kind, port).await {
-                            Ok(new_child) => {
-                                *child_guard = new_child;
-                                has_restarted = true;
-                                info!("Cloudflare tunnel restarted successfully");
-                            }
-                            Err(e) => {
-                                error!(
-                                    "Failed to restart tunnel: {}. \
-                                     Remote access is unavailable.",
-                                    e
-                                );
-                                return;
-                            }
+                // Read try_wait under the lock, then drop the guard
+                // before any await. Holding the child mutex across
+                // restart_tunnel().await would block aoe serve --stop
+                // (which also wants the lock to terminate the child)
+                // for the multi-second cloudflared spawn time.
+                let exit_status = {
+                    let mut child_guard = child.lock().await;
+                    match child_guard.try_wait() {
+                        Ok(Some(status)) => Some(status),
+                        Ok(None) => None,
+                        Err(e) => {
+                            warn!("Error checking tunnel status: {}", e);
+                            None
                         }
                     }
-                    Ok(None) => {} // Still running
+                };
+
+                let Some(status) = exit_status else {
+                    continue;
+                };
+
+                if has_restarted {
+                    error!(
+                        "Cloudflare tunnel exited again ({}). \
+                         Remote access is unavailable. \
+                         Restart with `aoe serve --remote`.",
+                        status
+                    );
+                    return;
+                }
+
+                warn!(
+                    "Cloudflare tunnel exited unexpectedly ({}). Attempting restart...",
+                    status
+                );
+
+                let restart_result = tokio::select! {
+                    _ = cancel.cancelled() => return,
+                    r = restart_tunnel(&kind, port) => r,
+                };
+
+                match restart_result {
+                    Ok(new_child) => {
+                        // Re-acquire the lock just long enough to install
+                        // the replacement child. The previous iteration's
+                        // try_wait branch is the only other holder; it
+                        // bails on Ok(None) within the lock, so contention
+                        // is bounded.
+                        *child.lock().await = new_child;
+                        has_restarted = true;
+                        info!("Cloudflare tunnel restarted successfully");
+                    }
                     Err(e) => {
-                        warn!("Error checking tunnel status: {}", e);
+                        error!(
+                            "Failed to restart tunnel: {}. \
+                             Remote access is unavailable.",
+                            e
+                        );
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
## Description

The Cloudflare tunnel watchdog at `src/server/tunnel.rs:425-477` held `child.lock().await` across `restart_tunnel().await`. The lock broadening had two visible effects:

1. **`aoe serve --stop` stalled.** The shutdown path also wants the same `child` lock to terminate the tunnel child. While the watchdog was inside `restart_tunnel` (which spawns cloudflared and waits for it to log a public URL, multiple seconds for quick tunnels and longer for named tunnels), `aoe serve --stop` could not progress, so graceful shutdown blew past the 5 s `SHUTDOWN_GRACE` budget and hit the force exit safety net.
2. **Cancellation during restart was deferred.** The existing `select!` at the top of the loop guarded only the 10 s poll sleep, not the restart itself. A cancel arriving while a restart was in flight was queued behind the multi second cloudflared startup.

### What changed

`src/server/tunnel.rs` watchdog reshaped:

- `try_wait()` runs under the guard, then the guard is dropped before any `.await`.
- `restart_tunnel(&kind, port)` is now wrapped in `tokio::select! { _ = cancel.cancelled() => return, r = restart_tunnel(&kind, port) => r }` so cancellation aborts a stuck restart cleanly. The partially spawned cloudflared child is killed by `kill_on_drop(true)` (set at tunnel startup) when the future is dropped.
- The replacement child is installed by re-acquiring the lock for the swap only: `*child.lock().await = new_child;`. The previous iteration's `try_wait` branch is the only other holder; it bails on `Ok(None)` within the lock, so contention is bounded.

### Why

Found via a cross validated tokio integration audit. Audit rated `MEDIUM` because the only other holder of the `child` mutex is the shutdown path, so this is not a deadlock; it is a graceful shutdown stall.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib server::tunnel` 9/9 pass

End to end testing requires a real `cloudflared` binary plus a flaky network condition; not practical in CI. The change is small and the existing tests cover URL extraction, proxy classification, and `cloudflared` install hint paths around the watchdog.

No e2e or web changes. No public API change. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 5/12 in a series resulting from a cross validated tokio integration audit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

The PR refactors the Cloudflare tunnel health monitor's restart logic to improve responsiveness and prevent graceful shutdown delays.

### What Changed
The `spawn_health_monitor` function in `src/server/tunnel.rs` was restructured to release the child-process mutex lock earlier and make cancellation responsive during tunnel restarts.

**Key modifications:**
- Shortened lock scope: The `try_wait()` status check is now read under the lock in a scoped block, then the lock is immediately released before any async operations
- Added cancellation awareness: The `restart_tunnel()` call is now wrapped in `tokio::select!` that races it against the shutdown cancellation signal
- Minimal lock re-acquisition: After a restart succeeds, the code briefly re-acquires the lock only to swap in the new child process

### Benefits

1. **Faster graceful shutdown**: Solves a stall where `aoe serve --stop` would block waiting for the same lock held during the multi-second cloudflared spawn process. The shutdown now completes within the 5-second budget.

2. **Responsive cancellation**: Shutdown signals arriving during an in-flight restart now abort immediately instead of deferring until after the restart completes.

3. **Reduced lock contention**: By holding the mutex only for brief operations (status checks and child swaps), other parts of the code can access the tunnel child more quickly.

### Technical Details

The original code held `child.lock().await` across the entire `restart_tunnel()` call, which spawns a new cloudflared process and waits for it to log its public URL (takes several seconds). This blocked the shutdown path's attempt to acquire the same lock to terminate the tunnel process.

The fix extracts the exit status into a local variable while holding the lock:
```rust
let exit_status = {
    let mut child_guard = child.lock().await;
    match child_guard.try_wait() { ... }
};
```

Then drops the guard before awaiting the restart, which is placed inside a select:
```rust
let restart_result = tokio::select! {
    _ = cancel.cancelled() => return,
    r = restart_tunnel(&kind, port) => r,
};
```

Finally, the lock is re-acquired only for the swap:
```rust
*child.lock().await = new_child;
```

### Tests
All 9 unit tests in `server::tunnel` pass. No e2e tests included due to external cloudflared dependency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1290?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->