### PR TITLE
feat: add status transition command hooks

### DIFF
--- a/docs/development/adding-agents.md
+++ b/docs/development/adding-agents.md
@@ -306,7 +306,7 @@ type = "command"
 command = "sh -c '...'"
 ```
 
-Set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/config.toml", ... })` in the agent def. Host installs still use `install_codex_hooks()` so `CODEX_HOME`, existing `[hooks.state]` trust data, and `[features].hooks = false` are respected. Codex status is hook-first, with targeted pane reconciliation for known hook gaps.
+Set `hook_config: Some(AgentHookConfig { settings_rel_path: ".codex/config.toml", ... })` in the agent def. Host installs still use `install_codex_hooks()` so `CODEX_HOME`, existing `[hooks.state]` trust data, `[features].hooks = false`, `config.toml.lock`, and atomic replacement are respected. Codex status is hook-first, with targeted pane reconciliation for known hook gaps.
 
 ### Hermes (custom YAML)
 
@@ -334,6 +334,7 @@ hooks:
 - **Forgetting `status_hook_env_prefix`**: Without `AOE_INSTANCE_ID`, hooks write nothing. Add your tool name to the check in `src/session/instance.rs`.
 - **Wrong hook format**: Each agent has its own schema; test that hooks actually fire by sending a message and checking `/tmp/aoe-hooks/*/status`.
 - **Sandbox hooks are separate**: Host hook installation (`install_agent_status_hooks`) doesn't cover sandbox sessions. You also need to wire hooks into `build_container_config` in `src/session/container_config.rs` so the sidecar volume is mounted and the agent config is materialized inside the container.
+- **Do not bypass the Codex writer**: Codex config mutations must go through `install_codex_hooks()` or `uninstall_codex_hooks()` so AoE preserves trust state and avoids partial writes during concurrent launches.
 - **Don't shell out in `install_*_hooks()`**: Keep hook installation as pure file IO. Any subprocess calls (like setting a default agent) should be in a separate function so `cargo test` doesn't mutate the developer's real environment.
 - **Use structured output when parsing agent CLIs**: If the agent CLI has `--format json` or similar, use it instead of substring matching on human-readable output. Human-readable formats change between versions.
 - **Waiting status needs a dedicated event**: Not all agents have an approval/permission event. If the agent doesn't expose one, document it as a limitation and consider filing upstream.

--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -26,7 +26,7 @@ Only a small set of sub-targets is enumerated in the settings dropdown (see `KNO
 | `tmux` | tmux invocations, cache refresh, status detection, pane CRUD. |
 | `http` | Axum request-scoped span with `request_id`/`method`/`path`/`status`/`latency_ms`, plus per-route semantic events. |
 | `serve` | `aoe serve` daemonize/foreground startup, PID/URL file IO, tunnel up/down, signal-driven shutdown. |
-| `hooks` | Agent hook integration (Claude/Settl/Hermes/Kiro) install/uninstall and hook status file lifecycle. |
+| `hooks` | Agent hook integration (Claude/Settl/Hermes/Kiro) install/uninstall, hook status file lifecycle, user-configured status hook command failures, and attached status hook watcher failures. |
 | `sound` | Notification sound asset download/install and per-event playback. |
 | `log.runtime` | Filter swaps (REST + runner file-watch). |
 

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -94,6 +94,36 @@ agent_status_hooks = true
 | `custom_agents` | `{}` | User-defined agents: name to command mapping. Custom agent names appear in the TUI agent picker alongside built-in agents. |
 | `agent_detect_as` | `{}` | Status detection mapping: maps an agent name to a built-in agent whose status heuristics should be used. |
 
+For Codex, AoE preserves existing `[hooks.state]` trust data and writes `~/.codex/config.toml` through `config.toml.lock` plus an atomic replace. This keeps repeated or concurrent AoE launches from duplicating hook blocks or leaving partial TOML.
+
+## Status Hooks
+
+Status hooks run local shell commands when the TUI sees a session status change. They are disabled by default and are intended for personal machine behavior such as desktop notifications.
+
+```toml
+[status_hooks]
+enabled = true
+debounce_ms = 100
+on_waiting = "notify-send -a aoe 'AoE: Waiting' \"$AOE_SESSION_TITLE is waiting for input\""
+on_idle = "notify-send -a aoe 'AoE: Idle' \"$AOE_SESSION_TITLE is idle\""
+on_error = "notify-send -u critical -a aoe 'AoE: Error' \"$AOE_SESSION_TITLE errored\""
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Run configured status hook commands from the TUI. |
+| `debounce_ms` | `100` | Wait this many milliseconds for a status to remain stable before running commands. Set to `0` to run hooks immediately. |
+| `on_starting` | unset | Command run when a session enters `Starting`. |
+| `on_running` | unset | Command run when a session enters `Running`. |
+| `on_waiting` | unset | Command run when a session enters `Waiting`. |
+| `on_idle` | unset | Command run when a session enters `Idle`. |
+| `on_error` | unset | Command run when a session enters `Error`. |
+| `on_change` | unset | Command run on every status change after the status-specific command. |
+
+Commands run in the session project directory and receive context through environment variables: `AOE_SESSION_ID`, `AOE_SESSION_TITLE`, `AOE_PROJECT_PATH`, `AOE_PROFILE`, `AOE_TOOL`, `AOE_GROUP_PATH`, `AOE_OLD_STATUS`, `AOE_NEW_STATUS`, and `AOE_STATUS_CHANGED_AT`. When both a status-specific hook and `on_change` are configured for the same transition, AoE runs them sequentially in one background worker, with the status-specific command first.
+
+Hook commands are best-effort and non-blocking. Failures are logged at `warn` under `hooks.status_hooks` and never block status updates or sound playback. While you are attached to a tmux session from the TUI, AoE keeps polling eligible sessions so status hook commands still fire during long attaches. Status hooks are configurable in global and profile settings, not repo config, because they run arbitrary local commands.
+
 ### Custom Agents
 
 Custom agents let you name commands for agents that AoE cannot detect as built-in binaries, such as SSH wrappers, local scripts, or remote Claude sessions. Configure them once in `custom_agents`, then select the configured name from the TUI picker, `aoe add --tool <name>`, or the Web session wizard.

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -234,7 +234,9 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
 
         if let Some(state) = preserved_state {
             let hooks = ensure_codex_hooks_table(&mut config)?;
-            hooks.insert("state", state);
+            if !hooks.contains_key("state") {
+                hooks.insert("state", state);
+            }
         }
         remove_codex_aoe_hooks(&mut config)?;
         merge_codex_hooks(&mut config, events)?;
@@ -247,11 +249,13 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
 }
 
 fn with_codex_config_lock<T>(config_path: &Path, f: impl FnOnce() -> Result<T>) -> Result<T> {
-    if let Some(parent) = config_path.parent() {
+    let lock_base_path = codex_config_write_path(config_path)?;
+
+    if let Some(parent) = lock_base_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
 
-    let lock_path = config_path.with_extension("toml.lock");
+    let lock_path = lock_base_path.with_extension("toml.lock");
     let lock_file = std::fs::OpenOptions::new()
         .read(true)
         .write(true)
@@ -1420,6 +1424,8 @@ mod tests {
         let config: toml::Value = toml::from_str(&config_text).unwrap();
         assert!(config["hooks"]["SessionStart"].is_array());
         assert!(config["hooks"]["UserPromptSubmit"].is_array());
+        assert!(target_path.with_extension("toml.lock").exists());
+        assert!(!config_path.with_extension("toml.lock").exists());
     }
 
     #[test]
@@ -1548,6 +1554,44 @@ command = {:?}
             Some("hook-trust")
         );
         assert_eq!(config_text.matches("sh -c").count(), codex_events().len());
+    }
+
+    #[test]
+    fn test_install_codex_hooks_does_not_overwrite_newer_hooks_state() {
+        let tmp = TempDir::new().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        let config_path = codex_dir.join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"[hooks.state.current]
+enabled = true
+trusted_hash = "new"
+"#,
+        )
+        .unwrap();
+
+        let mut stale_state = toml_edit::Table::new();
+        stale_state.insert("enabled", toml_edit::value(true));
+        stale_state.insert("trusted_hash", toml_edit::value("old"));
+        let mut preserved_state = toml_edit::Table::new();
+        preserved_state.insert("stale", toml_edit::Item::Table(stale_state));
+        let preserved_state = toml_edit::Item::Table(preserved_state);
+
+        install_codex_hooks_with_preserved_state(
+            &config_path,
+            codex_events(),
+            Some(preserved_state),
+        )
+        .unwrap();
+
+        let config_text = std::fs::read_to_string(config_path).unwrap();
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        assert_eq!(
+            config["hooks"]["state"]["current"]["trusted_hash"].as_str(),
+            Some("new")
+        );
+        assert!(config["hooks"]["state"].get("stale").is_none());
     }
 
     #[test]

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -12,6 +12,7 @@ mod status_file;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
+use fs2::FileExt as _;
 use serde_json::Value;
 
 pub use status_file::{cleanup_hook_status_dir, hook_status_dir, read_hook_status};
@@ -197,6 +198,10 @@ const CODEX_HOOK_EVENT_NAMES: &[&str] = &[
 ];
 
 /// Install AoE status hooks into Codex's `config.toml`.
+///
+/// Codex also stores hook trust state in this file. Keep every AoE mutation
+/// behind the lock and atomic replace below so repeated launches cannot leave
+/// duplicated hook blocks or torn TOML.
 pub fn install_codex_hooks(config_path: &Path, events: &[crate::agents::HookEvent]) -> Result<()> {
     install_codex_hooks_with_preserved_state(config_path, events, None)
 }
@@ -206,12 +211,14 @@ pub(crate) fn snapshot_codex_hooks_state(config_path: &Path) -> Result<Option<to
         return Ok(None);
     }
 
