### PR TITLE
test(web): right-panel diff list, large diff, and notifications coverage

### DIFF
--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -209,9 +209,13 @@
     },
     {
       "id": "right-panel.diff",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1221",
+      "kind": "live-playwright",
       "risk": "medium",
+      "specs": [
+        "tests/live/right-panel-diff-files.spec.ts",
+        "tests/live/right-panel-large-diff.spec.ts",
+        "tests/live/right-panel-notifications.spec.ts"
+      ],
       "components": [
         "web/src/components/RightPanel.tsx",
         "web/src/components/diff/DiffFileList.tsx",

--- a/web/tests/helpers/gitFixture.ts
+++ b/web/tests/helpers/gitFixture.ts
@@ -1,17 +1,25 @@
 // Git fixture helpers for live Playwright specs.
 //
-// Used by `tests/live/git-clone.spec.ts` (and any future spec exercising
-// the `POST /api/git/clone` endpoint) to spin up a throwaway bare repo
-// the wizard can clone from via `file://`. Keeping the source repo on
-// the local filesystem keeps the test deterministic, hermetic, and free
-// from any network dependency.
-//
-// The matching server-side validator accepts `file://` URLs by design.
-// See `src/server/api/git.rs::looks_like_git_url` for the allowlist.
+// Used by:
+//   - `tests/live/git-clone.spec.ts`: spins up a throwaway bare repo so
+//     the wizard can clone from `file://`. The matching server-side
+//     validator accepts `file://` URLs by design; see
+//     `src/server/api/git.rs::looks_like_git_url` for the allowlist.
+//   - `tests/live/right-panel-*.spec.ts`: builds a non-bare working repo
+//     with a committed `main` branch plus uncommitted modifications, so
+//     `aoe add` registers the dir as a session and the diff endpoint
+//     surfaces those modifications against the base branch.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+};
 
 export interface BareRepoFixture {
   /** Absolute path of the bare repo on disk. */
@@ -31,13 +39,7 @@ export function createBareRepo(parentDir: string, name = "bare.git"): BareRepoFi
   const path = join(parentDir, name);
   mkdirSync(parentDir, { recursive: true });
   const res = spawnSync("git", ["init", "--bare", "--quiet", path], {
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: "t",
-      GIT_AUTHOR_EMAIL: "t@t",
-      GIT_COMMITTER_NAME: "t",
-      GIT_COMMITTER_EMAIL: "t@t",
-    },
+    env: { ...process.env, ...GIT_ENV },
   });
   if (res.status !== 0) {
     throw new Error(
@@ -45,4 +47,103 @@ export function createBareRepo(parentDir: string, name = "bare.git"): BareRepoFi
     );
   }
   return { path, url: `file://${path}` };
+}
+
+function runGit(cwd: string, args: string[]): void {
+  const res = spawnSync("git", args, {
+    cwd,
+    env: { ...process.env, ...GIT_ENV },
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (cwd=${cwd}): status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+    );
+  }
+}
+
+/**
+ * Initialize a non-bare working repo at `repoPath` on `defaultBranch`
+ * with an initial empty commit so subsequent diffs have a base to
+ * compare against. Uses `-b <branch>` so the default branch is
+ * deterministic across hosts where `init.defaultBranch` may be unset.
+ */
+export function initWorkingRepo(
+  repoPath: string,
+  opts: { defaultBranch?: string } = {},
+): { path: string } {
+  const branch = opts.defaultBranch ?? "main";
+  mkdirSync(repoPath, { recursive: true });
+  runGit(repoPath, ["init", "-q", "-b", branch]);
+  runGit(repoPath, ["commit", "--allow-empty", "-q", "-m", "init"]);
+  return { path: repoPath };
+}
+
+/**
+ * Write a set of files into a repo (uncommitted). Paths are joined onto
+ * `repoPath`; nested directories are created automatically. Use to
+ * stage uncommitted modifications visible to the diff endpoint, or as
+ * the source for a follow-up `commitAll`.
+ */
+export function writeFiles(
+  repoPath: string,
+  files: Record<string, string>,
+): void {
+  for (const [relPath, content] of Object.entries(files)) {
+    const abs = join(repoPath, relPath);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+}
+
+/**
+ * Write a binary file (raw bytes) into a repo (uncommitted). Useful
+ * for exercising the diff viewer's "Binary file changed" branch.
+ */
+export function writeBinaryFile(
+  repoPath: string,
+  relPath: string,
+  bytes: Uint8Array,
+): void {
+  const abs = join(repoPath, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, bytes);
+}
+
+/** Stage every change in the working tree and commit with `message`. */
+export function commitAll(repoPath: string, message: string): void {
+  runGit(repoPath, ["add", "-A"]);
+  runGit(repoPath, ["commit", "-q", "-m", message]);
+}
+
+/**
+ * Deterministic large-file content generator. Produces `lineCount`
+ * lines, each unique so virtualization tests can grep for specific
+ * mid-file lines without ambiguity.
+ */
+export function generateLargeFileContent(
+  lineCount: number,
+  prefix = "line",
+): string {
+  const lines = new Array<string>(lineCount);
+  for (let i = 0; i < lineCount; i++) {
+    lines[i] = `${prefix} ${i}: ${"lorem ".repeat(8).trim()}`;
+  }
+  return lines.join("\n") + "\n";
+}
+
+/**
+ * Minimal valid PNG byte sequence (8-byte signature + IHDR + IEND).
+ * Just enough to make `git diff` classify the file as binary; not a
+ * decodable image. Returned as a fresh `Uint8Array` so callers can
+ * pass it to `writeBinaryFile` without sharing buffer state.
+ */
+export function pngStubBytes(): Uint8Array {
+  return new Uint8Array([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+    0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52, // IHDR length + type
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, // 1x1
+    0x08, 0x06, 0x00, 0x00, 0x00, 0x1f, 0x15, 0xc4, 0x89, // bit-depth, color-type, crc
+    0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44, // IEND length + type
+    0xae, 0x42, 0x60, 0x82, // IEND crc
+  ]);
 }

--- a/web/tests/live/right-panel-diff-files.spec.ts
+++ b/web/tests/live/right-panel-diff-files.spec.ts
@@ -92,32 +92,31 @@ base(
       await toFlat.first().click();
       await expect(toTree.first()).toBeVisible();
 
-      // Keyboard nav: focus a row (mouse-enter sets focusedIndex via
-      // the row's onMouseEnter, then ArrowDown moves it), press Enter,
-      // and assert the DiffFileViewer mounts for the modified file.
+      // Keyboard nav: focus row 0 via hover (`onMouseEnter` sets
+      // focusedIndex), click to open it, then ArrowDown + Enter to
+      // advance to row 1 and open that file.
+      //
+      // The backend sorts diff files by path
+      // (`src/git/diff.rs::compute_changed_files`, byte-lexicographic),
+      // so for our seed the order is:
+      //   row 0 -> README.md   (contains "# Old" / "# New")
+      //   row 1 -> lib/d.ts    (contains "export const d = 4")
+      // We assert per-file diff content (only rendered in the viewer,
+      // never in the file-list rows) so the post-keypress assertion
+      // proves a real state change rather than re-checking the
+      // already-visible "Modified" status label.
       const firstRow = page.locator('button[data-index="0"]').first();
       await firstRow.hover();
       await firstRow.click();
-      // After click, the file is selected. The DiffFileViewer header
-      // shows the status label "Modified" for a committed-then-edited
-      // file. The label is rendered in the left content pane, not the
-      // right-panel header, so scope by role to disambiguate.
-      await expect(page.getByText("Modified").first()).toBeVisible({
+      await expect(page.getByText("# Old").first()).toBeVisible({
         timeout: 10_000,
       });
 
-      // ArrowDown then Enter should move selection to row #2 and open
-      // it. Page-level keydown bubbles through React's handler on the
-      // scrollable list container.
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Enter");
-      // Any of the five paths will render in the viewer header once a
-      // row is opened; the exact one depends on sort order but Enter
-      // on focusedIndex 1 lands deterministically on the second sorted
-      // file. Sort order is `path` alphabetical (see compute_changed_files).
-      // Just assert the viewer header is still showing a Modified file
-      // and at least one diff line is on screen.
-      await expect(page.getByText("Modified").first()).toBeVisible();
+      await expect(page.getByText(/export const d = 4/).first()).toBeVisible({
+        timeout: 10_000,
+      });
     } finally {
       await serve.stop();
     }

--- a/web/tests/live/right-panel-diff-files.spec.ts
+++ b/web/tests/live/right-panel-diff-files.spec.ts
@@ -1,0 +1,123 @@
+// Live-backend spec: right panel's diff file list (#1221).
+//
+// Seeds a working git repo with five committed files on `main`, then
+// modifies those same files uncommitted. `aoe add` registers the dir as
+// a session whose `project_path` IS the modified working tree; the diff
+// endpoint then returns those five files. Exercises file-count rendering,
+// the flat/tree view toggle, and keyboard navigation (ArrowDown + Enter)
+// against the real backend.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, resolveAoeBinary } from "../helpers/aoeServe";
+import {
+  commitAll,
+  initWorkingRepo,
+  writeFiles,
+} from "../helpers/gitFixture";
+
+base(
+  "right panel diff list: counts, tree/flat toggle, keyboard select",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: ({ home, env }) => {
+        const projectDir = join(home, "project");
+        initWorkingRepo(projectDir);
+        const baseline = {
+          "src/a.ts": "export const a = 1;\n",
+          "src/b.ts": "export const b = 2;\n",
+          "src/nested/c.ts": "export const c = 3;\n",
+          "lib/d.ts": "export const d = 4;\n",
+          "README.md": "# Old\n",
+        };
+        writeFiles(projectDir, baseline);
+        commitAll(projectDir, "baseline");
+        writeFiles(projectDir, {
+          "src/a.ts": "export const a = 11;\n",
+          "src/b.ts": "export const b = 22;\n",
+          "src/nested/c.ts": "export const c = 33;\n",
+          "lib/d.ts": "export const d = 44;\n",
+          "README.md": "# New\n",
+        });
+        const addRes = spawnSync(
+          resolveAoeBinary(),
+          ["add", projectDir, "-t", "rp-files", "-c", "claude"],
+          { env },
+        );
+        if (addRes.status !== 0) {
+          throw new Error(
+            `aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+          );
+        }
+      },
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+      const sessionRow = page
+        .getByRole("link")
+        .filter({ hasText: "rp-files" })
+        .first();
+      await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+      await sessionRow.click();
+
+      // File count chip lives in the right-panel header; render is
+      // bounded by the diff fetch + react paint after the session route.
+      await expect(page.getByText("5 files", { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // Toggle title flips with current mode. Click whichever variant
+      // is currently shown so we land deterministically in tree mode.
+      const toTree = page.locator('button[title="Switch to tree view"]');
+      const toFlat = page.locator('button[title="Switch to flat list"]');
+      if (await toTree.first().isVisible().catch(() => false)) {
+        await toTree.first().click();
+      }
+      await expect(toFlat.first()).toBeVisible();
+
+      // Tree mode collapses parent dirs into rows. With files under
+      // `src/`, `src/nested/`, and `lib/`, expect at least the three
+      // top-level dir rows. Match a recognisable one.
+      await expect(page.getByRole("button", { name: /^src/ }).first()).toBeVisible();
+
+      // Flip back to flat so subsequent assertions hit the plain
+      // index-based list.
+      await toFlat.first().click();
+      await expect(toTree.first()).toBeVisible();
+
+      // Keyboard nav: focus a row (mouse-enter sets focusedIndex via
+      // the row's onMouseEnter, then ArrowDown moves it), press Enter,
+      // and assert the DiffFileViewer mounts for the modified file.
+      const firstRow = page.locator('button[data-index="0"]').first();
+      await firstRow.hover();
+      await firstRow.click();
+      // After click, the file is selected. The DiffFileViewer header
+      // shows the status label "Modified" for a committed-then-edited
+      // file. The label is rendered in the left content pane, not the
+      // right-panel header, so scope by role to disambiguate.
+      await expect(page.getByText("Modified").first()).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // ArrowDown then Enter should move selection to row #2 and open
+      // it. Page-level keydown bubbles through React's handler on the
+      // scrollable list container.
+      await page.keyboard.press("ArrowDown");
+      await page.keyboard.press("Enter");
+      // Any of the five paths will render in the viewer header once a
+      // row is opened; the exact one depends on sort order but Enter
+      // on focusedIndex 1 lands deterministically on the second sorted
+      // file. Sort order is `path` alphabetical (see compute_changed_files).
+      // Just assert the viewer header is still showing a Modified file
+      // and at least one diff line is on screen.
+      await expect(page.getByText("Modified").first()).toBeVisible();
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/right-panel-diff-files.spec.ts
+++ b/web/tests/live/right-panel-diff-files.spec.ts
@@ -65,9 +65,11 @@ base(
       await expect(sessionRow).toBeVisible({ timeout: 10_000 });
       await sessionRow.click();
 
-      // File count chip lives in the right-panel header; render is
-      // bounded by the diff fetch + react paint after the session route.
-      await expect(page.getByText("5 files", { exact: true })).toBeVisible({
+      // File count chip lives in the right-panel header. The dashboard
+      // mounts both a desktop and a mobile copy of the right panel
+      // (one hidden via CSS), so the chip appears twice; first() is
+      // unambiguous and matches the desktop pane on the test viewport.
+      await expect(page.getByText("5 files", { exact: true }).first()).toBeVisible({
         timeout: 15_000,
       });
 

--- a/web/tests/live/right-panel-large-diff.spec.ts
+++ b/web/tests/live/right-panel-large-diff.spec.ts
@@ -70,7 +70,9 @@ base(
       await sessionRow.click();
 
       // Two files surface: big.txt (modified) and image.png (added).
-      await expect(page.getByText("2 files", { exact: true })).toBeVisible({
+      // The dashboard renders both a desktop and a mobile right panel
+      // (one hidden via CSS); first() picks the desktop copy.
+      await expect(page.getByText("2 files", { exact: true }).first()).toBeVisible({
         timeout: 15_000,
       });
 
@@ -98,7 +100,7 @@ base(
         .first()
         .click();
       await expect(
-        page.getByText("Binary file changed", { exact: true }),
+        page.getByText("Binary file changed", { exact: true }).first(),
       ).toBeVisible({ timeout: 10_000 });
     } finally {
       await serve.stop();

--- a/web/tests/live/right-panel-large-diff.spec.ts
+++ b/web/tests/live/right-panel-large-diff.spec.ts
@@ -1,0 +1,107 @@
+// Live-backend spec: right panel's diff viewer rendering a 1000-line
+// file and a binary file (#1221).
+//
+// The diff viewer is non-virtualized: every row maps to a DOM node, so
+// a 1000-line modification produces ~1000 elements. Playwright's
+// auto-scroll resolves visibility, which lets us assert mid-file rows
+// without a hand-rolled scroll script. The binary-file path renders the
+// "Binary file changed" placeholder instead of hunks; see
+// `web/src/components/diff/DiffFileViewer.tsx:439`.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, resolveAoeBinary } from "../helpers/aoeServe";
+import {
+  commitAll,
+  generateLargeFileContent,
+  initWorkingRepo,
+  pngStubBytes,
+  writeBinaryFile,
+  writeFiles,
+} from "../helpers/gitFixture";
+
+base(
+  "right panel diff viewer: 1000-line file scrolls, binary file shows placeholder",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: ({ home, env }) => {
+        const projectDir = join(home, "project");
+        initWorkingRepo(projectDir);
+        // Baseline on main: same large file content the modified version
+        // will diverge from. Committing first means the diff lands on
+        // the "modified" path with hunks of changes, not "added" with
+        // one giant +1000.
+        writeFiles(projectDir, {
+          "big.txt": generateLargeFileContent(1000, "base"),
+        });
+        commitAll(projectDir, "baseline");
+        // Now replace with a deterministic prefix swap so every line
+        // shows in the diff. `generateLargeFileContent(1000, "edit")`
+        // produces 1000 lines all distinct from the baseline.
+        writeFiles(projectDir, {
+          "big.txt": generateLargeFileContent(1000, "edit"),
+        });
+        // Binary file: not committed in baseline, so it shows as added.
+        writeBinaryFile(projectDir, "image.png", pngStubBytes());
+        const addRes = spawnSync(
+          resolveAoeBinary(),
+          ["add", projectDir, "-t", "rp-large", "-c", "claude"],
+          { env },
+        );
+        if (addRes.status !== 0) {
+          throw new Error(
+            `aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+          );
+        }
+      },
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+      const sessionRow = page
+        .getByRole("link")
+        .filter({ hasText: "rp-large" })
+        .first();
+      await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+      await sessionRow.click();
+
+      // Two files surface: big.txt (modified) and image.png (added).
+      await expect(page.getByText("2 files", { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // Click big.txt; DiffFileViewer mounts. The viewer's left content
+      // pane shows the path; assert via the path label.
+      await page
+        .getByRole("button", { name: /big\.txt/ })
+        .first()
+        .click();
+      await expect(page.getByText("big.txt").first()).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Mid-file row: every replaced line emits an "edit N: lorem ..."
+      // line. Use a unique line number near the end of the file so
+      // Playwright must scroll the diff viewer to bring it into view.
+      // `edit 950:` is unambiguous and well past the initial viewport.
+      const midRow = page.getByText("edit 950:", { exact: false }).first();
+      await midRow.scrollIntoViewIfNeeded({ timeout: 10_000 });
+      await expect(midRow).toBeVisible();
+
+      // Switch to the binary file. Click via the row text.
+      await page
+        .getByRole("button", { name: /image\.png/ })
+        .first()
+        .click();
+      await expect(
+        page.getByText("Binary file changed", { exact: true }),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/right-panel-notifications.spec.ts
+++ b/web/tests/live/right-panel-notifications.spec.ts
@@ -50,14 +50,17 @@ base(
 
       // Paired-terminal pane lives in the lower half of RightPanel. The
       // "Shell" label sits above the Host / Container picker; assert it
-      // first to scope subsequent selectors to that pane.
-      await expect(page.getByText("Shell", { exact: true })).toBeVisible({
+      // first to scope subsequent selectors to that pane. The dashboard
+      // mounts both a desktop and a mobile right panel (one hidden via
+      // CSS), so use first() on visible-anywhere assertions.
+      await expect(page.getByText("Shell", { exact: true }).first()).toBeVisible({
         timeout: 10_000,
       });
       // Host button is rendered unconditionally; Container only when
-      // `is_sandboxed`. The seeded session is not sandboxed.
+      // `is_sandboxed`. The seeded session is not sandboxed, so no
+      // Container button should exist in either copy of the panel.
       await expect(
-        page.getByRole("button", { name: "Host", exact: true }),
+        page.getByRole("button", { name: "Host", exact: true }).first(),
       ).toBeVisible();
       await expect(
         page.getByRole("button", { name: "Container", exact: true }),
@@ -130,7 +133,9 @@ base(
       await sessionRow.click();
 
       // Wait for the file list to populate; one modified file expected.
-      await expect(page.getByText("1 file", { exact: true })).toBeVisible({
+      // first() picks the desktop right-panel copy (the dashboard also
+      // mounts a mobile copy hidden via CSS).
+      await expect(page.getByText("1 file", { exact: true }).first()).toBeVisible({
         timeout: 15_000,
       });
       await page.getByRole("button", { name: /notes\.md/ }).first().click();
@@ -154,23 +159,24 @@ base(
       // CommentsBanner now lives in the right panel showing the count
       // and the Send / Discard-all actions.
       await expect(
-        page.getByText("1 comment", { exact: true }),
+        page.getByText("1 comment", { exact: true }).first(),
       ).toBeVisible({ timeout: 10_000 });
       await expect(
-        page.getByRole("button", { name: "Send", exact: true }),
+        page.getByRole("button", { name: "Send", exact: true }).first(),
       ).toBeVisible();
       await expect(
-        page.getByRole("button", { name: "Discard all", exact: true }),
+        page.getByRole("button", { name: "Discard all", exact: true }).first(),
       ).toBeVisible();
 
       // Discard-all confirms via window.confirm (auto-accepted above)
-      // and clears the store, removing the banner.
+      // and clears the store, removing the banner from both panel copies.
       await page
         .getByRole("button", { name: "Discard all", exact: true })
+        .first()
         .click();
       await expect(
         page.getByText("1 comment", { exact: true }),
-      ).toBeHidden({ timeout: 10_000 });
+      ).toHaveCount(0, { timeout: 10_000 });
     } finally {
       await serve.stop();
     }

--- a/web/tests/live/right-panel-notifications.spec.ts
+++ b/web/tests/live/right-panel-notifications.spec.ts
@@ -1,0 +1,178 @@
+// Live-backend spec: right panel's "non-diff" surfaces (#1221).
+//
+// Two tests live here:
+//   1) Paired-terminal toggle on a non-cockpit session. The lower half
+//      of `RightPanel.tsx` exposes a Host / Container shell mode picker
+//      (`src/components/RightPanel.tsx:373-397`). Non-sandboxed sessions
+//      must show Host only; Container is gated on `is_sandboxed`. This
+//      asserts the toggle exists and that the paired-terminal pane
+//      mounts.
+//   2) Comments-banner notification flow on a cockpit session. Once a
+//      user stages a comment via the diff "+" gutter, the
+//      `CommentsBanner` (`src/components/diff/comments/CommentsBanner.tsx`)
+//      surfaces a notification chip in the right panel with the comment
+//      count, plus Send and Discard-all actions. This exercises the
+//      end-to-end staging + dismissal path.
+
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  listSessions,
+  resolveAoeBinary,
+  seedSessionViaAoeAdd,
+  spawnAoeServe,
+} from "../helpers/aoeServe";
+import {
+  commitAll,
+  initWorkingRepo,
+  writeFiles,
+} from "../helpers/gitFixture";
+
+base(
+  "right panel paired terminal: Host shown, Container hidden on non-sandboxed session",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "rp-paired" }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+      const sessionRow = page
+        .getByRole("link")
+        .filter({ hasText: "rp-paired" })
+        .first();
+      await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+      await sessionRow.click();
+
+      // Paired-terminal pane lives in the lower half of RightPanel. The
+      // "Shell" label sits above the Host / Container picker; assert it
+      // first to scope subsequent selectors to that pane.
+      await expect(page.getByText("Shell", { exact: true })).toBeVisible({
+        timeout: 10_000,
+      });
+      // Host button is rendered unconditionally; Container only when
+      // `is_sandboxed`. The seeded session is not sandboxed.
+      await expect(
+        page.getByRole("button", { name: "Host", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Container", exact: true }),
+      ).toHaveCount(0);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "right panel notifications: cockpit comments banner appears on stage, clears on discard",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: ({ home, env }) => {
+        const projectDir = join(home, "project");
+        initWorkingRepo(projectDir);
+        // Commit a baseline so the modified version produces a real
+        // hunk with gutter "+" buttons (the comments UI requires
+        // line numbers on at least one side).
+        writeFiles(projectDir, { "notes.md": "line a\nline b\nline c\n" });
+        commitAll(projectDir, "baseline");
+        writeFiles(projectDir, { "notes.md": "line A\nline B\nline C\n" });
+        const addRes = spawnSync(
+          resolveAoeBinary(),
+          ["add", projectDir, "-t", "rp-notif", "-c", "claude"],
+          { env },
+        );
+        if (addRes.status !== 0) {
+          throw new Error(
+            `aoe add failed: status=${addRes.status} stderr=${addRes.stderr?.toString() ?? "<none>"}`,
+          );
+        }
+      },
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId = sessions.find((s) => s.title === "rp-notif")?.id;
+      if (!sessionId) {
+        throw new Error("seeded cockpit session not visible in /api/sessions");
+      }
+
+      // Flip per-session cockpit_mode so the SPA renders the comments
+      // affordances on the diff viewer. Same pattern as
+      // cockpit-spawn-prompt.spec.ts; the supervisor spawn is async, so
+      // give it a beat before driving the UI.
+      const enableRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+        { method: "POST" },
+      );
+      expect(enableRes.ok).toBeTruthy();
+      await new Promise((r) => setTimeout(r, 2_000));
+
+      // Browser auto-accepts the window.confirm fired by Discard-all.
+      page.on("dialog", (dialog) => {
+        void dialog.accept();
+      });
+
+      await page.goto(`${serve.baseUrl}/`);
+      const sessionRow = page
+        .getByRole("link")
+        .filter({ hasText: "rp-notif" })
+        .first();
+      await expect(sessionRow).toBeVisible({ timeout: 10_000 });
+      await sessionRow.click();
+
+      // Wait for the file list to populate; one modified file expected.
+      await expect(page.getByText("1 file", { exact: true })).toBeVisible({
+        timeout: 15_000,
+      });
+      await page.getByRole("button", { name: /notes\.md/ }).first().click();
+
+      // First gutter "+" click sets range start; the same line again
+      // closes the range and opens the inline form. The buttons are
+      // opacity-0 until hover; click via aria-label + force to bypass
+      // the visibility-driven actionability checks.
+      const plus = page.getByRole("button", {
+        name: /Add comment on new line 1/,
+      });
+      await plus.first().click({ force: true });
+      await plus.first().click({ force: true });
+
+      // Form textarea autofocuses; type a body and save.
+      const textarea = page.getByPlaceholder(/Leave a comment/);
+      await expect(textarea).toBeFocused({ timeout: 5_000 });
+      await textarea.fill("nit");
+      await page.getByRole("button", { name: "Save", exact: true }).click();
+
+      // CommentsBanner now lives in the right panel showing the count
+      // and the Send / Discard-all actions.
+      await expect(
+        page.getByText("1 comment", { exact: true }),
+      ).toBeVisible({ timeout: 10_000 });
+      await expect(
+        page.getByRole("button", { name: "Send", exact: true }),
+      ).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "Discard all", exact: true }),
+      ).toBeVisible();
+
+      // Discard-all confirms via window.confirm (auto-accepted above)
+      // and clears the store, removing the banner.
+      await page
+        .getByRole("button", { name: "Discard all", exact: true })
+        .click();
+      await expect(
+        page.getByText("1 comment", { exact: true }),
+      ).toBeHidden({ timeout: 10_000 });
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds three live-backend Playwright specs and extends `gitFixture.ts` to cover the right-panel diff list, large diffs / binary files, and the paired-terminal + cockpit comments-banner notification flow, per #1221. Each spec spawns a real `aoe serve` against an isolated `HOME`, seeds a git repo with deterministic baseline-then-modify content, and drives the UI end-to-end so the matching matrix entry's components get real exercise instead of stubs.

What landed:

- `web/tests/helpers/gitFixture.ts` gains `initWorkingRepo`, `writeFiles`, `writeBinaryFile`, `commitAll`, `generateLargeFileContent`, and `pngStubBytes` so any future live spec can seed a working repo with controlled uncommitted modifications. `createBareRepo` (already used by `git-clone.spec.ts`) is unchanged.
- `web/tests/live/right-panel-diff-files.spec.ts`: 5 modified files across 2 dirs, asserts the file-count chip, flips the tree/flat toggle, and drives keyboard nav (ArrowDown + Enter) to open the focused file in the diff viewer.
- `web/tests/live/right-panel-large-diff.spec.ts`: 1000-line modified text file scrolls to a mid-file row (proving no virtualization regression), then a binary PNG file surfaces the "Binary file changed" placeholder.
- `web/tests/live/right-panel-notifications.spec.ts`: non-cockpit session asserts the paired-terminal Host button is visible and Container is hidden on a non-sandboxed session; a separate cockpit session stages a diff comment through the "+" gutter, asserts `CommentsBanner` shows "1 comment" with Send and Discard-all actions, and verifies Discard-all clears the banner.
- `web/tests/coverage-matrix.json` flips `right-panel.diff` from `deferred` (with `issue:`) to `live-playwright` (with the three new spec paths) and keeps the existing 11-component coverage list intact.

Issue #1221's spec name `right-panel-notifications.spec.ts` is preserved by interpreting the "notifications" scope as the diff-comments banner (a notification-style chip in the right panel) plus the paired-terminal Host/Container toggle, since there is no literal "notifications tab" in `RightPanel.tsx`. The Settings view's Notifications tab is out of scope here.

Closes #1221

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## How to test

- [ ] `cd web && node tests/validate-coverage-matrix.mjs` exits 0
- [ ] `cd web && npx tsc --noEmit` clean
- [ ] With a built `aoe` binary on disk (or `AOE_E2E_BINARY` set), `cd web && npx playwright test --config=playwright.live.config.ts tests/live/right-panel-diff-files.spec.ts` passes
- [ ] Same for `tests/live/right-panel-large-diff.spec.ts`
- [ ] Same for `tests/live/right-panel-notifications.spec.ts`
- [ ] Open the dashboard against a real session with five modified files in two subdirectories, confirm the "5 files" chip renders, flip tree / flat with the header toggle, and arrow-key + Enter through rows
- [ ] Open a session with a 1000-line modified file, scroll to the bottom of the diff viewer, confirm rows past line 900 are visible; switch to a binary file in the same session and confirm "Binary file changed"
- [ ] On a cockpit session with at least one modified file, click "+" twice on the same line in the diff viewer, save a comment, confirm "1 comment" banner appears in the right panel with Send and Discard-all, click Discard-all, confirm the banner disappears

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed the plan and made the scope decisions (including reinterpreting the "notifications" spec as paired-terminal + comments-banner since the issue body's literal "notifications tab" does not exist in `RightPanel.tsx`). Implementation is a sequence of small commits I reviewed before pushing.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds comprehensive test coverage for the right-panel component in the web application by introducing three new end-to-end test specs and extending test infrastructure to support live testing with real git repositories.

### What's New

**Three new Playwright test specs:**
- Diff file list test: Validates the right panel's ability to display modified files, toggle between tree/flat views, and navigate files using keyboard controls
- Large diff test: Ensures the diff viewer handles large files (1000+ lines) without performance regressions and correctly displays binary file indicators
- Notifications test: Covers paired-terminal visibility and the comments banner notification flow in the right panel

**Extended test helpers:**
- New git fixture utilities to programmatically initialize working repositories, write files, create binary files, and generate deterministic test data for reproducible testing

**Coverage tracking update:**
- Updated the coverage matrix to reflect right-panel.diff as "live-playwright" coverage instead of deferred, with pointers to the three new test specs

### Benefits

- **Improved test reliability**: Replaces deferred/skipped coverage with live backend tests that verify actual functionality
- **Better test reproducibility**: Standardized git fixture helpers ensure consistent test environment setup across all specs
- **Comprehensive edge-case coverage**: Tests validate not just happy paths but also performance edge cases (large diffs) and binary file handling
- **Keyboard and UI interaction coverage**: Tests include keyboard navigation and toolbar interactions that manual testing might miss

### Technical Details

The implementation includes:
- Deterministic git environment variables (fixed author/committer identity) for reproducible repository states
- Helper functions for writing both text and binary files with automatic directory creation
- Large file generation utility for virtualization regression testing
- Integration with AOE CLI (`aoe add`) for spawning local development servers
- Proper server lifecycle management with `try/finally` blocks
- Multi-view testing (tree/flat layout toggles, paired-terminal modes)
- Comment flow testing with banner state validation and dialog dismissal

All changes are scoped to the test layer with no modifications to production code.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->