### PR TITLE
fix(web): gate session route on first sessions fetch

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -196,6 +196,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     setWorkspaceOrdering,
     markLocalOrderingUpdate,
     error,
+    loaded: sessionsLoaded,
     injectSession,
     setSessionStatus,
   } = useSessions();
@@ -645,6 +646,16 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
           readOnly={serverAbout?.read_only}
         />
       );
+    }
+
+    // Refresh on `/session/<id>` paints once with `sessions === []` before
+    // the first poll resolves. Without this guard the lookup misses, the
+    // dashboard fallback renders, and the cockpit/terminal view only
+    // reappears once the fetch lands. Hold the minimal pre-auth shell
+    // until the first fetch settles, then let the real fallback decide.
+    // See #1351.
+    if (activeSessionId && !sessionsLoaded) {
+      return <div className="h-dvh bg-surface-900 safe-area-inset" />;
     }
 
     if (!activeWorkspace || !activeSession) {

--- a/web/src/hooks/useSessions.test.ts
+++ b/web/src/hooks/useSessions.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+//
+// Covers the `loaded` sentinel added for #1351. Without `loaded` the
+// session-route gate in App.tsx cannot tell "first fetch still in
+// flight" apart from "server confirmed there is no such session,"
+// which is why refresh on /session/<id> used to flash the dashboard.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useSessions } from "./useSessions";
+import * as api from "../lib/api";
+
+describe("useSessions / loaded sentinel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("starts loaded=false before the first fetch resolves", () => {
+    let resolveFetch: (value: api.SessionsEnvelope | null) => void = () => {};
+    vi.spyOn(api, "fetchSessions").mockImplementation(
+      () => new Promise((r) => (resolveFetch = r)),
+    );
+
+    const { result } = renderHook(() => useSessions());
+
+    expect(result.current.loaded).toBe(false);
+    expect(result.current.sessions).toEqual([]);
+    // Resolve the pending promise so the polling effect's cleanup
+    // does not leak past this test.
+    resolveFetch(null);
+  });
+
+  it("flips loaded=true after the first successful fetch", async () => {
+    vi.spyOn(api, "fetchSessions").mockResolvedValue({
+      sessions: [],
+      workspace_ordering: [],
+    });
+
+    const { result } = renderHook(() => useSessions());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    expect(result.current.error).toBe(false);
+  });
+
+  it("flips loaded=true even when the first fetch returns null", async () => {
+    vi.spyOn(api, "fetchSessions").mockResolvedValue(null);
+
+    const { result } = renderHook(() => useSessions());
+
+    await waitFor(() => expect(result.current.loaded).toBe(true));
+    // The null branch also flags error/serverDown surfaces; the
+    // important contract for #1351 is that `loaded` does not stay
+    // stuck at false, so the App.tsx gate can release the placeholder.
+    expect(result.current.error).toBe(true);
+  });
+});