-    let config = read_codex_config(config_path)?;
-    Ok(config
-        .get("hooks")
-        .and_then(|hooks| hooks.as_table_like())
-        .and_then(|hooks| hooks.get("state"))
-        .cloned())
+    with_codex_config_lock(config_path, || {
+        let config = read_codex_config(config_path)?;
+        Ok(config
+            .get("hooks")
+            .and_then(|hooks| hooks.as_table_like())
+            .and_then(|hooks| hooks.get("state"))
+            .cloned())
+    })
 }
 
 pub(crate) fn install_codex_hooks_with_preserved_state(
@@ -219,25 +226,97 @@ pub(crate) fn install_codex_hooks_with_preserved_state(
     events: &[crate::agents::HookEvent],
     preserved_state: Option<toml_edit::Item>,
 ) -> Result<()> {
-    if codex_hooks_feature_is_disabled(config_path)? {
-        return Ok(());
-    }
+    with_codex_config_lock(config_path, || {
+        let mut config = read_codex_config(config_path)?;
+        if codex_hooks_feature_is_disabled(&config, config_path) {
+            return Ok(());
+        }
 
-    let mut config = read_codex_config(config_path)?;
-    if let Some(state) = preserved_state {
-        let hooks = ensure_codex_hooks_table(&mut config)?;
-        hooks.insert("state", state);
-    }
-    remove_codex_aoe_hooks(&mut config)?;
-    merge_codex_hooks(&mut config, events)?;
-
-    if let Some(parent) = config_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(config_path, config.to_string())?;
+        if let Some(state) = preserved_state {
+            let hooks = ensure_codex_hooks_table(&mut config)?;
+            hooks.insert("state", state);
+        }
+        remove_codex_aoe_hooks(&mut config)?;
+        merge_codex_hooks(&mut config, events)?;
+        write_codex_config(config_path, &config)?;
+        Ok(())
+    })?;
 
     tracing::info!(target: "hooks.install", "Installed AoE hooks in {}", config_path.display());
     Ok(())
+}
+
+fn with_codex_config_lock<T>(config_path: &Path, f: impl FnOnce() -> Result<T>) -> Result<T> {
+    if let Some(parent) = config_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let lock_path = config_path.with_extension("toml.lock");
+    let lock_file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock_path)
+        .with_context(|| format!("Failed to open Codex config lock {}", lock_path.display()))?;
+
+    lock_file
+        .lock_exclusive()
+        .with_context(|| format!("Failed to lock Codex config {}", config_path.display()))?;
+
+    let result = f();
+    let unlock_result = fs2::FileExt::unlock(&lock_file);
+    match (result, unlock_result) {
+        (Ok(value), Ok(())) => Ok(value),
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error)
+            .with_context(|| format!("Failed to unlock Codex config lock {}", lock_path.display())),
+    }
+}
+
+fn write_codex_config(config_path: &Path, config: &toml_edit::DocumentMut) -> Result<()> {
+    let write_path = codex_config_write_path(config_path)?;
+    crate::session::atomic_write(&write_path, config.to_string().as_bytes())
+}
+
+fn codex_config_write_path(config_path: &Path) -> Result<PathBuf> {
+    let mut write_path = config_path.to_path_buf();
+
+    for _ in 0..32 {
+        let metadata = match std::fs::symlink_metadata(&write_path) {
+            Ok(metadata) => metadata,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(write_path),
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!("Failed to inspect Codex config {}", write_path.display())
+                });
+            }
+        };
+
+        if !metadata.file_type().is_symlink() {
+            return Ok(write_path);
+        }
+
+        let target = std::fs::read_link(&write_path).with_context(|| {
+            format!(
+                "Failed to read Codex config symlink {}",
+                write_path.display()
+            )
+        })?;
+        write_path = if target.is_absolute() {
+            target
+        } else {
+            write_path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .join(target)
+        };
+    }
+
+    Err(anyhow::anyhow!(
+        "Codex config symlink chain is too deep: {}",
+        config_path.display()
+    ))
 }
 
 fn read_codex_config(config_path: &Path) -> Result<toml_edit::DocumentMut> {
@@ -442,15 +521,7 @@ fn codex_toml_table_command(table: &dyn toml_edit::TableLike) -> Option<&str> {
     table.get("command").and_then(toml_edit::Item::as_str)
 }
 
-fn codex_hooks_feature_is_disabled(config_path: &Path) -> Result<bool> {
-    if !config_path.exists() {
-        return Ok(false);
-    }
-
-    let content = std::fs::read_to_string(config_path)?;
-    let config = content
-        .parse::<toml_edit::DocumentMut>()
-        .with_context(|| format!("Failed to parse {}", config_path.display()))?;
+fn codex_hooks_feature_is_disabled(config: &toml_edit::DocumentMut, config_path: &Path) -> bool {
     let disabled = config
         .get("features")
         .and_then(|features| {
@@ -469,7 +540,7 @@ fn codex_hooks_feature_is_disabled(config_path: &Path) -> Result<bool> {
         );
     }
 
-    Ok(disabled)
+    disabled
 }
 
 /// Remove AoE status hooks from Codex's `config.toml`.
@@ -478,14 +549,19 @@ pub fn uninstall_codex_hooks(config_path: &Path) -> Result<bool> {
         return Ok(false);
     }
 
-    let mut config = read_codex_config(config_path)?;
-    if !remove_codex_aoe_hooks(&mut config)? {
-        return Ok(false);
-    }
+    let modified = with_codex_config_lock(config_path, || {
+        let mut config = read_codex_config(config_path)?;
+        if !remove_codex_aoe_hooks(&mut config)? {
+            return Ok(false);
+        }
 
-    std::fs::write(config_path, config.to_string())?;
-    tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
-    Ok(true)
+        write_codex_config(config_path, &config)?;
+        Ok(true)
+    })?;
+    if modified {
+        tracing::info!(target: "hooks.uninstall", "Removed AoE hooks from {}", config_path.display());
+    }
+    Ok(modified)
 }
 
 /// Remove all AoE hooks from an agent's `settings.json` file.
@@ -1314,6 +1390,38 @@ mod tests {
         assert!(!codex_dir.join("hooks.json").exists());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_install_codex_hooks_preserves_symlinked_config() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        let dotfiles_dir = tmp.path().join("dotfiles");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        std::fs::create_dir_all(&dotfiles_dir).unwrap();
+
+        let target_path = dotfiles_dir.join("codex-config.toml");
+        std::fs::write(&target_path, "model = \"gpt-5.3-codex\"\n").unwrap();
+        let config_path = codex_dir.join("config.toml");
+        symlink("../dotfiles/codex-config.toml", &config_path).unwrap();
+
+        install_codex_hooks(&config_path, codex_events()).unwrap();
+
+        assert!(
+            std::fs::symlink_metadata(&config_path)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "Codex config path must remain a symlink"
+        );
+        let config_text = std::fs::read_to_string(&target_path).unwrap();
+        assert!(config_text.contains("model = \"gpt-5.3-codex\""));
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        assert!(config["hooks"]["SessionStart"].is_array());
+        assert!(config["hooks"]["UserPromptSubmit"].is_array());
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_codex_config_path_respects_codex_home() {
@@ -1438,6 +1546,133 @@ command = {:?}
         assert_eq!(
             config["hooks"]["state"]["existing"]["trusted_hash"].as_str(),
             Some("hook-trust")
+        );
+        assert_eq!(config_text.matches("sh -c").count(), codex_events().len());
+    }
+
+    #[test]
+    fn test_install_codex_hooks_collapses_duplicated_aoe_blocks() {
+        let tmp = TempDir::new().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        let config_path = codex_dir.join("config.toml");
+        let installed_once = format!(
+            r#"[hooks]
+
+[[hooks.SessionStart]]
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = {:?}
+
+[[hooks.PreToolUse]]
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = {:?}
+
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = {:?}
+
+[[hooks.SessionStart]]
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = {:?}
+
+[[hooks.PreToolUse]]
+
+[[hooks.PreToolUse.hooks]]
+type = "command"
+command = {:?}
+
+[[hooks.Stop]]
+
+[[hooks.Stop.hooks]]
+type = "command"
+command = {:?}
+
+[hooks.state.trusted]
+enabled = true
+trusted_hash = "sha256:keep"
+
+[projects."/tmp/aoe-project"]
+trust_level = "trusted"
+"#,
+            hook_command("idle"),
+            hook_command("running"),
+            hook_command("idle"),
+            hook_command("idle"),
+            hook_command("running"),
+            hook_command("idle")
+        );
+        std::fs::write(&config_path, installed_once).unwrap();
+
+        install_codex_hooks(&config_path, codex_events()).unwrap();
+
+        let config_text = std::fs::read_to_string(config_path).unwrap();
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        for event in codex_events() {
+            assert_eq!(config["hooks"][event.name].as_array().unwrap().len(), 1);
+        }
+        assert_eq!(
+            config["hooks"]["state"]["trusted"]["trusted_hash"].as_str(),
+            Some("sha256:keep")
+        );
+        assert_eq!(
+            config["projects"]["/tmp/aoe-project"]["trust_level"].as_str(),
+            Some("trusted")
+        );
+        assert_eq!(config_text.matches("sh -c").count(), codex_events().len());
+    }
+
+    #[test]
+    fn test_install_codex_hooks_concurrent_rewrites_keep_valid_toml() {
+        let tmp = TempDir::new().unwrap();
+        let codex_dir = tmp.path().join(".codex");
+        std::fs::create_dir_all(&codex_dir).unwrap();
+        let config_path = codex_dir.join("config.toml");
+        std::fs::write(
+            &config_path,
+            r#"model = "gpt-5.3-codex"
+
+[projects."/tmp/aoe-project"]
+trust_level = "trusted"
+"#,
+        )
+        .unwrap();
+
+        let workers = 8;
+        let barrier = std::sync::Arc::new(std::sync::Barrier::new(workers));
+        let mut handles = Vec::new();
+        for _ in 0..workers {
+            let barrier = barrier.clone();
+            let config_path = config_path.clone();
+            handles.push(std::thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..8 {
+                    install_codex_hooks(&config_path, codex_events()).unwrap();
+                    let config_text = std::fs::read_to_string(&config_path).unwrap();
+                    config_text.parse::<toml_edit::DocumentMut>().unwrap();
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let config_text = std::fs::read_to_string(config_path).unwrap();
+        let config: toml::Value = toml::from_str(&config_text).unwrap();
+        for event in codex_events() {
+            assert_eq!(config["hooks"][event.name].as_array().unwrap().len(), 1);
+        }
+        assert_eq!(
+            config["projects"]["/tmp/aoe-project"]["trust_level"].as_str(),
+            Some("trusted")
         );
         assert_eq!(config_text.matches("sh -c").count(), codex_events().len());
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod process;
 pub mod server;
 pub mod session;
 pub mod sound;
+pub mod status_hooks;
 pub mod task_util;
 pub mod terminal;
 pub mod tmux;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod process;
 pub mod server;
 pub mod session;
 pub mod sound;
-pub mod status_hooks;
+mod status_hooks;
 pub mod task_util;
 pub mod terminal;
 pub mod tmux;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -41,6 +41,9 @@ pub struct Config {
     pub sound: crate::sound::SoundConfig,
 
     #[serde(default)]
+    pub status_hooks: crate::status_hooks::StatusHookConfig,
+
+    #[serde(default)]
     pub app_state: AppStateConfig,
 
     #[serde(default)]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -50,6 +50,22 @@ pub enum Status {
     Creating,
 }
 
+impl Status {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Status::Running => "running",
+            Status::Waiting => "waiting",
+            Status::Idle => "idle",
+            Status::Unknown => "unknown",
+            Status::Stopped => "stopped",
+            Status::Error => "error",
+            Status::Starting => "starting",
+            Status::Deleting => "deleting",
+            Status::Creating => "creating",
+        }
+    }
+}
+
 /// Outcome of a `start_with_resume_fallback` cascade.
 ///
 /// Failures (both tiers) propagate as `Err` so callers keep the existing

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -18,6 +18,7 @@ pub(crate) mod serde_helpers;
 mod storage;
 
 pub use crate::sound::{SoundConfig, SoundConfigOverride};
+pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
     get_update_settings, load_config, save_config, Config, ContainerRuntimeName,

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -48,6 +48,9 @@ pub struct ProfileConfig {
     pub sound: Option<crate::sound::SoundConfigOverride>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status_hooks: Option<crate::status_hooks::StatusHookConfigOverride>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cockpit: Option<CockpitConfigOverride>,
 
     /// Per-profile override for the host-side `environment` list. When
@@ -302,6 +305,7 @@ pub fn profile_has_overrides(config: &ProfileConfig) -> bool {
         || config.session.is_some()
         || config.hooks.is_some()
         || config.sound.is_some()
+        || config.status_hooks.is_some()
         || config.cockpit.is_some()
         || config.environment.is_some()
 }
@@ -518,6 +522,13 @@ pub fn merge_configs(mut global: Config, profile: &ProfileConfig) -> Config {
         crate::sound::apply_sound_overrides(&mut global.sound, sound_override);
     }
 
+    if let Some(ref status_hook_override) = profile.status_hooks {
+        crate::status_hooks::apply_status_hook_overrides(
+            &mut global.status_hooks,
+            status_hook_override,
+        );
+    }
+
     if let Some(ref environment) = profile.environment {
         // Replace semantics (matches sandbox.environment override behaviour).
         global.environment = environment.clone();
@@ -695,6 +706,32 @@ mod tests {
         // notify_in_cli should retain global default since not overridden
         assert!(merged.updates.notify_in_cli);
         assert!(merged.worktree.enabled);
+    }
+
+    #[test]
+    fn test_merge_configs_with_status_hook_overrides() {
+        let mut global = Config::default();
+        global.status_hooks.enabled = false;
+        global.status_hooks.on_waiting = Some("global-waiting".to_string());
+        global.status_hooks.debounce_ms = 100;
+
+        let profile = ProfileConfig {
+            status_hooks: Some(crate::status_hooks::StatusHookConfigOverride {
+                enabled: Some(true),
+                debounce_ms: Some(500),
+                on_waiting: Some("profile-waiting".to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert!(merged.status_hooks.enabled);
+        assert_eq!(
+            merged.status_hooks.on_waiting.as_deref(),
+            Some("profile-waiting")
+        );
+        assert_eq!(merged.status_hooks.debounce_ms, 500);
     }
 
     #[test]

--- a/src/status_hooks.rs
+++ b/src/status_hooks.rs
@@ -454,6 +454,17 @@ pub fn reset_debounce_state() {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::time::Instant;
+
+    fn wait_for_recorded_launch_count(expected: usize) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while Instant::now() < deadline {
+            if recorded_launches().lock().unwrap().len() == expected {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
 
     #[test]
     fn default_config_is_disabled() {
@@ -569,7 +580,7 @@ mod tests {
         let observed_after = Utc::now();
         assert!(take_recorded_launches().is_empty());
 
-        std::thread::sleep(Duration::from_millis(30));
+        wait_for_recorded_launch_count(1);
         let launches = take_recorded_launches();
         assert_eq!(launches.len(), 1);
         assert_eq!(launches[0].command, "notify-waiting");
@@ -620,7 +631,7 @@ mod tests {
         run_for_transition(&instance, Status::Running, Status::Waiting, &config);
         run_for_transition(&instance, Status::Waiting, Status::Idle, &config);
 
-        std::thread::sleep(Duration::from_millis(30));
+        wait_for_recorded_launch_count(1);
         let launches = take_recorded_launches();
         assert_eq!(launches.len(), 1);
         assert_eq!(launches[0].command, "notify-idle");

--- a/src/status_hooks.rs
+++ b/src/status_hooks.rs
@@ -343,6 +343,16 @@ fn spawn_hook_commands(commands: Vec<String>, context: StatusHookContext) {
     }
 }
 
+/// Upper bound on how long a single status hook may block its worker
+/// thread. A misconfigured hook (e.g. one that opens a foreground GUI
+/// app, hangs on stdin, or `tail -f`s a log) would otherwise leak the
+/// std::thread spawned in `spawn_hook_commands` for the life of the
+/// TUI. 30s is generous for sound players and notifier CLIs, short
+/// enough that a steady stream of long-stuck hooks doesn't accumulate
+/// indefinitely.
+#[cfg(not(test))]
+const HOOK_COMMAND_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[cfg(not(test))]
 fn run_hook_command_blocking(
     command: &str,
@@ -350,14 +360,34 @@ fn run_hook_command_blocking(
     project_path: &Path,
 ) -> std::io::Result<()> {
     let mut child = build_command(command, context, project_path).spawn()?;
-    let status = child.wait()?;
-    if status.success() {
-        Ok(())
-    } else {
-        Err(std::io::Error::other(format!(
-            "command exited with status {:?}",
-            status.code()
-        )))
+    let deadline = std::time::Instant::now() + HOOK_COMMAND_TIMEOUT;
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                return if status.success() {
+                    Ok(())
+                } else {
+                    Err(std::io::Error::other(format!(
+                        "command exited with status {:?}",
+                        status.code()
+                    )))
+                };
+            }
+            None => {
+                if std::time::Instant::now() >= deadline {
+                    // Best-effort kill; if the child has already exited
+                    // between the try_wait above and here, kill is a
+                    // no-op error we don't care about.
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(std::io::Error::other(format!(
+                        "command timed out after {}s",
+                        HOOK_COMMAND_TIMEOUT.as_secs()
+                    )));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+        }
     }
 }
 

--- a/src/status_hooks.rs
+++ b/src/status_hooks.rs
@@ -1,0 +1,619 @@
+//! Local command hooks for session status transitions.
+
+use std::collections::HashMap;
+#[cfg(not(test))]
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::session::{Instance, Status};
+
+const DEFAULT_DEBOUNCE_MS: u64 = 100;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatusHookConfig {
+    #[serde(default)]
+    pub enabled: bool,
+
+    #[serde(
+        default = "default_debounce_ms",
+        skip_serializing_if = "is_default_debounce_ms"
+    )]
+    pub debounce_ms: u64,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_starting: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_running: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_waiting: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_idle: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_error: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_change: Option<String>,
+}
+
+impl Default for StatusHookConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            debounce_ms: DEFAULT_DEBOUNCE_MS,
+            on_starting: None,
+            on_running: None,
+            on_waiting: None,
+            on_idle: None,
+            on_error: None,
+            on_change: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct StatusHookConfigOverride {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub enabled: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub debounce_ms: Option<u64>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_starting: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_running: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_waiting: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_idle: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_error: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_change: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusHookContext {
+    pub session_id: String,
+    pub session_title: String,
+    pub project_path: String,
+    pub profile: String,
+    pub tool: String,
+    pub group_path: String,
+    pub old_status: Status,
+    pub new_status: Status,
+    pub changed_at: DateTime<Utc>,
+}
+
+impl StatusHookContext {
+    pub fn from_instance(
+        instance: &Instance,
+        old_status: Status,
+        new_status: Status,
+        changed_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            session_id: instance.id.clone(),
+            session_title: instance.title.clone(),
+            project_path: instance.project_path.clone(),
+            profile: instance.effective_profile(),
+            tool: instance.tool.clone(),
+            group_path: instance.group_path.clone(),
+            old_status,
+            new_status,
+            changed_at,
+        }
+    }
+
+    pub fn env_vars(&self) -> [(&'static str, String); 9] {
+        [
+            ("AOE_SESSION_ID", self.session_id.clone()),
+            ("AOE_SESSION_TITLE", self.session_title.clone()),
+            ("AOE_PROJECT_PATH", self.project_path.clone()),
+            ("AOE_PROFILE", self.profile.clone()),
+            ("AOE_TOOL", self.tool.clone()),
+            ("AOE_GROUP_PATH", self.group_path.clone()),
+            ("AOE_OLD_STATUS", self.old_status.as_str().to_string()),
+            ("AOE_NEW_STATUS", self.new_status.as_str().to_string()),
+            ("AOE_STATUS_CHANGED_AT", self.changed_at.to_rfc3339()),
+        ]
+    }
+}
+
+pub fn apply_status_hook_overrides(
+    target: &mut StatusHookConfig,
+    source: &StatusHookConfigOverride,
+) {
+    if let Some(enabled) = source.enabled {
+        target.enabled = enabled;
+    }
+    if let Some(debounce_ms) = source.debounce_ms {
+        target.debounce_ms = debounce_ms;
+    }
+    if source.on_starting.is_some() {
+        target.on_starting = source.on_starting.clone();
+    }
+    if source.on_running.is_some() {
+        target.on_running = source.on_running.clone();
+    }
+    if source.on_waiting.is_some() {
+        target.on_waiting = source.on_waiting.clone();
+    }
+    if source.on_idle.is_some() {
+        target.on_idle = source.on_idle.clone();
+    }
+    if source.on_error.is_some() {
+        target.on_error = source.on_error.clone();
+    }
+    if source.on_change.is_some() {
+        target.on_change = source.on_change.clone();
+    }
+}
+
+pub fn commands_for_transition(old: Status, new: Status, config: &StatusHookConfig) -> Vec<String> {
+    if !config.enabled || old == new {
+        return Vec::new();
+    }
+
+    let mut commands = Vec::new();
+    let specific = match new {
+        Status::Starting => config.on_starting.as_deref(),
+        Status::Running => config.on_running.as_deref(),
+        Status::Waiting => config.on_waiting.as_deref(),
+        Status::Idle => config.on_idle.as_deref(),
+        Status::Error => config.on_error.as_deref(),
+        Status::Unknown | Status::Stopped | Status::Deleting | Status::Creating => None,
+    };
+    if let Some(cmd) = non_empty_command(specific) {
+        commands.push(cmd.to_string());
+    }
+    if let Some(cmd) = non_empty_command(config.on_change.as_deref()) {
+        commands.push(cmd.to_string());
+    }
+    commands
+}
+
+pub fn has_configured_commands(config: &StatusHookConfig) -> bool {
+    config.enabled
+        && [
+            config.on_starting.as_deref(),
+            config.on_running.as_deref(),
+            config.on_waiting.as_deref(),
+            config.on_idle.as_deref(),
+            config.on_error.as_deref(),
+            config.on_change.as_deref(),
+        ]
+        .into_iter()
+        .any(|cmd| non_empty_command(cmd).is_some())
+}
+
+pub fn run_for_transition(
+    instance: &Instance,
+    old: Status,
+    new: Status,
+    config: &StatusHookConfig,
+) {
+    if !config.enabled || old == new {
+        return;
+    }
+
+    let commands = commands_for_transition(old, new, config);
+    if config.debounce_ms > 0 {
+        run_debounced_transition(instance, old, new, commands, config.debounce_ms);
+        return;
+    }
+
+    if commands.is_empty() {
+        return;
+    }
+    spawn_transition_commands(instance, old, new, commands);
+}
+
+fn non_empty_command(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|s| !s.is_empty())
+}
+
+fn default_debounce_ms() -> u64 {
+    DEFAULT_DEBOUNCE_MS
+}
+
+fn is_default_debounce_ms(value: &u64) -> bool {
+    *value == DEFAULT_DEBOUNCE_MS
+}
+
+fn spawn_transition_commands(instance: &Instance, old: Status, new: Status, commands: Vec<String>) {
+    let context = StatusHookContext::from_instance(instance, old, new, Utc::now());
+    // Keep one transition's commands in one worker so `on_change` cannot race
+    // ahead of the status-specific hook.
+    spawn_hook_commands(commands, context);
+}
+
+#[derive(Debug, Clone)]
+struct DebounceEntry {
+    stable_status: Status,
+    generation: u64,
+    pending_status: Option<Status>,
+}
+
+fn debounce_state() -> &'static Mutex<HashMap<String, DebounceEntry>> {
+    static STATE: OnceLock<Mutex<HashMap<String, DebounceEntry>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn run_debounced_transition(
+    instance: &Instance,
+    old: Status,
+    new: Status,
+    commands: Vec<String>,
+    debounce_ms: u64,
+) {
+    let session_id = instance.id.clone();
+    let mut state = debounce_state().lock().unwrap();
+    let entry = state.entry(session_id.clone()).or_insert(DebounceEntry {
+        stable_status: old,
+        generation: 0,
+        pending_status: None,
+    });
+    entry.generation = entry.generation.wrapping_add(1);
+    let generation = entry.generation;
+    let stable_status = entry.stable_status;
+
+    if new == stable_status {
+        entry.pending_status = None;
+        return;
+    }
+
+    if commands.is_empty() {
+        entry.stable_status = new;
+        entry.pending_status = None;
+        return;
+    }
+
+    entry.pending_status = Some(new);
+    drop(state);
+
+    let instance = instance.clone();
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(debounce_ms));
+        let mut state = debounce_state().lock().unwrap();
+        let should_run = match state.get_mut(&session_id) {
+            Some(entry) if entry.generation == generation && entry.pending_status == Some(new) => {
+                entry.stable_status = new;
+                entry.pending_status = None;
+                true
+            }
+            _ => false,
+        };
+        drop(state);
+
+        if should_run {
+            spawn_transition_commands(&instance, stable_status, new, commands);
+        }
+    });
+}
+
+#[cfg(not(test))]
+fn spawn_hook_commands(commands: Vec<String>, context: StatusHookContext) {
+    std::thread::spawn(move || {
+        let project_path = PathBuf::from(&context.project_path);
+        for command in commands {
+            let result = run_hook_command_blocking(&command, &context, &project_path);
+            if let Err(e) = result {
+                tracing::warn!(
+                    target: "hooks.status_hooks",
+                    session_id = %context.session_id,
+                    new_status = %context.new_status.as_str(),
+                    "status hook failed: {}",
+                    e
+                );
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+fn spawn_hook_commands(commands: Vec<String>, context: StatusHookContext) {
+    let mut launches = recorded_launches().lock().unwrap();
+    for command in commands {
+        launches.push(RecordedLaunch {
+            command,
+            context: context.clone(),
+        });
+    }
+}
+
+#[cfg(not(test))]
+fn run_hook_command_blocking(
+    command: &str,
+    context: &StatusHookContext,
+    project_path: &Path,
+) -> std::io::Result<()> {
+    let mut child = build_command(command, context, project_path).spawn()?;
+    let status = child.wait()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(std::io::Error::other(format!(
+            "command exited with status {:?}",
+            status.code()
+        )))
+    }
+}
+
+#[cfg(not(test))]
+fn build_command(
+    command: &str,
+    context: &StatusHookContext,
+    project_path: &Path,
+) -> std::process::Command {
+    let mut child = std::process::Command::new(crate::session::user_shell());
+    child
+        .arg("-c")
+        .arg(command)
+        .current_dir(project_path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ASKPASS", "true")
+        .env("SSH_ASKPASS", "true");
+    for (key, value) in context.env_vars() {
+        child.env(key, value);
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            child.pre_exec(|| {
+                nix::unistd::setsid().map_err(std::io::Error::other)?;
+                Ok(())
+            });
+        }
+    }
+
+    child
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RecordedLaunch {
+    pub command: String,
+    pub context: StatusHookContext,
+}
+
+#[cfg(test)]
+fn recorded_launches() -> &'static std::sync::Mutex<Vec<RecordedLaunch>> {
+    static LAUNCHES: std::sync::OnceLock<std::sync::Mutex<Vec<RecordedLaunch>>> =
+        std::sync::OnceLock::new();
+    LAUNCHES.get_or_init(|| std::sync::Mutex::new(Vec::new()))
+}
+
+#[cfg(test)]
+pub fn take_recorded_launches() -> Vec<RecordedLaunch> {
+    std::mem::take(&mut *recorded_launches().lock().unwrap())
+}
+
+#[cfg(test)]
+pub fn reset_debounce_state() {
+    debounce_state().lock().unwrap().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn default_config_is_disabled() {
+        let config = StatusHookConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.debounce_ms, DEFAULT_DEBOUNCE_MS);
+        assert!(commands_for_transition(Status::Running, Status::Waiting, &config).is_empty());
+    }
+
+    #[test]
+    fn deserializes_toml_config() {
+        let config: StatusHookConfig = toml::from_str(
+            r#"
+            enabled = true
+            on_waiting = "notify-send waiting"
+            on_change = "~/bin/aoe-hook"
+            "#,
+        )
+        .unwrap();
+        assert!(config.enabled);
+        assert_eq!(config.debounce_ms, DEFAULT_DEBOUNCE_MS);
+        assert_eq!(config.on_waiting.as_deref(), Some("notify-send waiting"));
+        assert_eq!(config.on_change.as_deref(), Some("~/bin/aoe-hook"));
+    }
+
+    #[test]
+    fn deserializes_debounce_ms() {
+        let config: StatusHookConfig = toml::from_str(
+            r#"
+            enabled = true
+            debounce_ms = 500
+            on_waiting = "notify-send waiting"
+            "#,
+        )
+        .unwrap();
+        assert_eq!(config.debounce_ms, 500);
+    }
+
+    #[test]
+    fn resolves_specific_command_before_catch_all() {
+        let config = StatusHookConfig {
+            enabled: true,
+            on_waiting: Some("waiting-command".to_string()),
+            on_change: Some("change-command".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(
+            commands_for_transition(Status::Running, Status::Waiting, &config),
+            vec!["waiting-command".to_string(), "change-command".to_string()]
+        );
+    }
+
+    #[test]
+    fn skips_empty_commands_and_same_status() {
+        let config = StatusHookConfig {
+            enabled: true,
+            on_waiting: Some("  ".to_string()),
+            on_change: Some("change-command".to_string()),
+            ..Default::default()
+        };
+        assert!(commands_for_transition(Status::Waiting, Status::Waiting, &config).is_empty());
+        assert_eq!(
+            commands_for_transition(Status::Running, Status::Waiting, &config),
+            vec!["change-command".to_string()]
+        );
+    }
+
+    #[test]
+    fn applies_profile_overrides() {
+        let mut config = StatusHookConfig {
+            enabled: true,
+            on_waiting: Some("global".to_string()),
+            ..Default::default()
+        };
+        let override_config = StatusHookConfigOverride {
+            enabled: Some(false),
+            on_waiting: Some("profile".to_string()),
+            ..Default::default()
+        };
+        apply_status_hook_overrides(&mut config, &override_config);
+        assert!(!config.enabled);
+        assert_eq!(config.on_waiting.as_deref(), Some("profile"));
+    }
+
+    #[test]
+    fn applies_debounce_profile_override() {
+        let mut config = StatusHookConfig::default();
+        let override_config = StatusHookConfigOverride {
+            debounce_ms: Some(500),
+            ..Default::default()
+        };
+        apply_status_hook_overrides(&mut config, &override_config);
+        assert_eq!(config.debounce_ms, 500);
+    }
+
+    #[test]
+    #[serial]
+    fn debounces_stable_transition() {
+        reset_debounce_state();
+        take_recorded_launches();
+
+        let mut instance = Instance::new("Debounce Stable", "/tmp/project");
+        instance.id = "debounce-stable".to_string();
+        let config = StatusHookConfig {
+            enabled: true,
+            debounce_ms: 10,
+            on_waiting: Some("notify-waiting".to_string()),
+            ..Default::default()
+        };
+
+        run_for_transition(&instance, Status::Running, Status::Waiting, &config);
+        assert!(take_recorded_launches().is_empty());
+
+        std::thread::sleep(Duration::from_millis(30));
+        let launches = take_recorded_launches();
+        assert_eq!(launches.len(), 1);
+        assert_eq!(launches[0].command, "notify-waiting");
+        assert_eq!(launches[0].context.old_status, Status::Running);
+        assert_eq!(launches[0].context.new_status, Status::Waiting);
+    }
+
+    #[test]
+    #[serial]
+    fn debounce_cancels_flicker_back_to_stable_status() {
+        reset_debounce_state();
+        take_recorded_launches();
+
+        let mut instance = Instance::new("Debounce Flicker", "/tmp/project");
+        instance.id = "debounce-flicker".to_string();
+        let config = StatusHookConfig {
+            enabled: true,
+            debounce_ms: 10,
+            on_waiting: Some("notify-waiting".to_string()),
+            ..Default::default()
+        };
+
+        run_for_transition(&instance, Status::Running, Status::Waiting, &config);
+        run_for_transition(&instance, Status::Waiting, Status::Running, &config);
+
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(take_recorded_launches().is_empty());
+    }
+
+    #[test]
+    #[serial]
+    fn debounce_coalesces_to_latest_pending_status() {
+        reset_debounce_state();
+        take_recorded_launches();
+
+        let mut instance = Instance::new("Debounce Latest", "/tmp/project");
+        instance.id = "debounce-latest".to_string();
+        let config = StatusHookConfig {
+            enabled: true,
+            debounce_ms: 10,
+            on_waiting: Some("notify-waiting".to_string()),
+            on_idle: Some("notify-idle".to_string()),
+            ..Default::default()
+        };
+
+        run_for_transition(&instance, Status::Running, Status::Waiting, &config);
+        run_for_transition(&instance, Status::Waiting, Status::Idle, &config);
+
+        std::thread::sleep(Duration::from_millis(30));
+        let launches = take_recorded_launches();
+        assert_eq!(launches.len(), 1);
+        assert_eq!(launches[0].command, "notify-idle");
+        assert_eq!(launches[0].context.old_status, Status::Running);
+        assert_eq!(launches[0].context.new_status, Status::Idle);
+    }
+
+    #[test]
+    fn builds_context_env_vars() {
+        let mut instance = Instance::new("Build API", "/tmp/project");
+        instance.id = "abc123".to_string();
+        instance.tool = "codex".to_string();
+        instance.group_path = "Backend".to_string();
+        instance.source_profile = "work".to_string();
+        let changed_at = DateTime::parse_from_rfc3339("2026-05-20T10:11:12Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let context = StatusHookContext::from_instance(
+            &instance,
+            Status::Running,
+            Status::Waiting,
+            changed_at,
+        );
+        let env = context.env_vars();
+        assert!(env.contains(&("AOE_SESSION_ID", "abc123".to_string())));
+        assert!(env.contains(&("AOE_SESSION_TITLE", "Build API".to_string())));
+        assert!(env.contains(&("AOE_PROJECT_PATH", "/tmp/project".to_string())));
+        assert!(env.contains(&("AOE_PROFILE", "work".to_string())));
+        assert!(env.contains(&("AOE_TOOL", "codex".to_string())));
+        assert!(env.contains(&("AOE_GROUP_PATH", "Backend".to_string())));
+        assert!(env.contains(&("AOE_OLD_STATUS", "running".to_string())));
+        assert!(env.contains(&("AOE_NEW_STATUS", "waiting".to_string())));
+        assert!(env.contains(&(
+            "AOE_STATUS_CHANGED_AT",
+            "2026-05-20T10:11:12+00:00".to_string()
+        )));
+    }
+}

--- a/src/status_hooks.rs
+++ b/src/status_hooks.rs
@@ -210,16 +210,17 @@ pub fn run_for_transition(
         return;
     }
 
+    let changed_at = Utc::now();
     let commands = commands_for_transition(old, new, config);
     if config.debounce_ms > 0 {
-        run_debounced_transition(instance, old, new, commands, config.debounce_ms);
+        run_debounced_transition(instance, old, new, changed_at, commands, config.debounce_ms);
         return;
     }
 
     if commands.is_empty() {
         return;
     }
-    spawn_transition_commands(instance, old, new, commands);
+    spawn_transition_commands(instance, old, new, changed_at, commands);
 }
 
 fn non_empty_command(value: Option<&str>) -> Option<&str> {
@@ -234,8 +235,14 @@ fn is_default_debounce_ms(value: &u64) -> bool {
     *value == DEFAULT_DEBOUNCE_MS
 }
 
-fn spawn_transition_commands(instance: &Instance, old: Status, new: Status, commands: Vec<String>) {
-    let context = StatusHookContext::from_instance(instance, old, new, Utc::now());
+fn spawn_transition_commands(
+    instance: &Instance,
+    old: Status,
+    new: Status,
+    changed_at: DateTime<Utc>,
+    commands: Vec<String>,
+) {
+    let context = StatusHookContext::from_instance(instance, old, new, changed_at);
     // Keep one transition's commands in one worker so `on_change` cannot race
     // ahead of the status-specific hook.
     spawn_hook_commands(commands, context);
@@ -257,6 +264,7 @@ fn run_debounced_transition(
     instance: &Instance,
     old: Status,
     new: Status,
+    changed_at: DateTime<Utc>,
     commands: Vec<String>,
     debounce_ms: u64,
 ) {
@@ -300,7 +308,7 @@ fn run_debounced_transition(
         drop(state);
 
         if should_run {
-            spawn_transition_commands(&instance, stable_status, new, commands);
+            spawn_transition_commands(&instance, stable_status, new, changed_at, commands);
         }
     });
 }
@@ -526,7 +534,9 @@ mod tests {
             ..Default::default()
         };
 
+        let observed_before = Utc::now();
         run_for_transition(&instance, Status::Running, Status::Waiting, &config);
+        let observed_after = Utc::now();
         assert!(take_recorded_launches().is_empty());
 
         std::thread::sleep(Duration::from_millis(30));
@@ -535,6 +545,8 @@ mod tests {
         assert_eq!(launches[0].command, "notify-waiting");
         assert_eq!(launches[0].context.old_status, Status::Running);
         assert_eq!(launches[0].context.new_status, Status::Waiting);
+        assert!(launches[0].context.changed_at >= observed_before);
+        assert!(launches[0].context.changed_at <= observed_after);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -10,7 +10,9 @@ use ratatui::prelude::*;
 use std::path::PathBuf;
 use std::time::Duration;
 
+use super::attached_status_hooks::AttachedStatusHookWatcher;
 use super::home::{HomeView, TerminalMode};
+use super::status_poller::StatusUpdate;
 use super::styles::Theme;
 use crate::session::{get_update_settings, load_config, save_config, Config};
 use crate::tmux::AvailableTools;
@@ -304,6 +306,26 @@ impl App {
         terminal.clear()?;
 
         Ok(result)
+    }
+
+    fn with_attached_status_hooks<F, R>(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+        f: F,
+    ) -> Result<(R, Vec<StatusUpdate>)>
+    where
+        F: FnOnce() -> R,
+    {
+        let watcher = AttachedStatusHookWatcher::start(self.home.attached_status_hook_sessions());
+        let result = self.with_raw_mode_disabled(terminal, f);
+        let mut attached_status_updates = Vec::new();
+
+        if let Some(watcher) = watcher {
+            attached_status_updates = watcher.stop();
+            self.home.reset_status_refresh();
+        }
+
+        result.map(|result| (result, attached_status_updates))
     }
 
     pub fn show_startup_warning(&mut self, message: &str) {
@@ -1209,11 +1231,14 @@ impl App {
             Some(inst) => inst.tmux_session()?,
             None => return Ok(()),
         };
-        let attach_result = self.with_raw_mode_disabled(terminal, || tmux_session.attach())?;
+        let (attach_result, attached_status_updates) =
+            self.with_attached_status_hooks(terminal, || tmux_session.attach())?;
 
         self.needs_redraw = true;
         crate::tmux::refresh_session_cache();
         self.home.reload()?;
+        self.home
+            .apply_status_updates_without_hooks(attached_status_updates);
         self.home.stamp_last_accessed(session_id);
         self.home.select_session_by_id(session_id);
 
@@ -1276,11 +1301,14 @@ impl App {
             }
         };
 
-        let attach_result = self.with_raw_mode_disabled(terminal, attach_fn)?;
+        let (attach_result, attached_status_updates) =
+            self.with_attached_status_hooks(terminal, attach_fn)?;
 
         self.needs_redraw = true;
         crate::tmux::refresh_session_cache();
         self.home.reload()?;
+        self.home
+            .apply_status_updates_without_hooks(attached_status_updates);
         self.home.select_session_by_id(session_id);
 
         if let Err(e) = attach_result {
@@ -1343,11 +1371,14 @@ impl App {
         );
 
         let attach_fn: Box<dyn FnOnce() -> Result<()>> = Box::new(move || tool_session.attach());
-        let attach_result = self.with_raw_mode_disabled(terminal, attach_fn)?;
+        let (attach_result, attached_status_updates) =
+            self.with_attached_status_hooks(terminal, attach_fn)?;
 
         self.needs_redraw = true;
         crate::tmux::refresh_session_cache();
         self.home.reload()?;
+        self.home
+            .apply_status_updates_without_hooks(attached_status_updates);
         self.home.select_session_by_id(session_id);
 
         if let Err(e) = attach_result {

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -322,8 +322,8 @@ impl App {
 
         if let Some(watcher) = watcher {
             attached_status_updates = watcher.stop();
-            self.home.reset_status_refresh();
         }
+        self.home.reset_status_refresh();
 
         result.map(|result| (result, attached_status_updates))
     }

--- a/src/tui/attached_status_hooks.rs
+++ b/src/tui/attached_status_hooks.rs
@@ -1,0 +1,191 @@
+//! Status hook polling while the TUI is blocked inside tmux attach.
+
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+use crate::session::{Instance, Status};
+use crate::status_hooks::StatusHookConfig;
+
+use super::status_poller::{poll_statuses_once, StatusPollState, StatusUpdate};
+
+const REFRESH_INTERVAL: Duration = Duration::from_millis(500);
+
+pub(super) struct AttachedStatusHookSession {
+    pub(super) instance: Instance,
+    pub(super) hook_config: StatusHookConfig,
+}
+
+pub(super) struct AttachedStatusHookWatcher {
+    stop_tx: mpsc::Sender<()>,
+    snapshot_rx: mpsc::Receiver<Vec<StatusUpdate>>,
+    handle: Option<thread::JoinHandle<()>>,
+}
+
+impl AttachedStatusHookWatcher {
+    pub(super) fn start(mut sessions: Vec<AttachedStatusHookSession>) -> Option<Self> {
+        sessions
+            .retain(|session| crate::status_hooks::has_configured_commands(&session.hook_config));
+        if sessions.is_empty() {
+            return None;
+        }
+
+        let (stop_tx, stop_rx) = mpsc::channel();
+        let (snapshot_tx, snapshot_rx) = mpsc::channel();
+        let handle = match thread::Builder::new()
+            .name("aoe-attached-status-hooks".to_string())
+            .spawn(move || run_loop(sessions, stop_rx, snapshot_tx))
+        {
+            Ok(handle) => handle,
+            Err(e) => {
+                tracing::warn!(
+                    target: "hooks.status_hooks",
+                    "failed to start attached status hook watcher: {}",
+                    e
+                );
+                return None;
+            }
+        };
+
+        Some(Self {
+            stop_tx,
+            snapshot_rx,
+            handle: Some(handle),
+        })
+    }
+
+    pub(super) fn stop(mut self) -> Vec<StatusUpdate> {
+        let _ = self.stop_tx.send(());
+        if let Some(handle) = self.handle.take() {
+            if let Err(e) = handle.join() {
+                tracing::warn!(
+                    target: "hooks.status_hooks",
+                    "attached status hook watcher panicked: {:?}",
+                    e
+                );
+            }
+        }
+
+        let mut latest = Vec::new();
+        while let Ok(snapshot) = self.snapshot_rx.try_recv() {
+            latest = snapshot;
+        }
+        latest
+    }
+}
+
+fn run_loop(
+    mut sessions: Vec<AttachedStatusHookSession>,
+    stop_rx: mpsc::Receiver<()>,
+    snapshot_tx: mpsc::Sender<Vec<StatusUpdate>>,
+) {
+    let mut state = StatusPollState::new();
+
+    loop {
+        if stop_rx.try_recv().is_ok() {
+            break;
+        }
+
+        let instances = sessions
+            .iter()
+            .map(|session| session.instance.clone())
+            .collect();
+        let updates = poll_statuses_once(instances, &mut state);
+        apply_updates(&mut sessions, updates, true);
+
+        if stop_rx.recv_timeout(REFRESH_INTERVAL).is_ok() {
+            break;
+        }
+    }
+
+    let _ = snapshot_tx.send(snapshot(&sessions));
+}
+
+fn apply_updates(
+    sessions: &mut [AttachedStatusHookSession],
+    updates: Vec<StatusUpdate>,
+    run_hooks: bool,
+) {
+    for update in updates {
+        let Some(session) = sessions
+            .iter_mut()
+            .find(|session| session.instance.id == update.id)
+        else {
+            continue;
+        };
+
+        let old = session.instance.status;
+        if matches!(old, Status::Deleting | Status::Creating | Status::Stopped)
+            || update.status == Status::Stopped
+        {
+            continue;
+        }
+
+        session.instance.status = update.status;
+        session.instance.last_error = update.last_error;
+        session.instance.idle_entered_at = update.idle_entered_at;
+
+        if run_hooks && old != update.status {
+            crate::status_hooks::run_for_transition(
+                &session.instance,
+                old,
+                update.status,
+                &session.hook_config,
+            );
+        }
+    }
+}
+
+fn snapshot(sessions: &[AttachedStatusHookSession]) -> Vec<StatusUpdate> {
+    sessions
+        .iter()
+        .map(|session| StatusUpdate {
+            id: session.instance.id.clone(),
+            status: session.instance.status,
+            last_error: session.instance.last_error.clone(),
+            idle_entered_at: session.instance.idle_entered_at,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::status_hooks::{take_recorded_launches, StatusHookConfig};
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn apply_updates_runs_status_hook_for_transition() {
+        let instance = Instance::new("Hook Target", "/tmp/hook-target");
+        let id = instance.id.clone();
+        let mut sessions = vec![AttachedStatusHookSession {
+            instance,
+            hook_config: StatusHookConfig {
+                enabled: true,
+                debounce_ms: 0,
+                on_waiting: Some("notify-waiting".to_string()),
+                ..Default::default()
+            },
+        }];
+        take_recorded_launches();
+
+        apply_updates(
+            &mut sessions,
+            vec![StatusUpdate {
+                id: id.clone(),
+                status: Status::Waiting,
+                last_error: None,
+                idle_entered_at: None,
+            }],
+            true,
+        );
+
+        let launches = take_recorded_launches();
+        assert_eq!(launches.len(), 1);
+        assert_eq!(launches[0].command, "notify-waiting");
+        assert_eq!(launches[0].context.session_id, id);
+        assert_eq!(launches[0].context.old_status, Status::Idle);
+        assert_eq!(launches[0].context.new_status, Status::Waiting);
+    }
+}

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -767,7 +767,7 @@ impl HomeView {
 
     pub(super) fn apply_status_updates_without_hooks(&mut self, updates: Vec<StatusUpdate>) {
         for update in updates {
-            self.apply_status_update(update, true, false);
+            self.apply_status_update(update, false, false);
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -253,6 +253,7 @@ pub struct HomeView {
     // Sound config for state transition sounds
     pub(super) sound_config: crate::sound::SoundConfig,
     pub(super) status_hook_config: crate::status_hooks::StatusHookConfig,
+    pub(super) status_hook_configs: HashMap<String, crate::status_hooks::StatusHookConfig>,
 
     /// Resolved decay window from `Config.theme.idle_decay_minutes`. Read
     /// at startup and re-resolved on settings reload. Used by render to
@@ -349,7 +350,14 @@ impl HomeView {
             DefaultTerminalMode::Container => TerminalMode::Container,
         };
         let sound_config = resolved.sound.clone();
-        let status_hook_config = resolved.status_hooks.clone();
+        let status_hook_configs = Self::load_status_hook_configs(Self::status_hook_profile_names(
+            active_profile.as_deref(),
+            &storages,
+        ));
+        let status_hook_config = status_hook_configs
+            .get(config_profile)
+            .cloned()
+            .unwrap_or_else(|| resolved.status_hooks.clone());
         let strict_hotkeys = resolved.session.strict_hotkeys;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
@@ -441,6 +449,7 @@ impl HomeView {
             default_terminal_mode,
             sound_config,
             status_hook_config,
+            status_hook_configs,
             strict_hotkeys,
             idle_decay_window,
             settings_view: None,
@@ -583,6 +592,7 @@ impl HomeView {
             }
             self.storages.retain(|k, _| current_profiles.contains(k));
         }
+        self.refresh_status_hook_config_cache();
 
         for (profile_name, storage) in &self.storages {
             let (mut instances, groups) = storage.load_with_groups()?;
@@ -822,7 +832,11 @@ impl HomeView {
         if self.active_profile.is_some() {
             return self.status_hook_config.clone();
         }
-        crate::session::resolve_config_or_warn(&inst.effective_profile()).status_hooks
+        let profile = inst.effective_profile();
+        self.status_hook_configs
+            .get(&profile)
+            .cloned()
+            .unwrap_or_else(|| self.status_hook_config.clone())
     }
 
     pub fn apply_deletion_results(&mut self) -> bool {
@@ -2152,6 +2166,7 @@ impl HomeView {
         };
         self.sound_config = config.sound.clone();
         self.status_hook_config = config.status_hooks.clone();
+        self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
@@ -2163,6 +2178,44 @@ impl HomeView {
                 "Tool hotkey config errors",
                 &hotkey_warnings.join("\n"),
             ));
+        }
+    }
+
+    fn status_hook_profile_names(
+        active_profile: Option<&str>,
+        storages: &HashMap<String, Storage>,
+    ) -> Vec<String> {
+        let mut profile_names = match active_profile {
+            Some(profile) => vec![profile.to_string()],
+            None => storages.keys().cloned().collect(),
+        };
+        if !profile_names.iter().any(|profile| profile == "default") {
+            profile_names.push("default".to_string());
+        }
+        profile_names.sort();
+        profile_names.dedup();
+        profile_names
+    }
+
+    fn load_status_hook_configs(
+        profile_names: Vec<String>,
+    ) -> HashMap<String, crate::status_hooks::StatusHookConfig> {
+        profile_names
+            .into_iter()
+            .map(|profile| {
+                let status_hooks = resolve_config_or_warn(&profile).status_hooks;
+                (profile, status_hooks)
+            })
+            .collect()
+    }
+
+    fn refresh_status_hook_config_cache(&mut self) {
+        let profile_names =
+            Self::status_hook_profile_names(self.active_profile.as_deref(), &self.storages);
+        self.status_hook_configs = Self::load_status_hook_configs(profile_names);
+        let profile = self.active_profile.as_deref().unwrap_or("default");
+        if let Some(status_hooks) = self.status_hook_configs.get(profile) {
+            self.status_hook_config = status_hooks.clone();
         }
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -252,6 +252,7 @@ pub struct HomeView {
 
     // Sound config for state transition sounds
     pub(super) sound_config: crate::sound::SoundConfig,
+    pub(super) status_hook_config: crate::status_hooks::StatusHookConfig,
 
     /// Resolved decay window from `Config.theme.idle_decay_minutes`. Read
     /// at startup and re-resolved on settings reload. Used by render to
@@ -348,6 +349,7 @@ impl HomeView {
             DefaultTerminalMode::Container => TerminalMode::Container,
         };
         let sound_config = resolved.sound.clone();
+        let status_hook_config = resolved.status_hooks.clone();
         let strict_hotkeys = resolved.session.strict_hotkeys;
         let idle_decay_window =
             crate::tui::styles::idle_decay_window(resolved.theme.idle_decay_minutes);
@@ -438,6 +440,7 @@ impl HomeView {
             terminal_modes: HashMap::new(),
             default_terminal_mode,
             sound_config,
+            status_hook_config,
             strict_hotkeys,
             idle_decay_window,
             settings_view: None,
@@ -704,6 +707,23 @@ impl HomeView {
             .collect()
     }
 
+    pub(super) fn attached_status_hook_sessions(
+        &self,
+    ) -> Vec<super::attached_status_hooks::AttachedStatusHookSession> {
+        self.pollable_instances()
+            .into_iter()
+            .filter_map(|instance| {
+                let hook_config = self.status_hook_config_for(&instance);
+                hook_config.enabled.then_some(
+                    super::attached_status_hooks::AttachedStatusHookSession {
+                        instance,
+                        hook_config,
+                    },
+                )
+            })
+            .collect()
+    }
+
     /// Request a status refresh in the background (non-blocking).
     /// Call `apply_status_updates` to check for and apply results.
     pub fn request_status_refresh(&mut self) {
@@ -732,6 +752,21 @@ impl HomeView {
     /// the apply path directly without having to push through the
     /// background polling thread.
     pub(super) fn apply_one_status_update(&mut self, update: StatusUpdate) {
+        self.apply_status_update(update, true, true);
+    }
+
+    pub(super) fn apply_status_updates_without_hooks(&mut self, updates: Vec<StatusUpdate>) {
+        for update in updates {
+            self.apply_status_update(update, true, false);
+        }
+    }
+
+    pub(super) fn reset_status_refresh(&mut self) {
+        self.status_poller = StatusPoller::new();
+        self.pending_status_refresh = false;
+    }
+
+    fn apply_status_update(&mut self, update: StatusUpdate, play_sound: bool, run_hooks: bool) {
         use crate::session::Status;
 
         let old_status = self.get_instance(&update.id).map(|i| i.status);
@@ -759,9 +794,35 @@ impl HomeView {
 
         if let Some(old) = old_status {
             if old != new_status {
-                crate::sound::play_for_transition(old, new_status, &self.sound_config);
+                if let Some(inst) = self.get_instance(&update.id).cloned() {
+                    self.handle_status_transition(&inst, old, new_status, play_sound, run_hooks);
+                }
             }
         }
+    }
+
+    fn handle_status_transition(
+        &self,
+        inst: &Instance,
+        old: crate::session::Status,
+        new: crate::session::Status,
+        play_sound: bool,
+        run_hooks: bool,
+    ) {
+        if play_sound {
+            crate::sound::play_for_transition(old, new, &self.sound_config);
+        }
+        if run_hooks {
+            let hook_config = self.status_hook_config_for(inst);
+            crate::status_hooks::run_for_transition(inst, old, new, &hook_config);
+        }
+    }
+
+    fn status_hook_config_for(&self, inst: &Instance) -> crate::status_hooks::StatusHookConfig {
+        if self.active_profile.is_some() {
+            return self.status_hook_config.clone();
+        }
+        crate::session::resolve_config_or_warn(&inst.effective_profile()).status_hooks
     }
 
     pub fn apply_deletion_results(&mut self) -> bool {
@@ -1817,7 +1878,15 @@ impl HomeView {
     }
 
     pub fn set_instance_status(&mut self, id: &str, status: crate::session::Status) {
+        let old_status = self.get_instance(id).map(|inst| inst.status);
         self.mutate_instance(id, |inst| inst.status = status);
+        if let Some(old) = old_status {
+            if old != status {
+                if let Some(inst) = self.get_instance(id).cloned() {
+                    self.handle_status_transition(&inst, old, status, false, true);
+                }
+            }
+        }
     }
 
     /// Stamp `last_accessed_at` on a session (user-initiated interaction).
@@ -2082,6 +2151,7 @@ impl HomeView {
             DefaultTerminalMode::Container => TerminalMode::Container,
         };
         self.sound_config = config.sound.clone();
+        self.status_hook_config = config.status_hooks.clone();
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -766,7 +766,7 @@ impl HomeView {
                     line_spans.push(Span::styled(badge, Style::default().fg(theme.sandbox)));
                 }
                 if column_fits {
-                    line_spans.push(Span::raw(" ".repeat(LAST_ACTIVITY_RIGHT_MARGIN)));
+                    line_spans.push(Span::raw(" ".to_string()));
                 }
             }
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -766,7 +766,9 @@ impl HomeView {
                     line_spans.push(Span::styled(badge, Style::default().fg(theme.sandbox)));
                 }
                 if column_fits {
-                    line_spans.push(Span::raw(" ".to_string()));
+                    let trailing_margin: String =
+                        std::iter::repeat_n(' ', LAST_ACTIVITY_RIGHT_MARGIN).collect();
+                    line_spans.push(Span::raw(trailing_margin));
                 }
             }
         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2909,6 +2909,33 @@ fn apply_status_update_runs_status_hook_on_transition() {
 
 #[test]
 #[serial]
+fn all_profiles_status_hook_lookup_uses_cache() {
+    use crate::status_hooks::StatusHookConfig;
+
+    let mut env = create_test_env_with_sessions(1);
+    env.view.active_profile = None;
+    env.view.status_hook_config = StatusHookConfig::default();
+    env.view.status_hook_configs.clear();
+    env.view.status_hook_configs.insert(
+        "cached".to_string(),
+        StatusHookConfig {
+            enabled: true,
+            debounce_ms: 0,
+            on_waiting: Some("notify-cached".to_string()),
+            ..Default::default()
+        },
+    );
+
+    let mut instance = Instance::new("Cached profile", "/tmp/cached");
+    instance.source_profile = "cached".to_string();
+
+    let config = env.view.status_hook_config_for(&instance);
+    assert!(config.enabled);
+    assert_eq!(config.on_waiting.as_deref(), Some("notify-cached"));
+}
+
+#[test]
+#[serial]
 fn apply_status_update_does_not_run_status_hook_for_same_status() {
     use crate::session::Status;
     use crate::status_hooks::{take_recorded_launches, StatusHookConfig};

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2870,6 +2870,133 @@ fn apply_status_update_skips_terminal_states() {
     assert_eq!(inst.idle_entered_at, None);
 }
 
+#[test]
+#[serial]
+fn apply_status_update_runs_status_hook_on_transition() {
+    use crate::session::Status;
+    use crate::status_hooks::{take_recorded_launches, StatusHookConfig};
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    env.view.status_hook_config = StatusHookConfig {
+        enabled: true,
+        debounce_ms: 0,
+        on_waiting: Some("notify-waiting".to_string()),
+        on_change: Some("notify-change".to_string()),
+        ..Default::default()
+    };
+    take_recorded_launches();
+
+    env.view.apply_one_status_update(StatusUpdate {
+        id: id.clone(),
+        status: Status::Waiting,
+        last_error: None,
+        idle_entered_at: None,
+    });
+
+    let launches = take_recorded_launches();
+    assert_eq!(launches.len(), 2);
+    assert_eq!(launches[0].command, "notify-waiting");
+    assert_eq!(launches[1].command, "notify-change");
+    assert_eq!(launches[0].context.session_id, id);
+    assert_eq!(launches[0].context.old_status, Status::Idle);
+    assert_eq!(launches[0].context.new_status, Status::Waiting);
+}
+
+#[test]
+#[serial]
+fn apply_status_update_does_not_run_status_hook_for_same_status() {
+    use crate::session::Status;
+    use crate::status_hooks::{take_recorded_launches, StatusHookConfig};
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    env.view.status_hook_config = StatusHookConfig {
+        enabled: true,
+        debounce_ms: 0,
+        on_change: Some("notify-change".to_string()),
+        ..Default::default()
+    };
+    take_recorded_launches();
+
+    env.view.apply_one_status_update(StatusUpdate {
+        id,
+        status: Status::Idle,
+        last_error: None,
+        idle_entered_at: None,
+    });
+
+    assert!(take_recorded_launches().is_empty());
+}
+
+#[test]
+#[serial]
+fn apply_status_updates_without_hooks_does_not_run_status_hook() {
+    use crate::session::Status;
+    use crate::status_hooks::{take_recorded_launches, StatusHookConfig};
+    use crate::tui::status_poller::StatusUpdate;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    env.view.status_hook_config = StatusHookConfig {
+        enabled: true,
+        debounce_ms: 0,
+        on_waiting: Some("notify-waiting".to_string()),
+        ..Default::default()
+    };
+    take_recorded_launches();
+
+    env.view
+        .apply_status_updates_without_hooks(vec![StatusUpdate {
+            id: id.clone(),
+            status: Status::Waiting,
+            last_error: None,
+            idle_entered_at: None,
+        }]);
+
+    assert_eq!(env.view.get_instance(&id).unwrap().status, Status::Waiting);
+    assert!(take_recorded_launches().is_empty());
+}
+
+#[test]
+#[serial]
+fn set_instance_status_runs_status_hook_on_transition() {
+    use crate::session::Status;
+    use crate::status_hooks::{take_recorded_launches, StatusHookConfig};
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = match env.view.flat_items.first() {
+        Some(Item::Session { id, .. }) => id.clone(),
+        _ => panic!("expected the fixture to seed a single Session item"),
+    };
+    env.view.status_hook_config = StatusHookConfig {
+        enabled: true,
+        debounce_ms: 0,
+        on_error: Some("notify-error".to_string()),
+        ..Default::default()
+    };
+    take_recorded_launches();
+
+    env.view.set_instance_status(&id, Status::Error);
+
+    let launches = take_recorded_launches();
+    assert_eq!(launches.len(), 1);
+    assert_eq!(launches[0].command, "notify-error");
+    assert_eq!(launches[0].context.old_status, Status::Idle);
+    assert_eq!(launches[0].context.new_status, Status::Error);
+}
+
 /// Regression: paste over a group header must stash to `pending_paste`,
 /// never open a compose dialog targeted at "the first running session".
 /// Earlier behavior fell through to the first-running fallback whenever

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,6 +1,7 @@
 //! Terminal User Interface module
 
 mod app;
+mod attached_status_hooks;
 #[cfg(feature = "serve")]
 pub(crate) mod cockpit_view;
 mod components;

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -21,6 +21,7 @@ pub enum SettingsCategory {
     Tmux,
     Session,
     Sound,
+    StatusHooks,
     Hooks,
     Web,
     Cockpit,
@@ -37,6 +38,7 @@ impl SettingsCategory {
             Self::Tmux => "Tmux",
             Self::Session => "Session",
             Self::Sound => "Sound",
+            Self::StatusHooks => "Status Hooks",
             Self::Hooks => "Hooks",
             Self::Web => "Web",
             Self::Cockpit => "Cockpit",
@@ -105,6 +107,15 @@ pub enum FieldKey {
     SoundOnIdle,
     SoundOnError,
     SoundOnApproval,
+    // Status hooks
+    StatusHooksEnabled,
+    StatusHookDebounceMs,
+    StatusHookOnStarting,
+    StatusHookOnRunning,
+    StatusHookOnWaiting,
+    StatusHookOnIdle,
+    StatusHookOnError,
+    StatusHookOnChange,
     // Hooks
     HookOnCreate,
     HookOnLaunch,
@@ -300,6 +311,7 @@ pub fn build_fields_for_category(
         SettingsCategory::Tmux => build_tmux_fields(scope, global, profile),
         SettingsCategory::Session => build_session_fields(scope, global, profile),
         SettingsCategory::Sound => build_sound_fields(scope, global, profile),
+        SettingsCategory::StatusHooks => build_status_hook_fields(scope, global, profile),
         SettingsCategory::Hooks => build_hooks_fields(scope, global, profile),
         SettingsCategory::Web => build_web_fields(scope, global, profile),
         SettingsCategory::Cockpit => build_cockpit_fields(scope, global, profile),
@@ -1879,6 +1891,158 @@ fn build_hooks_fields(
     ]
 }
 
+fn build_status_hook_fields(
+    scope: SettingsScope,
+    global: &Config,
+    profile: &ProfileConfig,
+) -> Vec<SettingField> {
+    let hooks = profile.status_hooks.as_ref();
+
+    let (enabled, o1) = resolve_value(
+        scope,
+        global.status_hooks.enabled,
+        hooks.and_then(|h| h.enabled),
+    );
+    let (debounce_ms, debounce_override) = resolve_value(
+        scope,
+        global.status_hooks.debounce_ms,
+        hooks.and_then(|h| h.debounce_ms),
+    );
+    let (on_starting, o2) = resolve_optional(
+        scope,
+        global.status_hooks.on_starting.clone(),
+        hooks.and_then(|h| h.on_starting.clone()),
+        hooks.map(|h| h.on_starting.is_some()).unwrap_or(false),
+    );
+    let (on_running, o3) = resolve_optional(
+        scope,
+        global.status_hooks.on_running.clone(),
+        hooks.and_then(|h| h.on_running.clone()),
+        hooks.map(|h| h.on_running.is_some()).unwrap_or(false),
+    );
+    let (on_waiting, o4) = resolve_optional(
+        scope,
+        global.status_hooks.on_waiting.clone(),
+        hooks.and_then(|h| h.on_waiting.clone()),
+        hooks.map(|h| h.on_waiting.is_some()).unwrap_or(false),
+    );
+    let (on_idle, o5) = resolve_optional(
+        scope,
+        global.status_hooks.on_idle.clone(),
+        hooks.and_then(|h| h.on_idle.clone()),
+        hooks.map(|h| h.on_idle.is_some()).unwrap_or(false),
+    );
+    let (on_error, o6) = resolve_optional(
+        scope,
+        global.status_hooks.on_error.clone(),
+        hooks.and_then(|h| h.on_error.clone()),
+        hooks.map(|h| h.on_error.is_some()).unwrap_or(false),
+    );
+    let (on_change, o7) = resolve_optional(
+        scope,
+        global.status_hooks.on_change.clone(),
+        hooks.and_then(|h| h.on_change.clone()),
+        hooks.map(|h| h.on_change.is_some()).unwrap_or(false),
+    );
+
+    vec![
+        SettingField {
+            key: FieldKey::StatusHooksEnabled,
+            label: "Enabled",
+            description: "Run local commands when TUI sessions change status",
+            value: FieldValue::Bool(enabled),
+            category: SettingsCategory::StatusHooks,
+            has_override: o1,
+            inherited_display: inherited_if(o1, FieldValue::Bool(global.status_hooks.enabled)),
+        },
+        SettingField {
+            key: FieldKey::StatusHookDebounceMs,
+            label: "Debounce (ms)",
+            description: "Milliseconds a status must remain stable before running hook commands",
+            value: FieldValue::Number(debounce_ms),
+            category: SettingsCategory::StatusHooks,
+            has_override: debounce_override,
+            inherited_display: inherited_if(
+                debounce_override,
+                FieldValue::Number(global.status_hooks.debounce_ms),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnStarting,
+            label: "On Starting",
+            description: "Shell command run when a session enters Starting",
+            value: FieldValue::OptionalText(on_starting),
+            category: SettingsCategory::StatusHooks,
+            has_override: o2,
+            inherited_display: inherited_if(
+                o2,
+                FieldValue::OptionalText(global.status_hooks.on_starting.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnRunning,
+            label: "On Running",
+            description: "Shell command run when a session enters Running",
+            value: FieldValue::OptionalText(on_running),
+            category: SettingsCategory::StatusHooks,
+            has_override: o3,
+            inherited_display: inherited_if(
+                o3,
+                FieldValue::OptionalText(global.status_hooks.on_running.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnWaiting,
+            label: "On Waiting",
+            description: "Shell command run when a session enters Waiting",
+            value: FieldValue::OptionalText(on_waiting),
+            category: SettingsCategory::StatusHooks,
+            has_override: o4,
+            inherited_display: inherited_if(
+                o4,
+                FieldValue::OptionalText(global.status_hooks.on_waiting.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnIdle,
+            label: "On Idle",
+            description: "Shell command run when a session enters Idle",
+            value: FieldValue::OptionalText(on_idle),
+            category: SettingsCategory::StatusHooks,
+            has_override: o5,
+            inherited_display: inherited_if(
+                o5,
+                FieldValue::OptionalText(global.status_hooks.on_idle.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnError,
+            label: "On Error",
+            description: "Shell command run when a session enters Error",
+            value: FieldValue::OptionalText(on_error),
+            category: SettingsCategory::StatusHooks,
+            has_override: o6,
+            inherited_display: inherited_if(
+                o6,
+                FieldValue::OptionalText(global.status_hooks.on_error.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::StatusHookOnChange,
+            label: "On Any Change",
+            description:
+                "Shell command run after the status-specific command on every status change",
+            value: FieldValue::OptionalText(on_change),
+            category: SettingsCategory::StatusHooks,
+            has_override: o7,
+            inherited_display: inherited_if(
+                o7,
+                FieldValue::OptionalText(global.status_hooks.on_change.clone()),
+            ),
+        },
+    ]
+}
+
 /// Apply a field's value back to the appropriate config.
 /// For profile scope, the value is always stored as an override.
 pub fn apply_field_to_config(
@@ -2043,6 +2207,31 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::SoundOnApproval, FieldValue::OptionalText(v)) => {
             config.sound.on_approval = v.clone();
+        }
+        // Status hooks
+        (FieldKey::StatusHooksEnabled, FieldValue::Bool(v)) => {
+            config.status_hooks.enabled = *v;
+        }
+        (FieldKey::StatusHookDebounceMs, FieldValue::Number(v)) => {
+            config.status_hooks.debounce_ms = *v;
+        }
+        (FieldKey::StatusHookOnStarting, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_starting = v.clone();
+        }
+        (FieldKey::StatusHookOnRunning, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_running = v.clone();
+        }
+        (FieldKey::StatusHookOnWaiting, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_waiting = v.clone();
+        }
+        (FieldKey::StatusHookOnIdle, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_idle = v.clone();
+        }
+        (FieldKey::StatusHookOnError, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_error = v.clone();
+        }
+        (FieldKey::StatusHookOnChange, FieldValue::OptionalText(v)) => {
+            config.status_hooks.on_change = v.clone();
         }
         // Hooks
         (FieldKey::HookOnCreate, FieldValue::List(v)) => config.hooks.on_create = v.clone(),
@@ -2443,6 +2632,49 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 .get_or_insert_with(crate::sound::SoundConfigOverride::default);
             s.on_approval = v.clone();
         }
+        // Status hooks
+        (FieldKey::StatusHooksEnabled, FieldValue::Bool(v)) => {
+            set_profile_override(*v, &mut config.status_hooks, |s, val| s.enabled = val);
+        }
+        (FieldKey::StatusHookDebounceMs, FieldValue::Number(v)) => {
+            set_profile_override(*v, &mut config.status_hooks, |s, val| s.debounce_ms = val);
+        }
+        (FieldKey::StatusHookOnStarting, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_starting = v.clone();
+        }
+        (FieldKey::StatusHookOnRunning, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_running = v.clone();
+        }
+        (FieldKey::StatusHookOnWaiting, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_waiting = v.clone();
+        }
+        (FieldKey::StatusHookOnIdle, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_idle = v.clone();
+        }
+        (FieldKey::StatusHookOnError, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_error = v.clone();
+        }
+        (FieldKey::StatusHookOnChange, FieldValue::OptionalText(v)) => {
+            let s = config
+                .status_hooks
+                .get_or_insert_with(crate::status_hooks::StatusHookConfigOverride::default);
+            s.on_change = v.clone();
+        }
         // Hooks
         (FieldKey::HookOnCreate, FieldValue::List(v)) => {
             set_profile_override(v.clone(), &mut config.hooks, |s, val| s.on_create = val);
@@ -2778,5 +3010,76 @@ mod tests {
 
         assert!(field.has_override);
         assert!(matches!(field.value, FieldValue::Bool(true)));
+    }
+
+    #[test]
+    fn test_status_hook_debounce_field_uses_default() {
+        let global = Config::default();
+        let profile = ProfileConfig::default();
+
+        let fields = build_fields_for_category(
+            SettingsCategory::StatusHooks,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        );
+        let field = fields
+            .iter()
+            .find(|f| f.key == FieldKey::StatusHookDebounceMs)
+            .expect("StatusHookDebounceMs field should exist");
+
+        assert_eq!(field.label, "Debounce (ms)");
+        assert!(matches!(field.value, FieldValue::Number(100)));
+    }
+
+    #[test]
+    fn test_status_hook_debounce_profile_override() {
+        let global = Config::default();
+        let profile = ProfileConfig {
+            status_hooks: Some(crate::status_hooks::StatusHookConfigOverride {
+                debounce_ms: Some(500),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let fields = build_fields_for_category(
+            SettingsCategory::StatusHooks,
+            SettingsScope::Profile,
+            &global,
+            &profile,
+        );
+        let field = fields
+            .iter()
+            .find(|f| f.key == FieldKey::StatusHookDebounceMs)
+            .expect("StatusHookDebounceMs field should exist");
+
+        assert!(field.has_override);
+        assert!(matches!(field.value, FieldValue::Number(500)));
+        assert_eq!(field.inherited_display.as_deref(), Some("100"));
+    }
+
+    #[test]
+    fn test_status_hook_debounce_apply_global_and_profile() {
+        let mut global = Config::default();
+        let mut profile = ProfileConfig::default();
+        let field = SettingField {
+            key: FieldKey::StatusHookDebounceMs,
+            label: "Debounce (ms)",
+            description: "",
+            value: FieldValue::Number(250),
+            category: SettingsCategory::StatusHooks,
+            has_override: false,
+            inherited_display: None,
+        };
+
+        apply_field_to_config(&field, SettingsScope::Global, &mut global, &mut profile);
+        assert_eq!(global.status_hooks.debounce_ms, 250);
+
+        apply_field_to_config(&field, SettingsScope::Profile, &mut global, &mut profile);
+        assert_eq!(
+            profile.status_hooks.as_ref().and_then(|s| s.debounce_ms),
+            Some(250)
+        );
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -118,6 +118,7 @@ impl SettingsView {
                     }
                     SettingsScope::Repo => SettingsScope::Global,
                 };
+                self.rebuild_categories_for_scope();
                 self.rebuild_fields();
                 SettingsAction::Continue
             }
@@ -136,6 +137,7 @@ impl SettingsView {
                     SettingsScope::Profile => SettingsScope::Global,
                     SettingsScope::Repo => SettingsScope::Profile,
                 };
+                self.rebuild_categories_for_scope();
                 self.rebuild_fields();
                 SettingsAction::Continue
             }
@@ -775,6 +777,47 @@ impl SettingsView {
             FieldKey::SoundOnApproval => {
                 if let Some(ref mut s) = config.sound {
                     s.on_approval = None;
+                }
+            }
+            // Status hooks
+            FieldKey::StatusHooksEnabled => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.enabled = None;
+                }
+            }
+            FieldKey::StatusHookDebounceMs => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.debounce_ms = None;
+                }
+            }
+            FieldKey::StatusHookOnStarting => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_starting = None;
+                }
+            }
+            FieldKey::StatusHookOnRunning => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_running = None;
+                }
+            }
+            FieldKey::StatusHookOnWaiting => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_waiting = None;
+                }
+            }
+            FieldKey::StatusHookOnIdle => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_idle = None;
+                }
+            }
+            FieldKey::StatusHookOnError => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_error = None;
+                }
+            }
+            FieldKey::StatusHookOnChange => {
+                if let Some(ref mut s) = config.status_hooks {
+                    s.on_change = None;
                 }
             }
             // Hooks

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -188,6 +188,7 @@ impl SettingsView {
             SettingsCategory::Tmux,
             SettingsCategory::Sound,
             SettingsCategory::Web,
+            SettingsCategory::Cockpit,
             SettingsCategory::Logging,
         ]);
         categories

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -140,18 +140,7 @@ impl SettingsView {
             available_profiles.sort();
         }
 
-        let categories = vec![
-            SettingsCategory::Theme,
-            SettingsCategory::Session,
-            SettingsCategory::Hooks,
-            SettingsCategory::Sandbox,
-            SettingsCategory::Worktree,
-            SettingsCategory::Updates,
-            SettingsCategory::Tmux,
-            SettingsCategory::Sound,
-            SettingsCategory::Web,
-            SettingsCategory::Logging,
-        ];
+        let categories = Self::categories_for_scope(SettingsScope::Global);
 
         let mut view = Self {
             profile: profile.to_string(),
@@ -181,6 +170,35 @@ impl SettingsView {
 
         view.rebuild_fields();
         Ok(view)
+    }
+
+    fn categories_for_scope(scope: SettingsScope) -> Vec<SettingsCategory> {
+        let mut categories = vec![
+            SettingsCategory::Theme,
+            SettingsCategory::Session,
+            SettingsCategory::Hooks,
+        ];
+        if scope != SettingsScope::Repo {
+            categories.push(SettingsCategory::StatusHooks);
+        }
+        categories.extend([
+            SettingsCategory::Sandbox,
+            SettingsCategory::Worktree,
+            SettingsCategory::Updates,
+            SettingsCategory::Tmux,
+            SettingsCategory::Sound,
+            SettingsCategory::Web,
+            SettingsCategory::Logging,
+        ]);
+        categories
+    }
+
+    pub(super) fn rebuild_categories_for_scope(&mut self) {
+        let current = self.categories.get(self.selected_category).copied();
+        self.categories = Self::categories_for_scope(self.scope);
+        self.selected_category = current
+            .and_then(|category| self.categories.iter().position(|c| *c == category))
+            .unwrap_or(0);
     }
 
     /// Rebuild the fields list based on current category and scope

--- a/src/tui/status_poller.rs
+++ b/src/tui/status_poller.rs
@@ -37,7 +37,7 @@ fn polling_tier(status: Status) -> u64 {
 }
 
 /// Result of a status check for a single session
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct StatusUpdate {
     pub id: String,
     pub status: Status,
@@ -48,6 +48,118 @@ pub struct StatusUpdate {
     /// wrapper's timestamp write lives only on the polling clone and is
     /// lost when we project the result back into a `StatusUpdate`.
     pub idle_entered_at: Option<DateTime<Utc>>,
+}
+
+pub(super) struct StatusPollState {
+    container_check_interval: Duration,
+    last_container_check: Instant,
+    container_states: HashMap<String, bool>,
+    credential_refresh_interval: Duration,
+    last_credential_refresh: Instant,
+    cycle_count: u64,
+}
+
+impl StatusPollState {
+    pub(super) fn new() -> Self {
+        let container_check_interval = Duration::from_secs(5);
+        let credential_refresh_interval = Duration::from_secs(1800);
+
+        Self {
+            container_check_interval,
+            last_container_check: Instant::now() - container_check_interval,
+            container_states: HashMap::new(),
+            credential_refresh_interval,
+            last_credential_refresh: Instant::now(),
+            cycle_count: TIER_COLD - 1,
+        }
+    }
+}
+
+pub(super) fn poll_statuses_once(
+    instances: Vec<Instance>,
+    state: &mut StatusPollState,
+) -> Vec<StatusUpdate> {
+    state.cycle_count = state.cycle_count.wrapping_add(1);
+
+    // Pre-scan: check if any instance would actually be polled this cycle.
+    // If not, skip the batch subprocess calls entirely.
+    let any_pollable = instances.iter().any(|inst| {
+        let tier = polling_tier(inst.status);
+        tier != 0 && state.cycle_count % tier == 0
+    });
+
+    let pane_metadata = if any_pollable {
+        crate::tmux::refresh_session_cache();
+        crate::tmux::batch_pane_metadata().unwrap_or_default()
+    } else {
+        HashMap::new()
+    };
+
+    // Refresh container health if any sandboxed session exists and interval elapsed
+    let has_sandboxed = if any_pollable {
+        let sandboxed = instances.iter().any(|i| i.is_sandboxed());
+        if sandboxed && state.last_container_check.elapsed() >= state.container_check_interval {
+            state.container_states = crate::containers::batch_container_health();
+            state.last_container_check = Instant::now();
+        }
+        sandboxed
+    } else {
+        false
+    };
+
+    // Periodically re-sync sandbox credentials from the macOS Keychain
+    // so long-lived sessions don't lose auth mid-run.
+    if has_sandboxed && state.last_credential_refresh.elapsed() >= state.credential_refresh_interval
+    {
+        state.last_credential_refresh = Instant::now();
+        crate::session::container_config::refresh_agent_configs();
+    }
+
+    instances
+        .into_iter()
+        .filter_map(|mut inst| {
+            // Adaptive polling: skip instances whose tier interval hasn't elapsed
+            let tier = polling_tier(inst.status);
+            if tier == 0 || state.cycle_count % tier != 0 {
+                return None;
+            }
+
+            // For sandboxed sessions, check if the container is dead before
+            // falling through to tmux-based status detection.
+            if inst.is_sandboxed()
+                && !matches!(
+                    inst.status,
+                    Status::Stopped | Status::Deleting | Status::Starting | Status::Creating
+                )
+            {
+                if let Some(sandbox) = &inst.sandbox_info {
+                    if let Some(&running) = state.container_states.get(&sandbox.container_name) {
+                        if !running {
+                            return Some(StatusUpdate {
+                                id: inst.id,
+                                status: Status::Error,
+                                last_error: Some("Container is not running".to_string()),
+                                idle_entered_at: None,
+                            });
+                        }
+                    }
+                }
+            }
+
+            // Look up pre-fetched metadata for this instance's tmux session
+            let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+            let metadata = pane_metadata.get(&session_name);
+
+            inst.update_status_with_metadata(metadata);
+
+            Some(StatusUpdate {
+                id: inst.id,
+                status: inst.status,
+                last_error: inst.last_error,
+                idle_entered_at: inst.idle_entered_at,
+            })
+        })
+        .collect()
 }
 
 /// Background thread that polls session status without blocking the UI
@@ -77,106 +189,10 @@ impl StatusPoller {
         request_rx: mpsc::Receiver<Vec<Instance>>,
         result_tx: mpsc::Sender<Vec<StatusUpdate>>,
     ) {
-        let container_check_interval = Duration::from_secs(5);
-        // Initialize to the past so the first check runs immediately
-        let mut last_container_check = Instant::now() - container_check_interval;
-        let mut container_states: HashMap<String, bool> = HashMap::new();
-
-        // Credential refresh: re-sync every 30 minutes so long-lived sandbox
-        // sessions pick up rotated OAuth tokens from the macOS Keychain.
-        let credential_refresh_interval = Duration::from_secs(1800);
-        // Start at now (not in the past) -- credentials are fresh from container creation
-        let mut last_credential_refresh = Instant::now();
-
-        // Start at TIER_COLD - 1 so the first wrapping_add produces TIER_COLD,
-        // which is divisible by all tier intervals -- ensuring every session is
-        // polled on the very first cycle.
-        let mut cycle_count: u64 = TIER_COLD - 1;
+        let mut state = StatusPollState::new();
 
         while let Ok(instances) = request_rx.recv() {
-            cycle_count = cycle_count.wrapping_add(1);
-
-            // Pre-scan: check if any instance would actually be polled this cycle.
-            // If not, skip the batch subprocess calls entirely.
-            let any_pollable = instances.iter().any(|inst| {
-                let tier = polling_tier(inst.status);
-                tier != 0 && cycle_count % tier == 0
-            });
-
-            let pane_metadata = if any_pollable {
-                crate::tmux::refresh_session_cache();
-                crate::tmux::batch_pane_metadata().unwrap_or_default()
-            } else {
-                HashMap::new()
-            };
-
-            // Refresh container health if any sandboxed session exists and interval elapsed
-            let has_sandboxed = if any_pollable {
-                let sandboxed = instances.iter().any(|i| i.is_sandboxed());
-                if sandboxed && last_container_check.elapsed() >= container_check_interval {
-                    container_states = crate::containers::batch_container_health();
-                    last_container_check = Instant::now();
-                }
-                sandboxed
-            } else {
-                false
-            };
-
-            // Periodically re-sync sandbox credentials from the macOS Keychain
-            // so long-lived sessions don't lose auth mid-run.
-            if has_sandboxed && last_credential_refresh.elapsed() >= credential_refresh_interval {
-                last_credential_refresh = Instant::now();
-                crate::session::container_config::refresh_agent_configs();
-            }
-
-            let updates: Vec<StatusUpdate> = instances
-                .into_iter()
-                .filter_map(|mut inst| {
-                    // Adaptive polling: skip instances whose tier interval hasn't elapsed
-                    let tier = polling_tier(inst.status);
-                    if tier == 0 || cycle_count % tier != 0 {
-                        return None;
-                    }
-
-                    // For sandboxed sessions, check if the container is dead before
-                    // falling through to tmux-based status detection.
-                    if inst.is_sandboxed()
-                        && !matches!(
-                            inst.status,
-                            Status::Stopped
-                                | Status::Deleting
-                                | Status::Starting
-                                | Status::Creating
-                        )
-                    {
-                        if let Some(sandbox) = &inst.sandbox_info {
-                            if let Some(&running) = container_states.get(&sandbox.container_name) {
-                                if !running {
-                                    return Some(StatusUpdate {
-                                        id: inst.id,
-                                        status: Status::Error,
-                                        last_error: Some("Container is not running".to_string()),
-                                        idle_entered_at: None,
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    // Look up pre-fetched metadata for this instance's tmux session
-                    let session_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
-                    let metadata = pane_metadata.get(&session_name);
-
-                    inst.update_status_with_metadata(metadata);
-
-                    Some(StatusUpdate {
-                        id: inst.id,
-                        status: inst.status,
-                        last_error: inst.last_error,
-                        idle_entered_at: inst.idle_entered_at,
-                    })
-                })
-                .collect();
+            let updates = poll_statuses_once(instances, &mut state);
 
             if result_tx.send(updates).is_err() {
                 break;

--- a/src/tui/styles/mod.rs
+++ b/src/tui/styles/mod.rs
@@ -196,7 +196,6 @@ pub fn export_theme_toml(theme: &Theme) -> Result<String, toml::ser::Error> {
 
 #[cfg(test)]
 mod tests {
-    use super::themes::ThemeAppearance;
     use super::*;
     use ratatui::style::Color;
     use std::io::Write;

--- a/tests/tui_attach_detach.rs
+++ b/tests/tui_attach_detach.rs
@@ -231,6 +231,23 @@ fn test_attach_applies_attached_status_snapshot_after_reload() {
     }
 }
 
+#[test]
+fn test_attach_resets_status_refresh_without_watcher() {
+    let source = std::fs::read_to_string("src/tui/app.rs").expect("Failed to read app.rs");
+    let attached_status_body = app_method_body(&source, "with_attached_status_hooks");
+
+    assert_contains_in_order(
+        attached_status_body,
+        &[
+            "if let Some(watcher) = watcher",
+            "attached_status_updates = watcher.stop()",
+            "}",
+            "self.home.reset_status_refresh()",
+            "result.map",
+        ],
+    );
+}
+
 /// Test that a failed restart inside attach surfaces a transient toast.
 ///
 /// Before the fix, when `restart_instance_with_size_opts` returned Err the

--- a/tests/tui_attach_detach.rs
+++ b/tests/tui_attach_detach.rs
@@ -14,6 +14,45 @@ fn tmux_available() -> bool {
         .unwrap_or(false)
 }
 
+fn app_method_body<'a>(source: &'a str, name: &str) -> &'a str {
+    let signature = format!("fn {name}");
+    let start = source
+        .find(&signature)
+        .unwrap_or_else(|| panic!("{name} method not found"));
+    let section = &source[start..];
+    let open = section
+        .find('{')
+        .unwrap_or_else(|| panic!("{name} method body not found"));
+    let body_start = start + open;
+    let mut depth = 0;
+
+    for (offset, ch) in source[body_start..].char_indices() {
+        match ch {
+            '{' => depth += 1,
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return &source[body_start..body_start + offset + 1];
+                }
+            }
+            _ => {}
+        }
+    }
+
+    panic!("{name} method body should have a closing brace");
+}
+
+fn assert_contains_in_order(haystack: &str, needles: &[&str]) {
+    let mut cursor = 0;
+
+    for needle in needles {
+        let relative_index = haystack[cursor..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("expected to find `{needle}` after byte {cursor}"));
+        cursor += relative_index + needle.len();
+    }
+}
+
 /// Test that tmux sessions can be created and killed
 #[test]
 fn test_tmux_session_lifecycle() {
@@ -80,48 +119,41 @@ fn test_session_name_format() {
 
 /// Test terminal mode switching sequence
 ///
-/// This test documents the expected sequence for attach/detach:
-/// 1. Drop EventStream (stop background stdin reader)
-/// 2. Disable raw mode
-/// 3. Leave alternate screen
-/// 4. Show cursor
-/// 5. [user interacts with tmux]
-/// 6. Recreate EventStream (fresh stdin reader)
-/// 7. Enable raw mode
-/// 8. Enter alternate screen
-/// 9. Hide cursor
-/// 10. Clear terminal
+/// This guards the production sequence around the attach closure:
+/// leave TUI mode, release the EventStream stdin reader, run the
+/// attach closure, recreate the EventStream, and restore TUI mode.
 #[test]
 fn test_terminal_mode_sequence_documented() {
-    // This test documents the expected behavior rather than testing it directly
-    // since testing terminal modes requires actual terminal interaction.
+    let source = std::fs::read_to_string("src/tui/app.rs").expect("Failed to read app.rs");
+    let helper_body = app_method_body(&source, "with_raw_mode_disabled");
 
-    let expected_exit_sequence = [
-        "drop_event_stream",
-        "disable_raw_mode",
-        "LeaveAlternateScreen",
-        "cursor::Show",
-        "flush",
-    ];
+    assert_contains_in_order(
+        helper_body,
+        &[
+            "disable_raw_mode",
+            "LeaveAlternateScreen",
+            "DisableBracketedPaste",
+            "DisableMouseCapture",
+            "cursor::Show",
+            "Write::flush",
+            "event_stream.take",
+            "let result = f()",
+        ],
+    );
 
-    let expected_reenter_sequence = [
-        "recreate_event_stream",
-        "enable_raw_mode",
-        "EnterAlternateScreen",
-        "cursor::Hide",
-        "flush",
-        "terminal.clear",
-        "set_needs_redraw",
-    ];
-
-    // Verify sequences have all required steps
-    assert!(expected_exit_sequence.contains(&"disable_raw_mode"));
-    assert!(expected_exit_sequence.contains(&"LeaveAlternateScreen"));
-    assert!(expected_exit_sequence.contains(&"drop_event_stream"));
-    assert!(expected_reenter_sequence.contains(&"enable_raw_mode"));
-    assert!(expected_reenter_sequence.contains(&"EnterAlternateScreen"));
-    assert!(expected_reenter_sequence.contains(&"recreate_event_stream"));
-    assert!(expected_reenter_sequence.contains(&"terminal.clear"));
+    assert_contains_in_order(
+        helper_body,
+        &[
+            "self.event_stream = Some(EventStream::new())",
+            "enable_raw_mode",
+            "EnterAlternateScreen",
+            "EnableBracketedPaste",
+            "cursor::Hide",
+            "sync_mouse_capture",
+            "Write::flush",
+            "terminal.clear",
+        ],
+    );
 }
 
 /// Test that attach/detach uses terminal backend, not std::io::stdout()
@@ -130,24 +162,15 @@ fn test_terminal_mode_sequence_documented() {
 /// using std::io::stdout() instead of terminal.backend_mut() caused
 /// file descriptor desynchronization, corrupting tmux sessions.
 ///
-/// The terminal leave/restore logic lives in `with_raw_mode_disabled`,
-/// which `attach_session` delegates to.
+/// The terminal leave/restore logic lives in `with_raw_mode_disabled`.
+/// Attach paths go through `with_attached_status_hooks`, which wraps that
+/// helper while polling status hooks during a blocked tmux attach.
 #[test]
 fn test_attach_uses_terminal_backend() {
     let source = std::fs::read_to_string("src/tui/app.rs").expect("Failed to read app.rs");
 
     // The shared helper that handles terminal mode switching must use backend_mut()
-    let helper_start = source
-        .find("fn with_raw_mode_disabled")
-        .expect("with_raw_mode_disabled helper not found");
-
-    let helper_section = &source[helper_start..];
-    let fn_end = helper_section
-        .find("\n}\n")
-        .map(|i| i + 3)
-        .unwrap_or(helper_section.len());
-
-    let helper_body = &helper_section[..fn_end];
+    let helper_body = app_method_body(&source, "with_raw_mode_disabled");
 
     assert!(
         !helper_body.contains("std::io::stdout()"),
@@ -161,28 +184,51 @@ fn test_attach_uses_terminal_backend() {
         "with_raw_mode_disabled should use terminal.backend_mut() for terminal operations"
     );
 
-    // attach_session must delegate to the helper, not bypass it
-    let attach_fn_start = source
-        .find("fn attach_session(")
-        .expect("attach_session function not found");
-
-    let attach_fn_section = &source[attach_fn_start..];
-    let attach_fn_end = attach_fn_section
-        .find("\n    fn ")
-        .or_else(|| attach_fn_section.find("\n}\n"))
-        .unwrap_or(attach_fn_section.len());
-
-    let attach_fn_body = &attach_fn_section[..attach_fn_end];
+    let attached_status_body = app_method_body(&source, "with_attached_status_hooks");
 
     assert!(
-        attach_fn_body.contains("with_raw_mode_disabled"),
-        "attach_session should delegate to with_raw_mode_disabled"
+        attached_status_body.contains("with_raw_mode_disabled"),
+        "with_attached_status_hooks should delegate to with_raw_mode_disabled"
     );
 
     assert!(
-        !attach_fn_body.contains("std::io::stdout()"),
-        "attach_session should not use std::io::stdout() directly"
+        !attached_status_body.contains("std::io::stdout()"),
+        "with_attached_status_hooks should not use std::io::stdout() directly"
     );
+
+    for attach_method in ["attach_session", "attach_terminal", "attach_tool_session"] {
+        let attach_body = app_method_body(&source, attach_method);
+
+        assert!(
+            attach_body.contains("with_attached_status_hooks"),
+            "{attach_method} should leave TUI mode through with_attached_status_hooks"
+        );
+
+        assert!(
+            !attach_body.contains("std::io::stdout()"),
+            "{attach_method} should not use std::io::stdout() directly"
+        );
+    }
+}
+
+/// Attached status hooks may already have fired while tmux owned the
+/// terminal. Apply their final snapshot after reload so the next normal
+/// poll sees the same runtime status and does not fire the transition again.
+#[test]
+fn test_attach_applies_attached_status_snapshot_after_reload() {
+    let source = std::fs::read_to_string("src/tui/app.rs").expect("Failed to read app.rs");
+
+    for attach_method in ["attach_session", "attach_terminal", "attach_tool_session"] {
+        let attach_body = app_method_body(&source, attach_method);
+        assert_contains_in_order(
+            attach_body,
+            &[
+                "attached_status_updates",
+                "self.home.reload()?",
+                "apply_status_updates_without_hooks(attached_status_updates)",
+            ],
+        );
+    }
 }
 
 /// Test that a failed restart inside attach surfaces a transient toast.


### PR DESCRIPTION
## Description
Closes #1139.

This adds opt-in custom command hooks for session status transitions so TUI users can run local commands such as desktop notifications or orchestration scripts when a session enters `Waiting`, `Idle`, `Error`, `Starting`, or `Running`.

Most important changes:

- Add a `[status_hooks]` config block with `enabled`, `debounce_ms`, per-status commands, and `on_change`.
- Pass useful `AOE_*` environment context to hook commands, including session id, title, project path, profile, tool, old status, new status, and timestamp.
- Run status hook commands asynchronously from TUI status transitions so slow or failing commands do not block status polling or sound playback.
- Run status-specific hooks before `on_change` for the same transition.
- Debounce status hooks by default with a 100 ms stability window to avoid notifications for short-lived status flicker, while allowing immediate hooks with `debounce_ms = 0`.
- Keep hooks active while attached to tmux from the TUI by polling eligible sessions in an attached-session watcher and applying the final snapshot after reload to avoid duplicate hook dispatch.
- Wire status hooks through global settings, profile overrides, profile merge logic, settings fields, and override clearing.
- Keep status hooks out of repo config because they run arbitrary local commands.
- Harden Codex hook config writes by preserving `hooks.state` and project trust data, honoring `[features].hooks = false`, collapsing duplicated AoE hook blocks, using `config.toml.lock`, writing atomically, and preserving symlinked `config.toml` targets.
- Document the new configuration, debounce behavior, attached-session behavior, logging target, and Codex writer constraints.

Why this was necessary:

AoE already knew when TUI session statuses changed, but only sound playback and web push could react to those transitions. That left TUI-only users without a way to trigger visible local notifications or external workflow hooks when an agent finished, errored, or started waiting for input. This PR exposes that transition point as a local command primitive while keeping it disabled by default and best-effort at runtime.

Testing:

- `git diff --cached --check`
- `cargo fmt --check`
- Commit hook: `cargo clippy -- -D warnings`
- Commit hook: `cargo fmt -- --check`
- `cargo test` outside the Codex sandbox, passed, including e2e tests; Docker-only tests remained ignored


## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Codex


**Any Additional AI Details you'd like to share:**

Codex helped amend the commit message, run checks, and draft this PR description from the final diff and issue context.


**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Pull Request Summary: Status Transition Command Hooks

## High-level overview
This PR adds an opt-in system for running local shell commands when a session's status changes (e.g., Waiting → Running, Idle → Error). Hooks are configurable per-status and globally, run asynchronously so they don't block the TUI, and include debounce logic to reduce noisy/flickering transitions. Codex config writes for installing/uninstalling hooks are hardened to be atomic and preserve trust metadata. Hooks are disabled by default.

## What changed (concise)
- New feature: status hooks that execute commands on status transitions.
- New module: src/status_hooks.rs implements config, context (AOE_* env vars), debounce/coalescing, and background command launches.
- TUI integration: background attached-session watcher (src/tui/attached_status_hooks.rs) keeps hooks active during tmux attaches; HomeView and attach flows updated to collect/apply attached snapshots without duplicating hooks.
- Configuration: [status_hooks] added to global config and profile overrides; excluded from repo config; wired through settings UI with a dedicated Status Hooks category and fields.
- Codex hardening: atomic config writes, lock on resolved symlink targets, preserve hooks.state trust metadata, collapse duplicate AoE blocks, honor [features].hooks = false.
- Tests & docs: unit tests for debounce/merge/launch behavior; documentation updates describing config, env vars, debounce and attached-session behavior.

## Key behaviors & decisions
- Commands run asynchronously in the background and are best-effort (failures logged).
- Debounce default: 100 ms (coalesces rapid changes); set debounce_ms = 0 for immediate execution.
- Status-specific hooks run before the generic on_change hook for the same transition.
- Hooks can access context via AOE_SESSION_ID, AOE_SESSION_TITLE, AOE_PROJECT_PATH, AOE_PROFILE, AOE_TOOL, AOE_OLD_STATUS, AOE_NEW_STATUS, AOE_CHANGED_AT.
- Hooks disabled by default; enable per global config or per-profile override.

## Benefits
- Enables local automation/notifications on session lifecycle events without blocking UI.
- Reduces noisy notifications through debounce/coalescing.
- Safe defaults and config-scope restrictions reduce risk of arbitrary repo-driven command execution.
- Robust Codex install/uninstall behavior prevents corrupted or partial hook config state.

## Technical notes (brief)
- Public API additions: StatusHookConfig, StatusHookConfigOverride, StatusHookContext, apply_status_hook_overrides, commands_for_transition, run_for_transition; Status::as_str helper.
- Files of interest: src/status_hooks.rs, src/tui/attached_status_hooks.rs, src/tui/home/*, src/session/{config,profile_config}.rs, src/hooks/mod.rs (Codex writer changes), settings UI changes under src/tui/settings/*.
- Tests updated/added for config merge, debounce semantics, attached watcher snapshots, and Codex config-write invariants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->