### PR TITLE
test(web): unskip cockpit-spawn-prompt, cockpit-approval, cockpit-mode-switch via claude-agent-acp shim + request_permission round-trip

### DIFF
--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -67,13 +67,13 @@ Fixtures:
 - `serve` : `aoe serve --no-auth`. Default for backend round-trip flows.
 - `servePassphrase` : `aoe serve --passphrase aoe-e2e-fixed-passphrase`. The harness mints a session cookie via `POST /api/login` and exposes it as `handle.sessionCookie`. Specs that drive auth from the browser side use `seedAuth(page, handle)` to inject cookie + binding secret before the first navigation.
 - `serveReadOnly` : `aoe serve --no-auth --read-only`.
-- `serveCockpit` : like `serve` but the fake-ACP agent (see below) is on `$PATH` as both `claude` and `aoe-agent`, and `PATCH /api/cockpit/master` is called after startup.
+- `serveCockpit` : like `serve` but the fake-ACP agent (see below) is on `$PATH` as `claude`, `claude-agent-acp`, and `aoe-agent`, and `PATCH /api/cockpit/master` is called after startup. The `claude-agent-acp` name matters because the cockpit supervisor resolves the `claude` tool key through `AgentRegistry` to command `claude-agent-acp`, not `claude`; without that shim the supervisor would fall through to the system-installed adapter and fail with "Authentication required" on the first prompt.
 
 Isolation per test:
 
 - Fresh `mkdtemp` for `HOME`, with `XDG_CONFIG_HOME`, `TMPDIR`, `TMUX_TMPDIR`, and `bin/` as subdirs (all `0700`).
 - Port: `5200 + workerIndex*100 + parallelIndex + attempt*7`. Five retries on bind failure.
