### PR TITLE
refactor: migrate fire-and-forget spawns to spawn_supervised (depends on #1293)

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -749,326 +749,333 @@ impl<S: BroadcastSink> Supervisor<S> {
         let sink = Arc::clone(&self.sink);
         let workers = Arc::clone(&self.workers);
         let next_seqs = Arc::clone(&self.next_seqs);
-        tokio::spawn(async move {
-            let mut inbound = initial_inbound;
-            loop {
-                // Tracks whether the connection task ended because the
-                // cancel-escalation watchdog declared the agent
-                // unresponsive (see acp_client.rs's CANCEL_ESCALATION_GRACE).
-                // When true, the runner subprocess is alive but wedged
-                // around a tool call the agent never cancelled, so the
-                // supervisor must SIGTERM it before respawning;
-                // otherwise the next `session/load` would attach to the
-                // same wedged process. See #1196.
-                let mut agent_unresponsive = false;
-                while let Some(event) = inbound.recv().await {
-                    if let Event::Stopped { reason } = &event {
-                        if reason == "agent_unresponsive" {
-                            agent_unresponsive = true;
+        crate::task_util::spawn_supervised(
+            "supervisor.drain",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                let mut inbound = initial_inbound;
+                loop {
+                    // Tracks whether the connection task ended because the
+                    // cancel-escalation watchdog declared the agent
+                    // unresponsive (see acp_client.rs's CANCEL_ESCALATION_GRACE).
+                    // When true, the runner subprocess is alive but wedged
+                    // around a tool call the agent never cancelled, so the
+                    // supervisor must SIGTERM it before respawning;
+                    // otherwise the next `session/load` would attach to the
+                    // same wedged process. See #1196.
+                    let mut agent_unresponsive = false;
+                    while let Some(event) = inbound.recv().await {
+                        if let Event::Stopped { reason } = &event {
+                            if reason == "agent_unresponsive" {
+                                agent_unresponsive = true;
+                            }
                         }
+                        // Mirror the agent-assigned id into the cached
+                        // spawn_config so a subsequent crash respawn picks
+                        // up the latest id and calls session/load instead
+                        // of session/new. Mirror SessionContextReset the
+                        // other way so a load failure on this run doesn't
+                        // keep retrying the same dead id on the next
+                        // respawn.
+                        match &event {
+                            Event::AcpSessionAssigned { acp_session_id } => {
+                                let mut guard = workers.lock().await;
+                                if let Some(handle) = guard.get_mut(&session_id) {
+                                    if let WorkerKind::Runner { spawn_config } = &mut handle.kind {
+                                        info!(
+                                            target: "cockpit.supervisor",
+                                            session = %session_id,
+                                            acp_session_id = %acp_session_id,
+                                            "caching agent-assigned id for future respawn"
+                                        );
+                                        spawn_config.stored_acp_session_id =
+                                            Some(acp_session_id.clone());
+                                    }
+                                }
+                                // Mirror into the on-disk registry so a fresh
+                                // `aoe serve` after a daemon restart issues
+                                // `session/load` instead of `session/new`.
+                                super::worker_registry::update_stored_acp_session_id(
+                                    &session_id,
+                                    Some(acp_session_id),
+                                );
+                            }
+                            Event::SessionContextReset { reason } => {
+                                let mut guard = workers.lock().await;
+                                if let Some(handle) = guard.get_mut(&session_id) {
+                                    if let WorkerKind::Runner { spawn_config } = &mut handle.kind {
+                                        info!(
+                                            target: "cockpit.supervisor",
+                                            session = %session_id,
+                                            %reason,
+                                            "clearing cached id after session/load failure"
+                                        );
+                                        spawn_config.stored_acp_session_id = None;
+                                    }
+                                }
+                                super::worker_registry::update_stored_acp_session_id(
+                                    &session_id,
+                                    None,
+                                );
+                            }
+                            _ => {}
+                        }
+                        let seq = next_seq(&next_seqs, &session_id);
+                        sink.publish(&session_id, seq, &event);
                     }
-                    // Mirror the agent-assigned id into the cached
-                    // spawn_config so a subsequent crash respawn picks
-                    // up the latest id and calls session/load instead
-                    // of session/new. Mirror SessionContextReset the
-                    // other way so a load failure on this run doesn't
-                    // keep retrying the same dead id on the next
-                    // respawn.
-                    match &event {
-                        Event::AcpSessionAssigned { acp_session_id } => {
-                            let mut guard = workers.lock().await;
-                            if let Some(handle) = guard.get_mut(&session_id) {
-                                if let WorkerKind::Runner { spawn_config } = &mut handle.kind {
+
+                    // Channel closed: the agent's connection task ended.
+                    // Either the subprocess exited or the transport broke.
+                    // Try to respawn within the restart budget; otherwise
+                    // park the session with a synthetic error event.
+                    warn!(
+                        target: "cockpit.supervisor",
+                        session = %session_id,
+                        agent_unresponsive,
+                        "drain channel closed (agent connection task ended); evaluating respawn"
+                    );
+                    // The connection task observed the cancel-escalation
+                    // watchdog fire: the agent ignored `session/cancel` for
+                    // CANCEL_ESCALATION_GRACE while a prompt was in flight.
+                    // The runner subprocess is still alive but wedged on a
+                    // tool call the agent never cancelled, and the next
+                    // `AcpClient::spawn` reuses the same UNIX socket path
+                    // (`<workers_dir>/<session_id>.sock`), so a respawn
+                    // before the old runner exits either binds against a
+                    // collided socket or reconnects to the wedged process.
+                    //
+                    // Sequence here:
+                    //   1. SIGTERM the old PID.
+                    //   2. Poll for PID death + socket file removal (cap 3s).
+                    //   3. SIGKILL if the wedged runner is still alive past
+                    //      the SIGTERM grace.
+                    //   4. Best-effort `remove_file` on the socket so the
+                    //      respawn binds cleanly.
+                    //
+                    // Do NOT call `terminate_runner_for_session` here: that
+                    // helper deletes the worker_registry entry, which
+                    // makes `restart_decision` interpret it as a
+                    // user-initiated stop and skip the respawn. See #1196.
+                    if agent_unresponsive {
+                        #[cfg(unix)]
+                        {
+                            use nix::sys::signal::{kill, Signal};
+                            use nix::unistd::Pid;
+                            let old_pid = super::worker_registry::load(&session_id)
+                                .ok()
+                                .flatten()
+                                .map(|r| r.pid);
+                            if let Some(pid) = old_pid {
+                                if super::worker_registry::is_pid_alive(pid) {
                                     info!(
                                         target: "cockpit.supervisor",
                                         session = %session_id,
-                                        acp_session_id = %acp_session_id,
-                                        "caching agent-assigned id for future respawn"
+                                        pid,
+                                        "SIGTERM wedged runner before respawn (agent_unresponsive)"
                                     );
-                                    spawn_config.stored_acp_session_id =
-                                        Some(acp_session_id.clone());
+                                    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+                                }
+                                // Poll for the runner to exit before
+                                // proceeding to respawn. ~3s budget, 100ms
+                                // tick. claude-agent-acp's shutdown path
+                                // is fast in practice; if it's truly
+                                // unkillable by SIGTERM we escalate to
+                                // SIGKILL below.
+                                for _ in 0..30 {
+                                    if !super::worker_registry::is_pid_alive(pid) {
+                                        break;
+                                    }
+                                    tokio::time::sleep(Duration::from_millis(100)).await;
+                                }
+                                if super::worker_registry::is_pid_alive(pid) {
+                                    warn!(
+                                        target: "cockpit.supervisor",
+                                        session = %session_id,
+                                        pid,
+                                        "wedged runner survived SIGTERM grace; escalating to SIGKILL"
+                                    );
+                                    let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
+                                    // One more brief tick for the kernel
+                                    // to reap and the socket inode to
+                                    // drop. We don't loop forever; spawn
+                                    // will surface its own error if the
+                                    // process is somehow still around.
+                                    tokio::time::sleep(Duration::from_millis(200)).await;
                                 }
                             }
-                            // Mirror into the on-disk registry so a fresh
-                            // `aoe serve` after a daemon restart issues
-                            // `session/load` instead of `session/new`.
-                            super::worker_registry::update_stored_acp_session_id(
-                                &session_id,
-                                Some(acp_session_id),
+                            if let Ok(socket_path) =
+                                super::worker_registry::socket_path_for(&session_id)
+                            {
+                                if socket_path.exists() {
+                                    let _ = std::fs::remove_file(&socket_path);
+                                }
+                            }
+                        }
+                        // Cockpit's runner transport is UNIX-socket-only today
+                        // (see `worker_registry::socket_path_for`), so a
+                        // non-unix daemon cannot reach this branch in practice.
+                        // Warn if it ever does so the assumption is loud.
+                        #[cfg(not(unix))]
+                        {
+                            warn!(
+                                target: "cockpit.supervisor",
+                                session = %session_id,
+                                "agent_unresponsive escalation on non-unix: wedged runner kill not implemented; respawn may collide on the runner socket"
                             );
                         }
-                        Event::SessionContextReset { reason } => {
-                            let mut guard = workers.lock().await;
-                            if let Some(handle) = guard.get_mut(&session_id) {
-                                if let WorkerKind::Runner { spawn_config } = &mut handle.kind {
-                                    info!(
-                                        target: "cockpit.supervisor",
-                                        session = %session_id,
-                                        %reason,
-                                        "clearing cached id after session/load failure"
-                                    );
-                                    spawn_config.stored_acp_session_id = None;
-                                }
-                            }
-                            super::worker_registry::update_stored_acp_session_id(&session_id, None);
-                        }
-                        _ => {}
                     }
-                    let seq = next_seq(&next_seqs, &session_id);
-                    sink.publish(&session_id, seq, &event);
-                }
-
-                // Channel closed: the agent's connection task ended.
-                // Either the subprocess exited or the transport broke.
-                // Try to respawn within the restart budget; otherwise
-                // park the session with a synthetic error event.
-                warn!(
-                    target: "cockpit.supervisor",
-                    session = %session_id,
-                    agent_unresponsive,
-                    "drain channel closed (agent connection task ended); evaluating respawn"
-                );
-                // The connection task observed the cancel-escalation
-                // watchdog fire: the agent ignored `session/cancel` for
-                // CANCEL_ESCALATION_GRACE while a prompt was in flight.
-                // The runner subprocess is still alive but wedged on a
-                // tool call the agent never cancelled, and the next
-                // `AcpClient::spawn` reuses the same UNIX socket path
-                // (`<workers_dir>/<session_id>.sock`), so a respawn
-                // before the old runner exits either binds against a
-                // collided socket or reconnects to the wedged process.
-                //
-                // Sequence here:
-                //   1. SIGTERM the old PID.
-                //   2. Poll for PID death + socket file removal (cap 3s).
-                //   3. SIGKILL if the wedged runner is still alive past
-                //      the SIGTERM grace.
-                //   4. Best-effort `remove_file` on the socket so the
-                //      respawn binds cleanly.
-                //
-                // Do NOT call `terminate_runner_for_session` here: that
-                // helper deletes the worker_registry entry, which
-                // makes `restart_decision` interpret it as a
-                // user-initiated stop and skip the respawn. See #1196.
-                if agent_unresponsive {
-                    #[cfg(unix)]
-                    {
-                        use nix::sys::signal::{kill, Signal};
-                        use nix::unistd::Pid;
-                        let old_pid = super::worker_registry::load(&session_id)
-                            .ok()
-                            .flatten()
-                            .map(|r| r.pid);
-                        if let Some(pid) = old_pid {
-                            if super::worker_registry::is_pid_alive(pid) {
+                    let respawn_config: SpawnConfig =
+                        match restart_decision(&workers, &session_id).await {
+                            RestartDecision::Respawn(cfg) => {
                                 info!(
                                     target: "cockpit.supervisor",
                                     session = %session_id,
-                                    pid,
-                                    "SIGTERM wedged runner before respawn (agent_unresponsive)"
+                                    command = %cfg.spec.command,
+                                    stored_id = ?cfg.stored_acp_session_id,
+                                    "respawn approved; sleeping {}ms before restart",
+                                    RESPAWN_BACKOFF.as_millis()
                                 );
-                                let _ = kill(Pid::from_raw(pid as i32), Signal::SIGTERM);
+                                *cfg
                             }
-                            // Poll for the runner to exit before
-                            // proceeding to respawn. ~3s budget, 100ms
-                            // tick. claude-agent-acp's shutdown path
-                            // is fast in practice; if it's truly
-                            // unkillable by SIGTERM we escalate to
-                            // SIGKILL below.
-                            for _ in 0..30 {
-                                if !super::worker_registry::is_pid_alive(pid) {
-                                    break;
-                                }
-                                tokio::time::sleep(Duration::from_millis(100)).await;
-                            }
-                            if super::worker_registry::is_pid_alive(pid) {
+                            RestartDecision::BudgetBurned => {
                                 warn!(
                                     target: "cockpit.supervisor",
                                     session = %session_id,
-                                    pid,
-                                    "wedged runner survived SIGTERM grace; escalating to SIGKILL"
+                                    max_respawns = MAX_RESPAWNS_IN_WINDOW,
+                                    window_secs = RESTART_WINDOW.as_secs(),
+                                    "restart budget burned; parking session"
                                 );
-                                let _ = kill(Pid::from_raw(pid as i32), Signal::SIGKILL);
-                                // One more brief tick for the kernel
-                                // to reap and the socket inode to
-                                // drop. We don't loop forever; spawn
-                                // will surface its own error if the
-                                // process is somehow still around.
-                                tokio::time::sleep(Duration::from_millis(200)).await;
-                            }
-                        }
-                        if let Ok(socket_path) =
-                            super::worker_registry::socket_path_for(&session_id)
-                        {
-                            if socket_path.exists() {
-                                let _ = std::fs::remove_file(&socket_path);
-                            }
-                        }
-                    }
-                    // Cockpit's runner transport is UNIX-socket-only today
-                    // (see `worker_registry::socket_path_for`), so a
-                    // non-unix daemon cannot reach this branch in practice.
-                    // Warn if it ever does so the assumption is loud.
-                    #[cfg(not(unix))]
-                    {
-                        warn!(
-                            target: "cockpit.supervisor",
-                            session = %session_id,
-                            "agent_unresponsive escalation on non-unix: wedged runner kill not implemented; respawn may collide on the runner socket"
-                        );
-                    }
-                }
-                let respawn_config: SpawnConfig =
-                    match restart_decision(&workers, &session_id).await {
-                        RestartDecision::Respawn(cfg) => {
-                            info!(
-                                target: "cockpit.supervisor",
-                                session = %session_id,
-                                command = %cfg.spec.command,
-                                stored_id = ?cfg.stored_acp_session_id,
-                                "respawn approved; sleeping {}ms before restart",
-                                RESPAWN_BACKOFF.as_millis()
-                            );
-                            *cfg
-                        }
-                        RestartDecision::BudgetBurned => {
-                            warn!(
-                                target: "cockpit.supervisor",
-                                session = %session_id,
-                                max_respawns = MAX_RESPAWNS_IN_WINDOW,
-                                window_secs = RESTART_WINDOW.as_secs(),
-                                "restart budget burned; parking session"
-                            );
-                            let seq = next_seq(&next_seqs, &session_id);
-                            sink.publish(
-                                &session_id,
-                                seq,
-                                &Event::AgentStartupError {
-                                    message: format!(
-                                        "ACP agent crashed more than {} times in {}s; \
+                                let seq = next_seq(&next_seqs, &session_id);
+                                sink.publish(
+                                    &session_id,
+                                    seq,
+                                    &Event::AgentStartupError {
+                                        message: format!(
+                                            "ACP agent crashed more than {} times in {}s; \
                                      not respawning. Use the web dashboard to retry.",
-                                        MAX_RESPAWNS_IN_WINDOW,
-                                        RESTART_WINDOW.as_secs()
-                                    ),
-                                },
-                            );
-                            // Remove the dead WorkerHandle so a retry
-                            // (POST /api/sessions/:id/cockpit/spawn) doesn't
-                            // hit AlreadyRunning. The seq counter and replay
-                            // buffer survive so the retry's events stay
-                            // monotonic and the user keeps the conversation
-                            // log up to the crash point.
-                            let mut guard = workers.lock().await;
-                            guard.remove(&session_id);
-                            return;
-                        }
-                        RestartDecision::Gone => {
-                            // The worker entry was removed (shutdown / delete).
-                            // Exit quietly.
-                            return;
-                        }
-                        RestartDecision::UserStopped => {
-                            info!(
-                                target: "cockpit.supervisor",
-                                session = %session_id,
-                                "worker registry deleted by user (`aoe cockpit stop|kill`); \
-                                 dropping WorkerHandle without respawn"
-                            );
-                            // Emit a Stopped so the UI clears any
-                            // "thinking" indicator the user might have
-                            // been staring at when they ran `aoe cockpit
-                            // stop`. The reconciler will spawn a fresh
-                            // worker on its next tick if the session is
-                            // still cockpit_mode.
-                            let seq = next_seq(&next_seqs, &session_id);
-                            sink.publish(
-                                &session_id,
-                                seq,
-                                &Event::Stopped {
-                                    reason: "user_stopped".into(),
-                                },
-                            );
-                            let mut guard = workers.lock().await;
-                            guard.remove(&session_id);
-                            return;
-                        }
-                    };
+                                            MAX_RESPAWNS_IN_WINDOW,
+                                            RESTART_WINDOW.as_secs()
+                                        ),
+                                    },
+                                );
+                                // Remove the dead WorkerHandle so a retry
+                                // (POST /api/sessions/:id/cockpit/spawn) doesn't
+                                // hit AlreadyRunning. The seq counter and replay
+                                // buffer survive so the retry's events stay
+                                // monotonic and the user keeps the conversation
+                                // log up to the crash point.
+                                let mut guard = workers.lock().await;
+                                guard.remove(&session_id);
+                                return;
+                            }
+                            RestartDecision::Gone => {
+                                // The worker entry was removed (shutdown / delete).
+                                // Exit quietly.
+                                return;
+                            }
+                            RestartDecision::UserStopped => {
+                                info!(
+                                    target: "cockpit.supervisor",
+                                    session = %session_id,
+                                    "worker registry deleted by user (`aoe cockpit stop|kill`); \
+                                     dropping WorkerHandle without respawn"
+                                );
+                                // Emit a Stopped so the UI clears any
+                                // "thinking" indicator the user might have
+                                // been staring at when they ran `aoe cockpit
+                                // stop`. The reconciler will spawn a fresh
+                                // worker on its next tick if the session is
+                                // still cockpit_mode.
+                                let seq = next_seq(&next_seqs, &session_id);
+                                sink.publish(
+                                    &session_id,
+                                    seq,
+                                    &Event::Stopped {
+                                        reason: "user_stopped".into(),
+                                    },
+                                );
+                                let mut guard = workers.lock().await;
+                                guard.remove(&session_id);
+                                return;
+                            }
+                        };
 
-                tokio::time::sleep(RESPAWN_BACKOFF).await;
+                    tokio::time::sleep(RESPAWN_BACKOFF).await;
 
-                let cockpit_session_id = CockpitSessionId(session_id.clone());
-                let mut new_client =
-                    match AcpClient::spawn(respawn_config.clone(), cockpit_session_id).await {
-                        Ok(c) => c,
-                        Err(e) => {
+                    let cockpit_session_id = CockpitSessionId(session_id.clone());
+                    let mut new_client =
+                        match AcpClient::spawn(respawn_config.clone(), cockpit_session_id).await {
+                            Ok(c) => c,
+                            Err(e) => {
+                                warn!(
+                                    target: "cockpit.supervisor",
+                                    session = %session_id,
+                                    "respawn failed: {e}"
+                                );
+                                let seq = next_seq(&next_seqs, &session_id);
+                                sink.publish(
+                                    &session_id,
+                                    seq,
+                                    &Event::AgentStartupError {
+                                        message: format!("ACP agent respawn failed: {e}"),
+                                    },
+                                );
+                                // Drop the dead WorkerHandle so the user can
+                                // retry via POST /api/sessions/:id/cockpit/spawn
+                                // without hitting AlreadyRunning. Without this
+                                // the entry sticks around with a closed cmd_tx
+                                // and every send_prompt fails until the daemon
+                                // restarts. Mirrors the BudgetBurned and
+                                // missing-inbound branches.
+                                let mut guard = workers.lock().await;
+                                guard.remove(&session_id);
+                                return;
+                            }
+                        };
+                    let new_inbound = match new_client.take_inbound() {
+                        Some(rx) => rx,
+                        None => {
+                            // Belt-and-braces: AcpClient::spawn pairs the
+                            // inbound receiver with the client today, so
+                            // this branch never fires. Logging instead of
+                            // panicking guards the daemon if a future
+                            // refactor breaks the invariant.
                             warn!(
                                 target: "cockpit.supervisor",
                                 session = %session_id,
-                                "respawn failed: {e}"
+                                "respawned client missing inbound receiver; parking",
                             );
                             let seq = next_seq(&next_seqs, &session_id);
                             sink.publish(
                                 &session_id,
                                 seq,
                                 &Event::AgentStartupError {
-                                    message: format!("ACP agent respawn failed: {e}"),
+                                    message: "respawned ACP client had no inbound channel".into(),
                                 },
                             );
-                            // Drop the dead WorkerHandle so the user can
-                            // retry via POST /api/sessions/:id/cockpit/spawn
-                            // without hitting AlreadyRunning. Without this
-                            // the entry sticks around with a closed cmd_tx
-                            // and every send_prompt fails until the daemon
-                            // restarts. Mirrors the BudgetBurned and
-                            // missing-inbound branches.
                             let mut guard = workers.lock().await;
                             guard.remove(&session_id);
                             return;
                         }
                     };
-                let new_inbound = match new_client.take_inbound() {
-                    Some(rx) => rx,
-                    None => {
-                        // Belt-and-braces: AcpClient::spawn pairs the
-                        // inbound receiver with the client today, so
-                        // this branch never fires. Logging instead of
-                        // panicking guards the daemon if a future
-                        // refactor breaks the invariant.
-                        warn!(
-                            target: "cockpit.supervisor",
-                            session = %session_id,
-                            "respawned client missing inbound receiver; parking",
-                        );
-                        let seq = next_seq(&next_seqs, &session_id);
-                        sink.publish(
-                            &session_id,
-                            seq,
-                            &Event::AgentStartupError {
-                                message: "respawned ACP client had no inbound channel".into(),
-                            },
-                        );
+
+                    {
                         let mut guard = workers.lock().await;
-                        guard.remove(&session_id);
-                        return;
+                        let Some(handle) = guard.get_mut(&session_id) else {
+                            return;
+                        };
+                        handle.client = Arc::new(new_client);
                     }
-                };
 
-                {
-                    let mut guard = workers.lock().await;
-                    let Some(handle) = guard.get_mut(&session_id) else {
-                        return;
-                    };
-                    handle.client = Arc::new(new_client);
+                    info!(
+                        target: "cockpit.supervisor",
+                        session = %session_id,
+                        "cockpit worker respawned"
+                    );
+                    inbound = new_inbound;
                 }
-
-                info!(
-                    target: "cockpit.supervisor",
-                    session = %session_id,
-                    "cockpit worker respawned"
-                );
-                inbound = new_inbound;
-            }
-        })
+            },
+        )
     }
 
     /// Wait until the worker for `session_id` is fully spawned, or the

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -816,32 +816,44 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     {
         let gc_map = state.recently_restarted.clone();
         let shutdown = state.shutdown.clone();
-        tokio::spawn(async move {
-            let mut interval =
-                tokio::time::interval(crate::session::recovery::RECENTLY_RESTARTED_GC_INTERVAL);
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        crate::session::recovery::gc_recently_restarted(&gc_map);
+        crate::task_util::spawn_supervised(
+            "server.gc.recently_restarted",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                let mut interval =
+                    tokio::time::interval(crate::session::recovery::RECENTLY_RESTARTED_GC_INTERVAL);
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            crate::session::recovery::gc_recently_restarted(&gc_map);
+                        }
+                        _ = shutdown.cancelled() => break,
                     }
-                    _ = shutdown.cancelled() => break,
                 }
-            }
-        });
+            },
+        );
     }
 
     if let Some((lock, candidates)) = recovery_inputs {
         let cascade_state = state.clone();
-        tokio::spawn(async move {
-            daemon_startup_recovery_cascade(cascade_state, lock, candidates).await;
-        });
+        crate::task_util::spawn_supervised(
+            "server.startup_recovery_cascade",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                daemon_startup_recovery_cascade(cascade_state, lock, candidates).await;
+            },
+        );
     }
 
     // Spawn background tasks
     let poll_state = state.clone();
-    tokio::spawn(async move {
-        status_poll_loop(poll_state).await;
-    });
+    crate::task_util::spawn_supervised(
+        "server.status_poll_loop",
+        crate::task_util::PanicPolicy::Log,
+        async move {
+            status_poll_loop(poll_state).await;
+        },
+    );
 
     // Cockpit broadcast listener: a single subscriber that handles
     // every in-process consumer of cockpit events. Status mirroring
@@ -852,9 +864,13 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
     // matter to both (e.g. AcpSessionAssigned).
     {
         let listener_state = state.clone();
-        tokio::spawn(async move {
-            cockpit_event_listener(listener_state).await;
-        });
+        crate::task_util::spawn_supervised(
+            "server.cockpit_event_listener",
+            crate::task_util::PanicPolicy::Log,
+            async move {
+                cockpit_event_listener(listener_state).await;
+            },
+        );
     }
 
     // Push-notification consumer: subscribes to status_tx, applies


### PR DESCRIPTION
## Description

Convert five long lived background tasks from raw `tokio::spawn` to `crate::task_util::spawn_supervised` so a panic in any of them surfaces through `tracing::error!(target = 'task.panic')` instead of disappearing into a `JoinError` that no caller awaits.

**Depends on #1293** (introduces `task_util::spawn_supervised`). The diff in this PR includes both the helper file and the migrations until #1293 merges; once #1293 lands, this PR collapses to the migrations alone.

### Migrated sites

- `src/server/mod.rs:765` `server.gc.recently_restarted`: the recently-restarted map GC loop.
- `src/server/mod.rs:781` `server.startup_recovery_cascade`: spawned at boot when there are recovery candidates.
- `src/server/mod.rs:788` `server.status_poll_loop`: long lived status poll.
- `src/server/mod.rs:801` `server.cockpit_event_listener`: the consolidated cockpit broadcast subscriber.
- `src/cockpit/supervisor.rs:748` `supervisor.drain`: per session drain task spawned from `Supervisor::start_drain_task`. Long lived (one per cockpit worker).

Each call uses `PanicPolicy::Log` so the runtime keeps running on panic and the diagnostic shows up in `aoe logs`. Names are namespaced `subsystem.purpose` so a single `task.panic` filter catches all of them.

### Sites deliberately NOT migrated in this PR

- **Cleanup loops** (`rate_limit`, `login`) and the **rotation loop** in `mod.rs` are touched by #1289 (shutdown token plumbing). Migrating them here would conflict; deferred to a follow up that lands after #1289 merges.
- **Push consumer** (`spawn_consumer` in `push.rs`) is touched by #1294 (semaphore lift). Same conflict avoidance.
- **Tunnel watchdog** is touched by #1290 (child guard release).
- **`ResumeReservation::Drop`** spawn site is removed entirely by #1284's `std::sync::Mutex` migration; no migration needed there.
- **ACP `run_connection_task`** spawn sites are short lived per connection rather than daemon lifetime; deferred to a follow up where span propagation matters more.

### Why

Found via a cross validated tokio integration audit. The crate has ~100 `tokio::spawn` call sites; almost none inspect `JoinError` for panics. A panic in (for example) the supervisor drain task currently dies silently and the supervisor's `workers` map is left believing the worker is alive. PR #1293 introduces the helper; this PR is the first wave of adoption.

### How tested

- `cargo clippy --features serve -- -D warnings` (CI shape) clean
- `cargo fmt --check` clean
- `cargo test --features serve --lib cockpit::supervisor` 30/30 pass
- `cargo test --lib task_util::` 3/3 pass

The 561 line delta in `supervisor.rs` is almost entirely re-indentation of the drain task body that got nested deeper under `spawn_supervised(arg1, arg2, async move { ... })`. Look at the diff with `-w` (ignore whitespace) to see the actual logical change.

No e2e or web changes. No public API change visible to external callers. No migration. No `coverage-matrix.json` entry needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

PR 11/12 in a series resulting from a cross validated tokio integration audit.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR introduces a new supervised task spawning utility and applies it to five long-lived background tasks that previously used raw `tokio::spawn`. The changes ensure that if any of these background tasks panic, the error is logged and captured rather than being silently lost.

## What Was Added

- **New module `src/task_util.rs`**: Contains a `spawn_supervised` helper function and a `PanicPolicy` configuration to control panic handling behavior
- **Module export in `src/lib.rs`**: The new `task_util` module is now publicly exported
- **Supervised spawns in five locations**:
  - Four background tasks in `src/server/mod.rs`: GC loop, startup recovery cascade, status polling, and cockpit event listener
  - One drain task in `src/cockpit/supervisor.rs`

## What Moved

The five background task spawns were migrated from `tokio::spawn` to `crate::task_util::spawn_supervised` with a `PanicPolicy::Log` setting.

## Technical Details

The `spawn_supervised` function wraps futures in `catch_unwind` to intercept panics and emit them via `tracing::error!` with a task-specific name (formatted as `subsystem.purpose`). The `PanicPolicy` enum offers two modes:
- **Log**: Converts panics into clean task completion so the runtime continues
- **Surface**: Logs the panic and re-raises it for test scenarios

Each migrated task is named with a namespaced identifier (e.g., `server.gc.recently_restarted`, `supervisor.drain`) allowing centralized filtering of task panics via a single `task.panic` tracing filter.

## Benefits

- **Improved observability**: Panics in background tasks are now logged and traceable instead of being swallowed
- **Runtime stability**: With `PanicPolicy::Log`, panics in background tasks no longer crash the entire runtime
- **Consistent naming**: All supervised tasks follow a consistent naming convention for easier monitoring and debugging
- **Test-friendly**: The `PanicPolicy::Surface` option allows tests to explicitly verify panic behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1296?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->