### PR TITLE
fix(tui): stop screen flash on Ctrl+x and drop favorite/archive toasts

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -971,6 +971,11 @@ impl App {
             // open so it doesn't fire during dialog input. On next launch
             // the startup check runs again and the bar reappears if the
             // update is still available.
+            //
+            // No `needs_redraw = true` here: that forces a `terminal.clear()`
+            // before the next event arrives, so the whole screen blanks for
+            // a beat (visible flash). Ratatui's diff renderer handles the
+            // 1-row layout shrink on the next normal draw.
             (KeyCode::Char('x'), KeyModifiers::CONTROL)
                 if (self.update_info.is_some() || self.update_status.is_some())
                     && !self.home.has_dialog() =>
@@ -978,7 +983,6 @@ impl App {
                 self.update_info = None;
                 self.update_status = None;
                 self.update_bar_dismissed = true;
-                self.needs_redraw = true;
                 return Ok(());
             }
             _ => {}

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -831,16 +831,16 @@ impl HomeView {
             // leading `* ` glyph. Favorite survives an unsnooze (positive
             // care-more signal) but archive clears it (mutex in
             // `Instance::archive()`).
-            KeyCode::Char('f') if !self.strict_hotkeys => match self.toggle_favorite_at_cursor() {
-                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
-                Ok(None) => {}
-                Err(e) => tracing::error!("toggle_favorite_at_cursor failed: {}", e),
-            },
-            KeyCode::Char('F') if self.strict_hotkeys => match self.toggle_favorite_at_cursor() {
-                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
-                Ok(None) => {}
-                Err(e) => tracing::error!("toggle_favorite_at_cursor failed: {}", e),
-            },
+            KeyCode::Char('f') if !self.strict_hotkeys => {
+                if let Err(e) = self.toggle_favorite_at_cursor() {
+                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
+                }
+            }
+            KeyCode::Char('F') if self.strict_hotkeys => {
+                if let Err(e) = self.toggle_favorite_at_cursor() {
+                    tracing::error!("toggle_favorite_at_cursor failed: {}", e);
+                }
+            }
             // `z` / `Z`: toggle archive on the cursor's session. Archive is
             // the "park this, I'm done with it" sink. The row drops to tier
             // 99 in the Attention sort, the spinner stops, and the agent
@@ -849,16 +849,16 @@ impl HomeView {
             // pane stays gone). Mnemonic: Zzz / archive box. Distinct from
             // `h`/`H` snooze (temporary, auto wakes) and separate from `d`/`D`
             // (destructive delete, unchanged).
-            KeyCode::Char('z') if !self.strict_hotkeys => match self.toggle_archive_at_cursor() {
-                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
-                Ok(None) => {}
-                Err(e) => tracing::error!("toggle_archive_at_cursor failed: {}", e),
-            },
-            KeyCode::Char('Z') if self.strict_hotkeys => match self.toggle_archive_at_cursor() {
-                Ok(Some(msg)) => return Some(Action::SetTransientStatus(msg)),
-                Ok(None) => {}
-                Err(e) => tracing::error!("toggle_archive_at_cursor failed: {}", e),
-            },
+            KeyCode::Char('z') if !self.strict_hotkeys => {
+                if let Err(e) = self.toggle_archive_at_cursor() {
+                    tracing::error!("toggle_archive_at_cursor failed: {}", e);
+                }
+            }
+            KeyCode::Char('Z') if self.strict_hotkeys => {
+                if let Err(e) = self.toggle_archive_at_cursor() {
+                    tracing::error!("toggle_archive_at_cursor failed: {}", e);
+                }
+            }
             KeyCode::Char('?') => {
                 self.show_help = true;
             }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -762,27 +762,22 @@ impl HomeView {
     /// but archiving clears it because archive is the strongest dismiss
     /// signal and a stale star on a buried row is just visual noise.
     /// Mutual exclusion lives in `Instance::archive()`, not here.
-    pub(super) fn toggle_favorite_at_cursor(&mut self) -> anyhow::Result<Option<String>> {
+    pub(super) fn toggle_favorite_at_cursor(&mut self) -> anyhow::Result<()> {
         let Some(id) = self.selected_session.clone() else {
-            return Ok(None);
+            return Ok(());
         };
-        let (is_fav, title) = {
-            let inst = self.instances.iter().find(|i| i.id == id);
-            match inst {
-                Some(i) => (i.is_favorited(), i.title.clone()),
-                None => return Ok(None),
-            }
+        let is_fav = match self.instances.iter().find(|i| i.id == id) {
+            Some(i) => i.is_favorited(),
+            None => return Ok(()),
         };
         if is_fav {
             self.mutate_instance(&id, |inst| inst.unfavorite());
-            self.save()?;
-            self.flat_items = self.build_flat_items();
-            return Ok(Some(format!("Unfavorited: {}", title)));
+        } else {
+            self.mutate_instance(&id, |inst| inst.favorite());
         }
-        self.mutate_instance(&id, |inst| inst.favorite());
         self.save()?;
         self.flat_items = self.build_flat_items();
-        Ok(Some(format!("Favorited: {}", title)))
+        Ok(())
     }
 
     /// Handle the archive keybind on the cursor's session. Symmetric toggle:
@@ -796,16 +791,13 @@ impl HomeView {
     /// indefinite, so there's nothing to ask the user before sinking the
     /// row. The session reappears at its real tier on unarchive or when
     /// the user sends a message (auto unarchive in `Instance::message_sent`).
-    pub(super) fn toggle_archive_at_cursor(&mut self) -> anyhow::Result<Option<String>> {
+    pub(super) fn toggle_archive_at_cursor(&mut self) -> anyhow::Result<()> {
         let Some(id) = self.selected_session.clone() else {
-            return Ok(None);
+            return Ok(());
         };
-        let (is_archived, title) = {
-            let inst = self.instances.iter().find(|i| i.id == id);
-            match inst {
-                Some(i) => (i.is_archived(), i.title.clone()),
-                None => return Ok(None),
-            }
+        let is_archived = match self.instances.iter().find(|i| i.id == id) {
+            Some(i) => i.is_archived(),
+            None => return Ok(()),
         };
         if is_archived {
             self.mutate_instance(&id, |inst| inst.unarchive());
@@ -816,7 +808,7 @@ impl HomeView {
             // tier, so without this the cursor stays at the old index and
             // ends up on whatever row slid into that slot.
             self.select_session_by_id(&id);
-            return Ok(Some(format!("Unarchived: {}", title)));
+            return Ok(());
         }
 
         // Kill the pane before flipping the archived bit. If the kill fails
@@ -834,6 +826,6 @@ impl HomeView {
         if self.sort_order == crate::session::config::SortOrder::Attention {
             self.select_top_attention(None);
         }
-        Ok(Some(format!("Archived: {}", title)))
+        Ok(())
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3480,9 +3480,9 @@ fn footer_hides_attention_workflow_hints_outside_attention_sort() {
     );
 }
 
-/// `toggle_favorite_at_cursor` flips the cursor's instance favorited state,
-/// persists the change, returns a toast message, and returns Ok(None) when
-/// nothing is selected.
+/// `toggle_favorite_at_cursor` flips the cursor's instance favorited state
+/// and persists the change. No toast: the row's visual treatment (bold +
+/// leading `* ` glyph) is the feedback.
 #[test]
 #[serial]
 fn toggle_favorite_at_cursor_round_trip() {
@@ -3493,37 +3493,25 @@ fn toggle_favorite_at_cursor_round_trip() {
     // Initial state: not favorited.
     assert!(!env.view.instances[0].is_favorited());
 
-    let fav_msg = env.view.toggle_favorite_at_cursor().unwrap();
+    env.view.toggle_favorite_at_cursor().unwrap();
     assert!(env.view.instances[0].is_favorited());
-    assert!(
-        fav_msg.as_deref().unwrap_or("").starts_with("Favorited: "),
-        "expected 'Favorited: ...' toast, got {fav_msg:?}",
-    );
 
-    let unfav_msg = env.view.toggle_favorite_at_cursor().unwrap();
+    env.view.toggle_favorite_at_cursor().unwrap();
     assert!(!env.view.instances[0].is_favorited());
-    assert!(
-        unfav_msg
-            .as_deref()
-            .unwrap_or("")
-            .starts_with("Unfavorited: "),
-        "expected 'Unfavorited: ...' toast, got {unfav_msg:?}",
-    );
 }
 
-/// When no session is selected, the toggle is a no-op and returns Ok(None).
+/// When no session is selected, the toggle is a silent no-op.
 #[test]
 #[serial]
-fn toggle_favorite_at_cursor_returns_none_with_no_selection() {
+fn toggle_favorite_at_cursor_noop_with_no_selection() {
     let mut env = create_test_env_empty();
     env.view.selected_session = None;
-    let msg = env.view.toggle_favorite_at_cursor().unwrap();
-    assert!(msg.is_none(), "expected None when nothing is selected");
+    env.view.toggle_favorite_at_cursor().unwrap();
 }
 
-/// `toggle_archive_at_cursor` flips the cursor's instance archived state,
-/// persists the change, returns a toast message, and returns Ok(None) when
-/// nothing is selected.
+/// `toggle_archive_at_cursor` flips the cursor's instance archived state
+/// and persists the change. No toast: the row sinks to tier 99 and that
+/// visible reordering is the feedback.
 #[test]
 #[serial]
 fn toggle_archive_at_cursor_round_trip() {
@@ -3534,35 +3522,20 @@ fn toggle_archive_at_cursor_round_trip() {
     // Initial state: not archived.
     assert!(!env.view.instances[0].is_archived());
 
-    let archived_msg = env.view.toggle_archive_at_cursor().unwrap();
+    env.view.toggle_archive_at_cursor().unwrap();
     assert!(env.view.instances[0].is_archived());
-    assert!(
-        archived_msg
-            .as_deref()
-            .unwrap_or("")
-            .starts_with("Archived: "),
-        "expected 'Archived: ...' toast, got {archived_msg:?}",
-    );
 
-    let unarchived_msg = env.view.toggle_archive_at_cursor().unwrap();
+    env.view.toggle_archive_at_cursor().unwrap();
     assert!(!env.view.instances[0].is_archived());
-    assert!(
-        unarchived_msg
-            .as_deref()
-            .unwrap_or("")
-            .starts_with("Unarchived: "),
-        "expected 'Unarchived: ...' toast, got {unarchived_msg:?}",
-    );
 }
 
-/// When no session is selected, the toggle is a no-op and returns Ok(None).
+/// When no session is selected, the toggle is a silent no-op.
 #[test]
 #[serial]
-fn toggle_archive_at_cursor_returns_none_with_no_selection() {
+fn toggle_archive_at_cursor_noop_with_no_selection() {
     let mut env = create_test_env_empty();
     env.view.selected_session = None;
-    let msg = env.view.toggle_archive_at_cursor().unwrap();
-    assert!(msg.is_none(), "expected None when nothing is selected");
+    env.view.toggle_archive_at_cursor().unwrap();
 }
 
 /// `restart_selected_session` must drop the press silently when nothing is


### PR DESCRIPTION
## Description

Two small TUI fixes around the footer toast bar.

**1. Ctrl+x flash.** Dismissing the footer (update bar / transient toast)
with Ctrl+x was setting \`needs_redraw = true\`, which forces a
\`terminal.clear()\` at the top of the next event-loop iteration *before*
the next event arrives. The screen blanked for a beat (visible flash)
until something woke the loop and drew a new frame. Ratatui's diff
renderer handles the 1-row layout shrink fine on the next normal draw,
so the flag was overkill. Drop it.

**2. No toast for favorite/archive.** \`f\` / \`F\` and \`z\` / \`Z\`
were emitting an \`Action::SetTransientStatus(\"Favorited: ...\")\` /
\`\"Archived: ...\"\` into the same dismissible footer slot used for
real errors. The row's visible change is already the feedback (star
glyph for favorite, sink to tier 99 for archive). Drop the toast so
there's nothing for the user to dismiss for a routine toggle.

\`toggle_favorite_at_cursor\` and \`toggle_archive_at_cursor\` no longer
return the unused \`Option<String>\` message; tests updated to match.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Reasoning and behavior call were the author's; Claude located the offending lines, made the edits, and updated tests.

- [ ] I am an AI Agent filling out this form (check box if true)

## Test plan

- [x] \`cargo fmt --check\`, \`cargo clippy\`, \`cargo build --profile dev-release\` clean
- [x] \`cargo test --lib tui::home::\` (199 passed, including the 4 updated toggle tests)
- [ ] Manual: press \`f\`/\`z\` on a row; no footer toast appears. Trigger a real error (e.g. failed restart) so the toast shows, then press Ctrl+x; bar disappears with no full-screen flash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR addresses two UI/UX issues in the Terminal User Interface (TUI):

1. **Screen flash on Ctrl+x**: Removed the unnecessary forced redraw when dismissing the status/update bar with Ctrl+x. The ratatui diff renderer now handles the layout change naturally on the next draw cycle, eliminating the visible flash.

2. **Unnecessary toast notifications**: Removed transient "Favorited" and "Archived" confirmation messages for the `f`/`F` and `z`/`Z` toggle hotkeys. The visual feedback from the item state change (star icon, item rank) is sufficient user feedback.

## What Changed

**Removed:**
- `needs_redraw = true` flag from the Ctrl+x dismiss handler
- `Option<String>` return types from `toggle_favorite_at_cursor()` and `toggle_archive_at_cursor()`
- Toast message emission (`Action::SetTransientStatus`) for favorite and archive operations
- Associated message construction logic in both toggle functions

**Updated:**
- Function signatures for `toggle_favorite_at_cursor()` and `toggle_archive_at_cursor()` now return `Result<()>` instead of `Result<Option<String>>`
- Hotkey handlers for f/F and z/Z now simply execute the toggle without branching on return values
- Test suite to validate the silent-toggle behavior and verify state changes still occur

**Files Modified:**
- `src/tui/app.rs` – Ctrl+x handler
- `src/tui/home/input.rs` – Favorite and archive hotkey dispatch
- `src/tui/home/operations.rs` – Toggle function implementations
- `src/tui/home/tests.rs` – Toggle tests

## Benefits

- **Smoother UX**: No more distracting full-screen flash when closing the status bar
- **Cleaner interaction**: Users no longer need to dismiss a toast after routine item toggles
- **Simpler API**: Functions no longer carry unused return values for status messages
- **Reduced cognitive load**: Immediate visual feedback (state changes) replaces confirmation messages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1369?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->