### PR TITLE
test(web): cockpit Vitest coverage for 8 issues (part of #986)

### DIFF
--- a/web/src/components/cockpit/ApprovalCard.test.tsx
+++ b/web/src/components/cockpit/ApprovalCard.test.tsx
@@ -1,0 +1,223 @@
+// @vitest-environment jsdom
+//
+// Approval card rendering + decision routing. The card is the only
+// UI gate between the agent and a destructive action, so the test
+// pins:
+//   - destructive vs benign chrome distinguishable to a screen
+//     reader (role=alertdialog, AlertTriangle vs Shield, label),
+//   - benign branch: single-tap Allow / Always / Deny each route
+//     `onResolve` with the matching ApprovalDecision,
+//   - destructive branch: only Hold-to-allow + Deny; instant click
+//     does NOT resolve until LONG_PRESS_MS elapses,
+//   - args_preview rendering: parsed JSON → <dl> with `_aoe_*` keys
+//     hidden; non-object → raw <pre>,
+//   - offline + rolled-back states disable the action surface.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { ApprovalCard } from "./ApprovalCard";
+import type { Approval, ApprovalDecision } from "../../lib/cockpitTypes";
+
+vi.mock("../../lib/connectionState", () => ({
+  useServerDown: () => false,
+  OFFLINE_TITLE: "Disconnected — reconnect to use",
+}));
+
+function makeApproval(over: Partial<Approval> = {}): Approval {
+  return {
+    nonce: "n-1",
+    tool_call: {
+      id: "t-1",
+      name: "Bash",
+      kind: "execute",
+      args_preview: JSON.stringify({ command: "ls -al" }),
+      started_at: "2026-05-21T00:00:00Z",
+    },
+    destructive: false,
+    requested_at: "2026-05-21T00:00:00Z",
+    ...over,
+  };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ApprovalCard (benign)", () => {
+  it("renders the tool name and Approval-needed chrome", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(<ApprovalCard approval={makeApproval()} onResolve={onResolve} />);
+    expect(
+      screen.getByRole("alertdialog", { name: /Approval needed: Bash/i }),
+    ).toBeTruthy();
+    expect(screen.getByText("Approval needed")).toBeTruthy();
+    expect(screen.getByText("Bash")).toBeTruthy();
+  });
+
+  it("renders the args JSON as a key/value list", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: JSON.stringify({ command: "ls", cwd: "/tmp" }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("command")).toBeTruthy();
+    expect(screen.getByText("ls")).toBeTruthy();
+    expect(screen.getByText("cwd")).toBeTruthy();
+    expect(screen.getByText("/tmp")).toBeTruthy();
+  });
+
+  it("hides bookkeeping keys whose name starts with _aoe_", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: JSON.stringify({
+              command: "ls",
+              _aoe_parent_tool_call_id: "parent-123",
+            }),
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.queryByText("_aoe_parent_tool_call_id")).toBeNull();
+    expect(screen.queryByText("parent-123")).toBeNull();
+    expect(screen.getByText("command")).toBeTruthy();
+  });
+
+  it("falls back to a raw pre block when args_preview is not a JSON object", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({
+          tool_call: {
+            id: "t-1",
+            name: "Bash",
+            kind: "execute",
+            args_preview: "raw text [truncated]",
+            started_at: "2026-05-21T00:00:00Z",
+          },
+        })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("raw text [truncated]")).toBeTruthy();
+  });
+
+  it("routes the Allow button to onResolve('Allow')", async () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(<ApprovalCard approval={makeApproval()} onResolve={onResolve} />);
+    fireEvent.click(screen.getByText("Allow"));
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith<ApprovalDecision[]>("Allow");
+  });
+
+  it("routes Always to onResolve('AllowAlways')", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(<ApprovalCard approval={makeApproval()} onResolve={onResolve} />);
+    fireEvent.click(screen.getByText("Always"));
+    expect(onResolve).toHaveBeenCalledWith("AllowAlways");
+  });
+
+  it("routes Deny to onResolve('Deny')", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(<ApprovalCard approval={makeApproval()} onResolve={onResolve} />);
+    fireEvent.click(screen.getByText("Deny"));
+    expect(onResolve).toHaveBeenCalledWith("Deny");
+  });
+
+  it("shows the rolled-back message when onResolve rejects", async () => {
+    const onResolve = vi.fn().mockRejectedValue(new Error("network"));
+    render(<ApprovalCard approval={makeApproval()} onResolve={onResolve} />);
+    await act(async () => {
+      fireEvent.click(screen.getByText("Allow"));
+    });
+    expect(
+      screen.getByText(/Could not reach the server/i),
+    ).toBeTruthy();
+  });
+});
+
+describe("ApprovalCard (destructive)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the destructive chrome (AlertTriangle + 'Destructive action' label)", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({ destructive: true })}
+        onResolve={onResolve}
+      />,
+    );
+    expect(screen.getByText("Destructive action")).toBeTruthy();
+    expect(screen.getByText("Hold to allow")).toBeTruthy();
+    expect(screen.queryByText("Always")).toBeNull();
+  });
+
+  it("does not approve on a quick click of Hold to allow", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({ destructive: true })}
+        onResolve={onResolve}
+      />,
+    );
+    const btn = screen.getByText("Hold to allow");
+    fireEvent.mouseDown(btn);
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+    fireEvent.mouseUp(btn);
+    expect(onResolve).not.toHaveBeenCalled();
+  });
+
+  it("approves after a sustained 800ms hold", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({ destructive: true })}
+        onResolve={onResolve}
+      />,
+    );
+    const btn = screen.getByText("Hold to allow");
+    fireEvent.mouseDown(btn);
+    act(() => {
+      vi.advanceTimersByTime(800);
+    });
+    expect(onResolve).toHaveBeenCalledTimes(1);
+    expect(onResolve).toHaveBeenCalledWith("Allow");
+  });
+
+  it("routes Deny without requiring a hold even in destructive mode", () => {
+    const onResolve = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ApprovalCard
+        approval={makeApproval({ destructive: true })}
+        onResolve={onResolve}
+      />,
+    );
+    fireEvent.click(screen.getByText("Deny"));
+    expect(onResolve).toHaveBeenCalledWith("Deny");
+  });
+});

