### PR TITLE
feat: keep web terminals alive behind beta setting

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useResolvedTheme } from "./hooks/useResolvedTheme";
+import { useWebSettings } from "./hooks/useWebSettings";
 import { useDiffFiles } from "./hooks/useDiffFiles";
 import { useDiffComments } from "./hooks/useDiffComments";
 import { SendCommentsDialog } from "./components/diff/comments/SendCommentsDialog";
@@ -40,7 +41,7 @@ import { WorkspaceSidebar } from "./components/WorkspaceSidebar";
 import { DeleteSessionDialog } from "./components/DeleteSessionDialog";
 import { TopBar } from "./components/TopBar";
 import { ContentSplit } from "./components/ContentSplit";
-import { TerminalView } from "./components/TerminalView";
+import { TerminalSessionStack } from "./components/TerminalSessionStack";
 // Lazy-load the cockpit surface so non-cockpit users never download
 // the @assistant-ui/react, shiki, and in-house StringDiff/DiffLine
 // dependency tree. Cuts ~hundreds of KB off the cold-start bundle
@@ -181,6 +182,7 @@ function isInsideEditable(target: EventTarget | null): boolean {
 function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLogout: () => void }) {
   const navigate = useNavigate();
   const idleDecayWindowMs = useIdleDecayWindowMs();
+  const { settings: webSettings } = useWebSettings();
   const sessionMatch = useMatch("/session/:sessionId");
   const settingsRootMatch = useMatch("/settings");
   const settingsTabMatch = useMatch("/settings/:tab");
@@ -684,11 +686,15 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                     />
                   </Suspense>
                 ) : (
-                  <TerminalView
-                    key={activeSessionId}
-                    session={activeSession}
+                  <TerminalSessionStack
+                    activeSessionId={activeSessionId!}
+                    sessions={sessions.filter((session) => !session.cockpit_mode)}
                     cockpitMasterEnabled={
                       !!serverAbout?.cockpit_master_enabled
+                    }
+                    persistent={webSettings.persistentTerminals}
+                    maxPersistentTerminals={
+                      webSettings.maxPersistentTerminals
                     }
                   />
                 )}

