### PR TITLE
fix(ci,tests): unbreak main test suite + upload vitest coverage on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,6 +86,7 @@ jobs:
       # Playwright coverage merge script already emits "web/src/..."
       # paths, so only the vitest LCOV needs the prefix.
       - name: Rewrite LCOV paths for codecov
+        if: ${{ !cancelled() }}
         run: sed -i 's|^SF:src/|SF:web/src/|' web/coverage/vitest/lcov.info
       - name: Upload to Codecov (vitest flag)
         if: ${{ !cancelled() }}

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -3133,8 +3133,10 @@ extra_volumes = ["/host/personal-only:/container/personal-only:ro"]
             return; // git not available, skip
         }
 
-        // Write repo-level config with volume_ignores
-        let config_dir = worktree_path.join(".agent-of-empires");
+        // Write repo-level config in the main repo dir, since
+        // resolve_config_with_repo loads it from there (find_main_repo) even
+        // when the session targets a sibling worktree.
+        let config_dir = repo_path.join(".agent-of-empires");
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("config.toml"),
@@ -3224,8 +3226,10 @@ volume_ignores = ["target", "node_modules"]
             return; // git worktree add failed, skip
         }
 
-        // Write repo-level config with volume_ignores
-        let config_dir = worktree_path.join(".agent-of-empires");
+        // Write repo-level config in the main repo dir, since
+        // resolve_config_with_repo loads it from there (find_main_repo) even
+        // when the session targets a sibling worktree.
+        let config_dir = main_repo_path.join(".agent-of-empires");
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("config.toml"),

--- a/web/src/components/settings/__tests__/ThemeSettings.test.tsx
+++ b/web/src/components/settings/__tests__/ThemeSettings.test.tsx
@@ -6,7 +6,7 @@
 // color mode). Part of #1217.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 
 vi.mock("../../../lib/api", () => ({
   fetchThemes: vi.fn(() =>
@@ -35,6 +35,7 @@ function mount(initial: Record<string, unknown> = {}) {
 }
 
 afterEach(() => {
+  cleanup();
   dispatchSpy.mockClear();
 });
 

--- a/web/tests/live/profile-lifecycle.spec.ts
+++ b/web/tests/live/profile-lifecycle.spec.ts
@@ -152,12 +152,20 @@ test("delete profile via Delete button round-trips through DELETE /api/profiles/
   await profileSelect.selectOption("scratch");
   await expect(profileSelect).toHaveValue("scratch");
 
+  const deletePromise = page.waitForResponse(
+    (res) =>
+      res.url().endsWith("/api/profiles/scratch") &&
+      res.request().method() === "DELETE",
+    { timeout: 30_000 },
+  );
+
   await page.getByRole("button", { name: "Delete" }).click();
 
-  await expect(async () => {
-    const profiles = await fetchProfiles(serve);
-    expect(profiles.map((p) => p.name)).toEqual(["default"]);
-  }).toPass({ timeout: 5_000 });
+  const deleteRes = await deletePromise;
+  expect(deleteRes.ok()).toBe(true);
+
+  const profiles = await fetchProfiles(serve);
+  expect(profiles.map((p) => p.name)).toEqual(["default"]);
 });
 
 test("invalid profile name: client validation blocks POST /api/profiles", async ({


### PR DESCRIPTION
## Description

Main has been red since df50ed9c (PR #1329 merge). Two real test failures plus a Vitest flake plus a CI coverage-upload bug. This PR ships fixes for all four.

### 1. `Cargo Test` — `test_volume_ignores_applied_to_{parent_repo_mount,bare_repo_worktree}`

#1329 rerouted `resolve_config_with_repo` through `find_main_repo`, so repo config now loads from the main repo rather than from the worktree dir. Both pre-existing tests still wrote their `.agent-of-empires/config.toml` inside the worktree, so the config was silently ignored and `volume_ignores` ended up empty:

```
anonymous_volumes should contain worktree target (...), got: []
```

Fix: write the config at the main repo path that `find_main_repo` actually returns (`repo_path` for the sibling-worktree case, `main_repo_path` for the bare-repo case).

### 2. `Vitest` — `ThemeSettings.test.tsx`

Tests pass 4/4, but React 19's scheduler flushes a microtask after the jsdom env is torn down, producing an Uncaught `ReferenceError: window is not defined` that fails the Vitest run. Added `cleanup()` in `afterEach` so the component tree unmounts between tests instead of racing teardown.

### 3. `Playwright (live)` — `profile-lifecycle.spec.ts:128`

The 5s `toPass` poll was tight enough that the DELETE round-trip occasionally missed the budget on CI:

```
Array [
    "default",
+   "scratch",
]
- Timeout 5000ms exceeded while waiting on the predicate
```

Switched to `page.waitForResponse` on `DELETE /api/profiles/scratch` with a 30s timeout, then a single `fetchProfiles` assertion. Mirrors the PATCH test directly above it.

### 4. `CI` — Vitest coverage dropped on red runs

The Vitest job's `Rewrite LCOV paths for codecov` step was the only coverage-pipeline step without `if: \${{ !cancelled() }}`. When tests failed it was skipped, so the subsequent Codecov upload sent raw `SF:src/...` paths that Codecov couldn't match against repo-root PR diffs, and vitest coverage was silently dropped on every red run. Gated it like the other steps.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --features serve --lib`: 2321 passed; `npx vitest run`: 555 passed, 0 errors; `cargo fmt --check` + `cargo clippy --features serve --lib --tests` clean; `npx tsc --noEmit` clean)
- [x] Documentation was updated where necessary (n/a, no user-visible behavior change)
- [ ] For UI changes: included screenshot or recording (n/a)

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Investigation, fixes, and PR body all written by the agent. Test runs and CI-log inspection done by the agent.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes four separate issues that have been breaking the main test suite since commit df50ed9c: two failing Cargo tests, a flaky Vitest test, and a CI coverage upload bug.

## What Changed

**Cargo Tests** — Two regression tests were updated to write their configuration files to the correct location (the main repository directory instead of the worktree directory), ensuring the code correctly loads configuration from where it expects to find it.

**Vitest Test (ThemeSettings)** — Added proper cleanup between test cases to prevent React component state from lingering after tests finish, which was causing "window is not defined" errors on CI.

**Playwright Test (Profile Lifecycle)** — Replaced a flaky polling mechanism with a more reliable approach that directly waits for the expected network response from the delete operation, with a longer timeout to accommodate CI performance variations.

**CI Workflow** — Added a cancellation guard to the codecov path rewriting step so it still runs when other steps fail, ensuring test coverage data is properly formatted before upload.

## Benefits
- Restores the main test suite to a passing state
- Improves test reliability on CI by fixing flaky retry logic
- Ensures test coverage data is correctly uploaded even when some tests fail
- Fixes test isolation issues that could cause intermittent failures

## Technical Details
- **Cargo**: Updated test setup to write `.agent-of-empires/config.toml` to the main repo path returned by `find_main_repo`, ensuring `build_container_config` resolves settings from the correct location
- **Vitest**: Imported `cleanup` from React Testing Library and added `afterEach` hook to unmount component trees between tests
- **Playwright**: Replaced `toPass()` polling block with `page.waitForResponse()` for the DELETE request with 30s timeout, then asserts profile fetch confirms deletion
- **CI**: Added `if: ${{ !cancelled() }}` guard to the "Rewrite LCOV paths for codecov" workflow step

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1342?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->