--- a/web/src/components/cockpit/ApprovalCard.test.tsx
+++ b/web/src/components/cockpit/ApprovalCard.test.tsx
@@ -21,7 +21,7 @@ import type { Approval, ApprovalDecision } from "../../lib/cockpitTypes";
 
 vi.mock("../../lib/connectionState", () => ({
   useServerDown: () => false,
-  OFFLINE_TITLE: "Disconnected — reconnect to use",
+  OFFLINE_TITLE: "Disconnected",
 }));
 
 function makeApproval(over: Partial<Approval> = {}): Approval {

--- a/web/src/components/cockpit/ContextPrimerBanner.test.tsx
+++ b/web/src/components/cockpit/ContextPrimerBanner.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+//
+// Context-primer banner. When the cockpit detects a context-reset
+// (`session/load` failure with prior turns in SQLite), this banner
+// offers the user a recap fetched from
+// `GET /api/sessions/:id/cockpit/context-primer`. The component owns
+// the loading/error transients and the Insert vs Dismiss routing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+
+vi.mock("../../lib/api", () => ({
+  fetchContextPrimer: vi.fn(),
+}));
+
+import { ContextPrimerBanner } from "./ContextPrimerBanner";
+import { fetchContextPrimer } from "../../lib/api";
+
+const mockFetch = vi.mocked(fetchContextPrimer);
+
+const AVAILABLE = { resetSeq: 7, reason: "session/load" };
+
+function mount(
+  props?: Partial<React.ComponentProps<typeof ContextPrimerBanner>>,
+) {
+  const onInsertPrimer = vi.fn();
+  const onDismiss = vi.fn();
+  const utils = render(
+    <ContextPrimerBanner
+      sessionId="s-1"
+      available={AVAILABLE}
+      onInsertPrimer={onInsertPrimer}
+      onDismiss={onDismiss}
+      {...props}
+    />,
+  );
+  return { onInsertPrimer, onDismiss, ...utils };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ContextPrimerBanner", () => {
+  it("renders nothing when `available` is null", () => {
+    const { container } = mount({ available: null });
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner copy and the Resume button when available is set", () => {
+    const { getByText } = mount();
+    expect(getByText(/Agent lost its prior model context/i)).toBeTruthy();
+    expect(getByText(/Resume with prior context/i)).toBeTruthy();
+  });
+
+  it("renders the dismiss control with its aria-label", () => {
+    const { getByLabelText } = mount();
+    expect(getByLabelText("Dismiss context-reset banner")).toBeTruthy();
+  });
+
+  it("calls onDismiss when the × button is clicked", () => {
+    const { getByLabelText, onDismiss } = mount();
+    fireEvent.click(getByLabelText("Dismiss context-reset banner"));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("hits the primer endpoint with the session id and reset seq", async () => {
+    mockFetch.mockResolvedValueOnce({
+      primer: "user: hi\nagent: hello",
+      included_event_count: 2,
+      included_turn_count: 1,
+      truncated: false,
+      max_chars: 4000,
+      unprocessed_prompt: null,
+    });
+    const { getByText } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+    expect(mockFetch.mock.calls[0]?.[0]).toBe("s-1");
+    expect(mockFetch.mock.calls[0]?.[1]).toBe(7);
+  });
+
+  it("inserts the fetched primer and triggers onDismiss on success", async () => {
+    mockFetch.mockResolvedValueOnce({
+      primer: "recap text",
+      included_event_count: 4,
+      included_turn_count: 2,
+      truncated: false,
+      max_chars: 4000,
+      unprocessed_prompt: null,
+    });
+    const { getByText, onInsertPrimer, onDismiss } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    await waitFor(() =>
+      expect(onInsertPrimer).toHaveBeenCalledWith("recap text"),
+    );
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces an error when the primer endpoint returns null", async () => {
+    mockFetch.mockResolvedValueOnce(null);
+    const { getByText, findByRole, onInsertPrimer, onDismiss } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    const alert = await findByRole("alert");
+    expect(alert.textContent).toMatch(/Failed to fetch primer/i);
+    expect(onInsertPrimer).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a 'no transcript' message when primer is empty", async () => {
+    mockFetch.mockResolvedValueOnce({
+      primer: "",
+      included_event_count: 0,
+      included_turn_count: 0,
+      truncated: false,
+      max_chars: 4000,
+      unprocessed_prompt: null,
+    });
+    const { getByText, findByRole, onInsertPrimer, onDismiss } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    const alert = await findByRole("alert");
+    expect(alert.textContent).toMatch(/No prior transcript/i);
+    expect(onInsertPrimer).not.toHaveBeenCalled();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a network error on fetch rejection (not AbortError)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+    const { getByText, findByRole, onInsertPrimer } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    const alert = await findByRole("alert");
+    expect(alert.textContent).toMatch(/Network error/i);
+    expect(onInsertPrimer).not.toHaveBeenCalled();
+  });
+
+  it("ignores an AbortError without surfacing an error message", async () => {
+    const err = Object.assign(new Error("aborted"), { name: "AbortError" });
+    mockFetch.mockRejectedValueOnce(err);
+    const { getByText, queryByRole, onInsertPrimer } = mount();
+    fireEvent.click(getByText(/Resume with prior context/i));
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+    // No alert role surfaces from an AbortError.
+    await Promise.resolve();
+    expect(queryByRole("alert")?.textContent ?? "").not.toMatch(
+      /Network error/i,
+    );
+    expect(onInsertPrimer).not.toHaveBeenCalled();
+  });
+
+  it("clears prior error state when resetSeq changes", async () => {
+    mockFetch.mockResolvedValueOnce(null);
+    const { getByText, findByRole, rerender, queryByRole } = render(
+      <ContextPrimerBanner
+        sessionId="s-1"
+        available={AVAILABLE}
+        onInsertPrimer={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    fireEvent.click(getByText(/Resume with prior context/i));
+    await findByRole("alert");
+    rerender(
+      <ContextPrimerBanner
+        sessionId="s-1"
+        available={{ resetSeq: 8, reason: "new reset" }}
+        onInsertPrimer={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(queryByRole("alert")).toBeNull();
+  });
+});

--- a/web/src/components/cockpit/Markdown.test.tsx
+++ b/web/src/components/cockpit/Markdown.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// Markdown wrapper contract. Scope: the customisations our wrapper
+// adds on top of @assistant-ui/react-markdown's MarkdownTextPrimitive.
+// The primitive itself needs a deep assistant-ui MessagePart context
+// to render, so we mock it and verify the wrapper:
+//   - mounts the primitive with `remark-gfm` in remarkPlugins,
+//   - forwards the `smooth` prop and the `text` content,
+//   - passes a `components` map with our custom Blockquote (warning
+//     variant when text starts with the ⚠️ glyph), TableWithScroll,
+//     ShikiSyntaxHighlighter, and CodeHeader entries.
+//
+// Then we exercise the captured custom components directly against
+// jsdom to assert their per-component contracts (warning class,
+// table-wrap container, copy-button click).
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import remarkGfm from "remark-gfm";
+
+vi.mock("../../hooks/useShikiTheme", () => ({
+  useShikiTheme: () => ({ theme: "vitesse-dark", appearance: "dark" }),
+}));
+
+vi.mock("../../lib/highlighter", () => ({
+  ensureThemeLoaded: vi.fn().mockResolvedValue("vitesse-dark"),
+  getHighlighter: vi.fn().mockResolvedValue({
+    codeToHtml: () => "<pre><code>highlighted</code></pre>",
+  }),
+  langKeyForExt: (s: string) => s,
+  loadLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+interface PrimitiveCall {
+  text: string;
+  smooth: boolean;
+  remarkPlugins: unknown[];
+  components: Record<string, React.ComponentType<unknown>>;
+}
+
+const primitiveCalls: PrimitiveCall[] = [];
+
+vi.mock("@assistant-ui/react-markdown", () => ({
+  MarkdownTextPrimitive: (props: {
+    preprocess: () => string;
+    smooth?: boolean;
+    remarkPlugins?: unknown[];
+    className?: string;
+    components?: Record<string, React.ComponentType<unknown>>;
+  }) => {
+    primitiveCalls.push({
+      text: props.preprocess(),
+      smooth: !!props.smooth,
+      remarkPlugins: props.remarkPlugins ?? [],
+      components: props.components ?? {},
+    });
+    return <div data-testid="markdown-primitive" className={props.className} />;
+  },
+}));
+
+import { Markdown } from "./Markdown";
+
+beforeEach(() => {
+  primitiveCalls.length = 0;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("Markdown wrapper config", () => {
+  it("renders the assistant-ui markdown primitive", () => {
+    const { getByTestId } = render(<Markdown text="hi" />);
+    expect(getByTestId("markdown-primitive")).toBeTruthy();
+  });
+
+  it("forwards the source text via preprocess", () => {
+    render(<Markdown text="hello world" />);
+    expect(primitiveCalls).toHaveLength(1);
+    expect(primitiveCalls[0]!.text).toBe("hello world");
+  });
+
+  it("defaults smooth=false and forwards smooth=true on demand", () => {
+    render(<Markdown text="a" />);
+    render(<Markdown text="b" smooth />);
+    expect(primitiveCalls[0]!.smooth).toBe(false);
+    expect(primitiveCalls[1]!.smooth).toBe(true);
+  });
+
+  it("registers remark-gfm in the plugin list", () => {
+    render(<Markdown text="x" />);
+    expect(primitiveCalls[0]!.remarkPlugins).toContain(remarkGfm);
+  });
+
+  it("registers cockpit-specific component overrides", () => {
+    render(<Markdown text="x" />);
+    const keys = Object.keys(primitiveCalls[0]!.components);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "SyntaxHighlighter",
+        "CodeHeader",
+        "table",
+        "blockquote",
+      ]),
+    );
+  });
+
+  it("attaches the cockpit-markdown class for global styling", () => {
+    const { container } = render(<Markdown text="x" />);
+    const node = container.querySelector(".cockpit-markdown");
+    expect(node).not.toBeNull();
+  });
+});
+
+describe("Blockquote override", () => {
+  function getBlockquote(): React.ComponentType<{
+    children: React.ReactNode;
+  }> {
+    render(<Markdown text="x" />);
+    const Comp = primitiveCalls.at(-1)!.components.blockquote;
+    return Comp as React.ComponentType<{ children: React.ReactNode }>;
+  }
+
+  it("applies the warning variant when the text starts with the warning glyph", () => {
+    const Blockquote = getBlockquote();
+    const { container } = render(<Blockquote>⚠️ context reset</Blockquote>);
+    const bq = container.querySelector("blockquote");
+    expect(bq).not.toBeNull();
+    expect(bq?.className).toContain("cockpit-callout-warn");
+  });
+
+  it("uses no warning class for plain text", () => {
+    const Blockquote = getBlockquote();
+    const { container } = render(<Blockquote>just a quote</Blockquote>);
+    const bq = container.querySelector("blockquote");
+    expect(bq).not.toBeNull();
+    expect(bq?.className ?? "").not.toContain("cockpit-callout-warn");
+  });
+
+  it("strips leading whitespace before checking for the warning glyph", () => {
+    const Blockquote = getBlockquote();
+    const { container } = render(<Blockquote>   ⚠️ warning</Blockquote>);
+    const bq = container.querySelector("blockquote");
+    expect(bq?.className).toContain("cockpit-callout-warn");
+  });
+
+  it("walks nested React children when inspecting the text", () => {
+    const Blockquote = getBlockquote();
+    const { container } = render(
+      <Blockquote>
+        <span>
+          <strong>⚠️</strong> nested warning
+        </span>
+      </Blockquote>,
+    );
+    expect(container.querySelector("blockquote")?.className).toContain(
+      "cockpit-callout-warn",
+    );
+  });
+});
+
+describe("TableWithScroll override", () => {
+  function getTable(): React.ComponentType<{
+    children: React.ReactNode;
+  }> {
+    render(<Markdown text="x" />);
+    const Comp = primitiveCalls.at(-1)!.components.table;
+    return Comp as React.ComponentType<{ children: React.ReactNode }>;
+  }
+
+  it("wraps the rendered table in a scroll container", () => {
+    const Table = getTable();
+    const { container } = render(
+      <Table>
+        <tbody>
+          <tr>
+            <td>cell</td>
+          </tr>
+        </tbody>
+      </Table>,
+    );
+    const wrap = container.querySelector(".cockpit-table-wrap");
+    expect(wrap).not.toBeNull();
+    expect(wrap?.querySelector("table")).not.toBeNull();
+    expect(wrap?.querySelector("td")?.textContent).toBe("cell");
+  });
+});
+
+describe("CodeHeader override", () => {
+  function getCodeHeader(): React.ComponentType<{
+    language?: string;
+    code: string;
+  }> {
+    render(<Markdown text="x" />);
+    return primitiveCalls.at(-1)!.components.CodeHeader as React.ComponentType<{
+      language?: string;
+      code: string;
+    }>;
+  }
+
+  it("renders the language label", () => {
+    const Header = getCodeHeader();
+    const { container } = render(<Header language="rust" code="fn main(){}" />);
+    expect(container.textContent).toContain("rust");
+  });
+
+  it("falls back to 'text' when no language is provided", () => {
+    const Header = getCodeHeader();
+    const { container } = render(<Header code="abc" />);
+    expect(container.textContent).toContain("text");
+  });
+
+  it("copies the raw source to the clipboard when the copy button is clicked", () => {
+    const Header = getCodeHeader();
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      value: { writeText },
+      configurable: true,
+    });
+    const { getByText } = render(<Header language="js" code="alert('hi')" />);
+    fireEvent.click(getByText("copy"));
+    expect(writeText).toHaveBeenCalledWith("alert('hi')");
+  });
+});

--- a/web/src/components/cockpit/SwitchSubstrateAction.test.tsx
+++ b/web/src/components/cockpit/SwitchSubstrateAction.test.tsx
@@ -18,7 +18,7 @@ import { SwitchSubstrateAction } from "./SwitchSubstrateAction";
 let mockOffline = false;
 vi.mock("../../lib/connectionState", () => ({
   useServerDown: () => mockOffline,
-  OFFLINE_TITLE: "Disconnected — reconnect to use",
+  OFFLINE_TITLE: "Disconnected",
 }));
 
 function mockOkFetch(): ReturnType<typeof vi.fn> {

--- a/web/src/components/cockpit/SwitchSubstrateAction.test.tsx
+++ b/web/src/components/cockpit/SwitchSubstrateAction.test.tsx
@@ -1,0 +1,206 @@
+// @vitest-environment jsdom
+//
+// Switch-substrate action button + confirm dialog. The live spec
+// covers the round-trip; this spec pins the button states (label
+// flip by current substrate, ACP-disabled hint, offline disable),
+// the confirm dialog routing, and the POST endpoint shape.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  waitFor,
+} from "@testing-library/react";
+
+import { SwitchSubstrateAction } from "./SwitchSubstrateAction";
+
+let mockOffline = false;
+vi.mock("../../lib/connectionState", () => ({
+  useServerDown: () => mockOffline,
+  OFFLINE_TITLE: "Disconnected — reconnect to use",
+}));
+
+function mockOkFetch(): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    text: async () => "",
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+function mockBadFetch(body = "boom", status = 500): ReturnType<typeof vi.fn> {
+  const fn = vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    text: async () => body,
+  });
+  vi.stubGlobal("fetch", fn);
+  return fn;
+}
+
+beforeEach(() => {
+  mockOffline = false;
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("SwitchSubstrateAction trigger", () => {
+  it("labels the icon as 'Switch to cockpit mode' when current substrate is terminal", () => {
+    render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    const btns = document.querySelectorAll(
+      "button[aria-label='Switch to cockpit mode']",
+    );
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it("labels the icon as 'Switch to terminal mode' when current substrate is cockpit", () => {
+    render(<SwitchSubstrateAction sessionId="s-1" cockpitMode={true} />);
+    const btns = document.querySelectorAll(
+      "button[aria-label='Switch to terminal mode']",
+    );
+    expect(btns.length).toBeGreaterThan(0);
+  });
+
+  it("renders 'Switch to terminal' text in button variant when cockpitMode is true", () => {
+    const { getByText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={true} variant="button" />,
+    );
+    expect(getByText("Switch to terminal")).toBeTruthy();
+  });
+
+  it("is disabled when the target is cockpit and the agent is not ACP-capable", () => {
+    const { getByLabelText } = render(
+      <SwitchSubstrateAction
+        sessionId="s-1"
+        cockpitMode={false}
+        acpCapable={false}
+      />,
+    );
+    const btn = getByLabelText("Switch to cockpit mode") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toMatch(/no ACP adapter/i);
+  });
+
+  it("is disabled when the server is offline", () => {
+    mockOffline = true;
+    const { getByLabelText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    const btn = getByLabelText("Switch to cockpit mode") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.title).toMatch(/Disconnected/i);
+  });
+});
+
+describe("SwitchSubstrateAction confirm dialog", () => {
+  it("opens the confirm dialog on trigger click", () => {
+    mockOkFetch();
+    const { getByLabelText, getByRole } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    expect(getByRole("dialog")).toBeTruthy();
+  });
+
+  it("cancel closes the dialog without firing fetch", () => {
+    const fetchFn = mockOkFetch();
+    const { getByLabelText, getByText, queryByRole } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Cancel"));
+    expect(queryByRole("dialog")).toBeNull();
+    expect(fetchFn).not.toHaveBeenCalled();
+  });
+
+  it("escape closes the dialog", () => {
+    mockOkFetch();
+    const { getByLabelText, queryByRole } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(queryByRole("dialog")).toBeNull();
+  });
+
+  it("POSTs to /cockpit/enable when switching FROM terminal TO cockpit", async () => {
+    const fetchFn = mockOkFetch();
+    const { getByLabelText, getByText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Switch"));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+    expect(fetchFn.mock.calls[0]?.[0]).toBe(
+      "/api/sessions/s-1/cockpit/enable",
+    );
+    expect(fetchFn.mock.calls[0]?.[1]).toMatchObject({ method: "POST" });
+  });
+
+  it("POSTs to /cockpit/disable when switching FROM cockpit TO terminal", async () => {
+    const fetchFn = mockOkFetch();
+    const { getByLabelText, getByText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={true} />,
+    );
+    fireEvent.click(getByLabelText("Switch to terminal mode"));
+    fireEvent.click(getByText("Switch"));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalledTimes(1));
+    expect(fetchFn.mock.calls[0]?.[0]).toBe(
+      "/api/sessions/s-1/cockpit/disable",
+    );
+  });
+
+  it("URL-encodes the session id in the endpoint", async () => {
+    const fetchFn = mockOkFetch();
+    const { getByLabelText, getByText } = render(
+      <SwitchSubstrateAction sessionId="weird/id" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Switch"));
+    await waitFor(() => expect(fetchFn).toHaveBeenCalled());
+    expect(fetchFn.mock.calls[0]?.[0]).toBe(
+      "/api/sessions/weird%2Fid/cockpit/enable",
+    );
+  });
+
+  it("surfaces a server error response in the dialog", async () => {
+    mockBadFetch("session not found", 404);
+    const { getByLabelText, getByText, findByText, queryByRole } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Switch"));
+    await findByText(/session not found/i);
+    // Dialog stays open on error so the user can retry.
+    expect(queryByRole("dialog")).not.toBeNull();
+  });
+
+  it("falls back to 'HTTP <status>' when the error body is empty", async () => {
+    mockBadFetch("", 500);
+    const { getByLabelText, getByText, findByText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Switch"));
+    await findByText(/HTTP 500/);
+  });
+
+  it("surfaces network rejection as the dialog error", async () => {
+    const fn = vi.fn().mockRejectedValue(new Error("offline"));
+    vi.stubGlobal("fetch", fn);
+    const { getByLabelText, getByText, findByText } = render(
+      <SwitchSubstrateAction sessionId="s-1" cockpitMode={false} />,
+    );
+    fireEvent.click(getByLabelText("Switch to cockpit mode"));
+    fireEvent.click(getByText("Switch"));
+    await findByText(/offline/);
+  });
+});

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -1,0 +1,202 @@
+// @vitest-environment jsdom
+//
+// Per-kind dispatch coverage for ToolCards. Today only the
+// `formatDurationMs` helper has a unit test; every per-kind render
+// branch (bash, read, edit, search, todo, skill, schedule, mcp,
+// generic) is uncovered. This spec pins each branch to a label / DOM
+// shape so a future refactor that drops or misroutes a card surfaces
+// here loudly.
+//
+// We render via the public `<ToolCard>` dispatcher because the
+// per-kind functions (ExecuteToolCard, EditToolCard, etc.) are not
+// exported. Shiki is mocked away so HighlightedBlock falls through to
+// a plain <pre> and the test doesn't depend on async theme loading.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import type { ReactNode } from "react";
+
+vi.mock("../../lib/highlighter", () => ({
+  ensureThemeLoaded: vi.fn().mockResolvedValue("dark-plus"),
+  getHighlighter: vi.fn().mockResolvedValue({
+    codeToHtml: (code: string) => `<pre>${code}</pre>`,
+  }),
+  langKeyForExt: (s: string) => s,
+  loadLanguage: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../hooks/useShikiTheme", () => ({
+  useShikiTheme: () => ({ theme: "dark-plus", appearance: "dark" }),
+}));
+
+import { ToolCard } from "./ToolCards";
+import { AgentProfileProvider } from "../../lib/agentProfileContext";
+import { fixtures, makeCompletion, makeError } from "./__fixtures__/toolCalls";
+
+function Wrap({
+  toolKey,
+  children,
+}: {
+  toolKey?: string;
+  children: ReactNode;
+}) {
+  return (
+    <AgentProfileProvider toolKey={toolKey ?? null}>
+      {children}
+    </AgentProfileProvider>
+  );
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolCards dispatch", () => {
+  it("renders bash kind with a 'bash' label and the command", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.bash} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("bash");
+    expect(container.textContent).toContain("ls -la");
+  });
+
+  it("renders read kind with a 'read' label and the file path", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.read} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("read");
+    expect(container.textContent).toContain("/tmp/main.rs");
+  });
+
+  it("renders edit kind with an 'edit' label when old_string is non-empty", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.edit} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("edit");
+    expect(container.textContent).toContain("/tmp/main.rs");
+  });
+
+  it("renders edit kind with a 'write' label when old_string is empty", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.write} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("write");
+    expect(container.textContent).toContain("/tmp/new.rs");
+  });
+
+  it("renders delete kind with a 'delete' label", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.del} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("delete");
+    expect(container.textContent).toContain("/tmp/gone.rs");
+  });
+
+  it("renders search kind with a 'search' label", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.search} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("search");
+  });
+
+  it("renders fetch kind with a 'fetch' label and the URL", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.fetch} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("fetch");
+    expect(container.textContent).toContain("example.com");
+  });
+
+  it("renders generic kind for unrecognised tool names", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard tool={fixtures.generic} result={undefined} />
+      </Wrap>,
+    );
+    // Generic falls back to tool.kind as the label.
+    expect(container.textContent).toContain("WeirdTool");
+  });
+
+  it("flips the status pill to 'failed' on tool_error results", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeError({ text: "command not found" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent?.toLowerCase()).toContain("failed");
+  });
+
+  it("renders the 'done' badge on tool_complete results", () => {
+    const { container } = render(
+      <Wrap>
+        <ToolCard
+          tool={fixtures.bash}
+          result={makeCompletion({ text: "hello\n" })}
+        />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("done");
+  });
+});
+
+describe("ToolCards profile-gated dispatch (claude)", () => {
+  it("routes TodoWrite to the todos card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.todoWrite} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("todos");
+    expect(container.textContent).toContain("Step one");
+    expect(container.textContent).toContain("Step two");
+    expect(container.textContent).toContain("Step three");
+  });
+
+  it("routes a Skill tool to the skill card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.skill} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("skill");
+  });
+
+  it("routes ScheduleWakeup to a wakeup card under the claude profile", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.scheduleWakeup} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("checking deploy");
+  });
+});
+
+describe("ToolCards MCP", () => {
+  it("renders an MCP card with the server name and verb", () => {
+    const { container } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.mcp} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent?.toLowerCase()).toContain("mcp");
+    expect(container.textContent?.toLowerCase()).toContain("slack");
+    expect(container.textContent?.toLowerCase()).toContain("send message");
+  });
+});

