### PR TITLE
refactor(tui): shorten home title suffix, drop j/k and q from footer

### DIFF
--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -30,26 +30,22 @@ fn session_offset(created_at: &DateTime<Utc>) -> usize {
 /// `profile` is `Some(name)` only when a real filter is active; when `None`,
 /// the `[<profile>]` segment is omitted so the default all-profiles state
 /// stays uncluttered.
-/// The `(by project)` and `sort: <label>` suffixes are merged into a single
-/// parenthesized hint, and each piece is dropped when it matches the default.
+/// Group and sort state hang off the prefix as `· project` / `· <sort label>`
+/// segments, each dropped when it matches the default.
 fn compose_list_title(
     prefix: &str,
     profile: Option<&str>,
     group_by: GroupByMode,
     sort_order: SortOrder,
 ) -> String {
-    let mut parts: Vec<String> = Vec::with_capacity(2);
+    let mut suffix = String::new();
     if group_by == GroupByMode::Project {
-        parts.push("by project".to_string());
+        suffix.push_str(" · project");
     }
     if sort_order != SortOrder::default() {
-        parts.push(format!("sort: {}", sort_order.label()));
+        suffix.push_str(" · ");
+        suffix.push_str(sort_order.label());
     }
-    let suffix = if parts.is_empty() {
-        String::new()
-    } else {
-        format!(" ({})", parts.join(", "))
-    };
     let profile_tag = match profile {
         Some(name) => format!(" [{}]", name),
         None => String::new(),
@@ -1296,8 +1292,8 @@ impl HomeView {
             ]
         };
         // Key-only entry for keys universal enough that a description would be
-        // noise (j/k for nav, ? for help, q for quit, / for search). Saves
-        // ~20 columns of footer width — meaningful at iPhone-Mosh sizes.
+        // noise (? for help, / for search). Saves footer width at iPhone-Mosh
+        // sizes.
         let mk_key =
             |key: &str| -> Vec<Span<'static>> { vec![Span::styled(key.to_string(), key_style)] };
 
@@ -1339,8 +1335,6 @@ impl HomeView {
                 groups.push((0, spans));
             }
         }
-
-        groups.push((0, mk_key("j/k")));
 
         if let Some(enter_action_text) = match self.flat_items.get(self.cursor) {
             Some(Item::Group {
@@ -1393,7 +1387,6 @@ impl HomeView {
         groups.push((4, mk(if strict { "^D" } else { "D" }, "Diff")));
         groups.push((1, mk("^K", "Cmds")));
         groups.push((0, mk_key("?")));
-        groups.push((0, mk_key(if strict { "Q" } else { "q" })));
 
         // Greedy pack by priority. Width of a group = sum of span char counts;
         // separator between kept groups adds 3 cols each (" · "). Reserve 1
@@ -1490,13 +1483,13 @@ mod tests {
     #[test]
     fn compose_list_title_shows_by_project_only() {
         let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::Newest);
-        assert_eq!(title, " aoe (by project) ");
+        assert_eq!(title, " aoe · project ");
     }
 
     #[test]
     fn compose_list_title_shows_sort_only_when_non_default() {
         let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::LastActivity);
-        assert_eq!(title, " aoe (sort: Recent) ");
+        assert_eq!(title, " aoe · Recent ");
     }
 
     #[test]
@@ -1507,7 +1500,7 @@ mod tests {
             GroupByMode::Project,
             SortOrder::LastActivity,
         );
-        assert_eq!(title, " aoe [alpha] (by project, sort: Recent) ");
+        assert_eq!(title, " aoe [alpha] · project · Recent ");
     }
 
     #[test]
@@ -1515,13 +1508,13 @@ mod tests {
         // Newest is the default; it must not appear in the title even when
         // group mode contributes its own suffix piece.
         let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::Newest);
-        assert_eq!(title, " aoe (by project) ");
+        assert_eq!(title, " aoe · project ");
     }
 
     #[test]
     fn compose_list_title_supports_tool_prefix() {
         let title = compose_list_title("Tool: foo", None, GroupByMode::Manual, SortOrder::AZ);
-        assert_eq!(title, " Tool: foo (sort: A-Z) ");
+        assert_eq!(title, " Tool: foo · A-Z ");
     }
 
     #[test]
@@ -1534,7 +1527,7 @@ mod tests {
             GroupByMode::Project,
             SortOrder::Newest,
         );
-        assert_eq!(title, " Terminals [work] (by project) ");
+        assert_eq!(title, " Terminals [work] · project ");
     }
 
     #[test]
@@ -1546,7 +1539,7 @@ mod tests {
             GroupByMode::Project,
             SortOrder::Newest,
         );
-        assert_eq!(title, " aoe [alpha] (by project) ");
+        assert_eq!(title, " aoe [alpha] · project ");
     }
 
     #[test]
