### PR TITLE
fix(cockpit): rebase session cost on /clear and /compact boundaries

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -728,6 +728,18 @@ Query init and does not rotate it when conversation context is reset,
 so the cached list stays authoritative for the lifetime of the
 cockpit's underlying agent process. See #1128.
 
+The session cost figure in the composer footer reads "since the most
+recent `/clear` (or `/compact`)" rather than session-lifetime
+cumulative. `claude-agent-acp` keeps reporting its cumulative cost
+across the ACP session's whole lifetime (the adapter does not rotate
+the ACP session id on `/clear`), so the cockpit captures the
+cumulative at each boundary and subtracts it from incoming
+`UsageUpdate` frames. Switching backends (`AgentSwitched`) or starting
+a fresh ACP session (`SessionContextReset`) clears the baseline, since
+the new backend reports its own cumulative starting at zero. The
+`used` / context-window figures stay raw because the adapter already
+reflects the post-boundary context size on its side. See #1354.
+
 ### "Force end turn" button under the spinner
 
 If the agent finished a turn but the cockpit's working spinner is

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -847,6 +847,289 @@ describe("applyEvent / ConversationCompacted", () => {
   });
 });
 
+describe("applyEvent / usageBaseline (#1354)", () => {
+  // /clear and /compact do not rotate the underlying ACP session, so
+  // claude-agent-acp keeps reporting session-lifetime cumulative cost
+  // via UsageUpdate. The reducer captures a baseline at each boundary
+  // and subtracts it from incoming UsageUpdate.cost so the composer
+  // footer reads "since the most recent boundary."
+  it("SessionCleared captures the cumulative cost as the baseline", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.42, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.42, 6);
+    expect(state.usageBaseline).toBeNull();
+
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.sessionUsage).toBeNull();
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.42, 6);
+  });
+
+  it("UsageUpdated after /clear subtracts the baseline from cumulative cost", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.42, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 5_000,
+            size: 200_000,
+            cost: { amount: 0.49, currency: "USD" },
+          },
+        },
+      },
+    });
+    // Cost is delta since clear; `used` and `size` flow through raw
+    // (the agent already reports post-clear context size).
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.07, 6);
+    expect(state.sessionUsage?.cost?.currency).toBe("USD");
+    expect(state.sessionUsage?.used).toBe(5_000);
+    expect(state.sessionUsage?.size).toBe(200_000);
+  });
+
+  it("/clear with no prior usage leaves the next UsageUpdate untouched", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "SessionCleared",
+    });
+    expect(state.usageBaseline?.cost).toBe(0);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 1_000,
+            size: 200_000,
+            cost: { amount: 0.05, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.05, 6);
+  });
+
+  it("repeated /clear accumulates the baseline to the true cumulative", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.10, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 4_000,
+            size: 200_000,
+            cost: { amount: 0.15, currency: "USD" },
+          },
+        },
+      },
+    });
+    // Delta since first clear is 0.05.
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.05, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: "SessionCleared",
+    });
+    // Baseline is now the true cumulative (0.15), not the displayed
+    // delta (0.05).
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.15, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 5,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 2_000,
+            size: 200_000,
+            cost: { amount: 0.18, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.03, 6);
+  });
+
+  it("ConversationCompacted captures the baseline the same way as /clear", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 20_000,
+            size: 200_000,
+            cost: { amount: 0.30, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "ConversationCompacted",
+    });
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.30, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 1_000,
+            size: 200_000,
+            cost: { amount: 0.32, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.02, 6);
+  });
+
+  it("AgentSwitched clears the baseline so the new backend starts at zero", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.42, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.42, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        AgentSwitched: { from: "claude", to: "codex", reason: "rate_limited" },
+      },
+    });
+    expect(state.usageBaseline).toBeNull();
+    // The new agent reports its own cumulative starting at zero; no
+    // subtraction should happen.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 500,
+            size: 200_000,
+            cost: { amount: 0.01, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.01, 6);
+  });
+
+  it("SessionContextReset clears the baseline (new ACP session starts at zero)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.20, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.20, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { SessionContextReset: { reason: "session/load failed" } },
+    });
+    expect(state.usageBaseline).toBeNull();
+  });
+
+  it("UsageUpdated with no cost field is a no-op for the baseline", () => {
+    // Codex / opencode / gemini adapters do not currently report cost.
+    // The reducer must not crash and must not invent a cost value.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: "SessionCleared",
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        UsageUpdated: { usage: { used: 100, size: 200_000 } },
+      },
+    });
+    expect(state.sessionUsage?.cost ?? null).toBeNull();
+    expect(state.sessionUsage?.used).toBe(100);
+  });
+});
+
 describe("applyEvent / AgentSwitched", () => {
   // Cockpit hand-off (#1282) moves the session from one ACP backend
   // to another. Reducer must drop everything tied to the prior

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1128,6 +1128,158 @@ describe("applyEvent / usageBaseline (#1354)", () => {
     expect(state.sessionUsage?.cost ?? null).toBeNull();
     expect(state.sessionUsage?.used).toBe(100);
   });
+
+  it("compact after /clear stacks the baseline onto the prior cumulative", () => {
+    // Baseline carries across boundaries: /clear stashes the agent's
+    // cumulative, then /compact must capture the still-cumulative value
+    // (displayed delta plus the existing baseline), not just the
+    // delta-since-clear. Otherwise the second boundary would
+    // under-subtract from subsequent UsageUpdate frames.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.10, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.10, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 5_000,
+            size: 200_000,
+            cost: { amount: 0.15, currency: "USD" },
+          },
+        },
+      },
+    });
+    // Displayed delta after /clear is 0.05.
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.05, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: "ConversationCompacted",
+    });
+    // Baseline at compact must be the true agent cumulative (0.15),
+    // i.e. previous baseline 0.10 plus displayed delta 0.05.
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.15, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 5,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 2_000,
+            size: 200_000,
+            cost: { amount: 0.17, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.02, 6);
+  });
+
+  it("UsageUpdated with baseline set but no incoming cost passes the usage through raw", () => {
+    // Branch coverage: baseline-set + missing cost should hit the else
+    // arm without crashing on the absent cost field, and store the raw
+    // usage so used / size still surface in the footer.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.10, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.usageBaseline?.cost).toBeCloseTo(0.10, 6);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: { usage: { used: 1_000, size: 200_000 } },
+      },
+    });
+    expect(state.sessionUsage?.used).toBe(1_000);
+    expect(state.sessionUsage?.cost ?? null).toBeNull();
+    // Baseline persists across a no-cost frame; the next cost-bearing
+    // frame still subtracts correctly.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 4,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 1_500,
+            size: 200_000,
+            cost: { amount: 0.12, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBeCloseTo(0.02, 6);
+  });
+
+  it("clamps cost to zero if the agent ever reports a smaller cumulative than the baseline", () => {
+    // Defensive: an upstream ACP-session restart could reset the
+    // adapter's cumulative below the captured baseline. The reducer
+    // must clamp at zero rather than display a negative dollar figure.
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 10_000,
+            size: 200_000,
+            cost: { amount: 0.50, currency: "USD" },
+          },
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        UsageUpdated: {
+          usage: {
+            used: 100,
+            size: 200_000,
+            cost: { amount: 0.10, currency: "USD" },
+          },
+        },
+      },
+    });
+    expect(state.sessionUsage?.cost?.amount).toBe(0);
+  });
 });
 
 describe("applyEvent / AgentSwitched", () => {
@@ -1641,6 +1793,35 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
     delete stale.agentOrphaned;
     const normalised = normaliseTurnCounters(stale);
     expect(normalised.agentOrphaned).toBe(false);
+  });
+
+  it("backfills usageBaseline=null on pre-#1354 persisted state", () => {
+    // Simulate a localStorage entry written before #1354: usageBaseline
+    // absent. normaliseTurnCounters must default it to null so the
+    // UsageUpdated reducer arm's `next.usageBaseline && ...` check sees
+    // a well-typed value rather than `undefined`.
+    const stale = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 0,
+      lastStoppedSeq: 0,
+    } as CockpitState & { usageBaseline?: { cost: number } | null };
+    delete stale.usageBaseline;
+    const normalised = normaliseTurnCounters(stale);
+    expect(normalised.usageBaseline).toBeNull();
+  });
+
+  it("preserves a non-null usageBaseline through normaliseTurnCounters", () => {
+    // A session that ran /clear before reload writes a baseline into
+    // localStorage. Hydration must keep it so post-reload UsageUpdate
+    // frames continue subtracting the boundary cumulative.
+    const cached: CockpitState = {
+      ...emptyCockpitState(),
+      pendingUserPromptSeq: 3,
+      lastStoppedSeq: 3,
+      usageBaseline: { cost: 0.42 },
+    };
+    const normalised = normaliseTurnCounters(cached);
+    expect(normalised.usageBaseline?.cost).toBeCloseTo(0.42, 6);
   });
 
   it("clears agentOrphaned on restart_pending", () => {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -197,6 +197,18 @@ export interface CockpitState {
   /** Latest agent-reported context-window usage. Null until the agent
    *  emits its first ACP `UsageUpdate`. */
   sessionUsage: SessionUsage | null;
+  /** Cumulative cost snapshot captured at the most recent context
+   *  boundary (`/clear`, `/compact`). The ACP agent keeps reporting
+   *  session-lifetime cumulative cost via `UsageUpdate`, but the user
+   *  expects the composer footer to read "since the most recent
+   *  clear/compact." The `UsageUpdated` reducer arm subtracts this
+   *  baseline from the incoming cumulative before storing it on
+   *  `sessionUsage.cost`. Reset to null on `AgentSwitched` and
+   *  `SessionContextReset` (new backend or new ACP session restarts
+   *  the agent-side cumulative at zero). Re-derived on hard reload via
+   *  the full event-store replay, since boundary events are applied in
+   *  seq order. See #1354. */
+  usageBaseline: { cost: number } | null;
   /** Most recent assistant message chunks accumulated as a single
    *  text body. Cleared each time a new prompt is sent. */
   assistantMessage: string;
@@ -418,6 +430,7 @@ export function emptyCockpitState(): CockpitState {
     thinking: false,
     rateLimit: null,
     sessionUsage: null,
+    usageBaseline: null,
     assistantMessage: "",
     activity: [],
     lastSeq: 0,
@@ -474,6 +487,14 @@ export function applyEvent(
       // `compacted` kind to a "Conversation compacted" divider that
       // makes the boundary visible without nudging the user toward
       // pre-filling duplicate context. See #1109.
+      // Capture the agent's cumulative cost snapshot as the new
+      // baseline so the next UsageUpdate reports cost-since-compact
+      // instead of session-lifetime cumulative. See #1354.
+      next.usageBaseline = {
+        cost:
+          (state.sessionUsage?.cost?.amount ?? 0) +
+          (state.usageBaseline?.cost ?? 0),
+      };
       next.sessionUsage = null;
       next.activity = [
         ...next.activity,
@@ -514,6 +535,17 @@ export function applyEvent(
       next.plan = null;
       next.mode = "Default";
       next.pendingApprovals = [];
+      // Capture the agent's cumulative cost snapshot as the new
+      // baseline so the next UsageUpdate reports cost-since-clear
+      // instead of session-lifetime cumulative. `sessionUsage.cost`
+      // already stores the delta since the previous baseline, so the
+      // new baseline is the sum of both to track the true cumulative.
+      // See #1354.
+      next.usageBaseline = {
+        cost:
+          (state.sessionUsage?.cost?.amount ?? 0) +
+          (state.usageBaseline?.cost ?? 0),
+      };
       next.sessionUsage = null;
     }
     return next;
@@ -655,7 +687,28 @@ export function applyEvent(
     return next;
   }
   if ("UsageUpdated" in event) {
-    next.sessionUsage = event.UsageUpdated.usage;
+    // claude-agent-acp keeps reporting session-lifetime cumulative
+    // cost via UsageUpdate; `/clear` and `/compact` don't rotate the
+    // ACP session id so the agent's cumulative carries pre-boundary
+    // spend. Subtract the baseline captured at the most recent
+    // SessionCleared / ConversationCompacted so the composer footer
+    // reads "since the most recent boundary." `used` already reflects
+    // the post-boundary context size from the agent's side and stays
+    // raw; only `cost` is rebased. clamp to zero defensively in case
+    // an upstream restart ever reports a smaller cumulative. See #1354.
+    const incoming = event.UsageUpdated.usage;
+    if (next.usageBaseline && incoming.cost) {
+      next.sessionUsage = {
+        used: incoming.used,
+        size: incoming.size,
+        cost: {
+          amount: Math.max(0, incoming.cost.amount - next.usageBaseline.cost),
+          currency: incoming.cost.currency,
+        },
+      };
+    } else {
+      next.sessionUsage = incoming;
+    }
     return next;
   }
   if ("ModeChanged" in event) {
@@ -927,6 +980,10 @@ export function applyEvent(
     // the composer footer doesn't keep showing the previous run's
     // "75k / 200k" until the next UsageUpdate arrives.
     next.sessionUsage = null;
+    // The new ACP session restarts the agent-side cumulative cost at
+    // zero, so any prior per-clear baseline no longer maps onto
+    // incoming UsageUpdate values. See #1354.
+    next.usageBaseline = null;
     // Suppress the visible notice on a session that never saw a user
     // prompt: claude-agent-acp doesn't persist a 0-prompt session, so
     // session/load failing on the next spawn is expected, not an
@@ -979,6 +1036,10 @@ export function applyEvent(
     next.thinking = false;
     next.pendingApprovals = [];
     next.sessionUsage = null;
+    // The new backend reports its own cumulative cost starting from
+    // zero, so the prior agent's per-clear baseline does not apply.
+    // See #1354.
+    next.usageBaseline = null;
     next.availableCommands = [];
     next.availableModes = [];
     next.currentModeId = null;
@@ -1080,6 +1141,7 @@ export function normaliseTurnCounters(
     rejectedPrompts?: RejectedPrompt[];
     agentUnresponsive?: boolean;
     agentOrphaned?: boolean;
+    usageBaseline?: { cost: number } | null;
   },
 ): CockpitState {
   const pendingUserPromptSeq =
@@ -1109,11 +1171,20 @@ export function normaliseTurnCounters(
   // `undefined`.
   const agentOrphaned =
     typeof state.agentOrphaned === "boolean" ? state.agentOrphaned : false;
+  // Pre-#1354 persisted entries lack usageBaseline; backfill to null
+  // so the UsageUpdated reducer's `next.usageBaseline && ...` check
+  // sees a well-typed value. The baseline stays null until the next
+  // SessionCleared / ConversationCompacted, which matches the
+  // pre-fix behaviour for that one session; subsequent /clear events
+  // start subtracting normally.
+  const usageBaseline =
+    state.usageBaseline === undefined ? null : state.usageBaseline;
   return {
     ...state,
     rejectedPrompts,
     agentUnresponsive,
     agentOrphaned,
+    usageBaseline,
     pendingUserPromptSeq,
     lastStoppedSeq,
     turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -490,11 +490,10 @@ export function applyEvent(
       // Capture the agent's cumulative cost snapshot as the new
       // baseline so the next UsageUpdate reports cost-since-compact
       // instead of session-lifetime cumulative. See #1354.
-      next.usageBaseline = {
-        cost:
-          (state.sessionUsage?.cost?.amount ?? 0) +
-          (state.usageBaseline?.cost ?? 0),
-      };
+      const compactCumulative =
+        (state.sessionUsage?.cost?.amount ?? 0) +
+        (state.usageBaseline?.cost ?? 0);
+      next.usageBaseline = { cost: compactCumulative };
       next.sessionUsage = null;
       next.activity = [
         ...next.activity,
@@ -541,11 +540,10 @@ export function applyEvent(
       // already stores the delta since the previous baseline, so the
       // new baseline is the sum of both to track the true cumulative.
       // See #1354.
-      next.usageBaseline = {
-        cost:
-          (state.sessionUsage?.cost?.amount ?? 0) +
-          (state.usageBaseline?.cost ?? 0),
-      };
+      const clearCumulative =
+        (state.sessionUsage?.cost?.amount ?? 0) +
+        (state.usageBaseline?.cost ?? 0);
+      next.usageBaseline = { cost: clearCumulative };
       next.sessionUsage = null;
     }
     return next;
@@ -698,14 +696,9 @@ export function applyEvent(
     // an upstream restart ever reports a smaller cumulative. See #1354.
     const incoming = event.UsageUpdated.usage;
     if (next.usageBaseline && incoming.cost) {
-      next.sessionUsage = {
-        used: incoming.used,
-        size: incoming.size,
-        cost: {
-          amount: Math.max(0, incoming.cost.amount - next.usageBaseline.cost),
-          currency: incoming.cost.currency,
-        },
-      };
+      const rebasedAmount = Math.max(0, incoming.cost.amount - next.usageBaseline.cost);
+      const rebasedCost = { amount: rebasedAmount, currency: incoming.cost.currency };
+      next.sessionUsage = { used: incoming.used, size: incoming.size, cost: rebasedCost };
     } else {
       next.sessionUsage = incoming;
     }

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -490,9 +490,9 @@ export function applyEvent(
       // Capture the agent's cumulative cost snapshot as the new
       // baseline so the next UsageUpdate reports cost-since-compact
       // instead of session-lifetime cumulative. See #1354.
-      const compactCumulative =
-        (state.sessionUsage?.cost?.amount ?? 0) +
-        (state.usageBaseline?.cost ?? 0);
+      const compactPriorUsage = state.sessionUsage?.cost?.amount ?? 0;
+      const compactPriorBaseline = state.usageBaseline?.cost ?? 0;
+      const compactCumulative = compactPriorUsage + compactPriorBaseline;
       next.usageBaseline = { cost: compactCumulative };
       next.sessionUsage = null;
       next.activity = [
@@ -540,9 +540,9 @@ export function applyEvent(
       // already stores the delta since the previous baseline, so the
       // new baseline is the sum of both to track the true cumulative.
       // See #1354.
-      const clearCumulative =
-        (state.sessionUsage?.cost?.amount ?? 0) +
-        (state.usageBaseline?.cost ?? 0);
+      const clearPriorUsage = state.sessionUsage?.cost?.amount ?? 0;
+      const clearPriorBaseline = state.usageBaseline?.cost ?? 0;
+      const clearCumulative = clearPriorUsage + clearPriorBaseline;
       next.usageBaseline = { cost: clearCumulative };
       next.sessionUsage = null;
     }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -382,6 +382,13 @@
       "components": []
     },
     {
+      "id": "cockpit.usage-baseline",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/cockpitTypes.test.ts"],
+      "components": ["web/src/components/cockpit/Composer.tsx"]
+    },
+    {
       "id": "cockpit.drafts",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -386,7 +386,7 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": ["src/lib/cockpitTypes.test.ts"],
-      "components": ["web/src/components/cockpit/Composer.tsx"]
+      "components": ["web/src/lib/cockpitTypes.ts"]
     },
     {
       "id": "cockpit.drafts",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`/clear` in cockpit visibly wipes the model's context but the composer footer's cost figure snapped back to the pre-clear cumulative on the next assistant turn. Same shape for `/compact`. The model genuinely forgot, but the UI looked like it hadn't.

Root cause: `claude-agent-acp` does not rotate the ACP session id when handling `/clear` or `/compact`. `SessionUpdate::UsageUpdate` keeps reporting session-lifetime cumulative cost, and `acp_client.rs::map_update_to_events` passes it straight through to `Event::UsageUpdated`. The reducer's `SessionCleared` arm nulls `sessionUsage` for one frame, then the next `UsageUpdate` restores the full cumulative.

Fix in the frontend reducer:

- Add `usageBaseline: { cost: number } | null` to `CockpitState`.
- On `SessionCleared` / `ConversationCompacted`: capture `sessionUsage.cost.amount + (prior baseline)` as the new baseline (true cumulative the agent will keep counting from), then null `sessionUsage`.
- On `UsageUpdated`: if a baseline is set and the frame carries a `cost`, store `max(0, incoming.cost.amount - baseline.cost)` while letting `used` / `size` flow through raw (the adapter already reflects the post-boundary context size on its side).
- On `AgentSwitched` / `SessionContextReset`: clear the baseline. New backend or new ACP session restarts cumulative at zero.
- Backfill `usageBaseline` to `null` in `normaliseTurnCounters` so persisted entries from before this change hydrate to a well-typed value.

Frontend-only because:
- The full event-store replay re-derives the baseline correctly via the in-order `SessionCleared` / `ConversationCompacted` arms, so hard reload survives.
- No on-disk format change.
- Sessions without `cost` (Codex, opencode, gemini) are unaffected since the `UsageUpdated` arm only subtracts when an incoming `cost` is present.

Tests in `web/src/lib/cockpitTypes.test.ts` cover each boundary, the no-prior-usage corner, repeated `/clear` cumulative accumulation, the `AgentSwitched` and `SessionContextReset` resets, and the no-`cost` adapters. Adds a `cockpit.usage-baseline` entry to `web/tests/coverage-matrix.json` pointing at the new Vitest cases. Updates `docs/cockpit.md` to document the cost-since-boundary semantics.

Closes #1354

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open a cockpit session against Claude. Send a couple of prompts so the composer footer shows a cost (e.g. `$0.05 USD`).
- [ ] Run `/clear`. The "Conversation cleared" divider appears and the cost label disappears for the boundary frame.
- [ ] Send another prompt and wait for the agent's first `UsageUpdate`. Cost label reappears and reads "since clear" (e.g. `$0.01 USD`), not the pre-clear cumulative.
- [ ] Send a few more prompts. Cost grows monotonically from the post-clear baseline, never re-jumps to include pre-clear spend.
- [ ] Run a second `/clear`, send a prompt. Cost resets to roughly zero again and grows from there.
- [ ] Run `/compact` instead of `/clear`. Same delta behaviour (no primer banner, just the compacted divider and the cost rebases).
- [ ] Hard reload the page mid-session after a `/clear` and a follow-up turn. Replay rebuilds state from seq=0; the cost displayed after replay completes matches what it read before the reload.
- [ ] Hand off to a different backend via `Switch agent` (`AgentSwitched`). The new backend's cost starts at zero (baseline cleared).
- [ ] Run a session on Codex (or opencode / gemini, anything without `cost` in `UsageUpdate`). The composer footer keeps showing only `used / size` with no crash; `/clear` does not regress that behaviour.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (frontend-only baseline; cost-only subtraction; clear baseline on AgentSwitched / SessionContextReset; uniform handling of `/clear` and `/compact`), and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes a Cockpit UI bug where the composer footer’s session cost could revert to pre-clear totals after the next assistant turn. The reducer now records a client-side "usage baseline" at /clear and /compact boundaries so the UI shows cost since the last boundary instead of the agent’s session-lifetime cumulative.

## What changed (high level)
- Docs: Clarified docs/cockpit.md to state the composer footer shows cost "since the most recent /clear or /compact" and explained rebasing behavior for adapters that report cumulative session cost (e.g., claude-agent-acp).
- State & reducer: Added usageBaseline to CockpitState. On SessionCleared/ConversationCompacted the reducer captures cumulative cost as a baseline and clears sessionUsage for the boundary frame. On UsageUpdated, incoming cost is rebased against the baseline (clamped ≥ 0). Baseline is cleared on AgentSwitched/SessionContextReset. Persisted state is backfilled so usageBaseline hydrates to null.
- Tests & coverage: Added Vitest tests covering boundary capture, delta computation, repeated clears/compacts, resets, no-cost adapters, baseline stacking, persistence across no-cost frames, and clamping. Added cockpit.usage-baseline to the coverage matrix.

## Technical summary
- New field: usageBaseline: { cost: number } | null on CockpitState (initialized null).
- SessionCleared / ConversationCompacted: set usageBaseline.cost = (state.sessionUsage?.cost.amount || 0) + (state.usageBaseline?.cost || 0); set sessionUsage to null.
- UsageUpdated: when usageBaseline and incoming.cost exist, store cost = max(0, incoming.cost.amount - usageBaseline.cost); used/size pass through unchanged. If incoming.cost is absent, cost stays null.
- AgentSwitched / SessionContextReset: reset usageBaseline to null.
- normaliseTurnCounters updated to accept/backfill usageBaseline for persisted state.
- Frontend-only; event-store replay re-derives baseline so hard reloads rebuild correct state. No on-disk format change.

## Benefits
- Composer footer consistently shows "cost since last clear/compact" and no longer reverts to prior totals.
- Works with adapters that report cumulative session cost and adapters that omit cost.
- Prevents negative deltas via clamping; low-risk frontend-only change with tests and docs.

Closes `#1354`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->