### PR TITLE
chore(coderabbit): re-enable auto_incremental_review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -81,11 +81,11 @@ reviews:
 
   auto_review:
     enabled: true
-    # Off to stop CodeRabbit from re-reviewing on every push, which edited
-    # its walkthrough comment and pinged subscribers each time. CodeRabbit
-    # still reviews once when a PR opens; ask for a re-review explicitly
-    # with `@coderabbitai review` after a meaningful change.
-    auto_incremental_review: false
+    # On. CodeRabbit does proper housekeeping between incremental reviews
+    # (does not keep previous reviews open) and self-caps at roughly 3
+    # follow-up commits per PR before switching to manual review, so the
+    # noise that originally motivated turning this off is bounded.
+    auto_incremental_review: true
     ignore_title_keywords:
       - "Dependencies"
       - "update dependency"


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Re-enable CodeRabbit's `auto_incremental_review` in `.coderabbit.yaml`.

PR #1277 turned this off to stop CodeRabbit from re-reviewing on every push, since the bot edited its walkthrough comment and pinged subscribers each time. Per Jerome's note on #1309, that concern is bounded: CodeRabbit now does proper housekeeping between incremental reviews (it does not keep previous reviews open) and self-caps at roughly 3 follow-up commits per PR before switching to manual review.

The inline yaml comment is rewritten to reflect the new reasoning, so the next reader sees why this is `true` rather than the stale "off because of noise" rationale.

Closes #1309

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(No tests touched; yaml-only config flip. No UI changes; no recording. No `docs/` page describes CodeRabbit behavior, so nothing under `docs/` needs to move with this.)

## How to test

- [ ] Open a fresh PR against this branch (or the next PR after merge) and push at least two follow-up commits. Confirm CodeRabbit posts an incremental review on each of the first ~3 follow-up commits.
- [ ] Confirm CodeRabbit's walkthrough comment is updated in place rather than spawning new top-level reviews per push.
- [ ] After ~3 follow-up commits, confirm CodeRabbit switches to manual mode and stops auto-reviewing further pushes until `@coderabbitai review` is requested.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and the one-line yaml flip plus comment rewrite were drafted by Claude under my direction. I reviewed the commit, made the design call to keep the change scoped to this single setting, and own the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR re-enables CodeRabbit's automatic incremental review feature by updating the configuration file `.coderabbit.yaml`. The setting `reviews.auto_incremental_review` is toggled from disabled (`false`) to enabled (`true`), along with an updated inline comment explaining the rationale.

## What changed

- **Configuration file updated**: `.coderabbit.yaml` was modified to switch `auto_incremental_review` from `false` to `true`
- **Comment clarified**: The inline YAML comment was rewritten to explain why incremental reviews are now safe to enable again
- **No code changes**: This is purely an infrastructure/CI configuration update—no application code or tests were modified

## Benefits

- **Restored automated follow-up reviews**: CodeRabbit will now automatically review subsequent commits within a PR, rather than waiting for manual review requests
- **Improved developer feedback loop**: Developers get faster, incremental feedback on follow-up commits without needing to request re-review
- **Controlled automation**: The feature is designed with safeguards—CodeRabbit self-limits to approximately three follow-up commits per PR before switching to manual review mode, preventing review fatigue
- **Better housekeeping**: CodeRabbit now properly manages previous reviews between incremental checks, avoiding the "noise" concerns that led to the feature being disabled in a prior PR (`#1277`)

## Technical details

The change modifies a boolean configuration flag in the CodeRabbit YAML configuration file. This enables the bot to automatically generate reviews for additional commits pushed to an open pull request, with built-in self-limiting behavior to cap incremental reviews at roughly three follow-ups per PR. The inline documentation was updated to reflect the current understanding of the bot's improved housekeeping capabilities and self-limiting thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->