### PR TITLE
refactor: point dev-release profile at the release namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 ## Build, Test, and Development Commands
 
 - `cargo build` / `cargo build --release`: TUI-only (release binary at `target/release/aoe`).
-- `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Lands on the release namespace (app dir, tmux prefix, serve port), so it shares state with an installed release `aoe`. Use `--release` for CI.
+- `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Lands on the release namespace (app dir, tmux prefix, serve port), so it shares state with an installed release `aoe`. Use `--release` only when producing a shipping binary.
 - `cargo build --features serve`: includes the web dashboard (needs Node.js + npm).
 - `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 ## Build, Test, and Development Commands
 
 - `cargo build` / `cargo build --release`: TUI-only (release binary at `target/release/aoe`).
-- `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Use `--release` for CI.
+- `cargo build --profile dev-release`: optimized local builds without LTO; faster compile. Lands on the release namespace (app dir, tmux prefix, serve port), so it shares state with an installed release `aoe`. Use `--release` for CI.
 - `cargo build --features serve`: includes the web dashboard (needs Node.js + npm).
 - `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -205,10 +205,11 @@ strip = true
 inherits = "release"
 lto = false
 codegen-units = 16
-# Same "is this a dev build?" gate as the default dev profile, so the
-# isolated app dir / tmux prefix / serve port apply here too. Anything
-# that's not a true release build shares the dev namespace.
-debug-assertions = true
+# Land on the release namespace (app dir, tmux prefix, serve port) so a
+# fast-compiled dev-release binary shares state with installed release
+# builds. Use the default `dev` profile when you want the isolated
+# `-dev` namespace.
+debug-assertions = false
 
 [[bin]]
 name = "aoe"

--- a/docs/development.md
+++ b/docs/development.md
@@ -47,6 +47,11 @@ nothing migrates from your real `~/.agent-of-empires`. Wipe dev state any
 time with `rm -rf ~/.agent-of-empires-dev` (or the Linux XDG equivalent);
 release data is untouched.
 
+`cargo build --profile dev-release` is treated as a release build for
+namespace purposes, so it shares the app dir, tmux prefix, and `aoe serve`
+port with an installed release `aoe`. Use the default `dev` profile when
+you want the isolated `-dev` namespace.
+
 ## Testing
 
 ```bash


### PR DESCRIPTION
## Description

Flips \`debug-assertions = false\` in \`[profile.dev-release]\` so a fast-compiled dev-release binary shares its app dir, tmux prefix, and \`aoe serve\` port with an installed release \`aoe\`. This lets you skip the slow LTO release link when iterating against your real release state, while \`cargo run\` on the default \`dev\` profile keeps its isolated \`-dev\` namespace.

Background discussion in the chat thread that led to this PR: the release link was the bottleneck for local iteration, the \`dev-release\` profile already skips LTO, and the only thing pinning it to the dev namespace was an explicit \`debug-assertions = true\` override. Single bit flip on a \`cfg!(debug_assertions)\` gate that drives the whole bundle: app dir, tmux session/terminal/tool prefixes, default \`aoe serve\` port, the v001 migration path, the system-API \`build_flavor\` field, and the dev-only \`AOE_RESUME_IDLE_GRACE_MS\` override in \`acp_client.rs\`.

**Breaking:** anyone currently using \`cargo build --profile dev-release\` against the \`-dev\` namespace will now land on the release namespace. Use the default \`dev\` profile if you want the isolated namespace.

Also tightens the AGENTS.md wording around \`--release\`: CI runs tests on the default \`dev\` profile, so the old "Use \`--release\` for CI" line was misleading. Reworded to point at shipping-binary production.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude drafted this PR via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's. The diff was discussed before implementation: investigated which subsystems \`cfg!(debug_assertions)\` gates, verified that flipping the bit affects only two real \`debug_assert!\` call sites (neither in a hot path), and confirmed the side effects (sharing tmux/port/state with installed release \`aoe\`) are the intended behavior.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview of Changes

This PR refactors the dev-release build profile to point at the release namespace instead of the dev namespace. Three files were updated:

**Documentation Changes:**
- **AGENTS.md**: Added guidance clarifying that `cargo build --profile dev-release` produces optimized local builds without LTO and lands on the release namespace (shared with installed release builds). Clarified that `--release` should only be used for shipping binaries, not CI.
- **docs/development.md**: Added explanation that dev-release builds share the same app directory, tmux prefix, and `aoe serve` port as release builds. Documented that the default `dev` profile should be used for isolated dev namespace builds.

**Configuration Change:**
- **Cargo.toml**: Flipped `debug-assertions` from `true` to `false` in the `[profile.dev-release]` section.

## Technical Details

The `debug-assertions` configuration value controls conditional compilation gates that affect:
- Application directory location
- tmux session/tool prefixes
- Default `aoe serve` port
- v001 migration path
- System API `build_flavor` field
- Dev-only environment variable overrides (`AOE_RESUME_IDLE_GRACE_MS`)

**Breaking Change:** Builds using `cargo build --profile dev-release` will now target the release namespace instead of the dev namespace. Users needing the isolated dev namespace should use the default `dev` profile instead.

## Benefits

This change allows developers to:
- Iterate on code with fast compilation (dev-release skips LTO optimization)
- Test against real release state without needing a separate installed release build
- Avoid the slow link-time optimization step while still sharing release configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1299?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->