### PR TITLE
refactor(tmux): RAII guard for tmux session cleanup in tests

### DIFF
--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -5,6 +5,8 @@ mod session;
 pub mod status_bar;
 pub(crate) mod status_detection;
 mod terminal_session;
+#[cfg(test)]
+mod test_helpers;
 mod tool_session;
 pub(crate) mod utils;
 
@@ -349,6 +351,7 @@ impl AvailableTools {
 
 #[cfg(test)]
 mod tests {
+    use super::test_helpers::TmuxTestSession;
     use super::*;
 
     // Session names embed `SESSION_PREFIX`, which differs between release
@@ -472,7 +475,8 @@ mod tests {
 
         // Ensure the tmux server is already running so the test session's
         // command string doesn't end up in the server process's argv.
-        let dummy = format!("aoe_test_compound_dummy_{}", std::process::id());
+        let dummy_guard = TmuxTestSession::new("aoe_test_compound_dummy");
+        let dummy = dummy_guard.name().to_string();
         let _ = Command::new("tmux")
             .args([
                 "new-session",
@@ -488,7 +492,8 @@ mod tests {
             .output();
         std::thread::sleep(std::time::Duration::from_millis(200));
 
-        let session_name = format!("aoe_test_compound_{}", std::process::id());
+        let session_guard = TmuxTestSession::new("aoe_test_compound");
+        let session_name = session_guard.name().to_string();
         let marker = format!("AOE_COMPOUND_TEST_{}", std::process::id());
         let secret_value = "s3cret_val!@#";
 
@@ -567,14 +572,6 @@ mod tests {
             is_dead,
             "Pane should be dead after exec'd command exits (lifecycle preserved)"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &dummy])
-            .output();
     }
 
     /// Verify that after `exec` replaces the outer shell, the secret
@@ -595,7 +592,8 @@ mod tests {
 
         // Ensure the tmux server is already running so our test session's
         // command string doesn't end up in the server process's argv.
-        let dummy = format!("aoe_test_ps_dummy_{}", std::process::id());
+        let dummy_guard = TmuxTestSession::new("aoe_test_ps_dummy");
+        let dummy = dummy_guard.name().to_string();
         let _ = Command::new("tmux")
             .args([
                 "new-session",
@@ -611,7 +609,8 @@ mod tests {
             .output();
         std::thread::sleep(std::time::Duration::from_millis(200));
 
-        let session_name = format!("aoe_test_ps_{}", std::process::id());
+        let session_guard = TmuxTestSession::new("aoe_test_ps");
+        let session_name = session_guard.name().to_string();
         let secret_value = format!("UNIQUE_SECRET_{}_xyzzy", std::process::id());
 
         // Simulate: export SECRET='val'; exec sleep 30
@@ -655,13 +654,5 @@ mod tests {
                 .collect::<Vec<_>>()
                 .join("\n")
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &dummy])
-            .output();
     }
 }

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -516,6 +516,7 @@ fn build_create_args(
 
 #[cfg(test)]
 mod tests {
+    use super::super::test_helpers::TmuxTestSession;
     use super::*;
 
     /// Helper: check if tmux is available for tests that need it
@@ -535,7 +536,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_remain_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_remain");
+        let session_name = guard.name().to_string();
         // Chain set-option -p with new-session to avoid race condition
         let output = Command::new("tmux")
             .args([
@@ -580,11 +582,6 @@ mod tests {
             .map(|s| s.trim() == "1")
             .unwrap_or(false);
         assert!(pane_dead, "Pane should be dead after command exits");
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     #[test]
@@ -595,7 +592,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_alive_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_alive");
+        let session_name = guard.name().to_string();
 
         // Create a session with a long-running command
         let output = Command::new("tmux")
@@ -632,11 +630,6 @@ mod tests {
             .map(|s| s.trim() == "1")
             .unwrap_or(false);
         assert!(!pane_dead, "Pane should be alive while command is running");
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test for #435: with multiple tmux windows, pane health
@@ -650,7 +643,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_multiwin_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_multiwin");
+        let session_name = guard.name().to_string();
 
         // Create session with a long-running command in window 0
         let output = Command::new("tmux")
@@ -709,11 +703,6 @@ mod tests {
             !is_pane_dead(&session_name),
             "is_pane_dead should check the first window's pane, not the active window"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test: capture_pane must target the first window's pane
@@ -727,7 +716,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_capture_multiwin_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_capture_multiwin");
+        let session_name = guard.name().to_string();
 
         // Create session running sleep in the first window
         let output = Command::new("tmux")
@@ -783,11 +773,6 @@ mod tests {
             !session.is_pane_running_shell(),
             "is_pane_running_shell should check first window (sleep), not active window (sh)"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test: is_pane_running_shell must target the first window's
@@ -800,7 +785,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_shell_multiwin_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_shell_multiwin");
+        let session_name = guard.name().to_string();
 
         // Create session running sleep (not a shell) in the first window
         let output = Command::new("tmux")
@@ -845,11 +831,6 @@ mod tests {
             !is_pane_running_shell(&session_name),
             "is_pane_running_shell should target first window (sleep), not active window (sh)"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test for #488: when a user creates a split pane and makes it
@@ -863,7 +844,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_splitpane_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_splitpane");
+        let session_name = guard.name().to_string();
 
         // Create session with a long-running command (the "agent")
         let output = Command::new("tmux")
@@ -916,11 +898,6 @@ mod tests {
             !is_pane_running_shell(&session_name),
             "is_pane_running_shell should check pane 0 (sleep), not the active split pane (shell)"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test for #488: ensure status checks work correctly when both
@@ -933,7 +910,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_splitpbi_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_splitpbi");
+        let session_name = guard.name().to_string();
 
         // Create session with pane-base-index 0 pinned (as aoe does)
         let output = Command::new("tmux")
@@ -990,11 +968,6 @@ mod tests {
             !is_pane_running_shell(&session_name),
             "is_pane_running_shell should check pane 0 (sleep) with pane-base-index pinned to 0"
         );
-
-        // Clean up
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     #[test]
@@ -1066,7 +1039,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_shell_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_shell");
+        let session_name = guard.name().to_string();
 
         let output = Command::new("tmux")
             .args([
@@ -1090,10 +1064,6 @@ mod tests {
             is_pane_running_shell(&session_name),
             "Session running sh should be detected as a shell"
         );
-
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     #[test]
@@ -1104,7 +1074,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_noshell_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_noshell");
+        let session_name = guard.name().to_string();
 
         let output = Command::new("tmux")
             .args([
@@ -1129,10 +1100,6 @@ mod tests {
             !is_pane_running_shell(&session_name),
             "Session running 'sleep' should not be detected as a shell"
         );
-
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// Regression test for the dead-pane restart bug: a session whose pane
@@ -1146,7 +1113,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_respawn_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_respawn");
+        let session_name = guard.name().to_string();
 
         // Start a session with a command that exits immediately and
         // remain-on-exit set, so we end up with a dead pane. Pin
@@ -1209,10 +1177,6 @@ mod tests {
             !respawned_again,
             "respawn_dead_pane should report no-op on live pane"
         );
-
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     /// respawn_dead_pane on a non-existent session is a safe no-op.

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -342,6 +342,7 @@ fn build_terminal_create_args(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tmux::test_helpers::TmuxTestSession;
     use crate::tmux::{Session, SESSION_PREFIX};
 
     #[test]
@@ -457,7 +458,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_terminal_dead_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_terminal_dead");
+        let session_name = guard.name().to_string();
         let session = TerminalSession {
             inner: PairedTerminal {
                 name: session_name.clone(),
@@ -494,10 +496,6 @@ mod tests {
             session.is_pane_dead(),
             "Terminal session pane should be dead after command exits"
         );
-
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 
     #[test]
@@ -508,7 +506,8 @@ mod tests {
             return;
         }
 
-        let session_name = format!("aoe_test_terminal_alive_{}", std::process::id());
+        let guard = TmuxTestSession::new("aoe_test_terminal_alive");
+        let session_name = guard.name().to_string();
         let session = TerminalSession {
             inner: PairedTerminal {
                 name: session_name.clone(),
@@ -545,9 +544,5 @@ mod tests {
             !session.is_pane_dead(),
             "Terminal session pane should be alive while command running"
         );
-
-        let _ = Command::new("tmux")
-            .args(["kill-session", "-t", &session_name])
-            .output();
     }
 }

--- a/src/tmux/test_helpers.rs
+++ b/src/tmux/test_helpers.rs
@@ -83,15 +83,17 @@ mod tests {
             assert!(output.status.success());
             let exists = Command::new("tmux")
                 .args(["has-session", "-t", guard.name()])
-                .status()
+                .output()
                 .expect("tmux has-session")
+                .status
                 .success();
             assert!(exists, "session should exist while guard is alive");
         }
         let exists = Command::new("tmux")
             .args(["has-session", "-t", &captured_name])
-            .status()
+            .output()
             .expect("tmux has-session")
+            .status
             .success();
         assert!(!exists, "session should be killed after guard drop");
     }

--- a/src/tmux/test_helpers.rs
+++ b/src/tmux/test_helpers.rs
@@ -1,0 +1,108 @@
+//! Test-only helpers for tmux integration tests.
+//!
+//! `TmuxTestSession` reserves a unique session name and tears the tmux
+//! session down on `Drop`, so a panicking `assert!`/`expect!` cannot leak a
+//! tmux session into the user's environment. Tests still call
+//! `tmux new-session` themselves (they need their own `-x`/`-y`/command and
+//! occasionally compound argv), so the guard does not create the session.
+
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// RAII guard that runs `tmux kill-session -t <name>` on drop. The guard
+/// owns the session name; tests call `guard.name()` wherever they need
+/// `&str`.
+pub(crate) struct TmuxTestSession {
+    name: String,
+}
+
+impl TmuxTestSession {
+    /// Reserve a unique name of the form `<prefix>_<pid>_<n>`. `n` is a
+    /// process-local atomic counter so a single test can hold multiple
+    /// guards without collision.
+    pub(crate) fn new(prefix: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        Self {
+            name: format!("{}_{}_{}", prefix, std::process::id(), n),
+        }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl Drop for TmuxTestSession {
+    fn drop(&mut self) {
+        // Best-effort, idempotent. Drop must not panic, so the Result is
+        // discarded: a missing tmux server or already-dead session is fine.
+        let _ = Command::new("tmux")
+            .args(["kill-session", "-t", &self.name])
+            .output();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmux_available() -> bool {
+        Command::new("tmux")
+            .arg("-V")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn drop_kills_session() {
+        if !tmux_available() {
+            eprintln!("Skipping test: tmux not available");
+            return;
+        }
+        let captured_name;
+        {
+            let guard = TmuxTestSession::new("aoe_test_guard_self");
+            captured_name = guard.name().to_string();
+            let output = Command::new("tmux")
+                .args([
+                    "new-session",
+                    "-d",
+                    "-s",
+                    guard.name(),
+                    "-x",
+                    "80",
+                    "-y",
+                    "24",
+                    "sleep 30",
+                ])
+                .output()
+                .expect("tmux new-session");
+            assert!(output.status.success());
+            let exists = Command::new("tmux")
+                .args(["has-session", "-t", guard.name()])
+                .status()
+                .expect("tmux has-session")
+                .success();
+            assert!(exists, "session should exist while guard is alive");
+        }
+        let exists = Command::new("tmux")
+            .args(["has-session", "-t", &captured_name])
+            .status()
+            .expect("tmux has-session")
+            .success();
+        assert!(!exists, "session should be killed after guard drop");
+    }
+
+    // No `#[serial_test::serial]`: this test only touches the in-process
+    // atomic counter, never tmux. Adding the attribute would needlessly
+    // serialize it against unrelated tmux-spawning tests.
+    #[test]
+    fn unique_names_within_process() {
+        let a = TmuxTestSession::new("aoe_test_unique");
+        let b = TmuxTestSession::new("aoe_test_unique");
+        assert_ne!(a.name(), b.name());
+    }
+}


### PR DESCRIPTION
## Description

Tests in [`src/tmux/{mod,session,terminal_session}.rs`](https://github.com/njbrake/agent-of-empires/tree/main/src/tmux) spawned tmux sessions named after `std::process::id()` and cleaned them up via a trailing `Command::new(\"tmux\").args([\"kill-session\", ...]).output()`. Any panicking `assert!`/`expect()` upstream of that call leaked the session into the user's tmux server, polluting `tmux ls`. Concrete leaks observed locally on macOS after a single `cargo test --lib` run included `aoe_test_capture_multiwin_*`, `aoe_test_compound_*`, `aoe_test_shell_multiwin_*`, `aoe_test_splitpbi_*` (15 orphans across 4 distinct prefixes, multiple PIDs each, all from tests where an assertion panicked before the trailing cleanup).

This PR introduces `TmuxTestSession`, a `pub(crate)` RAII guard:

- Reserves a unique name of the form `<prefix>_<pid>_<atomic-counter>` so a single test can hold multiple guards (compound + dummy).
- Runs `tmux kill-session -t <name>` on `Drop` (best-effort, idempotent, panic-safe via `let _ = ...output()`).

The guard reserves a name; it does *not* create the session. Tests still call their own `new-session` with their own `-x`/`-y`/argv, which keeps the migration mechanical and avoids constructor sprawl across 14 sites with varied flags.

Migrated:

- `src/tmux/session.rs`: 10 tests
- `src/tmux/mod.rs`: 2 tests, each holding 2 sessions (compound + dummy)
- `src/tmux/terminal_session.rs`: 2 tests
- `src/tmux/test_helpers.rs` (new): the guard + 2 self-tests (`drop_kills_session`, `unique_names_within_process`)

Net: ~75 lines of cleanup boilerplate removed; `+145 / -87` overall.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (\`cargo test --lib\`: 1789 passed, 0 failed)
- [x] Documentation was updated where necessary (module-level rustdoc on the new `test_helpers` module)
- [x] For UI changes: included screenshot or recording (N/A)

Verification:

- \`cargo fmt --check\`: clean
- \`cargo clippy --lib --tests -- -D warnings\`: clean
- \`cargo test --lib\`: 1789 passed
- After-run check: \`tmux ls | grep aoe_test_\` returns nothing even when an assertion panics mid-test (verified by running the pre-existing flaky `test_status_checks_with_split_panes_and_pane_base_index_1`, which still panics occasionally upstream; with this PR its `Drop` cleans up the orphan).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via opencode (Sisyphus agent)

**Any Additional AI Details you'd like to share:**

Two-Oracle cross-validation on the design (RAII guard semantics, module placement, naming uniqueness, multi-session ergonomics) before implementation; three rounds of code-review pass on the diff itself, each addressed in subsequent commits/edits before this PR. Final design is the smaller of the two proposals: guard reserves the name only, the test owns `new-session` setup. Drop order in multi-guard tests (compound, ps) preserves the previous explicit `kill session, kill dummy` order via reverse-LIFO drop semantics.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR introduces automated cleanup for tmux sessions used in tests, replacing manual session termination commands throughout the test suite.

### New Addition
- **New `test_helpers` module** (`src/tmux/test_helpers.rs`): Introduces `TmuxTestSession`, a reusable guard that automatically cleans up tmux sessions when tests complete or panic.

### Files Updated
- **`src/tmux/mod.rs`**: Two tmux-based tests now use the new guard; manual cleanup removed.
- **`src/tmux/session.rs`**: Ten tests refactored to use the guard; approximately 36 lines of manual `kill-session` commands removed.
- **`src/tmux/terminal_session.rs`**: Two lifecycle tests updated to use the guard; manual cleanup removed.

### Code Removal & Addition
- Removed: ~75 lines of explicit manual `tmux kill-session` cleanup code scattered across tests.
- Added: New guard implementation and two self-tests verifying guard behavior.
- Net change: +145 lines / -87 lines overall.

## Benefits

1. **Leak Prevention**: Automatically cleans up tmux sessions even if tests panic mid-execution, preventing orphaned session accumulation.
2. **Cleaner Test Code**: Eliminates boilerplate cleanup code from each test, making tests more readable and maintainable.
3. **Panic-Safe**: The cleanup mechanism is designed to never panic, using idempotent `tmux kill-session` calls.
4. **Multiple Sessions Per Test**: Supports multiple sessions within a single test through unique naming (using PID + atomic counter).
5. **Verified**: All tests pass (1,789 passed); no orphaned sessions remain after test runs, even with intentional panics.

---

## Technical Details

The `TmuxTestSession` guard:
- Generates unique session names using the pattern `<prefix>_<pid>_<counter>`, allowing multiple guards per test.
- Implements the RAII pattern: reserves the name on construction, cleans up via `Drop::drop()`.
- Uses `tmux kill-session -t <name>` with `let _ = ...output()` to ensure cleanup is best-effort and never panics.
- Tests still invoke `tmux new-session` with their own flags, maintaining flexibility without requiring constructor changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1325?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->