### PR TITLE
test(web): devices and disconnect-banner live Playwright coverage

### DIFF
--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -76,6 +76,7 @@ Isolation per test:
 - Port: `5200 + workerIndex*100 + parallelIndex + attempt*7`. Five retries on bind failure.
 - Fake `claude` shim in `home/bin/claude` (`exec tail -f /dev/null`). Cockpit fixture overrides with the fake-ACP shim, installed under `claude`, `claude-agent-acp`, and `aoe-agent`.
 - `stop()` does `SIGTERM` with a 2s wait, `SIGKILL` fallback, then `rm -rf home`. Never calls `tmux kill-server` (would kill the developer's tmux).
+- `restart()` kills the running proc (`SIGTERM` then `SIGKILL` after 2s) and respawns with the same args on the same port. Used by connectivity-recovery specs (`disconnect-banner.spec.ts`) that need to observe `setServerDown(true)` on SIGTERM and `setServerDown(false)` after the server comes back. Token mode re-reads the freshly written `serve.token` so `handle.authToken` tracks the second boot. Does NOT re-run passphrase prelogin or cockpit master-enable across the restart; specs that need those should call `spawnAoeServe` again.
 
 Binary resolution: `AOE_E2E_BINARY` env wins; otherwise `<repo>/target/release/aoe`. `liveGlobalSetup.ts` runs once before any worker and calls `cargo build --features serve --release` if the binary is missing.
 

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -228,16 +228,16 @@
     },
     {
       "id": "devices",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1222",
+      "kind": "live-playwright",
       "risk": "low",
+      "specs": ["tests/live/devices.spec.ts"],
       "components": ["web/src/components/ConnectedDevices.tsx"]
     },
     {
       "id": "connectivity.disconnect-banner",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1222",
+      "kind": "live-playwright",
       "risk": "medium",
+      "specs": ["tests/live/disconnect-banner.spec.ts"],
       "components": ["web/src/components/DisconnectBanner.tsx"]
     },
     {

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -559,18 +559,30 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     if (child.exitCode !== null || child.signalCode !== null) return;
     child.kill("SIGTERM");
     await new Promise<void>((resolveExit) => {
-      const t = setTimeout(() => {
+      let resolved = false;
+      const done = () => {
+        if (resolved) return;
+        resolved = true;
+        clearTimeout(escalate);
+        clearTimeout(backstop);
+        resolveExit();
+      };
+      // 2s after SIGTERM, escalate to SIGKILL. Do NOT resolve here:
+      // restart() reuses the same port and a too-early resolve races
+      // the kernel's TCP cleanup, so spawnOnce can land on EADDRINUSE.
+      // Wait for the real exit event (or the backstop below).
+      const escalate = setTimeout(() => {
         try {
           child.kill("SIGKILL");
         } catch {
           // ignore
         }
-        resolveExit();
       }, 2000);
-      child.once("exit", () => {
-        clearTimeout(t);
-        resolveExit();
-      });
+      // Hard backstop so a pathologically uncooperative child can't
+      // hang the test forever. SIGKILL is uninterruptible on POSIX
+      // outside zombie/D-state, so this should not fire in practice.
+      const backstop = setTimeout(done, 4000);
+      child.once("exit", done);
     });
   }
 
@@ -597,24 +609,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     },
     async stop() {
       try {
-        if (proc && proc.exitCode === null && proc.signalCode === null) {
-          proc.kill("SIGTERM");
-          // Give the server 2s to drain, then SIGKILL.
-          await new Promise<void>((resolveExit) => {
-            const t = setTimeout(() => {
-              try {
-                proc!.kill("SIGKILL");
-              } catch {
-                // ignore
-              }
-              resolveExit();
-            }, 2000);
-            proc!.once("exit", () => {
-              clearTimeout(t);
-              resolveExit();
-            });
-          });
-        }
+        if (proc) await killProc(proc);
       } finally {
         // Best-effort: kill any tmux server bound to the isolated socket
         // before deleting the dir. Cockpit specs leave tmux child

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -139,6 +139,18 @@ export interface ServeHandle {
    */
   tmuxPrefix: "aoe_" | "aoe_dev_";
   stop(): Promise<void>;
+  /**
+   * Kill the running `aoe serve` proc and respawn it with the same args
+   * on the same port. Used by connectivity-recovery specs (disconnect
+   * banner) that need to observe the dashboard's `setServerDown(true)`
+   * path on SIGTERM and then `setServerDown(false)` once the server is
+   * back. The captured port is reused after the dead listener releases
+   * it on `exit`. Token-mode reads the freshly written `serve.token`
+   * and updates `handle.authToken`. Does NOT re-run passphrase
+   * `preloginViaHarness` or cockpit master enable; specs that need
+   * those across a restart should call `spawnAoeServe` again.
+   */
+  restart(): Promise<void>;
 }
 
 /**
@@ -447,14 +459,9 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   const passphrase = authMode === "passphrase" ? opts.passphrase ?? DEFAULT_PASSPHRASE : undefined;
 
   const spawnTimeoutMs = opts.spawnTimeoutMs ?? 10_000;
-  let proc: ChildProcess | null = null;
-  let port = 0;
-  let baseUrl = "";
 
-  for (let attempt = 0; attempt < 5; attempt++) {
-    port = portFor(opts.workerIndex, opts.parallelIndex, attempt);
-    baseUrl = `http://127.0.0.1:${port}`;
-    const args = ["serve", "--host", "127.0.0.1", "--port", String(port)];
+  function buildArgs(boundPort: number): string[] {
+    const args = ["serve", "--host", "127.0.0.1", "--port", String(boundPort)];
     if (authMode === "none") args.push("--no-auth");
     if (authMode === "token") args.push("--auth", "token");
     if (authMode === "passphrase") {
@@ -472,8 +479,14 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     if (passphrase) args.push("--passphrase", passphrase);
     if (opts.readOnly) args.push("--read-only");
     if (opts.extraArgs) args.push(...opts.extraArgs);
+    return args;
+  }
 
-    proc = spawn(aoeBinary, args, {
+  async function spawnOnce(
+    args: string[],
+    boundBaseUrl: string,
+  ): Promise<ChildProcess> {
+    const child = spawn(aoeBinary, args, {
       stdio: ["ignore", "pipe", "pipe"],
       env: seedEnv,
     });
@@ -486,26 +499,43 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
       const fs = await import("node:fs");
       const log = fs.createWriteStream(logPath, { flags: "a" });
       log.write(`\n=== spawn ${args.join(" ")} (home=${home}) ===\n`);
-      proc.stdout?.on("data", (b) => log.write(`[stdout] ${b}`));
-      proc.stderr?.on("data", (b) => log.write(`[stderr] ${b}`));
+      child.stdout?.on("data", (b) => log.write(`[stdout] ${b}`));
+      child.stderr?.on("data", (b) => log.write(`[stderr] ${b}`));
     }
 
     let spawnFailed = false;
-    proc.once("error", () => {
+    child.once("error", () => {
       spawnFailed = true;
     });
 
     try {
-      await waitForServer(baseUrl, spawnTimeoutMs, proc, authMode);
-      break;
+      await waitForServer(boundBaseUrl, spawnTimeoutMs, child, authMode);
+      return child;
     } catch (err) {
       try {
-        proc.kill("SIGKILL");
+        child.kill("SIGKILL");
       } catch {
         // ignore
       }
-      proc = null;
-      if (spawnFailed || attempt === 4) {
+      const wrapped = spawnFailed
+        ? new Error(`spawn failed before listen: ${String(err)}`)
+        : err;
+      throw wrapped;
+    }
+  }
+
+  let proc: ChildProcess | null = null;
+  let port = 0;
+  let baseUrl = "";
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    port = portFor(opts.workerIndex, opts.parallelIndex, attempt);
+    baseUrl = `http://127.0.0.1:${port}`;
+    try {
+      proc = await spawnOnce(buildArgs(port), baseUrl);
+      break;
+    } catch (err) {
+      if (attempt === 4) {
         rmSync(home, { recursive: true, force: true });
         throw err;
       }
@@ -525,6 +555,25 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     authToken = await readTokenFile(tokenFile, spawnTimeoutMs);
   }
 
+  async function killProc(child: ChildProcess): Promise<void> {
+    if (child.exitCode !== null || child.signalCode !== null) return;
+    child.kill("SIGTERM");
+    await new Promise<void>((resolveExit) => {
+      const t = setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
+        resolveExit();
+      }, 2000);
+      child.once("exit", () => {
+        clearTimeout(t);
+        resolveExit();
+      });
+    });
+  }
+
   const handle: ServeHandle = {
     baseUrl,
     port,
@@ -536,6 +585,16 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     authToken,
     tokenFile,
     tmuxPrefix: tmuxPrefixFor(aoeBinary),
+    async restart() {
+      if (proc) await killProc(proc);
+      const next = await spawnOnce(buildArgs(port), baseUrl);
+      proc = next;
+      handle.proc = next;
+      if (authMode === "token" && tokenFile) {
+        const refreshed = await readTokenFile(tokenFile, spawnTimeoutMs);
+        handle.authToken = refreshed;
+      }
+    },
     async stop() {
       try {
         if (proc && proc.exitCode === null && proc.signalCode === null) {

--- a/web/tests/live/devices.spec.ts
+++ b/web/tests/live/devices.spec.ts
@@ -149,9 +149,10 @@ test("settings -> devices renders ConnectedDevices with captured browser", async
     page.getByRole("heading", { name: /connected devices/i }),
   ).toBeVisible({ timeout: 10_000 });
 
-  // The list renders one row per (ip, user_agent). 127.0.0.1 is the
-  // loopback IP every harness device authenticates from.
-  await expect(page.getByText("127.0.0.1").first()).toBeVisible({
+  // The list renders one row per (ip, user_agent). The loopback IP
+  // varies by host stack: 127.0.0.1 on most Linux/macOS setups, ::1
+  // where IPv6 wins the bind. Match either so the spec stays portable.
+  await expect(page.getByText(/(127\.0\.0\.1|::1)/).first()).toBeVisible({
     timeout: 10_000,
   });
 });

--- a/web/tests/live/devices.spec.ts
+++ b/web/tests/live/devices.spec.ts
@@ -1,0 +1,157 @@
+// GET /api/devices coverage.
+//
+// `ConnectedDevices.tsx` lists devices that have authenticated against
+// the server. In `--no-auth` mode the middleware bypasses
+// `record_device` entirely (src/server/auth.rs:530-553), so this spec
+// uses `serveToken` where every successful token-authenticated request
+// hits `record_device` (src/server/auth.rs:697-703).
+//
+// Three flows:
+//   1. Endpoint shape: after browser navigation, GET /api/devices
+//      returns at least one entry with the documented fields.
+//   2. Multi-device: a second authenticated request from a custom
+//      User-Agent grows the list to two entries.
+//   3. UI: the /settings/devices panel mounts ConnectedDevices and
+//      renders the captured browser device.
+//
+// The issue (#1222) mentions "revoke path if an endpoint exists" --
+// no such endpoint exists in the server today, so the multi-device
+// flow asserts only the GET shape, per the issue note.
+
+import { test, expect } from "../helpers/liveTest";
+
+const DEVICE_FIELDS = [
+  "ip",
+  "user_agent",
+  "first_seen",
+  "last_seen",
+  "request_count",
+] as const;
+
+test("GET /api/devices returns the navigating browser after token auth", async ({
+  serveToken,
+  page,
+}) => {
+  const token = serveToken.authToken!;
+  expect(token, "harness exposes a token in token mode").toBeTruthy();
+
+  await page.goto(`${serveToken.baseUrl}/?token=${token}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  // Reach into the page context's cookie jar so the GET below carries
+  // the same aoe_token the SPA persisted. Asserting via page.request
+  // mirrors what the dashboard does after navigation.
+  await expect
+    .poll(
+      async () => {
+        const res = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+        if (!res.ok()) return -1;
+        const list = (await res.json()) as unknown[];
+        return list.length;
+      },
+      { timeout: 10_000, message: "browser device should be recorded" },
+    )
+    .toBeGreaterThan(0);
+
+  const res = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+  expect(res.ok()).toBeTruthy();
+  const list = (await res.json()) as Array<Record<string, unknown>>;
+
+  expect(list.length).toBeGreaterThan(0);
+  const browserDevice = list[0]!;
+  for (const field of DEVICE_FIELDS) {
+    expect(browserDevice, `device entry has '${field}'`).toHaveProperty(field);
+  }
+  expect(typeof browserDevice.ip).toBe("string");
+  expect(typeof browserDevice.user_agent).toBe("string");
+  expect(typeof browserDevice.first_seen).toBe("string");
+  expect(typeof browserDevice.last_seen).toBe("string");
+  expect(typeof browserDevice.request_count).toBe("number");
+  expect(browserDevice.request_count as number).toBeGreaterThan(0);
+});
+
+test("multi-device: a second authenticated UA appears as a distinct entry", async ({
+  serveToken,
+  page,
+}) => {
+  const token = serveToken.authToken!;
+  await page.goto(`${serveToken.baseUrl}/?token=${token}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  await expect
+    .poll(async () => {
+      const r = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+      if (!r.ok()) return 0;
+      return ((await r.json()) as unknown[]).length;
+    }, { timeout: 10_000 })
+    .toBeGreaterThan(0);
+
+  // Hit any token-gated endpoint with a distinct UA via Bearer auth.
+  // record_device keys on (ip, user_agent), so the curl-like UA lands
+  // as a new entry even though the IP is the same loopback.
+  const curlUa = "aoe-e2e-fake-curl/1.0";
+  const second = await fetch(`${serveToken.baseUrl}/api/about`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": curlUa,
+    },
+  });
+  expect(second.status).toBe(200);
+
+  await expect
+    .poll(
+      async () => {
+        const r = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+        if (!r.ok()) return [];
+        const list = (await r.json()) as Array<{ user_agent: string }>;
+        return list.map((d) => d.user_agent);
+      },
+      { timeout: 10_000, message: "second UA should land as a new device row" },
+    )
+    .toContain(curlUa);
+
+  const final = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+  const list = (await final.json()) as Array<{ user_agent: string }>;
+  expect(list.length).toBeGreaterThanOrEqual(2);
+});
+
+test("settings -> devices renders ConnectedDevices with captured browser", async ({
+  serveToken,
+  page,
+}) => {
+  const token = serveToken.authToken!;
+  await page.goto(`${serveToken.baseUrl}/?token=${token}`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  // Wait for the dashboard to finish bootstrap. /api/login/status
+  // fires once on load and the dashboard is gated on its 200.
+  await expect
+    .poll(
+      async () => {
+        const r = await page.request.get(`${serveToken.baseUrl}/api/devices`);
+        if (!r.ok()) return 0;
+        return ((await r.json()) as unknown[]).length;
+      },
+      { timeout: 10_000 },
+    )
+    .toBeGreaterThan(0);
+
+  await page.goto(`${serveToken.baseUrl}/settings/devices`, {
+    waitUntil: "domcontentloaded",
+  });
+
+  // Heading text is uppercased via Tailwind but the underlying DOM
+  // node is "Connected Devices" (see ConnectedDevices.tsx).
+  await expect(
+    page.getByRole("heading", { name: /connected devices/i }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  // The list renders one row per (ip, user_agent). 127.0.0.1 is the
+  // loopback IP every harness device authenticates from.
+  await expect(page.getByText("127.0.0.1").first()).toBeVisible({
+    timeout: 10_000,
+  });
+});

--- a/web/tests/live/disconnect-banner.spec.ts
+++ b/web/tests/live/disconnect-banner.spec.ts
@@ -20,6 +20,17 @@ test("SIGTERM surfaces the alert; restart() clears it and flashes reconnected", 
   serve,
   page,
 }) => {
+  // Narrow role queries by text content. The dashboard has an unrelated
+  // dnd-kit live region (`<div role="status" aria-live="assertive">`)
+  // that would otherwise match `getByRole("status")` and false-trigger
+  // the reconnected assertion.
+  const alertBanner = page
+    .getByRole("alert")
+    .filter({ hasText: /server unreachable/i });
+  const reconnectedBanner = page
+    .getByRole("status")
+    .filter({ hasText: /reconnected/i });
+
   await page.goto(serve.baseUrl, { waitUntil: "domcontentloaded" });
 
   // Let the first /api/sessions poll land so `useSessions` has set
@@ -30,8 +41,8 @@ test("SIGTERM surfaces the alert; restart() clears it and flashes reconnected", 
     { timeout: 10_000 },
   );
 
-  await expect(page.getByRole("alert")).toBeHidden();
-  await expect(page.getByRole("status")).toBeHidden();
+  await expect(alertBanner).toBeHidden();
+  await expect(reconnectedBanner).toBeHidden();
 
   // SIGTERM directly so we can observe the disconnect banner BEFORE
   // the harness respawns. `restart()` would kill + respawn in one
@@ -40,8 +51,7 @@ test("SIGTERM surfaces the alert; restart() clears it and flashes reconnected", 
 
   // The poll interval is 3s; allow up to 8s for the first failed
   // tick to land + React commit to render the alert.
-  await expect(page.getByRole("alert")).toBeVisible({ timeout: 8_000 });
-  await expect(page.getByRole("alert")).toContainText(/server unreachable/i);
+  await expect(alertBanner).toBeVisible({ timeout: 8_000 });
 
   // Bring the server back on the same port. `restart()` is a no-op
   // SIGTERM on the dead proc, then a fresh spawn with the captured args.
@@ -65,11 +75,10 @@ test("SIGTERM surfaces the alert; restart() clears it and flashes reconnected", 
   // Reconnected flash renders inside its 3s window. The poll interval
   // is 3s, so worst-case we wait ~3s before the next /api/sessions
   // succeeds + setServerDown(false) fires.
-  await expect(page.getByRole("status")).toBeVisible({ timeout: 8_000 });
-  await expect(page.getByRole("status")).toContainText(/reconnected/i);
+  await expect(reconnectedBanner).toBeVisible({ timeout: 8_000 });
 
   // 3s timer in DisconnectBanner auto-clears the flash. Wait past it
   // with a small margin and confirm both banners are gone.
-  await expect(page.getByRole("status")).toBeHidden({ timeout: 6_000 });
-  await expect(page.getByRole("alert")).toBeHidden();
+  await expect(reconnectedBanner).toBeHidden({ timeout: 6_000 });
+  await expect(alertBanner).toBeHidden();
 });

--- a/web/tests/live/disconnect-banner.spec.ts
+++ b/web/tests/live/disconnect-banner.spec.ts
@@ -1,0 +1,75 @@
+// DisconnectBanner recovery flow.
+//
+// `useSessions` polls /api/sessions every 3s and flips
+// `setServerDown(true/false)` based on success. When the server is
+// down, `DisconnectBanner` renders `role=alert` "Server unreachable".
+// When the server comes back, a `role=status` "Reconnected" flash
+// shows for ~3s and then auto-dismisses.
+//
+// Spec drives the full cycle:
+//   1. Navigate to the dashboard in no-auth mode.
+//   2. SIGTERM the live `aoe serve` proc.
+//   3. Wait for the alert banner.
+//   4. Re-spawn the server on the same port via `serve.restart()`.
+//   5. Wait for the reconnected flash.
+//   6. Assert the flash auto-dismisses inside its 3s timer.
+
+import { test, expect } from "../helpers/liveTest";
+
+test("SIGTERM surfaces the alert; restart() clears it and flashes reconnected", async ({
+  serve,
+  page,
+}) => {
+  await page.goto(serve.baseUrl, { waitUntil: "domcontentloaded" });
+
+  // Let the first /api/sessions poll land so `useSessions` has set
+  // serverDown = false. Without this gate, the SIGTERM can race the
+  // initial fetch and the "Reconnected" assertion comes too early.
+  await page.waitForResponse(
+    (r) => r.url().endsWith("/api/sessions") && r.status() === 200,
+    { timeout: 10_000 },
+  );
+
+  await expect(page.getByRole("alert")).toBeHidden();
+  await expect(page.getByRole("status")).toBeHidden();
+
+  // SIGTERM directly so we can observe the disconnect banner BEFORE
+  // the harness respawns. `restart()` would kill + respawn in one
+  // shot and the banner would never get its 3s poll window to render.
+  serve.proc.kill("SIGTERM");
+
+  // The poll interval is 3s; allow up to 8s for the first failed
+  // tick to land + React commit to render the alert.
+  await expect(page.getByRole("alert")).toBeVisible({ timeout: 8_000 });
+  await expect(page.getByRole("alert")).toContainText(/server unreachable/i);
+
+  // Bring the server back on the same port. `restart()` is a no-op
+  // SIGTERM on the dead proc, then a fresh spawn with the captured args.
+  await serve.restart();
+
+  // /api/about responds on the new boot.
+  await expect
+    .poll(
+      async () => {
+        try {
+          const r = await fetch(`${serve.baseUrl}/api/about`);
+          return r.status;
+        } catch {
+          return -1;
+        }
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(200);
+
+  // Reconnected flash renders inside its 3s window. The poll interval
+  // is 3s, so worst-case we wait ~3s before the next /api/sessions
+  // succeeds + setServerDown(false) fires.
+  await expect(page.getByRole("status")).toBeVisible({ timeout: 8_000 });
+  await expect(page.getByRole("status")).toContainText(/reconnected/i);
+
+  // 3s timer in DisconnectBanner auto-clears the flash. Wait past it
+  // with a small margin and confirm both banners are gone.
+  await expect(page.getByRole("status")).toBeHidden({ timeout: 6_000 });
+  await expect(page.getByRole("alert")).toBeHidden();
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Closes #1222 by landing the two live Playwright specs that flip the `devices` and `connectivity.disconnect-banner` entries in `web/tests/coverage-matrix.json` from `deferred` to populated. Both target the foundation harness from #1228.

`tests/live/devices.spec.ts` covers `web/src/components/ConnectedDevices.tsx`:

- Asserts the `GET /api/devices` shape (`ip`, `user_agent`, `first_seen`, `last_seen`, `request_count`) after the browser authenticates against a token-mode server.
- Drives a second authenticated request with a distinct `User-Agent` and confirms the device list grows to two entries (loopback IP, two UAs).
- Mounts the `/settings/devices` panel and confirms `ConnectedDevices` renders the captured browser row.

The spec uses the `serveToken` fixture rather than `serve` because `auth_middleware` short-circuits before `record_device` in `--no-auth` mode (`src/server/auth.rs:530-553`); `record_device` only fires on the token-validation and session-authenticated paths.

`tests/live/disconnect-banner.spec.ts` covers `web/src/components/DisconnectBanner.tsx`:

- Navigates to the dashboard, waits for the first `/api/sessions` poll to land.
- SIGTERMs the live `aoe serve` proc directly so the dashboard observes the failure window before the harness brings the server back.
- Waits up to one poll cycle for the `role="alert"` "Server unreachable" banner.
- Calls `serve.restart()` to respawn on the same port with the same args, then asserts the `role="status"` "Reconnected" flash, and finally that the 3s timer auto-dismisses the flash.

Banner role queries are narrowed by text content because the dashboard mounts an unrelated dnd-kit `<div role="status">` live region; an unfiltered `getByRole("status")` would false-trigger on it.

To support the restart flow without re-deriving spawn args from the outside, the harness gains a `restart()` method on `ServeHandle`. Implementation extracts the per-attempt spawn into a `spawnOnce()` closure inside `spawnAoeServe`, so the bind loop and `restart()` share the same path. `restart()` SIGTERMs the existing proc with the same 2s/SIGKILL fallback `stop()` uses, respawns with the captured args on the captured port, and re-reads `serve.token` for token mode. Passphrase prelogin and cockpit master-enable are not re-run across the restart; documented as a known limitation on the JSDoc and in `docs/development/playwright.md`.

Closes #1222

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] `node web/tests/validate-coverage-matrix.mjs` reports passing (the `devices` and `connectivity.disconnect-banner` entries are now `live-playwright` with `specs[]` populated).
- [ ] `cd web && npx playwright test --config=playwright.live.config.ts devices.spec.ts` passes (3 tests).
- [ ] `cd web && npx playwright test --config=playwright.live.config.ts disconnect-banner.spec.ts` passes (1 test).
- [ ] In the disconnect-banner spec the `Server unreachable` alert is observed before the restart and the `Reconnected` flash is observed after, then the flash auto-clears within ~3s.
- [ ] Open `docs/development/playwright.md` and confirm the "Isolation per test" section now documents `restart()` alongside `stop()`.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, approved the plan, and ran the live Playwright suite locally against `target/release/aoe` to confirm the four tests pass.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds comprehensive live Playwright test coverage for two previously untested features and includes supporting infrastructure improvements. The changes close issue `#1222` by populating test coverage for the devices management and disconnect-banner reconnection flow.

### What Changed

**New Test Coverage:**
- Added live test spec for device tracking (`devices.spec.ts`) that validates the `/api/devices` endpoint returns proper device data (IP, user agent, timestamps, request count) and that the connected devices UI correctly displays tracked devices in token-authenticated mode
- Added live test spec for disconnect/reconnect behavior (`disconnect-banner.spec.ts`) that verifies the server unreachable alert appears when the server goes down, and the reconnected flash appears after the server recovers

**Test Infrastructure Improvement:**
- Enhanced the serve test harness with a new `restart()` method to gracefully stop and respawn the test server, enabling tests that need to simulate server failures and recovery

**Documentation & Configuration:**
- Updated the Playwright development documentation to explain the restart behavior and its limitations
- Updated the test coverage matrix to mark devices and disconnect-banner as live-tested (moved from "deferred" status)

### Benefits

- Closes a gap in test coverage for critical user-facing features (device management and network error handling)
- Enables E2E validation of server recovery scenarios, improving reliability testing
- Provides reusable test infrastructure for future tests that need server restart functionality
- Documents test harness capabilities for future test development

### Technical Details

The serve harness refactoring extracts the spawn logic into a reusable `spawnOnce()` closure and adds a `killProc()` helper for orderly process shutdown (SIGTERM → wait up to 2s → SIGKILL if needed). The `restart()` method reuses the original port and arguments while refreshing the auth token in token mode, though it intentionally does not re-run passphrase prelogin or cockpit master-enable logic (which would require calling `spawnAoeServe` directly). The disconnect-banner test narrows banner role selectors by text content to avoid false matches with unrelated live regions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->