### PR TITLE
ci(tests): drop redundant cargo test, scope macOS, cache playwright

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,15 +44,25 @@ jobs:
       # so its deps must be installed before `cargo test --features serve`
       # runs. The shim itself auto-skips if node is missing, but on a
       # GitHub runner node is always present; without the install step
-      # the shim crashes before the ACP handshake completes.
+      # the shim crashes before the ACP handshake completes. macOS only
+      # runs --lib --bins (no integration crates), so the shim isn't
+      # exercised there and we can skip the install.
       - name: Install ACP shim deps
+        if: runner.os == 'Linux'
         working-directory: cockpit-worker/test-shim
         run: npm ci
-      - run: cargo test
-      # The server-side audit lives under `#[cfg(feature = "serve")]`
-      # (whole `src/server/` tree). Without this run the read-only
-      # guard audit and other serve-gated tests are silently skipped.
-      - run: cargo test --features serve
+      # `--features serve` is a strict superset of the default-feature
+      # suite (1759 -> 2269 unit tests, 67 -> 72 e2e), so a single run
+      # under serve covers both feature gates. macOS-specific code lives
+      # in src/process/macos.rs plus one cfg in container_config.rs;
+      # the integration and e2e crates exercise OS-portable code that
+      # the Linux leg already covers, so macOS only runs --lib --bins.
+      - name: Cargo test (Linux, full suite incl. integration + e2e)
+        if: runner.os == 'Linux'
+        run: cargo test --features serve
+      - name: Cargo test (macOS, lib + bins only)
+        if: runner.os == 'macOS'
+        run: cargo test --features serve --lib --bins
 
   vitest:
     name: Vitest
@@ -103,9 +113,22 @@ jobs:
       - name: Validate coverage matrix
         working-directory: web
         run: node tests/validate-coverage-matrix.mjs
+      # The Playwright browser cache (~150MB chromium) is keyed on the
+      # web/package-lock.json hash so it invalidates when @playwright/test
+      # bumps. --with-deps is omitted: the ubuntu-latest runner image
+      # already ships the apt packages Chromium needs.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: web
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
       - name: Run Playwright (mocked) with coverage
         working-directory: web
         env:
@@ -171,9 +194,21 @@ jobs:
       - name: Install web deps
         working-directory: web
         run: npm ci
+      # Same scheme as the mocked job: cache Chromium under
+      # ~/.cache/ms-playwright, key on the lockfile, skip --with-deps
+      # because ubuntu-latest already has the apt prerequisites.
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('web/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
       - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
         working-directory: web
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install chromium
       - name: Run live Playwright with coverage
         working-directory: web
         env:


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Speeds up the `Tests` workflow by removing redundant work, narrowing macOS scope, and caching the Playwright browser. Fixes #1305.

**Where the time goes on `main` today** (reference run [26167456067](https://github.com/njbrake/agent-of-empires/actions/runs/26167456067)):

- `Cargo Test (macos-latest)` 6m48s: `cargo test` 2m15s, `cargo test --features serve` 3m47s. Two compiles, common unit + e2e suites run twice.
- `Cargo Test (ubuntu-latest)` 6m07s: same shape.
- `Playwright (mocked)` 5m59s: 4m of tests, 20s of `playwright install --with-deps`.
- `Playwright (live)` 4m56s: 75s `cargo build`, 158s `playwright install --with-deps`, 20s actual tests.

**Three changes in this PR:**

1. Replace `cargo test` + `cargo test --features serve` with a single `cargo test --features serve`. Serve is strictly additive (1759 to 2269 unit tests, 67 to 72 e2e). Saves the second compile and the duplicated test execution.
2. macOS now runs `cargo test --features serve --lib --bins` only. Platform-specific code lives in `src/process/macos.rs` and one `cfg(target_os = "macos")` in `container_config.rs`; the integration and e2e crates exercise OS-portable code that the Linux leg already covers. The ACP shim `npm ci` becomes Linux-only since macOS no longer runs `cockpit_acp_smoke.rs`.
3. Both Playwright jobs cache `~/.cache/ms-playwright` via `actions/cache@v5.0.5`, keyed on `web/package-lock.json` so the cache invalidates when `@playwright/test` bumps. `--with-deps` is dropped; ubuntu-24.04 runners already ship the Chromium apt prerequisites.

**Expected impact** (the warm-cache case for `actions/cache`):

| Job | Before | After (est.) |
|---|---|---|
| Cargo Test (macos-latest) | 6m48s | ~2m30s |
| Cargo Test (ubuntu-latest) | 6m07s | ~3m45s |
| Playwright (mocked) | 5m59s | ~5m30s |
| Playwright (live) | 4m56s | ~2m45s |

**Out of scope, captured for follow-up:**

- Bumping mocked Playwright workers from 2 to 4 and investigating the 5 retries observed in CI.
- Sharing the `aoe` binary between `cargo-ubuntu` and `playwright-live`.
- Switching to `cargo nextest`.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

`actionlint` clean against the modified `tests.yml`. No source files changed; pre-commit `cargo clippy -D warnings` and `cargo fmt --check` both passed. Real CI run on this PR is the load-bearing verification, since the fixes are about CI itself.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Opus 4.7) via Claude Code

**Any Additional AI Details you'd like to share:** Claude analyzed the CI run logs, proposed the three optimizations, and drafted the workflow edits and this PR body. The selection of which optimizations to apply (1, 2, 3 out of a longer list, with 4-6 deferred) was made by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1305

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->