### PR TITLE
feat(tui): click + double-click + hover on session list

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -657,6 +657,17 @@ impl App {
                             }
                             if let Some(action) = click_action {
                                 self.execute_action(action, terminal)?;
+                                // Mirror the handle_key path: Action::OpenCockpit
+                                // only stashes the id in `pending_cockpit_open`
+                                // because the cockpit view needs async
+                                // EventStream access that the sync
+                                // `execute_action` can't lend. Drain here so a
+                                // double-click on a cockpit session actually
+                                // opens it.
+                                #[cfg(feature = "serve")]
+                                if let Some(session_id) = self.pending_cockpit_open.take() {
+                                    self.run_cockpit_view(&session_id, terminal).await?;
+                                }
                             }
                             continue;
                         }

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -3,7 +3,7 @@
 use anyhow::Result;
 use crossterm::event::{
     DisableBracketedPaste, DisableMouseCapture, EnableBracketedPaste, EnableMouseCapture, Event,
-    EventStream, KeyCode, KeyEvent, KeyModifiers, MouseEventKind,
+    EventStream, KeyCode, KeyEvent, KeyModifiers, MouseButton, MouseEventKind,
 };
 use futures_util::StreamExt;
 use ratatui::prelude::*;
@@ -564,6 +564,14 @@ impl App {
                                                 match mouse.kind {
                                                     MouseEventKind::ScrollUp if hit_scroll_target => { self.home.handle_scroll_up(mouse.column, mouse.row); }
                                                     MouseEventKind::ScrollDown if hit_scroll_target => { self.home.handle_scroll_down(mouse.column, mouse.row); }
+                                                    // Burst-deferred clicks update selection but can't
+                                                    // execute an activation action mid-burst (it'd tear
+                                                    // down and reattach the terminal while we're still
+                                                    // draining keystrokes). A user double-clicking
+                                                    // during dictation can click again after the burst
+                                                    // ends.
+                                                    MouseEventKind::Down(MouseButton::Left) if hit_list => { let _ = self.home.handle_click(mouse.column, mouse.row); }
+                                                    MouseEventKind::Moved => { self.home.handle_hover(mouse.column, mouse.row); }
                                                     _ => {}
                                                 }
                                             }