@@ -1558,26 +1551,26 @@ mod tests {
             GroupByMode::Manual,
             SortOrder::LastActivity,
         );
-        assert_eq!(title, " aoe [alpha] (sort: Recent) ");
+        assert_eq!(title, " aoe [alpha] · Recent ");
     }
 
     #[test]
     fn compose_list_title_non_default_sort_with_project_no_profile() {
         // Matrix cell: non-default sort + project group + no profile.
         let title = compose_list_title("aoe", None, GroupByMode::Project, SortOrder::LastActivity);
-        assert_eq!(title, " aoe (by project, sort: Recent) ");
+        assert_eq!(title, " aoe · project · Recent ");
     }
 
     #[test]
     fn compose_list_title_renders_oldest_sort_label() {
         let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::Oldest);
-        assert_eq!(title, " aoe (sort: Oldest) ");
+        assert_eq!(title, " aoe · Oldest ");
     }
 
     #[test]
     fn compose_list_title_renders_za_sort_label() {
         let title = compose_list_title("aoe", None, GroupByMode::Manual, SortOrder::ZA);
-        assert_eq!(title, " aoe (sort: Z-A) ");
+        assert_eq!(title, " aoe · Z-A ");
     }
 
     #[test]

--- a/tests/e2e/tui_launch.rs
+++ b/tests/e2e/tui_launch.rs
@@ -13,9 +13,10 @@ fn test_tui_launches_and_shows_home_screen() {
 
     h.wait_for(" aoe ");
     h.assert_screen_contains("No sessions yet");
-    // Status bar should be visible. Use the j/k key hint (which has no
-    // accompanying description in the compact footer).
-    h.assert_screen_contains("j/k");
+    // Status bar should be visible. ^K Cmds is priority-1 (kept even on
+    // narrow footers) and the caret glyph is distinctive enough to survive
+    // any future reshuffling.
+    h.assert_screen_contains("^K Cmds");
 }
 
 #[test]


### PR DESCRIPTION
## Description

Tightens the home view chrome:

- Header suffix: `(by project, sort: Recent)` → `· project · Recent`. Uses the existing `·` separator (same glyph the footer uses between groups), drops the `by`/`sort:` prefixes. Default state still renders as just ` aoe `; profile tag `[name]` still renders before the suffix.
- Footer: dropped the `j/k` and `q`/`Q` key-only hints. These are universal enough that the hint was visual noise (`?` and `/` stay since they're slightly less load-bearing).

Trade-off discussion: considered moving sort/group state to the footer when there's spare width, but kept it in the header — header is where "what am I looking at" lives, footer is for action affordances, and the footer already has a priority-drop system that this would interfere with.

## PR Type

- [x] Refactor

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo fmt`, `cargo clippy`, `cargo test` — 1758 passed)
- [x] Documentation was updated where necessary (doc comment on `compose_list_title` updated to match new format)
- [x] For UI changes: included screenshot or recording — N/A, TUI label tweak; before/after captured in updated unit tests (`compose_list_title_*`)

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This refactor tightens the visual presentation of the home view in the TUI application by simplifying the title formatting and streamlining footer shortcuts.

**What changed:**
- **Home view title format**: Replaced the parenthesized suffix `(by project, sort: Recent)` with a cleaner dot-separated format `· project · Recent`. This removes the explicit "by" and "sort:" labels while maintaining the same information.
- **Profile filters**: Now display as `[name]` in the title, making them more visually distinct.
- **Footer shortcuts**: Removed the key-only hints for `j/k` (navigation) and `Q/q` (quit), while keeping hints for `?` (help) and `/` (search).

**Benefits:**
- **Reduced visual clutter**: The new dot-separated format is more compact and modern, improving readability in the TUI.
- **Cleaner interface**: Removing rarely-used key hints from the footer reduces cognitive load and noise without sacrificing functionality—users can still discover these keys via help.
- **Preserved context**: The sort and group state remains visible in the header, maintaining the "what am I looking at" semantic clarity.

**Technical details:**
- `compose_list_title()` function refactored to use a simplified suffix-building model
- Default state still renders as ` aoe ` with profile tags preceding the suffix
- Unit tests updated to validate the new dot-separated title format across multiple scenarios (project grouping, non-default sorts, profile filtering)
- All 1758 tests pass; documentation and type signatures remain unchanged

This is a non-breaking visual polish that improves the user experience without changing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1301?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->