### PR TITLE
docs(push): tighten send_semaphore coverage doc to actual paths (#1294 follow-up)

### DIFF
--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -332,11 +332,12 @@ pub struct PushState {
     /// either `mailto:` or an `https://` URL per the spec. Not strongly
     /// validated by push endpoints in practice.
     pub subject: String,
-    /// Shared `SEND_CONCURRENCY` budget across every send_one path.
-    /// `spawn_consumer`'s fire_due_pushes loop and the wake fire path
-    /// both `acquire_owned` here, so a session with many subscribers
-    /// cannot fan out beyond the gateway concurrency the consumer
-    /// pipeline expects.
+    /// Shared `SEND_CONCURRENCY` budget across the consumer-driven
+    /// (`fire_due_pushes`) and wake-fire (`fire_wake_fired_push`) fan-out
+    /// paths, so a session with many subscribers cannot fan out beyond
+    /// the gateway concurrency the consumer pipeline expects. The admin
+    /// test-push handler (`send_one` in the `/api/push/test` route) is
+    /// intentionally ungated since it is a one-shot user-triggered send.
     pub send_semaphore: std::sync::Arc<tokio::sync::Semaphore>,
 }
 


### PR DESCRIPTION
## Description

Follow-up to #1294 (push wake-fire respects SEND_CONCURRENCY semaphore).

### What changed

The `send_semaphore` field doc on `PushState` claimed the budget was shared across "every send_one path", but `git grep` reveals **three** `send_one` callers:
1. `fire_due_pushes` — semaphore-gated ✓
2. `fire_wake_fired_push` — semaphore-gated ✓
3. **The `/api/push/test` admin handler at ~line 1072** — intentionally **ungated** (one-shot user-triggered send, not fan-out)

The doc is tightened to name the two fan-out paths exactly and document the deliberate test-path exception. **Documentation-only**; no behavior change.

Diff stats: `1 file changed, 6 insertions(+), 5 deletions(-)`.

### Comments dismissed

Cross-validation (3 oracles, same prompt) determined the other 3 review comments are not actionable:

- **Comment 1 (`expect()` at line 443 can panic if refactored)**: REJECT 3/3. The early-return at line 427 (`if state.push.is_none() { return; }`) is in the same function as the `expect()`, 14 lines above. The expect message references this guard verbatim. Bot's "if refactored" is hypothetical; this is the idiomatic Rust pattern for "I just proved this `Some` moments ago." `state.push` is set once at init and never mutated.

- **Comment 2 (acquire-before-spawn vs spawn-then-acquire at line 784)**: REJECT 3/3. Maintainer @njbrake explicitly addressed this in the APPROVAL ("`SEND_CONCURRENCY=8` is well above typical subscriber counts and there's no starvation risk in either direction"). For a personal-server / cockpit deployment, subscribers per user = 1-5 (laptop + phone + maybe tablet). At N≤10, spawning then acquiring 8 permits costs ~few KB of parked task stacks; trivial. Acquire-before-spawn would either serialize the subscriber loop (defeats parallel fan-out) or require a `JoinSet` + `try_acquire` ladder for no gain at this N. The bot is applying a high-fan-out gateway pattern to a single-user app. The pattern is also **symmetric** with `fire_due_pushes` (the consumer path) — bot would have to flag both, but the symmetry was deliberate.

- **Comment 4 (silent permit failure at line 783)**: DISMISS 3/3. `acquire_owned()` only errors when the semaphore is `close()`d, which never happens anywhere in the codebase (`git grep` confirms). The error branch is unreachable in practice. A `tracing::debug!` would be defensive scaffolding for a state that doesn't exist today; revisit if a graceful shutdown ever closes the semaphore.

### Why a follow-up rather than amending #1294

#1294 was already merged. The doc tightening is the only post-merge correction worth a separate PR.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib server::push` **24/24** pass

No behavior change. No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1294. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 ACCEPT for comment 3 (doc overstates), REJECT for comments 1, 2, 4 (false positives + maintainer-addressed scaling concern + unreachable error path).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Updated the documentation for `PushState.send_semaphore` to more accurately reflect how the concurrent send budget is allocated in the codebase.

### What Changed

The inline documentation comment for `send_semaphore` in `src/server/push.rs` was clarified to tighten its scope. Previously, the documentation overstated coverage by stating the shared budget applied to "every send_one path." The updated documentation now explicitly identifies:

- **Two semaphore-gated paths**: 
  - Consumer-driven fan-out via `fire_due_pushes`
  - Wake-fired push via `fire_wake_fired_push`
- **One intentional exception**: The `/api/push/test` admin handler, which performs one-shot user-triggered sends without semaphore gating

### Benefits

- **Improved clarity**: Future maintainers now understand exactly which code paths are covered by the concurrency budget and which are deliberately excluded
- **Better documentation accuracy**: The doc now precisely reflects the three callers of `send_one` that were identified during code inspection
- **Reduced confusion**: Eliminates ambiguity about scope that could have led to incorrect assumptions during future maintenance

### Changes Scope

- **Files modified**: 1 (`src/server/push.rs`)
- **Lines changed**: +6/-5
- **Code changes**: None — documentation only
- **Behavior changes**: None

All existing tests pass (24/24 for push-related tests) and linting checks remain clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1317?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->