### PR TITLE
fix(cockpit): assert exit_code in concurrent-drain test and document lossy decode (#1283 follow-ups)

### DIFF
--- a/src/cockpit/terminal_handler.rs
+++ b/src/cockpit/terminal_handler.rs
@@ -48,6 +48,11 @@ pub enum TerminalError {
 pub type TerminalId = String;
 
 /// One terminal's captured output and exit status.
+///
+/// `stdout` and `stderr` are decoded from raw child bytes via
+/// `String::from_utf8_lossy`, so invalid UTF-8 from misbehaving tools is
+/// replaced with U+FFFD rather than failing the whole capture (the agent
+/// still gets partial output instead of an error).
 #[derive(Debug, Clone)]
 pub struct TerminalOutput {
     pub stdout: String,
@@ -268,6 +273,7 @@ mod tests {
         let out = mgr.output(&id).await.unwrap();
         assert_eq!(out.stdout.len(), 204_800);
         assert_eq!(out.stderr.len(), 204_800);
+        assert_eq!(out.exit_code, Some(0));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Two follow-ups surfaced by post-merge review of #1283 (drain stdout+stderr concurrently in `terminal_handler`).

### What changed

1. **Test parity** in `large_stdout_and_stderr_drain_concurrently`: add `assert_eq!(out.exit_code, Some(0));` after the existing length asserts, matching the sibling regression test `large_stderr_does_not_deadlock` (which already does this). Without it, a future change where `wait_with_output()` succeeds but the underlying child status is lost would still pass the size checks.

2. **API doc on `TerminalOutput`**: add a rustdoc paragraph noting that `stdout` and `stderr` are decoded via `String::from_utf8_lossy`, so non-UTF-8 bytes become `U+FFFD` instead of failing the whole capture. The call-site comment in `create_and_run` already explains the implementation choice; this surfaces the contract on the data type that callers of `terminal/output` actually see.

Both changes are documentation- and test-only. No behavior change, no public API change.

### Why a follow-up rather than amending #1283

#1283 was already merged when the review feedback was synthesized. Post-merge analysis cross-validated the 5 inline review comments via 3 independent reviewers; only these 2 items reached consensus as worth acting on. The other 3 (gating tests with `#[cfg(unix)]`, bumping the 5s test timeouts) were dismissed unanimously: the project does not target Windows (CI matrix is `ubuntu-latest, macos-latest`; tmux is required) and the 5s ceiling is a hang detector for a deadlock-regression test, not a perf budget.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::terminal_handler` 6/6 pass (including both regression tests with the new assertion)

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1283. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 2/3 or 3/3 per comment. Stage 2 (design fix) used 3 oracles, consensus on identical 2-hunk diff. Stage 3 (review implementation) used 2 oracles, both APPROVE.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR contains two documentation and test improvements to the cockpit terminal handler, building on the concurrent stdout/stderr draining changes from PR `#1283`:

**Documentation Update**: Added clarifying notes to the `TerminalOutput` documentation explaining that captured stdout and stderr are decoded using lossy UTF-8 decoding, meaning invalid UTF-8 bytes are replaced with the Unicode replacement character (U+FFFD) rather than causing the capture to fail.

**Test Enhancement**: Strengthened the concurrent drain regression test by adding an assertion that verifies the process exits with code 0, ensuring both the output capture and process exit status are validated together.

## Why It Matters

These changes address two practical concerns that arose during review of the concurrent draining feature:

1. **Clarity on Behavior**: Developers using this API now have clear documentation about how non-UTF-8 bytes are handled, preventing confusion or incorrect assumptions about capture behavior.

2. **Improved Test Coverage**: The additional exit code assertion prevents a potential regression where the captured output sizes might be correct while the child process's exit status information is lost—catching a broader class of failures.

## Technical Details

- **Files Modified**: `src/cockpit/terminal_handler.rs`
- **Changes**: Documentation enhancement and test assertion addition
- **Impact**: No behavioral changes, no public API modifications
- **Test Status**: All existing tests pass (6/6 in cockpit::terminal_handler suite)
- **Code Quality**: Clean clippy and formatting checks

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->