### PR TITLE
fix(cockpit): extract spawn_blocking_fs helper, drop fs handler clones (#1292 follow-up)

### DIFF
--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2899,6 +2899,33 @@ fn enter_timestamp_ns() -> u64 {
     epoch.elapsed().as_nanos() as u64
 }
 
+/// Run a synchronous `fs_handler` operation on the blocking pool and
+/// flatten the join + handler result into a single `FsError`. Centralizes
+/// the panic / cancellation observability so future fs offload sites
+/// stay consistent (the offload series spans seven PRs).
+async fn spawn_blocking_fs<F, T>(handler: &'static str, f: F) -> Result<T, fs_handler::FsError>
+where
+    F: FnOnce() -> Result<T, fs_handler::FsError> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(inner) => inner,
+        Err(e) => {
+            warn!(
+                target: "cockpit.acp",
+                handler,
+                panic = e.is_panic(),
+                cancelled = e.is_cancelled(),
+                error = %e,
+                "fs blocking task join failed"
+            );
+            Err(fs_handler::FsError::Io(std::io::Error::other(format!(
+                "fs {handler} join: {e}"
+            ))))
+        }
+    }
+}
+
 async fn handle_read_text_file(
     request: ReadTextFileRequest,
     responder: Responder<ReadTextFileResponse>,
@@ -2923,24 +2950,20 @@ async fn handle_read_text_file(
     // same worker. FsPolicy is Arc + Clone so the clone is cheap.
     let policy = Arc::clone(&res.fs_policy);
     let label = res.label.clone();
-    let path_clone = request.path.clone();
-    let read_outcome =
-        tokio::task::spawn_blocking(move || fs_handler::handle_read(&policy, &label, &path_clone))
-            .await
-            .map_err(|e| {
-                fs_handler::FsError::Io(std::io::Error::other(format!("fs read join: {e}")))
-            })
-            .and_then(|r| r);
+    let ReadTextFileRequest {
+        path, line, limit, ..
+    } = request;
+    let read_outcome = spawn_blocking_fs("read", move || {
+        fs_handler::handle_read(&policy, &label, &path)
+    })
+    .await;
     let result = match read_outcome {
         Ok(content) => {
             // Honor optional line/limit slicing for ACP semantics: 1-based.
-            let sliced = if request.line.is_some() || request.limit.is_some() {
+            let sliced = if line.is_some() || limit.is_some() {
                 let lines: Vec<&str> = content.lines().collect();
-                let start = request
-                    .line
-                    .map(|l| l.saturating_sub(1) as usize)
-                    .unwrap_or(0);
-                let limit = request.limit.map(|n| n as usize).unwrap_or(usize::MAX);
+                let start = line.map(|l| l.saturating_sub(1) as usize).unwrap_or(0);
+                let limit = limit.map(|n| n as usize).unwrap_or(usize::MAX);
                 let end = start.saturating_add(limit).min(lines.len());
                 if start >= lines.len() {
                     String::new()
@@ -2985,14 +3008,11 @@ async fn handle_write_text_file(
     // the duration of the write.
     let policy = Arc::clone(&res.fs_policy);
     let label = res.label.clone();
-    let path_clone = request.path.clone();
-    let content_clone = request.content.clone();
-    let write_outcome = tokio::task::spawn_blocking(move || {
-        fs_handler::handle_write(&policy, &label, &path_clone, &content_clone)
+    let WriteTextFileRequest { path, content, .. } = request;
+    let write_outcome = spawn_blocking_fs("write", move || {
+        fs_handler::handle_write(&policy, &label, &path, &content)
     })
-    .await
-    .map_err(|e| fs_handler::FsError::Io(std::io::Error::other(format!("fs write join: {e}"))))
-    .and_then(|r| r);
+    .await;
     let result = match write_outcome {
         Ok(()) => responder.respond(WriteTextFileResponse::new()),
         Err(e) => {


### PR DESCRIPTION
## Description

Follow-up to #1292 (offload fs_handler IO to spawn_blocking).

### What changed

Three findings from post-merge cross-validation, addressed in one commit against `src/cockpit/acp_client.rs`:

1. **Extract `spawn_blocking_fs` helper** (maintainer-endorsed). The `spawn_blocking + JoinError mapping + .and_then(|r| r)` pattern was duplicated byte-for-byte across `handle_read_text_file` and `handle_write_text_file`. The new helper wraps `spawn_blocking`, maps `JoinError` to `FsError::Io` with a `tracing::warn!` ladder (`panic` / `cancelled` / `error` structured fields), and flattens the inner `Result`. Both handlers now call it in one line. The maintainer's approval comment on #1292 explicitly suggested this shape: "this is the seventh PR in the offload series. A small helper `spawn_blocking_fs<F, T>(f) -> Result<T, FsError>` would dedupe the `map_err + and_then` pattern if more handlers follow."

2. **Drop unnecessary clones in both handlers**. `WriteTextFileRequest` and `ReadTextFileRequest` are taken by value and the cloned fields are not read after the `.await`, so `request.path.clone()` and `request.content.clone()` were pure waste — a full allocation + memcpy on every `fs/write_text_file`, which can be MB-sized. Both call sites now destructure with `let WriteTextFileRequest { path, content, .. } = request;` (and similar for read) and move owned fields into the closure. The bot's `Bytes`/`Arc<str>` alternative is correctly out of scope (would require an upstream `agent-client-protocol` crate change).

3. **Structured `JoinError` observability**. The `unwrap_or_default()`-style swallow at the join site previously produced no log line on panic/cancellation. The helper emits `tracing::warn!(target: "cockpit.acp", handler, panic, cancelled, error, "fs blocking task join failed")` before mapping, matching the `cockpit.acp.tool_dispatch` convention used elsewhere in the file.

Diff stats: `1 file changed, 41 insertions(+), 21 deletions(-)`.

### Why a follow-up rather than amending #1292

#1292 was already merged when the review feedback was synthesized. Cross-validation (3 independent oracle reviewers, same prompt for cross-validation) reached consensus on all three fixes:
- Comment 1 (clone): VALID 3/3 — drop via destructure (in scope), `Bytes`/`Arc<str>` upstream rewrite (out of scope).
- Comment 2 (JoinError observability): PARTIAL VALID 3/3 — bot's "info loss" framing overstated (`JoinError::Display` already differentiates panic/cancel), but structured log adds real diagnostic value. Maintainer endorsed.
- Comment 3 (helper extraction): VALID 3/3 — maintainer-endorsed.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::fs_handler` **11/11** pass

No behavior change on the success path. The `JoinError` path is unreachable in normal CI; the new structured log surfaces it if production ever does hit it.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1292. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 on all three fixes (helper extract + drop clones + tracing::warn!). Diff design converged byte-level across all 3 oracles independently.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR refactors the Cockpit file handling code in `src/cockpit/acp_client.rs` to eliminate code duplication, improve memory efficiency, and enhance observability when handling asynchronous blocking I/O operations.

## What Changed

**Code Added:**
- New `spawn_blocking_fs<F, T>` helper function that wraps `tokio::spawn_blocking` with centralized error handling and structured logging

**Code Refactored:**
- Both `handle_read_text_file` and `handle_write_text_file` now use the new helper instead of duplicating error handling logic
- Request objects are now destructured to extract and move owned fields directly into closures, eliminating clones
- Removed `request.path.clone()` from `handle_read_text_file` 
- Removed both `request.path.clone()` and `request.content.clone()` from `handle_write_text_file`

**Code Removed:**
- Duplicate `map_err` and `and_then` error handling patterns that appeared in both handlers

**Observability Enhanced:**
- Added structured `tracing::warn!` logging when blocking operations fail, capturing:
  - Handler name (read/write)
  - Panic flag
  - Cancellation flag
  - Full error details
  - Human-readable message

## Key Benefits

1. **Eliminates Code Duplication:** The identical error mapping and result flattening pattern that existed in both `handle_read_text_file` and `handle_write_text_file` is now centralized in one reusable helper

2. **Improves Memory Efficiency:** Removes unnecessary clones of `request.path` and `request.content` by destructuring requests and moving owned fields into closures—particularly beneficial for large file payloads

3. **Better Production Diagnostics:** Structured logging captures panic and cancellation flags separately from the error, providing richer observability without changing behavior on the success path

4. **Cleaner, More Maintainable Code:** Consolidates common error handling into a single source of truth, reducing maintenance burden and potential for bugs

## Testing

- All 11 tests in the `cockpit::fs_handler` module pass
- Code formatting and linting pass without warnings
- No behavior changes on success path; only enhanced error path diagnostics

## Stats
- **File changed:** 1
- **Lines added:** 41
- **Lines removed:** 21
- **PR type:** Bug Fix & Refactor

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->