### PR TITLE
fix(hooks): accept "error" in status legend file → Status::Error

### DIFF
--- a/src/hooks/status_file.rs
+++ b/src/hooks/status_file.rs
@@ -29,6 +29,7 @@ pub fn read_hook_status(instance_id: &str) -> Option<Status> {
         "running" => Some(Status::Running),
         "waiting" => Some(Status::Waiting),
         "idle" => Some(Status::Idle),
+        "error" => Some(Status::Error),
         other => {
             tracing::warn!(target: "hooks.status", "Unexpected hook status value: {:?}", other);
             None
@@ -82,6 +83,14 @@ mod tests {
         let id = "test_read_idle";
         let dir = setup_status_file(id, "idle");
         assert_eq!(read_hook_status(id), Some(Status::Idle));
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn test_read_error_status() {
+        let id = "test_read_error";
+        let dir = setup_status_file(id, "error");
+        assert_eq!(read_hook_status(id), Some(Status::Error));
         fs::remove_dir_all(dir).ok();
     }
 


### PR DESCRIPTION
## Description

`src/hooks/status_file.rs::read_hook_status` accepted only `{running, waiting, idle}`. Any other value (including `error`) was logged as `WARN Unexpected hook status value` and discarded. `Status::Error` already exists in the enum and serializes back to `"error"`, so the asymmetry was a pure parse-side gap.

Effect for hook authors: tier 1 (Error) had no in-band representation. Authors worked around it by routing Error events through the `waiting` legend, which then collapsed them into tier 0 in `attention_tier()` — losing the orange Error styling and the priority distinction between "needs human input" and "broken."

This change adds the `"error" => Some(Status::Error)` arm so hooks can emit `error` and have it round-trip correctly through the attention sort. No behavior change for hooks that don't emit `error`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (1788/1788 lib tests; `test_read_error_status` added)
- [x] Documentation was updated where necessary (N/A — internal parser fix)
- [ ] For UI changes: included screenshot or recording (N/A)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7), pairing with the human author. Root cause was diagnosed by the human after observing Error sessions silently demoted to Waiting in their TUI; the fix is mechanical.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The `read_hook_status()` function in `src/hooks/status_file.rs` now recognizes and correctly parses the `"error"` status value from hook status files. Previously, unrecognized values (including `"error"`) were logged as warnings and discarded, returning `None`. 

A new match arm was added to the status parsing logic:
```rust
"error" => Some(Status::Error),
```

Additionally, a new unit test `test_read_error_status()` was added to verify that reading `"error"` from a status file correctly returns `Some(Status::Error)`.

## What This Fixes

**The Problem:** The `Status` enum already contained `Status::Error` and serialized to `"error"`, but the parser had a gap—it only accepted `"running"`, `"waiting"`, and `"idle"`. Hook authors worked around this by routing Error events through the `"waiting"` legend, which caused errors to be incorrectly demoted to the waiting (tier 0) tier instead of maintaining their proper error (tier 1) status and styling.

**The Solution:** By adding the `"error"` case to the parser, hooks can now emit error status directly and have it round-trip correctly through the attention sorting system with proper tier assignment and visual styling.

## Code Quality

- Full test suite passes (1788/1788 tests)
- Minimal, focused change with no impact to public API signatures
- Comprehensive test coverage maintained with the new test case

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->