### PR TITLE
refactor(task_util): unbox panic_payload_string + clarify test name (#1293 follow-ups)

### DIFF
--- a/src/task_util.rs
+++ b/src/task_util.rs
@@ -49,7 +49,7 @@ where
         match AssertUnwindSafe(fut).catch_unwind().await {
             Ok(()) => {}
             Err(payload) => {
-                let msg = panic_payload_string(&payload);
+                let msg = panic_payload_string(&*payload);
                 tracing::error!(
                     target: "task.panic",
                     task = name,
@@ -64,7 +64,7 @@ where
     })
 }
 
-fn panic_payload_string(payload: &Box<dyn std::any::Any + Send>) -> String {
+fn panic_payload_string(payload: &(dyn std::any::Any + Send)) -> String {
     if let Some(s) = payload.downcast_ref::<&'static str>() {
         return (*s).to_string();
     }
@@ -81,7 +81,7 @@ mod tests {
     use std::sync::Arc;
 
     #[tokio::test]
-    async fn normal_completion_returns_value() {
+    async fn normal_completion_runs_to_end() {
         let touched = Arc::new(AtomicBool::new(false));
         let t = touched.clone();
         let handle = spawn_supervised("test.normal", PanicPolicy::Log, async move {


### PR DESCRIPTION
## Description

Follow-up to #1293 (`spawn_supervised` helper).

### What changed

Two follow-ups against `src/task_util.rs` from post-merge cross-validation:

1. **Drop the `Box` indirection in `panic_payload_string`** (maintainer-endorsed). `@njbrake`'s APPROVAL note: "`panic_payload_string(payload: &Box<dyn std::any::Any + Send>)` would trigger `clippy::pedantic::borrowed_box`. `&(dyn std::any::Any + Send)` would be more idiomatic but the current form compiles fine." The body only calls `downcast_ref`, which works identically through deref coercion. Sole call site at line 52 passes `&*payload` to coerce the `Box` deref.

2. **Rename test `normal_completion_returns_value` → `normal_completion_runs_to_end`**. The spawned task returns `()` and the test asserts an `AtomicBool` side effect; the old name claimed a return value that doesn't exist. Sibling tests (`panic_in_log_policy_does_not_propagate`, `panic_in_surface_policy_propagates_join_error`) already follow this contract-describing convention.

Diff stats: `1 file changed, 3 insertions(+), 3 deletions(-)`.

### Comments dismissed

- **`name: &'static str` is too restrictive (`Cow<'static, str>`)**: REJECT 3/3 — all 5 existing call sites pass static literals (`"supervisor.drain"`, `"server.gc.recently_restarted"`, `"server.startup_recovery_cascade"`, `"server.status_poll_loop"`, `"server.cockpit_event_listener"`). Per-instance context (e.g. `session_id`) is meant to flow through the `tracing::Instrument` span shown in the rustdoc example, not the task name. `Cow<'static, str>` is generality with no current customer.
- **`aoe logs` unclear / typo / jargon**: REJECT 2/3 — `aoe logs` is the actual project CLI subcommand (`src/cli/logs.rs`: "view the configured AoE log file with a pretty viewer"). The bot mistook a literal command invocation for a typo.
- **Missing `tracing::error!` assertion test**: REJECT 2/3 — author explicitly documented the trade-off inline ("We can't assert on the tracing output without a custom subscriber, but absence of a JoinError is the contract we depend on"). The three existing tests cover the public contract (clean join on success, clean join on `Log` panic, `JoinError::is_panic()` on `Surface` panic). Adding a custom subscriber-Layer for one test would be disproportionate; revisit only if a future bug shows the log line getting dropped.

### Why a follow-up rather than amending #1293

#1293 was already merged when the review feedback was synthesized. Maintainer @njbrake explicitly endorsed the `&dyn Any` swap.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib task_util` **3/3** pass

No behavior change; pure cleanup.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [ ] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1293. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 ACCEPT for comments 2 and 4, REJECT for comments 1, 3, 5 (one false positive: bot didn't realize `aoe logs` is a real CLI subcommand).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This is a refactor of the task utility module with no behavioral changes. The PR improves code clarity through two targeted updates: simplifying the function signature for panic message conversion and clarifying a misleading test name.

## Changes Made
**File modified:** `src/task_util.rs`

1. **Simplified panic payload handling:** Updated the `panic_payload_string` helper function to accept a reference to the panic payload directly, removing an unnecessary layer of indirection. The calling code was adjusted to dereference the payload when passing it to this function.

2. **Renamed test:** Changed the test name from `normal_completion_returns_value` to `normal_completion_runs_to_end` to better reflect what the test actually validates—that the spawned task executes successfully and the handle joins cleanly—rather than implying a return value assertion.

## Technical Details
- **Signature change:** `panic_payload_string(payload: &Box<dyn Any + Send>)` → `panic_payload_string(payload: &(dyn Any + Send))` eliminates the unnecessary `Box` reference, allowing the downcast logic to work through deref coercion rather than operating on a boxed reference.
- **Rationale:** This change follows Rust idioms and eliminates clippy's `borrowed_box` warning (clippy::pedantic). The surrounding panic handling logic and `PanicPolicy` behavior remain unchanged.
- **Test preservation:** The test logic is intact; only the name was updated for clarity.

## Code Quality Impact
- **Lines changed:** 3 insertions, 3 deletions
- **Idiomatic improvement:** Aligns with Rust best practices by avoiding unnecessary boxing indirection
- **Test clarity:** Reduces confusion about what the test validates
- **CI status:** All tests pass; code formatting and linting checks clean

## No Impact On
- Public API surface (exported types and functions retain their signatures)
- Behavioral logic (pure refactor)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1316?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->