### PR TITLE
fix(session): resolve repo config from main repo for worktree sessions

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -2534,6 +2534,84 @@ extra_volumes = ["/host/data:/container/data:ro"]
         );
     }
 
+    /// Regression: when project_path is a sibling worktree, `.agent-of-empires/config.toml`
+    /// lives in the main repo, not the worktree. `build_container_config` must
+    /// resolve repo config from the main repo path so extra_volumes still mount.
+    #[test]
+    #[serial_test::serial]
+    fn test_build_container_config_sibling_worktree_loads_main_repo_extra_volumes() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        // Main repo with repo config under .agent-of-empires/
+        let parent = TempDir::new().unwrap();
+        let main_repo = parent.path().join("main");
+        fs::create_dir_all(&main_repo).unwrap();
+        let repo = git2::Repository::init(&main_repo).unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = repo.index().unwrap().write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        repo.commit(Some("HEAD"), &sig, &sig, "Initial", &tree, &[])
+            .unwrap();
+
+        let config_dir = main_repo.join(".agent-of-empires");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::write(
+            config_dir.join("config.toml"),
+            r#"
+[sandbox]
+extra_volumes = ["/host/screenshots:/root/screenshots"]
+"#,
+        )
+        .unwrap();
+
+        // Sibling worktree under <parent>/worktrees/feat
+        let worktree_path = parent.path().join("worktrees").join("feat");
+        fs::create_dir_all(worktree_path.parent().unwrap()).unwrap();
+        let out = std::process::Command::new("git")
+            .args(["worktree", "add", worktree_path.to_str().unwrap(), "HEAD"])
+            .current_dir(&main_repo)
+            .output()
+            .expect("git worktree add");
+        if !out.status.success() {
+            // git not available or worktree add failed; skip.
+            return;
+        }
+
+        let sandbox_info = super::super::instance::SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test:latest".to_string(),
+            container_name: "test-container".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let config = build_container_config(
+            worktree_path.to_str().unwrap(),
+            &sandbox_info,
+            ContainerAgentSelection::new("claude", None),
+            false,
+            "test-instance-id",
+            None,
+            "",
+        )
+        .unwrap();
+
+        let volume_pairs: Vec<(&str, &str)> = config
+            .volumes
+            .iter()
+            .map(|v| (v.host_path.as_str(), v.container_path.as_str()))
+            .collect();
+        assert!(
+            volume_pairs.contains(&("/host/screenshots", "/root/screenshots")),
+            "extra_volumes from main-repo config should mount in sibling worktree session, got: {:?}",
+            volume_pairs
+        );
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_build_container_config_installs_codex_hooks_files() {

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -276,11 +276,28 @@ pub fn profile_to_repo_config(profile: &ProfileConfig) -> RepoConfig {
     }
 }
 
