### PR TITLE
ci: retry npm-hash push on non-fast-forward and add workflow_dispatch

### DIFF
--- a/.github/workflows/nix-npm-hash.yml
+++ b/.github/workflows/nix-npm-hash.yml
@@ -11,6 +11,7 @@ on:
     branches: [main]
     paths:
       - web/package-lock.json
+  workflow_dispatch:
 
 # Only one instance runs at a time. If a second lockfile push lands while
 # this is running, cancel the in-progress run and start fresh with the
@@ -87,11 +88,33 @@ jobs:
           echo "Updated flake.nix:"
           grep "npmDepsHash" flake.nix
 
-      - name: Commit updated hash
+      - name: Commit and push updated hash
         if: steps.hash.outputs.changed == 'true'
         run: |
+          set -euo pipefail
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add flake.nix
           git commit -m "chore: update Nix npmDepsHash for web dependencies"
-          git push
+
+          # A fast-follow merge to main can land between checkout and here,
+          # rejecting the push as non-fast-forward. Rebase our one-line hash
+          # bump on top of any new commits and retry. If a concurrent commit
+          # also edits flake.nix, bail out so a human can resolve.
+          for attempt in 1 2 3 4 5; do
+            if git push; then
+              echo "Pushed hash bump on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt; fetching and rebasing"
+            git fetch origin main
+            if ! git rebase origin/main; then
+              git rebase --abort
+              echo "Rebase conflict on flake.nix; aborting so a human can resolve"
+              exit 1
+            fi
+            sleep $((attempt * 3))
+          done
+          echo "Push still failing after 5 attempts"
+          exit 1


### PR DESCRIPTION
## Description

Fixes the root cause behind the recent stretch of failing `Push to Cachix` runs on main.

When `web/package-lock.json` changes on main, `Update Nix npm Hash` checks out main, computes the new `npmDepsHash`, commits it, and pushes. If any other commit lands on main during that ~90s window (e.g. a fast-follow merge of an unrelated PR) the push is rejected as non-fast-forward and the workflow dies, leaving `flake.nix` pinned to a stale hash. Every subsequent push to main matching the cachix workflow's `paths:` then fails on `nix build .#aoe-with-web` with:

```
ERROR: npmDepsHash is out of date
The package-lock.json in src is not the same as the in /nix/store/...-web-0-npm-deps.
```

That's the symptom we just hit: after #1275 landed, two other PRs (#1278, #1280) merged within ~90s, the hash bump push was rejected ([run 26161177808](https://github.com/njbrake/agent-of-empires/actions/runs/26161177808)), and every subsequent cachix run on main has been failing the nix build before ever reaching the cachix push step.

This PR:

- Wraps the final `git push` in a fetch + rebase + retry loop (5 attempts, modest backoff). If a concurrent commit also touched `flake.nix`, bail out with a clear error so a human can resolve rather than silently merging.
- Adds `workflow_dispatch:` so the hash workflow can be re-triggered manually without inventing a fake lockfile change. Also gives us a one-shot recovery path right after this lands to bump main back to a healthy hash.

The existing `concurrency: cancel-in-progress` only handles races with other lockfile pushes, not races with arbitrary commits to main, which is what bit us.

## PR Type

- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (CI-only change; no test surface)
- [x] Documentation was updated where necessary (n/a)
- [x] For UI changes: included screenshot or recording (n/a)

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Claude diagnosed the failing cachix runs, traced the root cause to the non-fast-forward race in `nix-npm-hash.yml`, and drafted the retry loop. I reviewed the diagnosis and the change.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR improves the `Update Nix npm Hash` workflow by fixing a race condition that caused hash updates to fail when concurrent commits landed on `main`.

### What Changed

**Added manual workflow trigger:** The workflow can now be manually triggered via GitHub's `workflow_dispatch` option, allowing developers to recover from hash sync failures without waiting for a new `package-lock.json` change.

**Replaced simple push with retry logic:** The git push operation now includes a resilient retry mechanism:
- Attempts to push up to 5 times before giving up
- On each rejection, fetches the latest changes from `main` and rebases the hash bump on top
- Automatically detects if another commit modified `flake.nix` and aborts with a clear error message (requiring manual resolution) instead of silently merging
- Implements exponential backoff between attempts (3s, 6s, 9s, 12s, 15s)

### Benefits

- **Reliability:** Eliminates transient failures when concurrent commits land on `main` during the ~90 second window before the push
- **Safety:** Prevents silent, unintended merges of conflicting changes to `flake.nix` 
- **Recoverability:** Manual workflow dispatch allows quick recovery without waiting for the next dependency change
- **Clarity:** Failed cases now fail explicitly with actionable error messages for human intervention

### Technical Details

The retry logic works by:
1. Attempting a push
2. If rejected (non-fast-forward), fetching `origin/main` and rebasing the current commit on top
3. If the rebase conflicts (indicating concurrent `flake.nix` edits), aborting and failing immediately to signal a need for human review
4. Waiting 3 seconds per attempt before the next try
5. Exiting with success if any attempt succeeds, or failure if all 5 attempts are exhausted

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1307?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->