### PR TITLE
chore(cockpit): replace mpsc(1) shutdown signal with CancellationToken

### DIFF
--- a/src/cockpit/client/ws.rs
+++ b/src/cockpit/client/ws.rs
@@ -63,7 +63,12 @@ pub enum WsMessage {
 pub struct WsHandle {
     rx: mpsc::Receiver<Result<WsMessage, WsError>>,
     task: JoinHandle<()>,
-    shutdown: Option<mpsc::Sender<()>>,
+    /// Cancellation signal observed by `reader_loop`. The previous
+    /// shape used `mpsc::channel(1)` for a single shot signal; a
+    /// `CancellationToken` is the same shape with the rest of the
+    /// codebase (`state.shutdown`, tunnel watchdog) and avoids the
+    /// `Option<Sender>` dance because cancellation is idempotent.
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 /// Wait this long for the reader task to send its close frame and
@@ -82,9 +87,7 @@ impl WsHandle {
     /// `SHUTDOWN_GRACE` so a stuck or already-aborted task can't
     /// block teardown.
     pub async fn shutdown(mut self) {
-        if let Some(tx) = self.shutdown.take() {
-            let _ = tx.try_send(());
-        }
+        self.shutdown.cancel();
         match tokio::time::timeout(SHUTDOWN_GRACE, &mut self.task).await {
             Ok(_) => {}
             Err(_) => self.task.abort(),
@@ -112,24 +115,24 @@ pub async fn connect(
         .map_err(|e| WsError::InvalidUrl(e.to_string()))?;
     let (stream, _) = connect_async(request).await?;
     let (frame_tx, frame_rx) = mpsc::channel(64);
-    let (shutdown_tx, shutdown_rx) = mpsc::channel(1);
-    let task = tokio::spawn(reader_loop(stream, frame_tx, shutdown_rx));
+    let shutdown = tokio_util::sync::CancellationToken::new();
+    let task = tokio::spawn(reader_loop(stream, frame_tx, shutdown.clone()));
     Ok(WsHandle {
         rx: frame_rx,
         task,
-        shutdown: Some(shutdown_tx),
+        shutdown,
     })
 }
 
 async fn reader_loop(
     mut stream: WebSocketStream<MaybeTlsStream<TcpStream>>,
     tx: mpsc::Sender<Result<WsMessage, WsError>>,
-    mut shutdown: mpsc::Receiver<()>,
+    shutdown: tokio_util::sync::CancellationToken,
 ) {
     loop {
         tokio::select! {
             biased;
-            _ = shutdown.recv() => {
+            _ = shutdown.cancelled() => {
                 let _ = stream
                     .send(Message::Close(Some(CloseFrame {
                         code: CloseCode::Normal,


### PR DESCRIPTION
## Description

`cockpit/client/ws.rs` used `mpsc::channel(1)` as a single shot shutdown signal for the WebSocket reader task. The pattern required wrapping the sender in `Option<Sender>` so the consume on send (`mpsc::Sender::send` takes `&self` but `try_send` is fallible) mapped onto the `take` and `try_send` dance in `WsHandle::shutdown`.

Replace with `tokio_util::sync::CancellationToken`. Cancellation is idempotent so the `Option` wrapping disappears, and the shape matches every other 'tell this task to stop' signal in the codebase: `state.shutdown`, the tunnel watchdog cancel token, the cleanup task tokens introduced in #1289.

### Why

Found via a cross validated tokio integration audit. Audit rated `LOW` (it is a code style and consistency improvement, not a bug). Worth shipping for the 'principle of least surprise' on this struct field type when a future contributor opens the file.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::client` 17/17 pass

No e2e or web changes. No public API change visible to external callers (struct is in a private module). No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Best categorised as a chore: code style + consistency.)

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

PR 10/12 in a series resulting from a cross validated tokio integration audit. The two remaining items in the original audit's NIT bundle (test wall clock sleeps to `tokio::time::pause()`, TUI `tailscale_*_sync` to `spawn_blocking`) are deferred per the design phase recommendation.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Changes Overview

The PR refactors the WebSocket client shutdown mechanism in `src/cockpit/client/ws.rs` from a manual single-shot channel pattern to Tokio's `CancellationToken`.

### What Changed

**Removed:**
- One-shot `mpsc::channel(1)` implementation for shutdown signaling
- `Option<mpsc::Sender<()>>` wrapper in the `WsHandle` struct
- Manual take/try_send dance in the shutdown logic

**Added:**
- `CancellationToken` field in `WsHandle` for the shutdown mechanism
- Token-based cancellation in the `reader_loop` that listens for `shutdown.cancelled()` and sends a WebSocket Close frame with reason "client shutdown"

**Modified:**
- `WsHandle::shutdown()` method now triggers cancellation via `cancel()` instead of sending on a channel
- `connect()` function creates the `CancellationToken`, clones it into `reader_loop`, and stores it on the handle
- `reader_loop`'s select block replaces channel receive with cancellation token listening

### Benefits

1. **Consistency**: Aligns shutdown signal pattern with other parts of the codebase (`state.shutdown`, tunnel watchdog tokens, cleanup tasks)
2. **Simplicity**: Eliminates the `Option<Sender>` wrapper and related conditional logic, reducing code complexity
3. **Safety**: CancellationToken is idempotent, so calling `cancel()` multiple times is safe without error handling
4. **Clarity**: Better semantics—using a dedicated cancellation primitive is clearer than a one-shot channel pattern

### Technical Details

- No public API changes (module is private, internal refactor only)
- All internal shutdown wiring remains functionally equivalent
- Lines changed: +12/-9
- Tests pass: 17/17 for cockpit::client library tests
- Verified with clippy and fmt checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1295?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->