### PR TITLE
fix(web/diff,server/csp): restore WASM-compile CSP so Shiki works; defense-in-depth for invisible diff text

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1299,8 +1299,13 @@ async fn http_request_span(
 /// Content-Security-Policy for the dashboard.
 ///
 /// - `default-src 'self'`: deny everything we don't explicitly allow.
-/// - `script-src 'self'`: scripts are bundled by Vite from the same
-///   origin; no inline scripts, no `eval`, no WASM.
+/// - `script-src 'self' 'wasm-unsafe-eval'`: scripts are bundled by
+///   Vite from the same origin; no inline scripts, no `eval`. The
+///   `'wasm-unsafe-eval'` source is the CSP3 opt-in for WebAssembly
+///   compilation; Shiki's Oniguruma regex engine ships as WASM, so
+///   the diff syntax highlighter falls over without it (PR #1275
+///   dropped this when wterm was replaced with xterm.js on the
+///   incorrect premise that nothing else still needed WASM).
 /// - `style-src 'self' 'unsafe-inline'`: React writes to element.style at
 ///   runtime (terminal font-size updates) and Tailwind v4 emits inline
 ///   `<style>` blocks in dev. Blocking inline styles breaks xterm.js's
@@ -1315,7 +1320,7 @@ async fn http_request_span(
 /// - `base-uri 'self'`, `form-action 'self'`, `object-src 'none'`: tighten
 ///   the usual attack surfaces on injection bugs.
 const CSP: &str = "default-src 'self'; \
-    script-src 'self'; \
+    script-src 'self' 'wasm-unsafe-eval'; \
     style-src 'self' 'unsafe-inline'; \
     img-src 'self' data: https://github.com https://avatars.githubusercontent.com; \
     font-src 'self'; \
@@ -2598,7 +2603,7 @@ mod tests {
         // accidentally drops one fails loudly.
         for needle in [
             "default-src 'self'",
-            "script-src 'self'",
+            "script-src 'self' 'wasm-unsafe-eval'",
             "img-src 'self' data: https://github.com https://avatars.githubusercontent.com",
             "connect-src 'self' ws: wss:",
             "frame-ancestors 'none'",

--- a/web/src/components/diff/DiffFileViewer.tsx
+++ b/web/src/components/diff/DiffFileViewer.tsx
@@ -75,7 +75,6 @@ function HunkView({
   hunk,
   hunkIndex,
   lineTokens,
-  highlightPending,
   rangeStart,
   draft,
   cardsByEndRow,
@@ -90,7 +89,6 @@ function HunkView({
   hunk: RichDiffHunk;
   hunkIndex: number;
   lineTokens?: SyntaxToken[][];
-  highlightPending?: boolean;
   rangeStart: RangeStart | null;
   draft: DraftRange | null;
   cardsByEndRow: Map<number, AnchoredComment[]>;
@@ -131,7 +129,6 @@ function HunkView({
             <DiffLine
               line={line}
               tokens={lineTokens?.[i]}
-              highlightPending={highlightPending}
               plusEnabled={plusEnabled}
               plusHunkIndex={hunkIndex}
               plusSide={side ?? undefined}
@@ -231,7 +228,7 @@ export function DiffFileViewer({
     repoName,
     revision,
   );
-  const { tokens: tokenGrid, loading: highlightLoading } = useHighlightedLines(
+  const { tokens: tokenGrid } = useHighlightedLines(
     diff?.hunks ?? [],
     diff?.file.path ?? filePath,
   );
@@ -483,7 +480,6 @@ export function DiffFileViewer({
                 hunk={hunk}
                 hunkIndex={hi}
                 lineTokens={tokenGrid?.[hi]}
-                highlightPending={highlightLoading}
                 rangeStart={rangeStart}
                 draft={draft?.hunkIndex === hi ? draft : null}
                 cardsByEndRow={cardsByHunkRow.get(hi) ?? EMPTY_MAP}

--- a/web/src/components/diff/DiffLine.tsx
+++ b/web/src/components/diff/DiffLine.tsx
@@ -7,8 +7,6 @@ type PlusSide = "old" | "new";
 interface Props {
   line: RichDiffLine;
   tokens?: SyntaxToken[];
-  /** True while Shiki is loading; hides content to avoid a flash of unstyled text. */
-  highlightPending?: boolean;
   /** Hide the per-side line-number gutters. Used inside compact embedded
    *  diffs (e.g. the cockpit Edit card) where snippet line numbers add
    *  more clutter than signal. */
@@ -34,7 +32,6 @@ interface Props {
 function DiffLineImpl({
   line,
   tokens,
-  highlightPending,
   hideLineNumbers,
   plusEnabled,
   plusHunkIndex,
@@ -126,7 +123,7 @@ function DiffLineImpl({
         {prefix}
       </span>
       <span
-        className={`flex-1 font-mono text-[12px] whitespace-pre transition-opacity duration-100${tokens ? "" : ` ${textClass}`}${highlightPending ? " opacity-0" : ""}`}
+        className={`flex-1 font-mono text-[12px] whitespace-pre${tokens ? "" : ` ${textClass}`}`}
       >
         {renderContent()}
       </span>

--- a/web/src/components/diff/StringDiff.tsx
+++ b/web/src/components/diff/StringDiff.tsx
@@ -24,7 +24,7 @@ export function StringDiff({ oldText, newText, filePath }: Props) {
     [oldText, newText],
   );
   const hunks = useMemo(() => [hunk], [hunk]);
-  const { tokens, loading } = useHighlightedLines(hunks, filePath);
+  const { tokens } = useHighlightedLines(hunks, filePath);
 
   if (hunk.lines.length === 0) return null;
 
@@ -37,7 +37,6 @@ export function StringDiff({ oldText, newText, filePath }: Props) {
           key={`${line.old_line_num ?? "_"}-${line.new_line_num ?? "_"}-${i}`}
           line={line}
           tokens={lineTokens?.[i]}
-          highlightPending={loading}
           hideLineNumbers
         />
       ))}

--- a/web/src/components/diff/__tests__/DiffLine.test.tsx
+++ b/web/src/components/diff/__tests__/DiffLine.test.tsx
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+//
+// Regression test for the bug where diff line content was invisible
+// while Shiki was loading (or had silently failed). The previous
+// implementation gated the content span with `opacity-0` until
+// `highlightPending` flipped, which left text invisible forever when
+// the async highlighter rejected. Plain text must render unconditionally;
+// token colors layer on top once tokenization completes.
+
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+import { DiffLine } from "../DiffLine";
+import type { RichDiffLine } from "../../../lib/types";
+
+function row(type: "equal" | "add" | "delete", content: string): RichDiffLine {
+  return {
+    type,
+    old_line_num: type === "add" ? null : 1,
+    new_line_num: type === "delete" ? null : 1,
+    content,
+  };
+}
+
+describe("DiffLine", () => {
+  it("renders raw text when no syntax tokens are provided", () => {
+    const { container } = render(<DiffLine line={row("add", "const x = 42;")} />);
+    expect(container.textContent).toContain("const x = 42;");
+    const spans = container.querySelectorAll("span");
+    for (const span of spans) {
+      expect(span.className).not.toMatch(/\bopacity-0\b/);
+    }
+  });
+
+  it("renders token spans with inline colors when tokens are provided", () => {
+    const tokens = [
+      { content: "const", color: "#f97583" },
+      { content: " x = 42;", color: "#e1e4e8" },
+    ];
+    const { container } = render(
+      <DiffLine line={row("add", "const x = 42;")} tokens={tokens} />,
+    );
+    const colored = container.querySelectorAll("span[style*='color']");
+    expect(colored.length).toBeGreaterThanOrEqual(2);
+    expect(container.textContent).toContain("const x = 42;");
+  });
+});

--- a/web/src/components/diff/__tests__/StringDiff.test.tsx
+++ b/web/src/components/diff/__tests__/StringDiff.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+//
+// Render contract for StringDiff: even with no token grid (the hook is
+// stubbed to return `tokens: null`), the raw old / new text must still
+// surface. Captures the same opacity-0 regression as the DiffLine
+// regression test but exercised through the cockpit Edit-card embed
+// path so a future refactor of StringDiff cannot reintroduce the gate.
+
+import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { StringDiff } from "../StringDiff";
+
+vi.mock("../../../hooks/useHighlightedLines", () => ({
+  useHighlightedLines: () => ({ tokens: null }),
+}));
+
+describe("StringDiff", () => {
+  it("renders both sides of an edit even without syntax tokens", () => {
+    const { container } = render(
+      <StringDiff
+        oldText="const x = 1;\n"
+        newText="const x = 42;\n"
+        filePath="snippet.ts"
+      />,
+    );
+    expect(container.textContent).toContain("const x");
+    expect(container.textContent).toMatch(/42/);
+    for (const span of container.querySelectorAll("span")) {
+      expect(span.className).not.toMatch(/\bopacity-0\b/);
+    }
+  });
+
+  it("returns null for an empty diff", () => {
+    const { container } = render(
+      <StringDiff oldText="" newText="" filePath="snippet.ts" />,
+    );
+    expect(container.textContent).toBe("");
+  });
+});

--- a/web/src/hooks/__tests__/useHighlightedLines.test.tsx
+++ b/web/src/hooks/__tests__/useHighlightedLines.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment jsdom
+//
+// Direct unit tests for the `useHighlightedLines` hook. Mocks
+// `../../lib/highlighter` and `../useShikiTheme` so the hook can run
+// in jsdom without WASM. Covers:
+//
+// - No-language path: `langImportForPath` returns null, the effect
+//   bails before any async work and `tokens` stays null.
+// - Success path: theme + grammar + tokens resolve, state settles
+//   with a grid for every hunk line.
+// - Catch path: ensureThemeLoaded / getHighlighter / langImport /
+//   loadLanguage / codeToTokens reject. The IIFE must catch and
+//   settle state with an empty grid rather than leaving the hook
+//   loading forever (PR #1355 root regression).
+// - Reqid guard: a stale request must not overwrite a newer one.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { RichDiffHunk } from "../../lib/types";
+
+const ensureThemeLoaded = vi.fn();
+const getHighlighter = vi.fn();
+const langImportForPath = vi.fn();
+const useShikiTheme = vi.fn();
+
+vi.mock("../../lib/highlighter", () => ({
+  ensureThemeLoaded: (...args: unknown[]) => ensureThemeLoaded(...args),
+  getHighlighter: () => getHighlighter(),
+  langImportForPath: (path: string) => langImportForPath(path),
+}));
+
+vi.mock("../useShikiTheme", () => ({
+  useShikiTheme: () => useShikiTheme(),
+}));
+
+// Imported AFTER the mocks so it picks up the stubs.
+import { useHighlightedLines } from "../useHighlightedLines";
+
+function hunkOf(content: string): RichDiffHunk {
+  return {
+    old_start: 1,
+    old_lines: 1,
+    new_start: 1,
+    new_lines: 1,
+    lines: [{ type: "equal", old_line_num: 1, new_line_num: 1, content }],
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useHighlightedLines", () => {
+  it("returns tokens=null when the file extension has no grammar", async () => {
+    useShikiTheme.mockReturnValue({ theme: "github-dark", appearance: "dark" });
+    langImportForPath.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useHighlightedLines([hunkOf("some text\n")], "README.unknown"),
+    );
+
+    expect(result.current.tokens).toBeNull();
+    expect(ensureThemeLoaded).not.toHaveBeenCalled();
+    expect(getHighlighter).not.toHaveBeenCalled();
+  });
+
+  it("settles tokens with a grid when shiki resolves", async () => {
+    useShikiTheme.mockReturnValue({ theme: "github-dark", appearance: "dark" });
+    const langModule = { default: [{ name: "tsx" }] };
+    langImportForPath.mockReturnValue(() => Promise.resolve(langModule));
+    ensureThemeLoaded.mockResolvedValue("github-dark");
+    const codeToTokens = vi.fn(() => ({
+      tokens: [[{ content: "x", color: "#abcdef" }]],
+    }));
+    getHighlighter.mockResolvedValue({
+      getLoadedLanguages: () => [],
+      loadLanguage: vi.fn().mockResolvedValue(undefined),
+      codeToTokens,
+    });
+
+    const { result } = renderHook(() =>
+      useHighlightedLines([hunkOf("x\n")], "src/example.tsx"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.tokens).not.toBeNull();
+    });
+    expect(result.current.tokens).toEqual([[[{ content: "x", color: "#abcdef" }]]]);
+    expect(codeToTokens).toHaveBeenCalledWith(
+      "x",
+      expect.objectContaining({ lang: "tsx", theme: "github-dark" }),
+    );
+  });
+
+  it("falls back to empty grid when the highlighter rejects", async () => {
+    useShikiTheme.mockReturnValue({ theme: "github-dark", appearance: "dark" });
+    langImportForPath.mockReturnValue(() => Promise.resolve({ default: [{ name: "tsx" }] }));
+    ensureThemeLoaded.mockResolvedValue("github-dark");
+    // Simulates the real-world CSP WASM block: createHighlighterCore
+    // rejects with a CompileError, so the IIFE must enter the catch
+    // and settle state instead of leaving loading=true forever.
+    getHighlighter.mockRejectedValue(
+      new Error("call to WebAssembly.instantiate() blocked by CSP"),
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { result } = renderHook(() =>
+      useHighlightedLines([hunkOf("x\n")], "src/example.tsx"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.tokens).toEqual([]);
+    });
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+
+  it("treats unknown language registration as success with empty grid", async () => {
+    // A registered grammar without a `name` field would otherwise leave
+    // the hook stuck. The hook should still settle state (empty grid)
+    // so the caller renders raw text.
+    useShikiTheme.mockReturnValue({ theme: "github-dark", appearance: "dark" });
+    langImportForPath.mockReturnValue(() =>
+      Promise.resolve({ default: [{ /* missing name */ patterns: [] }] }),
+    );
+    ensureThemeLoaded.mockResolvedValue("github-dark");
+    getHighlighter.mockResolvedValue({
+      getLoadedLanguages: () => [],
+      loadLanguage: vi.fn().mockResolvedValue(undefined),
+      codeToTokens: vi.fn(),
+    });
+
+    const { result } = renderHook(() =>
+      useHighlightedLines([hunkOf("x\n")], "src/example.tsx"),
+    );
+
+    await waitFor(() => {
+      expect(result.current.tokens).toEqual([]);
+    });
+  });
+
+  it("returns null tokens after filePath switches until the new path settles", async () => {
+    useShikiTheme.mockReturnValue({ theme: "github-dark", appearance: "dark" });
+    langImportForPath.mockReturnValue(() =>
+      Promise.resolve({ default: [{ name: "tsx" }] }),
+    );
+    ensureThemeLoaded.mockResolvedValue("github-dark");
+    getHighlighter.mockResolvedValue({
+      getLoadedLanguages: () => [],
+      loadLanguage: vi.fn().mockResolvedValue(undefined),
+      codeToTokens: vi.fn(() => ({
+        tokens: [[{ content: "x", color: "#222222" }]],
+      })),
+    });
+
+    const { result, rerender } = renderHook(
+      ({ path }: { path: string }) =>
+        useHighlightedLines([hunkOf("x\n")], path),
+      { initialProps: { path: "first.tsx" } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.tokens).not.toBeNull();
+    });
+
+    rerender({ path: "second.tsx" });
+    // First render after the switch: `state.path` still says
+    // `first.tsx`, so tokens reads as null even though state is set.
+    expect(result.current.tokens).toBeNull();
+
+    await waitFor(() => {
+      expect(result.current.tokens).not.toBeNull();
+    });
+  });
+});

--- a/web/src/hooks/useHighlightedLines.ts
+++ b/web/src/hooks/useHighlightedLines.ts
@@ -27,18 +27,21 @@ interface GridState {
 }
 
 export interface HighlightResult {
-  /** Tokenized lines, or null if the language is unrecognised. */
+  /** Tokenized lines, or null if the language is unrecognised or
+   *  highlighting has not arrived yet. Callers must render plain text
+   *  when null; DiffLine handles this automatically by falling back to
+   *  its textClass when no tokens are passed for a row. */
   tokens: TokenGrid | null;
-  /** True while Shiki is loading the grammar and tokenizing. */
-  loading: boolean;
 }
 
 /**
  * Asynchronously syntax-highlights all lines in the given diff hunks.
  *
- * Returns `{ tokens, loading }`. `loading` is true while the grammar is
- * being fetched so the caller can avoid flashing unstyled text. For
- * unrecognised languages, `loading` is always false and `tokens` is null.
+ * Returns `{ tokens }` (null until the grammar loads, null forever for
+ * unrecognised languages). Callers must always render the raw text
+ * regardless of token state; do not gate visibility on highlighting,
+ * since any failure in the async load would otherwise hide content
+ * permanently.
  */
 export function useHighlightedLines(
   hunks: RichDiffHunk[],
@@ -48,8 +51,6 @@ export function useHighlightedLines(
   const requestRef = useRef(0);
   const shiki = useShikiTheme();
 
-  const hasLang = !!langImportForPath(filePath);
-
   useEffect(() => {
     const reqId = ++requestRef.current;
 
@@ -57,70 +58,83 @@ export function useHighlightedLines(
     if (!langImport) return;
 
     (async () => {
-      const resolvedTheme = await ensureThemeLoaded(
-        shiki.theme,
-        shiki.appearance,
-      );
-      const hl = await getHighlighter();
+      try {
+        const resolvedTheme = await ensureThemeLoaded(
+          shiki.theme,
+          shiki.appearance,
+        );
+        const hl = await getHighlighter();
 
-      // Load the grammar if not already registered.
-      const mod = await langImport();
-      const registration = (mod as Record<string, unknown>).default ?? mod;
-      const langs = Array.isArray(registration)
-        ? registration
-        : [registration];
-      for (const lang of langs) {
-        const id = (lang as { name?: string }).name;
-        if (id && !hl.getLoadedLanguages().includes(id)) {
-          await hl.loadLanguage(lang as Parameters<typeof hl.loadLanguage>[0]);
-        }
-      }
-
-      if (reqId !== requestRef.current) return;
-
-      // Determine the language id from the first registration.
-      const langId = (langs[0] as { name?: string }).name;
-      if (!langId) {
-        setState(null);
-        return;
-      }
-
-      const result: TokenGrid = [];
-
-      for (const hunk of hunks) {
-        const hunkTokens: SyntaxToken[][] = [];
-        for (const line of hunk.lines) {
-          const raw = line.content.replace(/\r?\n$/, "");
-          if (!raw) {
-            hunkTokens.push([]);
-            continue;
-          }
-          try {
-            const { tokens } = hl.codeToTokens(raw, {
-              lang: langId,
-              theme: resolvedTheme,
-            });
-            const mapped: SyntaxToken[] = (
-              tokens[0] as ThemedToken[] | undefined
-            )?.map((t) => ({ content: t.content, color: t.color })) ?? [
-              { content: raw },
-            ];
-            hunkTokens.push(mapped);
-          } catch {
-            hunkTokens.push([{ content: raw }]);
+        // Load the grammar if not already registered.
+        const mod = await langImport();
+        const registration = (mod as Record<string, unknown>).default ?? mod;
+        const langs = Array.isArray(registration)
+          ? registration
+          : [registration];
+        for (const lang of langs) {
+          const id = (lang as { name?: string }).name;
+          if (id && !hl.getLoadedLanguages().includes(id)) {
+            await hl.loadLanguage(
+              lang as Parameters<typeof hl.loadLanguage>[0],
+            );
           }
         }
-        result.push(hunkTokens);
-      }
 
-      if (reqId === requestRef.current) {
-        setState({ grid: result, path: filePath });
+        if (reqId !== requestRef.current) return;
+
+        // Determine the language id from the first registration.
+        const langId = (langs[0] as { name?: string }).name;
+        if (!langId) {
+          setState({ grid: [], path: filePath });
+          return;
+        }
+
+        const result: TokenGrid = [];
+
+        for (const hunk of hunks) {
+          const hunkTokens: SyntaxToken[][] = [];
+          for (const line of hunk.lines) {
+            const raw = line.content.replace(/\r?\n$/, "");
+            if (!raw) {
+              hunkTokens.push([]);
+              continue;
+            }
+            try {
+              const { tokens } = hl.codeToTokens(raw, {
+                lang: langId,
+                theme: resolvedTheme,
+              });
+              const mapped: SyntaxToken[] = (
+                tokens[0] as ThemedToken[] | undefined
+              )?.map((t) => ({ content: t.content, color: t.color })) ?? [
+                { content: raw },
+              ];
+              hunkTokens.push(mapped);
+            } catch {
+              hunkTokens.push([{ content: raw }]);
+            }
+          }
+          result.push(hunkTokens);
+        }
+
+        if (reqId === requestRef.current) {
+          setState({ grid: result, path: filePath });
+        }
+      } catch (err) {
+        // Theme load, grammar import, or highlighter init failed.
+        // Settle state with an empty grid so callers stop waiting and
+        // the diff renders unstyled (DiffLine falls back to textClass
+        // when tokens is undefined for a row). Without this, an
+        // unhandled rejection would leave loading=true forever.
+        if (reqId === requestRef.current) {
+          console.error("useHighlightedLines: highlighter failed", err);
+          setState({ grid: [], path: filePath });
+        }
       }
     })();
   }, [hunks, filePath, shiki.theme, shiki.appearance]);
 
   // Only return the grid if it matches the current file path.
   const tokens = state && state.path === filePath ? state.grid : null;
-  // Loading: language is recognised but tokens haven't arrived yet.
-  return { tokens, loading: hasLang && !tokens };
+  return { tokens };
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -270,6 +270,16 @@
       ]
     },
     {
+      "id": "right-panel.diff-line-visibility",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/diff/__tests__/DiffLine.test.tsx"],
+      "components": [
+        "web/src/components/diff/DiffLine.tsx",
+        "web/src/hooks/useHighlightedLines.ts"
+      ]
+    },
+    {
       "id": "devices",
       "kind": "live-playwright",
       "risk": "low",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -273,9 +273,14 @@
       "id": "right-panel.diff-line-visibility",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/diff/__tests__/DiffLine.test.tsx"],
+      "specs": [
+        "src/components/diff/__tests__/DiffLine.test.tsx",
+        "src/components/diff/__tests__/StringDiff.test.tsx",
+        "src/hooks/__tests__/useHighlightedLines.test.tsx"
+      ],
       "components": [
         "web/src/components/diff/DiffLine.tsx",
+        "web/src/components/diff/StringDiff.tsx",
         "web/src/hooks/useHighlightedLines.ts"
       ]
     },

--- a/web/tests/diff-syntax-highlight.spec.ts
+++ b/web/tests/diff-syntax-highlight.spec.ts
@@ -122,6 +122,70 @@ test.describe("Diff syntax highlighting", () => {
     expect(count).toBeGreaterThan(3);
   });
 
+  test("renders diff text even when Shiki dynamic imports fail", async ({
+    page,
+  }) => {
+    // Regression for the case where the content span was rendered with
+    // `opacity-0` until `useHighlightedLines.loading` flipped. The async
+    // IIFE in that hook had no top-level try/catch, so any rejected
+    // dynamic import (grammar or theme module) left the text invisible
+    // forever. Playwright's `toBeVisible` ignores opacity, so we probe
+    // the computed opacity directly. We deliberately block the Shiki
+    // language modules to keep the highlighter pending; the diff text
+    // must still render at opacity 1. See PR #1355.
+    await setupDiffMocks(page);
+    // Block the dynamic imports Shiki uses for language grammars
+    // (`/assets/typescript-*.js`, `/assets/tsx-*.js`, ...). The pre-fix
+    // build kept the content span at opacity 0 forever while the
+    // highlighter promise was unresolved; the fix renders raw text
+    // unconditionally.
+    await page.route(/\/assets\/(typescript|tsx|jsx|javascript)-[^/]+\.js/, (r) =>
+      r.abort(),
+    );
+    await page.goto("/");
+    await openSessionAndWaitForDiffList(page);
+    await page.getByText("example.ts").first().click();
+
+    const diffRoot = page.locator(".leading-\\[1\\.6\\]");
+    await expect(diffRoot).toBeVisible({ timeout: 10000 });
+    // Give the (failing) highlighter promise time to settle.
+    await page.waitForTimeout(1500);
+
+    // Pick the content span on every diff row: the last direct-child
+    // <span> of each row's wrapping div (row > [linenumOld, linenumNew,
+    // prefix, contentSpan]).
+    const probes = await page.evaluate(() => {
+      const rows = Array.from(
+        document.querySelectorAll(".leading-\\[1\\.6\\] > div > div"),
+      );
+      return rows.map((row) => {
+        const directSpans = Array.from(row.children).filter(
+          (c) => c.tagName === "SPAN",
+        );
+        const contentSpan = directSpans[directSpans.length - 1] as
+          | HTMLSpanElement
+          | undefined;
+        if (!contentSpan) return null;
+        const cs = getComputedStyle(contentSpan);
+        return {
+          opacity: cs.opacity,
+          text: contentSpan.textContent ?? "",
+          hasOpacity0Class: contentSpan.className.includes("opacity-0"),
+        };
+      });
+    });
+
+    const contentProbes = probes.filter(
+      (p): p is { opacity: string; text: string; hasOpacity0Class: boolean } =>
+        p !== null && p.text.trim().length > 0,
+    );
+    expect(contentProbes.length).toBeGreaterThan(0);
+    for (const probe of contentProbes) {
+      expect(probe.opacity).toBe("1");
+      expect(probe.hasOpacity0Class).toBe(false);
+    }
+  });
+
   test("preserves diff +/- prefix markers alongside syntax tokens", async ({
     page,
   }) => {


### PR DESCRIPTION
> **Note:** Claude handled the investigation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Diffs in the web dashboard rendered with line numbers, +/- markers, and red/green row tints but no code text. Firefox eventually crashed under repeated diff opens.

**Root cause:** PR #1275 (wterm → xterm.js) dropped `'wasm-unsafe-eval'` from the dashboard's CSP `script-src`, on the (incorrect) premise that swapping the terminal removed the last WASM caller. Shiki's Oniguruma regex engine is also WASM. Every diff render hit:

```
useHighlightedLines: highlighter failed
CompileError: call to WebAssembly.instantiate() blocked by CSP
```

The async IIFE in `useHighlightedLines` had no top-level `try/catch`, so the rejected promise left `loading=true` forever. `DiffLine` then held its content span at `opacity-0` (the FOUC dance keyed on `loading`), leaving the text invisible. Playwright's `toBeVisible` ignores opacity, so the existing `diff-syntax-highlight.spec.ts` happily passed against a fully broken render.

## Fixes (two layers)

1. **`src/server/mod.rs` — restore `'wasm-unsafe-eval'` on `script-src`.** Real root cause. Updates the inline comment + the CSP audit test to reflect that Shiki, not wterm, is now the WASM caller that needs it.
2. **`web/src/components/diff/DiffLine.tsx` + `useHighlightedLines.ts` — defense-in-depth.** Drop the `opacity-0` / `transition-opacity` dance on the content span; always render raw text and let token colors layer on top via inline `style` once tokenization arrives. Wrap the highlighter IIFE in `try/catch` that settles state on failure so future shiki regressions degrade to plain text instead of invisible content. Drop the now-dead `highlightPending` prop from `DiffLine` + callers (`HunkView`, `StringDiff`) and the unused `loading` field from `useHighlightedLines`.

## Tests

- `src/components/diff/__tests__/DiffLine.test.tsx` (Vitest): asserts content renders with no `opacity-0` regardless of token state and that token spans carry inline colors when provided.
- `web/tests/diff-syntax-highlight.spec.ts` (Playwright): new case `renders diff text even when Shiki dynamic imports fail` aborts `/assets/(typescript|tsx|jsx|javascript)-*.js` via `page.route`, then probes `getComputedStyle().opacity` on every diff content span. Captures the regression that `toBeVisible` could not.
  - Pre-fix HEAD (e6eebd60): FAIL `Expected: "1" / Received: "0"`
  - Post-fix HEAD (1be009f8): PASS
- Coverage matrix entry `right-panel.diff-line-visibility` added so CI enforces the new vitest spec.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Testing

- [ ] `cargo fmt && cargo clippy --features serve && cargo test --features serve` — all clean
- [ ] `cd web && npm run build && npx tsc -b`
- [ ] `cd web && npx vitest run src/components/diff/__tests__/DiffLine.test.tsx`
- [ ] `cd web && npx playwright test --config=playwright.config.ts diff-syntax-highlight.spec.ts diff-comments.spec.ts diff-base-override.spec.ts diff-multirepo-tree.spec.ts`
- [ ] `cd web && node tests/validate-coverage-matrix.mjs`
- [ ] `cargo build --features serve`, launch `aoe serve`, open a diff in Firefox and Chrome — colored tokens render, no `CompileError: call to WebAssembly.instantiate()` in the console, no crash.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (Opus 4.7, 1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Investigation + diff + commit / PR prose via back-and-forth. Idea, decisions, and everything non-research/non-prose are mine.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a regression where diff code text became invisible in the UI (line numbers and +/- markers still showed) and could cause Firefox instability. Root causes: the dashboard CSP blocked WebAssembly compilation used by Shiki’s Oniguruma engine, and the highlighting flow could get stuck in a loading state that left line text opacity set to 0.

### What changed (high-level)
- Restored WASM compilation permission in the dashboard Content-Security-Policy (added 'wasm-unsafe-eval' to script-src).
- Removed the opacity-based hide/transition behavior so diff text is always rendered in the DOM.
- Made the highlighting hook resilient: added try/catch and clear failure behavior so failures don’t leave components stuck.
- Removed the highlightPending/loading prop plumbing (no longer passed through HunkView/DiffLine/StringDiff).
- Added tests and coverage to prevent regressions.

### Added / Removed / Moved
- Added: Vitest unit tests for DiffLine, StringDiff, and useHighlightedLines; a Playwright regression test that aborts Shiki imports and verifies visible text; coverage-matrix entry for diff-line visibility.
- Removed: opacity-0/transition-opacity gating and the highlightPending/loading field/prop surface.
- Updated: server CSP header and its audit test to allow WASM; useHighlightedLines hook behavior and contract.

### Benefits
- Users always see diff text even if syntax highlighting fails.
- More robust error handling prevents visual corruption and lingering loading states.
- Restoring WASM support allows Shiki to function correctly when available.
- Regression tests and coverage reduce the chance of recurrence.

### Technical notes (concise)
- DiffLine now always renders raw text; when token data exists, colored spans are layered via inline color styles.
- useHighlightedLines returns tokens (TokenGrid | null) and no longer exposes loading; it catches errors, logs failures, and settles with an empty grid on error or unknown language.
- CSP change: script-src now includes 'self' 'wasm-unsafe-eval' to permit WebAssembly.instantiate() required by Shiki’s Oniguruma.
- Tests: Vitest assertions ensure content spans are not opacity-0 and token spans carry inline colors; Playwright asserts computed opacity === "1" when Shiki imports are aborted.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->