### PR TITLE
fix(server): push wake fire respects SEND_CONCURRENCY semaphore

### DIFF
--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -332,6 +332,12 @@ pub struct PushState {
     /// either `mailto:` or an `https://` URL per the spec. Not strongly
     /// validated by push endpoints in practice.
     pub subject: String,
+    /// Shared `SEND_CONCURRENCY` budget across every send_one path.
+    /// `spawn_consumer`'s fire_due_pushes loop and the wake fire path
+    /// both `acquire_owned` here, so a session with many subscribers
+    /// cannot fan out beyond the gateway concurrency the consumer
+    /// pipeline expects.
+    pub send_semaphore: std::sync::Arc<tokio::sync::Semaphore>,
 }
 
 /// VAPID `sub` claim (RFC 8292). Spec requires a `mailto:` or `https://`
@@ -348,6 +354,7 @@ impl PushState {
             vapid,
             store,
             subject: VAPID_SUBJECT.to_string(),
+            send_semaphore: std::sync::Arc::new(tokio::sync::Semaphore::new(SEND_CONCURRENCY)),
         })
     }
 }
@@ -429,7 +436,11 @@ pub fn spawn_consumer(state: std::sync::Arc<super::AppState>) {
                 return;
             }
         };
-        let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(SEND_CONCURRENCY));
+        let semaphore = state
+            .push
+            .as_ref()
+            .map(|p| p.send_semaphore.clone())
+            .expect("spawn_consumer requires push enabled; checked above");
         let mut rx = state.status_tx.subscribe();
         let mut dwell: HashMap<String, DwellState> = HashMap::new();
         // Tracks the last suppression reason so we only log on transitions
@@ -755,6 +766,7 @@ pub async fn fire_wake_fired_push(
         };
         let client = client.clone();
         let push = push.clone();
+        let permit_sem = push.send_semaphore.clone();
         let payload_clone = super::push_send::PushPayload {
             title: "Scheduled wakeup fired".to_string(),
             body: body.clone(),
@@ -763,6 +775,13 @@ pub async fn fire_wake_fired_push(
             session_id: session_id.to_string(),
         };
         tokio::spawn(async move {
+            // Acquire from the same SEND_CONCURRENCY budget that
+            // `spawn_consumer`'s fire_due_pushes uses, so a wake
+            // fire with many subscribers cannot outrun the gateway
+            // concurrency cap the rest of the pipeline expects.
+            let Ok(_permit) = permit_sem.acquire_owned().await else {
+                return;
+            };
             let outcome =
                 super::push_send::send_one(&client, push.as_ref(), &sub, &payload_clone).await;
             if outcome == super::push_send::SendOutcome::Gone {


### PR DESCRIPTION
## Description

`fire_wake_fired_push` spawned one `tokio::spawn` per subscription with no semaphore acquire, while `spawn_consumer`'s `fire_due_pushes` ran every `send_one` under an `Arc<Semaphore::new(SEND_CONCURRENCY)>`. A session with many subscribers could fan out the wake fire unbounded against the push gateway, even though the rest of the push pipeline was capped at `SEND_CONCURRENCY = 8`.

### What changed

- `src/server/push.rs`:
  - Added `send_semaphore: Arc<Semaphore>` field on `PushState`. Initialised in `PushState::init` with `Semaphore::new(SEND_CONCURRENCY)`.
  - `spawn_consumer` now reads the semaphore from `state.push.send_semaphore.clone()` instead of constructing a private one.
  - `fire_wake_fired_push` per subscription `tokio::spawn` now does `permit_sem.acquire_owned().await` before `send_one`.

### Why

Found via a cross validated tokio integration audit. Audit rated `LOW` because the practical impact is bounded by the number of subscribers per session (typically a handful), but the fix removes a foot gun: every previous PR that added a wake fire path could have introduced a runaway send if it forgot to thread a semaphore through.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib server::push` 24/24 pass

No e2e or web changes. No public API change. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

PR 9/12 in a series resulting from a cross validated tokio integration audit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**File Modified:** `src/server/push.rs`

**Core Issue:** The push notification system had unbounded concurrency in the wake-fire push path. When a scheduled wakeup fired, it spawned one async task per subscription without any concurrency limit, while the rest of the push pipeline was capped at `SEND_CONCURRENCY = 8`. This allowed a session with many subscribers to fan out unlimited concurrent sends to the push gateway.

**Solution:** A shared semaphore was promoted from a local variable to a public field on `PushState`, creating a single unified concurrency budget for all push delivery paths.

## What Was Added

- **New field:** `send_semaphore: Arc<tokio::sync::Semaphore>` on `PushState` struct
- Initialized during `PushState::init()` with `SEND_CONCURRENCY` permits (value: 8)

## What Changed in Behavior

1. **Status-change consumer (`spawn_consumer`):** Now uses `push.send_semaphore.clone()` instead of creating its own local semaphore
2. **Wake-fire path (`fire_wake_fired_push`):** Now acquires a permit from `push.send_semaphore` via `acquire_owned().await` before sending each push

## Benefits

- **Concurrency control:** All outbound push delivery is now subject to the same `SEND_CONCURRENCY = 8` budget, preventing the gateway from being overwhelmed
- **Consistent behavior:** Whether pushes are triggered by status changes or scheduled wakeups, the gateway sees the same concurrency cap
- **Runaway prevention:** Sessions with many subscribers can no longer bypass the concurrency limit through the wake-fire code path

## Testing

- `cargo clippy --features serve` — clean
- `cargo test --features serve --lib server::push` — all 24 tests pass

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->