### PR TITLE
perf(cockpit): offload fs_handler::handle_read/write to spawn_blocking

### DIFF
--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2916,7 +2916,22 @@ async fn handle_read_text_file(
         enter_ns,
         "ACP request handler entered"
     );
-    let result = match fs_handler::handle_read(&res.fs_policy, &res.label, &request.path) {
+    // Offload the synchronous file read to the blocking pool. ACP
+    // `fs/read_text_file` is agent driven; a multi-MB file or a slow
+    // disk would otherwise stall the runtime worker for the duration
+    // of the read, blocking every other ACP handler scheduled on the
+    // same worker. FsPolicy is Arc + Clone so the clone is cheap.
+    let policy = Arc::clone(&res.fs_policy);
+    let label = res.label.clone();
+    let path_clone = request.path.clone();
+    let read_outcome =
+        tokio::task::spawn_blocking(move || fs_handler::handle_read(&policy, &label, &path_clone))
+            .await
+            .map_err(|e| {
+                fs_handler::FsError::Io(std::io::Error::other(format!("fs read join: {e}")))
+            })
+            .and_then(|r| r);
+    let result = match read_outcome {
         Ok(content) => {
             // Honor optional line/limit slicing for ACP semantics: 1-based.
             let sliced = if request.line.is_some() || request.limit.is_some() {
@@ -2964,13 +2979,26 @@ async fn handle_write_text_file(
         enter_ns,
         "ACP request handler entered"
     );
-    let result =
-        match fs_handler::handle_write(&res.fs_policy, &res.label, &request.path, &request.content)
-        {
-            Ok(()) => responder.respond(WriteTextFileResponse::new()),
-            Err(e) => responder
-                .respond_with_error(agent_client_protocol::util::internal_error(e.to_string())),
-        };
+    // Offload the synchronous file write to the blocking pool. ACP
+    // `fs/write_text_file` is agent driven; a large content payload
+    // or a slow disk would otherwise stall the runtime worker for
+    // the duration of the write.
+    let policy = Arc::clone(&res.fs_policy);
+    let label = res.label.clone();
+    let path_clone = request.path.clone();
+    let content_clone = request.content.clone();
+    let write_outcome = tokio::task::spawn_blocking(move || {
+        fs_handler::handle_write(&policy, &label, &path_clone, &content_clone)
+    })
+    .await
+    .map_err(|e| fs_handler::FsError::Io(std::io::Error::other(format!("fs write join: {e}"))))
+    .and_then(|r| r);
+    let result = match write_outcome {
+        Ok(()) => responder.respond(WriteTextFileResponse::new()),
+        Err(e) => {
+            responder.respond_with_error(agent_client_protocol::util::internal_error(e.to_string()))
+        }
+    };
     trace!(
         target: "cockpit.acp.tool_dispatch",
         handler = "write_text_file",


### PR DESCRIPTION
## Description

Offload the synchronous file I/O in the cockpit ACP fs handlers to `tokio::task::spawn_blocking` so a multi-MB read, a slow disk, or contended I/O cannot stall every other ACP handler scheduled on the same runtime worker.

### What changed

- `src/cockpit/acp_client.rs`:
  - `handle_read_text_file` (the ACP `fs/read_text_file` handler): wrap `fs_handler::handle_read(...)` in `tokio::task::spawn_blocking`. The line/limit slicing that runs after the read stays on the async path because it is pure CPU work on a `String`.
  - `handle_write_text_file` (the ACP `fs/write_text_file` handler): wrap `fs_handler::handle_write(...)` in `tokio::task::spawn_blocking`.

`FsPolicy` is already `Arc + Clone` so the move closure is cheap. `PathBuf` and the content `String` are cloned once per call. `JoinError` maps back to `FsError::Io(io::Error::other(...))` so the handler keeps its existing error contract for the agent.

### Why

Found via a cross validated tokio integration audit. `fs_handler::handle_read` and `handle_write` use `std::fs` (`read_to_string`, `OpenOptions::open` with `O_NOFOLLOW`, `write_all`), which blocks the calling tokio worker for the duration of the syscall. Both handlers are reachable via agent driven ACP requests, so the agent picks the I/O size. An agent that reads or writes a multi-MB file or hits a slow disk stalls every other ACP handler scheduled on the same runtime worker until the syscall returns. With multiple cockpit sessions doing concurrent fs work this compounds into runtime starvation.

### Trust boundary preserved

`fs_handler::handle_read` and `handle_write` already perform the path policy check inside the function (`FsPolicy::resolve_inside`) and use `O_NOFOLLOW` at the leaf. Both checks run on the same blocking thread as the actual open/read, so the canonicalize plus open atomicity is preserved. The migration to `spawn_blocking` does not change the policy enforcement.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::fs_handler` 11/11 pass

No e2e or web changes. No public API change. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 7/12 in a series resulting from a cross validated tokio integration audit. Sister PR to #1291 (EventStore offload); both move heavy synchronous I/O off the runtime workers, but using different primitives because of their ordering requirements.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1292?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->