### PR TITLE
feat(session/poller): runtime-configurable thread cap via TUI Settings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,11 @@ async fn main() -> Result<()> {
     // poller seed below the early-return command dispatch. Staying lazy here
     // means commands that don't need app data (`aoe completion`,
     // `aoe init`, `aoe agents`, `aoe uninstall`, `aoe update`, …) never
-    // call `get_app_dir()` as a side effect.
+    // call `get_app_dir()` as a side effect. `config_load_attempted` lets
+    // the seed block skip a redundant load (and a redundant error warning)
+    // when the logging block already tried.
     let mut loaded_config: Option<agent_of_empires::session::Config> = None;
+    let mut config_load_attempted = false;
 
     let mut debug_log_warning: Option<String> = None;
     // Subscriber installation. One resolver picks the sink based on
@@ -115,6 +118,7 @@ async fn main() -> Result<()> {
                         None
                     }
                 };
+                config_load_attempted = true;
                 let log_cfg = loaded_config
                     .as_ref()
                     .map(|c| c.logging.clone())
@@ -230,21 +234,25 @@ async fn main() -> Result<()> {
     // Seed the session-id poller cap from persisted config. Reached only
     // for commands that may spawn sessions (early-return commands above
     // have already exited). Reuses the config loaded by the logging-init
-    // block when available; otherwise loads now.
-    let cap_config =
-        loaded_config
-            .take()
-            .or_else(|| match agent_of_empires::session::load_config() {
-                Ok(opt) => opt,
-                Err(e) => {
-                    eprintln!(
-                        "warning: could not load config to seed session-id poller cap, \
+    // block when available; otherwise loads now. Skips a redundant load
+    // (and a redundant warning) when the logging block already attempted.
+    let cap_config = if let Some(cfg) = loaded_config.take() {
+        Some(cfg)
+    } else if config_load_attempted {
+        None
+    } else {
+        match agent_of_empires::session::load_config() {
+            Ok(opt) => opt,
+            Err(e) => {
+                eprintln!(
+                    "warning: could not load config to seed session-id poller cap, \
                      using built-in default of {}: {e}",
-                        agent_of_empires::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS,
-                    );
-                    None
-                }
-            });
+                    agent_of_empires::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS,
+                );
+                None
+            }
+        }
+    };
     if let Some(cfg) = cap_config {
         agent_of_empires::session::poller::set_session_id_poller_max_threads(
             cfg.session.session_id_poller_max_threads,

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,14 @@ async fn main() -> Result<()> {
     // process). Compiled away in release builds.
     let debug_namespace_drift = agent_of_empires::session::debug_namespace_drift();
 
+    // Lazy holder for the loaded config. Populated by the logging-init block
+    // when it needs the `[logging]` section, and reused by the session-id
+    // poller seed below the early-return command dispatch. Staying lazy here
+    // means commands that don't need app data (`aoe completion`,
+    // `aoe init`, `aoe agents`, `aoe uninstall`, `aoe update`, …) never
+    // call `get_app_dir()` as a side effect.
+    let mut loaded_config: Option<agent_of_empires::session::Config> = None;
+
     let mut debug_log_warning: Option<String> = None;
     // Subscriber installation. One resolver picks the sink based on
     // `ProcessContext` + `[logging]` config (see `logging::resolve_sink`).
@@ -100,10 +108,16 @@ async fn main() -> Result<()> {
 
         match agent_of_empires::session::get_app_dir() {
             Ok(app_dir) => {
-                let log_cfg = agent_of_empires::session::load_config()
-                    .ok()
-                    .flatten()
-                    .map(|c| c.logging)
+                loaded_config = match agent_of_empires::session::load_config() {
+                    Ok(opt) => opt,
+                    Err(e) => {
+                        eprintln!("warning: could not load config, using built-in defaults: {e}");
+                        None
+                    }
+                };
+                let log_cfg = loaded_config
+                    .as_ref()
+                    .map(|c| c.logging.clone())
                     .unwrap_or_default();
                 let resolution = logging::resolve_sink(&log_cfg, &app_dir, ctx);
                 let path_for_msg = match &resolution.target {
@@ -212,6 +226,30 @@ async fn main() -> Result<()> {
 
     let profile_explicit = cli.profile.is_some();
     let profile = cli.profile.unwrap_or_default();
+
+    // Seed the session-id poller cap from persisted config. Reached only
+    // for commands that may spawn sessions (early-return commands above
+    // have already exited). Reuses the config loaded by the logging-init
+    // block when available; otherwise loads now.
+    let cap_config =
+        loaded_config
+            .take()
+            .or_else(|| match agent_of_empires::session::load_config() {
+                Ok(opt) => opt,
+                Err(e) => {
+                    eprintln!(
+                        "warning: could not load config to seed session-id poller cap, \
+                     using built-in default of {}: {e}",
+                        agent_of_empires::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS,
+                    );
+                    None
+                }
+            });
+    if let Some(cfg) = cap_config {
+        agent_of_empires::session::poller::set_session_id_poller_max_threads(
+            cfg.session.session_id_poller_max_threads,
+        );
+    }
 
     // TUI mode handles migrations with a spinner; CLI runs them silently
     if cli.command.is_some() {

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -559,6 +559,13 @@ pub struct SessionConfig {
     /// suppress the row label entirely.
     #[serde(default)]
     pub row_tag: RowTagMode,
+
+    /// Process-wide cap on concurrent session-id poller threads (one per
+    /// live session). Edited via the TUI Settings panel; saving in Global
+    /// scope pushes the new value into the runtime atomic for new sessions
+    /// to pick up immediately.
+    #[serde(default = "default_session_id_poller_max_threads")]
+    pub session_id_poller_max_threads: u32,
 }
 
 /// What to render in the per-row tag slot next to the session title.
@@ -600,6 +607,7 @@ impl Default for SessionConfig {
             snooze_duration_minutes: 30,
             restart_wake_message: default_restart_wake_message(),
             row_tag: RowTagMode::default(),
+            session_id_poller_max_threads: default_session_id_poller_max_threads(),
         }
     }
 }
@@ -626,6 +634,10 @@ pub fn validate_snooze_duration(minutes: u64) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn default_session_id_poller_max_threads() -> u32 {
+    crate::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS
 }
 
 impl SessionConfig {
@@ -1157,7 +1169,8 @@ impl Config {
         }
 
         let content = fs::read_to_string(&path)?;
-        let config: Config = toml::from_str(&content)?;
+        let mut config: Config = toml::from_str(&content)?;
+        config.normalize();
         Ok(config)
     }
 
@@ -1170,6 +1183,15 @@ impl Config {
                 tracing::warn!(target: "session.store", "Failed to load global config, using defaults: {e}");
                 Config::default()
             }
+        }
+    }
+
+    /// Clamp invariants that the type system can't enforce. Keeps config,
+    /// TUI, and runtime in agreement when a user hand-edits a value below
+    /// its minimum (zero would silently disable session-id polling).
+    fn normalize(&mut self) {
+        if self.session.session_id_poller_max_threads == 0 {
+            self.session.session_id_poller_max_threads = 1;
         }
     }
 }
@@ -1854,6 +1876,48 @@ mod tests {
             deserialized.session.agent_extra_args.get("opencode"),
             Some(&"--port 8080".to_string()),
             "agent_extra_args should survive roundtrip"
+        );
+    }
+
+    #[test]
+    fn test_session_config_default_session_id_poller_max_threads() {
+        let cfg = SessionConfig::default();
+        assert_eq!(
+            cfg.session_id_poller_max_threads,
+            crate::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS
+        );
+    }
+
+    #[test]
+    fn test_session_config_session_id_poller_max_threads_roundtrip() {
+        let mut config = Config::default();
+        config.session.session_id_poller_max_threads = 137;
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.session.session_id_poller_max_threads, 137);
+    }
+
+    #[test]
+    fn test_session_config_session_id_poller_max_threads_defaults_when_absent() {
+        let toml = r#"
+            [session]
+            default_tool = "claude"
+        "#;
+        let cfg: Config = toml::from_str(toml).unwrap();
+        assert_eq!(
+            cfg.session.session_id_poller_max_threads,
+            crate::session::poller::DEFAULT_SESSION_ID_POLLER_MAX_THREADS
+        );
+    }
+
+    #[test]
+    fn test_session_config_normalize_clamps_zero_poller_threads() {
+        let mut cfg = Config::default();
+        cfg.session.session_id_poller_max_threads = 0;
+        cfg.normalize();
+        assert_eq!(
+            cfg.session.session_id_poller_max_threads, 1,
+            "normalize() must clamp zero to 1 to keep config, UI, and runtime aligned"
         );
     }
 

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -6,11 +6,37 @@ use std::sync::mpsc::RecvTimeoutError;
 use std::thread::JoinHandle;
 use std::time::Duration;
 
-/// Global count of active poller threads for budget enforcement
+/// Global count of active session-id poller threads for budget enforcement
 static ACTIVE_POLLER_COUNT: AtomicU32 = AtomicU32::new(0);
 
-/// Maximum number of concurrent poller threads allowed
-const MAX_POLLER_THREADS: u32 = 20;
+/// Default ceiling on concurrent session-id poller threads.
+///
+/// Each session that loses its poller stops refreshing the agent session id
+/// shown in its TUI row, so this cap doubles as a "how many concurrent
+/// sessions can keep their identity live" budget.
+pub const DEFAULT_SESSION_ID_POLLER_MAX_THREADS: u32 = 50;
+
+/// Resolved cap, settable at runtime from the TUI Settings panel.
+///
+/// Read with `Ordering::Relaxed` inside the CAS loop in `try_acquire` so each
+/// retry observes the latest cap. The counter's own CAS uses `SeqCst` and is
+/// the authoritative gate against imbalance. There is no ordering dependency
+/// between this cap and any other memory location, so `Release`/`Acquire`
+/// would add a fence with zero semantic benefit.
+static SESSION_ID_POLLER_MAX_THREADS: AtomicU32 =
+    AtomicU32::new(DEFAULT_SESSION_ID_POLLER_MAX_THREADS);
+
+/// Push a new cap into the atomic. Clamped to ≥1 because zero would
+/// silently disable polling for every future session.
+pub fn set_session_id_poller_max_threads(n: u32) {
+    SESSION_ID_POLLER_MAX_THREADS.store(n.max(1), Ordering::Relaxed);
+}
+
+/// Read the currently effective cap. Used by the budget-exhausted warn
+/// message and by tests.
+pub fn session_id_poller_max_threads() -> u32 {
+    SESSION_ID_POLLER_MAX_THREADS.load(Ordering::Relaxed)
+}
 
 /// RAII guard that decrements `ACTIVE_POLLER_COUNT` on drop.
 ///
@@ -23,7 +49,8 @@ impl PollerCountGuard {
     fn try_acquire() -> Option<Self> {
         let mut current = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
         loop {
-            if current >= MAX_POLLER_THREADS {
+            let cap = SESSION_ID_POLLER_MAX_THREADS.load(Ordering::Relaxed);
+            if current >= cap {
                 return None;
             }
             match ACTIVE_POLLER_COUNT.compare_exchange_weak(
@@ -178,10 +205,12 @@ impl SessionPoller {
             Some(g) => g,
             None => {
                 tracing::warn!(target: "session.create",
-                    "Poller thread budget exhausted ({}/{}), skipping poller for {}",
+                    "Session-id poller budget exhausted ({}/{}), skipping poller for {}; \
+                     raise the cap from the TUI Settings panel \
+                     (Session > Max Session-ID Poller Threads) before creating new sessions",
                     ACTIVE_POLLER_COUNT.load(Ordering::SeqCst),
-                    MAX_POLLER_THREADS,
-                    instance_id
+                    SESSION_ID_POLLER_MAX_THREADS.load(Ordering::Relaxed),
+                    instance_id,
                 );
                 self.cmd_rx = Some(cmd_rx);
                 return false;
@@ -297,6 +326,24 @@ mod tests {
     use super::*;
     use serial_test::serial;
     use std::sync::{Arc, Mutex};
+
+    /// Restores `SESSION_ID_POLLER_MAX_THREADS` to its original value on drop,
+    /// even if the test panics. Mirrors the `VibeHomeGuard` / `TmuxCleanup`
+    /// pattern used elsewhere in the test suite.
+    struct CapRestorer(u32);
+    impl Drop for CapRestorer {
+        fn drop(&mut self) {
+            set_session_id_poller_max_threads(self.0);
+        }
+    }
+
+    /// Restores `ACTIVE_POLLER_COUNT` to its original value on drop.
+    struct CountRestorer(u32);
+    impl Drop for CountRestorer {
+        fn drop(&mut self) {
+            ACTIVE_POLLER_COUNT.store(self.0, Ordering::SeqCst);
+        }
+    }
 
     #[test]
     fn test_adaptive_interval_initial() {
@@ -470,9 +517,30 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_set_session_id_poller_max_threads_clamps_zero() {
+        let _restore = CapRestorer(session_id_poller_max_threads());
+        set_session_id_poller_max_threads(0);
+        assert_eq!(
+            session_id_poller_max_threads(),
+            1,
+            "zero must be clamped to 1 to avoid silently disabling polling"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_set_session_id_poller_max_threads_roundtrip() {
+        let _restore = CapRestorer(session_id_poller_max_threads());
+        set_session_id_poller_max_threads(42);
+        assert_eq!(session_id_poller_max_threads(), 42);
+    }
+
+    #[test]
+    #[serial]
     fn test_thread_budget_cap() {
-        let original = ACTIVE_POLLER_COUNT.load(Ordering::SeqCst);
-        ACTIVE_POLLER_COUNT.store(MAX_POLLER_THREADS, Ordering::SeqCst);
+        let _restore_count = CountRestorer(ACTIVE_POLLER_COUNT.load(Ordering::SeqCst));
+        let _restore_cap = CapRestorer(session_id_poller_max_threads());
+        ACTIVE_POLLER_COUNT.store(session_id_poller_max_threads(), Ordering::SeqCst);
 
         let mut poller = SessionPoller::new("test-session".to_string());
         poller.start(
@@ -490,8 +558,6 @@ mod tests {
             poller.cmd_rx.is_some(),
             "cmd_rx should be returned when budget exhausted"
         );
-
-        ACTIVE_POLLER_COUNT.store(original, Ordering::SeqCst);
     }
 
     #[test]

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -100,6 +100,7 @@ pub enum FieldKey {
     CustomAgents,
     AgentDetectAs,
     HostEnvironment,
+    SessionIdPollerMaxThreads,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -1603,7 +1604,7 @@ fn build_session_fields(
         items
     };
 
-    vec![
+    let mut fields = vec![
         SettingField {
             key: FieldKey::DefaultTool,
             label: "Default Tool",
@@ -1765,7 +1766,24 @@ fn build_session_fields(
                 FieldValue::List(global.environment.clone()),
             ),
         },
-    ]
+    ];
+
+    if scope == SettingsScope::Global {
+        fields.push(SettingField {
+            key: FieldKey::SessionIdPollerMaxThreads,
+            label: "Max Session-ID Poller Threads",
+            description:
+                "Process-wide cap on threads polling the tmux session ID for live sessions \
+                 (one thread per session). When the cap is reached, new sessions are not \
+                 polled and their session ID will not refresh.",
+            value: FieldValue::Number(u64::from(global.session.session_id_poller_max_threads)),
+            category: SettingsCategory::Session,
+            has_override: false,
+            inherited_display: None,
+        });
+    }
+
+    fields
 }
 
 fn build_sound_fields(
@@ -2491,6 +2509,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
             config.logging.show_spans = *v;
         }
         (FieldKey::HostEnvironment, FieldValue::List(v)) => config.environment = v.clone(),
+        (FieldKey::SessionIdPollerMaxThreads, FieldValue::Number(v)) => {
+            config.session.session_id_poller_max_threads = (*v).clamp(1, u32::MAX as u64) as u32;
+        }
         _ => {}
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -935,6 +935,7 @@ impl SettingsView {
             }
             // Logging is global-only for v1 (no profile overrides); the
             // "clear override" gesture is a no-op for these keys.
+            // SessionIdPollerMaxThreads is also global-only.
             FieldKey::LoggingDefaultLevel
             | FieldKey::LoggingTarget(_)
             | FieldKey::LoggingOutput
@@ -942,7 +943,8 @@ impl SettingsView {
             | FieldKey::LoggingRotation
             | FieldKey::LoggingMaxSizeMib
             | FieldKey::LoggingKeepCount
-            | FieldKey::LoggingShowSpans => {}
+            | FieldKey::LoggingShowSpans
+            | FieldKey::SessionIdPollerMaxThreads => {}
             FieldKey::HostEnvironment => {
                 config.environment = None;
             }

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -330,6 +330,9 @@ impl SettingsView {
                         &app_dir,
                     );
                 }
+                crate::session::poller::set_session_id_poller_max_threads(
+                    self.global_config.session.session_id_poller_max_threads,
+                );
             }
             SettingsScope::Profile => {
                 save_profile_config(&self.profile, &self.profile_config)?;


### PR DESCRIPTION
## Description

Replace the hard-coded `MAX_POLLER_THREADS = 20` const with a runtime-mutable `AtomicU32` (default 50) editable from the TUI Settings panel under **Session > Max Session-ID Poller Threads**. Saving in Global scope pushes the new value into the atomic, taking effect for sessions started afterwards. `main()` seeds the atomic from the persisted config before any subcommand dispatches, so every entry path (TUI, `aoe serve`, `aoe add --launch`, `aoe session start`) honors the user's configured cap.

Closes #1327. Addresses the runtime-tunability + TUI-panel concerns raised in review of that PR.

**Behavior change:** default cap raised from 20 to 50. Fleets with >20 long-lived sessions previously hit a silent budget exhaustion that left new sessions without a poller. Operators can now raise the cap further from the panel without recompiling.

## Design choices

- **Global-only field.** The atomic is process-wide; per-profile overrides have no semantic meaning and would conflict on profile switch. Wired through `SessionConfig` directly, not `SessionConfigOverride`; matches the `LoggingConfig` precedent. Field is only built into `build_session_fields()` under `SettingsScope::Global`.
- **No env var.** The previous proposal in #1327 exposed `AOE_MAX_POLLER_THREADS`; the TUI panel + persisted TOML now own the cap end-to-end.
- **Naming:** `session_id_poller_max_threads` / `SESSION_ID_POLLER_MAX_THREADS` / `SessionIdPollerMaxThreads` — one base name in the three Rust conventions, Domain-first to match `CockpitMaxConcurrentWorkers`.
- **Atomic ordering:** `Relaxed` on the cap (read fresh inside the CAS retry loop), `SeqCst` on the `ACTIVE_POLLER_COUNT` counter (authoritative gate).
- **Lazy config load.** `main()` does not load `config.toml` eagerly. The logging-init block populates an `Option<Config>` only when it actually needs `[logging]`; the poller-cap seed lives below the no-app-data early-return command dispatch and reuses that value or loads on demand. As a result, `aoe completion`, `aoe init`, `aoe agents`, `aoe theme`, `aoe uninstall`, `aoe update`, … never call `get_app_dir()` as a side effect.
- **Hand-edited `0` is normalized.** `Config::load()` calls a new `normalize()` that clamps `session_id_poller_max_threads` to ≥1, so a manually-edited TOML with `0` can't drift from what the runtime atomic and TUI display.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

### Tests

- 21 poller tests pass, including new setter clamp + roundtrip cases. Tests now use RAII `CapRestorer` / `CountRestorer` Drop guards so a panic between save and restore can't pollute global atomics (matches the existing `VibeHomeGuard` / `TmuxCleanup` pattern).
- 4 `SessionConfig` tests added: default value, TOML roundtrip, forward-compat when the field is absent, and `normalize()` clamps zero.
- `cargo fmt` clean, `cargo clippy --features serve -- -D warnings` clean.
- Full lib suite: 2310/2312 (2 pre-existing parallel-test flakes in `containers::runtime`, pass under `--test-threads=1`; same flakes called out in #1327).
- Manual TUI smoke: field renders in Global scope with default 50, hidden in Profile/Repo scope.

### TUI screenshot

```
Max Session-ID Poller Threads
Process-wide cap on threads polling the tmux session ID for live sessions
(one thread per session). When the cap is reached, new sessions are not
polled and their session ID will not refresh.
50
```

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (opencode), used for cross-validating implementation plan against existing codebase patterns (`LoggingConfig` precedent, atomic ordering, scope guard idiom, RAII test guards) and producing the diff. Each output was reviewed and re-checked against `AGENTS.md` conventions and the reviews of both #1327 (initial proposal) and this PR (Copilot + CodeRabbit).

- [x] I am an AI Agent filling out this form (check box if true)