### PR TITLE
docs(task_util): tighten spawn_supervised return-type doc (#1296 follow-up)

### DIFF
--- a/src/task_util.rs
+++ b/src/task_util.rs
@@ -29,9 +29,10 @@ pub enum PanicPolicy {
 }
 
 /// Spawn a future on the tokio runtime with panic logging. The
-/// returned `JoinHandle` matches `tokio::spawn`'s shape; callers
-/// that drop it still get the diagnostic via `tracing::error!` on
-/// panic, which is the whole point.
+/// returned `JoinHandle<()>` is equivalent to `tokio::spawn` for
+/// futures with `Output = ()`; callers that drop it still get the
+/// diagnostic via `tracing::error!` on panic, which is the whole
+/// point.
 ///
 /// Pair with `tracing::Instrument` at the call site to propagate
 /// a span across the spawn boundary:


### PR DESCRIPTION
## Description

Follow-up to #1296 (migrate fire-and-forget spawns to `spawn_supervised`).

### What changed

The `spawn_supervised` doc said the returned `JoinHandle` "matches `tokio::spawn`'s shape", but the helper hard-codes `JoinHandle<()>` via the `F: Future<Output = ()>` bound. `tokio::spawn` returns `JoinHandle<F::Output>` for arbitrary outputs, so the wording overstates. Tightened to "equivalent to `tokio::spawn` for futures with `Output = ()`".

Pure documentation change. No API change, no behavior change.

Diff stats: `1 file changed, 4 insertions(+), 3 deletions(-)`.

### Comments dismissed / deferred

Cross-validation by 3 oracles, same prompt:

- **Comment 1 (`tokio::select!` "missing comma" compile claim, mod.rs:775)**: INVALID 3/3. The bot misread `tokio::select!` macro grammar. Block-bodied arms self-terminate at `}` — trailing commas are optional, exactly like `match` arms. PR #1296 was MERGED green, which is sufficient proof the build works. Bot also targeted line 775 when the actual `select!` is at line 826 (the GC loop).

- **Comment 4 (test name `normal_completion_returns_value` misleading, task_util.rs:84)**: VALID but DEFERRED to #1316 (the PR #1293 follow-up I already opened that renames to `normal_completion_runs_to_end`). Renaming here would create a merge conflict.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib task_util` **3/3** pass

No behavior change. No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [ ] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1296. Stage 1 (analyze + validate) used 3 oracles in parallel; consensus 3/3 INVALID for comment 1 (macro grammar false positive), VALID 3/3 for comments 2+3 (doc tightening), DEFER for comment 4 (already in flight in #1316).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR refines the documentation for the `spawn_supervised` function to more accurately describe the type of `JoinHandle` it returns.

### What Changed

The documentation comment for `spawn_supervised` was updated to clarify the return type. The previous wording stated that the returned `JoinHandle` "matches `tokio::spawn`'s shape," but this was imprecise. Since the helper constrains futures to have `Output = ()` (via `F: Future<Output = ()>`), it always returns `JoinHandle<()>`, whereas `tokio::spawn` returns `JoinHandle<F::Output>` for arbitrary output types.

The doc text now states that the returned `JoinHandle<()>` is "equivalent to `tokio::spawn` for futures with `Output = ()`."

### Impact

- **No code changes**: This is purely a documentation improvement
- **No behavior changes**: The function works exactly as before
- **No API changes**: The function signature remains unchanged
- **Clarity benefit**: Developers using this function now understand precisely what type is returned and how it relates to the standard `tokio::spawn` behavior

### Testing

All existing tests pass (3/3 in task_util), and code formatting and linting checks are clean.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1319?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->