### PR TITLE
fix(session/recovery): skip archived/snoozed rows in startup recovery

### DIFF
--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -96,11 +96,23 @@ fn recovery_lock_path() -> Result<PathBuf> {
 
 /// Pure predicate: should this instance go through the startup recovery
 /// cascade? Excludes cockpit-mode sessions (handled by `cockpit_reconciler`),
-/// sessions whose agent has `ResumeStrategy::Unsupported`, and sessions
-/// without a valid `agent_session_id`. Live tmux panes are filtered separately
-/// by the caller using `Instance::has_live_tmux_pane()`.
+/// sessions whose agent has `ResumeStrategy::Unsupported`, sessions without
+/// a valid `agent_session_id`, and sunk rows (archived or currently snoozed).
+/// Live tmux panes are filtered separately by the caller using
+/// `Instance::has_live_tmux_pane()`.
+///
+/// Archive and snooze are explicit "leave this session alone" signals; the
+/// archive path actively kills the tmux pane, so without this guard the next
+/// TUI launch (or daemon startup) would observe a dead pane on a resumable
+/// agent and respawn the row the user just dismissed. Snooze shares the
+/// guard because `is_snoozed()` returns false once the timer expires, so the
+/// row naturally re-enters recovery eligibility on its own schedule rather
+/// than the moment a pane goes missing.
 pub fn is_recovery_candidate(inst: &Instance) -> bool {
-    !inst.is_cockpit_mode() && should_attempt_resume(inst.agent_session_id.as_deref(), &inst.tool)
+    !inst.is_cockpit_mode()
+        && !inst.is_archived()
+        && !inst.is_snoozed()
+        && should_attempt_resume(inst.agent_session_id.as_deref(), &inst.tool)
 }
 
 /// Warm up the tmux server so that the first concurrent `new-session` from
@@ -286,6 +298,51 @@ mod tests {
         let g = map.read().unwrap();
         assert!(!g.contains_key("stale"));
         assert!(g.contains_key("fresh"));
+    }
+
+    /// Regression: archiving a session kills its tmux pane, so the next
+    /// startup observes a dead pane on a resume-capable agent. Without an
+    /// archive guard on `is_recovery_candidate`, the cascade respawns the
+    /// row the user just dismissed (reported: "archive a session, leave
+    /// and re-enter the TUI, it restarts").
+    #[test]
+    fn archived_instance_is_not_recovery_candidate() {
+        let mut inst = Instance::new("archived", "/tmp/test");
+        inst.agent_session_id = Some("11111111-1111-4111-8111-111111111111".into());
+        assert!(
+            is_recovery_candidate(&inst),
+            "baseline: claude + valid sid is a recovery candidate"
+        );
+        inst.archive();
+        assert!(
+            !is_recovery_candidate(&inst),
+            "archived sessions must be excluded from startup recovery"
+        );
+        inst.unarchive();
+        assert!(
+            is_recovery_candidate(&inst),
+            "unarchive must restore recovery eligibility"
+        );
+    }
+
+    /// Snooze is the temporary sibling of archive. While the timer is in
+    /// the future, the row sits in tier 99 and must not be revived by a
+    /// pane-dead probe; once the timer expires, `is_snoozed()` flips to
+    /// false and the row naturally rejoins the recovery set.
+    #[test]
+    fn snoozed_instance_is_not_recovery_candidate_until_expiry() {
+        let mut inst = Instance::new("snoozed", "/tmp/test");
+        inst.agent_session_id = Some("22222222-2222-4222-8222-222222222222".into());
+        inst.snooze(30);
+        assert!(
+            !is_recovery_candidate(&inst),
+            "snoozed sessions must be excluded while the timer is live"
+        );
+        inst.snoozed_until = Some(chrono::Utc::now() - chrono::Duration::minutes(1));
+        assert!(
+            is_recovery_candidate(&inst),
+            "expired snooze must restore recovery eligibility"
+        );
     }
 
     /// Cross-process exclusion is a POSIX `flock(2)` guarantee, not


### PR DESCRIPTION
## Description

Archiving a session, leaving the TUI, and re-entering it would restart the
session you just dismissed. Same bug on the daemon's startup path.

`is_recovery_candidate` in `src/session/recovery.rs` only excluded cockpit
sessions and agents without a valid resume sid. Archive actively kills the
tmux pane (`toggle_archive_at_cursor` in `src/tui/home/operations.rs:818`,
`archive_session` in `src/cli/session.rs:305`), so on next launch:

1. `maybe_start_startup_recovery` walks every instance.
2. `has_live_tmux` returns false (we killed the pane on archive).
3. `is_recovery_candidate` returns true (the archive bit was not checked).
4. The cascade respawns the row.

The daemon's `daemon_startup_recovery` (`src/server/mod.rs:1803, :1888`)
went through the same predicate and shipped the same bug.

Fix: add `!inst.is_archived() && !inst.is_snoozed()` to
`is_recovery_candidate`. Single edit, both call sites inherit. Snooze gets
the same guard because once the snooze timer expires, `is_snoozed()` flips
to false and the row naturally rejoins the recovery set on its own schedule
(rather than the moment a pane goes missing).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How I tested

- `cargo test --lib session::recovery::tests` — 3 pass including the two new regression tests.
- `cargo test --lib session::` — 772 pass, 0 fail.
- `cargo fmt --check` clean.
- `cargo clippy --all-targets` clean.

Two regression tests added:

- `archived_instance_is_not_recovery_candidate` — baseline=true, then `archive()` → false, then `unarchive()` → true.
- `snoozed_instance_is_not_recovery_candidate_until_expiry` — `snooze(30)` → false; setting `snoozed_until` into the past → true.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**
Investigation, fix, and regression tests drafted by Claude via back-and-forth with @njbrake. He pointed at the symptom (archive + re-enter TUI restarts the session), reviewed the root-cause analysis, and approved the fix and the PR description.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

Modified the session recovery logic to prevent archived and snoozed sessions from being incorrectly restarted when the TUI or daemon starts up.

## What Was Added

1. **Recovery check enhancement**: Added explicit checks in the `is_recovery_candidate` function to exclude archived and snoozed sessions, ensuring only active sessions are considered for recovery during startup.

2. **Documentation**: Expanded function documentation to clarify the eligibility constraints and explain how archived/snoozed sessions are handled.

3. **Regression tests**: Two new unit tests prevent future regressions:
   - Verifies archived sessions are excluded from recovery and become eligible again after unarchiving
   - Verifies snoozed sessions are excluded until the snooze timer expires

## Benefits

- **Bug fix**: Prevents the unintended restart of archived sessions (which have killed tmux panes) during daemon/TUI startup
- **Better user control**: Respects user actions—sessions that are manually archived or snoozed remain in that state instead of being automatically recovered
- **Simplified maintenance**: Single-point fix covers both TUI and daemon startup recovery paths, reducing inconsistencies

## Technical Details

The fix adds `!inst.is_archived() && !inst.is_snoozed()` conditions to the existing recovery eligibility checks in `src/session/recovery.rs`. Snoozed sessions naturally return to recovery eligibility once their snooze expiry timer expires. Testing shows the change passes all validation checks (unit tests, cargo fmt, cargo clippy).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1391?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->