--- a/web/src/components/cockpit/ToolErrorBody.test.tsx
+++ b/web/src/components/cockpit/ToolErrorBody.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+//
+// Shared wrapper around per-kind tool-card bodies that surfaces the
+// adapter's failure reason on err status. Without it, EditToolCard
+// and similar drop the error text on the floor and the only signal
+// is a tiny status dot.
+//
+// The parsing helper (parseToolError / describeToolErrorTag) is
+// covered by toolErrorParse.test.ts; this spec pins what the wrapper
+// does with the parser output.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { ToolErrorBody } from "./ToolErrorBody";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ToolErrorBody", () => {
+  it("renders children verbatim when status is 'running'", () => {
+    const { getByText, queryByText } = render(
+      <ToolErrorBody status="running" errorText="ignored">
+        <div>child body</div>
+      </ToolErrorBody>,
+    );
+    expect(getByText("child body")).toBeTruthy();
+    expect(queryByText(/tool failed/i)).toBeNull();
+  });
+
+  it("renders children verbatim when status is 'ok'", () => {
+    const { getByText, queryByText } = render(
+      <ToolErrorBody status="ok" errorText="ignored">
+        <div>child body</div>
+      </ToolErrorBody>,
+    );
+    expect(getByText("child body")).toBeTruthy();
+    expect(queryByText(/tool failed/i)).toBeNull();
+  });
+
+  it("renders the error chrome and the unwrapped body on status 'err'", () => {
+    const { getByText, container } = render(
+      <ToolErrorBody
+        status="err"
+        errorText="<tool_use_error>File does not exist.</tool_use_error>"
+      >
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(getByText(/tool failed/i)).toBeTruthy();
+    expect(getByText("agent-reported error")).toBeTruthy();
+    expect(container.textContent).toContain("File does not exist.");
+  });
+
+  it("hides the attempted-action details by default on err", () => {
+    const { container } = render(
+      <ToolErrorBody status="err" errorText="<error>boom</error>">
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    const details = container.querySelector("details");
+    expect(details).not.toBeNull();
+    expect(details?.hasAttribute("open")).toBe(false);
+  });
+
+  it("renders the summary copy on the collapsible details", () => {
+    const { getByText } = render(
+      <ToolErrorBody status="err" errorText="<error>boom</error>">
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(getByText(/Show attempted action/i)).toBeTruthy();
+  });
+
+  it("renders an explicit fallback when errorText is empty / missing", () => {
+    const { container } = render(
+      <ToolErrorBody status="err" errorText="">
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(container.textContent).toContain("(no error detail provided)");
+  });
+
+  it("renders the explicit fallback when errorText is undefined", () => {
+    const { container } = render(
+      <ToolErrorBody status="err">
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(container.textContent).toContain("(no error detail provided)");
+  });
+
+  it("omits the wrapper-tag chip when the error body is raw (no wrapper)", () => {
+    const { queryByText, container } = render(
+      <ToolErrorBody status="err" errorText="file not found: foo.rs">
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(container.textContent).toContain("file not found: foo.rs");
+    // describeToolErrorTag(null) is null → no chip rendered.
+    expect(queryByText("agent-reported error")).toBeNull();
+  });
+
+  it("passes through arbitrary single-pair wrapper tags as the chip label", () => {
+    const { getByText, container } = render(
+      <ToolErrorBody
+        status="err"
+        errorText="<custom_wrapper>weird failure</custom_wrapper>"
+      >
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    expect(getByText("custom_wrapper")).toBeTruthy();
+    expect(container.textContent).toContain("weird failure");
+  });
+
+  it("does not render the attempted-action details when children is empty", () => {
+    const { container } = render(
+      <ToolErrorBody status="err" errorText="boom">
+        {null}
+      </ToolErrorBody>,
+    );
+    expect(container.querySelector("details")).toBeNull();
+  });
+
+  it("preserves linebreaks in the error body", () => {
+    const { container } = render(
+      <ToolErrorBody
+        status="err"
+        errorText={
+          "<tool_use_error>line one\nline two\nline three</tool_use_error>"
+        }
+      >
+        <div>attempted body</div>
+      </ToolErrorBody>,
+    );
+    const pre = container.querySelector("pre");
+    expect(pre).not.toBeNull();
+    expect(pre?.textContent).toBe("line one\nline two\nline three");
+  });
+});

--- a/web/src/components/cockpit/__fixtures__/toolCalls.ts
+++ b/web/src/components/cockpit/__fixtures__/toolCalls.ts
@@ -1,0 +1,130 @@
+// Reusable ToolCall / ActivityRow fixtures for cockpit per-kind
+// render tests. Shapes mirror the wire types emitted by
+// `src/cockpit/state.rs` and consumed by `ToolCards.tsx`.
+
+import type { ActivityRow, ToolCall } from "../../../lib/cockpitTypes";
+
+export function makeToolCall(over: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "tc-1",
+    name: "Tool",
+    kind: "other",
+    args_preview: "{}",
+    started_at: "2026-05-21T00:00:00Z",
+    ...over,
+  };
+}
+
+export function makeCompletion(
+  over: Partial<ActivityRow> = {},
+): ActivityRow {
+  return {
+    id: "row-1",
+    kind: "tool_complete",
+    text: "",
+    toolCallId: "tc-1",
+    at: "2026-05-21T00:00:01Z",
+    ...over,
+  };
+}
+
+export function makeError(over: Partial<ActivityRow> = {}): ActivityRow {
+  return makeCompletion({ kind: "tool_error", text: "failed", ...over });
+}
+
+export const fixtures = {
+  bash: makeToolCall({
+    id: "bash-1",
+    name: "Bash",
+    kind: "execute",
+    args_preview: JSON.stringify({ command: "ls -la", description: "list" }),
+  }),
+  read: makeToolCall({
+    id: "read-1",
+    name: "Read",
+    kind: "read",
+    args_preview: JSON.stringify({ file_path: "/tmp/main.rs" }),
+  }),
+  edit: makeToolCall({
+    id: "edit-1",
+    name: "Edit",
+    kind: "edit",
+    args_preview: JSON.stringify({
+      file_path: "/tmp/main.rs",
+      old_string: "fn foo() {}",
+      new_string: "fn foo() { bar(); }",
+    }),
+  }),
+  write: makeToolCall({
+    id: "write-1",
+    name: "Write",
+    kind: "edit",
+    args_preview: JSON.stringify({
+      file_path: "/tmp/new.rs",
+      content: "fn main() {}",
+    }),
+  }),
+  del: makeToolCall({
+    id: "del-1",
+    name: "Delete",
+    kind: "delete",
+    args_preview: JSON.stringify({ file_path: "/tmp/gone.rs" }),
+  }),
+  search: makeToolCall({
+    id: "search-1",
+    name: "Grep",
+    kind: "search",
+    args_preview: JSON.stringify({ pattern: "TODO", path: "/tmp" }),
+  }),
+  fetch: makeToolCall({
+    id: "fetch-1",
+    name: "WebFetch",
+    kind: "fetch",
+    args_preview: JSON.stringify({ url: "https://example.com" }),
+  }),
+  think: makeToolCall({
+    id: "think-1",
+    name: "Think",
+    kind: "think",
+    args_preview: JSON.stringify({ thought: "consider the problem" }),
+  }),
+  todoWrite: makeToolCall({
+    id: "todo-1",
+    name: "TodoWrite",
+    kind: "other",
+    args_preview: JSON.stringify({
+      todos: [
+        { content: "Step one", status: "completed", activeForm: "doing one" },
+        { content: "Step two", status: "in_progress", activeForm: "doing two" },
+        { content: "Step three", status: "pending", activeForm: "doing three" },
+      ],
+    }),
+  }),
+  skill: makeToolCall({
+    id: "skill-1",
+    name: "Skill",
+    kind: "other",
+    args_preview: JSON.stringify({ skill: "investigate" }),
+  }),
+  scheduleWakeup: makeToolCall({
+    id: "sched-1",
+    name: "ScheduleWakeup",
+    kind: "other",
+    args_preview: JSON.stringify({
+      delaySeconds: 300,
+      reason: "checking deploy",
+    }),
+  }),
+  mcp: makeToolCall({
+    id: "mcp-1",
+    name: "mcp__slack__send_message",
+    kind: "other",
+    args_preview: JSON.stringify({ channel: "#general", text: "hi" }),
+  }),
+  generic: makeToolCall({
+    id: "gen-1",
+    name: "WeirdTool",
+    kind: "other",
+    args_preview: JSON.stringify({ x: 1 }),
+  }),
+};

--- a/web/src/components/cockpit/useFilesIndex.test.tsx
+++ b/web/src/components/cockpit/useFilesIndex.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+//
+// Workspace file picker hook + fuzzy filter. The fuzzy filter drives
+// the @-mention picker's ordering; if prefix-vs-substring weighting
+// breaks, the picker stops surfacing the file the user is typing.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
+
+import { fuzzyFilter, useFilesIndex } from "./useFilesIndex";
+
+interface Item {
+  label: string;
+  description?: string;
+}
+
+describe("fuzzyFilter", () => {
+  it("returns the first cap items unfiltered for an empty query", () => {
+    const items: Item[] = [
+      { label: "a" },
+      { label: "b" },
+      { label: "c" },
+      { label: "d" },
+    ];
+    expect(fuzzyFilter(items, "", 2)).toEqual([{ label: "a" }, { label: "b" }]);
+  });
+
+  it("ranks prefix match above substring match", () => {
+    const items: Item[] = [
+      { label: "zfoo" },
+      { label: "foobar" },
+    ];
+    const out = fuzzyFilter(items, "foo");
+    expect(out.map((i) => i.label)).toEqual(["foobar", "zfoo"]);
+  });
+
+  it("label substring beats description substring", () => {
+    const items: Item[] = [
+      { label: "other", description: "contains foo in description" },
+      { label: "has-foo-in-label" },
+    ];
+    const out = fuzzyFilter(items, "foo");
+    expect(out.map((i) => i.label)).toEqual([
+      "has-foo-in-label",
+      "other",
+    ]);
+  });
+
+  it("breaks score ties by shorter label", () => {
+    const items: Item[] = [
+      { label: "foobarbaz" },
+      { label: "foobar" },
+      { label: "foo" },
+    ];
+    const out = fuzzyFilter(items, "foo");
+    expect(out.map((i) => i.label)).toEqual([
+      "foo",
+      "foobar",
+      "foobarbaz",
+    ]);
+  });
+
+  it("caps results at the cap limit", () => {
+    const items: Item[] = Array.from({ length: 50 }, (_, i) => ({
+      label: `foo${i}`,
+    }));
+    expect(fuzzyFilter(items, "foo", 5)).toHaveLength(5);
+  });
+
+  it("drops items that don't match label or description", () => {
+    const items: Item[] = [
+      { label: "alpha" },
+      { label: "beta", description: "the quick" },
+      { label: "gamma" },
+    ];
+    expect(fuzzyFilter(items, "xyz")).toEqual([]);
+  });
+
+  it("is case-insensitive", () => {
+    const items: Item[] = [{ label: "README.md" }];
+    expect(fuzzyFilter(items, "readme")).toEqual([{ label: "README.md" }]);
+  });
+});
+
+describe("useFilesIndex hook", () => {
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns loading=true on first render and resolves with files", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ files: ["a.txt", "b.rs"] }),
+    });
+    const { result } = renderHook(() => useFilesIndex("s-1"));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.files).toEqual([]);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files).toEqual(["a.txt", "b.rs"]);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "/api/sessions/s-1/cockpit/files",
+    );
+  });
+
+  it("URL-encodes the session id", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ files: [] }),
+    });
+    renderHook(() => useFilesIndex("session/with/slash"));
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/sessions/session%2Fwith%2Fslash/cockpit/files",
+      ),
+    );
+  });
+
+  it("re-fetches when sessionId changes", async () => {
+    fetchSpy
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ files: ["one"] }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ files: ["two"] }),
+      });
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useFilesIndex(id),
+      { initialProps: { id: "s-1" } },
+    );
+    await waitFor(() => expect(result.current.files).toEqual(["one"]));
+    rerender({ id: "s-2" });
+    await waitFor(() => expect(result.current.files).toEqual(["two"]));
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns empty list when fetch rejects", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("network down"));
+    const { result } = renderHook(() => useFilesIndex("s-1"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files).toEqual([]);
+  });
+
+  it("treats non-ok responses as an empty file list", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ files: ["should-not-appear"] }),
+    });
+    const { result } = renderHook(() => useFilesIndex("s-1"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files).toEqual([]);
+  });
+
+  it("tolerates a response without a files field", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+    const { result } = renderHook(() => useFilesIndex("s-1"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.files).toEqual([]);
+  });
+
+  it("does not update state after unmount", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    const pending = new Promise<unknown>((res) => {
+      resolveFetch = res;
+    });
+    fetchSpy.mockReturnValueOnce(pending);
+    const { result, unmount } = renderHook(() => useFilesIndex("s-1"));
+    unmount();
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => ({ files: ["x"] }) });
+    });
+    expect(result.current.files).toEqual([]);
+  });
+});

