### PR TITLE
fix(tui): help overlay advertised stale H/L resize binding

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 49;
+const DIALOG_HEIGHT: u16 = 50;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -44,6 +44,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("R", "Rename session/group"),
                     ("M", "Send message to agent"),
                     ("F", "Toggle favorite"),
+                    ("H", "Snooze (toggle)"),
                     ("E", "Restart session"),
                     ("F5", "Restart session"),
                 ],
@@ -84,7 +85,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                 vec![
                     ("j/↓", "Move down"),
                     ("k/↑", "Move up"),
-                    ("h/←", "Collapse group"),
+                    ("←", "Collapse group"),
                     ("l/→", "Expand group"),
                     ("Home/End/G", "Go to top / bottom"),
                     ("PgUp/Dn", "Move 10 (also Shift+↑/↓, { })"),
@@ -105,6 +106,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("r", "Rename session/group"),
                     ("m", "Send message to agent"),
                     ("f", "Toggle favorite"),
+                    ("h", "Snooze (toggle)"),
                     ("e", "Restart session"),
                     ("F5", "Restart session"),
                 ],
@@ -249,6 +251,26 @@ mod tests {
             assert!(
                 keys.iter().any(|(k, _)| *k == "< >"),
                 "Views section should contain < > resize shortcut"
+            );
+        }
+    }
+
+    #[test]
+    fn help_lists_snooze() {
+        // PR #1084 introduced the snooze primitive (H in strict mode, h in
+        // non-strict) but did not advertise it in the help overlay. Lock the
+        // listing in so a future binding rename keeps the docs honest.
+        for (strict, expected_key) in [(false, "h"), (true, "H")] {
+            let all = shortcuts(strict);
+            let actions = all
+                .iter()
+                .find(|(name, _)| name.starts_with("Actions"))
+                .expect("Actions section should exist");
+            let (_, keys) = actions;
+            assert!(
+                keys.iter()
+                    .any(|(k, desc)| *k == expected_key && desc.contains("Snooze")),
+                "Actions section should contain {expected_key} Snooze entry (strict={strict})"
             );
         }
     }

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -54,7 +54,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("T", "Toggle Agent/Terminal view"),
                     ("C", "Toggle container/host (sandbox)"),
                     ("Ctrl+D", "Diff view (git changes)"),
-                    ("H/L", "Resize list panel"),
+                    ("< >", "Resize list panel"),
                     ("O", "Cycle sort forward"),
                     ("Ctrl+O", "Cycle sort backward"),
                     ("Ctrl+G", "Toggle group by project"),
@@ -115,7 +115,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("t", "Toggle Agent/Terminal view"),
                     ("c", "Toggle container/host (sandbox)"),
                     ("D", "Diff view (git changes)"),
-                    ("H/L", "Resize list panel"),
+                    ("< >", "Resize list panel"),
                     ("o", "Cycle sort forward"),
                     ("Ctrl+o", "Cycle sort backward"),
                     ("g", "Toggle group by project"),
@@ -247,8 +247,8 @@ mod tests {
             assert!(views_section.is_some(), "Views section should exist");
             let (_, keys) = views_section.unwrap();
             assert!(
-                keys.iter().any(|(k, _)| *k == "H/L"),
-                "Views section should contain H/L resize shortcut"
+                keys.iter().any(|(k, _)| *k == "< >"),
+                "Views section should contain < > resize shortcut"
             );
         }
     }


### PR DESCRIPTION
## Description

PR #1084 rebound capital `H` to snooze (mnemonic: **H**ide) and moved the list-pane resize controls from `H`/`L` to `<` and `>`. The `input.rs` handler was updated, but the help overlay was not — `?` still advertised "H/L Resize list panel" in both strict and non-strict Views sections, and the `help_contains_resize_shortcut` test locked in the stale text.

Symptom: pressing capital `H` snoozes the row instead of widening the sidebar; users following the in-app help got no resize at all.

This patch updates both help entries (strict at `src/tui/components/help.rs:57`, non-strict at `:118`) and the test assertion at `:248-251` to point at `< >`, matching what `input.rs:1771-1776` actually wires up. No behavior change — the bindings already worked; only the documentation was lying.

Not in scope (but flagging for follow-up): the same PR also made lowercase `h` snooze in non-strict mode, so `help.rs:87` "h/← Collapse group" is now also stale, and neither help section lists snooze in its Actions block.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

Tested via \`cargo test --lib tui::components::help\` (3/3 pass) and the full TUI suite (747/747 pass). \`cargo fmt\` and \`cargo clippy\` clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Investigation, root-cause trace, and the help.rs edit were drafted by Claude via the gstack /investigate skill. The PR scope was confirmed interactively before any code changed.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR updates the help overlay text and tests to match recent keybinding changes (no runtime behavior changes).

What changed (high-level)
- Replaced the outdated "H/L Resize list panel" help text with "< >" in both strict and non-strict help views.
- Advertised the snooze binding in the help overlay (H in strict mode, h in non-strict mode).
- Removed the stale "h/← Collapse group" listing in non-strict navigation (now only "←").
- Increased the help dialog height by 1 line to accommodate the extra Actions row.
- Updated and added tests to assert the new help text and the presence of the snooze entry.

Technical details
- File updated: src/tui/components/help.rs
  - DIALOG_HEIGHT bumped from 49 to 50.
  - shortcuts(strict) updated:
    - Views section: ("< >", "Resize list panel")
    - Actions (strict): added ("H", "Snooze (toggle)")
    - Actions (non-strict): added ("h", "Snooze (toggle)")
    - Navigation (non-strict): changed ("←", "Collapse group") (removed "h/←")
  - Tests updated/added in the same file:
    - help_contains_resize_shortcut now asserts "< >"
    - help_lists_snooze added/updated to check snooze entries for strict/non-strict
    - content-fit test adjusted to account for DIALOG_HEIGHT change

Benefits
- Help overlay now reflects actual keybindings, preventing user confusion (e.g., pressing H no longer appears to be a resize command).
- Tests lock these documentation entries to prevent regressions when keybindings change.
- Small UI layout tweak ensures help content fits without truncation.

Notes / follow-up
- The PR flags other potentially stale help entries (e.g., other lowercase/uppercase mismatches) for a later cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1393?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->