-- Fake `claude` shim in `home/bin/claude` (`exec tail -f /dev/null`). Cockpit fixture overrides with the fake-ACP shim.
+- Fake `claude` shim in `home/bin/claude` (`exec tail -f /dev/null`). Cockpit fixture overrides with the fake-ACP shim, installed under `claude`, `claude-agent-acp`, and `aoe-agent`.
 - `stop()` does `SIGTERM` with a 2s wait, `SIGKILL` fallback, then `rm -rf home`. Never calls `tmux kill-server` (would kill the developer's tmux).
 
 Binary resolution: `AOE_E2E_BINARY` env wins; otherwise `<repo>/target/release/aoe`. `liveGlobalSetup.ts` runs once before any worker and calls `cargo build --features serve --release` if the binary is missing.

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -246,15 +246,19 @@ function writeFakeClaudeShim(binDir: string): void {
 }
 
 function writeFakeAcpShim(binDir: string, fakeAcpScript: string | undefined): void {
-  // The cockpit supervisor calls `claude` (or `aoe-agent`) and handshakes
-  // ACP over its stdio. The shim is a tiny bash wrapper that execs the
-  // fake ACP agent under node with the optional script env baked in.
+  // The cockpit supervisor resolves the agent through `AgentRegistry`
+  // (src/cockpit/agent_registry.rs): the `claude` tool key maps to
+  // command `claude-agent-acp`, not `claude`. `resolve_agent_command`
+  // walks $PATH and node-version dirs, so without a `claude-agent-acp`
+  // entry in the shim dir the supervisor falls through to the real
+  // installed adapter, which then surfaces "Authentication required"
+  // on the first prompt. Shim every name a cockpit test can land on.
   const fakeAgentJs = resolve(__dirname, "fakeAcpAgent.mjs");
   const scriptLine = fakeAcpScript
     ? `export FAKE_ACP_SCRIPT=${JSON.stringify(fakeAcpScript)}\n`
     : "";
   const script = `#!/bin/bash\n${scriptLine}exec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
-  for (const name of ["claude", "aoe-agent"]) {
+  for (const name of ["claude", "claude-agent-acp", "aoe-agent"]) {
     const path = join(binDir, name);
     writeFileSync(path, script);
     chmodSync(path, 0o755);

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -8,7 +8,12 @@
 //   session/new         -> return a deterministic sessionId
 //   session/load        -> same shape; lets cockpit's Resume mode work
 //   session/prompt      -> emit scripted session/update notifications,
-//                          then return a stop response
+//                          then return a stop response. Script entries
+//                          with `sessionUpdate: "permission_request"`
+//                          are translated into a real outbound
+//                          `session/request_permission` JSON-RPC
+//                          REQUEST; the fake awaits the client's
+//                          response before continuing the turn.
 //   session/setMode     -> emit current_mode_changed
 //   session/cancel      -> emit stopped { stopReason: "cancelled" }
 //
@@ -89,8 +94,69 @@ function sendNotification(method, params) {
   send({ jsonrpc: "2.0", method, params });
 }
 
+// Track outbound requests we send to the client so we can resolve them
+// when the client's response arrives. Keyed on the request id.
+let nextOutboundId = 1;
+const pendingOutbound = new Map();
+
+function sendRequest(method, params) {
+  const id = `fake-acp-req-${nextOutboundId++}`;
+  send({ jsonrpc: "2.0", id, method, params });
+  return new Promise((resolve, reject) => {
+    pendingOutbound.set(id, { resolve, reject });
+  });
+}
+
+function resolveOutbound(msg) {
+  const entry = pendingOutbound.get(msg.id);
+  if (!entry) {
+    process.stderr.write(
+      `[fakeAcpAgent] response for unknown id ${msg.id}\n`,
+    );
+    return;
+  }
+  pendingOutbound.delete(msg.id);
+  if (msg.error) {
+    entry.reject(msg.error);
+  } else {
+    entry.resolve(msg.result);
+  }
+}
+
+// Default permission options when a `permission_request` script entry
+// omits its own. Covers every PermissionOptionKind aoe's
+// `pick_option_id` (src/cockpit/acp_client.rs) consults so an
+// `allow` / `allow_always` / `deny` decision always maps cleanly.
+const DEFAULT_PERMISSION_OPTIONS = [
+  { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+  { optionId: "allow-always", name: "Allow always", kind: "allow_always" },
+  { optionId: "reject-once", name: "Reject once", kind: "reject_once" },
+  { optionId: "reject-always", name: "Reject always", kind: "reject_always" },
+];
+
 async function emitSessionUpdates(sessionId, updates) {
   for (const u of updates) {
+    if (u && u.sessionUpdate === "permission_request") {
+      // ACP carries permissions on a separate JSON-RPC request, not on
+      // session/update. Translate the scripted entry into a real
+      // `session/request_permission` request and wait for the client's
+      // decision before continuing the turn so the assertions in the
+      // approval spec can observe ApprovalRequested + resolve it.
+      await sendRequest("session/request_permission", {
+        sessionId,
+        toolCall: u.toolCall ?? {
+          toolCallId: `fake-tool-call-${Date.now()}`,
+          title: "fake tool call",
+          kind: "edit",
+        },
+        options: u.options ?? DEFAULT_PERMISSION_OPTIONS,
+      }).catch((err) => {
+        process.stderr.write(
+          `[fakeAcpAgent] permission_request rejected: ${JSON.stringify(err)}\n`,
+        );
+      });
+      continue;
+    }
     sendNotification("session/update", { sessionId, update: u });
     // Tiny tick between updates so the cockpit reducer can apply each
     // event in order rather than batching them.
@@ -203,6 +269,10 @@ async function main() {
         process.stderr.write(`[fakeAcpAgent] handler error: ${err}\n`);
         sendError(msg.id, -32603, `internal: ${err}`);
       }
+    } else if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+      // Response to one of our outbound requests (e.g.
+      // session/request_permission). Resolve the awaiting Promise.
+      resolveOutbound(msg);
     } else if (msg.method) {
       // Notification from client (e.g. fs/* response). We don't model
       // delegated FS/terminal call results; tests that need them script
@@ -211,7 +281,6 @@ async function main() {
         `[fakeAcpAgent] received notification: ${msg.method}\n`,
       );
     }
-    // Responses to our outbound requests (we don't make any) are ignored.
   });
 
   rl.on("close", () => {

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -99,11 +99,34 @@ function sendNotification(method, params) {
 let nextOutboundId = 1;
 const pendingOutbound = new Map();
 
+// 15s ceiling so a wedged supervisor surfaces as an explicit timeout
+// instead of a hung promise that stalls the script's remaining updates
+// and leaves Playwright to time out generically.
+const OUTBOUND_REQUEST_TIMEOUT_MS = 15_000;
+
 function sendRequest(method, params) {
   const id = `fake-acp-req-${nextOutboundId++}`;
   send({ jsonrpc: "2.0", id, method, params });
   return new Promise((resolve, reject) => {
-    pendingOutbound.set(id, { resolve, reject });
+    const timer = setTimeout(() => {
+      if (pendingOutbound.delete(id)) {
+        reject(
+          new Error(
+            `fakeAcpAgent: outbound ${method} id=${id} timed out after ${OUTBOUND_REQUEST_TIMEOUT_MS}ms`,
+          ),
+        );
+      }
+    }, OUTBOUND_REQUEST_TIMEOUT_MS);
+    pendingOutbound.set(id, {
+      resolve: (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      reject: (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    });
   });
 }
 

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -23,10 +23,15 @@ const APPROVAL_SCRIPT = {
           content: { type: "text", text: "Considering write..." },
         },
         {
+          // The fake translates this into a real
+          // `session/request_permission` JSON-RPC request. ACP has no
+          // `permission_request` session/update variant; aoe carries
+          // permissions on a separate request that emits an
+          // ApprovalRequested event server-side with a server-generated
+          // nonce. The spec reads that nonce out of replay below.
           sessionUpdate: "permission_request",
-          nonce: "fake-nonce-1",
           toolCall: {
-            id: "fake-tool-call-1",
+            toolCallId: "fake-tool-call-1",
             title: "Write file",
             kind: "edit",
           },
@@ -37,10 +42,15 @@ const APPROVAL_SCRIPT = {
   ],
 };
 
-// Skipped pending #1237. Same underlying issue as cockpit-spawn-prompt:
-// supervisor surfaces AgentStartupError before the scripted
-// permission_request reaches the replay endpoint.
-base.skip("permission_request flows through to the server", async ({}, testInfo) => {
+interface ApprovalRequestedEvent {
+  ApprovalRequested?: {
+    approval?: {
+      nonce?: string;
+    };
+  };
+}
+
+base("permission_request flows through to the server", async ({}, testInfo) => {
   const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-acp-script-"));
   const scriptPath = join(scriptDir, "script.json");
   writeFileSync(scriptPath, JSON.stringify(APPROVAL_SCRIPT));
@@ -73,31 +83,43 @@ base.skip("permission_request flows through to the server", async ({}, testInfo)
       body: JSON.stringify({ text: "write a file" }),
     });
 
-    let sawApproval = false;
+    // Poll the disk-backed replay endpoint for the ApprovalRequested
+    // event aoe emits when the fake agent sends `session/request_permission`.
+    // The nonce is generated server-side (src/cockpit/permissions.rs::
+    // build_approval), so the spec must read it back instead of
+    // hard-coding a value.
+    let nonce: string | undefined;
     for (let attempt = 0; attempt < 30; attempt++) {
       const replay = await fetch(
         `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
       ).then((r) => r.json());
-      const json = JSON.stringify(replay);
-      if (
-        json.includes("permission_request") ||
-        json.includes("ApprovalRequested")
-      ) {
-        sawApproval = true;
-        break;
+      const frames: Array<{ event?: ApprovalRequestedEvent }> = Array.isArray(
+        replay,
+      )
+        ? replay
+        : replay.frames ?? [];
+      for (const frame of frames) {
+        const candidate = frame.event?.ApprovalRequested?.approval?.nonce;
+        if (candidate) {
+          nonce = candidate;
+          break;
+        }
       }
+      if (nonce) break;
       await new Promise((r) => setTimeout(r, 200));
     }
-    expect(sawApproval).toBe(true);
+    expect(nonce).toBeDefined();
 
     // Resolve via the explicit endpoint (UI click path is covered by a
     // follow-up under #1224 once cockpit UI selectors are stable).
     const resolveRes = await fetch(
-      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/approvals/fake-nonce-1`,
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/approvals/${nonce}`,
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ decision: "allow" }),
+        // ApprovalDecisionWire (src/cockpit/protocol.rs) is serialized
+        // as PascalCase, so "allow" deserializes as a 422 invalid body.
+        body: JSON.stringify({ decision: "Allow" }),
       },
     );
     expect(resolveRes.status).toBeGreaterThanOrEqual(200);

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -4,7 +4,7 @@
 // harness) emits a `permission_request` mid-turn. Seeds the session via
 // `aoe add` BEFORE serve boots so the server picks it up in-memory.
 
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test as base, expect } from "@playwright/test";
@@ -126,5 +126,6 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     expect(resolveRes.status).toBeLessThan(300);
   } finally {
     await serve.stop();
+    rmSync(scriptDir, { recursive: true, force: true });
   }
 });

