### PR TITLE
fix(cockpit): drop stale 50ms doc + bump notify regression test timeout (#1297 follow-up)

### DIFF
--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1108,11 +1108,7 @@ impl<S: BroadcastSink> Supervisor<S> {
     /// click Send right after enabling cockpit, while `Supervisor::spawn`
     /// is still in the 2-3s ACP handshake. Without this wait, those
     /// requests would 404 because the WorkerHandle isn't in `workers`
-    /// yet, even though it's about to be. Polling at 50ms keeps the
-    /// happy-path latency negligible while bounding the wait.
-    /// Block until either the worker for `session_id` lands in
-    /// `workers` or the pending reservation falls off (giving up
-    /// fast on a dead path) or `deadline` lapses.
+    /// yet, even though it's about to be.
     ///
     /// Uses `tokio::sync::Notify` for edge triggered wakeups instead
     /// of polling. The previous shape woke every 50 ms, which added
@@ -2799,9 +2795,9 @@ mod tests {
         let dropped_at = std::time::Instant::now();
         drop(reservation);
 
-        let result = tokio::time::timeout(std::time::Duration::from_millis(20), waiter)
+        let result = tokio::time::timeout(std::time::Duration::from_millis(200), waiter)
             .await
-            .expect("waiter must wake on notify, not at the 50 ms poll")
+            .expect("waiter must wake on notify well under the old 50 ms poll")
             .expect("waiter task must not panic");
         let elapsed = dropped_at.elapsed();
 


### PR DESCRIPTION
## Description

Follow-up to #1297 (replace `wait_for_worker` poll with `Notify`).

### What changed

Two follow-ups against `src/cockpit/supervisor.rs`, both **maintainer-confirmed** in the original PR review:

1. **Stale doc cleanup**. The `wait_for_worker` docstring still contained the obsolete *"Polling at 50ms keeps the happy-path latency negligible while bounding the wait."* sentence from before the Notify migration, plus a duplicate intro line. Two contradictory paragraphs sat back-to-back. Maintainer @njbrake explicitly flagged this in the APPROVAL ("the doc paragraph at `src/cockpit/supervisor.rs:~1093-1098` ... still describes the removed poll behavior. Worth deleting or merging with the new paragraph below it"). Delete the stale text; the new paragraph below already documents the edge-triggered Notify design.

2. **Test timeout flake guard**. The `wait_for_worker_wakes_on_reservation_drop` regression test uses a 20ms outer `tokio::time::timeout` for the waiter await. On contended CI runners (CPU-starved containers, GitHub Actions shared hosts, scheduler jitter routinely 20-50ms), this can panic before the actual regression assertion ever runs. The regression signal is the **separate** `assert!(elapsed < 50ms)` against the old poll interval; the outer timeout is just a hang guard. Bump it to 200ms (4× old poll) and update the panic message; the `elapsed < 50ms` assertion stays intact since that is what proves Notify wakes faster than the polled shape.

Diff stats: `1 file changed, 3 insertions(+), 7 deletions(-)`.

### Comments dismissed

Cross-validation by 3 oracles, same prompt:

- **`notify_waiters` race claim (line 1133)**: INVALID 3/3, explicitly refuted by maintainer @njbrake with tokio source citation: *"`Notify::notified()` snapshots the `notify_waiters_calls` counter at construction, so a `notify_waiters()` arriving between `notified()` and the first poll resolves Ready immediately."* The double-check pattern (subscribe to `notified()` BEFORE peeking maps, then await) is the canonical correct shape and exactly what the PR uses. The bot's claim conflates `notify_one()` semantics (waker registration on poll) with `notify_waiters()` semantics (counter-based).

- **`std::sync::Mutex` blocks Tokio claim (line 569)**: INVALID 3/3, same generic concern previously dismissed on PR #1284's identical `lock_recover` pattern. Critical sections are sub-microsecond `HashMap` ops, never held across `.await`. The sync mutex is required for runtime-independent `ResumeReservation::Drop` — the explicit motivating constraint of #1284 — and switching to `parking_lot` or async mutex would either reintroduce poisoning concerns differently or break runtime-independence in `Drop`.

### Why a follow-up rather than amending #1297

#1297 was already merged. Maintainer endorsed both fixes in the APPROVAL note.

### Tests

- `cargo fmt --check` clean
- `cargo clippy --features serve -- -D warnings` clean
- `cargo test --features serve --lib cockpit::supervisor::tests::wait_for_worker_wakes_on_reservation_drop` pass

No behavior change. The test still proves Notify wakes faster than 50ms; only the outer hang-guard is more generous on contended runners.

No web changes, no `coverage-matrix.json` update needed.

## PR Type

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**
Follow-up to #1297. Stage 1 (analyze + validate) used 3 oracles in parallel; consensus 3/3 INVALID for comments 1+3 (both refuted with concrete evidence: tokio source for notify_waiters, prior #1284 dismissal for sync mutex), VALID 3/3 for comments 2+4 (stale doc + tight test timeout, both maintainer-confirmed).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR applies targeted follow-up fixes to the cockpit supervisor module, addressing documentation and test robustness issues surfaced during code review of PR `#1297` (which replaced wait_for_worker polling with Notify).

## Changes Made

**Documentation cleanup**: Removed an obsolete sentence from the `wait_for_worker` docstring that described the previous 50ms polling behavior ("Polling at 50ms keeps the happy-path latency negligible while bounding the wait."). Also removed a duplicate introductory line that contradicted the new paragraph documenting the actual edge-triggered Notify design. The updated docstring now clearly reflects the current implementation using tokio::sync::Notify for wakeups.

**Test timeout adjustment**: Increased the outer `tokio::time::timeout` in the `wait_for_worker_wakes_on_reservation_drop` regression test from 20ms to 200ms (4x the old poll interval) and updated the timeout panic message. This prevents the test from timing out prematurely on contended CI runners where scheduler jitter can exceed 20ms, which would cause the test to panic before the actual regression assertion could run. The internal assertion validating that Notify wakes faster than the old 50ms poll interval remains intact as the true regression signal.

## Technical Rationale

The changes stabilize a regression test that was too sensitive to scheduling latency while maintaining the actual performance validation (the elapsed < 50ms assertion proving Notify outperforms polling). The documentation updates bring the code comments into sync with the Notify-based implementation introduced in PR `#1297`.

## Validation

- cargo fmt: clean
- cargo clippy --features serve: clean  
- cargo test wait_for_worker_wakes_on_reservation_drop: passes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->