### PR TITLE
feat(hooks): expose session env vars to lifecycle hooks

### DIFF
--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -65,9 +65,11 @@ Example: use a sibling CLI to track session directories.
 
 ```toml
 [hooks]
-on_create = ["port $AOE_SESSION_TITLE"]
-on_destroy = ["port rm $AOE_SESSION_TITLE"]
+on_create = ["port \"$AOE_SESSION_TITLE\""]
+on_destroy = ["port rm \"$AOE_SESSION_TITLE\""]
 ```
+
+Quote any expansion that may contain spaces; titles often do, and the values are passed as-is to the shell.
 
 Container hooks receive the same variables (forwarded via `docker exec -e`). Inside `on_create` and `on_launch` the hook's working directory is already `$AOE_PROJECT_PATH`, so `$PWD` works too.
 

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -55,7 +55,7 @@ Lifecycle hooks (`on_create`, `on_launch`, `on_destroy`) get session metadata as
 | --- | --- |
 | `AOE_SESSION_ID` | Stable session identifier (e.g. `s_abc123`). |
 | `AOE_SESSION_TITLE` | The session title (also used as the worktree branch name). |
-| `AOE_PROJECT_PATH` | Absolute path to the session's working directory (worktree path when applicable). |
+| `AOE_PROJECT_PATH` | Absolute path to the session's working directory (worktree path when applicable). Equal to `$PWD` inside `on_create` / `on_launch`. |
 | `AOE_PROFILE` | The resolved profile name. |
 | `AOE_TOOL` | The agent tool name (e.g. `claude`, `codex`). |
 | `AOE_GROUP_PATH` | Group path for grouped sessions; empty string otherwise. |

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -47,6 +47,32 @@ on_launch = "npm install"
 
 For sandboxed sessions, hooks run inside the Docker container.
 
