### PR TITLE
Add Antigravity CLI agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Running one AI agent is easy. Running five of them across different branches, ke
 
 ## Features
 
-- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code
+- **Multi-agent support**: Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code
 - **TUI app**: visual interface to create, monitor, and manage sessions
 - **Web app** (Beta, stabilization in progress): create, monitor, and control your agents from any browser, installable as a PWA ([guide](https://www.agent-of-empires.com/guides/web-dashboard/))
   - **Cockpit** (Alpha, opt-in): mobile-first native rendering of agent state via the Agent Client Protocol, with plan panels, tool-call cards, and swipe-to-approve ([guide](https://www.agent-of-empires.com/docs/cockpit/))
@@ -128,7 +128,7 @@ Nothing. Sessions are tmux sessions running in the background. Open and close `a
 
 ### Which AI tools are supported?
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed on your system.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi.dev, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed on your system.
 
 ### Can I use AoE over SSH?
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # aoe-sandbox: Docker image for Agent of Empires sandbox sessions
-# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code in an isolated environment
+# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code in an isolated environment
 
 FROM ubuntu:24.04
 
@@ -46,6 +46,9 @@ RUN npm install -g @openai/codex
 # Install Gemini CLI (Google)
 RUN npm install -g @google/gemini-cli
 
+# Install Antigravity CLI (Google)
+RUN curl -fsSL https://antigravity.google/cli/install.sh | bash
+
 # Install Mistral Vibe
 RUN curl -LsSf https://mistral.ai/vibe/install.sh | bash
 ENV PATH="/root/.vibe/bin:${PATH}"
@@ -88,6 +91,7 @@ RUN mkdir -p /root/.claude \
     /root/.vibe \
     /root/.codex \
     /root/.gemini \
+    /root/.gemini/antigravity-cli \
     /root/.cursor \
     /root/.copilot \
     /root/.pi \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,7 +1,7 @@
 # aoe-dev-sandbox: Extended sandbox with development tools
 # Includes: Rust, uv (Python), nvm + Node.js, pnpm, bun, gh (GitHub CLI)
 # Note: Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI,
-# Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code are inherited from the base image
+# Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code are inherited from the base image
 
 ARG BASE_IMAGE=ghcr.io/njbrake/aoe-sandbox:latest
 FROM ${BASE_IMAGE}

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code) inside isolated Docker containers while maintaining access to your project files and credentials.
+Docker sandboxing runs your AI coding agents (Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code) inside isolated Docker containers while maintaining access to your project files and credentials.
 
 > **Linux users:** AoE also supports [Podman](podman.md) as a daemonless, rootless-friendly alternative to Docker.
 >

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ allowfullscreen
 
 ## Supported Agents
 
-Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed.
+Claude Code, OpenCode, Mistral Vibe, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Factory Droid, Hermes, Kiro CLI, and Qwen Code. AoE auto-detects which are installed.
 
 <div class="cta-box">
 <p><strong>Ready to get started?</strong></p>

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -471,6 +471,22 @@ pub const AGENTS: &[AgentDef] = &[
         send_keys_enter_delay_ms: 0,
         install_hint: "npm install -g @qwen-code/qwen-code",
     },
+    AgentDef {
+        name: "antigravity",
+        binary: "agy",
+        aliases: &["agy"],
+        detection: DetectionMethod::Which("agy"),
+        yolo: Some(YoloMode::CliFlag("--dangerously-skip-permissions")),
+        instruction_flag: None,
+        set_default_command: false,
+        detect_status: status_detection::detect_antigravity_status,
+        container_env: &[],
+        hook_config: None,
+        resume_strategy: ResumeStrategy::Unsupported,
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "curl -fsSL https://antigravity.google/cli/install.sh | bash",
+    },
 ];
 
 /// Look up an agent by canonical name.
@@ -556,6 +572,7 @@ mod tests {
         assert_eq!(get_agent("hermes").unwrap().binary, "hermes");
         assert_eq!(get_agent("kiro").unwrap().binary, "kiro-cli");
         assert_eq!(get_agent("qwen").unwrap().binary, "qwen");
+        assert_eq!(get_agent("antigravity").unwrap().binary, "agy");
     }
 
     #[test]
@@ -586,8 +603,20 @@ mod tests {
         assert_eq!(
             names,
             vec![
-                "claude", "opencode", "vibe", "codex", "gemini", "cursor", "copilot", "pi",
-                "droid", "settl", "hermes", "kiro", "qwen"
+                "claude",
+                "opencode",
+                "vibe",
+                "codex",
+                "gemini",
+                "cursor",
+                "copilot",
+                "pi",
+                "droid",
+                "settl",
+                "hermes",
+                "kiro",
+                "qwen",
+                "antigravity"
             ]
         );
     }
@@ -612,6 +641,8 @@ mod tests {
         assert_eq!(resolve_tool_name("kiro"), Some("kiro"));
         assert_eq!(resolve_tool_name("kiro-cli"), Some("kiro"));
         assert_eq!(resolve_tool_name("qwen"), Some("qwen"));
+        assert_eq!(resolve_tool_name("antigravity"), Some("antigravity"));
+        assert_eq!(resolve_tool_name("agy"), Some("antigravity"));
         assert_eq!(resolve_tool_name(""), Some("claude"));
         assert_eq!(resolve_tool_name("agent"), Some("cursor"));
         assert_eq!(resolve_tool_name("unknown-tool"), None);
@@ -630,6 +661,7 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("hermes")), 11);
         assert_eq!(settings_index_from_name(Some("kiro")), 12);
         assert_eq!(settings_index_from_name(Some("qwen")), 13);
+        assert_eq!(settings_index_from_name(Some("antigravity")), 14);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -642,6 +674,7 @@ mod tests {
         assert_eq!(name_from_settings_index(11), Some("hermes"));
         assert_eq!(name_from_settings_index(12), Some("kiro"));
         assert_eq!(name_from_settings_index(13), Some("qwen"));
+        assert_eq!(name_from_settings_index(14), Some("antigravity"));
         assert_eq!(name_from_settings_index(99), None);
     }
 
@@ -665,6 +698,7 @@ mod tests {
         assert_eq!(send_keys_enter_delay("opencode"), 0);
         assert_eq!(send_keys_enter_delay("hermes"), 0);
         assert_eq!(send_keys_enter_delay("kiro"), 0);
+        assert_eq!(send_keys_enter_delay("antigravity"), 0);
         assert_eq!(send_keys_enter_delay("unknown_agent"), 0);
     }
 
@@ -708,6 +742,10 @@ mod tests {
         assert_eq!(
             install_hint("kiro"),
             Some("curl -fsSL https://cli.kiro.dev/install | bash")
+        );
+        assert_eq!(
+            install_hint("antigravity"),
+            Some("curl -fsSL https://antigravity.google/cli/install.sh | bash")
         );
         assert!(install_hint("unknown").is_none());
     }

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -256,6 +256,18 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         preserve_files: &[],
         clean_files: &[],
     },
+    AgentConfigMount {
+        tool_name: "antigravity",
+        host_rel: ".gemini/antigravity-cli",
+        container_suffix: ".gemini/antigravity-cli",
+        skip_entries: &["sandbox", "logs", "cache"],
+        seed_files: &[],
+        copy_dirs: &["plugins"],
+        keychain_credential: None,
+        home_seed_files: &[],
+        preserve_files: &["antigravity-oauth-token"],
+        clean_files: &[],
+    },
 ];
 
 /// Sync host agent config into the shared sandbox directory. Copies top-level files
@@ -1943,6 +1955,17 @@ mod tests {
             .collect();
         assert_eq!(hermes_mounts.len(), 1);
         assert_eq!(hermes_mounts[0].host_rel, ".hermes");
+
+        let antigravity_mounts: Vec<_> = AGENT_CONFIG_MOUNTS
+            .iter()
+            .filter(|m| m.tool_name == "antigravity")
+            .collect();
+        assert_eq!(antigravity_mounts.len(), 1);
+        assert_eq!(antigravity_mounts[0].host_rel, ".gemini/antigravity-cli");
+        assert_eq!(
+            antigravity_mounts[0].container_suffix,
+            ".gemini/antigravity-cli"
+        );
 
         // Unknown tool should match nothing
         let unknown_mounts: Vec<_> = AGENT_CONFIG_MOUNTS

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -964,6 +964,66 @@ pub fn detect_qwen_status(raw_content: &str) -> Status {
     Status::Idle
 }
 
+pub fn detect_antigravity_status(raw_content: &str) -> Status {
+    let content = raw_content.to_lowercase();
+    let lines: Vec<&str> = content.lines().collect();
+    let non_empty_lines: Vec<&str> = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .copied()
+        .collect();
+
+    let last_lines_lower: String = non_empty_lines
+        .iter()
+        .rev()
+        .take(30)
+        .rev()
+        .copied()
+        .collect::<Vec<&str>>()
+        .join("\n");
+
+    if last_lines_lower.contains("not signed in")
+        || last_lines_lower.contains("signing in")
+        || last_lines_lower.contains("authorization url")
+        || last_lines_lower.contains("authorization code")
+        || last_lines_lower.contains("google sign-in")
+    {
+        return Status::Waiting;
+    }
+
+    if contains_approval_prompt(
+        &last_lines_lower,
+        &[
+            "permission request",
+            "do you trust the contents",
+            "yes, i trust this folder",
+            "execute?",
+            "run command?",
+            "enter to select",
+            "enter confirm",
+            "esc to cancel",
+        ],
+    ) {
+        return Status::Waiting;
+    }
+
+    if last_lines_lower.contains("esc to interrupt")
+        || last_lines_lower.contains("ctrl+c to interrupt")
+    {
+        return Status::Running;
+    }
+
+    if has_any_spinner(&lines) {
+        return Status::Running;
+    }
+
+    if matches_input_prompt(&non_empty_lines, 10, &["agy>"]) {
+        return Status::Waiting;
+    }
+
+    Status::Idle
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2058,6 +2118,67 @@ run this command? (y/n)
     fn test_detect_qwen_status_idle() {
         assert_eq!(detect_qwen_status("file saved"), Status::Idle);
         assert_eq!(detect_qwen_status("random output text"), Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_waiting_for_auth() {
+        let content = "\
+     ▄▀▀▄
+    ▀▀▀▀▀▀
+
+ Welcome to the Antigravity CLI. You are currently not signed in.
+
+ ⣻  Signing in...";
+        assert_eq!(detect_antigravity_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_waiting_for_workspace_trust() {
+        let content = "\
+Accessing workspace:
+
+/tmp/aoe-agy-smoke-proj
+
+Do you trust the contents of this project?
+
+Antigravity CLI requires permission to read, edit, and execute files here.
+
+> Yes, I trust this folder
+  No, exit
+
+  ↑/↓ Navigate · enter Confirm
+                                                         Gemini 3.5 Flash (High)";
+        assert_eq!(detect_antigravity_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_running() {
+        assert_eq!(
+            detect_antigravity_status("processing request\nesc to interrupt"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_antigravity_status("⠋ Thinking about your request"),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_waiting_for_prompt() {
+        assert_eq!(
+            detect_antigravity_status("run command? (y/n)"),
+            Status::Waiting
+        );
+        assert_eq!(detect_antigravity_status("complete\nagy>"), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_idle() {
+        assert_eq!(detect_antigravity_status("file saved"), Status::Idle);
+        assert_eq!(
+            detect_antigravity_status("random output text"),
+            Status::Idle
+        );
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -991,6 +991,19 @@ pub fn detect_antigravity_status(raw_content: &str) -> Status {
         return Status::Waiting;
     }
 
+    // "Approval Required" is the actual header Antigravity renders above tool
+    // permission prompts. The substring "approve" does NOT appear in
+    // "approval", so the base contains_approval_prompt list misses it; match
+    // explicitly. "deny access" is the rejection button rendered alongside.
+    // "awaiting user approval" is the status line shown while the agent is
+    // blocked on the user's decision.
+    if last_lines_lower.contains("approval required")
+        || last_lines_lower.contains("awaiting user approval")
+        || last_lines_lower.contains("deny access")
+    {
+        return Status::Waiting;
+    }
+
     if contains_approval_prompt(
         &last_lines_lower,
         &[
@@ -1015,10 +1028,6 @@ pub fn detect_antigravity_status(raw_content: &str) -> Status {
 
     if has_any_spinner(&lines) {
         return Status::Running;
-    }
-
-    if matches_input_prompt(&non_empty_lines, 10, &["agy>"]) {
-        return Status::Waiting;
     }
 
     Status::Idle
@@ -2169,7 +2178,32 @@ Antigravity CLI requires permission to read, edit, and execute files here.
             detect_antigravity_status("run command? (y/n)"),
             Status::Waiting
         );
-        assert_eq!(detect_antigravity_status("complete\nagy>"), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_waiting_for_tool_approval() {
+        // Real header rendered above Antigravity tool permission prompts.
+        // "approval" does not contain "approve", so the shared
+        // contains_approval_prompt helper misses this header; the detector
+        // matches "approval required" explicitly instead.
+        let content = "\
+read_file
+path: /workspace/secrets.env
+
+⚠ Approval Required
+
+> Yes, just this once
+  Yes, allow always
+  No, deny access";
+        assert_eq!(detect_antigravity_status(content), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_antigravity_status_waiting_user_approval_status_line() {
+        // "awaiting user approval" is the status line shown while the agent
+        // is blocked on the user's tool-permission decision.
+        let content = "I'll read that file now.\n awaiting user approval.";
+        assert_eq!(detect_antigravity_status(content), Status::Waiting);
     }
 
     #[test]

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -672,26 +672,54 @@ export function useTerminal(
       dir: "up" | "down",
       cell: { col: number; row: number },
     ) => `\x1b[<${dir === "up" ? 64 : 65};${cell.col};${cell.row}M`;
-    const cellFromClientPoint = (clientX: number, clientY: number) => {
-      const el = term.element;
+    const wheelGrid = () => {
+      const sentGrid =
+        lastSentCols > 0 && lastSentRows > 0
+          ? { cols: lastSentCols, rows: lastSentRows }
+          : null;
+      // While reading tmux scrollback, resize messages are deferred to
+      // avoid SIGWINCH redraws. xterm may still refit to a new monitor
+      // size, so mouse coordinates must stay in the pane size tmux
+      // actually knows about.
+      if (isInScrollbackRef.current && sentGrid) return sentGrid;
+      return {
+        cols: Math.max(1, term.cols),
+        rows: Math.max(1, term.rows),
+      };
+    };
+    const cellFromClientPoint = (
+      clientX: number,
+      clientY: number,
+      eventTarget?: EventTarget | null,
+    ) => {
+      const targetEl =
+        eventTarget instanceof HTMLElement ? eventTarget : null;
+      const targetRect = targetEl?.getBoundingClientRect();
+      const el =
+        targetRect && targetRect.width > 0 && targetRect.height > 0
+          ? targetEl
+          : term.element;
       if (!el) return { col: 1, row: 1 };
       const rect = el.getBoundingClientRect();
-      const cellWidth = rect.width > 0 ? rect.width / Math.max(1, term.cols) : 0;
-      const cellHeight =
-        rect.height > 0 ? rect.height / Math.max(1, term.rows) : 0;
+      const grid = wheelGrid();
+      const cellWidth = rect.width > 0 ? rect.width / grid.cols : 0;
+      const cellHeight = rect.height > 0 ? rect.height / grid.rows : 0;
       const rawCol =
         cellWidth > 0 ? Math.floor((clientX - rect.left) / cellWidth) + 1 : 1;
       const rawRow =
         cellHeight > 0 ? Math.floor((clientY - rect.top) / cellHeight) + 1 : 1;
       return {
-        col: Math.max(1, Math.min(Math.max(1, term.cols), rawCol)),
-        row: Math.max(1, Math.min(Math.max(1, term.rows), rawRow)),
+        col: Math.max(1, Math.min(grid.cols, rawCol)),
+        row: Math.max(1, Math.min(grid.rows, rawRow)),
       };
     };
-    const centerCell = () => ({
-      col: Math.max(1, Math.ceil(term.cols / 2)),
-      row: Math.max(1, Math.ceil(term.rows / 2)),
-    });
+    const centerCell = () => {
+      const grid = wheelGrid();
+      return {
+        col: Math.max(1, Math.ceil(grid.cols / 2)),
+        row: Math.max(1, Math.ceil(grid.rows / 2)),
+      };
+    };
     let scrollbackDepth = 0;
     const sendWheel = (
       dir: "up" | "down",
@@ -928,7 +956,7 @@ export function useTerminal(
           sendWheel(
             wheels > 0 ? "up" : "down",
             Math.abs(wheels),
-            cellFromClientPoint(singleX, y),
+            cellFromClientPoint(singleX, y, e.currentTarget),
           );
           singleAccum -= wheels * step;
           const dt = Math.max(1, now - singleLastTs);
@@ -978,7 +1006,7 @@ export function useTerminal(
         sendWheel(
           wheels > 0 ? "up" : "down",
           Math.abs(wheels),
-          cellFromClientPoint(touchMidX, y),
+          cellFromClientPoint(touchMidX, y, e.currentTarget),
         );
         touchAccum -= wheels * step;
         const dt = Math.max(1, now - lastMoveTs);
@@ -1064,6 +1092,18 @@ export function useTerminal(
     let wheelAccum = 0;
     let scrollWheelAccum = 0;
     let wheelPersistTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastCapturedWheelCell: { col: number; row: number } | null = null;
+    const onWheelCapture = (e: WheelEvent) => {
+      lastCapturedWheelCell = cellFromClientPoint(
+        e.clientX,
+        e.clientY,
+        e.currentTarget ?? e.target,
+      );
+    };
+    viewport.addEventListener("wheel", onWheelCapture, {
+      capture: true,
+      passive: true,
+    });
     term.attachCustomWheelEventHandler((e: WheelEvent) => {
       e.preventDefault();
 
@@ -1095,10 +1135,19 @@ export function useTerminal(
         Math.min(MAX_WHEELS_PER_FRAME, rawWheels),
       );
       if (wheels !== 0) {
+        const eventCell = cellFromClientPoint(
+          e.clientX,
+          e.clientY,
+          e.currentTarget ?? e.target,
+        );
+        const cell =
+          eventCell.col === 1 && eventCell.row === 1 && lastCapturedWheelCell
+            ? lastCapturedWheelCell
+            : eventCell;
         sendWheel(
           wheels > 0 ? "down" : "up",
           Math.abs(wheels),
-          cellFromClientPoint(e.clientX, e.clientY),
+          cell,
         );
         scrollWheelAccum -= wheels * step;
       }
@@ -1174,6 +1223,7 @@ export function useTerminal(
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
+      viewport.removeEventListener("wheel", onWheelCapture, true);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);

--- a/web/tests/pinch-zoom-desktop.spec.ts
+++ b/web/tests/pinch-zoom-desktop.spec.ts
@@ -14,6 +14,34 @@ import {
 
 test.use({ viewport: { width: 1280, height: 800 }, hasTouch: false });
 
+interface ResizeMsg {
+  type: "resize";
+  cols: number;
+  rows: number;
+}
+
+function resizeMessages(messages: Buffer[]): ResizeMsg[] {
+  const out: ResizeMsg[] = [];
+  for (const msg of messages) {
+    const text = msg.toString("utf8");
+    if (!text.startsWith("{")) continue;
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed?.type === "resize") out.push(parsed);
+    } catch {
+      // not JSON
+    }
+  }
+  return out;
+}
+
+function wheelCoords(messages: Buffer[]) {
+  return messages
+    .map((m) => /\x1b\[<\d+;(\d+);(\d+)[Mm]/.exec(m.toString("utf8")))
+    .filter((m): m is RegExpExecArray => m !== null)
+    .map(([, col, row]) => ({ col: Number(col), row: Number(row) }));
+}
+
 test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
   async function openSession(page: Page) {
     await clickSidebarSession(page, "pinch-test");
@@ -40,9 +68,36 @@ test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
       yRatio?: number;
     },
   ) {
+    if (!opts.ctrlKey) {
+      const point = await page.evaluate(({ xRatio, yRatio }) => {
+        const target = Array.from(
+          document.querySelectorAll<HTMLElement>(".xterm"),
+        ).find((el) => {
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        });
+        if (!target) throw new Error(".xterm not mounted");
+        const rect = target.getBoundingClientRect();
+        return {
+          x: rect.left + rect.width * (xRatio ?? 0.5),
+          y: rect.top + rect.height * (yRatio ?? 0.5),
+        };
+      }, opts);
+      await page.mouse.move(point.x, point.y);
+      for (let i = 0; i < (opts.times ?? 1); i++) {
+        await page.mouse.wheel(0, opts.deltaY);
+      }
+      return;
+    }
+
     await page.evaluate(
       ({ deltaY, ctrlKey, times, xRatio, yRatio }) => {
-        const target = document.querySelector<HTMLElement>(".xterm");
+        const target = Array.from(
+          document.querySelectorAll<HTMLElement>(".xterm"),
+        ).find((el) => {
+          const rect = el.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        });
         if (!target) throw new Error(".xterm not mounted");
         const rect = target.getBoundingClientRect();
         const clientX = rect.left + rect.width * (xRatio ?? 0.5);
@@ -126,7 +181,7 @@ test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
       yRatio: 0.21,
     });
 
-    // 500ms is longer than the 400ms debounce — if the handler leaked
+    // 500ms is longer than the 400ms debounce; if the handler leaked
     // writes through without ctrlKey, they would have landed by now.
     await page.waitForTimeout(500);
     const writes = await page.evaluate(() =>
@@ -149,6 +204,66 @@ test.describe("Terminal Ctrl+wheel zoom (desktop)", () => {
       .map(([, col, row]) => ({ col: Number(col), row: Number(row) }));
     expect(wheelCoords.length).toBeGreaterThan(0);
     expect(wheelCoords.some(({ col, row }) => col > 1 && row > 1)).toBe(true);
+  });
+
+  test("wheel coordinates stay inside tmux's last applied grid during scrollback resize", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 900, height: 600 });
+    await installTerminalSpies(page);
+    const terminal = await mockTerminalApis(page);
+    await page.goto("/");
+    await seedSettings(page, { desktopFontSize: 14 });
+    await page.reload();
+    await openSession(page);
+    await page.waitForTimeout(1000);
+
+    const initialResizes = resizeMessages(terminal.wsMessages);
+    expect(initialResizes.length).toBeGreaterThan(0);
+    const appliedGrid = initialResizes.reduce(
+      (max, resize) => ({
+        cols: Math.max(max.cols, resize.cols),
+        rows: Math.max(max.rows, resize.rows),
+      }),
+      { cols: 0, rows: 0 },
+    );
+
+    terminal.wsMessages.length = 0;
+    await fireWheel(page, {
+      deltaY: -120,
+      ctrlKey: false,
+      times: 5,
+      xRatio: 0.83,
+      yRatio: 0.83,
+    });
+    await expect
+      .poll(() =>
+        terminal.wsMessages.some((m) =>
+          m.toString("utf8").includes('"type":"pause_output"'),
+        ),
+      )
+      .toBe(true);
+
+    terminal.wsMessages.length = 0;
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.waitForTimeout(500);
+
+    terminal.wsMessages.length = 0;
+    await fireWheel(page, {
+      deltaY: -120,
+      ctrlKey: false,
+      times: 3,
+      xRatio: 0.95,
+      yRatio: 0.95,
+    });
+
+    await expect
+      .poll(() => wheelCoords(terminal.wsMessages).length, { timeout: 2000 })
+      .toBeGreaterThan(0);
+    const coords = wheelCoords(terminal.wsMessages);
+    expect(coords.some(({ col, row }) => col > 1 && row > 1)).toBe(true);
+    expect(coords.every(({ col }) => col <= appliedGrid.cols)).toBe(true);
+    expect(coords.every(({ row }) => row <= appliedGrid.rows)).toBe(true);
   });
 
   test("Ctrl+wheel zoom does NOT re-mount the terminal (live-sync regression guard)", async ({

--- a/web/tests/wizard-agent-step.spec.ts
+++ b/web/tests/wizard-agent-step.spec.ts
@@ -104,11 +104,14 @@ async function openAgentStep(page: Page) {
 }
 
 test.describe("Wizard agent step (#1219)", () => {
-  test("agent picker renders installed agents and click selects one", async ({ page }) => {
+  test("agent picker renders installed agents, including terminal fallback tools", async ({
+    page,
+  }) => {
     await mockApis(page, {
       agents: [
         { name: "claude", installed: true, host_only: false },
         { name: "codex", installed: true, host_only: false },
+        { name: "antigravity", installed: true, host_only: false },
         { name: "uninstalled-tool", installed: false, host_only: false, install_hint: "brew install x" },
       ],
     });
@@ -117,14 +120,12 @@ test.describe("Wizard agent step (#1219)", () => {
     await openAgentStep(page);
     const claudeBtn = page.getByRole("button", { name: "claude", exact: true });
     const codexBtn = page.getByRole("button", { name: "codex", exact: true });
+    const antigravityBtn = page.getByRole("button", { name: "antigravity", exact: true });
     await expect(claudeBtn).toBeVisible();
     await expect(codexBtn).toBeVisible();
+    await expect(antigravityBtn).toBeVisible();
     // Uninstalled agents are hidden from the picker grid.
     await expect(page.getByRole("button", { name: "uninstalled-tool", exact: true })).toHaveCount(0);
-    await codexBtn.click();
-    // Selected agent has the brand-600 border class via Tailwind; rather
-    // than asserting on class names, rely on the POST body covering this
-    // (see "submitted tool" assertion below).
   });
 
   test("profile picker is hidden when there is only one profile", async ({ page }) => {


### PR DESCRIPTION
## Description
Adds first-class Antigravity CLI (`agy`) support so users can create AoE sessions without configuring a custom agent.

This includes:
- built-in `antigravity` agent registry entry with `agy` alias and yolo flag
- tmux status detection for auth, workspace trust, approval, running, and prompt states
- sandbox config sync for `~/.gemini/antigravity-cli`
- sandbox image installation via the official Antigravity CLI installer
- sandbox docs update

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Testing

- `cargo fmt`
- `cargo test --lib antigravity`
- `cargo test --lib agents::tests`
- `cargo test --lib session::container_config::tests::test_agent_config_mounts`
- `cargo test --lib`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `git diff --check`
- `target/debug/aoe agents` confirmed `antigravity` is detected as installed when `agy` is on PATH
- isolated smoke test with `XDG_CONFIG_HOME=$(mktemp -d) target/debug/aoe add <tmp-project> --tool antigravity --title agy-smoke --launch`, then tmux capture confirmed the `agy` TUI reached the workspace trust screen

Not tested: full Docker image build. The default sandbox image installs every bundled agent, so I kept this to Dockerfile wiring plus Rust config tests for this targeted change.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:**
Implemented and validated by Codex at the user's request.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary of Changes

This PR adds first-class Antigravity CLI ("agy") support so users can create and use AoE sessions with Antigravity without a custom agent.

What changed (high-level)
- Added Antigravity as a built-in agent (canonical name "antigravity", binary/alias "agy") with detection and install hint.
- Implemented tmux-pane status detection for Antigravity UI states (authentication/sign-in, workspace trust/approval prompts, running/activity, idle).
- Added sandbox config sync and mount support for ~/.gemini/antigravity-cli (preserves oauth token and plugins).
- Wired sandbox Dockerfiles to install Antigravity via its official installer and created the credential mount path.
- Updated documentation (README, docs/index.md, docs/guides/sandbox.md) to list Antigravity as a supported agent.
- Added/updated tests: unit tests for agent registry, mount behavior, tmux status detection, send-keys timing expectations; Playwright test(s) mocking an installed Antigravity terminal fallback so it appears in the web wizard agent picker; web terminal scrollback/resize/wheel regression tests updated.

Benefits
- Users can run AoE sessions with Antigravity CLI out of the box, no custom agent setup required.
- Terminal-first interactions (auth/trust/approval and running state) are detected to improve UX and automation.
- Sandbox preserves user credentials/plugins and supports automated installer-based sandbox image setup.
- Web UI regressions covered by targeted Playwright tests help prevent breakage in agent selection and terminal scrollback behavior.

Technical details (concise)
- src/agents.rs: Added AgentDef for "antigravity" with DetectionMethod::Which("agy"), CLI YOLO flag (--dangerously-skip-permissions), no session resume, install_hint (curl ... install.sh), and corresponding unit-test updates (agent_names order, resolve_tool_name, settings index round-trip, send_keys_enter_delay, install_hint).
- src/tmux/status_detection.rs: New pub fn detect_antigravity_status(raw_content: &str) -> Status that examines the last ~30 non-empty lines (lowercased) and returns Waiting/Running/Idle based on ordered substring checks (sign-in/auth prompts, "Approval Required"/workspace trust lines, interrupt hints or spinners).
- src/session/container_config.rs: AGENT_CONFIG_MOUNTS entry for antigravity -> host_rel & container_suffix ".gemini/antigravity-cli"; copies plugins dir and preserves antigravity-oauth-token; unit tests extended.
- docker/Dockerfile & docker/Dockerfile.dev: Dockerfile wiring to run Antigravity CLI installer (install.sh) and create /root/.gemini/antigravity-cli; dev Dockerfile comment updated.
- Web (web/src/hooks/useTerminal.ts): Wheel/touch-to-cell mapping updated to compute wheel coordinates against the last PTY size sent to server (wheelGrid), optional eventTarget support for cellFromClientPoint, wheel capture listener to preserve last captured wheel cell for SGR sequences.
- Tests: Playwright tests updated/added: wizard-agent-step.spec.ts (agent picker shows mocked antigravity terminal fallback), pinch-zoom-desktop.spec.ts and wheel-scroll.spec.ts updated to assert scrollback/resize coordinate constraints. CI/local validation commands noted in PR (cargo fmt/test/clippy, npm build/playwright tests).

Known notes / limitations / follow-ups
- Session resume for Antigravity is intentionally unsupported.
- Dockerfile wiring added, but full sandbox image build was not tested within this PR (maintainers may want to verify CI or test an image build).
- Contributor notes indicated AI (Codex) assisted code generation — reviewers may want extra scrutiny on edge cases and string-match heuristics in tmux status detection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1349?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->