--- a/web/src/lib/cockpitArgs.test.ts
+++ b/web/src/lib/cockpitArgs.test.ts
@@ -1,0 +1,99 @@
+// JSON-shaped args_preview parser. Every cockpit tool card runs the
+// args through these helpers; if parseJsonObject silently accepts
+// arrays or non-object scalars, ApprovalCard's <dl> renderer crashes
+// when callers iterate Object.entries on a non-object.
+
+import { describe, expect, it } from "vitest";
+
+import { parseJsonObject, pickFirst, pickStr } from "./cockpitArgs";
+
+describe("parseJsonObject", () => {
+  it("returns the object for valid JSON object input", () => {
+    expect(parseJsonObject("{}")).toEqual({});
+    expect(parseJsonObject('{"a":1,"b":"x"}')).toEqual({ a: 1, b: "x" });
+  });
+
+  it("rejects arrays", () => {
+    expect(parseJsonObject("[]")).toBeNull();
+    expect(parseJsonObject("[1,2,3]")).toBeNull();
+  });
+
+  it("rejects scalar JSON values", () => {
+    expect(parseJsonObject('"hello"')).toBeNull();
+    expect(parseJsonObject("42")).toBeNull();
+    expect(parseJsonObject("true")).toBeNull();
+    expect(parseJsonObject("false")).toBeNull();
+    expect(parseJsonObject("null")).toBeNull();
+  });
+
+  it("returns null for non-JSON input", () => {
+    expect(parseJsonObject("not json")).toBeNull();
+    expect(parseJsonObject("")).toBeNull();
+  });
+
+  it("returns null for truncated JSON", () => {
+    expect(parseJsonObject("{")).toBeNull();
+    expect(parseJsonObject('{"a":')).toBeNull();
+    expect(parseJsonObject('{"a":1,')).toBeNull();
+  });
+
+  it("returns null when the agent appends a truncation marker", () => {
+    expect(parseJsonObject('{"a":1}[truncated]')).toBeNull();
+  });
+
+  it("preserves nested object/array values inside the parsed object", () => {
+    const out = parseJsonObject('{"items":[1,2],"meta":{"n":3}}');
+    expect(out).toEqual({ items: [1, 2], meta: { n: 3 } });
+  });
+});
+
+describe("pickStr", () => {
+  it("returns the value of the first string-typed key", () => {
+    const o = { command: "ls", path: "/tmp" };
+    expect(pickStr(o, "command", "path")).toBe("ls");
+    expect(pickStr(o, "path", "command")).toBe("/tmp");
+  });
+
+  it("skips keys whose values are not strings", () => {
+    const o = { a: 1, b: true, c: null, d: "found" };
+    expect(pickStr(o, "a", "b", "c", "d")).toBe("found");
+  });
+
+  it("returns null when no key matches", () => {
+    expect(pickStr({ a: 1 }, "b", "c")).toBeNull();
+  });
+
+  it("returns null when the object is null", () => {
+    expect(pickStr(null, "anything")).toBeNull();
+  });
+
+  it("returns null on an empty object", () => {
+    expect(pickStr({}, "a")).toBeNull();
+  });
+
+  it("does not pick up an inherited prototype key", () => {
+    // The args_preview is JSON.parse output, which never has a custom
+    // prototype, but the helper should still only look at own keys.
+    class Bag {
+      hidden = "via prototype";
+    }
+    const o = new Bag() as unknown as Record<string, unknown>;
+    expect(pickStr(o, "hidden")).toBe("via prototype");
+  });
+});
+
+describe("pickFirst", () => {
+  it("returns the first non-empty string", () => {
+    expect(pickFirst(null, undefined, "", "first", "second")).toBe("first");
+  });
+
+  it("skips strings that are only whitespace", () => {
+    expect(pickFirst("   ", "real")).toBe("real");
+  });
+
+  it("returns null when every candidate is empty or absent", () => {
+    expect(pickFirst(null, undefined, "")).toBeNull();
+    expect(pickFirst()).toBeNull();
+    expect(pickFirst("   ", "\t")).toBeNull();
+  });
+});

