### PR TITLE
fix: force color for Antigravity launches

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1323,6 +1323,7 @@ impl Instance {
             }
 
             self.apply_session_flags(&mut tool_cmd, "sandboxed");
+            apply_agent_launch_env(&mut tool_cmd, agent);
 
             let sandbox = self
                 .sandbox_info
@@ -1504,6 +1505,7 @@ impl Instance {
                     }
                 }
                 self.apply_session_flags(&mut cmd, "host agent");
+                apply_agent_launch_env(&mut cmd, agent);
                 wrap_command_ignore_suspend(&format!("{}{}", env_prefix, cmd))
             })
         } else {
@@ -1517,6 +1519,7 @@ impl Instance {
                 }
             }
             self.apply_session_flags(&mut cmd, "host custom");
+            apply_agent_launch_env(&mut cmd, agent);
             Some(wrap_command_ignore_suspend(&format!(
                 "{}{}",
                 env_prefix, cmd
@@ -2594,6 +2597,14 @@ fn truncate_error_line(line: &str) -> String {
 fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
     let escaped = shell_escape(value);
     format!("{}={} {}", key, escaped, cmd)
+}
+
+fn apply_agent_launch_env(cmd: &mut String, agent: Option<&'static crate::agents::AgentDef>) {
+    if !matches!(agent.map(|a| a.name), Some("antigravity")) {
+        return;
+    }
+
+    *cmd = format!("env -u NO_COLOR FORCE_COLOR=1 COLORTERM=truecolor {}", cmd);
 }
 
 /// Wrap a command to disable Ctrl-Z (SIGTSTP) suspension.
@@ -3823,6 +3834,45 @@ mod tests {
         let cmd_str = cmd.unwrap();
         assert!(cmd_str.contains("ses_abc123def456"));
         assert!(cmd_str.contains("--session-id") || cmd_str.contains("--resume"));
+    }
+
+    #[test]
+    fn test_build_host_command_antigravity_forces_color() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "antigravity".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("FORCE_COLOR=1"));
+        assert!(cmd_str.contains("COLORTERM=truecolor"));
+        assert!(cmd_str.contains("agy"));
+    }
+
+    #[test]
+    fn test_build_host_custom_command_antigravity_forces_color() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "antigravity".to_string();
+        inst.command = "agy --some-flag".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("antigravity"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("FORCE_COLOR=1"));
+        assert!(cmd_str.contains("COLORTERM=truecolor"));
+        assert!(cmd_str.contains("agy --some-flag"));
+    }
+
+    #[test]
+    fn test_build_host_command_color_env_is_antigravity_only() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "codex".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("codex"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(!cmd_str.contains("env -u NO_COLOR"));
+        assert!(!cmd_str.contains("FORCE_COLOR=1"));
+        assert!(!cmd_str.contains("COLORTERM=truecolor"));
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2599,6 +2599,13 @@ fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
     format!("{}={} {}", key, escaped, cmd)
 }
 
+/// Prepend agent-specific environment overrides to a launch command.
+///
+/// Antigravity inherits the parent tmux env, which can carry `NO_COLOR=1` and
+/// silently disable its terminal palette even though the web renderer handles
+/// ANSI fine. Unsetting `NO_COLOR` and forcing `FORCE_COLOR=1` /
+/// `COLORTERM=truecolor` at launch keeps color on without leaking the override
+/// to other agents.
 fn apply_agent_launch_env(cmd: &mut String, agent: Option<&'static crate::agents::AgentDef>) {
     if !matches!(agent.map(|a| a.name), Some("antigravity")) {
         return;


### PR DESCRIPTION
## Description
Antigravity can inherit `NO_COLOR=1` from the parent tmux environment, which makes its terminal UI render without color even though the web terminal supports ANSI color.

This scopes a launch-time env fix to Antigravity sessions only: unset `NO_COLOR` and set `FORCE_COLOR=1` plus `COLORTERM=truecolor` for host, custom, and sandboxed Antigravity commands. Other agents keep their existing environment behavior.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Codex

**Any Additional AI Details you'd like to share:** Implemented and validated by Codex in response to observed Antigravity launch env behavior.

- [x] I am an AI Agent filling out this form (check box if true)

## Testing

- `cargo fmt --check`
- `cargo test test_build_host_command`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`
- `cargo build --profile dev-release --features serve`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

The PR forces ANSI color for Antigravity sessions by adding a small launch-time environment wrapper that unsets NO_COLOR and sets FORCE_COLOR=1 and COLORTERM=truecolor. This wrapper is applied only for the Antigravity agent and is injected consistently across sandboxed (Docker) launches, host launches using the agent binary, and host launches using a custom command. Unit tests verify the wrapper is added for Antigravity and not applied to other agents.

## What Was Added

- apply_agent_launch_env helper in src/session/instance.rs to wrap Antigravity launch commands with the color-forcing environment
- Calls to that helper in all command-construction paths: Docker sandbox, host default-binary, and host custom-command launches
- Unit tests (including test_build_host_custom_command_antigravity_forces_color) asserting the wrapper is present for Antigravity and absent for other agents

## Benefits

- Ensures Antigravity always renders with ANSI color in the web terminal even if the parent environment has NO_COLOR set
- Limits change scope to Antigravity, avoiding unintended effects on other agents
- Provides consistent behavior across all launch methods, improving user experience

## Technical details

The helper prefixes Antigravity commands with:
env -u NO_COLOR FORCE_COLOR=1 COLORTERM=truecolor
Applied at launch-time in src/session/instance.rs; unit tests cover default-binary and custom-command host paths and a non-Antigravity agent case.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->