--- a/web/src/hooks/useSessions.ts
+++ b/web/src/hooks/useSessions.ts
@@ -15,6 +15,12 @@ export function useSessions() {
   const [sessions, setSessions] = useState<SessionResponse[]>([]);
   const [workspaceOrdering, setWorkspaceOrdering] = useState<string[]>([]);
   const [error, setError] = useState(false);
+  // True once the first fetch attempt resolves (success or failure). Lets
+  // callers distinguish "still loading" from "list confirmed empty / no
+  // such session," which matters for refresh on `/session/<id>` where an
+  // empty `sessions` array during initial paint otherwise indistinguishably
+  // collapses to the dashboard fallback. See #1351.
+  const [loaded, setLoaded] = useState(false);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastLocalOrderingAtRef = useRef<number>(0);
 
@@ -45,6 +51,7 @@ export function useSessions() {
       setError(true);
       setServerDown(true);
     }
+    setLoaded(true);
   }, []);
 
   const refresh = useCallback(async () => {
@@ -72,6 +79,7 @@ export function useSessions() {
     setWorkspaceOrdering,
     markLocalOrderingUpdate,
     error,
+    loaded,
     refresh,
     injectSession,
     setSessionStatus,

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -125,6 +125,13 @@
       "components": ["web/src/components/TopBar.tsx"]
     },
     {
+      "id": "app-shell.routing",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/routing.spec.ts"],
+      "components": []
+    },
+    {
       "id": "profiles.lifecycle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -132,6 +132,13 @@
       "components": []
     },
     {
+      "id": "app-shell.sessions-loaded-sentinel",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/hooks/useSessions.test.ts"],
+      "components": []
+    },
+    {
       "id": "profiles.lifecycle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -40,6 +40,37 @@ test.describe("URL routing", () => {
     await expect(page).toHaveURL("/session/does-not-exist");
   });
 
+  test("'/session/<id>' holds the loading shell while the sessions list is still in flight", async ({ page }) => {
+    // Hold the sessions list open for 1s before responding so the
+    // App.tsx render gate added for #1351 (the `!sessionsLoaded`
+    // branch) executes for long enough to be observable. Without the
+    // gate the dashboard fallback would render immediately and the
+    // dark-shell assertion below would fail. After the response lands
+    // the dashboard fallback takes over because the response carries
+    // no matching session.
+    await page.route("**/api/sessions", async (r) => {
+      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await r.fulfill({
+        json: { sessions: [], workspace_ordering: [] },
+      });
+    });
+
+    await page.goto("/session/loading-window");
+    // The minimal pre-auth shell is just a dark <div> with no text or
+    // role-bearing children, so the assertion negates the dashboard
+    // CTA which is what would otherwise render in this window.
+    await expect(
+      page.getByRole("button", { name: NEW_SESSION_PANE_NAME }),
+    ).not.toBeVisible();
+    // After the stubbed response lands the dashboard fallback takes
+    // over, since the response carries no matching session.
+    await expect(
+      page.getByRole("button", { name: NEW_SESSION_PANE_NAME }),
+    ).toBeVisible();
+    await expect(page).toHaveURL("/session/loading-window");
+  });
+
   test("refresh on /session/<id> for a known session keeps the user on that session", async ({ page }) => {
     // Stub the sessions list with a single known session, then visit
     // /session/<id>, reload, and assert the dashboard fallback never

--- a/web/tests/routing.spec.ts
+++ b/web/tests/routing.spec.ts
@@ -40,6 +40,69 @@ test.describe("URL routing", () => {
     await expect(page).toHaveURL("/session/does-not-exist");
   });
 
+  test("refresh on /session/<id> for a known session keeps the user on that session", async ({ page }) => {
+    // Stub the sessions list with a single known session, then visit
+    // /session/<id>, reload, and assert the dashboard fallback never
+    // shows. This pins #1351: before the fix the dashboard would flash
+    // on every refresh during the brief window where `useSessions` had
+    // not yet resolved its first fetch.
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+      return r.fulfill({
+        json: {
+          sessions: [
+            {
+              id: "known-session",
+              title: "known-session",
+              project_path: "/tmp/known",
+              group_path: "/tmp",
+              tool: "claude",
+              status: "Running",
+              yolo_mode: false,
+              created_at: new Date().toISOString(),
+              last_accessed_at: null,
+              idle_entered_at: null,
+              last_error: null,
+              branch: null,
+              main_repo_path: null,
+              is_sandboxed: false,
+              has_managed_worktree: false,
+              has_terminal: true,
+              profile: "default",
+              cleanup_defaults: {},
+              remote_owner: null,
+              notify_on_waiting: null,
+              notify_on_idle: null,
+              notify_on_error: null,
+              claude_fullscreen: false,
+              workspace_repos: [],
+            },
+          ],
+          workspace_ordering: [],
+        },
+      });
+    });
+    await page.route("**/api/sessions/*/ensure", (r) =>
+      r.fulfill({ json: { ok: true } }),
+    );
+    await page.route("**/api/sessions/*/terminal", (r) =>
+      r.fulfill({ status: 200, body: "" }),
+    );
+    await page.routeWebSocket(/\/sessions\/.*\/(ws|cockpit-ws)$/, () => {});
+
+    await page.goto("/session/known-session");
+    await expect(page).toHaveURL("/session/known-session");
+    await expect(
+      page.getByRole("button", { name: NEW_SESSION_PANE_NAME }),
+    ).not.toBeVisible();
+
+    await page.reload();
+    await expect(page).toHaveURL("/session/known-session");
+    await expect(
+      page.getByRole("button", { name: NEW_SESSION_PANE_NAME }),
+    ).not.toBeVisible();
+  });
+
   test("legacy '?session=X' URL is rewritten to '/session/X'", async ({ page }) => {
     await page.goto("/?session=abc-123");
     await expect(page).toHaveURL("/session/abc-123");


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Refreshing the browser on `/session/<id>` flashed the dashboard fallback for one render tick before the session view reappeared, because the empty `sessions` state during the initial fetch was indistinguishable from "no such session." On a slow connection, mobile cold start, or any transient backend hiccup that returned `null`, the dashboard stuck and the user appeared to lose their place.

Root cause was in `web/src/App.tsx:649`: `if (!activeWorkspace || !activeSession) return <Dashboard />` ran before `useSessions` had a chance to resolve its first fetch. `useSessions` only exposed `sessions` and `error`, both of which conflated "still loading" with "the server confirmed nothing is there."

Fix adds a `loaded` sentinel to `useSessions`, flipped to `true` once the first `fetchSessions` resolves (success or null). `App.tsx` reads it as `sessionsLoaded` and, when a `/session/<id>` route is matched but the first fetch has not landed, renders the minimal pre-auth shell instead of the dashboard. Once `sessionsLoaded` flips the existing fallback decides between cockpit/terminal view and dashboard, preserving the existing not-found UX.

Test coverage: new mocked-playwright case in `web/tests/routing.spec.ts` stubs `/api/sessions` with a known session, navigates to `/session/<id>`, reloads, asserts the dashboard fallback never shows. New `app-shell.routing` surface in `web/tests/coverage-matrix.json` so routing is an owned surface.

Closes #1351

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the web dashboard, create or pick a session, navigate to `/session/<id>`, hit browser refresh. Confirm the session view (cockpit or terminal) reappears without a flash to the dashboard. URL stays at `/session/<id>`.
- [ ] In Chrome DevTools, throttle to Slow 3G, then refresh on `/session/<id>`. Confirm the screen shows a blank dark shell (matches the pre-auth shell) for the duration of the initial fetch, then transitions to the session view.
- [ ] Navigate to `/session/does-not-exist`, confirm the dashboard renders once the first fetch resolves and the URL stays put.
- [ ] Refresh on `/settings`, confirm settings still renders (unchanged behavior).
- [ ] Refresh on `/` (dashboard root), confirm dashboard still renders without a flash.
- [ ] Stop `aoe serve` mid-session, refresh on `/session/<id>`, confirm the dashboard renders once the fetch fails (offline path) and the URL stays put.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (placeholder shape, scope of test coverage, where to add the matrix entry), and ran the validation locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes a UI regression where reloading a session page (e.g., /session/<id>) briefly showed the dashboard instead of the session view while session data was still loading.

### What changed (high-level)
- Introduced an initial-load sentinel so the app can tell "still loading" apart from "no sessions found".
- Gate the dashboard fallback: when a session route is active but sessions haven’t finished loading, the app renders a minimal pre-auth/loading shell instead of the dashboard; once the first load completes the app resumes normal routing (session view or dashboard).
- Added tests and coverage entries to lock in the behavior: a Playwright routing test for the refresh flow, a Vitest for the hook’s loaded sentinel, and coverage-matrix updates.

### Benefits
- Eliminates the transient dashboard flash on session-page refresh.
- Provides a clearer loading UX (shows a loading/pre-auth shell instead of navigating to dashboard).
- Adds tests to prevent regressions related to routing and session-load timing.

### Technical details
- useSessions hook: adds a boolean loaded flag that starts false and flips true once the initial fetchSessions promise resolves (success or null); the hook now returns loaded.
- App.tsx: reads sessionsLoaded from useSessions; when a /session/<id> route is matched but sessionsLoaded is false, App renders a minimal pre-auth shell early. After sessionsLoaded becomes true, existing logic selects the session cockpit/terminal view or the dashboard fallback (preserving not-found behavior).
- Tests: Playwright test stubs /api/sessions and related endpoints to verify reloading /session/<id> never shows the dashboard fallback; Vitest covers the loaded sentinel flipping true on both successful and null initial responses; coverage matrix updated with app-shell routing surface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->