--- a/web/src/lib/cockpitDrafts.test.ts
+++ b/web/src/lib/cockpitDrafts.test.ts
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+//
+// Storage + pub/sub contract for cockpit composer drafts. The "unsent
+// draft" dot in the sidebar relies on the listener filter for cheap
+// per-session updates; if the filter logic drifts, every keystroke
+// re-renders every sidebar entry.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getDraft,
+  hasDraft,
+  setDraft,
+  subscribeDrafts,
+} from "./cockpitDrafts";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("getDraft / setDraft", () => {
+  it("returns empty string when no draft is persisted", () => {
+    expect(getDraft("s-1")).toBe("");
+  });
+
+  it("round-trips a written draft", () => {
+    setDraft("s-1", "hello world");
+    expect(getDraft("s-1")).toBe("hello world");
+  });
+
+  it("scopes drafts per session id", () => {
+    setDraft("s-1", "one");
+    setDraft("s-2", "two");
+    expect(getDraft("s-1")).toBe("one");
+    expect(getDraft("s-2")).toBe("two");
+  });
+
+  it("empty text removes the key entirely", () => {
+    setDraft("s-1", "filled");
+    setDraft("s-1", "");
+    expect(getDraft("s-1")).toBe("");
+    expect(localStorage.getItem("cockpit:draft:s-1")).toBeNull();
+  });
+
+  it("returns empty string when localStorage.getItem throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    expect(getDraft("s-1")).toBe("");
+    spy.mockRestore();
+  });
+
+  it("setDraft swallows localStorage write errors", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "setItem")
+      .mockImplementation(() => {
+        throw new Error("quota");
+      });
+    expect(() => setDraft("s-1", "x")).not.toThrow();
+    spy.mockRestore();
+  });
+});
+
+describe("hasDraft", () => {
+  it("returns false for an empty session", () => {
+    expect(hasDraft("s-1")).toBe(false);
+  });
+
+  it("returns true once a non-empty draft is written", () => {
+    setDraft("s-1", "x");
+    expect(hasDraft("s-1")).toBe(true);
+  });
+
+  it("returns false after clearing a draft", () => {
+    setDraft("s-1", "x");
+    setDraft("s-1", "");
+    expect(hasDraft("s-1")).toBe(false);
+  });
+
+  it("returns false when localStorage throws", () => {
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    expect(hasDraft("s-1")).toBe(false);
+    spy.mockRestore();
+  });
+});
+
+describe("subscribeDrafts pub/sub", () => {
+  it("fires for setDraft writes on the listener's filter set", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    setDraft("s-1", "hello");
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+
+  it("does not fire for sessions outside the filter set", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    setDraft("s-2", "hello");
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("fires for any draft change when filter is null", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, null);
+    setDraft("s-1", "a");
+    setDraft("s-7", "b");
+    expect(cb).toHaveBeenCalledTimes(2);
+    unsub();
+  });
+
+  it("unsubscribe stops further notifications", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, null);
+    unsub();
+    setDraft("s-1", "x");
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("cross-tab storage event for the matching key fires the listener", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "cockpit:draft:s-1",
+        newValue: "x",
+      }),
+    );
+    expect(cb).toHaveBeenCalledTimes(1);
+    unsub();
+  });
+
+  it("cross-tab storage event for an unrelated key is ignored", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "some-other-key",
+        newValue: "x",
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("storage event for a non-filtered session does not fire", () => {
+    const cb = vi.fn();
+    const unsub = subscribeDrafts(cb, new Set(["s-1"]));
+    window.dispatchEvent(
+      new StorageEvent("storage", {
+        key: "cockpit:draft:s-other",
+        newValue: "x",
+      }),
+    );
+    expect(cb).not.toHaveBeenCalled();
+    unsub();
+  });
+
+  it("storage event with null key (whole-storage wipe) fires unconditionally", () => {
+    const cbFiltered = vi.fn();
+    const cbWildcard = vi.fn();
+    const unsub1 = subscribeDrafts(cbFiltered, new Set(["s-1"]));
+    const unsub2 = subscribeDrafts(cbWildcard, null);
+    window.dispatchEvent(
+      new StorageEvent("storage", { key: null, newValue: null }),
+    );
+    expect(cbFiltered).toHaveBeenCalledTimes(1);
+    expect(cbWildcard).toHaveBeenCalledTimes(1);
+    unsub1();
+    unsub2();
+  });
+});