@@ -608,6 +616,25 @@ impl App {
                             let hit_diff = self.home.is_diff_open()
                                 && self.home.hit_diff(mouse.column, mouse.row);
                             let hit_scroll_target = hit_diff || hit_list || hit_preview;
+                            // Left-click is handled outside the unified
+                            // match because it returns an `Option<Action>`
+                            // (a double-click activates the session and
+                            // needs to flow through `execute_action`), not
+                            // a bool. The single-click selection always
+                            // mutates `cursor` so we redraw unconditionally
+                            // before dispatching the action.
+                            let click_action = if matches!(
+                                mouse.kind,
+                                MouseEventKind::Down(MouseButton::Left)
+                            ) && hit_list
+                            {
+                                let action =
+                                    self.home.handle_click(mouse.column, mouse.row);
+                                self.draw(terminal)?;
+                                action
+                            } else {
+                                None
+                            };
                             let handled = match mouse.kind {
                                 MouseEventKind::ScrollUp if hit_scroll_target => {
                                     self.home.handle_scroll_up(mouse.column, mouse.row)
@@ -615,10 +642,21 @@ impl App {
                                 MouseEventKind::ScrollDown if hit_scroll_target => {
                                     self.home.handle_scroll_down(mouse.column, mouse.row)
                                 }
+                                // Moved events are dispatched unconditionally
+                                // (no `hit_list` guard) so the handler can
+                                // clear the hover state the moment the
+                                // cursor leaves the list, even when the new
+                                // position lands on the preview or border.
+                                MouseEventKind::Moved => {
+                                    self.home.handle_hover(mouse.column, mouse.row)
+                                }
                                 _ => false,
                             };
                             if handled {
                                 self.draw(terminal)?;
+                            }
+                            if let Some(action) = click_action {
+                                self.execute_action(action, terminal)?;
                             }
                             continue;
                         }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -21,6 +21,12 @@ use crate::tui::dialogs::{
 use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::settings::{SettingsAction, SettingsView};
 
+/// Maximum gap between two left-clicks on the same row that still
+/// counts as a double-click. 400ms matches the default on most desktop
+/// environments. Worth tuning if real-world feedback says it's too
+/// fast for trackpads or too slow on remote sessions.
+const DOUBLE_CLICK_THRESHOLD: std::time::Duration = std::time::Duration::from_millis(400);
+
 fn resolve_hook_install_agent(
     tool_name: &str,
     session_config: &crate::session::config::SessionConfig,
@@ -1722,43 +1728,8 @@ impl HomeView {
                 self.update_selected();
             }
             KeyCode::Enter => {
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if matches!(inst.status, Status::Deleting | Status::Creating) {
-                            return None;
-                        }
-                        if inst.is_cockpit_mode() {
-                            #[cfg(feature = "serve")]
-                            {
-                                return Some(Action::OpenCockpit(id.clone()));
-                            }
-                            #[cfg(not(feature = "serve"))]
-                            {
-                                return Some(Action::SetTransientStatus(
-                                    "Cockpit session: rebuild with --features serve to attach"
-                                        .to_string(),
-                                ));
-                            }
-                        }
-                    }
-                    return match self.view_mode {
-                        ViewMode::Agent => Some(Action::AttachSession(id.clone())),
-                        ViewMode::Terminal => {
-                            let terminal_mode = if let Some(inst) = self.get_instance(id) {
-                                if inst.is_sandboxed() {
-                                    self.get_terminal_mode(id)
-                                } else {
-                                    TerminalMode::Host
-                                }
-                            } else {
-                                TerminalMode::Host
-                            };
-                            Some(Action::AttachTerminal(id.clone(), terminal_mode))
-                        }
-                        ViewMode::Tool(ref tool_name) => {
-                            Some(Action::AttachToolSession(id.clone(), tool_name.clone()))
-                        }
-                    };
+                if self.selected_session.is_some() {
+                    return self.activate_selected_session();
                 } else if let Some(Item::Group { path, .. }) = self.flat_items.get(self.cursor) {
                     let path = path.clone();
                     self.toggle_group_collapsed(&path);
@@ -2043,6 +2014,49 @@ impl HomeView {
         self.update_selected();
     }
 
+    /// Resolve the action that "activating" the currently-selected session
+    /// should produce (cockpit open, attach to tmux session, attach to a
+    /// tool session, etc.). Returns `None` for in-flight sessions
+    /// (`Creating`/`Deleting`) and when no session is selected. Shared
+    /// between the `Enter` keybind and double-click activation so the two
+    /// paths can't drift.
+    pub(super) fn activate_selected_session(&mut self) -> Option<Action> {
+        let id = self.selected_session.clone()?;
+        if let Some(inst) = self.get_instance(&id) {
+            if matches!(inst.status, Status::Deleting | Status::Creating) {
+                return None;
+            }
+            if inst.is_cockpit_mode() {
+                #[cfg(feature = "serve")]
+                {
+                    return Some(Action::OpenCockpit(id));
+                }
+                #[cfg(not(feature = "serve"))]
+                {
+                    return Some(Action::SetTransientStatus(
+                        "Cockpit session: rebuild with --features serve to attach".to_string(),
+                    ));
+                }
+            }
+        }
+        match self.view_mode {
+            ViewMode::Agent => Some(Action::AttachSession(id)),
+            ViewMode::Terminal => {
+                let terminal_mode = if let Some(inst) = self.get_instance(&id) {
+                    if inst.is_sandboxed() {
+                        self.get_terminal_mode(&id)
+                    } else {
+                        TerminalMode::Host
+                    }
+                } else {
+                    TerminalMode::Host
+                };
+                Some(Action::AttachTerminal(id, terminal_mode))
+            }
+            ViewMode::Tool(ref tool_name) => Some(Action::AttachToolSession(id, tool_name.clone())),
+        }
+    }
+
     pub(super) fn update_selected(&mut self) {
         if let Some(item) = self.flat_items.get(self.cursor) {
             let prev_session = self.selected_session.clone();
@@ -2183,6 +2197,142 @@ impl HomeView {
         }
         self.preview_scroll_offset = clamped;
         true
+    }
+
+    /// Map a (col, row) inside the list's inner content rect to a
+    /// `flat_items` index, or `None` for rows that don't resolve to a real
+    /// item (search bar, `[N more above/below]` indicator rows, empty list,
+    /// outside the inner rect, dialog open, diff view active). Shared by
+    /// `handle_click` and `hovered_index` so selection and hover use the
+    /// exact same math.
+    pub(super) fn resolve_row_to_index(&self, col: u16, row: u16) -> Option<usize> {
+        if self.diff_view.is_some() || self.has_dialog() {
+            return None;
+        }
+        let inner = self.list_inner_area;
+        if !inner.contains(Position::from((col, row))) {
+            return None;
+        }
+        if self.flat_items.is_empty() {
+            return None;
+        }
+        let visible_height = if self.search_active {
+            (inner.height as usize).saturating_sub(1)
+        } else {
+            inner.height as usize
+        };
+        if visible_height == 0 {
+            return None;
+        }
+        let row_in_inner = row.saturating_sub(inner.y) as usize;
+        if self.search_active && row_in_inner + 1 == inner.height as usize {
+            return None;
+        }
+
+        let scroll = crate::tui::components::scroll::calculate_scroll(
+            self.flat_items.len(),
+            self.cursor,
+            visible_height,
+        );
+        let row_offset = if scroll.has_more_above { 1 } else { 0 };
+        if row_in_inner < row_offset {
+            return None;
+        }
+        let item_row = row_in_inner - row_offset;
+        if item_row >= scroll.list_visible {
+            return None;
+        }
+        let abs_idx = scroll.scroll_offset + item_row;
+        if abs_idx >= self.flat_items.len() {
+            return None;
+        }
+        Some(abs_idx)
+    }
+
+    /// Currently hovered `flat_items` index, derived from the last mouse
+    /// position. `None` when the mouse is off the list or over a row that
+    /// doesn't resolve to a real item. Recomputed on every call so wheel
+    /// scrolls implicitly move the hover with the items under the cursor.
+    pub(super) fn hovered_index(&self) -> Option<usize> {
+        self.mouse_pos
+            .and_then(|(c, r)| self.resolve_row_to_index(c, r))
+    }
+
+    /// Route a left-click at (col, row) inside the session list. A single
+    /// click on a session row selects it (same effect as arrow-key
+    /// navigation); a single click on a group row toggles its collapsed
+    /// state; a second click on the same row within
+    /// `DOUBLE_CLICK_THRESHOLD` activates the session (the same Action
+    /// the `Enter` keybind would have produced). Returns the activation
+    /// `Action` for the caller to dispatch, or `None` for selection-only /
+    /// no-op clicks. The caller redraws unconditionally so the moved
+    /// cursor / toggled group always paints before the action executes.
+    /// Gated by `has_dialog()` (via `resolve_row_to_index`) so clicks
+    /// don't shift selection out from under an open modal.
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<Action> {
+        self.handle_click_at(std::time::Instant::now(), col, row)
+    }
+
+    /// Same as `handle_click`, but the caller supplies `now`. Used by
+    /// unit tests to drive double-click detection deterministically
+    /// without relying on `thread::sleep`.
+    pub(super) fn handle_click_at(
+        &mut self,
+        now: std::time::Instant,
+        col: u16,
+        row: u16,
+    ) -> Option<Action> {
+        let abs_idx = self.resolve_row_to_index(col, row)?;
+
+        let is_double_click = matches!(
+            self.last_click,
+            Some((prev_time, _, prev_row))
+                if prev_row == row
+                    && now.duration_since(prev_time) <= DOUBLE_CLICK_THRESHOLD
+        );
+        self.last_click = Some((now, col, row));
+
+        let item = self.flat_items[abs_idx].clone();
+        if is_double_click {
+            // First click already selected the row (and toggled a group);
+            // the second click only activates a session. Re-toggling a
+            // group on the second click would undo the first toggle and
+            // flicker, so groups intentionally swallow the second click.
+            return match item {
+                Item::Session { .. } => self.activate_selected_session(),
+                Item::Group { .. } => None,
+            };
+        }
+
+        match item {
+            Item::Group { path, .. } => {
+                self.toggle_group_collapsed(&path);
+            }
+            Item::Session { .. } => {
+                if self.cursor != abs_idx {
+                    self.cursor = abs_idx;
+                    self.update_selected();
+                }
+            }
+        }
+        None
+    }
+
+    /// Record the mouse position from a `MouseEventKind::Moved` event so
+    /// the list can render a hover highlight on the row under the cursor.
+    /// `mouse_pos` is cleared when the cursor leaves `list_inner_area`.
+    /// Returns `true` only when the resolved hovered item changes, so the
+    /// caller can skip a redraw on every pixel-level mouse twitch.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let new_pos = if self.list_inner_area.contains(Position::from((col, row))) {
+            Some((col, row))
+        } else {
+            None
+        };
+        let prev_idx = self.hovered_index();
+        self.mouse_pos = new_pos;
+        let new_idx = self.hovered_index();
+        prev_idx != new_idx
     }
 
     /// Route a mouse-wheel-down at (col, row); see handle_scroll_up.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2298,8 +2298,22 @@ impl HomeView {
             // the second click only activates a session. Re-toggling a
             // group on the second click would undo the first toggle and
             // flicker, so groups intentionally swallow the second click.
+            //
+            // We re-sync `cursor` to `abs_idx` before activating because
+            // anything between the two clicks (an arrow keypress, a
+            // status-poll-driven re-sort) can move the cursor away from
+            // the row the user is actually double-clicking. Without this,
+            // `activate_selected_session()` reads `selected_session` —
+            // which tracks `cursor`, not the click target — and we'd open
+            // the wrong session.
             return match item {
-                Item::Session { .. } => self.activate_selected_session(),
+                Item::Session { .. } => {
+                    if self.cursor != abs_idx {
+                        self.cursor = abs_idx;
+                        self.update_selected();
+                    }
+                    self.activate_selected_session()
+                }
                 Item::Group { .. } => None,
             };
         }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -255,6 +255,22 @@ pub struct HomeView {
     pub(super) preview_area: Rect,
     pub(super) diff_area: Rect,
     pub(super) list_area: Rect,
+    /// Inner content rect of the session list (borders/padding stripped).
+    /// Used to map a click coordinate to a `flat_items` index. The outer
+    /// `list_area` still drives `hit_list` so wheel events over the border
+    /// keep working; clicks use the inner rect so we don't try to select
+    /// the border row.
+    pub(super) list_inner_area: Rect,
+    /// Last reported mouse position when it was over `list_inner_area`,
+    /// `None` when the cursor is outside the list. Stored as a position
+    /// rather than a resolved item index so wheel scrolls implicitly
+    /// re-resolve the hovered item without an extra event round-trip.
+    pub(super) mouse_pos: Option<(u16, u16)>,
+    /// Timestamp and row of the previous left-click. The next click is
+    /// classified as a double-click when it lands within
+    /// `DOUBLE_CLICK_THRESHOLD` on the same row, which then activates the
+    /// session (same as pressing Enter on the selected row).
+    pub(super) last_click: Option<(std::time::Instant, u16, u16)>,
 
     // Terminal mode for sandboxed sessions (per-session, ephemeral)
     pub(super) terminal_modes: HashMap<String, TerminalMode>,
@@ -479,6 +495,9 @@ impl HomeView {
             preview_area: Rect::default(),
             diff_area: Rect::default(),
             list_area: Rect::default(),
+            list_inner_area: Rect::default(),
+            mouse_pos: None,
+            last_click: None,
             terminal_modes: HashMap::new(),
             default_terminal_mode,
             sound_config,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -557,6 +557,7 @@ impl HomeView {
             .padding(Padding::horizontal(1));
 
         let inner = block.inner(area);
+        self.list_inner_area = inner;
         frame.render_widget(block, area);
 
         if self.instances().is_empty() && !self.has_any_groups() {
@@ -592,6 +593,7 @@ impl HomeView {
             )));
         }
 
+        let hover_idx = self.hovered_index();
         for (i, item) in self
             .flat_items
             .iter()
@@ -601,16 +603,24 @@ impl HomeView {
         {
             let abs_idx = i + scroll.scroll_offset;
             let is_selected = abs_idx == self.cursor;
+            let is_hovered = !is_selected && Some(abs_idx) == hover_idx;
             let is_match =
                 !self.search_matches.is_empty() && self.search_matches.contains(&abs_idx);
             let mut line = self.render_item_line(item, is_selected, is_match, theme, inner.width);
-            if is_selected {
-                // Pad to full width so the selection background fills the entire row
+            // Selection wins over hover: when the mouse is over the
+            // already-selected row, keep the brighter selected bg rather
+            // than the dimmer hover bg.
+            if is_selected || is_hovered {
                 let pad = (inner.width as usize).saturating_sub(line.width());
                 if pad > 0 {
                     line.spans.push(Span::raw(" ".repeat(pad)));
                 }
-                line = line.style(Style::default().bg(theme.session_selection));
+                let bg = if is_selected {
+                    theme.session_selection
+                } else {
+                    theme.selection
+                };
+                line = line.style(Style::default().bg(bg));
             }
             lines.push(line);
         }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4195,6 +4195,47 @@ mod click_to_select {
 
     #[test]
     #[serial]
+    fn double_click_activates_clicked_row_even_if_cursor_moved_between_clicks() {
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        // Capture the id at flat_items[2] so we know which session
+        // the row-3 click is targeting.
+        let clicked_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
+        let t0 = Instant::now();
+        env.view.handle_click_at(t0, 5, 3);
+        assert_eq!(env.view.cursor, 2);
+
+        // Simulate the cursor drifting away between clicks (e.g., a
+        // keyboard arrow press or an async list refresh that selected
+        // a different row).
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let t1 = t0 + Duration::from_millis(150);
+        let action = env.view.handle_click_at(t1, 5, 3);
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::AttachSession(clicked_id)),
+            "double-click must activate the row that was clicked, \
+             not whatever the cursor drifted to"
+        );
+        assert_eq!(
+            env.view.cursor, 2,
+            "double-click should also re-sync cursor onto the clicked row"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn double_click_on_creating_session_returns_no_action() {
         use std::time::{Duration, Instant};
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4038,3 +4038,313 @@ mod scroll_pane_isolation {
         assert_eq!(env.view.cursor, 0, "wheel over list should retreat cursor");
     }
 }
+
+mod click_to_select {
+    //! Left-click on a session row in the list selects it (same effect as
+    //! arrow-key navigation). Clicks outside the inner list rect, clicks on
+    //! a row past the last item, and clicks while a dialog is open are
+    //! no-ops.
+
+    use super::*;
+    use ratatui::layout::Rect;
+
+    /// Inner rect chosen with comfortable headroom so all sessions fit
+    /// without "[N more above/below]" indicators consuming a row.
+    fn setup_inner(env: &mut TestEnv) {
+        env.view.list_inner_area = Rect::new(1, 1, 28, 10);
+    }
+
+    #[test]
+    #[serial]
+    fn click_selects_session_at_clicked_row() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        // Click the third visible row (inner.y + 2 == 3) -> flat_items[2].
+        let action = env.view.handle_click(5, 3);
+        assert!(action.is_none(), "single click should not activate");
+        assert_eq!(env.view.cursor, 2);
+    }
+
+    #[test]
+    #[serial]
+    fn click_on_already_selected_row_does_not_move_cursor() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+
+        let action = env.view.handle_click(5, 2);
+        assert!(action.is_none());
+        assert_eq!(env.view.cursor, 1);
+    }
+
+    #[test]
+    #[serial]
+    fn click_below_last_item_is_noop() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        // inner.y=1, three items occupy rows 1..=3. Row 5 is inside the
+        // inner rect but past the last item.
+        let action = env.view.handle_click(5, 5);
+        assert!(action.is_none());
+        assert_eq!(env.view.cursor, 0);
+    }
+
+    #[test]
+    #[serial]
+    fn click_outside_inner_rect_is_noop() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        // Row 0 is above inner.y; column 50 is past inner.x + inner.width.
+        assert!(env.view.handle_click(5, 0).is_none());
+        assert!(env.view.handle_click(50, 2).is_none());
+        assert_eq!(env.view.cursor, 0);
+    }
+
+    #[test]
+    #[serial]
+    fn click_with_dialog_open_is_noop() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.show_help = true;
+
+        let action = env.view.handle_click(5, 3);
+        assert!(action.is_none(), "dialog should swallow the click");
+        assert_eq!(env.view.cursor, 0);
+    }
+
+    #[test]
+    #[serial]
+    fn double_click_on_session_returns_attach_action() {
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let expected_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
+        let t0 = Instant::now();
+        let first = env.view.handle_click_at(t0, 5, 3);
+        assert!(first.is_none(), "first click only selects");
+        assert_eq!(env.view.cursor, 2);
+
+        let t1 = t0 + Duration::from_millis(150);
+        let second = env.view.handle_click_at(t1, 5, 3);
+        assert_eq!(
+            second,
+            Some(crate::tui::app::Action::AttachSession(expected_id)),
+            "second click within threshold should activate the session"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn two_clicks_on_different_rows_do_not_activate() {
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let t0 = Instant::now();
+        env.view.handle_click_at(t0, 5, 2);
+        let t1 = t0 + Duration::from_millis(100);
+        let action = env.view.handle_click_at(t1, 5, 3);
+        assert!(
+            action.is_none(),
+            "different-row second click is a fresh single click, not a double-click"
+        );
+        assert_eq!(env.view.cursor, 2);
+    }
+
+    #[test]
+    #[serial]
+    fn click_after_threshold_does_not_activate() {
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let t0 = Instant::now();
+        env.view.handle_click_at(t0, 5, 3);
+        let t1 = t0 + Duration::from_millis(1500);
+        let action = env.view.handle_click_at(t1, 5, 3);
+        assert!(
+            action.is_none(),
+            "second click past threshold should not activate"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn double_click_on_creating_session_returns_no_action() {
+        use std::time::{Duration, Instant};
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        // Force the target session into Creating; activation must bail.
+        let target_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        env.view.mutate_instance(&target_id, |inst| {
+            inst.status = crate::session::Status::Creating;
+        });
+
+        let t0 = Instant::now();
+        env.view.handle_click_at(t0, 5, 3);
+        let t1 = t0 + Duration::from_millis(150);
+        let action = env.view.handle_click_at(t1, 5, 3);
+        assert!(
+            action.is_none(),
+            "Creating sessions are not attachable; double-click should noop"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn hover_sets_resolved_index_for_row_under_mouse() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        let changed = env.view.handle_hover(5, 3);
+        assert!(
+            changed,
+            "first hover over a fresh row should request redraw"
+        );
+        assert_eq!(env.view.hovered_index(), Some(2));
+    }
+
+    #[test]
+    #[serial]
+    fn hover_moving_to_a_new_row_requests_redraw() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.handle_hover(5, 1);
+        let changed = env.view.handle_hover(5, 2);
+        assert!(changed);
+        assert_eq!(env.view.hovered_index(), Some(1));
+    }
+
+    #[test]
+    #[serial]
+    fn hover_pixel_twitch_on_same_row_is_noop() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.handle_hover(5, 2);
+        let changed = env.view.handle_hover(6, 2);
+        assert!(
+            !changed,
+            "same-row movement should not trigger a redraw request"
+        );
+        assert_eq!(env.view.hovered_index(), Some(1));
+    }
+
+    #[test]
+    #[serial]
+    fn hover_leaving_list_clears_resolved_index() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.handle_hover(5, 2);
+        assert_eq!(env.view.hovered_index(), Some(1));
+
+        // Row 0 is above the inner rect (inner.y = 1).
+        let changed = env.view.handle_hover(5, 0);
+        assert!(changed, "leaving the list should request a redraw");
+        assert_eq!(env.view.hovered_index(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn hover_resolves_to_none_when_dialog_open() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.show_help = true;
+        env.view.handle_hover(5, 2);
+        assert_eq!(env.view.hovered_index(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn hover_below_last_item_resolves_to_none() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.handle_hover(5, 5);
+        assert_eq!(env.view.hovered_index(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn click_on_group_row_toggles_collapsed() {
+        let mut env = create_test_env_with_mixed_sessions();
+        setup_inner(&mut env);
+
+        // Find the first group row in flat_items; record initial collapsed.
+        let (group_idx, group_path) = env
+            .view
+            .flat_items
+            .iter()
+            .enumerate()
+            .find_map(|(i, item)| match item {
+                crate::session::Item::Group { path, .. } => Some((i, path.clone())),
+                _ => None,
+            })
+            .expect("mixed env should produce at least one group row");
+
+        let click_row = env.view.list_inner_area.y + group_idx as u16;
+        let was_collapsed = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Group {
+                    path, collapsed, ..
+                } if path == &group_path => Some(*collapsed),
+                _ => None,
+            })
+            .unwrap();
+
+        let action = env.view.handle_click(5, click_row);
+        assert!(
+            action.is_none(),
+            "single click on a group should not activate"
+        );
+
+        let now_collapsed = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Group {
+                    path, collapsed, ..
+                } if path == &group_path => Some(*collapsed),
+                _ => None,
+            })
+            .expect("group row should still be present after toggle");
+        assert_ne!(was_collapsed, now_collapsed, "group collapsed state flips");
+    }
+}


### PR DESCRIPTION
## Description

Adds mouse-driven interaction to the home view's session list:

- **Click** on a session row selects it (same effect as arrow-key navigation); click on a group row toggles its collapsed state.
- **Hover** highlights the row under the cursor using `theme.selection` (distinct from `theme.session_selection`, so hover and the keyboard-cursor selection don't collide visually).
- **Double-click** (<=400 ms, same row) on a session activates it by returning the same `Action` the Enter keybind emits (`AttachSession` / `AttachTerminal` / `AttachToolSession` / `OpenCockpit`), respecting `Creating`/`Deleting` state. The routing was factored out of the Enter handler into `activate_selected_session()` so the two paths can't drift.

Mouse capture is already on by default (`AOE_MOUSE_CAPTURE=0` opts out), so no new env or settings surface is introduced.

### Implementation notes

- `mouse_pos` stores the last mouse position rather than a resolved index, so wheel scrolls slide the hover with the items under the cursor without an extra event round-trip.
- `hovered_index()` and `handle_click` both delegate to a shared `resolve_row_to_index()` helper, so what you see hovered is what the next click selects.
- `handle_hover` returns `true` only when the resolved item changes, so pixel-level mouse twitches on the same row don't trigger a redraw.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary (none needed; existing docs do not enumerate mouse interactions)
- [ ] For UI changes: included screenshot or recording (interaction is local mouse behavior on the TUI; no static screenshot captures it well, will add a recording on request)

### How I tested

- 16 new unit tests in \`tui::home::tests::click_to_select\` covering: single-click select, single-click group toggle, click-below-last-item, click-outside-inner-rect, click-while-dialog-open, hover sets/clears, pixel-twitch noop, hover under dialog, double-click activates, two-clicks-on-different-rows is not a double-click, click past the 400 ms threshold is not a double-click, and double-click on a Creating session is suppressed.
- \`cargo fmt\`, \`cargo clippy --all-targets\`, \`cargo test --lib\` (1947 passing), \`cargo test --tests\` (116 passing).

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-7)

**Any Additional AI Details you'd like to share:** Iterated interactively, design discussed before implementation. I reviewed each diff before commit; tests were written to spec rather than generated and accepted blindly.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Adds full mouse support to the TUI home view session list: click to select, click a group to toggle collapse, hover highlight, and double-click to activate a session. Activation was unified with keyboard Enter via a new helper so mouse and keyboard behave identically. Mouse capture is enabled by default (opt-out via AOE_MOUSE_CAPTURE=0); no persistent settings added.

### Core Functionality Added
- Single-click selects a session row; clicking a group toggles collapse.
- Hover highlights the row under the cursor using theme.selection (kept visually distinct from keyboard selection).
- Double-click (<= 400 ms, same row) activates the session (AttachSession / AttachTerminal / AttachToolSession / OpenCockpit), skipping activation for Creating/Deleting sessions and group rows.
- Shared activation logic via activate_selected_session() used by Enter and double-click.
- Mouse handling in the TUI event loop separates selection from activation and defers destructive activation during paste-burst sequences.

### Files Changed (high-level)
- src/tui/app.rs — mouse event dispatch updated: selects vs activates separately, safely handles paste-burst, forces redraws where needed, and drains pending_cockpit_open after click-driven actions.
- src/tui/home/input.rs — added double-click threshold and many mouse helpers: resolve_row_to_index, hovered_index, handle_hover, handle_click/_at, and activate_selected_session; refactored Enter path.
- src/tui/home/mod.rs — HomeView gains list_inner_area, mouse_pos, and last_click fields and initializes them.
- src/tui/home/render.rs — render stores list inner rect and paints hovered rows (fills row width) while preserving selected-row styling priority.
- src/tui/home/tests.rs — expanded click_to_select tests (hover, selection, group toggle, double-click timing/row rules, dialog suppression, Creating-session suppression).

### Benefits
- Better discoverability and usability of the session list for mouse users.
- Consistent behavior between keyboard and mouse via shared activation path.
- Reduced unnecessary redraws by only updating hover when resolved item changes and by tracking coordinates (so wheel scroll moves the hover naturally).
- Improved robustness: 16 new unit tests and local checks (fmt, clippy, tests) included.

### Potential Enhancements
- Expose mouse-capture preference in persistent settings rather than relying on environment opt-out.
- Make double-click threshold configurable for accessibility.
- Add integration tests that exercise platform mouse events.

### Technical Notes (concise)
- DOUBLE_CLICK_THRESHOLD = 400 ms.
- mouse_pos stores last cursor coordinates (col, row) so scroll keeps hover aligned with items under pointer.
- resolve_row_to_index(col,row) maps coordinates to flat_items indices and ignores non-item rows (search bar, empty regions, “more” rows) or when dialogs/diff view are active.
- hovered_index() and handle_click delegate to resolve_row_to_index(); handle_hover returns true only when resolved index changed to avoid redraw thrash.
- handle_click records (Instant, col, row) for double-click detection; before activating on double-click, the cursor is re-synced to the clicked row so activation uses the originally clicked item even if the pointer drifted between clicks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->