### PR TITLE
perf(cockpit): offload EventStore SQLite to block_in_place + spawn_blocking

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1781,8 +1781,26 @@ impl BroadcastSink for ChannelSink {
         // gap event in its place — the frontend reducer can render a
         // "history truncated at seq N" notice and the user can
         // reload to recover via the `/cockpit/replay` endpoint.
+        //
+        // Wrap the synchronous rusqlite write in `block_in_place` so
+        // the multi-thread runtime can migrate other tasks off this
+        // worker for the duration of the fsync. Ordering is preserved
+        // because the call is still synchronous from the caller's
+        // perspective; switching to `spawn_blocking` would break the
+        // "publish in seq order" contract that the on-disk replay
+        // relies on. `block_in_place` panics on `current_thread`, so
+        // tests (which default to that flavor) fall back to a direct
+        // call. The daemon runs on `#[tokio::main]` default which is
+        // `multi_thread` and gets the runtime aware variant.
         let event_to_publish: Event;
-        let event_ref: &Event = match self.event_store.record(session_id, seq, event) {
+        let record_result = match tokio::runtime::Handle::try_current().map(|h| h.runtime_flavor())
+        {
+            Ok(tokio::runtime::RuntimeFlavor::MultiThread) => {
+                tokio::task::block_in_place(|| self.event_store.record(session_id, seq, event))
+            }
+            _ => self.event_store.record(session_id, seq, event),
+        };
+        let event_ref: &Event = match record_result {
             Ok(()) => event,
             Err(e) => {
                 tracing::warn!(

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -165,7 +165,12 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
             attempted.insert(id);
             continue;
         }
-        let in_flight_turn = state.cockpit_event_store.has_in_flight_turn(&id);
+        let store = Arc::clone(&state.cockpit_event_store);
+        let id_owned = id.clone();
+        let in_flight_turn =
+            tokio::task::spawn_blocking(move || store.has_in_flight_turn(&id_owned))
+                .await
+                .unwrap_or(false);
         // Mark before spawning so the next 2s tick doesn't double-poke
         // while the parallel resume task is still in flight. A task
         // that returns RetryAfterAttachTimeout will clear itself below.

--- a/src/server/cockpit_ws.rs
+++ b/src/server/cockpit_ws.rs
@@ -240,7 +240,15 @@ async fn drain_replay_into_socket(
     session_id: &str,
     since: u64,
 ) -> usize {
-    let entries = state.cockpit_event_store.replay_from(session_id, since);
+    // Offload the rusqlite read to the blocking pool. A session with
+    // a large retained history may iterate thousands of rows; running
+    // that on the runtime worker stalls every other concurrent task on
+    // the same worker for the duration of the read.
+    let store = Arc::clone(&state.cockpit_event_store);
+    let session_id_owned = session_id.to_string();
+    let entries = tokio::task::spawn_blocking(move || store.replay_from(&session_id_owned, since))
+        .await
+        .unwrap_or_default();
     let mut sent = 0usize;
     for (seq, event) in entries {
         let frame = CockpitBroadcastFrame {


### PR DESCRIPTION
## Description

Move three synchronous SQLite call sites off the runtime worker threads so a slow disk, a WAL checkpoint, or the on insert retention prune cannot stall the tokio scheduler.

### What changed

- `src/cockpit/supervisor.rs` `ChannelSink::publish`: wrap the synchronous `event_store.record(...)` call in `tokio::task::block_in_place`. Ordering is preserved (the call is still synchronous from the caller's perspective). Switching to `spawn_blocking` would break the publish in seq order contract that the on disk replay depends on.
- `src/server/cockpit_ws.rs` `drain_replay_into_socket`: wrap `replay_from(...)` in `tokio::task::spawn_blocking`. A session with a large retained history can iterate thousands of rows; reads are not on the ordering path so spawn blocking is fine.
- `src/server/cockpit_reconciler.rs` per session reconcile tick: wrap `has_in_flight_turn(...)` in `tokio::task::spawn_blocking`. Runs every 2 s for every session at startup recovery.

### Why `block_in_place` for publish but `spawn_blocking` for reads

- `block_in_place` keeps the call synchronous and on the calling task; ordering is preserved.
- `spawn_blocking` schedules onto a separate task with no ordering guarantees between sibling calls.

The cockpit publish path allocates a sequence number via `next_seq` and immediately calls `publish`. Two events from the same session at seq=N and seq=N+1 must reach the on disk store in that order so the replay path can reconstruct the timeline. Using `spawn_blocking` for publish would let the scheduler reorder them.

The reconciler and replay reads do not allocate sequence numbers and do not need ordering between sibling reads.

### Runtime flavor handling

`tokio::task::block_in_place` panics on the `current_thread` runtime, which is what `#[tokio::test]` uses by default. The publish path detects the runtime flavor via `Handle::try_current().runtime_flavor()` and falls back to a direct call when not on `multi_thread`. The daemon runs `#[tokio::main]` default, which is `multi_thread`, so production gets the optimised path.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::supervisor` 30/30 pass (including `channel_sink_publishes_to_broadcast_and_disk` which exercises the publish path through the runtime fallback)
- `cargo test --features serve --lib cockpit::event_store` 27/27 pass
- `cargo test --features serve --lib cockpit::` 200/200 pass

No e2e or web changes. No public API change. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 6/12 in a series resulting from a cross validated tokio integration audit. The audit deliberated between three designs (per call `spawn_blocking`, `block_in_place`, and a dedicated writer thread); `block_in_place` for publish + `spawn_blocking` for reads preserves the seq order contract while still freeing the worker for other tasks. Two of the three oracles independently picked this combination after reading the code.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR optimizes the performance of the Cockpit module by offloading three synchronous SQLite database operations from Tokio's main worker threads to prevent scheduler stalling during slow disk operations, WAL checkpoints, or retention pruning.

### What Changed

**Three database call sites were optimized:**

1. **Event Publishing** (`src/cockpit/supervisor.rs`) — The `ChannelSink::publish` method now detects the runtime type and uses Tokio's `block_in_place` to allow other work to be scheduled off the current thread while keeping the database write synchronous to maintain event ordering.

2. **Event Replay** (`src/server/cockpit_ws.rs`) — The replay read operation was moved to Tokio's blocking thread pool via `spawn_blocking` since reads don't require strict ordering guarantees.

3. **Session Health Check** (`src/server/cockpit_reconciler.rs`) — The per-session `in_flight_turn` check (which runs every 2 seconds during startup recovery) was moved to the blocking thread pool via `spawn_blocking`.

### Compatibility

The implementation includes smart runtime detection: when running on Tokio's multi-threaded runtime (the production default), it uses the optimized offloading path. On single-threaded runtimes (used in tests), it falls back to direct calls to avoid panics.

### Benefits

- **Improved responsiveness**: Prevents long-running SQLite operations from blocking the Tokio scheduler and stalling other async tasks
- **Better resource utilization**: Allows Tokio to schedule other work while database operations are in progress
- **Zero breaking changes**: No public API modifications, no data migrations required
- **Well-tested**: All existing test suites pass (200+ cockpit tests, including supervisor and event_store tests)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->