--- a/web/src/components/TerminalSessionStack.tsx
+++ b/web/src/components/TerminalSessionStack.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useMemo, useState } from "react";
+import type { SessionResponse } from "../lib/types";
+import {
+  DEFAULT_PERSISTENT_TERMINALS,
+  normalizePersistentTerminalLimit,
+} from "../lib/persistentTerminals";
+import { TerminalView } from "./TerminalView";
+
+interface Props {
+  activeSessionId: string;
+  sessions: SessionResponse[];
+  cockpitMasterEnabled: boolean;
+  persistent: boolean;
+  maxPersistentTerminals?: number;
+}
+
+export function TerminalSessionStack({
+  activeSessionId,
+  sessions,
+  cockpitMasterEnabled,
+  persistent,
+  maxPersistentTerminals = DEFAULT_PERSISTENT_TERMINALS,
+}: Props) {
+  const [recentIds, setRecentIds] = useState<string[]>([]);
+  const limit = normalizePersistentTerminalLimit(maxPersistentTerminals);
+  const sessionsById = useMemo(
+    () => new Map(sessions.map((session) => [session.id, session])),
+    [sessions],
+  );
+  const activeSession = sessionsById.get(activeSessionId);
+
+  useEffect(() => {
+    let cancelled = false;
+    queueMicrotask(() => {
+      if (cancelled) return;
+      if (!persistent) {
+        setRecentIds([]);
+        return;
+      }
+      setRecentIds((ids) => {
+        const inactiveLimit = Math.max(0, limit - 1);
+        const inactive = ids
+          .filter((id) => id !== activeSessionId)
+          .filter((id) => sessionsById.has(id))
+          .slice(0, inactiveLimit);
+        const next = [activeSessionId, ...inactive];
+        return next.join("\0") === ids.join("\0") ? ids : next;
+      });
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, limit, persistent, sessionsById]);
+
+  if (!activeSession) return null;
+
+  const visibleIds = persistent
+    ? [activeSessionId, ...recentIds.filter((id) => id !== activeSessionId)]
+    : [activeSessionId];
+
+  return (
+    <div className="flex-1 min-h-0 overflow-hidden relative">
+      {visibleIds.map((sessionId) => {
+        const session = sessionsById.get(sessionId);
+        if (!session) return null;
+        const active = sessionId === activeSessionId;
+        return (
+          <div
+            key={sessionId}
+            aria-hidden={!active}
+            className={
+              active
+                ? "absolute inset-0 flex flex-col min-h-0"
+                : "absolute inset-0 flex flex-col min-h-0 invisible pointer-events-none"
+            }
+          >
+            <TerminalView
+              session={session}
+              active={active}
+              cockpitMasterEnabled={cockpitMasterEnabled}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -1,9 +1,17 @@
 import { useWebSettings } from "../hooks/useWebSettings";
+import {
+  MAX_PERSISTENT_TERMINALS,
+  MIN_PERSISTENT_TERMINALS,
+  normalizePersistentTerminalLimit,
+} from "../lib/persistentTerminals";
 
 const FONT_SIZES = Array.from({ length: 23 }, (_, i) => i + 6); // 6..28
 
 export function TerminalSettings() {
   const { settings, update } = useWebSettings();
+  const maxPersistentTerminals = normalizePersistentTerminalLimit(
+    settings.maxPersistentTerminals,
+  );
 
   return (
     <div>
@@ -104,6 +112,81 @@ export function TerminalSettings() {
               className="accent-brand-600 w-4 h-4 shrink-0"
             />
           </label>
+        </div>
+
+        <div>
+          <div className="space-y-3">
+            <label className="flex items-center justify-between gap-3 cursor-pointer">
+              <div>
+                <div className="text-[13px] text-text-secondary">
+                  Keep terminals alive{" "}
+                  <span className="font-mono text-[11px] text-text-muted">
+                    (Beta)
+                  </span>
+                </div>
+                <p className="text-[11px] text-text-muted mt-1">
+                  Keep recently viewed web terminals mounted for faster switching
+                  across many sessions. Uses more browser memory and keeps extra
+                  terminal connections open.
+                </p>
+              </div>
+              <input
+                type="checkbox"
+                checked={settings.persistentTerminals}
+                onChange={(e) =>
+                  update({ persistentTerminals: e.target.checked })
+                }
+                className="accent-brand-600 w-4 h-4 shrink-0"
+              />
+            </label>
+
+            {settings.persistentTerminals && (
+              <div>
+                <label className="block text-[13px] text-text-secondary mb-2">
+                  Terminal keep-alive limit
+                </label>
+                <div className="flex items-center gap-3">
+                  <input
+                    type="range"
+                    min={MIN_PERSISTENT_TERMINALS}
+                    max={MAX_PERSISTENT_TERMINALS}
+                    step={1}
+                    value={maxPersistentTerminals}
+                    onChange={(e) =>
+                      update({
+                        maxPersistentTerminals:
+                          normalizePersistentTerminalLimit(
+                            Number(e.target.value),
+                          ),
+                      })
+                    }
+                    className="flex-1 accent-brand-600 h-1.5"
+                  />
+                  <input
+                    type="number"
+                    min={MIN_PERSISTENT_TERMINALS}
+                    max={MAX_PERSISTENT_TERMINALS}
+                    step={1}
+                    value={maxPersistentTerminals}
+                    onChange={(e) =>
+                      update({
+                        maxPersistentTerminals:
+                          normalizePersistentTerminalLimit(
+                            Number(e.target.value),
+                          ),
+                      })
+                    }
+                    className="bg-surface-800 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary font-mono w-16 text-center"
+                  />
+                </div>
+                <p className="text-[11px] text-text-muted mt-1">
+                  Higher limits improve switching across large workspaces but
+                  keep more total terminal renderers, sockets, and tmux
+                  attachments alive.
+                </p>
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/web/src/components/TerminalView.tsx
+++ b/web/src/components/TerminalView.tsx
@@ -20,6 +20,7 @@ import "@xterm/xterm/css/xterm.css";
 
 interface Props {
   session: SessionResponse;
+  active?: boolean;
   /** When false (the default) the switch-to-cockpit pill is hidden
    *  entirely so users with the master switch off aren't tempted
    *  by a button that the server will reject. */
@@ -29,7 +30,11 @@ interface Props {
 const SCROLL_HINT_SEEN_KEY = "aoe-mobile-scroll-hint-seen";
 const SCROLL_HINT_TIMEOUT_MS = 8000;
 
-export function TerminalView({ session, cockpitMasterEnabled = false }: Props) {
+export function TerminalView({
+  session,
+  active = true,
+  cockpitMasterEnabled = false,
+}: Props) {
   const [ensureState, setEnsureState] = useState<"pending" | "ready" | "error">(
     "pending",
   );
@@ -48,8 +53,9 @@ export function TerminalView({ session, cockpitMasterEnabled = false }: Props) {
   } = useTerminal(
     ensureState === "ready" ? session.id : null,
     "ws",
-    true,
+    active,
     session.claude_fullscreen,
+    active,
   );
   const { isMobile, keyboardOpen, keyboardHeight, reservedKeyboardHeight } =
     useMobileKeyboard();
@@ -164,6 +170,10 @@ export function TerminalView({ session, cockpitMasterEnabled = false }: Props) {
     if (ensureState !== "ready") return;
     if (consumePendingTerminalFocus("agent")) focusSelf();
   }, [ensureState, focusSelf]);
+
+  useEffect(() => {
+    if (active && ensureState === "ready") activate();
+  }, [active, ensureState, activate]);
 
   // Auto-keyboard-open on initial connect removed (#1178): the
   // KeyboardFab is always visible and lets the user open the keyboard

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -10,7 +10,6 @@ import {
   type MutableRefObject,
 } from "react";
 import { createPortal } from "react-dom";
-import { Link } from "react-router-dom";
 import { Pencil } from "lucide-react";
 import {
   DndContext,
@@ -225,17 +224,6 @@ function formatDurationSecondsShort(seconds: number): string {
   return remM === 0 ? `${h}h` : `${h}h ${remM}m`;
 }
 
-function isPlainLeftClick(event: React.MouseEvent<HTMLAnchorElement>): boolean {
-  return (
-    event.button === 0 &&
-    !event.defaultPrevented &&
-    !event.metaKey &&
-    !event.altKey &&
-    !event.ctrlKey &&
-    !event.shiftKey
-  );
-}
-
 // Wraps a SessionRow with @dnd-kit sortable plumbing. The row itself
 // is the drag handle: a short tap/click navigates as before, but a
 // press-and-hold (sensor delay) lifts the row so the user can reorder.
@@ -266,9 +254,9 @@ function useSuppressClickAfterDrag(ref: MutableRefObject<number>) {
       }
     };
     // The click Chromium dispatches after a drag-release can bypass
-    // React's event delegation and land on the inner Link without
-    // firing any wrapping capture handler. A document-level capture
-    // listener catches it before navigation kicks in.
+    // React's event delegation and land on the inner row without firing
+    // any wrapping capture handler. A document-level capture listener
+    // catches it before row activation kicks in.
     document.addEventListener("click", handler, true);
     return () => document.removeEventListener("click", handler, true);
   }, [ref]);
@@ -367,10 +355,10 @@ const SessionRow = memo(function SessionRow({
     },
     idleDecayWindowMs,
   );
+  const firstSession = workspace.sessions[0];
   const runningSession = workspace.sessions.find((s) =>
     isSessionActive(s, idleDecayWindowMs),
   );
-  const firstSession = workspace.sessions[0];
   const singleSession = workspace.sessions.length === 1;
   const sessionTitle = firstSession?.title.trim() ?? "";
   const branchLabel = workspace.branch ?? null;
@@ -545,23 +533,32 @@ const SessionRow = memo(function SessionRow({
 
   return (
     <>
-      <Link
-        to={sessionPath}
+      <a
+        href={sessionPath}
+        tabIndex={isDeleting ? -1 : undefined}
+        aria-disabled={isDeleting || undefined}
         data-testid="sidebar-session-row"
-        // Anchors are HTML5-draggable by default; the browser would
-        // start its own drag-the-link gesture in parallel with dnd-kit
-        // and finish with a synthetic click that bypassed React's event
-        // delegation, navigating despite our suppression. See #1169.
         draggable={false}
         onClick={(e) => {
+          if (
+            e.button !== 0 ||
+            e.metaKey ||
+            e.ctrlKey ||
+            e.shiftKey ||
+            e.altKey
+          ) {
+            return;
+          }
+          if (isDeleting) {
+            e.preventDefault();
+            return;
+          }
           if (longPressFired.current) {
             e.preventDefault();
             return;
           }
-          if (isPlainLeftClick(e)) {
-            e.preventDefault();
-            onClick();
-          }
+          e.preventDefault();
+          onClick();
         }}
         onContextMenu={handleContextMenu}
         onTouchStart={handleTouchStart}
@@ -667,7 +664,7 @@ const SessionRow = memo(function SessionRow({
             )}
           </div>
         </div>
-      </Link>
+      </a>
       {contextMenu && createPortal(
         <div
           ref={menuRef}
@@ -835,18 +832,20 @@ export function WorkspaceSidebar({
   const [width, setWidth] = useState(loadSavedWidth);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [optimisticActive, setOptimisticActive] = useState<{
+    id: string;
+    fromActiveId: string | null;
+  } | null>(null);
   const filterRef = useRef<HTMLInputElement>(null);
   const dragging = useRef(false);
+  const displayedActiveId =
+    optimisticActive?.fromActiveId === activeId ? optimisticActive.id : activeId;
 
-  // Whole-row press-and-hold drag. The delay lets a quick click or tap
-  // pass through to the row's navigation link unchanged; only a held
-  // pointer (150ms with <8px movement) flips the row into drag mode.
-  // 150ms is the iOS Reminders/Notes ballpark: long enough to filter
-  // out scroll-flicks and accidental taps, short enough that the lift
-  // feels immediate. Same delay on mouse and touch so the gesture is
-  // identical on desktop and mobile.
+  // Whole-row drag. Desktop uses distance activation so a deliberate
+  // but stationary click still navigates; touch keeps a long-press delay
+  // so scroll-flicks and taps do not reorder rows.
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 150, tolerance: 8 } }),
   );
 
@@ -1042,7 +1041,7 @@ export function WorkspaceSidebar({
             {filteredGroups.map((group) => {
               const showExpanded = q ? true : !group.collapsed;
               const hasActiveChild = group.workspaces.some(
-                (ws) => ws.id === activeId,
+                (ws) => ws.id === displayedActiveId,
               );
               return (
                 <div key={group.id}>
@@ -1066,8 +1065,11 @@ export function WorkspaceSidebar({
                         <SortableSessionRow
                           key={ws.id}
                           workspace={ws}
-                          isActive={ws.id === activeId}
-                          onClick={() => onSelect(ws.id)}
+                          isActive={ws.id === displayedActiveId}
+                          onClick={() => {
+                            setOptimisticActive({ id: ws.id, fromActiveId: activeId });
+                            onSelect(ws.id);
+                          }}
                           onDelete={onDeleteSession}
                           readOnly={readOnly}
                         />

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -838,6 +838,14 @@ export function WorkspaceSidebar({
   } | null>(null);
   const filterRef = useRef<HTMLInputElement>(null);
   const dragging = useRef(false);
+  // Drop the optimistic hint once the parent's activeId has moved off
+  // fromActiveId. Otherwise a later navigation back to fromActiveId
+  // (e.g. browser back, deep link) would re-engage the stale id and
+  // highlight the wrong row. Adjusting state during render is the
+  // pattern React docs recommend for derived resets like this.
+  if (optimisticActive && optimisticActive.fromActiveId !== activeId) {
+    setOptimisticActive(null);
+  }
   const displayedActiveId =
     optimisticActive?.fromActiveId === activeId ? optimisticActive.id : activeId;
 

--- a/web/src/components/__tests__/TerminalSessionStack.test.tsx
+++ b/web/src/components/__tests__/TerminalSessionStack.test.tsx
@@ -1,0 +1,215 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { SessionResponse } from "../../lib/types";
+
+vi.mock("../TerminalView", () => ({
+  TerminalView: ({
+    session,
+    active,
+  }: {
+    session: SessionResponse;
+    active: boolean;
+  }) => (
+    <div data-testid={`terminal-${session.id}`} data-active={String(active)}>
+      {session.title}
+    </div>
+  ),
+}));
+
+import { normalizePersistentTerminalLimit } from "../../lib/persistentTerminals";
+import { TerminalSessionStack } from "../TerminalSessionStack";
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeSession(id: string): SessionResponse {
+  return {
+    id,
+    title: id,
+    project_path: `/tmp/${id}`,
+    group_path: "/tmp",
+    tool: "claude",
+    status: "Running",
+    yolo_mode: false,
+    created_at: new Date().toISOString(),
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+  };
+}
+
+describe("TerminalSessionStack", () => {
+  it("renders only the active session when persistence is disabled", () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <TerminalSessionStack
+        activeSessionId="s1"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={false}
+      />,
+    );
+
+    expect(screen.getByTestId("terminal-s1").dataset.active).toBe("true");
+    expect(screen.queryByTestId("terminal-s2")).toBeNull();
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s2"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={false}
+      />,
+    );
+
+    expect(screen.queryByTestId("terminal-s1")).toBeNull();
+    expect(screen.getByTestId("terminal-s2").dataset.active).toBe("true");
+  });
+
+  it("keeps recent inactive sessions mounted when persistence is enabled", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2")];
+    const { rerender } = render(
+      <TerminalSessionStack
+        activeSessionId="s1"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1").dataset.active).toBe("true");
+    });
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s2"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1").dataset.active).toBe("false");
+      expect(screen.getByTestId("terminal-s2").dataset.active).toBe("true");
+    });
+  });
+
+  it("evicts older inactive sessions beyond the configured limit", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+    const { rerender } = render(
+      <TerminalSessionStack
+        activeSessionId="s1"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1")).toBeDefined();
+    });
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s2"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1")).toBeDefined();
+      expect(screen.getByTestId("terminal-s2")).toBeDefined();
+    });
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s3"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={1}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("terminal-s1")).toBeNull();
+      expect(screen.queryByTestId("terminal-s2")).toBeNull();
+      expect(screen.getByTestId("terminal-s3").dataset.active).toBe("true");
+    });
+  });
+
+  it("counts the configured limit as the total mounted terminal count", async () => {
+    const sessions = [makeSession("s1"), makeSession("s2"), makeSession("s3")];
+    const { rerender } = render(
+      <TerminalSessionStack
+        activeSessionId="s1"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1")).toBeDefined();
+    });
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s2"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByTestId("terminal-s1")).toBeDefined();
+      expect(screen.getByTestId("terminal-s2")).toBeDefined();
+    });
+
+    rerender(
+      <TerminalSessionStack
+        activeSessionId="s3"
+        sessions={sessions}
+        cockpitMasterEnabled={false}
+        persistent={true}
+        maxPersistentTerminals={2}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.queryByTestId("terminal-s1")).toBeNull();
+      expect(screen.getByTestId("terminal-s2").dataset.active).toBe("false");
+      expect(screen.getByTestId("terminal-s3").dataset.active).toBe("true");
+    });
+  });
+
+  it("normalizes configured limits to the supported range", () => {
+    expect(normalizePersistentTerminalLimit(0)).toBe(1);
+    expect(normalizePersistentTerminalLimit(5.4)).toBe(5);
+    expect(normalizePersistentTerminalLimit(99)).toBe(50);
+    expect(normalizePersistentTerminalLimit("10")).toBe(5);
+  });
+});

--- a/web/src/components/__tests__/TerminalSettings.test.tsx
+++ b/web/src/components/__tests__/TerminalSettings.test.tsx
@@ -59,11 +59,36 @@ describe("TerminalSettings localStorage contract", () => {
 
   it("autoOpenKeyboard checkbox writes the boolean flag", () => {
     const { container } = render(<TerminalSettings />);
-    const checkbox = container.querySelector(
+    const checkbox = container.querySelectorAll(
       "input[type=checkbox]",
-    ) as HTMLInputElement;
+    )[0] as HTMLInputElement;
     fireEvent.click(checkbox);
     expect(readStored().autoOpenKeyboard).toBe(false);
+  });
+
+  it("persistent terminals checkbox writes the beta flag", () => {
+    const { container } = render(<TerminalSettings />);
+    const checkbox = container.querySelectorAll(
+      "input[type=checkbox]",
+    )[1] as HTMLInputElement;
+    fireEvent.click(checkbox);
+    expect(readStored().persistentTerminals).toBe(true);
+  });
+
+  it("persistent terminal limit input writes a clamped number", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ persistentTerminals: true }),
+    );
+    const { container } = render(<TerminalSettings />);
+    const input = container.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "50" } });
+    expect(readStored().maxPersistentTerminals).toBe(50);
+
+    fireEvent.change(input, { target: { value: "99" } });
+    expect(readStored().maxPersistentTerminals).toBe(50);
   });
 
   it("preserves unrelated keys when persisting an update", () => {
@@ -73,6 +98,8 @@ describe("TerminalSettings localStorage contract", () => {
         mobileFontSize: 8,
         desktopFontSize: 14,
         autoOpenKeyboard: true,
+        persistentTerminals: false,
+        maxPersistentTerminals: 5,
         diffViewMode: "tree",
         collapsedDiffDirs: ["a/b"],
       }),
@@ -87,6 +114,8 @@ describe("TerminalSettings localStorage contract", () => {
       mobileFontSize: 12,
       desktopFontSize: 14,
       autoOpenKeyboard: true,
+      persistentTerminals: false,
+      maxPersistentTerminals: 5,
       diffViewMode: "tree",
       collapsedDiffDirs: ["a/b"],
     });
@@ -99,6 +128,8 @@ describe("TerminalSettings localStorage contract", () => {
         mobileFontSize: 22,
         desktopFontSize: 16,
         autoOpenKeyboard: false,
+        persistentTerminals: true,
+        maxPersistentTerminals: 42,
       }),
     );
     const { container } = render(<TerminalSettings />);
@@ -108,11 +139,51 @@ describe("TerminalSettings localStorage contract", () => {
     const desktopSelect = container.querySelectorAll(
       "select",
     )[1] as HTMLSelectElement;
-    const checkbox = container.querySelector(
-      "input[type=checkbox]",
+    const checkboxes = container.querySelectorAll("input[type=checkbox]");
+    const checkbox = checkboxes[0] as HTMLInputElement;
+    const persistentCheckbox = checkboxes[1] as HTMLInputElement;
+    const persistentLimit = container.querySelector(
+      "input[type=number]",
     ) as HTMLInputElement;
     expect(mobileSelect.value).toBe("22");
     expect(desktopSelect.value).toBe("16");
     expect(checkbox.checked).toBe(false);
+    expect(persistentCheckbox.checked).toBe(true);
+    expect(persistentLimit.value).toBe("42");
+  });
+
+  it("normalizes malformed persistent terminal settings on read", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        persistentTerminals: "yes",
+        maxPersistentTerminals: 1000,
+      }),
+    );
+    const { container } = render(<TerminalSettings />);
+    const checkboxes = container.querySelectorAll("input[type=checkbox]");
+    const persistentCheckbox = checkboxes[1] as HTMLInputElement;
+    const persistentLimit = container.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement | null;
+
+    expect(persistentCheckbox.checked).toBe(false);
+    expect(persistentLimit).toBeNull();
+  });
+
+  it("clamps a persisted terminal keep-alive limit on read", () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        persistentTerminals: true,
+        maxPersistentTerminals: 1000,
+      }),
+    );
+    const { container } = render(<TerminalSettings />);
+    const persistentLimit = container.querySelector(
+      "input[type=number]",
+    ) as HTMLInputElement;
+
+    expect(persistentLimit.value).toBe("50");
   });
 });

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -297,6 +297,37 @@ describe("useTerminal lifecycle", () => {
     }
   });
 
