### PR TITLE
feat(util): add spawn_supervised helper for panic logging + span propagation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod process;
 pub mod server;
 pub mod session;
 pub mod sound;
+pub mod task_util;
 pub mod terminal;
 pub mod tmux;
 pub mod tui;

--- a/src/task_util.rs
+++ b/src/task_util.rs
@@ -1,0 +1,125 @@
+//! Tokio task helpers: panic aware spawning plus tracing span
+//! propagation for long lived background work.
+//!
+//! `tokio::spawn` swallows panics into a `JoinError` returned from
+//! `JoinHandle::await`. For long lived tasks whose `JoinHandle` is
+//! dropped (every fire and forget `tokio::spawn(...)` in this crate),
+//! the panic message is lost. `spawn_supervised` wraps the future in
+//! `catch_unwind` so a panic surfaces through `tracing::error!` with
+//! a static task name attached, which makes `aoe logs` answer
+//! "why did the cleanup task stop running" instead of dropping the
+//! signal on the floor.
+
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
+
+use futures_util::FutureExt;
+use tokio::task::JoinHandle;
+
+/// What to do when the wrapped future panics. Production code logs;
+/// tests surface so failures are loud.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum PanicPolicy {
+    /// Log the panic via `tracing::error!(target = "task.panic", ...)`
+    /// and let the runtime continue. The default for daemon tasks.
+    Log,
+    /// Re-raise the panic after logging it. Use in tests so a
+    /// panicking task fails the test instead of disappearing.
+    Surface,
+}
+
+/// Spawn a future on the tokio runtime with panic logging. The
+/// returned `JoinHandle` matches `tokio::spawn`'s shape; callers
+/// that drop it still get the diagnostic via `tracing::error!` on
+/// panic, which is the whole point.
+///
+/// Pair with `tracing::Instrument` at the call site to propagate
+/// a span across the spawn boundary:
+///
+/// ```ignore
+/// use tracing::Instrument;
+/// let span = tracing::info_span!("my.task", session_id = %id);
+/// spawn_supervised("my.task", PanicPolicy::Log, work.instrument(span));
+/// ```
+pub fn spawn_supervised<F>(name: &'static str, policy: PanicPolicy, fut: F) -> JoinHandle<()>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    tokio::spawn(async move {
+        match AssertUnwindSafe(fut).catch_unwind().await {
+            Ok(()) => {}
+            Err(payload) => {
+                let msg = panic_payload_string(&payload);
+                tracing::error!(
+                    target: "task.panic",
+                    task = name,
+                    message = %msg,
+                    "background task panicked",
+                );
+                if matches!(policy, PanicPolicy::Surface) {
+                    std::panic::resume_unwind(payload);
+                }
+            }
+        }
+    })
+}
+
+fn panic_payload_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        return (*s).to_string();
+    }
+    if let Some(s) = payload.downcast_ref::<String>() {
+        return s.clone();
+    }
+    "<non string panic payload>".to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn normal_completion_returns_value() {
+        let touched = Arc::new(AtomicBool::new(false));
+        let t = touched.clone();
+        let handle = spawn_supervised("test.normal", PanicPolicy::Log, async move {
+            t.store(true, Ordering::SeqCst);
+        });
+        handle.await.expect("task should join cleanly");
+        assert!(touched.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn panic_in_log_policy_does_not_propagate() {
+        // The wrapper catches the panic; the caller's join completes
+        // Ok(()) and the runtime survives. We can't assert on the
+        // tracing output without a custom subscriber, but absence
+        // of a JoinError is the contract we depend on.
+        let handle = spawn_supervised("test.panic.log", PanicPolicy::Log, async {
+            panic!("intentional panic for test");
+        });
+        let result = handle.await;
+        assert!(
+            result.is_ok(),
+            "Log policy must convert panic into a clean join: {result:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn panic_in_surface_policy_propagates_join_error() {
+        let handle = spawn_supervised("test.panic.surface", PanicPolicy::Surface, async {
+            panic!("intentional panic that must surface");
+        });
+        let result = handle.await;
+        assert!(
+            result.is_err(),
+            "Surface policy must propagate panic as JoinError: {result:?}",
+        );
+        assert!(
+            result.unwrap_err().is_panic(),
+            "JoinError must report is_panic() = true",
+        );
+    }
+}


### PR DESCRIPTION
## Description

Introduce `src/task_util.rs` exposing `spawn_supervised(name, policy, fut)` and `PanicPolicy { Log, Surface }`. Purely additive: this PR wires the new module into `src/lib.rs` but does not migrate any existing `tokio::spawn` call site. PR #8b will migrate the long lived spawns identified by the audit.

### What changed

- **New file** `src/task_util.rs`:
  - `pub fn spawn_supervised<F>(name: &'static str, policy: PanicPolicy, fut: F) -> JoinHandle<()>` wraps the future in `AssertUnwindSafe(fut).catch_unwind()` so a panic surfaces through `tracing::error!(target = "task.panic", task = name, message = ...)` instead of disappearing.
  - `PanicPolicy::Log` (production default): catch the panic, log it, let the runtime continue.
  - `PanicPolicy::Surface` (test default): catch the panic, log it, re-raise so the host test fails.
  - 3 unit tests: clean completion, log policy converts panic to a clean join, surface policy propagates `JoinError::is_panic()`.
- `src/lib.rs`: register the new module.

### Why

Found via a cross validated tokio integration audit. The crate has ~100 `tokio::spawn` call sites, most of them fire and forget (the `JoinHandle` is dropped). Almost none of them inspect `JoinError` for panics. A panic in (for example) the rate limit cleanup task, the cockpit drain task, the push consumer, or the tunnel watchdog currently dies silently and the daemon keeps running with a dead but believed live subsystem.

`spawn_supervised` is the centralised hook so every long lived task gets uniform panic visibility through a single tracing target (`task.panic`) that ops can grep for in `aoe logs`.

### Span propagation

The helper does not implicitly carry spans. Callers compose with `tracing::Instrument`:

```rust
use tracing::Instrument;
let span = tracing::info_span!("supervisor.drain", session_id = %session_id);
spawn_supervised(
    "supervisor.drain",
    PanicPolicy::Log,
    drain_loop.instrument(span),
);
```

For daemon lifetime tasks that should not inherit a request span, callers `info_span!(...).entered()` at the top of the spawned future instead of `.instrument(...)` of an outer span.

### Why split into two PRs

This PR introduces the helper and its tests in isolation so a reviewer can audit the panic catching logic in one focused diff. The migration of existing call sites (estimated ~10 long lived spawns: the cleanup tasks from #1289, the rotation loop, the supervisor drain, the push consumer, the tunnel watchdog, plus ACP connection tasks) lands separately so each migrated site can be reviewed against the canonical helper.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --lib task_util::` 3/3 pass

No e2e or web changes. No public API change to existing types. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

PR 8/12 in a series resulting from a cross validated tokio integration audit. PR #8b will migrate the long lived spawn call sites to use this helper.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request introduces a new task supervision helper to prevent background tasks from failing silently when panics occur. The changes are purely additive with no modifications to existing code.

## What Changed

**New Module Added**: `src/task_util.rs`
- Introduces panic supervision for long-running async tasks spawned with tokio
- Provides a safer alternative to raw `tokio::spawn()` that ensures panics are logged and visible

**Module Registration**: `src/lib.rs`
- Exports the new `task_util` module as part of the public library interface

## What Was Added

1. **`PanicPolicy` enum**: Controls how panics are handled in supervised tasks
   - `Log`: Catches panics, logs them, and allows the runtime to continue (production default)
   - `Surface`: Logs panics and re-raises them for test failure propagation (test default)

2. **`spawn_supervised()` function**: A drop-in wrapper for spawning async tasks that:
   - Wraps futures with panic catching to prevent silent failures
   - Logs panic information via structured tracing with a static task identifier
   - Returns a `JoinHandle` for task status tracking
   - Supports caller-controlled span propagation via `tracing::Instrument`

3. **Unit tests**: Three tests validating normal task completion, log-only behavior, and panic propagation

## Benefits

- **Improved observability**: Panics in background tasks are no longer silently lost; they're logged and traced
- **Reduced debugging friction**: Centralized panic logging under the `task.panic` tracing target makes failures discoverable
- **Flexible failure handling**: Policy choice allows production systems to remain resilient while tests can fail fast on subsystem crashes
- **Span isolation**: Callers can prevent daemon tasks from accidentally inheriting request-scoped tracing spans
- **Backward compatible**: Additive only; no breaking changes or required migrations of existing code

## Technical Details

The implementation:
- Uses `AssertUnwindSafe` and `catch_unwind()` to intercept panics in async contexts
- Extracts panic payloads as strings for structured logging
- Emits `tracing::error!` with task name and panic message
- Supports conditional re-unwinding based on the `PanicPolicy`
- Includes helper logic for robust panic message extraction

All tests pass and code quality checks (clippy, fmt) are clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1293?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->