### PR TITLE
chore(dev): drop clippy from cargo-husky pre-commit, keep fmt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,7 @@
 - `cargo build --features serve`: includes the web dashboard (needs Node.js + npm).
 - `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.
+- Pre-commit hook (auto-installed by `cargo-husky` during `cargo build`) runs `cargo fmt -- --check` only. Clippy is enforced in CI (`.github/workflows/ci.yml`), not on every commit, to keep `git commit` fast. If you have an older clone with a stale hook that still runs clippy, run `cargo build` once to regenerate `.git/hooks/pre-commit`, or delete the file and let the next build re-create it.
 - Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
 - Running from source needs `tmux` installed.
 - Debug builds use an isolated namespace so they don't collide with an installed release `aoe`: app data dir is `~/.agent-of-empires-dev` (macOS/Windows) or `~/.config/agent-of-empires-dev` (Linux), tmux session prefix is `aoe_dev_`, and `aoe serve` defaults to port `8081`. Release builds keep the original `agent-of-empires` paths, `aoe_` prefix, and port `8080`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,6 @@
 - `cargo build --features serve`: includes the web dashboard (needs Node.js + npm).
 - `cargo test`: unit + integration tests (some skip if `tmux` unavailable).
 - `cargo fmt` + `cargo clippy`: run before pushing; fix clippy warnings unless there's a strong reason not to.
-- Pre-commit hook (auto-installed by `cargo-husky` during `cargo build`) runs `cargo fmt -- --check` only. Clippy is enforced in CI (`.github/workflows/ci.yml`), not on every commit, to keep `git commit` fast. If you have an older clone with a stale hook that still runs clippy, run `cargo build` once to regenerate `.git/hooks/pre-commit`, or delete the file and let the next build re-create it.
 - Debug logging: `AGENT_OF_EMPIRES_DEBUG=1 cargo run` (writes `debug.log` in app data dir).
 - Running from source needs `tmux` installed.
 - Debug builds use an isolated namespace so they don't collide with an installed release `aoe`: app data dir is `~/.agent-of-empires-dev` (macOS/Windows) or `~/.config/agent-of-empires-dev` (Linux), tmux session prefix is `aoe_dev_`, and `aoe serve` defaults to port `8081`. Release builds keep the original `agent-of-empires` paths, `aoe_` prefix, and port `8080`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ serve = [
 
 [dev-dependencies]
 serial_test = "3.4"
-cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt", "run-cargo-clippy"] }
+cargo-husky = { version = "1", default-features = false, features = ["precommit-hook", "run-cargo-fmt"] }
 # Test-only axum dep, used by the update e2e fixture server that serves
 # a fake release tarball. The runtime code uses reqwest, not axum.
 axum = { version = "0.8", features = ["ws"] }


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

The `cargo-husky` pre-commit hook was running a full `cargo clippy -- -D warnings` on every commit, which is slow (1 to 3 minutes cold, 5 to 30 seconds warm) and duplicates the same check that CI already enforces in `.github/workflows/ci.yml`. In agent-driven commit flows the cost is worse, because the default Bash tool timeout is 2 minutes; the agent observes an empty result, assumes the commit failed, retries, and stacks more clippy invocations behind each other. Concrete sessions today (`04eb6f85640c4a0e`, `6294bcd8e3be4ba7`, `1a7cbb803b074a67`) each spent 5 to 10 minutes per commit, mostly on `Monitor` and `ps` probes trying to figure out whether the commit landed.

This PR implements option A from #1370: drop `run-cargo-clippy` from the cargo-husky features in `Cargo.toml`, keep `run-cargo-fmt`. `cargo fmt --check` runs in roughly a second and is the one local check fast enough to pay for itself on every commit; clippy stays in CI where it already lives.

Existing clones will keep their stale `.git/hooks/pre-commit` until `cargo build` next runs (cargo-husky writes the hook from its `build.rs`). `AGENTS.md` now documents this so devs hitting slow commits know the one-time fix.

Closes #1370

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

- [ ] On a clone that has built the project at least once on this branch, inspect `.git/hooks/pre-commit` (or `$(git rev-parse --git-common-dir)/hooks/pre-commit` from a worktree) and confirm it only runs `cargo fmt -- --check`, with no `cargo clippy` line.
- [ ] Make a trivial edit and run `git commit -m "test"`. Observe that the hook finishes in roughly a second (fmt-only) instead of the prior minutes-long clippy compile.
- [ ] Introduce a `cargo fmt` violation (e.g. extra spaces) and confirm the hook still rejects the commit.
- [ ] Confirm CI on this PR still runs both `cargo fmt --all -- --check` and `cargo clippy -- -D warnings` per `.github/workflows/ci.yml:21,35`.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and diff drafted by Claude under my direction. I chose option A from the issue, reviewed the change, and own the design call.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes the slow `cargo clippy` pre-commit hook while keeping the faster `cargo fmt` check.

### What Changed

- **Removed**: The `run-cargo-clippy` feature from the `cargo-husky` dev-dependency in `Cargo.toml`
- **Kept**: The `precommit-hook` and `run-cargo-fmt` features, so `cargo fmt` validation still runs on commit
- **Added**: Documentation updates in `AGENTS.md` to guide existing developers about the change

### Benefits

**Performance**: Pre-commit checks now run in ~1 second instead of 1–3 minutes (or 5–30 seconds on warm builds), eliminating long commit latency and retry loops that affect automated agent workflows.

**Reduced duplication**: Clippy enforcement moves entirely to CI (which already runs it), avoiding redundant checks locally. Developers still get fast formatting feedback from `cargo fmt` to catch style issues immediately.

**Minimal disruption**: The change is backward-compatible for existing clones (stale hooks remain until `cargo build` regenerates them) with clear guidance provided in the documentation.

### Technical Details

The `cargo-husky` configuration now only includes `features = ["precommit-hook", "run-cargo-fmt"]` instead of `["precommit-hook", "run-cargo-clippy", "run-cargo-fmt"]`. This removes the generated pre-commit hook's execution of `cargo clippy -- -D warnings`, leaving only `cargo fmt -- --check`. CI workflows continue to enforce both clippy and fmt, so code quality standards are maintained.

Closes `#1370`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->