+/// For worktrees, `.agent-of-empires/config.toml` lives in the main repo, not
+/// the worktree dir. Resolve the main repo path so repo config follows the
+/// session regardless of which checkout it was created from.
+///
+/// Only attempts the lookup when `project_path` itself has a `.git` entry,
+/// matching the guard in `compute_volume_paths` (avoids `Repository::discover`
+/// walking up to an unrelated ancestor repo, e.g. a dotfile-managed `$HOME`).
+fn repo_config_source_path(project_path: &Path) -> PathBuf {
+    if project_path.join(".git").exists() {
+        if let Ok(main_repo) = crate::git::GitWorktree::find_main_repo(project_path) {
+            return main_repo;
+        }
+    }
+    project_path.to_path_buf()
+}
+
 /// Resolve config with repo overrides: global -> profile -> repo.
 pub fn resolve_config_with_repo(profile: &str, project_path: &Path) -> Result<Config> {
     let config = super::profile_config::resolve_config(profile)?;
+    let config_path = repo_config_source_path(project_path);
 
-    match load_repo_config(project_path)? {
+    match load_repo_config(&config_path)? {
         Some(repo_config) => Ok(merge_repo_config(config, &repo_config)),
         None => Ok(config),
     }
@@ -292,13 +309,14 @@ pub fn resolve_config_with_repo(profile: &str, project_path: &Path) -> Result<Co
 /// and a malformed profile config degrades to defaults.
 pub fn resolve_config_with_repo_or_warn(profile: &str, project_path: &Path) -> Config {
     let base = super::profile_config::resolve_config_or_warn(profile);
-    match load_repo_config(project_path) {
+    let config_path = repo_config_source_path(project_path);
+    match load_repo_config(&config_path) {
         Ok(Some(repo_config)) => merge_repo_config(base, &repo_config),
         Ok(None) => base,
         Err(e) => {
             tracing::warn!(target: "session.store",
                 "Failed to load repo config at '{}', falling back to profile config: {e}",
-                project_path.display()
+                config_path.display()
             );
             base
         }
@@ -454,8 +472,12 @@ pub enum HookTrustStatus {
 
 /// Check hook trust status for a project path.
 /// Loads the repo config, checks for hooks, and validates trust.
+///
+/// `project_path` may be a worktree path; the repo config and trust entry
+/// live with the main repo, so resolve that before lookup.
 pub fn check_hook_trust(project_path: &Path) -> Result<HookTrustStatus> {
-    let normalized = normalize_path(project_path);
+    let config_path = repo_config_source_path(project_path);
+    let normalized = normalize_path(&config_path);
     let repo_config = match load_repo_config(Path::new(&normalized))? {
         Some(rc) => rc,
         None => return Ok(HookTrustStatus::NoHooks),


### PR DESCRIPTION
## Description

`.agent-of-empires/config.toml` lives in the main repo, but `resolve_config_with_repo`, `resolve_config_with_repo_or_warn`, and `check_hook_trust` were called with the session's `project_path`, which for worktree sessions points at the worktree dir. Result: `extra_volumes`, repo-level sandbox env, and repo `on_launch` hooks were silently dropped for any session created from a sibling worktree.

`on_create` hooks happened to work because `cli/add.rs:543` already resolves the original (main-repo) path before calling `check_hook_trust`. Every other consumer used the worktree path and got `None`.

I confirmed locally by inspecting a running sandbox spawned against a sibling worktree of `notarize-web` — none of the configured `extra_volumes` appeared in `docker inspect ... Mounts`.

Fixes #1328

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Approach

Centralized the lookup via a new `repo_config_source_path` helper that calls `GitWorktree::find_main_repo`, guarded by `project_path.join(\".git\").exists()` to avoid `Repository::discover` walking up to an unrelated ancestor repo (same guard `compute_volume_paths` uses at `container_config.rs:642`). Falls back to `project_path` for non-git directories. This fixes all three consumers (container build, cockpit env at `terminal/create`, `resolve_on_launch_hooks`) with one change.

Trust keying stays consistent: `cli/add.rs::trust_repo` stored entries against the original (main-repo) path, and `check_hook_trust` now resolves to the same path before lookup.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy` (pre-commit hook clean)
- [x] `cargo fmt --check` (pre-commit hook clean)
- [x] New regression test `test_build_container_config_sibling_worktree_loads_main_repo_extra_volumes`: creates a main repo with `.agent-of-empires/config.toml`, adds a sibling worktree, then runs `build_container_config` against the worktree path and asserts `extra_volumes` are mounted. Skips gracefully if `git worktree add` is unavailable.
- [ ] Manual: rebuilt `aoe` and verified `/root/screenshots` mounts inside a sandbox spawned against a sibling worktree of a repo whose `.agent-of-empires/config.toml` defines `extra_volumes`.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary (none required; behavior now matches existing docs and the hook-resolution path)
- [ ] For UI changes: included screenshot or recording (N/A)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-7)

**Any Additional AI Details you'd like to share:** Used Claude Code to trace the load path through `build_container_config`, `resolve_config_with_repo`, `check_hook_trust`, and the cockpit `terminal/create` env resolver, and to draft the centralized fix. I reviewed each change manually, verified the bug by inspecting a running sandbox's mounts, and wrote/ran the regression test myself.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR fixes a bug where repository-level configuration settings were being dropped for sessions created from worktree directories. The repository configuration file (`.agent-of-empires/config.toml`) lives in the main repository, but the code was attempting to load it from the worktree directory instead, causing settings like extra volume mounts, sandbox environment variables, and launch hooks to be silently ignored for worktree sessions.

## What Changed

**src/session/repo_config.rs:**
- Added a new `repo_config_source_path` helper function that intelligently resolves whether a given path is a Git worktree and returns the main repository path if so (checked via `.git` existence and `GitWorktree::find_main_repo`), falling back to the original path for non-Git directories
- Updated `resolve_config_with_repo` to resolve the configuration source path before loading the repo config
- Updated `resolve_config_with_repo_or_warn` to use the resolved configuration path for both loading and warning messages
- Updated `check_hook_trust` to resolve the main repo path when checking hook trust status

**src/session/container_config.rs:**
- Added regression test `test_build_container_config_sibling_worktree_loads_main_repo_extra_volumes` that:
  - Creates a main Git repository with a `.agent-of-empires/config.toml` file containing `extra_volumes`
  - Creates a sibling worktree using `git worktree add`
  - Builds container configuration from the worktree path
  - Asserts that the extra volumes from the main repo config are correctly included

## Benefits

- **Worktree sessions now correctly inherit repo-level settings**: Extra volumes, sandbox environment variables, and lifecycle hooks defined in the main repository's `.agent-of-empires/config.toml` are now properly loaded and applied
- **Centralized solution**: A single helper function fixes the issue across all three consumers (container build, cockpit environment resolution, and hook loading)
- **Safe repository discovery**: The fix guards against unintended repository discovery by checking for `.git` existence before attempting to find the main repo
- **Backward compatible**: Non-Git directories continue to work as before, using the provided path directly

## Technical Details

The core issue was that Git worktree sessions would pass the worktree directory path to configuration loading functions, which would fail to find the config file (since it exists only in the main repository). The fix uses Git's worktree discovery mechanism (`GitWorktree::find_main_repo`) to locate the main repository when `project_path` is a worktree, ensuring configuration is always loaded from the correct location. The guard condition (`project_path.join(".git").exists()`) prevents expensive repository discovery walks for non-Git projects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1329?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->