### PR TITLE
fix(cockpit): close attach-vs-shutdown race + restore test rustdocs (#1284 follow-ups)

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -61,12 +61,12 @@ pub enum SupervisorError {
     /// rather than retrying.
     #[error("cockpit worker capacity full ({current}/{limit}); raise [cockpit] max_concurrent_workers or delete an existing cockpit session")]
     CapacityFull { current: usize, limit: u32 },
-    /// The spawn was cancelled by a concurrent `shutdown` call (e.g. the
-    /// user clicked Disable while the ACP handshake was still in
-    /// flight). The freshly-spawned client is dropped cleanly. Callers
-    /// should treat this as a soft success: the requested end state
-    /// (no worker for this session) holds.
-    #[error("spawn for session {0:?} was cancelled by a concurrent shutdown")]
+    /// The in-flight resume (spawn or attach) was cancelled by a
+    /// concurrent `shutdown` call, e.g. the user clicked Disable while
+    /// the ACP handshake was still in flight. The freshly-built client
+    /// is dropped cleanly. Callers should treat this as a soft success:
+    /// the requested end state (no worker for this session) holds.
+    #[error("resume of session {0:?} was cancelled by a concurrent shutdown")]
     SpawnCancelled(String),
 }
 
@@ -192,15 +192,17 @@ pub struct Supervisor<S: BroadcastSink> {
     /// check and race to insert. The RAII `ResumeReservation` guard
     /// removes the entry on success, error, or panic.
     pending_resumes: Arc<std::sync::Mutex<HashMap<String, ResumeKind>>>,
-    /// Session ids whose in-flight `spawn` should bail out instead of
-    /// inserting the freshly-spawned WorkerHandle. Set by `shutdown`
-    /// when it observes a session that's in `pending_resumes` but not
-    /// yet in `workers` — without this, a `cockpit_disable` arriving
-    /// during the 2-3s ACP handshake would no-op (shutdown returns
-    /// UnknownSession) but the in-flight spawn would still complete a
-    /// few seconds later, producing an orphaned worker the user can no
+    /// Session ids whose in-flight resume (spawn or attach) should
+    /// bail out instead of inserting the freshly-built WorkerHandle.
+    /// Set by `shutdown` when it observes a session that's in
+    /// `pending_resumes`, either with no live runner record (the
+    /// `pending_has_it` path) or against an existing runner about to
+    /// be SIGTERMed (the registry-terminate path). Without this, a
+    /// `cockpit_disable` arriving during the 2-3s ACP handshake
+    /// would no-op while the in-flight resume still completed a few
+    /// seconds later, producing an orphaned worker the user can no
     /// longer manage.
-    cancelled_spawns: Arc<std::sync::Mutex<HashSet<String>>>,
+    cancelled_resumes: Arc<std::sync::Mutex<HashSet<String>>>,
     /// Per-agent install gate. claude-agent-acp lazy-installs its
     /// native binary on first ever run; two concurrent `session/new`
     /// calls against a partially-installed SDK race the install and
@@ -320,7 +322,7 @@ impl<S: BroadcastSink> Supervisor<S> {
             workers: Arc::new(Mutex::new(HashMap::new())),
             next_seqs: Arc::new(std::sync::Mutex::new(HashMap::new())),
             pending_resumes: Arc::new(std::sync::Mutex::new(HashMap::new())),
-            cancelled_spawns: Arc::new(std::sync::Mutex::new(HashSet::new())),
+            cancelled_resumes: Arc::new(std::sync::Mutex::new(HashSet::new())),
             warmed_up_agents: Arc::new(std::sync::Mutex::new(HashSet::new())),
             agent_warmup_locks: Arc::new(std::sync::Mutex::new(HashMap::new())),
             worker_notify: Arc::new(tokio::sync::Notify::new()),
@@ -704,7 +706,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         // and skip the workers insert so the user's "disable" actually
         // takes effect instead of being silently overwritten by the
         // 2-3s-late spawn completion.
-        if lock_recover(&self.cancelled_spawns).remove(&session_id) {
+        if lock_recover(&self.cancelled_resumes).remove(&session_id) {
             debug!(
                 target: "cockpit.supervisor",
                 session = %session_id,
@@ -1290,21 +1292,28 @@ impl<S: BroadcastSink> Supervisor<S> {
             .is_some()
         {
             drop(workers);
+            // If a resume is mid-handshake against this same runner,
+            // the SIGTERM below races the handshake; mark the session
+            // so attach's (or spawn's) pre-insert check bails instead
+            // of installing a worker pointing at a dying agent.
+            if pending_has_it {
+                lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
+            }
             terminate_runner_for_session(session_id);
             return Ok(());
         }
         if pending_has_it {
-            // Spawn is mid-handshake. Mark it cancelled so
-            // `Supervisor::spawn`'s pre-insert check bails instead of
-            // installing an orphaned worker. The reservation cleanup
-            // (ResumeReservation::Drop) clears `pending_resumes` on
-            // exit, so we don't have to.
+            // Resume is mid-handshake. Mark it cancelled so the
+            // resume's pre-insert check (in `spawn` or `attach`)
+            // bails instead of installing an orphaned worker. The
+            // reservation cleanup (ResumeReservation::Drop) clears
+            // `pending_resumes` on exit, so we don't have to.
             drop(workers);
-            lock_recover(&self.cancelled_spawns).insert(session_id.to_string());
+            lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
             debug!(
                 target: "cockpit.supervisor",
                 session = %session_id,
-                "shutdown: spawn in flight; marked for cancellation"
+                "shutdown: resume in flight; marked for cancellation"
             );
             return Ok(());
         }
@@ -1494,6 +1503,21 @@ impl<S: BroadcastSink> Supervisor<S> {
             drop(workers);
             drop(client);
             return Err(SupervisorError::AlreadyRunning(session_id));
+        }
+        // Cancellation: a concurrent shutdown observed this session
+        // mid-attach (or terminated its runner) and asked us to bail.
+        // Mirrors `spawn`'s pre-insert check so the breadcrumb
+        // shutdown sets in either the `pending_has_it` path or the
+        // registry-terminate path is honored regardless of ResumeKind.
+        if lock_recover(&self.cancelled_resumes).remove(&session_id) {
+            debug!(
+                target: "cockpit.supervisor",
+                session = %session_id,
+                "attach cancelled by concurrent shutdown; dropping freshly-attached client"
+            );
+            drop(workers);
+            drop(client);
+            return Err(SupervisorError::SpawnCancelled(session_id));
         }
         let drain_task = self.start_drain_task(session_id.clone(), inbound);
         workers.insert(
@@ -1807,11 +1831,17 @@ fn next_seq(next_seqs: &SeqMap, session_id: &str) -> u64 {
 
 /// Take a `std::sync::Mutex` guard, recovering the inner data if
 /// the lock is poisoned. The supervisor maps wrapped in `std::sync::Mutex`
-/// only ever hold short, panic free critical sections (HashMap inserts
+/// only ever hold short, panic-free critical sections (HashMap inserts
 /// or removes), so a poisoned lock from an unrelated panic on the same
 /// state is recoverable rather than fatal.
 fn lock_recover<T>(m: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
-    m.lock().unwrap_or_else(|e| e.into_inner())
+    m.lock().unwrap_or_else(|e| {
+        warn!(
+            target: "cockpit.supervisor",
+            "recovered poisoned supervisor lock"
+        );
+        e.into_inner()
+    })
 }
 
 /// A `BroadcastSink` impl backed by a tokio broadcast channel. The
@@ -2698,15 +2728,6 @@ mod tests {
         );
     }
 
-    /// Regression: `publish_startup_error` and a subsequent drain-task
-    /// publish must not collide on seq=1, otherwise the client-side
-    /// dedupe (`frame.seq <= state.lastSeq → drop`) eats the agent's
-    /// Regression: `shutdown` arriving while a spawn is mid-handshake
-    /// must mark the in-flight spawn for cancellation, so the spawn's
-    /// pre-insert check drops the freshly-built client instead of
-    /// installing an orphaned worker. This test exercises the
-    /// supervisor-side state machine without a real ACP handshake by
-    /// pre-seeding `pending_resumes` and asserting `shutdown`'s effect.
     /// Regression: `ResumeReservation::drop` must not need a tokio
     /// runtime. The previous shape detached a `tokio::spawn` to
     /// release a `tokio::sync::Mutex`; that pattern panicked or
@@ -2815,13 +2836,19 @@ mod tests {
         );
     }
 
+    /// Regression: `shutdown` arriving while a spawn is mid-handshake
+    /// must mark the in-flight spawn for cancellation, so the spawn's
+    /// pre-insert check drops the freshly-built client instead of
+    /// installing an orphaned worker. This test exercises the
+    /// supervisor-side state machine without a real ACP handshake by
+    /// pre-seeding `pending_resumes` and asserting `shutdown`'s effect.
     #[tokio::test]
     async fn shutdown_during_pending_spawn_marks_for_cancellation() {
         let sink = VecSink::new();
         let sup = Supervisor::new(sink);
         // Simulate "spawn in flight": session is in pending_resumes
         // but no WorkerHandle yet. This is the exact window where
-        // the bug used to bite — shutdown returned UnknownSession
+        // the bug used to bite, shutdown returned UnknownSession
         // and the late spawn completion installed an orphan.
         sup.pending_resumes
             .lock()
@@ -2830,13 +2857,13 @@ mod tests {
         assert!(sup.is_running("s-cancel").await);
 
         // The new shutdown contract: success (Ok(())), and the id is
-        // recorded in cancelled_spawns so the spawn's pre-insert
+        // recorded in cancelled_resumes so the spawn's pre-insert
         // check can bail.
         sup.shutdown("s-cancel")
             .await
             .expect("shutdown of pending spawn should succeed");
         assert!(
-            sup.cancelled_spawns.lock().unwrap().contains("s-cancel"),
+            sup.cancelled_resumes.lock().unwrap().contains("s-cancel"),
             "shutdown must mark the pending spawn for cancellation"
         );
 
@@ -2848,6 +2875,34 @@ mod tests {
         }
     }
 
+    /// Regression: `shutdown` arriving while an `attach` is
+    /// mid-handshake must also set the cancellation breadcrumb, so
+    /// `attach`'s pre-insert check bails before installing a worker
+    /// against a SIGTERMed runner. Mirrors the spawn variant; the
+    /// breadcrumb is kind-agnostic by design.
+    #[tokio::test]
+    async fn shutdown_during_pending_attach_marks_for_cancellation() {
+        let sink = VecSink::new();
+        let sup = Supervisor::new(sink);
+        sup.pending_resumes
+            .lock()
+            .unwrap()
+            .insert("s-attach-cancel".into(), ResumeKind::Attach);
+        sup.shutdown("s-attach-cancel")
+            .await
+            .expect("shutdown of pending attach should succeed");
+        assert!(
+            sup.cancelled_resumes
+                .lock()
+                .unwrap()
+                .contains("s-attach-cancel"),
+            "shutdown must mark the pending attach for cancellation regardless of ResumeKind"
+        );
+    }
+
+    /// Regression: `publish_startup_error` and a subsequent drain-task
+    /// publish must not collide on seq=1, otherwise the client-side
+    /// dedupe (`frame.seq <= state.lastSeq → drop`) eats the agent's
     /// first message after a retry.
     #[tokio::test]
     async fn startup_error_then_drain_publish_have_distinct_seqs() {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1291,25 +1291,31 @@ impl<S: BroadcastSink> Supervisor<S> {
             .flatten()
             .is_some()
         {
-            drop(workers);
             // If a resume is mid-handshake against this same runner,
             // the SIGTERM below races the handshake; mark the session
             // so attach's (or spawn's) pre-insert check bails instead
-            // of installing a worker pointing at a dying agent.
+            // of installing a worker pointing at a dying agent. Set
+            // the breadcrumb under the workers lock so the racing
+            // resume that re-acquires workers cannot observe an empty
+            // cancelled_resumes between our drop and its read.
             if pending_has_it {
                 lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
             }
+            drop(workers);
             terminate_runner_for_session(session_id);
             return Ok(());
         }
         if pending_has_it {
             // Resume is mid-handshake. Mark it cancelled so the
             // resume's pre-insert check (in `spawn` or `attach`)
-            // bails instead of installing an orphaned worker. The
-            // reservation cleanup (ResumeReservation::Drop) clears
-            // `pending_resumes` on exit, so we don't have to.
-            drop(workers);
+            // bails instead of installing an orphaned worker. Insert
+            // under the workers lock so a resume that re-acquires
+            // workers cannot observe an empty cancelled_resumes
+            // between our drop and its read. The reservation cleanup
+            // (ResumeReservation::Drop) clears `pending_resumes` on
+            // exit, so we don't have to.
             lock_recover(&self.cancelled_resumes).insert(session_id.to_string());
+            drop(workers);
             debug!(
                 target: "cockpit.supervisor",
                 session = %session_id,


### PR DESCRIPTION
## Description

Four follow-ups surfaced by post-merge review of #1284 (`std::sync::Mutex` for supervisor state maps + sync `Drop`).

### What changed

1. **Attach race** (real bug). `shutdown()` set a `cancelled_spawns` cancellation breadcrumb only on the `pending_has_it` branch; but during an attach handshake the runner registry record is live, so shutdown takes the **registry-terminate** branch first and returns `Ok(())` without seeding the breadcrumb. Meanwhile `attach()` had no pre-insert cancellation check, so the freshly-attached client was installed as a `WorkerHandle` after the user requested stop.
   - Rename `cancelled_spawns` → `cancelled_resumes` (the set was already kind-agnostic on the producer side).
   - Set the breadcrumb in `shutdown`'s registry-terminate branch when `pending_has_it` (closing the actual race window).
   - Add the matching `lock_recover(&self.cancelled_resumes).remove(&session_id)` pre-insert check in `attach()`, mirroring `spawn()`.
   - `SupervisorError::SpawnCancelled` variant **kept**; only its docstring + `#[error]` string broaden to cover both spawn and attach.
   - Adds `shutdown_during_pending_attach_marks_for_cancellation` regression test pinning the producer-side contract for `ResumeKind::Attach`.

2. **Test rustdoc misattribution** (regression cosmetic). Three `///` doc blocks had stacked above the new `resume_reservation_drop_is_synchronous_no_runtime_needed` test, leaving the truncated head of `startup_error_then_drain_publish_have_distinct_seqs` ("eats the agent's") and the dangling tail ("first message after a retry.") split across the file, plus the `shutdown_during_pending_spawn_marks_for_cancellation` doc on the wrong test. Each block reattached to its owner.

3. **Poison-recovery observability**. `lock_recover` silently swallowed poisoned mutexes via `unwrap_or_else(|e| e.into_inner())`; added a `tracing::warn!(target: "cockpit.supervisor", "recovered poisoned supervisor lock")` inside the recovery branch so production incidents are no longer invisible.

4. **Hyphenation**. `lock_recover` docstring read "panic free critical sections"; corrected to "panic-free" per standard compound-modifier style.

### Why a follow-up rather than amending #1284

#1284 was already merged when the review feedback was synthesized. Post-merge cross-validation flagged the attach-side cancellation gap as a real bug worth a separate fix.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::supervisor` **33/33** pass (including the new `shutdown_during_pending_attach_marks_for_cancellation` regression test)

No web changes, no `coverage-matrix.json` update needed.

### Comments dismissed

- **Sync `Mutex` blocks Tokio worker threads**: 3-oracle consensus INVALID. All `lock_recover` sites hold guards across `HashMap::contains_key`/`insert`/`remove` only, never across `.await`. The bot's "split sync vs async maps" middle ground would re-introduce exactly the heterogeneity #1284 set out to remove.
- **Nested `std::sync::Mutex` outer + unqualified inner `Mutex<()>`**: 3-oracle consensus PARTIALLY VALID but cosmetic only (compiler unambiguous, code is correct). Out of scope for a focused follow-up.

### Out of scope (filed as follow-up issue)

Both shutdown breadcrumb branches (the new registry-terminate one and the pre-existing `pending_has_it` one) call `drop(workers)` **before** `lock_recover(&self.cancelled_resumes).insert(...)`. A spawn/attach mid-handshake could theoretically acquire `workers`, find no entry, see `cancelled_resumes` empty, and insert just before shutdown's insert runs. Window is microseconds, but it's the exact race the leading comment of `shutdown` claims to prevent. Pre-existing pattern in main; not introduced by this PR.

## PR Type

- [x] Bug Fix
- [x] Refactor
- [ ] New Feature
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1284. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 on attach race + rustdoc misattribution as real defects worth fixing. Stage 2 (design fix) used 3 oracles in parallel; 2/3 majority pointed out the registry-terminate breadcrumb hoist is required (Stage-1 brief had under-scoped this). Stage 3 (review implementation) used 2 oracles, both APPROVE.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary of Changes

### What Changed

The PR addresses four follow-up issues discovered after introducing synchronized mutex-based supervisor state management:

**1. Attach-vs-Shutdown Race (Bug Fix)**
- Renamed the cancellation tracking field from `cancelled_spawns` to `cancelled_resumes` to reflect that it handles both spawn and attach resumption flows
- Enhanced `shutdown()` to mark pending attach operations as cancelled (in addition to pending spawns), preventing orphaned workers from being installed after shutdown
- Updated `attach()` to check and clear cancelled session IDs before proceeding, mirroring the same pattern used in `spawn()`
- Clarified `SupervisorError::SpawnCancelled` documentation to describe resume cancellation (covering both spawn and attach scenarios)
- Added a regression test `shutdown_during_pending_attach_marks_for_cancellation` to prevent this race from recurring

**2. Test Documentation**
- Fixed displaced documentation blocks in tests to properly associate with their test functions, improving test doc clarity

**3. Poison-Recovery Logging**
- Added `tracing::warn!()` call in `lock_recover()` to log when a poisoned `std::sync::Mutex` is recovered, making mutex-poison recovery events visible for debugging

**4. Documentation Polish**
- Fixed hyphenation in docstring: "panic free" → "panic-free"

### Benefits

- **Eliminates a race condition**: Prevents the supervisor from installing workers for sessions being shut down during the attach handshake
- **Improved observability**: Poisoned lock recoveries are now logged, aiding in troubleshooting concurrency issues
- **Better code maintainability**: Generalized naming (`cancelled_resumes` vs `cancelled_spawns`) more accurately reflects the code's purpose
- **Test reliability**: New regression test ensures the attach-shutdown race doesn't resurface

### Technical Details

The core fix standardizes how `shutdown()` handles both pending spawns and pending attaches by consistently marking them in `cancelled_resumes`. Both `spawn()` and `attach()` check this set before proceeding, ensuring that if shutdown races ahead, the in-flight handshake aborts cleanly without installing a worker. The `lock_recover()` helper now provides tracing output when mutexes are poisoned, improving visibility into lock poisoning events that could indicate concurrency problems.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1308?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->