### PR TITLE
fix(cockpit/ws): restore drop-cancels-reader semantics + drop mut from shutdown (#1295 follow-up)

### DIFF
--- a/src/cockpit/client/ws.rs
+++ b/src/cockpit/client/ws.rs
@@ -69,6 +69,14 @@ pub struct WsHandle {
     /// codebase (`state.shutdown`, tunnel watchdog) and avoids the
     /// `Option<Sender>` dance because cancellation is idempotent.
     shutdown: tokio_util::sync::CancellationToken,
+    /// Drop-cancel: restores the prior `mpsc::Sender`-drop semantics
+    /// from before #1295. Without this, dropping a `WsHandle` without
+    /// an explicit `shutdown().await` would leave `reader_loop` parked
+    /// on `stream.next()` instead of sending a Close frame and
+    /// exiting. The guard cancels the same token on drop; the
+    /// explicit `shutdown()` path's earlier `cancel()` is idempotent
+    /// so there is no double-cancel hazard.
+    _drop_guard: tokio_util::sync::DropGuard,
 }
 
 /// Wait this long for the reader task to send its close frame and
@@ -86,11 +94,12 @@ impl WsHandle {
     /// Falls back to `abort()` if the task doesn't finish within
     /// `SHUTDOWN_GRACE` so a stuck or already-aborted task can't
     /// block teardown.
-    pub async fn shutdown(mut self) {
+    pub async fn shutdown(self) {
         self.shutdown.cancel();
-        match tokio::time::timeout(SHUTDOWN_GRACE, &mut self.task).await {
+        let mut task = self.task;
+        match tokio::time::timeout(SHUTDOWN_GRACE, &mut task).await {
             Ok(_) => {}
-            Err(_) => self.task.abort(),
+            Err(_) => task.abort(),
         }
     }
 }
@@ -116,11 +125,13 @@ pub async fn connect(
     let (stream, _) = connect_async(request).await?;
     let (frame_tx, frame_rx) = mpsc::channel(64);
     let shutdown = tokio_util::sync::CancellationToken::new();
+    let _drop_guard = shutdown.clone().drop_guard();
     let task = tokio::spawn(reader_loop(stream, frame_tx, shutdown.clone()));
     Ok(WsHandle {
         rx: frame_rx,
         task,
         shutdown,
+        _drop_guard,
     })
 }
 


### PR DESCRIPTION
## Description

Follow-up to #1295 (replace `mpsc(1)` shutdown signal with `CancellationToken` for `WsHandle`).

### What changed

Two follow-ups against `src/cockpit/client/ws.rs`:

1. **Drop regression** (real bug found by review-bot, validated 3/3 by cross-validation). The pre-PR shape used `Option<mpsc::Sender<()>>`, so dropping the `WsHandle` dropped the sole `Sender`, resolved `shutdown.recv()` to `None` on the receiver side, and let `reader_loop` send the WS Close frame and exit cleanly. The `CancellationToken` refactor in #1295 lost this contract: `CancellationToken` does **not** cancel on drop, and `JoinHandle` drop only detaches, so dropping a `WsHandle` without an explicit `shutdown().await` left `reader_loop` parked on `stream.next()` until the next inbound frame errored. **No `Close` frame was ever sent**, and idle daemons saw an abrupt TCP teardown.

   Add a `tokio_util::sync::DropGuard` field on `WsHandle` that holds a clone of the same shutdown token. The guard cancels the token on drop, restoring the prior "drop = clean shutdown with Close frame" contract that the public docstring already advertised (*"Drop or call [`Self::shutdown`] to close"*). The explicit `shutdown()` path's `cancel()` now happens before the guard's, but `CancellationToken::cancel` is idempotent, so there is no double-cancel hazard.

   This restores the regression in callers that drop `WsHandle` without ever calling `shutdown()`:
   - `src/cli/cockpit.rs:768` (`aoe cockpit tail` Ctrl-C)
   - `src/tui/cockpit_view/mod.rs:218,223,263` (cockpit-view exit)

2. **Cosmetic: drop `mut` from `shutdown` signature** (maintainer-endorsed). The `mut self` was only needed for `&mut self.task`. Move `self.task` into a local first; the rest of `self` drops at scope end.

   **Why DropGuard rather than `impl Drop for WsHandle`**: an explicit `impl Drop` forbids partial moves (`let mut task = self.task;` would fail with E0509), making it incompatible with the `mut self` → `self` cosmetic. The `DropGuard` approach lets us land both fixes simultaneously.

Diff stats: `1 file changed, 14 insertions(+), 3 deletions(-)`.

### Why a follow-up rather than amending #1295

#1295 was already merged. Maintainer @njbrake explicitly endorsed the `mut` cosmetic in the APPROVAL note; the Drop regression was only flagged by Stage-1 cross-validation post-merge.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::client::ws` **6/6** pass

The `DropGuard` is exercised on every existing test that drops a `WsHandle`. Adding a regression test would require driving a real or mock WebSocket; covered by the type system + the docstring contract.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1295. Stage 1 (analyze + validate review comments) used 3 oracles in parallel with the same prompt for cross-validation; consensus 3/3 VALID for both comments, with one oracle (Oracle 3) catching the critical compatibility issue: an `impl Drop for WsHandle` would block the partial move in the cosmetic refactor (E0509), so `DropGuard` is the unifying solution.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The `WsHandle` struct now includes an additional field `_drop_guard` that automatically triggers WebSocket cleanup when the handle is dropped. The `shutdown()` method was refactored to use a local task variable instead of requiring `mut` self.

## What Was Added

- **New field in `WsHandle`**: `_drop_guard: tokio_util::sync::DropGuard` (line 79) — a guard that automatically cancels the shutdown token when dropped
- **Drop-cancel mechanism** (lines 128, 134): The `connect()` function now creates and stores a drop guard from the cancellation token

## What Was Modified

- **`shutdown()` method** (lines 97-104): Refactored to take ownership of `self` without `mut`, moving the task into a local variable before cleanup. This allows the method to cancel the token, wait for the task with a 200ms timeout, and abort if necessary without requiring mutability

## What Was Removed

- `mut` keyword from the `shutdown()` method signature

## Benefits

1. **Fixes drop regression**: Dropping a `WsHandle` now automatically triggers a clean WebSocket Close frame, preventing abrupt TCP teardowns
2. **Improves CLI/TUI exits**: Applications that simply drop the handle (without calling shutdown) now get proper cleanup
3. **Idempotent cancellation**: The explicit `shutdown()` call still works correctly; calling `cancel()` twice is safe, so there's no risk of double-cancel issues
4. **Maintains clean semantics**: Restores the prior behavior where dropping the handle equals a graceful shutdown

## Technical Details

The fix uses `tokio_util::sync::DropGuard`, which wraps the `CancellationToken` and calls `cancel()` when dropped. Since `CancellationToken::cancel()` is idempotent, both the drop path and the explicit `shutdown()` path work harmoniously. The `shutdown()` method gives the reader task 200ms (SHUTDOWN_GRACE) to send a Close frame and exit cleanly before falling back to `abort()`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1318?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->