### PR TITLE
fix(server): use MissedTickBehavior::Skip for cleanup intervals + unify CancellationToken import (#1289 follow-up)

### DIFF
--- a/src/server/login.rs
+++ b/src/server/login.rs
@@ -30,6 +30,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
 
 use super::auth::resolve_client_ip;
 use super::AppState;
@@ -336,10 +337,11 @@ impl LoginManager {
     /// Spawn periodic cleanup (piggybacks on the rate limiter's interval).
     /// Exits cleanly on shutdown so `aoe serve --stop` drains within one
     /// tick instead of waiting for the 5 s force exit safety net.
-    pub fn spawn_cleanup_task(self: &Arc<Self>, shutdown: tokio_util::sync::CancellationToken) {
+    pub fn spawn_cleanup_task(self: &Arc<Self>, shutdown: CancellationToken) {
         let manager = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 tokio::select! {
                     _ = interval.tick() => manager.cleanup_expired().await,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -822,6 +822,7 @@ pub async fn start_server(config: ServerConfig<'_>) -> anyhow::Result<()> {
             async move {
                 let mut interval =
                     tokio::time::interval(crate::session::recovery::RECENTLY_RESTARTED_GC_INTERVAL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 loop {
                     tokio::select! {
                         _ = interval.tick() => {

--- a/src/server/rate_limit.rs
+++ b/src/server/rate_limit.rs
@@ -155,6 +155,7 @@ impl RateLimiter {
         let limiter = Arc::clone(self);
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(CLEANUP_INTERVAL);
+            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
                 tokio::select! {
                     _ = interval.tick() => {


### PR DESCRIPTION
## Description

Polish follow-up to #1289 (shutdown-aware cleanup loops).

### What changed

Three cleanup-style intervals defaulted to `MissedTickBehavior::Burst`:

1. `RateLimiter::spawn_cleanup_task` (`src/server/rate_limit.rs`)
2. `LoginManager::spawn_cleanup_task` (`src/server/login.rs`)
3. `recently_restarted` GC task (`src/server/mod.rs`)

After a runtime stall (laptop sleep, GC pause, host starvation), `Burst` replays every missed tick back-to-back, immediately re-acquiring the same write lock or running back-to-back GC sweeps. All three now call `interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip)` so a stall coalesces into a single sweep, matching the convention already established by `push.rs`, `cockpit_ws.rs`, and `ws.rs`.

**Drive-by**: import `tokio_util::sync::CancellationToken` in `login.rs` to match `rate_limit.rs`'s style; drop the inline fully-qualified path on `spawn_cleanup_task`'s signature.

Diff stats: `3 files changed, 5 insertions(+), 1 deletion(-)`.

### Why a follow-up rather than amending #1289

#1289 was already merged when the review feedback was synthesized. Maintainer @njbrake explicitly accepted the `CancellationToken` import nit in their approval; Stage-3 cross-validation flagged the `recently_restarted` GC task as the same bug class as the two original cleanup tasks and worth bundling.

Out of scope (suggest separate PR): `status_poll_loop` in `src/server/mod.rs:1586` is a 2s poll (not a cleanup task) but would also benefit from `Skip` to avoid a backlog of `spawn_blocking` tmux scrapes after a stall. Naming-wise this PR is scoped to cleanup tasks; that's a separate follow-up.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib server` **221/221** pass

No behavior change beyond the documented `MissedTickBehavior` shift; steady-state behavior is unchanged. The difference only manifests after a runtime stall.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1289. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 VALID for all three review comments. Stage 2 (design fix) used 3 oracles in parallel; identical diff converged. Stage 3 (review implementation) used 2 oracles, both APPROVE; one flagged the `recently_restarted` GC task as same bug class so I bundled it.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The PR updates three periodic cleanup tasks to handle missed ticks more gracefully:
- Rate limiter cleanup task
- Login manager cleanup task  
- Recently-restarted garbage collection task

Additionally, the login manager imports a standard utility type that was previously being written out in full within the code.

## Why This Matters

When the runtime experiences delays (such as from system sleep, garbage collection pauses, or CPU starvation), the old behavior would attempt to "catch up" by running the cleanup multiple times back-to-back. The new approach skips these accumulated missed ticks and runs only once, preventing:
- Repeated lock contention
- Redundant memory scans
- Unnecessary CPU wake-ups after stalls
- Cleanup backlogs

This results in smoother behavior when the system recovers from interruptions, reducing resource waste and unnecessary work.

## Technical Details

**Files Modified:**
- `src/server/login.rs` (3 lines: +3, -1)
  - Added `CancellationToken` import from `tokio_util::sync`
  - Updated `spawn_cleanup_task()` signature to use the imported type instead of the fully-qualified path
  - Configured interval with `set_missed_tick_behavior(MissedTickBehavior::Skip)`

- `src/server/rate_limit.rs` (1 line: +1)
  - Configured interval with `set_missed_tick_behavior(MissedTickBehavior::Skip)`

- `src/server/mod.rs` (1 line: +1)
  - Configured `recently_restarted` GC task's interval with `set_missed_tick_behavior(MissedTickBehavior::Skip)`

**Key Change:** Switching from `MissedTickBehavior::Burst` (the default, replays every missed tick) to `MissedTickBehavior::Skip` (coalesces missed ticks into a single execution).

All tests pass (221/221 in server library tests); no behavioral changes during normal operation—effects only manifest after runtime stalls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1312?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->