### PR TITLE
test: write worktree repo config to main repo in volume_ignores test

### DIFF
--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3224,8 +3224,12 @@ volume_ignores = ["target", "node_modules"]
             return; // git worktree add failed, skip
         }
 
-        // Write repo-level config with volume_ignores
-        let config_dir = worktree_path.join(".agent-of-empires");
+        // Write repo-level config with volume_ignores. Since #1329, repo config
+        // for a worktree is resolved from the main repo (via
+        // repo_config_source_path), not the worktree dir, so the config must
+        // live in the main repo. The ignore is still applied to the worktree's
+        // working dir, where builds run.
+        let config_dir = main_repo_path.join(".agent-of-empires");
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("config.toml"),


### PR DESCRIPTION
## Description

`#1329` (`fix(session): resolve repo config from main repo for worktree sessions`) changed worktree sessions to resolve repo-level config via `repo_config_source_path()` from the **main repo** (`GitWorktree::find_main_repo`) instead of the worktree directory.

`test_volume_ignores_applied_to_bare_repo_worktree` (the `#599` regression test for `volume_ignores` in bare-repo layouts) still writes `.agent-of-empires/config.toml` into the **worktree** dir. After `#1329`, `build_container_config` resolves repo config from the main repo, reads an empty config, never produces the asserted `anonymous_volumes` entry, and the test fails on `main`:

```
thread 'session::container_config::tests::test_volume_ignores_applied_to_bare_repo_worktree' panicked at src/session/container_config.rs:3271:
anonymous_volumes should contain worktree target (/workspace/.../main/target), got: []
```

This PR writes the config into the main repo, matching where `#1329` resolves it from. The assertion still verifies the ignore is applied to the worktree's working dir, where builds run, so the original `#599` coverage is preserved.

This is a test-only change; no production code is touched.

### Note (not fixed here)

The sibling test `test_volume_ignores_applied_to_parent_repo_mount` self-skips when `git worktree add` fails in the temp fixture and can leak a `my-worktree` dir. That is a separate, pre-existing latent issue and is intentionally left out of scope for this focused fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

`cargo test --lib volume_ignores` → 8 passed (was 1 failing on `main`). `cargo fmt` + `cargo clippy --lib` clean. No UI change.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** AI traced the failing test to `#1329`'s config-source change and drafted the one-line fix plus this description; reviewed and verified by a human.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Summary

The test `test_volume_ignores_applied_to_bare_repo_worktree` was updated to align with changes introduced in PR `#1329`. Previously, the test wrote configuration files to the worktree directory, but since PR `#1329`, worktree sessions now resolve configuration from the main repository instead. The fix moves where the test writes the config file—from the worktree directory to the main repository directory—allowing the test to read the expected configuration and pass successfully.

This is a test-only change with no modifications to production code.

## Technical Details

**File Modified:** `src/session/container_config.rs`

**Changes Made:**
- Moved repo config file location from `worktree_path/.agent-of-empires/config.toml` to `main_repo_path/.agent-of-empires/config.toml`
- Updated surrounding comments to clarify that worktree config is resolved from the main repo via `repo_config_source_path` and `GitWorktree::find_main_repo`
- Maintained the test's assertion that `volume_ignores` apply to the worktree's working directory

**Impact:**
- Fixes 1 failing test; all 8 `volume_ignores` tests now pass
- Makes test behavior consistent with the actual implementation behavior introduced in PR `#1329`
- No impact on production code or API behavior

**Code Review Effort:** Medium (test-only change with clear scope)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->