### PR TITLE
docs(quick-start): document attaching to existing worktrees and Claude sessions

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -48,6 +48,23 @@ aoe add . -w feat/my-feature -b
 
 This creates a new git branch, a worktree directory, and a session pointing at it. When you delete the session, AoE offers to clean up the worktree too.
 
+## Attach to Existing Work
+
+Already have a worktree checked out, or a Claude Code conversation you want to keep going? AoE can wrap both without forcing you to start over.
+
+**Attach to an existing branch or worktree.** Omit the `-b` flag and AoE re-uses the worktree if one exists for that branch, or checks the branch out into a new worktree if not:
+
+```bash
+# CLI: attach to whatever worktree/branch already exists
+aoe add . -w feat/my-feature
+```
+
+In the TUI, press `Ctrl+P` on the Worktree field and toggle **Attach to existing branch**. The web wizard exposes the same toggle under the worktree name input. See [Worktrees Reference](guides/worktrees.md) for the full matrix.
+
+When you later remove the session, AoE only cleans up worktrees it created; attached ones are left alone.
+
+**Resume an existing Claude Code conversation.** After attaching, run `/resume` inside the Claude pane and pick the conversation you want. AoE's session-id poller watches `~/.claude/projects/<project>/` and persists the new id so the next launch reattaches to the same conversation automatically. Details in [Session Resume](guides/session-resume.md), including the `aoe session set-session-id` command for setting the Claude UUID explicitly.
+
 ## Create a Sandboxed Session
 
 To run an agent inside a Docker container:


### PR DESCRIPTION
## Description

Documents the existing "attach to existing work" paths in the quick-start guide. The functionality is already shipped (omit `-b` on `aoe add -w` to wrap an existing worktree; `/resume` inside Claude plus the session-id poller picks up an existing conversation), but neither path was framed for users coming from an established workflow. Per discussion on #1056, this case kept tripping up first-time users.

Adds a short "Attach to Existing Work" section between "Create a Worktree Session" and "Create a Sandboxed Session" with pointers into `docs/guides/worktrees.md` and `docs/guides/session-resume.md` for full detail. No code changes, no new standalone guide.

Fixes #1056

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Drafted the prose via back-and-forth: I asked Claude whether docs were warranted or the issue should be closed. Claude read `docs/quick-start.md`, `docs/guides/worktrees.md`, and `docs/guides/session-resume.md`, confirmed the functionality is already documented in those guides but not surfaced for the "I'm coming from existing work" flow, and proposed the quick-start addition. I approved the approach and the draft. Reasoning and decisions are mine; the prose is Claude's.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

Added a new "Attach to Existing Work" section to the quick-start documentation, positioned between "Create a Worktree Session" and "Create a Sandboxed Session" sections.

## What Was Added

The new section (+17 lines) documents two existing features previously undocumented in the quick-start guide:

1. **Attaching to existing worktrees**: Explains how to reuse or wrap an existing branch/worktree by omitting the `-b` flag when running `aoe add . -w feat/my-feature`. Provides CLI and TUI instructions (including the `Ctrl+P` toggle for "Attach to existing branch" in both TUI and web wizard).

2. **Resuming existing Claude Code conversations**: Documents the `/resume` command for picking an existing Claude conversation, and explains how AoE's session-id poller automatically persists the conversation ID for seamless reattachment on next launch. References the `aoe session set-session-id` command for explicitly setting the Claude UUID.

3. **Cleanup behavior clarification**: Clarifies that when removing a session, AoE only cleans up worktrees it created—attached worktrees are left untouched.

## Benefits

- **Improved discoverability**: Users are guided to existing attach functionality directly from the quick-start guide instead of having to discover it independently.
- **Cross-reference guidance**: Links to detailed guides in `docs/guides/worktrees.md` and `docs/guides/session-resume.md` for comprehensive reference.
- **Risk mitigation**: Clarifies cleanup behavior to prevent accidental deletion of pre-existing worktrees.
- **Reduced friction**: Enables users to continue work in existing branches and Claude conversations without starting from scratch, streamlining workflow continuity.

## Technical Notes

- No code changes; documentation-only update
- Features described were already implemented; this PR increases their visibility in the quick-start guide
- Closes issue `#1056`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1298?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->