### PR TITLE
fix(cockpit): warn on blocking-task JoinError instead of silent fallback (#1291 follow-up)

### DIFF
--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -168,9 +168,22 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
         let store = Arc::clone(&state.cockpit_event_store);
         let id_owned = id.clone();
         let in_flight_turn =
-            tokio::task::spawn_blocking(move || store.has_in_flight_turn(&id_owned))
-                .await
-                .unwrap_or(false);
+            match tokio::task::spawn_blocking(move || store.has_in_flight_turn(&id_owned)).await {
+                Ok(v) => v,
+                Err(e) => {
+                    // `attempted.insert` below runs unconditionally, so a swallowed
+                    // panic does not produce a retry storm; the only consequence is
+                    // the synthetic Stopped fanout is skipped this tick and the UI
+                    // may stay "thinking" until the next live event.
+                    tracing::warn!(
+                        target: "cockpit.supervisor",
+                        session_id = %id,
+                        error = %e,
+                        "in-flight turn probe blocking task failed; assuming no in-flight turn"
+                    );
+                    false
+                }
+            };
         // Mark before spawning so the next 2s tick doesn't double-poke
         // while the parallel resume task is still in flight. A task
         // that returns RetryAfterAttachTimeout will clear itself below.

--- a/src/server/cockpit_ws.rs
+++ b/src/server/cockpit_ws.rs
@@ -246,9 +246,25 @@ async fn drain_replay_into_socket(
     // the same worker for the duration of the read.
     let store = Arc::clone(&state.cockpit_event_store);
     let session_id_owned = session_id.to_string();
-    let entries = tokio::task::spawn_blocking(move || store.replay_from(&session_id_owned, since))
-        .await
-        .unwrap_or_default();
+    let entries = match tokio::task::spawn_blocking(move || {
+        store.replay_from(&session_id_owned, since)
+    })
+    .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            // Blocking task panicked or was cancelled. Live broadcast still
+            // flows and the client dedupes by seq, so empty drain is benign,
+            // but the silent swallow would hide the panic from operators.
+            warn!(
+                target: "cockpit.ws",
+                session_id = %session_id,
+                error = %e,
+                "replay drain blocking task failed; sending zero frames"
+            );
+            Vec::new()
+        }
+    };
     let mut sent = 0usize;
     for (seq, event) in entries {
         let frame = CockpitBroadcastFrame {


### PR DESCRIPTION
## Description

Follow-up to #1291 (offload SQLite to spawn_blocking).

### What changed

`drain_replay_into_socket` (`src/server/cockpit_ws.rs`) and the in-flight-turn probe in the reconciler (`src/server/cockpit_reconciler.rs`) both unwrapped a `spawn_blocking` `JoinError` into a default value (`Vec::new()` and `false` respectively), so a panic or cancellation in the blocking task disappeared without any tracing event.

Both now use an explicit `match` that emits `tracing::warn!` with `session_id` and the error before returning the same default. **Pure observability change; no behavior change.** Tracing targets follow each file's existing conventions: `cockpit.ws` for the websocket drain, `cockpit.supervisor` for the reconciler.

Diff stats: `2 files changed, 35 insertions(+), 6 deletions(-)`.

### Why

Maintainer @njbrake explicitly endorsed adding a `tracing::warn!` ladder on these two sites in the #1291 approval comment ("would aid observability if a panic does land here").

### What was NOT changed

- **Comment 3 (batching reconcile spawn_blocking calls)** dismissed as INVALID by 3-oracle Stage-1 cross-validation: the resume loop is serial (one `await` per iteration, not concurrent), default `max_concurrent_workers = 5`, `attempted.insert` makes per-id checks one-shot rather than every-tick, and `has_in_flight_turn` is a sub-millisecond indexed `SELECT`. Tokio's default 512-thread blocking pool is not pressured at any realistic worker count, and `EventStore`'s `Mutex<Connection>` would serialize a "batched" version anyway. Refactor saves ~5 task-spawn allocations per cold-start tick at no measurable cost; not worth the change without a measured hot path.

- **Bot's "duplicate poke" framing on Comment 2** rejected as inaccurate: cross-validation confirmed `attempted.insert` runs unconditionally after the unwrap (line 175), so a swallowed panic does not cause a retry storm. The conservative `false` default is preserved; the bot's suggested `true` fallback would actually be worse (would publish a phantom `synthesize_stopped_for_orphan` for sessions that aren't mid-turn).

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib server::cockpit_ws` 3/3 pass
- `cargo test --features serve --lib server::cockpit_reconciler` (no in-module unit tests; covered by integration tests)

No behavior change; defaults unchanged. The `JoinError` path is unreachable in normal CI.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1291. Stage 1 (analyze + validate) used 3 oracles in parallel with the same prompt for cross-validation; consensus VALID 3/3 on observability for comments 1+2, INVALID 3/3 on comment 3 (batching). Stage 2 (design fix) used 3 oracles in parallel; identical diff structure converged. Stage 3 (review implementation) used 2 oracles, both APPROVE.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR enhances observability in two critical areas of the cockpit system by adding warning logs when blocking operations fail. Previously, errors from these operations were silently swallowed, making it difficult to diagnose problems.

## What Changed

**In the WebSocket drain (`cockpit_ws.rs`):**
- Added explicit error handling when the replay task completes
- Now logs a warning if the task fails (panics or is cancelled) before returning an empty result

**In the reconciler worker probe (`cockpit_reconciler.rs`):**
- Added explicit error handling for the "in-flight turn" check
- Now logs a warning if the blocking task fails before returning the fallback value

## What Was Added

- Warning-level tracing events in two locations, each including:
  - Session ID (for context)
  - The specific error that occurred
  - Target labels following each module's convention (`cockpit.ws` and `cockpit.supervisor`)

## What Was Removed

- Silent error suppression that previously masked panics and cancellations

## Benefits

- **Improved Debuggability:** Failures in blocking operations are now visible through tracing/logging instead of failing silently
- **No Behavior Changes:** Default fallback behavior is preserved; this is purely an observability improvement
- **Maintainer Confidence:** Aligns with maintainer recommendations for better operational visibility
- **Reliability:** Ensures the system can continue operating even if blocking tasks fail, while still alerting operators

---

## Technical Details

Both changes follow the same pattern: replacing `.unwrap_or(default_value)` with `.match` on the `Result`, emitting `tracing::warn!` with context (session_id and error details), then returning the same default values. This preserves the conservative fallback semantics—the websocket sends zero frames, and the reconciler continues with a false probe result—while making failures observable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1314?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->