+  it("claimPrimary=false keeps the socket warm without auto-activating", async () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-passive", "ws", false, false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+      const ws = sockets[0]!;
+
+      act(() => {
+        ws.readyState = FakeWebSocket.OPEN;
+        ws.onopen?.(new Event("open"));
+      });
+      await flushAsync();
+
+      const activate = ws.sent.find(
+        (m) => typeof m === "string" && m.includes('"activate"'),
+      );
+      expect(activate).toBeUndefined();
+    } finally {
+      div.remove();
+    }
+  });
+
   it("suppresses tiny resize messages from hidden containers", async () => {
     // Hidden container = no offsetParent + a tiny proposed grid. The
     // hook should never let that bogus measurement reach the server.

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -145,8 +145,10 @@ export function useTerminal(
   wsPath: string = "ws",
   autoFocus: boolean = true,
   claudeFullscreen: boolean = false,
+  claimPrimary: boolean = true,
 ) {
   const { settings, update } = useWebSettings();
+  const claimPrimaryRef = useRef(claimPrimary);
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -200,6 +202,10 @@ export function useTerminal(
     isPrimary: true,
     isInScrollback: false,
   });
+
+  useEffect(() => {
+    claimPrimaryRef.current = claimPrimary;
+  }, [claimPrimary]);
 
   useEffect(() => {
     if (!sessionId || !containerRef.current) return;
@@ -490,10 +496,12 @@ export function useTerminal(
           isPrimary: true,
         }));
         if (autoFocus) term.focus();
-        // Claim primary immediately so this client's resize is applied.
-        // Without this, the first resize lands in "vacant" state (which
-        // works) but a race with focus/visibility events could delay it.
-        ws.send(JSON.stringify({ type: "activate" } as ActivateMessage));
+        // Claim primary immediately for visible terminals so this
+        // client's resize is applied. Hidden persistent terminals keep
+        // their socket warm without stealing primary from the active tab.
+        if (claimPrimaryRef.current) {
+          ws.send(JSON.stringify({ type: "activate" } as ActivateMessage));
+        }
         // Send initial PTY dimensions only if FitAddon has actually
         // measured the container. Reading term.cols/term.rows directly
         // would yield xterm's 80x24 default before fit() runs, and
@@ -1157,6 +1165,7 @@ export function useTerminal(
     // When the user switches to this tab/window, tell the server so it
     // can claim primary and resize the PTY to match this viewport.
     const sendActivate = () => {
+      if (!claimPrimaryRef.current) return;
       const ws = wsRef.current;
       if (ws?.readyState === WebSocket.OPEN) {
         const msg: ActivateMessage = { type: "activate" };

--- a/web/src/hooks/useWebSettings.ts
+++ b/web/src/hooks/useWebSettings.ts
@@ -1,5 +1,9 @@
 import { useCallback, useSyncExternalStore } from "react";
 
+import {
+  DEFAULT_PERSISTENT_TERMINALS,
+  normalizePersistentTerminalLimit,
+} from "../lib/persistentTerminals";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 
 const STORAGE_KEY = "aoe-web-settings";
@@ -8,6 +12,8 @@ export interface WebSettings {
   mobileFontSize: number;
   desktopFontSize: number;
   autoOpenKeyboard: boolean;
+  persistentTerminals: boolean;
+  maxPersistentTerminals: number;
   diffViewMode: "flat" | "tree";
   collapsedDiffDirs: string[];
 }
@@ -17,8 +23,24 @@ function getDefaults(): WebSettings {
     mobileFontSize: 8,
     desktopFontSize: 14,
     autoOpenKeyboard: true,
+    persistentTerminals: false,
+    maxPersistentTerminals: DEFAULT_PERSISTENT_TERMINALS,
     diffViewMode: window.innerWidth < 768 ? "flat" : "tree",
     collapsedDiffDirs: [],
+  };
+}
+
+function normalizeSnapshot(settings: WebSettings): WebSettings {
+  const defaults = getDefaults();
+  return {
+    ...settings,
+    persistentTerminals:
+      typeof settings.persistentTerminals === "boolean"
+        ? settings.persistentTerminals
+        : defaults.persistentTerminals,
+    maxPersistentTerminals: normalizePersistentTerminalLimit(
+      settings.maxPersistentTerminals,
+    ),
   };
 }
 
@@ -26,7 +48,7 @@ function getSnapshot(): WebSettings {
   const raw = safeGetItem(STORAGE_KEY);
   if (raw) {
     try {
-      return { ...getDefaults(), ...JSON.parse(raw) };
+      return normalizeSnapshot({ ...getDefaults(), ...JSON.parse(raw) });
     } catch {
       // malformed JSON; fall through to defaults
     }

--- a/web/src/lib/persistentTerminals.ts
+++ b/web/src/lib/persistentTerminals.ts
@@ -1,0 +1,14 @@
+export const MIN_PERSISTENT_TERMINALS = 1;
+export const MAX_PERSISTENT_TERMINALS = 50;
+export const DEFAULT_PERSISTENT_TERMINALS = 5;
+
+export function normalizePersistentTerminalLimit(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return DEFAULT_PERSISTENT_TERMINALS;
+  }
+  return Math.min(
+    MAX_PERSISTENT_TERMINALS,
+    Math.max(MIN_PERSISTENT_TERMINALS, Math.round(value)),
+  );
+}
+

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -115,7 +115,10 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": ["src/components/__tests__/TerminalSettings.test.tsx"],
-      "components": ["web/src/components/TerminalSettings.tsx"]
+      "components": [
+        "web/src/components/TerminalSettings.tsx",
+        "web/src/components/TerminalSessionStack.tsx"
+      ]
     },
     {
       "id": "app-shell.topbar-dev-badge",
@@ -202,6 +205,13 @@
       "kind": "live-playwright",
       "risk": "medium",
       "specs": ["tests/live/workspace-ordering.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
+      "id": "sidebar.client-side-navigation",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": ["tests/sidebar-multi-session.spec.ts"],
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {

--- a/web/tests/sidebar-multi-session.spec.ts
+++ b/web/tests/sidebar-multi-session.spec.ts
@@ -11,6 +11,7 @@ interface MockSession {
   title: string;
   project_path: string;
   branch: string | null;
+  status?: string;
 }
 
 async function mockApis(page: Page, sessions: MockSession[]) {
@@ -27,7 +28,7 @@ async function mockApis(page: Page, sessions: MockSession[]) {
           project_path: s.project_path,
           group_path: s.project_path,
           tool: "claude",
-          status: "Idle",
+          status: s.status ?? "Idle",
           yolo_mode: false,
           created_at: new Date().toISOString(),
           last_accessed_at: null,
@@ -82,6 +83,121 @@ test.describe("Sidebar multi-session (#956)", () => {
     await expect(page.locator("header")).toBeVisible();
     await expect(page.getByRole("link", { name: /Ethiopians/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /Celts/i })).toBeVisible();
+  });
+
+  test("clicking a session row uses client-side navigation", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+      {
+        id: "sess-b",
+        title: "Celts",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+    ]);
+    let sessionDocumentRequests = 0;
+    page.on("request", (request) => {
+      if (
+        request.resourceType() === "document" &&
+        /\/session\/sess-[ab]$/.test(new URL(request.url()).pathname)
+      ) {
+        sessionDocumentRequests += 1;
+      }
+    });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+    const row = page.getByRole("link", { name: /Ethiopians/i });
+
+    await expect(row).toHaveJSProperty("tagName", "A");
+    await expect(row).toHaveAttribute("href", /\/session\/sess-a$/);
+    await row.click();
+
+    await expect(page).toHaveURL(/\/session\/sess-a$/);
+    expect(sessionDocumentRequests).toBe(0);
+  });
+
+  test("a deliberate desktop click does not get swallowed as a drag", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+      {
+        id: "sess-b",
+        title: "Celts",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/session/sess-b");
+    await expect(page.locator("header")).toBeVisible();
+    await expect(page).toHaveURL(/\/session\/sess-b$/);
+
+    const row = page.getByRole("link", { name: /Ethiopians/i });
+    const box = await row.boundingBox();
+    expect(box).not.toBeNull();
+
+    await page.mouse.move(box!.x + box!.width / 2, box!.y + box!.height / 2);
+    await page.mouse.down();
+    await page.waitForTimeout(220);
+    await page.mouse.up();
+    await page.waitForTimeout(16);
+
+    expect(await row.getAttribute("class")).toContain("border-brand-600");
+    await expect(page).toHaveURL(/\/session\/sess-a$/);
+  });
+
+  test("deleting rows are disabled for pointer and keyboard activation", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+        status: "Deleting",
+      },
+      {
+        id: "sess-b",
+        title: "Celts",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+    ]);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/session/sess-b");
+    await expect(page.locator("header")).toBeVisible();
+    const row = page.getByRole("link", { name: /Ethiopians/i });
+
+    await expect(row).toHaveAttribute("aria-disabled", "true");
+    await expect(row).toHaveAttribute("tabindex", "-1");
+
+    await row.evaluate((el) => (el as HTMLElement).click());
+    await expect(page).toHaveURL(/\/session\/sess-b$/);
+
+    await row.evaluate((el) => {
+      el.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await expect(page).toHaveURL(/\/session\/sess-b$/);
   });
 
   test("collapsing still applies when sessions share a non-null branch (worktree)", async ({


### PR DESCRIPTION
## Description
Adds an opt-in web dashboard beta setting to keep recently viewed terminal sessions mounted for faster switching across many sessions.

This also hardens the sidebar session-switch path:
- no `/session/...` document navigation during row clicks
- desktop held clicks are not swallowed as drag gestures
- active row styling updates immediately on click
- deleting rows are not focusable or activatable

The keep-alive limit is configurable from 1 to 50, defaults to 5, and persisted settings are normalized on read.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate the web terminal keep-alive beta, sidebar switching regressions, and CodeRabbit follow-up fixes. Changes were tested locally with targeted Vitest, Playwright, lint, build, and Rust commit-hook checks.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npm run test:unit -- src/components/__tests__/TerminalSettings.test.tsx src/components/__tests__/TerminalSessionStack.test.tsx src/hooks/useTerminal.lifecycle.test.ts`
- `npx playwright test sidebar-multi-session.spec.ts`
- `npx eslint src/components/WorkspaceSidebar.tsx tests/sidebar-multi-session.spec.ts src/components/TerminalSessionStack.tsx src/components/TerminalSettings.tsx src/components/__tests__/TerminalSessionStack.test.tsx src/components/__tests__/TerminalSettings.test.tsx src/hooks/useWebSettings.ts src/lib/persistentTerminals.ts`
- `node tests/validate-coverage-matrix.mjs`
- `npm run build`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`

## Notes

`npm run test:unit` was also run across the full web suite earlier: 722/723 tests passed, then the single timed-out `src/lib/cockpitTypes.test.ts` case passed when rerun directly (`62 passed`). The timeout appears unrelated to this web terminal change.
