### PR TITLE
fix(tests/live): poll for cockpit supervisor readiness instead of fixed sleep

### DIFF
--- a/web/tests/helpers/cockpit.ts
+++ b/web/tests/helpers/cockpit.ts
@@ -1,0 +1,42 @@
+import { expect } from "@playwright/test";
+
+/**
+ * Wait for the cockpit supervisor to be ready to accept prompts after a
+ * `POST /api/sessions/<id>/cockpit/enable`.
+ *
+ * `cockpit/enable` is fire-and-forget: it flips the per-session
+ * `cockpit_mode` flag and `tokio::spawn`s the supervisor, returning
+ * before the ACP `initialize` + `session/new` handshake completes.
+ * Sending a `/cockpit/prompt` immediately races that handshake and the
+ * prompt can be lost or queued unpredictably, which surfaces as flaky
+ * test failures (notably `cockpit-approval.spec.ts` and
+ * `cockpit-spawn-prompt.spec.ts` used to do this with a hardcoded
+ * `setTimeout(2_000)` that proved tight under CI load).
+ *
+ * This helper polls the disk-backed replay endpoint until any frame
+ * appears, indicating the supervisor finished its handshake and is
+ * emitting events. After this resolves, sending a prompt is safe.
+ *
+ * Default timeout is 15s; the local happy-path completes in well under
+ * 1s, so 15s only kicks in on contended CI runners.
+ */
+export async function waitForCockpitReady(
+  baseUrl: string,
+  sessionId: string,
+  timeoutMs = 15_000,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        const replay = await fetch(
+          `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+        ).then((r) => r.json());
+        const frames: unknown[] = Array.isArray(replay)
+          ? replay
+          : (replay.frames ?? []);
+        return frames.length;
+      },
+      { timeout: timeoutMs, intervals: [100, 200, 200, 200] },
+    )
+    .toBeGreaterThan(0);
+}

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -13,6 +13,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { waitForCockpitReady } from "../helpers/cockpit";
 
 const APPROVAL_SCRIPT = {
   turns: [
@@ -72,11 +73,10 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`, {
       method: "POST",
     });
-    // Wait for the supervisor to come up before prompting. The spawn is
-    // a `tokio::spawn` inside enable and the ACP handshake races the
-    // prompt unless we wait long enough for `initialize` + `session/new`
-    // to complete. 2s is conservative.
-    await new Promise((r) => setTimeout(r, 2_000));
+    // Wait for the supervisor to finish its ACP handshake before prompting,
+    // by polling replay for any frame. The previous `setTimeout(2_000)` race
+    // proved tight under CI load.
+    await waitForCockpitReady(serve.baseUrl, sessionId);
     await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/web/tests/live/cockpit-spawn-prompt.spec.ts
+++ b/web/tests/live/cockpit-spawn-prompt.spec.ts
@@ -12,6 +12,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { waitForCockpitReady } from "../helpers/cockpit";
 
 base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -37,10 +38,11 @@ base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}
       { method: "POST" },
     );
     expect(enableRes.ok).toBeTruthy();
-    // Wait for the tokio::spawn'd supervisor to come up before prompting.
-    // The ACP handshake (initialize + session/new) needs to complete
-    // before prompts route to the fake agent. 2s is conservative.
-    await new Promise((r) => setTimeout(r, 2_000));
+    // Wait for the tokio::spawn'd supervisor to finish its ACP handshake
+    // (initialize + session/new) before prompting, by polling replay for
+    // any frame. The previous `setTimeout(2_000)` race proved tight under
+    // CI load.
+    await waitForCockpitReady(serve.baseUrl, sessionId);
 
     const promptRes = await fetch(
       `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`,


### PR DESCRIPTION
## Description

`cockpit/enable` is fire-and-forget: it flips the per-session `cockpit_mode` flag and `tokio::spawn`s the supervisor, returning before the ACP `initialize` + `session/new` handshake completes.

Two live specs (`cockpit-approval.spec.ts` and `cockpit-spawn-prompt.spec.ts`) waited for the handshake with a hardcoded `setTimeout(2_000)` and then sent a prompt. Under CI load that 2s budget was tight enough to flake: the prompt would race the handshake, the agent never saw it, and the downstream replay polling loop would time out without finding the expected event. The most recent flake was `cockpit-approval.spec.ts` on main run [26228160605](https://github.com/njbrake/agent-of-empires/actions/runs/26228160605/job/77180762699) (sha `1593ec81`); `cockpit-spawn-prompt.spec.ts` has the same race and same `setTimeout(2_000)`, just hasn't tripped yet.

Replacing the fixed sleep with `waitForCockpitReady(baseUrl, sessionId)`, a small helper that polls the disk-backed replay endpoint until any frame appears (the supervisor's first visible signal of life after the handshake). Default timeout is 15s; the local happy path completes in well under 1s.

This also lets the per-result poll loops in those specs go back to their original 6s budget, since readiness is now guaranteed by the time they start.

Future cockpit specs should import `waitForCockpitReady` from `tests/helpers/cockpit.ts` instead of copying the 2s sleep.

### Diff

- New `web/tests/helpers/cockpit.ts` with `waitForCockpitReady`.
- `cockpit-approval.spec.ts`: `setTimeout(2_000)` → `waitForCockpitReady(...)`.
- `cockpit-spawn-prompt.spec.ts`: same swap.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording. N/A, test-only change.

## AI Usage

- [x] AI was used for drafting/refactoring

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

Note: this PR was drafted by Claude via back-and-forth with @njbrake during a PR review session. After an initial timeout-bump version got the "is there a better fix" pushback, the diff was rewritten to address the root cause (the `setTimeout(2_000)` race) rather than just give the polling loop more headroom.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

What changed

- Tests: Increased the polling budget in web/tests/live/cockpit-approval.spec.ts from 30×200ms (6s) to 75×200ms (15s) when waiting for the server-issued ApprovalRequested nonce.
- Tests: Replaced brittle fixed 2s delays with a new readiness helper in two tests (cockpit-approval.spec.ts and cockpit-spawn-prompt.spec.ts).
- New helper: Added web/tests/helpers/cockpit.ts with waitForCockpitReady(baseUrl, sessionId, timeoutMs?) which polls the disk-backed /api/sessions/<id>/cockpit/replay endpoint until at least one replay frame appears (default timeout 15s).

Benefits

- Reduces CI flakiness caused by slow or contended GitHub runners where the end-to-end sequence (prompt → supervisor/ACP handshake → fake agent permission_request → server materializes ApprovalRequested → disk flush) can exceed the previous 6s budget.
- Avoids race conditions introduced by hardcoded sleeps by waiting for observable supervisor activity before sending prompts.
- Keeps local/fast-path behavior unchanged (local runs finish well under 1s) while still failing quickly on genuine regressions.

Technical details

- cockpit-approval.spec.ts: nonce polling loop changed from 30 to 75 iterations with 200ms sleeps (6s → 15s total). Expect assertion still verifies nonce presence.
- cockpit-spawn-prompt.spec.ts: replaced setTimeout(2000) with await waitForCockpitReady(...) to ensure the cockpit supervisor completed its ACP handshake before prompting.
- helpers/cockpit.ts: exports async function waitForCockpitReady(baseUrl, sessionId, timeoutMs = 15000) that uses Playwright expect.poll to repeatedly fetch the replay endpoint and assert frames.length > 0 with short, increasing intervals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->