### PR TITLE
refactor(cockpit): extract client_for_session helper in Supervisor (#1285 follow-up)

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1150,17 +1150,27 @@ impl<S: BroadcastSink> Supervisor<S> {
         }
     }
 
+    /// Resolve a `session_id` to its `AcpClient`, holding `self.workers`
+    /// only long enough to clone the `Arc<AcpClient>` so the caller can
+    /// `.await` on the agent without serializing every other supervisor
+    /// operation behind that lock. Centralizing this also routes every
+    /// caller through the same `UnknownSession` error variant.
+    async fn client_for_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Arc<AcpClient>, SupervisorError> {
+        let workers = self.workers.lock().await;
+        workers
+            .get(session_id)
+            .map(|h| Arc::clone(&h.client))
+            .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
+    }
+
     /// Send a user prompt to a running cockpit worker.
     pub async fn send_prompt(&self, session_id: &str, text: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let client = {
-            let workers = self.workers.lock().await;
-            workers
-                .get(session_id)
-                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
-                .map(|h| Arc::clone(&h.client))?
-        };
+        let client = self.client_for_session(session_id).await?;
         client.send_prompt(text).await?;
         Ok(())
     }
@@ -1170,13 +1180,7 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn cancel_prompt(&self, session_id: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let client = {
-            let workers = self.workers.lock().await;
-            workers
-                .get(session_id)
-                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
-                .map(|h| Arc::clone(&h.client))?
-        };
+        let client = self.client_for_session(session_id).await?;
         client.cancel_prompt().await?;
         Ok(())
     }
@@ -1199,11 +1203,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
         // Best-effort cancel; ignore UnknownSession because the headline
         // intent is "free the UI", which the publish above already did.
-        let client = {
-            let workers = self.workers.lock().await;
-            workers.get(session_id).map(|h| Arc::clone(&h.client))
-        };
-        if let Some(client) = client {
+        if let Ok(client) = self.client_for_session(session_id).await {
             let _ = client.cancel_prompt().await;
         }
     }
@@ -1212,13 +1212,7 @@ impl<S: BroadcastSink> Supervisor<S> {
     pub async fn set_mode(&self, session_id: &str, mode_id: &str) -> Result<(), SupervisorError> {
         self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
             .await;
-        let client = {
-            let workers = self.workers.lock().await;
-            workers
-                .get(session_id)
-                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
-                .map(|h| Arc::clone(&h.client))?
-        };
+        let client = self.client_for_session(session_id).await?;
         client.set_mode(mode_id).await?;
         Ok(())
     }
@@ -1230,13 +1224,7 @@ impl<S: BroadcastSink> Supervisor<S> {
         nonce: Nonce,
         decision: ApprovalDecision,
     ) -> Result<(), SupervisorError> {
-        let client = {
-            let workers = self.workers.lock().await;
-            workers
-                .get(session_id)
-                .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
-                .map(|h| Arc::clone(&h.client))?
-        };
+        let client = self.client_for_session(session_id).await?;
         client.resolve_permission(nonce, decision).await?;
         Ok(())
     }


### PR DESCRIPTION
## Description

Follow-up to #1285 (drop `Mutex<AcpClient>` from `WorkerHandle`).

### What changed

Five `Supervisor` methods (`send_prompt`, `cancel_prompt`, `set_mode`, `resolve_permission`, plus the best-effort branch in `force_end_turn`) duplicated the same lock-scope dance: acquire the `workers` Mutex, look up the session, clone `Arc<AcpClient>`, drop the lock before awaiting the agent RPC.

This PR centralizes the pattern in a private `Supervisor::client_for_session` helper:

```rust
async fn client_for_session(
    &self,
    session_id: &str,
) -> Result<Arc<AcpClient>, SupervisorError> {
    let workers = self.workers.lock().await;
    workers
        .get(session_id)
        .map(|h| Arc::clone(&h.client))
        .ok_or_else(|| SupervisorError::UnknownSession(session_id.into()))
}
```

The four fallible callers collapse to a single line `let client = self.client_for_session(session_id).await?;`, and `force_end_turn` keeps its best-effort semantics by consuming the helper through `if let Ok(client) = self.client_for_session(...).await` (preserves the original swallow-on-absence behavior through the helper's `Result` return type, without needing a parallel `Option` variant).

### Why

Centralizing the `lock-release-before-await` discipline in one function:
- keeps the rule (don't `.await` while holding `self.workers`) as a property of one helper instead of a convention applied five times,
- guarantees every caller produces an identical `SupervisorError::UnknownSession` variant,
- shrinks each callsite to a single line, making the actual ACP call the focus of each method.

Diff stats: `1 file changed, 21 insertions(+), 33 deletions(-)`.

### Why a follow-up rather than amending #1285

#1285 was already merged when the review feedback was synthesized. Cross-validation (3 independent oracle reviewers) determined the bot's other comment ("ACP ordering / shutdown race") is a **false positive** (every `AcpClient` method is a single `mpsc::Sender::send().await` and the channel itself imposes FIFO; the previous `Mutex<AcpClient>` only serialized method entry, not ACP request order; no `is_shutting_down` contract exists in the codebase; supervisor removes the `WorkerHandle` from `self.workers` *before* calling `shutdown` so no new Arc clones are mintable after shutdown begins). That comment is dismissed.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::supervisor` **33/33** pass (pure refactor; existing tests cover all five paths)

No behavior change. No public API change. No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1285. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 INVALID for the ACP ordering claim, 3/3 PARTIAL VALID for the helper extraction. Stage 2 (design fix) used 3 oracles in parallel; identical diff converged. Stage 3 (review implementation) used 2 oracles, both APPROVE.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a new private helper method `client_for_session` to the `Supervisor` struct that centralizes a common pattern used across multiple control methods. Previously, five methods (`send_prompt`, `cancel_prompt`, `set_mode`, `resolve_permission`, and `force_end_turn`) each duplicated the same logic: acquiring a lock, looking up a session's client, and handling missing sessions. The new helper extracts this logic into a single place, reducing code duplication and improving maintainability.

### What Changed

**Added:**
- New private async helper method `client_for_session` that handles session lookups and client retrieval

**Refactored:**
- Five methods now delegate to the new helper instead of implementing the lookup logic themselves
- Best-effort behavior in `force_end_turn` is preserved using `if let Ok(...)` pattern

**Removed:**
- Redundant session lookup and client cloning code from five different methods

### Code Changes

- **File:** `src/cockpit/supervisor.rs`
- **Lines:** +21/-33 (net reduction of 12 lines despite adding the helper, due to consolidated duplicated code)

### Benefits

- **Reduced duplication:** Eliminates five instances of nearly identical code
- **Consistent error handling:** All session lookups now return the same `UnknownSession` error variant
- **Improved maintainability:** Future changes to session lookup logic only need to be made in one place
- **Better discipline:** Enforces the lock-release-before-await pattern consistently across all callers
- **No behavioral changes:** All existing functionality is preserved, including best-effort semantics

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->