--- a/web/tests/live/cockpit-mode-switch.spec.ts
+++ b/web/tests/live/cockpit-mode-switch.spec.ts
@@ -11,14 +11,7 @@ import {
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
 
-// Skipped pending #1237: the supervisor's ACP handshake against the
-// fake agent fails with "Authentication required" before the worker
-// registers, so set-mode 404s. Sibling cockpit live specs
-// (cockpit-spawn-prompt, cockpit-approval) are skipped for the same
-// reason. Unskip once the harness installs a `claude-agent-acp` shim
-// (or the supervisor's agent registry honors an env-var override) so
-// the fake ACP agent actually drives the handshake.
-base.skip("session/mode round-trips through the fake ACP agent", async ({}, testInfo) => {
+base("session/mode round-trips through the fake ACP agent", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",
     cockpit: true,

--- a/web/tests/live/cockpit-spawn-prompt.spec.ts
+++ b/web/tests/live/cockpit-spawn-prompt.spec.ts
@@ -13,14 +13,7 @@ import {
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
 
-// Skipped pending #1237. After cockpit/enable + a fake-ACP-driven
-// prompt, the supervisor publishes AgentStartupError ("ACP connection
-// failed: Authentication required") between UserPromptSent and the
-// expected agent_message_chunk. The companion cockpit-mode-switch spec
-// drives the same harness path and passes, so the harness itself is
-// sound; the prompt-side flow needs deeper investigation in
-// fakeAcpAgent.mjs or the supervisor's auth wall.
-base.skip("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}, testInfo) => {
+base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
     authMode: "none",
     cockpit: true,
@@ -65,10 +58,15 @@ base.skip("cockpit spawn + prompt round-trip emits an agent_message_chunk", asyn
       const replay = await fetch(
         `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
       ).then((r) => r.json());
-      const events: unknown[] = Array.isArray(replay)
+      // GET /cockpit/replay returns { frames, lost, highest_seq, lowest_seq }
+      // (src/server/api/cockpit.rs::cockpit_replay). Each frame's serialized
+      // `event` is an externally-tagged enum, so the chunk is keyed
+      // `AgentMessageChunk`. Match either casing to stay robust if the
+      // wire format ever moves to snake_case.
+      const frames: unknown[] = Array.isArray(replay)
         ? replay
-        : replay.events ?? [];
-      const json = JSON.stringify(events);
+        : replay.frames ?? [];
+      const json = JSON.stringify(frames);
       if (
         json.includes("agent_message_chunk") ||
         json.includes("AgentMessageChunk")


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Unskips the three live cockpit Playwright specs (`cockpit-spawn-prompt`, `cockpit-approval`, `cockpit-mode-switch`) that #1228 had to `base.skip(...)` because the supervisor was reaching the real `claude-agent-acp` adapter (not the fake) and getting back `AuthRequired` on the first prompt.

Root cause: the cockpit supervisor's `AgentRegistry` (`src/cockpit/agent_registry.rs`) maps the `claude` tool key to command `claude-agent-acp`, but the test harness only installed the fake-ACP shim under `claude` and `aoe-agent`. With no `claude-agent-acp` entry in the per-test `bin/` dir, `resolve_agent_command` (`src/cockpit/acp_client.rs`) walked `$PATH` and node-version dirs, found the system-installed adapter, and spawned it. The real adapter then called the Anthropic API with no credentials and the supervisor surfaced `AgentStartupError { message: "ACP connection failed: Authentication required" }`.

Investigation also surfaced three pre-existing spec/fake-agent bugs that the skip had been hiding:

1. **`cockpit-spawn-prompt.spec.ts`** read `replay.events ?? []`, but `GET /cockpit/replay` returns `{ frames, lost, highest_seq, lowest_seq }` (`src/server/api/cockpit.rs::cockpit_replay`), so the chunk-search ran against an empty array.
2. **`fakeAcpAgent.mjs`** emitted a `session/update` with a non-existent `sessionUpdate: "permission_request"` variant. ACP carries permissions on a separate `session/request_permission` JSON-RPC **request**, not a session/update notification. The bogus notification fell through `map_session_update`'s catch-all and was silently dropped.
3. **`cockpit-approval.spec.ts`** posted to `/cockpit/approvals/fake-nonce-1`, but the approval nonce is generated server-side in `src/cockpit/permissions.rs::build_approval`, and `ApprovalDecisionWire` (`src/cockpit/protocol.rs`) serializes as PascalCase (`Allow`, not `allow`).

This PR fixes all four issues. Live suite passes 20/20 at `workers=4` locally.

### Changes

- `web/tests/helpers/aoeServe.ts`: install the fake-ACP shim under `claude`, `claude-agent-acp`, and `aoe-agent` (was: `claude` and `aoe-agent` only). Documented why `claude-agent-acp` matters so a future shim-list trim does not silently regress cockpit specs.
- `web/tests/helpers/fakeAcpAgent.mjs`: translate a script entry shaped like `{ sessionUpdate: "permission_request", toolCall, options? }` into a real outbound `session/request_permission` JSON-RPC **request**, await the client's response, then continue the turn. Adds a small pending-response map for outbound requests.
- `web/tests/live/cockpit-spawn-prompt.spec.ts`: read `replay.frames` (with a comment pointing at `cockpit_replay`'s response shape so the fix sticks). Unskipped.
- `web/tests/live/cockpit-approval.spec.ts`: parse the server-generated nonce out of the `ApprovalRequested` event in replay before posting the resolve; switch the decision payload to PascalCase. Unskipped.
- `web/tests/live/cockpit-mode-switch.spec.ts`: unskipped (no spec-side bugs once the shim is in place).
- `docs/development/playwright.md`: document the three shim names and why `claude-agent-acp` is the one that matters.

Closes #1237

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] `cargo build --features serve` to refresh `target/debug/aoe`.
- [ ] `cd web && AOE_E2E_BINARY=$PWD/../target/debug/aoe npx playwright test --config=playwright.live.config.ts` reports 20/20 passing, including `cockpit-spawn-prompt`, `cockpit-approval`, and `cockpit-mode-switch`.
- [ ] `cd web && node tests/validate-coverage-matrix.mjs` prints `Coverage matrix validation passed.`
- [ ] `cd web && AOE_E2E_BINARY=$PWD/../target/debug/aoe npx playwright test --config=playwright.live.config.ts -g "cockpit spawn"` shows the spawn-prompt spec passing alone (proves the chunk-search reads `frames`, not `events`).
- [ ] `cd web && AOE_E2E_BINARY=$PWD/../target/debug/aoe npx playwright test --config=playwright.live.config.ts -g "permission_request"` shows the approval spec passing alone, exercising the `session/request_permission` round-trip and the server-side nonce.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (no UI changes; test infra only)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context), Claude Code, agent-of-empires `/aoe-implement` skill

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. The plan started narrow (just install the missing shim) but validation surfaced three spec-side bugs the skip had been hiding; I authorized expanding scope to cover them so the issue's acceptance criteria (both specs passing, plus the resolvable approval flow) actually land in one PR. I reviewed each commit, made the design calls, and ran the live suite at `workers=2` and `workers=4` locally before opening.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR restores end-to-end functionality for three cockpit live tests that were previously skipped due to the test environment inadvertently invoking the real `claude-agent-acp` adapter instead of the fake test stub. The fix involves installing the fake adapter shim under the correct command names, enhancing the fake agent to handle permission request workflows, and updating the test specs to correctly parse server responses.

## What Changed

**Installation and Configuration:**
- Updated the ACP agent shim installation to cover `claude`, `claude-agent-acp`, and `aoe-agent` command names (previously only `claude` and `aoe-agent`)
- Updated documentation to explain why `claude-agent-acp` must be shimmed and clarify the cockpit PATCH behavior

**Test Helper Enhancement:**
- Enhanced `fakeAcpAgent.mjs` to support real JSON-RPC request/response round-trips for `permission_request` workflows, including:
  - Tracking outbound requests and awaiting responses
  - Parsing server-generated approval nonces
  - Handling response callbacks to continue scripted turns

**Test Spec Fixes and Restoration:**
- `cockpit-spawn-prompt.spec.ts`: Fixed to read `replay.frames` (not `replay.events`) and scan for `agent_message_chunk` markers; unskipped the test
- `cockpit-approval.spec.ts`: Fixed to extract server-generated nonce from `ApprovalRequested` events, use correct PascalCase decision payloads (`Allow`), and poll replay endpoint; unskipped the test
- `cockpit-mode-switch.spec.ts`: Unskipped with no further changes needed

## Benefits

- **Spec Coverage**: Restores 3 previously skipped cockpit specs to active testing, improving test coverage for prompt spawning, approvals, and mode switching workflows
- **Correct Adapter Resolution**: Prevents tests from accidentally invoking the real Anthropic API adapter, eliminating auth failures and startup errors
- **Full Workflow Testing**: Enables end-to-end testing of permission request flows with real request/response round-trips through the supervisor
- **Better Maintainability**: Corrects response parsing to match actual server structures, reducing brittleness and improving alignment with production behavior

**Result**: All 20 cockpit live suite tests now pass locally with no external API dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1303?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->