--- a/web/src/lib/cockpitRattle.test.ts
+++ b/web/src/lib/cockpitRattle.test.ts
@@ -1,0 +1,110 @@
+// Spinner verb selection. The verb cycle is purely cosmetic, but
+// pickIndex must be deterministic per seed (otherwise the verb flips
+// every render and reads as a glitch) and stay in-bounds for any
+// pool size including zero.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  chooseVerb,
+  pickIndex,
+  SPINNER_FRAMES,
+  SPINNER_INTERVAL_MS,
+  THINKING_VERBS,
+  VERB_INTERVAL_MS,
+  WORKING_VERBS,
+} from "./cockpitRattle";
+
+describe("pickIndex", () => {
+  it("is deterministic for a fixed seed", () => {
+    const seeds = [0, 1, 17, 42, 99, 1_000_000];
+    for (const s of seeds) {
+      const a = pickIndex(10, s);
+      const b = pickIndex(10, s);
+      expect(a).toBe(b);
+    }
+  });
+
+  it("stays in range [0, len)", () => {
+    for (let s = 0; s < 200; s++) {
+      const r = pickIndex(7, s);
+      expect(r).toBeGreaterThanOrEqual(0);
+      expect(r).toBeLessThan(7);
+    }
+  });
+
+  it("returns 0 for an empty pool without dividing by zero", () => {
+    expect(pickIndex(0, 42)).toBe(0);
+    expect(Number.isNaN(pickIndex(0, 0))).toBe(false);
+  });
+
+  it("handles negative-ish hash output (Math.abs guard)", () => {
+    // The mulberry-ish hash can produce sign-flipped intermediate
+    // values; any seed must yield a non-negative index.
+    for (let s = -10; s <= 10; s++) {
+      const r = pickIndex(5, s);
+      expect(r).toBeGreaterThanOrEqual(0);
+    }
+  });
+});
+
+describe("chooseVerb", () => {
+  it("appends … and picks from WORKING_VERBS in the working state", () => {
+    const out = chooseVerb("working", 7);
+    expect(out.endsWith("…")).toBe(true);
+    const verb = out.slice(0, -1);
+    expect(WORKING_VERBS).toContain(verb);
+  });
+
+  it("picks from THINKING_VERBS in the thinking state", () => {
+    const out = chooseVerb("thinking", 7);
+    expect(out.endsWith("…")).toBe(true);
+    const verb = out.slice(0, -1);
+    expect(THINKING_VERBS).toContain(verb);
+  });
+
+  it("formats tool state as '<verb> <toolName>…' when toolName is set", () => {
+    const out = chooseVerb("tool", 3, "Bash");
+    expect(out.endsWith("…")).toBe(true);
+    expect(out.endsWith(" Bash…")).toBe(true);
+  });
+
+  it("falls back to WORKING_VERBS when state=tool but toolName is null", () => {
+    const out = chooseVerb("tool", 1, null);
+    expect(out.endsWith("…")).toBe(true);
+    expect(WORKING_VERBS).toContain(out.slice(0, -1));
+  });
+
+  it("falls back to WORKING_VERBS when state=tool but toolName is empty", () => {
+    const out = chooseVerb("tool", 1, "");
+    expect(out.endsWith("…")).toBe(true);
+    expect(WORKING_VERBS).toContain(out.slice(0, -1));
+  });
+
+  it("returns the same label for the same (state, seed, toolName)", () => {
+    expect(chooseVerb("working", 42)).toBe(chooseVerb("working", 42));
+    expect(chooseVerb("thinking", 42)).toBe(chooseVerb("thinking", 42));
+    expect(chooseVerb("tool", 42, "Read")).toBe(
+      chooseVerb("tool", 42, "Read"),
+    );
+  });
+});
+
+describe("constants", () => {
+  it("SPINNER_FRAMES is 10 single-codepoint frames", () => {
+    expect(SPINNER_FRAMES).toHaveLength(10);
+    for (const frame of SPINNER_FRAMES) {
+      // Each braille glyph is a single codepoint above U+FFFF? No,
+      // they sit in the BMP at U+28xx, so .length === 1 is correct.
+      expect(frame).toHaveLength(1);
+    }
+  });
+
+  it("SPINNER_INTERVAL_MS is a positive number", () => {
+    expect(SPINNER_INTERVAL_MS).toBeGreaterThan(0);
+  });
+
+  it("VERB_INTERVAL_MS is well above SPINNER_INTERVAL_MS", () => {
+    expect(VERB_INTERVAL_MS).toBeGreaterThan(SPINNER_INTERVAL_MS * 10);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -416,6 +416,13 @@
       "components": ["web/src/components/cockpit/ContextPrimerBanner.tsx"]
     },
     {
+      "id": "cockpit.switch-substrate-action",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/cockpit/SwitchSubstrateAction.test.tsx"],
+      "components": ["web/src/components/cockpit/SwitchSubstrateAction.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -409,6 +409,13 @@
       "components": ["web/src/components/cockpit/ToolCards.tsx"]
     },
     {
+      "id": "cockpit.context-primer-banner",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/cockpit/ContextPrimerBanner.test.tsx"],
+      "components": ["web/src/components/cockpit/ContextPrimerBanner.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -395,6 +395,13 @@
       "components": ["web/src/components/cockpit/ApprovalCard.tsx"]
     },
     {
+      "id": "cockpit.markdown",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/cockpit/Markdown.test.tsx"],
+      "components": ["web/src/components/cockpit/Markdown.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -374,6 +374,20 @@
       "components": ["web/src/components/cockpit/useFilesIndex.ts"]
     },
     {
+      "id": "cockpit.rattle",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/cockpitRattle.test.ts"],
+      "components": ["web/src/lib/cockpitRattle.ts"]
+    },
+    {
+      "id": "cockpit.args",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/cockpitArgs.test.ts"],
+      "components": ["web/src/lib/cockpitArgs.ts"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -423,6 +423,13 @@
       "components": ["web/src/components/cockpit/SwitchSubstrateAction.tsx"]
     },
     {
+      "id": "cockpit.tool-error-body",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/cockpit/ToolErrorBody.test.tsx"],
+      "components": ["web/src/components/cockpit/ToolErrorBody.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -360,6 +360,20 @@
       "components": []
     },
     {
+      "id": "cockpit.drafts",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/cockpitDrafts.test.ts"],
+      "components": ["web/src/lib/cockpitDrafts.ts"]
+    },
+    {
+      "id": "cockpit.files-index",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/components/cockpit/useFilesIndex.test.tsx"],
+      "components": ["web/src/components/cockpit/useFilesIndex.ts"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -388,6 +388,13 @@
       "components": ["web/src/lib/cockpitArgs.ts"]
     },
     {
+      "id": "cockpit.approval-card",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/cockpit/ApprovalCard.test.tsx"],
+      "components": ["web/src/components/cockpit/ApprovalCard.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -402,6 +402,13 @@
       "components": ["web/src/components/cockpit/Markdown.tsx"]
     },
     {
+      "id": "cockpit.tool-cards",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/cockpit/ToolCards.render.test.tsx"],
+      "components": ["web/src/components/cockpit/ToolCards.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds Vitest unit coverage for ten cockpit modules previously sitting at zero unit coverage. All eight issues are part of the #986 cockpit coverage program. The new specs all live alongside their source under `web/src/`, the matrix is updated, and the validator passes.

The eight specs:

- `cockpitDrafts.test.ts` (32 tests with `useFilesIndex.test.tsx`): localStorage round-trip, listener filter sets, cross-tab `storage` events, fan-out on whole-storage wipe (#1341).
- `useFilesIndex.test.tsx`: `fuzzyFilter` ordering (prefix > substring, label > description, length tiebreak, cap) and the hook lifecycle (loading flag, refetch on `sessionId` change, fetch failure, unmount safety) (#1341).
- `cockpitRattle.test.ts` + `cockpitArgs.test.ts` (29 tests): pickIndex determinism + in-range, verb dispatch by state, JSON parser rejects arrays / scalars / truncated input, `pickStr` + `pickFirst` edge cases (#1340).
- `ApprovalCard.test.tsx` (12 tests): destructive vs benign chrome, Allow / Always / Deny → `ApprovalDecision` routing, args rendering with `_aoe_*` keys filtered, 800ms long-press gate (#1333).
- `Markdown.test.tsx` (14 tests): mocks the upstream `MarkdownTextPrimitive` and pins wrapper config (remark-gfm, custom components map), then exercises the custom Blockquote (`⚠️` warning variant), TableWithScroll, and CodeHeader (copy button) directly. Upstream sanitization is delegated to the primitive and not exercised (#1334).
- `ToolCards.render.test.tsx` + `__fixtures__/toolCalls.ts` (14 tests): per-kind dispatch through the public `<ToolCard>` (bash, read, edit vs write, delete, search, fetch, generic), status pill on err vs ok, profile-gated branches (todos, skill, schedule under claude), MCP card with humanized server name (#1335).
- `ContextPrimerBanner.test.tsx` (11 tests): null available → hidden, Insert routes onInsertPrimer + onDismiss, null response / empty primer / network error → inline alert, AbortError swallowed, resetSeq change clears transient error (#1336).
- `SwitchSubstrateAction.test.tsx` (14 tests): label flip by current substrate, ACP-disabled hint, offline disable, confirm dialog (cancel + Escape close without fetch), per-direction endpoint (`/cockpit/enable` vs `/cockpit/disable`), URL-encoded session id, server error + HTTP status fallback + network rejection (#1337).
- `ToolErrorBody.test.tsx` (11 tests): running / ok render children verbatim, err renders the wrapper-stripped body + chip, collapsed attempted-action details, empty fallback, raw error without wrapper, custom wrapper passes through as the chip, linebreak preservation (#1338).

Total: 9 new specs, 1 shared fixture file, 10 new entries in `web/tests/coverage-matrix.json`. Full Vitest run: 692 tests pass across 69 files.

Closes #1341
Closes #1340
Closes #1333
Closes #1334
Closes #1335
Closes #1336
Closes #1337
Closes #1338

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Tests

## How to test

- [ ] `cd web && npm install`
- [ ] `cd web && npm run test:unit` and confirm 692 tests across 69 files pass with no skips.
- [ ] `cd web && node tests/validate-coverage-matrix.mjs` and confirm `Coverage matrix validation passed.`
- [ ] `cd web && npm run test:unit -- src/lib/cockpitDrafts.test.ts src/components/cockpit/useFilesIndex.test.tsx` and confirm both #1341 specs pass.
- [ ] `cd web && npm run test:unit -- src/lib/cockpitRattle.test.ts src/lib/cockpitArgs.test.ts` for #1340.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/ApprovalCard.test.tsx` for #1333.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/Markdown.test.tsx` for #1334.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/ToolCards.render.test.tsx` for #1335.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/ContextPrimerBanner.test.tsx` for #1336.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/SwitchSubstrateAction.test.tsx` for #1337.
- [ ] `cd web && npm run test:unit -- src/components/cockpit/ToolErrorBody.test.tsx` for #1338.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, and per-issue implementation drafted by Claude under my direction. I reviewed each commit, made the per-issue scope calls (e.g. scoping the Markdown spec to the wrapper's contract rather than to the upstream primitive's XSS sanitization, and testing what the ApprovalCard / SwitchSubstrateAction / ContextPrimerBanner actually do rather than the partly-aspirational spec text in the original issues), and ran the validation sweep before opening the PR.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR adds comprehensive Vitest unit test coverage for the cockpit feature in the web module, introducing 9 new test files and 1 shared test fixture module, totaling approximately 1,738 lines of new test code. The tests cover previously untested cockpit modules and update the coverage configuration matrix with 10 new entries.

## New Test Coverage

**Test Files Added (9):**
- **cockpitDrafts.test.ts** – Tests localStorage functionality for cockpit drafts including round-trip persistence, scoping by session, cross-tab storage events, and error handling
- **useFilesIndex.test.tsx** – Tests a custom hook for file listing with fuzzy filtering, loading states, refetch on session change, and unmount safety
- **cockpitArgs.test.ts** – Tests JSON argument parsing and string selection utilities used throughout the cockpit
- **cockpitRattle.test.ts** – Tests utility functions for deterministic index picking and verb selection with various state combinations
- **ApprovalCard.test.tsx** – Tests approval workflow UI including benign actions, destructive mode with 800ms hold-to-allow gestures, and error messaging
- **ContextPrimerBanner.test.tsx** – Tests context-resumption banner including visibility, fetch/dismiss behavior, error alerts, and cross-tab signal handling
- **Markdown.test.tsx** – Tests markdown rendering wrapper with custom components (blockquote warnings, table wrapping, code header with copy)
- **ToolCards.render.test.tsx** – Tests tool card dispatching by kind, status pill updates, profile-gated routing, and MCP server rendering
- **ToolErrorBody.test.tsx** – Tests error body rendering for different tool states (running, ok, error) with collapsible action details and newline preservation

**Shared Fixture Module:**
- **__fixtures__/toolCalls.ts** – Provides helper constructors and a fixture map for creating test `ToolCall` and `ActivityRow` objects across all tool kinds

## Configuration Updates

- **coverage-matrix.json** – Added 10 new coverage entries mapping the new test files to their corresponding implementation modules in the cockpit area

## Impact

- Closes 8 GitHub issues (`#1341`, `#1340`, `#1333`, `#1334`, `#1335`, `#1336`, `#1337`, `#1338`) from the cockpit coverage initiative (`#986`)
- All 692 tests pass across 69 files
- Provides regression protection for critical workflows (approvals, storage, error handling, rendering)
- Establishes test patterns for future cockpit feature development

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->