+#### Available environment variables
+
+Lifecycle hooks (`on_create`, `on_launch`, `on_destroy`) get session metadata as environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `AOE_SESSION_ID` | Stable session identifier (e.g. `s_abc123`). |
+| `AOE_SESSION_TITLE` | The session title (also used as the worktree branch name). |
+| `AOE_PROJECT_PATH` | Absolute path to the session's working directory (worktree path when applicable). |
+| `AOE_PROFILE` | The resolved profile name. |
+| `AOE_TOOL` | The agent tool name (e.g. `claude`, `codex`). |
+| `AOE_GROUP_PATH` | Group path for grouped sessions; empty string otherwise. |
+| `AOE_SESSION_BRANCH` | The git branch name. Only set when the session has a worktree. |
+
+Example: use a sibling CLI to track session directories.
+
+```toml
+[hooks]
+on_create = ["port $AOE_SESSION_TITLE"]
+on_destroy = ["port rm $AOE_SESSION_TITLE"]
+```
+
+Container hooks receive the same variables (forwarded via `docker exec -e`). Inside `on_create` and `on_launch` the hook's working directory is already `$AOE_PROJECT_PATH`, so `$PWD` works too.
+
+The same naming is used for the status-transition hooks configured in `[status_hooks]`; those add `AOE_OLD_STATUS`, `AOE_NEW_STATUS`, and `AOE_STATUS_CHANGED_AT` on top.
+
 ### Session
 
 ```toml

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -590,7 +590,8 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         if let Some(hooks) = resolved_hooks {
             if !hooks.on_create.is_empty() {
                 println!("Running on_create hooks...");
-                repo_config::execute_hooks(&hooks.on_create, &path)?;
+                let hook_env = repo_config::lifecycle_env_vars(&instance);
+                repo_config::execute_hooks(&hooks.on_create, &path, &hook_env)?;
                 println!("✓ on_create hooks completed");
             }
         }

--- a/src/cockpit/sandbox.rs
+++ b/src/cockpit/sandbox.rs
@@ -65,7 +65,7 @@ pub async fn ensure_container_for_session(
     // and create the container, both of which can take many seconds;
     // running it here keeps the tokio worker free for other requests.
     let session_id_owned = session_id.to_string();
-    let (sandbox_info, container_workdir, hooks) =
+    let (sandbox_info, container_workdir, hooks, hook_env) =
         tokio::task::spawn_blocking(move || -> Result<_> {
             let _container = instance_clone
                 .get_container_for_instance()
@@ -77,7 +77,8 @@ pub async fn ensure_container_for_session(
             } else {
                 None
             };
-            Ok((instance_clone.sandbox_info.clone(), workdir, hooks))
+            let env = crate::session::repo_config::lifecycle_env_vars(&instance_clone);
+            Ok((instance_clone.sandbox_info.clone(), workdir, hooks, env))
         })
         .await
         .context("docker ensure task failed to join")??;
@@ -111,6 +112,7 @@ pub async fn ensure_container_for_session(
                     &container_name,
                     &workdir,
                     true,
+                    &hook_env,
                 )
             })
             .await

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -371,6 +371,7 @@ fn run_on_destroy_hooks(instance: &Instance, detach: bool) {
     tracing::info!(target: "session.delete", "Running on_destroy hooks for session {}", instance.id);
 
     let is_sandboxed = instance.sandbox_info.as_ref().is_some_and(|s| s.enabled);
+    let hook_env = repo_config::lifecycle_env_vars(instance);
 
     // The caller controls detachment: TUI/web pass detach=true to avoid
     // corrupting the rendered UI (see issue #901); CLI passes detach=false
@@ -383,12 +384,18 @@ fn run_on_destroy_hooks(instance: &Instance, detach: bool) {
                 &sandbox.container_name,
                 &workdir,
                 detach,
+                &hook_env,
             )
         } else {
             vec![]
         }
     } else {
-        repo_config::execute_hooks_best_effort(&resolved_on_destroy, project_path, detach)
+        repo_config::execute_hooks_best_effort(
+            &resolved_on_destroy,
+            project_path,
+            detach,
+            &hook_env,
+        )
     };
 
     if !errors.is_empty() {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1277,12 +1277,14 @@ impl Instance {
         let cmd = if self.is_sandboxed() {
             let container = self.get_container_for_instance()?;
             if let Some(ref hook_cmds) = on_launch_hooks {
+                let hook_env = super::repo_config::lifecycle_env_vars(self);
                 if let Some(ref sandbox) = self.sandbox_info {
                     let workdir = self.container_workdir();
                     if let Err(e) = super::repo_config::execute_hooks_in_container(
                         hook_cmds,
                         &sandbox.container_name,
                         &workdir,
+                        &hook_env,
                     ) {
                         tracing::warn!(target: "session.store", "on_launch hook failed in container: {}", e);
                     }
@@ -1468,9 +1470,12 @@ impl Instance {
     ) -> Option<String> {
         // Run on_launch hooks on host for non-sandboxed sessions
         if let Some(ref hook_cmds) = on_launch_hooks {
-            if let Err(e) =
-                super::repo_config::execute_hooks(hook_cmds, Path::new(&self.project_path))
-            {
+            let hook_env = super::repo_config::lifecycle_env_vars(self);
+            if let Err(e) = super::repo_config::execute_hooks(
+                hook_cmds,
+                Path::new(&self.project_path),
+                &hook_env,
+            ) {
                 tracing::warn!(target: "session.store", "on_launch hook failed: {}", e);
             }
         }

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -1679,15 +1679,21 @@ mod tests {
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
             .collect();
-        let joined = args.join(" ");
+        // Assert directly against the argv vector so a value with spaces ("My
+        // Title") must be a single argument; a substring match on the joined
+        // string would pass even if the value were split across two args.
+        let has_pair = |k: &str, v: &str| -> bool {
+            args.windows(2)
+                .any(|w| w[0] == "-e" && w[1] == format!("{}={}", k, v))
+        };
         assert!(
-            joined.contains("-e AOE_SESSION_ID=s_abc"),
-            "expected -e AOE_SESSION_ID=s_abc in args, got: {:?}",
+            has_pair("AOE_SESSION_ID", "s_abc"),
+            "expected (-e, AOE_SESSION_ID=s_abc) pair in argv, got: {:?}",
             args
         );
         assert!(
-            joined.contains("-e AOE_SESSION_TITLE=My Title"),
-            "expected -e AOE_SESSION_TITLE=My Title in args, got: {:?}",
+            has_pair("AOE_SESSION_TITLE", "My Title"),
+            "expected (-e, AOE_SESSION_TITLE=My Title) pair as single argv element, got: {:?}",
             args
         );
     }

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -576,10 +576,16 @@ const PROMPT_SUPPRESS_ENV: &[(&str, &str)] = &[
 
 /// Build a `Command` for running a hook. Local hooks use the user's `$SHELL`;
 /// container hooks use `bash` since the user shell may not be installed.
+///
+/// `extra_env` carries session metadata (see [`lifecycle_env_vars`]) that
+/// scripts can read via `$AOE_SESSION_ID`, `$AOE_PROJECT_PATH`, etc. For
+/// container hooks these are re-emitted as `docker exec -e KEY=VALUE` since
+/// host env vars don't propagate into `docker exec` by default.
 fn build_hook_command(
     cmd: &str,
     target: &HookTarget,
     opts: HookSpawnOpts,
+    extra_env: &[(&'static str, String)],
 ) -> std::process::Command {
     let shell_cmd = if opts.merge_stderr {
         format!("{} 2>&1", cmd)
@@ -592,6 +598,9 @@ fn build_hook_command(
             let shell = super::environment::user_shell();
             let mut command = std::process::Command::new(shell);
             command.arg("-c").arg(shell_cmd).current_dir(project_path);
+            for (k, v) in extra_env {
+                command.env(k, v);
+            }
             command
         }
         HookTarget::Container {
@@ -603,6 +612,9 @@ fn build_hook_command(
             command.arg("exec").arg("--workdir").arg(workdir);
             // For container hooks, env vars on the `docker exec` parent do not
             // propagate inside the container; inject them via `-e` instead.
+            for (k, v) in extra_env {
+                command.arg("-e").arg(format!("{}={}", k, v));
+            }
             if opts.detach_tty {
                 for (k, v) in PROMPT_SUPPRESS_ENV {
                     command.arg("-e").arg(format!("{}={}", k, v));
@@ -649,6 +661,27 @@ fn build_hook_command(
     command
 }
 
+/// Env vars exposed to lifecycle hooks (`on_create`, `on_launch`, `on_destroy`).
+///
+/// Mirrors the naming in [`crate::status_hooks::StatusHookContext::env_vars`]
+/// so a single vocabulary covers both hook surfaces. `AOE_SESSION_BRANCH` is
+/// only present when the session has a worktree; other fields may be empty
+/// strings (e.g., `AOE_GROUP_PATH` for ungrouped sessions).
+pub(crate) fn lifecycle_env_vars(instance: &super::Instance) -> Vec<(&'static str, String)> {
+    let mut env = vec![
+        ("AOE_SESSION_ID", instance.id.clone()),
+        ("AOE_SESSION_TITLE", instance.title.clone()),
+        ("AOE_PROJECT_PATH", instance.project_path.clone()),
+        ("AOE_PROFILE", instance.effective_profile()),
+        ("AOE_TOOL", instance.tool.clone()),
+        ("AOE_GROUP_PATH", instance.group_path.clone()),
+    ];
+    if let Some(wt) = instance.worktree_info.as_ref() {
+        env.push(("AOE_SESSION_BRANCH", wt.branch.clone()));
+    }
+    env
+}
+
 /// Format a hook failure error message from captured output.
 fn format_hook_error(
     cmd: &str,
@@ -678,12 +711,16 @@ fn format_hook_error(
 }
 
 /// Run hook commands with captured output (non-streamed).
-fn run_hooks_captured(commands: &[String], target: &HookTarget) -> Result<()> {
+fn run_hooks_captured(
+    commands: &[String],
+    target: &HookTarget,
+    extra_env: &[(&'static str, String)],
+) -> Result<()> {
     let in_container = matches!(target, HookTarget::Container { .. });
 
     for cmd in commands {
         tracing::info!(target: "session.store", "Running hook: {}", cmd);
-        let mut command = build_hook_command(cmd, target, HookSpawnOpts::default());
+        let mut command = build_hook_command(cmd, target, HookSpawnOpts::default(), extra_env);
         let output = command
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
@@ -717,6 +754,7 @@ fn run_hooks_streamed(
     commands: &[String],
     target: &HookTarget,
     progress_tx: &mpsc::Sender<HookProgress>,
+    extra_env: &[(&'static str, String)],
 ) -> Result<()> {
     use std::io::BufRead;
 
@@ -733,6 +771,7 @@ fn run_hooks_streamed(
                 merge_stderr: true,
                 detach_tty: true,
             },
+            extra_env,
         );
         let mut child = command
             .stdout(std::process::Stdio::piped())
@@ -760,8 +799,16 @@ fn run_hooks_streamed(
 }
 
 /// Execute a list of hook commands in the given directory.
-pub fn execute_hooks(commands: &[String], project_path: &Path) -> Result<()> {
-    run_hooks_captured(commands, &HookTarget::Local { project_path })
+///
+/// `extra_env` is exported to each hook process; see [`lifecycle_env_vars`]
+/// for the canonical set of session env vars. Pass `&[]` if no session context
+/// is available.
+pub fn execute_hooks(
+    commands: &[String],
+    project_path: &Path,
+    extra_env: &[(&'static str, String)],
+) -> Result<()> {
+    run_hooks_captured(commands, &HookTarget::Local { project_path }, extra_env)
 }
 
 /// Execute hooks inside a Docker container.
@@ -769,6 +816,7 @@ pub fn execute_hooks_in_container(
     commands: &[String],
     container_name: &str,
     workdir: &str,
+    extra_env: &[(&'static str, String)],
 ) -> Result<()> {
     run_hooks_captured(
         commands,
@@ -776,6 +824,7 @@ pub fn execute_hooks_in_container(
             container_name,
             workdir,
         },
+        extra_env,
     )
 }
 
@@ -790,6 +839,7 @@ fn run_hooks_best_effort(
     commands: &[String],
     target: &HookTarget,
     detach_tty: bool,
+    extra_env: &[(&'static str, String)],
 ) -> Vec<String> {
     let in_container = matches!(target, HookTarget::Container { .. });
     let mut errors = Vec::new();
@@ -803,6 +853,7 @@ fn run_hooks_best_effort(
                 merge_stderr: false,
                 detach_tty,
             },
+            extra_env,
         );
         match command
             .stdout(std::process::Stdio::piped())
@@ -850,8 +901,14 @@ pub fn execute_hooks_best_effort(
     commands: &[String],
     project_path: &Path,
     detach_tty: bool,
+    extra_env: &[(&'static str, String)],
 ) -> Vec<String> {
-    run_hooks_best_effort(commands, &HookTarget::Local { project_path }, detach_tty)
+    run_hooks_best_effort(
+        commands,
+        &HookTarget::Local { project_path },
+        detach_tty,
+        extra_env,
+    )
 }
 
 /// Execute hooks in a container with best-effort semantics (all commands attempted).
@@ -864,6 +921,7 @@ pub fn execute_hooks_in_container_best_effort(
     container_name: &str,
     workdir: &str,
     detach_tty: bool,
+    extra_env: &[(&'static str, String)],
 ) -> Vec<String> {
     run_hooks_best_effort(
         commands,
@@ -872,6 +930,7 @@ pub fn execute_hooks_in_container_best_effort(
             workdir,
         },
         detach_tty,
+        extra_env,
     )
 }
 
@@ -880,8 +939,14 @@ pub fn execute_hooks_streamed(
     commands: &[String],
     project_path: &Path,
     progress_tx: &mpsc::Sender<HookProgress>,
+    extra_env: &[(&'static str, String)],
 ) -> Result<()> {
-    run_hooks_streamed(commands, &HookTarget::Local { project_path }, progress_tx)
+    run_hooks_streamed(
+        commands,
+        &HookTarget::Local { project_path },
+        progress_tx,
+        extra_env,
+    )
 }
 
 /// Execute hooks inside a Docker container with streamed output.
@@ -890,6 +955,7 @@ pub fn execute_hooks_in_container_streamed(
     container_name: &str,
     workdir: &str,
     progress_tx: &mpsc::Sender<HookProgress>,
+    extra_env: &[(&'static str, String)],
 ) -> Result<()> {
     run_hooks_streamed(
         commands,
@@ -898,6 +964,7 @@ pub fn execute_hooks_in_container_streamed(
             workdir,
         },
         progress_tx,
+        extra_env,
     )
 }
 
@@ -1286,6 +1353,7 @@ mod tests {
             &["echo test".to_string()],
             "nonexistent_container",
             "/workspace/myproject",
+            &[],
         );
         // Should fail because docker/container doesn't exist, but should not panic
         assert!(result.is_err());
@@ -1339,7 +1407,7 @@ mod tests {
             echo "SSH_ASKPASS=${SSH_ASKPASS:-unset}"
         "#;
         let (tx, rx) = mpsc::channel();
-        execute_hooks_streamed(&[probe.to_string()], tmp.path(), &tx).unwrap();
+        execute_hooks_streamed(&[probe.to_string()], tmp.path(), &tx, &[]).unwrap();
         drop(tx);
 
         let lines: Vec<String> = rx
@@ -1381,7 +1449,7 @@ mod tests {
     fn captured_hook_does_not_force_git_env() {
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
-        execute_hooks(&[probe.to_string()], tmp.path()).unwrap();
+        execute_hooks(&[probe.to_string()], tmp.path(), &[]).unwrap();
         let out = std::fs::read_to_string(tmp.path().join("out.txt")).unwrap();
         assert!(
             !out.contains("GIT_TERMINAL_PROMPT=0"),
@@ -1407,6 +1475,7 @@ mod tests {
                 merge_stderr: true,
                 detach_tty: true,
             },
+            &[],
         );
         let args: Vec<String> = detached
             .get_args()
@@ -1429,7 +1498,8 @@ mod tests {
             args
         );
 
-        let attached = build_hook_command("rm -rf /work/build", &target, HookSpawnOpts::default());
+        let attached =
+            build_hook_command("rm -rf /work/build", &target, HookSpawnOpts::default(), &[]);
         let attached_args: Vec<String> = attached
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())
@@ -1448,7 +1518,7 @@ mod tests {
     fn best_effort_hook_detaches_when_requested() {
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
-        let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), true);
+        let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), true, &[]);
         assert!(
             errors.is_empty(),
             "hook should succeed, errors: {:?}",
@@ -1466,7 +1536,7 @@ mod tests {
     fn best_effort_hook_attached_for_cli() {
         let tmp = tempfile::tempdir().unwrap();
         let probe = "echo \"GIT_TERMINAL_PROMPT=${GIT_TERMINAL_PROMPT:-unset}\" > out.txt";
-        let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), false);
+        let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), false, &[]);
         assert!(
             errors.is_empty(),
             "hook should succeed, errors: {:?}",
@@ -1477,6 +1547,148 @@ mod tests {
             !out.contains("GIT_TERMINAL_PROMPT=0"),
             "CLI best-effort path must not force GIT_TERMINAL_PROMPT, got: {}",
             out
+        );
+    }
+
+    /// `lifecycle_env_vars` is the contract advertised to hook authors in
+    /// docs/guides/repo-config.md. Keys (and conditional inclusion of
+    /// `AOE_SESSION_BRANCH`) must stay stable; pin the shape here so changes
+    /// have to update both the helper and the docs in lockstep.
+    #[test]
+    fn lifecycle_env_vars_shape() {
+        use super::super::instance::WorktreeInfo;
+        use crate::session::Instance;
+
+        let mut instance = Instance::new("My Session", "/tmp/proj");
+        instance.tool = "claude".to_string();
+        instance.group_path = "backend/api".to_string();
+        instance.source_profile = "work".to_string();
+
+        let env: std::collections::HashMap<_, _> =
+            lifecycle_env_vars(&instance).into_iter().collect();
+
+        assert_eq!(
+            env.get("AOE_SESSION_ID").map(String::as_str),
+            Some(instance.id.as_str())
+        );
+        assert_eq!(
+            env.get("AOE_SESSION_TITLE").map(String::as_str),
+            Some("My Session")
+        );
+        assert_eq!(
+            env.get("AOE_PROJECT_PATH").map(String::as_str),
+            Some("/tmp/proj")
+        );
+        assert_eq!(env.get("AOE_TOOL").map(String::as_str), Some("claude"));
+        assert_eq!(
+            env.get("AOE_GROUP_PATH").map(String::as_str),
+            Some("backend/api")
+        );
+        assert!(env.contains_key("AOE_PROFILE"));
+        assert!(
+            !env.contains_key("AOE_SESSION_BRANCH"),
+            "branch should be omitted when no worktree is attached"
+        );
+
+        instance.worktree_info = Some(WorktreeInfo {
+            branch: "feature/auth".to_string(),
+            main_repo_path: "/tmp/proj".to_string(),
+            managed_by_aoe: true,
+            created_at: chrono::Utc::now(),
+            base_branch: None,
+        });
+        let env_with_branch: std::collections::HashMap<_, _> =
+            lifecycle_env_vars(&instance).into_iter().collect();
+        assert_eq!(
+            env_with_branch
+                .get("AOE_SESSION_BRANCH")
+                .map(String::as_str),
+            Some("feature/auth")
+        );
+    }
+
+    /// End-to-end check that session env vars actually reach the hook process:
+    /// run a real local hook that echoes its env into a file, then read it
+    /// back. Covers the captured (`execute_hooks`), streamed
+    /// (`execute_hooks_streamed`), and best-effort (`execute_hooks_best_effort`)
+    /// paths so a regression in any one of them fails this test.
+    #[test]
+    fn local_hooks_see_session_env_vars() {
+        use crate::session::Instance;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let mut instance = Instance::new("My Title", tmp.path().to_str().unwrap());
+        instance.tool = "codex".to_string();
+        instance.source_profile = "work".to_string();
+        let env = lifecycle_env_vars(&instance);
+
+        let probe = r#"
+            echo "ID=${AOE_SESSION_ID}" > env.txt
+            echo "TITLE=${AOE_SESSION_TITLE}" >> env.txt
+            echo "PATH=${AOE_PROJECT_PATH}" >> env.txt
+            echo "TOOL=${AOE_TOOL}" >> env.txt
+        "#;
+
+        execute_hooks(&[probe.to_string()], tmp.path(), &env).unwrap();
+        let out = std::fs::read_to_string(tmp.path().join("env.txt")).unwrap();
+        assert!(
+            out.contains(&format!("ID={}", instance.id)),
+            "captured: {}",
+            out
+        );
+        assert!(out.contains("TITLE=My Title"), "captured: {}", out);
+        assert!(out.contains("TOOL=codex"), "captured: {}", out);
+
+        std::fs::remove_file(tmp.path().join("env.txt")).unwrap();
+        let errors = execute_hooks_best_effort(&[probe.to_string()], tmp.path(), false, &env);
+        assert!(errors.is_empty(), "best-effort errors: {:?}", errors);
+        let out = std::fs::read_to_string(tmp.path().join("env.txt")).unwrap();
+        assert!(
+            out.contains(&format!("ID={}", instance.id)),
+            "best-effort: {}",
+            out
+        );
+
+        std::fs::remove_file(tmp.path().join("env.txt")).unwrap();
+        let (tx, _rx) = mpsc::channel();
+        execute_hooks_streamed(&[probe.to_string()], tmp.path(), &tx, &env).unwrap();
+        drop(tx);
+        let out = std::fs::read_to_string(tmp.path().join("env.txt")).unwrap();
+        assert!(
+            out.contains(&format!("ID={}", instance.id)),
+            "streamed: {}",
+            out
+        );
+    }
+
+    /// Container hooks must forward session env via `docker exec -e KEY=VALUE`
+    /// since host env doesn't propagate into `docker exec`. Structural check
+    /// against the constructed argv (CI has no docker daemon).
+    #[test]
+    fn container_hook_forwards_session_env_via_dash_e() {
+        let target = HookTarget::Container {
+            container_name: "test_container",
+            workdir: "/work",
+        };
+        let env = vec![
+            ("AOE_SESSION_ID", "s_abc".to_string()),
+            ("AOE_SESSION_TITLE", "My Title".to_string()),
+        ];
+        let cmd = build_hook_command("true", &target, HookSpawnOpts::default(), &env);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        let joined = args.join(" ");
+        assert!(
+            joined.contains("-e AOE_SESSION_ID=s_abc"),
+            "expected -e AOE_SESSION_ID=s_abc in args, got: {:?}",
+            args
+        );
+        assert!(
+            joined.contains("-e AOE_SESSION_TITLE=My Title"),
+            "expected -e AOE_SESSION_TITLE=My Title in args, got: {:?}",
+            args
         );
     }
 }

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -146,6 +146,7 @@ impl CreationPoller {
         let has_on_create = hooks.as_ref().is_some_and(|h| !h.on_create.is_empty());
         let has_on_launch = hooks.as_ref().is_some_and(|h| !h.on_launch.is_empty());
         let mut container_started = false;
+        let hook_env = repo_config::lifecycle_env_vars(&instance);
 
         // Execute on_create hooks after worktree setup, before starting
         if has_on_create {
@@ -170,6 +171,7 @@ impl CreationPoller {
                         &sandbox.container_name,
                         &workdir,
                         progress_tx,
+                        &hook_env,
                     ) {
                         tracing::warn!(target: "session.create", "on_create hook failed in container: {:#}", e);
                         return CreationResult::Error(format!("on_create hook failed: {:#}", e));
@@ -179,6 +181,7 @@ impl CreationPoller {
                 &hooks.on_create,
                 std::path::Path::new(&instance.project_path),
                 progress_tx,
+                &hook_env,
             ) {
                 builder::cleanup_instance(
                     &instance,
@@ -211,6 +214,7 @@ impl CreationPoller {
                             &sandbox.container_name,
                             &workdir,
                             progress_tx,
+                            &hook_env,
                         ) {
                             tracing::warn!(target: "session.create", "on_launch hook failed in container: {}", e);
                         }
@@ -220,6 +224,7 @@ impl CreationPoller {
                 &hooks.on_launch,
                 std::path::Path::new(&instance.project_path),
                 progress_tx,
+                &hook_env,
             ) {
                 tracing::warn!(target: "session.create", "on_launch hook failed: {}", e);
             }

--- a/tests/integration/repo_config.rs
+++ b/tests/integration/repo_config.rs
@@ -113,7 +113,7 @@ fn test_hook_execution_simple_echo() {
     let marker = tmp.path().join("hook_ran");
 
     let cmd = format!("touch {}", marker.display());
-    agent_of_empires::session::repo_config::execute_hooks(&[cmd], tmp.path()).unwrap();
+    agent_of_empires::session::repo_config::execute_hooks(&[cmd], tmp.path(), &[]).unwrap();
 
     assert!(marker.exists());
 }
@@ -121,8 +121,11 @@ fn test_hook_execution_simple_echo() {
 #[test]
 fn test_hook_execution_failure() {
     let tmp = TempDir::new().unwrap();
-    let result =
-        agent_of_empires::session::repo_config::execute_hooks(&["exit 1".to_string()], tmp.path());
+    let result = agent_of_empires::session::repo_config::execute_hooks(
+        &["exit 1".to_string()],
+        tmp.path(),
+        &[],
+    );
     assert!(result.is_err());
 }
 


### PR DESCRIPTION
## Description

Fixes #1347.

Lifecycle hooks (`on_create`, `on_launch`, `on_destroy`) now run with session metadata injected as environment variables, so a hook script can read `$AOE_SESSION_ID`, `$AOE_SESSION_TITLE`, etc. Issue #1347 asked for this to let CLIs like [`port`](https://github.com/jdtzmn/port) cooperate with aoe via:

```toml
[hooks]
on_create = ["port $AOE_SESSION_TITLE"]
on_destroy = ["port rm $AOE_SESSION_TITLE"]
```

### Vars exposed

| Variable | Value |
| --- | --- |
| `AOE_SESSION_ID` | Stable session identifier. |
| `AOE_SESSION_TITLE` | The session title (also the worktree branch name on worktree sessions). |
| `AOE_PROJECT_PATH` | Absolute path to the session's working directory. |
| `AOE_PROFILE` | The resolved profile name. |
| `AOE_TOOL` | The agent tool name. |
| `AOE_GROUP_PATH` | Group path; empty string for ungrouped sessions. |
| `AOE_SESSION_BRANCH` | Git branch name. Present only when the session has a worktree. |

### Naming note for @jdtzmn

The issue asked for `AOE_SESSION_NAME`, `AOE_SESSION_SLUG`, and `AOE_SESSION_DIRECTORY`. I reused the names already established by the status-transition hook surface in `src/status_hooks.rs` (`AOE_SESSION_TITLE`, `AOE_PROJECT_PATH`, etc.) so a single vocabulary covers both hook types. `AOE_SESSION_BRANCH` covers what the issue called "slug" for worktree sessions. Happy to add aliases under the original names if that's a strong preference.

### Implementation

The change threads an `extra_env: &[(&'static str, String)]` parameter through the single hook-execution chokepoint at `build_hook_command` in `src/session/repo_config.rs`, plus the three `run_hooks_*` helpers and all six public entry points. For container hooks the vars are forwarded as `docker exec -e KEY=VALUE` since host env doesn't propagate into `docker exec` by default. A new `pub(crate) fn lifecycle_env_vars(&Instance)` near the hook code mirrors `StatusHookContext::env_vars()`; status hooks add `AOE_OLD_STATUS`, `AOE_NEW_STATUS`, `AOE_STATUS_CHANGED_AT` on top of the same base set.

Six callsites compute the env from the in-hand `Instance` and pass it through: `tui/creation_poller.rs` (on_create + on_launch), `cockpit/sandbox.rs` (cockpit on_launch), `session/deletion.rs` (on_destroy), `session/instance.rs` (tmux-path on_launch, local + container), and `cli/add.rs` (CLI on_create).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` (1911 unit + 67 e2e + 116 integration passed, 0 failed)
- [x] `cargo build --features serve` clean (touches `src/cockpit/sandbox.rs`)
- [x] New unit tests cover: `lifecycle_env_vars` shape (including the worktree-conditional branch var), end-to-end env injection through all three local execution paths (`execute_hooks`, `execute_hooks_best_effort`, `execute_hooks_streamed`), and structural verification that container hooks emit `-e AOE_SESSION_ID=...` args.
- [ ] Manual smoke: try a real `on_create = ["env | grep AOE_ > /tmp/aoe-hook.txt"]` on a fresh worktree session.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Claude drafted the implementation and prose via back-and-forth with @njbrake. The naming and design decisions (matching status-hook naming, putting the helper next to the execution chokepoint, exposing `AOE_SESSION_BRANCH` for the worktree case) were @njbrake's calls.

- [x] I am an AI Agent filling out this form

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR exposes session metadata to lifecycle hooks (on_create, on_launch, on_destroy), fulfilling issue `#1347`. Hook scripts can now access stable AOE_* environment variables at runtime instead of relying on hardcoded values.

## What changed

Added
- New env vars for lifecycle hooks: AOE_SESSION_ID, AOE_SESSION_TITLE, AOE_PROJECT_PATH, AOE_PROFILE, AOE_TOOL, AOE_GROUP_PATH, and AOE_SESSION_BRANCH (only for worktree sessions).
- Helper: lifecycle_env_vars(instance) to build the canonical AOE_* set.
- Documentation: docs/guides/repo-config.md documents available variables, examples, and notes about container forwarding and quoting.
- Tests: unit/integration/e2e coverage for env shape, local injection, and container forwarding.

Modified
- Threaded an extra_env: &[(&'static str, String)] through the central hook execution chokepoint and all hook runners.
- Updated function signatures in src/session/repo_config.rs to accept extra_env for local and container variants (streamed, best-effort, direct).
- Updated call sites to compute/pass the lifecycle env: cli/add.rs, cockpit/sandbox.rs, session/deletion.rs, session/instance.rs, tui/creation_poller.rs, and test call sites.
- Container hooks now receive vars via docker exec -e KEY=VALUE; host hooks use Command::env.

Removed
- No behavioral removals; hook selection/trust logic unchanged.

## Benefits

- Enables session-aware hook scripts (e.g., external tooling that needs session ID/title/path).
- Consistent naming with existing status hooks and uniform behavior across host and container execution.
- Low-risk integration: only hook execution surfaces extended; core logic and policies unchanged.

## Technical notes (concise)

- lifecycle_env_vars mirrors StatusHookContext::env_vars and conditionally includes AOE_SESSION_BRANCH when the session uses a worktree.
- build_hook_command in src/session/repo_config.rs accepts extra_env and injects pairs into spawned processes (Command::env) or into docker exec via -e KEY=VALUE.
- Six public hook-runner signatures changed to accept extra_env; tests updated accordingly.
- Automated checks passed (fmt, clippy, unit/e2e/integration, build with serve); one manual smoke check remains unchecked.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1372?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->