### PR TITLE
test(web): live Playwright coverage for sidebar groups + session lifecycle (#1220)

### DIFF
--- a/web/src/components/DeleteSessionDialog.tsx
+++ b/web/src/components/DeleteSessionDialog.tsx
@@ -89,6 +89,7 @@ export function DeleteSessionDialog({
       role="dialog"
       aria-modal="true"
       aria-labelledby="delete-session-dialog-title"
+      data-testid="delete-session-dialog"
       className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 animate-fade-in"
       onClick={onCancel}
     >
@@ -122,6 +123,7 @@ export function DeleteSessionDialog({
                     onChange={setDeleteWorktree}
                     label="Delete worktree"
                     detail={branchName ? `Removes worktree for branch "${branchName}"` : undefined}
+                    testId="delete-session-checkbox-worktree"
                   />
                   {deleteWorktree && (
                     <div className="pl-6">
@@ -130,6 +132,7 @@ export function DeleteSessionDialog({
                         onChange={setForceDelete}
                         label="Force delete"
                         detail="Delete even if worktree has uncommitted changes"
+                        testId="delete-session-checkbox-force"
                       />
                     </div>
                   )}
@@ -138,6 +141,7 @@ export function DeleteSessionDialog({
                     onChange={setDeleteBranch}
                     label="Delete branch"
                     detail={branchName ? `Removes branch "${branchName}"` : undefined}
+                    testId="delete-session-checkbox-branch"
                   />
                 </>
               )}
@@ -147,6 +151,7 @@ export function DeleteSessionDialog({
                   onChange={setDeleteSandbox}
                   label="Delete container"
                   detail="Removes the Docker sandbox container"
+                  testId="delete-session-checkbox-sandbox"
                 />
               )}
             </div>
@@ -187,14 +192,20 @@ function Checkbox({
   onChange,
   label,
   detail,
+  testId,
 }: {
   checked: boolean;
   onChange: (val: boolean) => void;
   label: string;
   detail?: string;
+  testId?: string;
 }) {
   return (
-    <label className="flex items-start gap-2.5 cursor-pointer group">
+    <label
+      className="flex items-start gap-2.5 cursor-pointer group"
+      data-testid={testId}
+      data-checked={checked ? "true" : "false"}
+    >
       <span
         onClick={() => onChange(!checked)}
         className={`mt-0.5 w-4 h-4 rounded border flex items-center justify-center shrink-0 transition-colors ${

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -534,6 +534,7 @@ const SessionRow = memo(function SessionRow({
             if (e.key === "Enter") commitRename();
             if (e.key === "Escape") setRenaming(false);
           }}
+          data-testid="sidebar-rename-input"
           className="w-full bg-surface-900 border border-brand-600 rounded px-2 py-1 text-[13px] md:text-[14px] font-mono text-text-primary focus:outline-none"
         />
       </div>
@@ -544,6 +545,7 @@ const SessionRow = memo(function SessionRow({
     <>
       <Link
         to={sessionPath}
+        data-testid="sidebar-session-row"
         // Anchors are HTML5-draggable by default; the browser would
         // start its own drag-the-link gesture in parallel with dnd-kit
         // and finish with a synthetic click that bypassed React's event
@@ -658,11 +660,13 @@ const SessionRow = memo(function SessionRow({
       {contextMenu && createPortal(
         <div
           ref={menuRef}
+          data-testid="sidebar-context-menu"
           className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px]"
           style={{ left: contextMenu.x, top: contextMenu.y }}
         >
           <button
             onClick={startRename}
+            data-testid="sidebar-context-menu-rename"
             className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
           >
             Rename
@@ -699,6 +703,7 @@ const SessionRow = memo(function SessionRow({
               <div className="border-t border-surface-700/20 my-1" />
               <button
                 onClick={handleDelete}
+                data-testid="sidebar-context-menu-delete"
                 className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-status-error hover:bg-status-error/10 cursor-pointer transition-colors"
               >
                 Delete
@@ -732,6 +737,8 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
 
   return (
     <div
+      data-testid="sidebar-group-header"
+      data-group-id={group.id}
       className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary hover:bg-surface-800/50 ${
         hasActiveChild ? "border-l-2 border-brand-600" : ""
       }`}
@@ -1008,6 +1015,7 @@ export function WorkspaceSidebar({
                 if (e.key === "Escape") toggleFilter();
               }}
               placeholder="Filter by name, branch, agent..."
+              data-testid="sidebar-filter-input"
               className="w-full bg-surface-800 border border-surface-700 rounded-md px-2.5 py-1.5 text-[13px] text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
             />
           </div>

--- a/web/src/components/__tests__/DeleteSessionDialog.test.tsx
+++ b/web/src/components/__tests__/DeleteSessionDialog.test.tsx
@@ -138,6 +138,137 @@ describe("DeleteSessionDialog keyboard affordances", () => {
     expect(titleEl?.textContent).toMatch(/Delete Session/);
   });
 
+  it("toggling delete-worktree off hides the force checkbox and sends a worktree=false body", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({ onConfirm });
+
+    const worktreeBox = container.querySelector<HTMLLabelElement>(
+      '[data-testid="delete-session-checkbox-worktree"]',
+    );
+    expect(worktreeBox).toBeTruthy();
+    expect(worktreeBox!.dataset.checked).toBe("true");
+    // The force-delete checkbox is only rendered while delete-worktree is on.
+    expect(
+      container.querySelector('[data-testid="delete-session-checkbox-force"]'),
+    ).toBeTruthy();
+
+    fireEvent.click(worktreeBox!.querySelector("span")!);
+    expect(worktreeBox!.dataset.checked).toBe("false");
+    expect(
+      container.querySelector('[data-testid="delete-session-checkbox-force"]'),
+    ).toBeNull();
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+      force_delete: false,
+    });
+  });
+
+  it("force checkbox flips force_delete in the confirm body when enabled", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({ onConfirm });
+
+    const forceBox = container.querySelector<HTMLLabelElement>(
+      '[data-testid="delete-session-checkbox-force"]',
+    );
+    expect(forceBox).toBeTruthy();
+    expect(forceBox!.dataset.checked).toBe("false");
+
+    fireEvent.click(forceBox!.querySelector("span")!);
+    expect(forceBox!.dataset.checked).toBe("true");
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: true,
+      delete_branch: false,
+      delete_sandbox: false,
+      force_delete: true,
+    });
+  });
+
+  it("enabling delete-branch flips delete_branch in the confirm body", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({ onConfirm });
+
+    const branchBox = container.querySelector<HTMLLabelElement>(
+      '[data-testid="delete-session-checkbox-branch"]',
+    );
+    expect(branchBox).toBeTruthy();
+    expect(branchBox!.dataset.checked).toBe("false");
+
+    fireEvent.click(branchBox!.querySelector("span")!);
+    expect(branchBox!.dataset.checked).toBe("true");
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: true,
+      delete_branch: true,
+      delete_sandbox: false,
+      force_delete: false,
+    });
+  });
+
+  it("sandbox checkbox is the only one rendered when the session has no managed worktree", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({
+      onConfirm,
+      hasManagedWorktree: false,
+      isSandboxed: true,
+    });
+
+    expect(
+      container.querySelector('[data-testid="delete-session-checkbox-worktree"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="delete-session-checkbox-branch"]'),
+    ).toBeNull();
+    expect(
+      container.querySelector('[data-testid="delete-session-checkbox-force"]'),
+    ).toBeNull();
+
+    const sandboxBox = container.querySelector<HTMLLabelElement>(
+      '[data-testid="delete-session-checkbox-sandbox"]',
+    );
+    expect(sandboxBox).toBeTruthy();
+    // Sandbox default flips on automatically because cleanupDefaults.delete_sandbox
+    // is false but the dialog re-derives off isSandboxed. Here cleanupDefaults
+    // has delete_sandbox=false, so it should start off.
+    expect(sandboxBox!.dataset.checked).toBe("false");
+
+    fireEvent.click(sandboxBox!.querySelector("span")!);
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: true,
+      force_delete: false,
+    });
+  });
+
+  it("no-options session (no worktree, no sandbox) confirms with an all-false body", () => {
+    const onConfirm = vi.fn().mockResolvedValue(undefined);
+    const { container } = setup({
+      onConfirm,
+      hasManagedWorktree: false,
+      isSandboxed: false,
+    });
+
+    expect(
+      container.querySelectorAll('[data-testid^="delete-session-checkbox-"]'),
+    ).toHaveLength(0);
+
+    fireEvent.keyDown(document, { key: "Enter" });
+    expect(onConfirm).toHaveBeenCalledWith({
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+      force_delete: false,
+    });
+  });
+
   it("restores focus to the previously focused element when the dialog unmounts", () => {
     // Create a trigger button outside the dialog and focus it before mount,
     // mirroring how the sidebar context-menu item is focused when the user

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -191,10 +191,27 @@
       "components": ["web/src/components/DirectoryBrowser.tsx"]
     },
     {
+      "id": "sidebar.groups",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/sidebar-groups.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
+      "id": "sidebar.workspace-ordering",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/workspace-ordering.spec.ts"],
+      "components": []
+    },
+    {
       "id": "session.lifecycle",
-      "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/1220",
+      "kind": "live-playwright",
       "risk": "high",
+      "specs": [
+        "tests/live/session-rename.spec.ts",
+        "tests/live/session-delete.spec.ts"
+      ],
       "components": [
         "web/src/components/DeleteSessionDialog.tsx",
         "web/src/components/WorkspaceSidebar.tsx"

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -202,7 +202,7 @@
       "kind": "live-playwright",
       "risk": "medium",
       "specs": ["tests/live/workspace-ordering.spec.ts"],
-      "components": []
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {
       "id": "session.lifecycle",

--- a/web/tests/live/session-delete.spec.ts
+++ b/web/tests/live/session-delete.spec.ts
@@ -1,0 +1,168 @@
+// Live coverage for the session-delete flow from the sidebar:
+//   - Right-click row → context menu → Delete → DeleteSessionDialog.
+//   - Confirm button fires DELETE /api/sessions/:id with the expected
+//     options body and removes the row.
+//   - Cancel button + Escape both dismiss the dialog without a DELETE.
+//
+// The toggle-combination matrix (delete_worktree / force / delete_branch
+// / delete_sandbox permutations) is covered by the Vitest suite at
+// `web/src/components/__tests__/DeleteSessionDialog.test.tsx`. This spec
+// covers the round-trip: the dialog actually fires DELETE against a real
+// server, and the session disappears from `GET /api/sessions`.
+//
+// `aoe add` without `-w` creates an attached-mode session (no managed
+// worktree, not sandboxed), so DeleteSessionDialog renders the bare
+// confirm form and the request body has all four flags `false`.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("session delete via sidebar context menu (#1220)", () => {
+  base("Delete button fires DELETE /api/sessions/:id and removes the row", async ({ page }, testInfo) => {
+    const title = "delete-me";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      const seeded = await listSessions(serve.baseUrl);
+      expect(seeded).toHaveLength(1);
+      const sessionId = seeded[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title);
+      await row.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-delete']")
+        .click();
+
+      const dialog = page.locator("[data-testid='delete-session-dialog']");
+      await expect(dialog).toBeVisible();
+
+      const deletePromise = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}`) &&
+          res.request().method() === "DELETE",
+      );
+
+      // `aoe add` does not produce a managed worktree, so the dialog
+      // skips the checkbox section and the confirm body is all-false.
+      await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+      const deleteRes = await deletePromise;
+      expect(deleteRes.ok()).toBe(true);
+      expect(deleteRes.request().postDataJSON()).toEqual({
+        delete_worktree: false,
+        delete_branch: false,
+        delete_sandbox: false,
+        force_delete: false,
+      });
+
+      await expect
+        .poll(
+          async () => (await listSessions(serve.baseUrl)).length,
+          { timeout: 10_000 },
+        )
+        .toBe(0);
+      await expect(row).toHaveCount(0, { timeout: 10_000 });
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("Cancel button closes the dialog without firing DELETE", async ({ page }, testInfo) => {
+    const title = "cancel-keeps-me";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      let deleteSeen = false;
+      await page.route("**/api/sessions/*", (route) => {
+        if (route.request().method() === "DELETE") {
+          deleteSeen = true;
+        }
+        return route.continue();
+      });
+
+      await page
+        .locator("[data-testid='sidebar-session-row']")
+        .click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-delete']")
+        .click();
+
+      const dialog = page.locator("[data-testid='delete-session-dialog']");
+      await expect(dialog).toBeVisible();
+
+      await dialog.getByRole("button", { name: "Cancel" }).click();
+      await expect(dialog).toBeHidden();
+
+      await page.waitForTimeout(200);
+      expect(deleteSeen).toBe(false);
+
+      // Session remains listed after the cancel.
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      expect(sessions[0]!.title).toBe(title);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("Escape closes the dialog without firing DELETE", async ({ page }, testInfo) => {
+    const title = "escape-keeps-me";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      let deleteSeen = false;
+      await page.route("**/api/sessions/*", (route) => {
+        if (route.request().method() === "DELETE") {
+          deleteSeen = true;
+        }
+        return route.continue();
+      });
+
+      await page
+        .locator("[data-testid='sidebar-session-row']")
+        .click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-delete']")
+        .click();
+
+      const dialog = page.locator("[data-testid='delete-session-dialog']");
+      await expect(dialog).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(dialog).toBeHidden();
+
+      await page.waitForTimeout(200);
+      expect(deleteSeen).toBe(false);
+
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/session-delete.spec.ts
+++ b/web/tests/live/session-delete.spec.ts
@@ -39,7 +39,12 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
       await page.goto(`${serve.baseUrl}/`);
 
       const row = page.locator("[data-testid='sidebar-session-row']");
-      await expect(row).toContainText(title);
+      // Live specs run with `workers: 4`, so the first paint can lag while
+      // four `aoe serve` instances cold-start in parallel. The default 5s
+      // assertion timeout is enough on a warm cache but flakes cold, so
+      // bump the wait for the initial row paint here (and elsewhere in
+      // this file). Subsequent assertions keep the default.
+      await expect(row).toContainText(title, { timeout: 10_000 });
       await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-delete']")
@@ -99,9 +104,9 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
         return route.continue();
       });
 
-      await page
-        .locator("[data-testid='sidebar-session-row']")
-        .click({ button: "right" });
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
+      await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-delete']")
         .click();
@@ -144,9 +149,9 @@ base.describe("session delete via sidebar context menu (#1220)", () => {
         return route.continue();
       });
 
-      await page
-        .locator("[data-testid='sidebar-session-row']")
-        .click({ button: "right" });
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
+      await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-delete']")
         .click();

--- a/web/tests/live/session-rename.spec.ts
+++ b/web/tests/live/session-rename.spec.ts
@@ -1,0 +1,156 @@
+// Live coverage for the sidebar rename flow:
+//   - Right-click a session row → context menu → Rename → inline input.
+//   - Enter commits, firing PATCH /api/sessions/:id with `{ title }`.
+//   - Escape cancels the edit, no PATCH.
+//   - A blank value short-circuits before any PATCH fires.
+//
+// The contract under test lives in `SessionRow.commitRename` in
+// `web/src/components/WorkspaceSidebar.tsx`. The PATCH handler is
+// `update_session` in `src/server/api/sessions.rs`; live coverage
+// catches a wire-format drift on either side that mocked specs miss.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("session rename via sidebar context menu (#1220)", () => {
+  base("Enter commits the new title and round-trips through PATCH /api/sessions/:id", async ({ page }, testInfo) => {
+    const original = "rename-source";
+    const updated = "rename-target";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: original }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toHaveCount(1);
+      await expect(row).toContainText(original);
+
+      await row.click({ button: "right" });
+      const menu = page.locator("[data-testid='sidebar-context-menu']");
+      await expect(menu).toBeVisible();
+
+      const patchPromise = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}`) &&
+          res.request().method() === "PATCH",
+      );
+
+      await menu.locator("[data-testid='sidebar-context-menu-rename']").click();
+      const input = page.locator("[data-testid='sidebar-rename-input']");
+      await expect(input).toBeVisible();
+      await input.fill(updated);
+      await input.press("Enter");
+
+      const patchRes = await patchPromise;
+      expect(patchRes.ok()).toBe(true);
+      expect(patchRes.request().postDataJSON()).toEqual({ title: updated });
+
+      await expect(page.getByText(updated)).toBeVisible({ timeout: 5_000 });
+
+      await expect
+        .poll(async () => (await listSessions(serve.baseUrl))[0]?.title, {
+          timeout: 5_000,
+        })
+        .toBe(updated);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("Escape cancels mid-edit, no PATCH fires", async ({ page }, testInfo) => {
+    const title = "escape-cancels";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      // Spy on every PATCH-shaped request to the sessions endpoint.
+      let patchSeen = false;
+      await page.route("**/api/sessions/*", (route) => {
+        if (route.request().method() === "PATCH") {
+          patchSeen = true;
+        }
+        return route.continue();
+      });
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await row.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-rename']")
+        .click();
+
+      const input = page.locator("[data-testid='sidebar-rename-input']");
+      await input.fill("should-not-stick");
+      await input.press("Escape");
+
+      // The input unmounts on Escape, the row reverts to its label.
+      await expect(input).toBeHidden();
+      await expect(row).toContainText(title);
+
+      // Give the browser a beat to make sure no PATCH is in flight.
+      await page.waitForTimeout(200);
+      expect(patchSeen).toBe(false);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("blank title is rejected by commitRename without firing PATCH", async ({ page }, testInfo) => {
+    const title = "blank-rejected";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      let patchSeen = false;
+      await page.route("**/api/sessions/*", (route) => {
+        if (route.request().method() === "PATCH") {
+          patchSeen = true;
+        }
+        return route.continue();
+      });
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await row.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-rename']")
+        .click();
+
+      const input = page.locator("[data-testid='sidebar-rename-input']");
+      await input.fill("   ");
+      await input.press("Enter");
+
+      // commitRename short-circuits on a blank trimmed value; the row
+      // label keeps the original title and no PATCH leaves the page.
+      await expect(input).toBeHidden();
+      await expect(row).toContainText(title);
+      await page.waitForTimeout(200);
+      expect(patchSeen).toBe(false);
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/session-rename.spec.ts
+++ b/web/tests/live/session-rename.spec.ts
@@ -35,8 +35,10 @@ base.describe("session rename via sidebar context menu (#1220)", () => {
       await page.goto(`${serve.baseUrl}/`);
 
       const row = page.locator("[data-testid='sidebar-session-row']");
-      await expect(row).toHaveCount(1);
-      await expect(row).toContainText(original);
+      // Live specs run with `workers: 4`, so the first row paint can
+      // lag cold. Bump the wait above the 5s assertion default.
+      await expect(row).toHaveCount(1, { timeout: 10_000 });
+      await expect(row).toContainText(original, { timeout: 10_000 });
 
       await row.click({ button: "right" });
       const menu = page.locator("[data-testid='sidebar-context-menu']");
@@ -92,6 +94,7 @@ base.describe("session rename via sidebar context menu (#1220)", () => {
       });
 
       const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
       await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-rename']")
@@ -134,6 +137,7 @@ base.describe("session rename via sidebar context menu (#1220)", () => {
       });
 
       const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
       await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-rename']")

--- a/web/tests/live/sidebar-groups.spec.ts
+++ b/web/tests/live/sidebar-groups.spec.ts
@@ -1,0 +1,171 @@
+// Live coverage for the WorkspaceSidebar repo-group surface:
+//   - Two sessions seeded in two different repo dirs surface as two
+//     groups, each with its session row.
+//   - The filter input narrows the visible groups/rows by matching
+//     against title, project path, branch, or agent (see
+//     `workspaceMatchesFilter` in WorkspaceSidebar.tsx).
+//   - Tapping the group header chevron flips `aria-expanded` and hides
+//     the row list; tapping again restores it. State lives in
+//     `useRepoGroups`'s in-memory + localStorage map.
+//
+// Pairs with the within-group drag-reorder spec in
+// `workspace-ordering.spec.ts`. Drag-into-group is not a real feature
+// (drag is constrained to a single group; see #1169).
+//
+// The session-creation seed runs BEFORE serve spawns so `state.instances`
+// picks up both records on boot, mirroring `ensure-session-restart.spec.ts`.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../helpers/aoeServe";
+
+function seedTwoRepoSessions(opts: {
+  repoA: { dir: string; title: string };
+  repoB: { dir: string; title: string };
+}) {
+  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
+    const binary = resolveAoeBinary();
+    for (const { dir, title } of [opts.repoA, opts.repoB]) {
+      const projectDir = join(home, dir);
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+base.describe("sidebar repo groups (#1220)", () => {
+  base("two repos render as two groups, both rows visible", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedTwoRepoSessions({
+        repoA: { dir: "repo-alpha", title: "alpha-session" },
+        repoB: { dir: "repo-beta", title: "beta-session" },
+      }),
+    });
+
+    try {
+      const seeded = await listSessions(serve.baseUrl);
+      expect(seeded).toHaveLength(2);
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const groupHeaders = page.locator("[data-testid='sidebar-group-header']");
+      await expect(groupHeaders).toHaveCount(2);
+      await expect(page.getByText("repo-alpha")).toBeVisible();
+      await expect(page.getByText("repo-beta")).toBeVisible();
+
+      const rows = page.locator("[data-testid='sidebar-session-row']");
+      await expect(rows).toHaveCount(2);
+      await expect(page.getByText("alpha-session")).toBeVisible();
+      await expect(page.getByText("beta-session")).toBeVisible();
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("filter input narrows visible groups + rows by repo name", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedTwoRepoSessions({
+        repoA: { dir: "repo-alpha", title: "alpha-session" },
+        repoB: { dir: "repo-beta", title: "beta-session" },
+      }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      await expect(page.locator("[data-testid='sidebar-group-header']")).toHaveCount(2);
+
+      await page.getByLabel("Filter sessions").click();
+      const filter = page.locator("[data-testid='sidebar-filter-input']");
+      await expect(filter).toBeVisible();
+
+      await filter.fill("alpha");
+      await expect(page.locator("[data-testid='sidebar-group-header']")).toHaveCount(1);
+      await expect(page.getByText("repo-alpha")).toBeVisible();
+      await expect(page.getByText("repo-beta")).toBeHidden();
+
+      // Clearing the input restores both groups; we drive the same input
+      // rather than toggling the filter off because the toggle button
+      // ALSO clears the query, which would hide the input we'd want to
+      // assert on.
+      await filter.fill("");
+      await expect(page.locator("[data-testid='sidebar-group-header']")).toHaveCount(2);
+
+      // No-match query renders the empty-state placeholder.
+      await filter.fill("nonexistent-repo-xyz");
+      await expect(page.getByText(/No matches for/)).toBeVisible();
+      await expect(page.locator("[data-testid='sidebar-session-row']")).toHaveCount(0);
+    } finally {
+      await serve.stop();
+    }
+  });
+
+  base("group header chevron toggles aria-expanded and hides rows", async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedTwoRepoSessions({
+        repoA: { dir: "repo-alpha", title: "alpha-session" },
+        repoB: { dir: "repo-beta", title: "beta-session" },
+      }),
+    });
+
+    try {
+      await page.goto(`${serve.baseUrl}/`);
+
+      const alphaHeader = page.locator(
+        "[data-testid='sidebar-group-header']",
+        { has: page.getByText("repo-alpha") },
+      );
+      const expandBtn = alphaHeader.locator("button[aria-expanded]");
+      await expect(expandBtn).toHaveAttribute("aria-expanded", "true");
+
+      await expandBtn.click();
+      await expect(expandBtn).toHaveAttribute("aria-expanded", "false");
+
+      // Collapsing the alpha group hides its row but leaves beta's row
+      // (in the other group) untouched.
+      await expect(page.getByText("alpha-session")).toBeHidden();
+      await expect(page.getByText("beta-session")).toBeVisible();
+
+      await expandBtn.click();
+      await expect(expandBtn).toHaveAttribute("aria-expanded", "true");
+      await expect(page.getByText("alpha-session")).toBeVisible();
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/sidebar-groups.spec.ts
+++ b/web/tests/live/sidebar-groups.spec.ts
@@ -77,8 +77,11 @@ base.describe("sidebar repo groups (#1220)", () => {
 
       await page.goto(`${serve.baseUrl}/`);
 
+      // 4-worker cold start can lag past Playwright's 5s assertion
+      // default; bump the first paint waits here and in the other two
+      // tests in this file.
       const groupHeaders = page.locator("[data-testid='sidebar-group-header']");
-      await expect(groupHeaders).toHaveCount(2);
+      await expect(groupHeaders).toHaveCount(2, { timeout: 10_000 });
       await expect(page.getByText("repo-alpha")).toBeVisible();
       await expect(page.getByText("repo-beta")).toBeVisible();
 
@@ -105,7 +108,9 @@ base.describe("sidebar repo groups (#1220)", () => {
     try {
       await page.goto(`${serve.baseUrl}/`);
 
-      await expect(page.locator("[data-testid='sidebar-group-header']")).toHaveCount(2);
+      await expect(
+        page.locator("[data-testid='sidebar-group-header']"),
+      ).toHaveCount(2, { timeout: 10_000 });
 
       await page.getByLabel("Filter sessions").click();
       const filter = page.locator("[data-testid='sidebar-filter-input']");
@@ -151,7 +156,9 @@ base.describe("sidebar repo groups (#1220)", () => {
         { has: page.getByText("repo-alpha") },
       );
       const expandBtn = alphaHeader.locator("button[aria-expanded]");
-      await expect(expandBtn).toHaveAttribute("aria-expanded", "true");
+      await expect(expandBtn).toHaveAttribute("aria-expanded", "true", {
+        timeout: 10_000,
+      });
 
       await expandBtn.click();
       await expect(expandBtn).toHaveAttribute("aria-expanded", "false");

--- a/web/tests/live/workspace-ordering.spec.ts
+++ b/web/tests/live/workspace-ordering.spec.ts
@@ -66,8 +66,14 @@ async function readVisibleSessionTitles(page: import("@playwright/test").Page): 
         "[data-testid='sidebar-session-row']",
       ),
     );
+    // Scope to the label span specifically (see WorkspaceSidebar.tsx:587).
+    // A bare `[title]` selector can pick up a Wakeup or Plan chip if either
+    // ever renders on the row.
     return rows
-      .map((r) => r.querySelector("[title]")?.getAttribute("title") ?? "")
+      .map(
+        (r) =>
+          r.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+      )
       .filter(Boolean);
   });
 }

--- a/web/tests/live/workspace-ordering.spec.ts
+++ b/web/tests/live/workspace-ordering.spec.ts
@@ -102,6 +102,11 @@ base.describe("workspace ordering live round-trip (#1220)", () => {
       await page.setViewportSize({ width: 1280, height: 720 });
       await page.goto(`${serve.baseUrl}/`);
 
+      // The sidebar paints after a `GET /api/sessions` round-trip, so
+      // poll rather than reading once. Three rows is the steady state.
+      await expect
+        .poll(() => readVisibleSessionTitles(page), { timeout: 8_000 })
+        .toEqual(expect.arrayContaining(["alpha", "beta", "gamma"]));
       const initial = await readVisibleSessionTitles(page);
       expect(initial).toHaveLength(3);
       expect(new Set(initial)).toEqual(new Set(["alpha", "beta", "gamma"]));

--- a/web/tests/live/workspace-ordering.spec.ts
+++ b/web/tests/live/workspace-ordering.spec.ts
@@ -1,0 +1,174 @@
+// Live coverage for `PUT /api/workspace-ordering`. The mocked spec at
+// `web/tests/sidebar-drag-reorder.spec.ts` already drives the press-and-
+// hold drag against a stubbed `/api/workspace-ordering`; this spec hits
+// the real backend so a wire-format drift on either side blows up
+// before reaching `main`.
+//
+// Why not "session-group-move": #1220 originally asked for a
+// `PATCH /api/groups/:id/sessions` spec, but no such endpoint exists.
+// Sessions belong to the group derived from their `project_path` (see
+// `useRepoGroups` in `web/src/hooks/useRepoGroups.ts`), and drag is
+// constrained to a single group per #1169. The "move a session to a
+// different group" flow has no UI or API to exercise; the actually
+// movable thing is the workspace ordering, covered here.
+//
+// The press-and-hold mouse sequence mirrors `sidebar-drag-reorder.spec.ts`
+// (mouse.move → mouse.down → 250ms wait → mouse.move with steps →
+// mouse.up); dnd-kit's MouseSensor uses `{ delay: 150, tolerance: 8 }`,
+// so the hold has to outlast the activation window without moving more
+// than 8px.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../helpers/aoeServe";
+
+function seedThreeSessionsInOneRepo(titles: [string, string, string]) {
+  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
+    const binary = resolveAoeBinary();
+    const projectDir = join(home, "repo");
+    mkdirSync(projectDir, { recursive: true });
+    spawnSync("git", ["init", "-q"], { cwd: projectDir });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+      cwd: projectDir,
+      env: {
+        ...env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+    for (const title of titles) {
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+async function readVisibleSessionTitles(page: import("@playwright/test").Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "[data-testid='sidebar-session-row']",
+      ),
+    );
+    return rows
+      .map((r) => r.querySelector("[title]")?.getAttribute("title") ?? "")
+      .filter(Boolean);
+  });
+}
+
+base.describe("workspace ordering live round-trip (#1220)", () => {
+  base("press-and-hold drag reorders and round-trips PUT /api/workspace-ordering", async ({ page }, testInfo) => {
+    // `aoe add` records workspace ids as `<project_path>::<title>` (see
+    // `merge_workspace_ordering` in `src/server/api/sessions.rs`); the
+    // server prepends new ids newest-first, so the seeded order in
+    // arrival sequence is gamma at the top, beta in the middle, alpha
+    // at the bottom.
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedThreeSessionsInOneRepo(["alpha", "beta", "gamma"]),
+    });
+
+    try {
+      const seeded = await listSessions(serve.baseUrl);
+      expect(seeded).toHaveLength(3);
+
+      const puts: string[][] = [];
+      await page.route("**/api/workspace-ordering", (route) => {
+        if (route.request().method() === "PUT") {
+          const body = route.request().postDataJSON() as { order?: string[] };
+          if (Array.isArray(body.order)) puts.push(body.order);
+        }
+        return route.continue();
+      });
+
+      await page.setViewportSize({ width: 1280, height: 720 });
+      await page.goto(`${serve.baseUrl}/`);
+
+      const initial = await readVisibleSessionTitles(page);
+      expect(initial).toHaveLength(3);
+      expect(new Set(initial)).toEqual(new Set(["alpha", "beta", "gamma"]));
+
+      // Press the bottom wrapper, hold past the 150ms activation delay,
+      // then drag onto the top wrapper.
+      const wrappers = page.locator(
+        "[aria-roledescription='Press and hold to reorder']",
+      );
+      await expect(wrappers).toHaveCount(3);
+
+      const sourceBox = await wrappers.nth(2).boundingBox();
+      const targetBox = await wrappers.nth(0).boundingBox();
+      if (!sourceBox || !targetBox) throw new Error("row boxes missing");
+
+      await page.mouse.move(
+        sourceBox.x + sourceBox.width - 4,
+        sourceBox.y + sourceBox.height / 2,
+      );
+      await page.mouse.down();
+      await page.waitForTimeout(250);
+      await page.mouse.move(
+        targetBox.x + targetBox.width / 2,
+        targetBox.y + targetBox.height / 2,
+        { steps: 12 },
+      );
+
+      // Source row gets the active-drag amber ring; assert before
+      // releasing so a future visual regression trips the test.
+      const sourceClass = await wrappers.nth(2).getAttribute("class");
+      expect(sourceClass ?? "").toContain("ring-2");
+
+      await page.mouse.up();
+
+      // After release, the bottom row is now at the top and the PUT
+      // body reflects the new full flat order.
+      await expect
+        .poll(() => readVisibleSessionTitles(page), { timeout: 4_000 })
+        .toEqual([initial[2], initial[0], initial[1]]);
+
+      // Reconstruct expected workspace ids from the seeded sessions in
+      // the dragged order. Workspace ids without a branch are
+      // `<project_path>::__session__::<session_id>` (see
+      // `useWorkspaces.ts:31`).
+      const byTitle = new Map<string, string>(
+        seeded.map((s) => [
+          s.title as string,
+          `${(s.project_path as string).replace(/\/+$/, "")}::__session__::${s.id as string}`,
+        ]),
+      );
+
+      await expect
+        .poll(() => puts.at(-1), { timeout: 4_000 })
+        .toEqual([
+          byTitle.get(initial[2]!),
+          byTitle.get(initial[0]!),
+          byTitle.get(initial[1]!),
+        ]);
+
+      // After the drag completes, the server's persisted ordering
+      // mirrors the PUT body. Probe via `GET /api/sessions` which
+      // returns the merged ordering envelope.
+      const after = await fetch(`${serve.baseUrl}/api/sessions`);
+      const body = (await after.json()) as { workspace_ordering: string[] };
+      expect(body.workspace_ordering.slice(0, 3)).toEqual(puts.at(-1));
+    } finally {
+      await serve.stop();
+    }
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Foundation PR #1228 left the `session.lifecycle` entry in `web/tests/coverage-matrix.json` as `deferred`, pointing at this issue. This PR fills that gap with live Playwright specs that drive the WorkspaceSidebar and DeleteSessionDialog against a real `aoe serve`.

Four new specs under `web/tests/live/`:

- `sidebar-groups.spec.ts` (3 tests) seeds two sessions in two separate repo dirs and asserts that the two group headers render with their session rows, that the filter input narrows the visible groups by repo name, and that the group chevron flips `aria-expanded` and hides the row list. Each test re-spawns `aoe serve` against an isolated HOME so the seeded `state.instances` snapshot is deterministic.
- `session-rename.spec.ts` (3 tests) covers the right-click rename flow end to end: Enter commits and round-trips through `PATCH /api/sessions/:id` with the expected `{ title }` body, while Escape and a blank input both short-circuit before any PATCH fires.
- `session-delete.spec.ts` (3 tests) opens DeleteSessionDialog from the sidebar context menu and asserts that the Delete button fires `DELETE /api/sessions/:id` with the all-false body (the seed has no managed worktree or sandbox), while the Cancel button and the Escape key both dismiss the dialog without firing DELETE. Toggle-combination coverage for the four checkboxes lives in the Vitest suite per the project's testing taxonomy.
- `workspace-ordering.spec.ts` (1 test) seeds three sessions in one repo, drags the bottom row to the top with the same press-and-hold mouse sequence used by the mocked `sidebar-drag-reorder.spec.ts`, and asserts the body sent to `PUT /api/workspace-ordering` plus the merged ordering returned by the next `GET /api/sessions`. This replaces the `session-group-move.spec.ts` bullet from the issue, since no `PATCH /api/groups/:id/sessions` endpoint exists (sessions belong to the group derived from their `project_path`; the only user-controlled reordering is the workspace order).

To keep the new specs robust against future styling tweaks, `WorkspaceSidebar.tsx` and `DeleteSessionDialog.tsx` pick up small `data-testid` hooks on the session row, repo group header, context menu items, rename input, filter input, the dialog root, and the four cleanup checkboxes.

`web/src/components/__tests__/DeleteSessionDialog.test.tsx` gains five toggle-combination cases asserting that each checkbox flips the matching key in the confirm body, that flipping delete-worktree off unmounts the force checkbox, and that no-options sessions confirm with an all-false body.

`web/tests/coverage-matrix.json` flips `session.lifecycle` from `deferred` to `live-playwright` and adds two new entries: `sidebar.groups` (pointing at the new groups spec, with `WorkspaceSidebar.tsx` as the component) and `sidebar.workspace-ordering` (pointing at the new live drag-reorder spec). `node web/tests/validate-coverage-matrix.mjs` passes.

Closes #1220

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

(Tests-only; not a flow-changing PR.)

## How to test

- [ ] Build the binary: `cargo build --features serve --release` (or reuse an existing release build).
- [ ] Run the four new live specs: `cd web && AOE_E2E_BINARY=../target/release/aoe npx playwright test --config=playwright.live.config.ts tests/live/sidebar-groups.spec.ts tests/live/session-rename.spec.ts tests/live/session-delete.spec.ts tests/live/workspace-ordering.spec.ts` and confirm 10 tests pass.
- [ ] Run the extended Vitest suite for the delete dialog: `cd web && npx vitest run src/components/__tests__/DeleteSessionDialog.test.tsx` and confirm 13 tests pass (8 original keyboard cases + 5 new toggle-combination cases).
- [ ] Run the full Vitest suite: `cd web && npx vitest run` and confirm 517 tests pass across 54 files.
- [ ] Validate the coverage matrix: `node web/tests/validate-coverage-matrix.mjs` prints "Coverage matrix validation passed."
- [ ] Manual sanity check in a browser: start `aoe serve`, seed two sessions in two different repo dirs, open the sidebar, see two group headers, click the chevron on one to collapse / expand it, type in the filter input to narrow to one group, right-click a row to rename or delete and confirm the round-trip lands.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Opus 4.7, 1M context) via Claude Code, using the agent-of-empires `/aoe-implement` skill.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and spec drafts written by Claude under my direction. I reviewed each commit, approved the plan (including the call to replace `session-group-move.spec.ts` with `workspace-ordering.spec.ts` since the `PATCH /api/groups/:id/sessions` endpoint named in the issue doesn't exist), and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds comprehensive automated testing for session and sidebar management features. Four new end-to-end tests were introduced to verify critical user workflows against a real server, while test hooks were added to UI components to enable reliable test targeting. Existing unit tests were extended to cover additional edge cases.

### What Changed

**UI Components**: Added test identification markers (`data-testid` attributes) to `DeleteSessionDialog.tsx` and `WorkspaceSidebar.tsx` to enable stable test selectors for the new automated tests. These changes are purely for testing purposes and do not alter functionality.

**Unit Tests**: Extended the `DeleteSessionDialog` test suite with five new test cases covering different combinations of checkbox states (delete worktree, force delete, delete branch) and their effects on the API request payload and UI rendering.

**End-to-End Tests**: Added four new live Playwright test files covering:
- Session renaming via sidebar context menu (Enter/Escape/blank input behavior)
- Session deletion with dialog confirmation (Delete/Cancel/Escape paths)
- Sidebar group expansion/collapse and filter search functionality
- Session drag-and-drop reordering and workspace ordering API round-trip

**Test Coverage Tracking**: Updated the coverage matrix to mark session lifecycle and sidebar features as now covered by live Playwright tests instead of deferred.

### Technical Details

The new Playwright specs exercise real HTTP endpoints:
- `PATCH /api/sessions/:id` for rename operations with `{ title }` payload
- `DELETE /api/sessions/:id` for session deletion with toggle flags (`delete_worktree`, `delete_branch`, `delete_sandbox`, `force_delete`)
- `PUT /api/workspace-ordering` for session reordering with workspace ID arrays
- `GET /api/sessions` for verifying persisted state

Each test spawns an isolated `aoe serve` instance with a dedicated HOME directory to ensure deterministic, snapshot-friendly behavior. Tests validate both UI state changes (row visibility, group expansion, input display) and underlying API request/response contracts.

### Benefits

- **End-to-end coverage**: Critical user workflows (rename, delete, reorder, group collapse) are now tested against a real server, catching integration issues that unit tests may miss
- **Stable selectors**: `data-testid` hooks provide maintainable test selectors resistant to CSS/styling changes
- **Comprehensive validation**: Tests verify both API contract correctness and UI state synchronization
- **Reduced manual testing**: Automated verification of complex interactions reduces QA burden

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1323?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->