### PR TITLE
fix(hooks): make status hook tolerant + drop fragile orphan sweep

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -77,11 +77,10 @@ pub(crate) fn codex_config_path_display_for_host_environment(entries: &[String])
 ///
 /// The command must never exit non-zero, otherwise the agent treats the hook
 /// as a blocking failure and refuses to run further tool calls. `/tmp/aoe-hooks/<id>`
-/// can disappear mid-session (e.g. when another AoE TUI in a different
-/// namespace runs its orphan-dir sweep, or when /tmp is swept by the OS), so
-/// both mkdir and printf must tolerate a missing parent dir. We swallow stderr
-/// and force a final `exit 0`: at worst the status file is one tick stale and
-/// the next hook call recreates the dir.
+/// can disappear mid-session (OS /tmp cleanup, transient FS hiccup, external
+/// tooling), so both mkdir and printf must tolerate a missing parent dir. We
+/// swallow stderr and force a final `exit 0`: at worst the status file is one
+/// tick stale and the next hook call recreates the dir.
 fn hook_command(status: &str) -> String {
     hook_command_with_base(status, HOOK_STATUS_BASE)
 }
@@ -1824,8 +1823,8 @@ command = "echo user-hook"
     #[test]
     fn test_hook_command_tolerates_unwritable_base_dir() {
         // Regression for #1390: if /tmp/aoe-hooks/<id> disappears mid-session
-        // (e.g. a sibling AoE namespace sweeps it, or /tmp gets cleaned), the
-        // hook must still exit 0 so the agent doesn't treat it as blocking and
+        // (OS /tmp cleanup, transient FS hiccup, external tooling), the hook
+        // must still exit 0 so the agent doesn't treat it as blocking and
         // freeze further tool calls.
         use std::process::Command;
 

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -73,39 +73,22 @@ pub(crate) fn codex_config_path_display_for_host_environment(entries: &[String])
         .unwrap_or_else(codex_config_path_display)
 }
 
-/// Sweep `/tmp/aoe-hooks/*/` removing per-instance dirs that no longer
-/// correspond to a live AoE session. Called on TUI startup to clean up
-/// dirs left behind by sessions destroyed while the TUI was not running.
-/// Skips the special `_global` dir (holds session-aggregate state).
-pub fn sweep_orphaned_hook_dirs(live_session_ids: &std::collections::HashSet<String>) {
-    let base = std::path::Path::new(HOOK_STATUS_BASE);
-    let Ok(entries) = std::fs::read_dir(base) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let Ok(name) = entry.file_name().into_string() else {
-            continue;
-        };
-        if name == "_global" {
-            continue;
-        }
-        if live_session_ids.contains(&name) {
-            continue;
-        }
-        let path = entry.path();
-        if let Err(e) = std::fs::remove_dir_all(&path) {
-            tracing::warn!("hooks: failed to remove orphan dir {:?}: {}", path, e);
-        } else {
-            tracing::info!("hooks: removed orphan dir {:?}", path);
-        }
-    }
+/// Build the shell command for a hook that writes a status value.
+///
+/// The command must never exit non-zero, otherwise the agent treats the hook
+/// as a blocking failure and refuses to run further tool calls. `/tmp/aoe-hooks/<id>`
+/// can disappear mid-session (e.g. when another AoE TUI in a different
+/// namespace runs its orphan-dir sweep, or when /tmp is swept by the OS), so
+/// both mkdir and printf must tolerate a missing parent dir. We swallow stderr
+/// and force a final `exit 0`: at worst the status file is one tick stale and
+/// the next hook call recreates the dir.
+fn hook_command(status: &str) -> String {
+    hook_command_with_base(status, HOOK_STATUS_BASE)
 }
 
-/// Build the shell command for a hook that writes a status value.
-fn hook_command(status: &str) -> String {
+fn hook_command_with_base(status: &str, base: &str) -> String {
     format!(
-        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID && printf {} > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status'",
-        status
+        "sh -c '[ -n \"$AOE_INSTANCE_ID\" ] || exit 0; mkdir -p {base}/$AOE_INSTANCE_ID 2>/dev/null; printf {status} > {base}/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'"
     )
 }
 
@@ -1836,6 +1819,54 @@ command = "echo user-hook"
         let cmd = hook_command("idle");
         assert!(cmd.contains("AOE_INSTANCE_ID"));
         assert!(cmd.contains("printf idle"));
+    }
+
+    #[test]
+    fn test_hook_command_tolerates_unwritable_base_dir() {
+        // Regression for #1390: if /tmp/aoe-hooks/<id> disappears mid-session
+        // (e.g. a sibling AoE namespace sweeps it, or /tmp gets cleaned), the
+        // hook must still exit 0 so the agent doesn't treat it as blocking and
+        // freeze further tool calls.
+        use std::process::Command;
+
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join("aoe-hooks-blocked");
+        // Pre-create base as a regular file so mkdir -p can never succeed.
+        std::fs::write(&base, "i am a file, not a dir").unwrap();
+
+        let cmd = hook_command_with_base("running", base.to_str().unwrap());
+
+        let output = Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "regression_1390")
+            .output()
+            .expect("spawn sh");
+
+        assert!(
+            output.status.success(),
+            "hook must exit 0 even when its dir cannot be created: {:?}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_hook_command_writes_status_on_happy_path() {
+        use std::process::Command;
+
+        let tmp = TempDir::new().unwrap();
+        let base = tmp.path().join("aoe-hooks");
+
+        let cmd = hook_command_with_base("waiting", base.to_str().unwrap());
+
+        let output = Command::new("sh")
+            .args(["-c", &cmd])
+            .env("AOE_INSTANCE_ID", "happy_path")
+            .output()
+            .expect("spawn sh");
+
+        assert!(output.status.success(), "happy-path hook should exit 0");
+        let status_path = base.join("happy_path").join("status");
+        assert_eq!(std::fs::read_to_string(&status_path).unwrap(), "waiting");
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -360,13 +360,6 @@ impl HomeView {
             .map(|i| (i.id.clone(), i.clone()))
             .collect();
 
-        // One-shot sweep of orphaned /tmp/aoe-hooks/<id>/ dirs left behind
-        // by sessions destroyed while the TUI was not running. Per-session
-        // cleanup on destroy is handled by cleanup_hook_status_dir in
-        // src/session/deletion.rs; this is the catch-up pass.
-        let live_ids: std::collections::HashSet<String> = instance_map.keys().cloned().collect();
-        crate::hooks::sweep_orphaned_hook_dirs(&live_ids);
-
         // In unified mode there is no single active profile, so config is
         // resolved from the user's default profile.
         let config_profile = active_profile


### PR DESCRIPTION
## Description

Fixes #1390.

Long-running TUI sessions could freeze with every tool call returning:

```
sh: 1: cannot create /tmp/aoe-hooks/<id>/status: Directory nonexistent
```

Every `PreToolUse` exit-non-zero is treated by the agent as a blocking hook failure, so once it starts, no further tool runs.

Two issues compound:

1. **The hook command was fragile.** `mkdir -p && printf` exits non-zero if either step fails. When `/tmp/aoe-hooks/<id>/` disappears between the two calls (transient FS hiccup, OS sweep, or sibling sweep — see #2), the hook blocks the agent.

2. **`sweep_orphaned_hook_dirs` was unsafe across namespaces.** It deleted any subdir under `/tmp/aoe-hooks/` whose name was not in the current TUI's `live_session_ids`. But `live_ids` is per-namespace: a debug build (`~/.agent-of-empires-dev/`) cannot know about a release build's session IDs (`~/.agent-of-empires/`), so each TUI's startup sweep stomped on the other's dirs. This is what triggered the freeze in the wild (release + debug TUIs running concurrently, debug launched from a paired terminal inside a release session).

### Fix

- `hook_command` now uses `;` instead of `&&`, swallows stderr on both ops, and ends with `exit 0`. A missed status write becomes one tick of stale data, never a blocking failure. Extracted `hook_command_with_base` so tests can run the script against a `TempDir`.
- Dropped `sweep_orphaned_hook_dirs` entirely. It was added in `1c990621` as a hygiene measure ("33 stale dirs accumulated"), but per-session cleanup is still wired through `perform_deletion` (covers `aoe rm`, TUI delete, web API delete) and `Instance::stop()`. OS-level `/tmp` cleanup handles rare external-kill cases. Each orphan dir is a few bytes; the cost was not worth stomping on sibling-namespace state (urgent flags, status).

### Tests

Two new regression tests under `hooks::tests`, both execute the actual hook command via `sh`:

- `test_hook_command_tolerates_unwritable_base_dir` — base path pre-created as a regular file so `mkdir -p` cannot succeed; hook must still exit 0. Fails on the old `&&`-chained command, passes on the new one.
- `test_hook_command_writes_status_on_happy_path` — verifies the new command still writes the status file correctly.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (1939 lib + 67 integration + 116 unit tests, 0 failures; \`cargo fmt\` + \`cargo clippy --all-targets -- -D warnings\` clean)
- [x] Documentation was updated where necessary (doc-comment on \`hook_command\` explains the invariant)
- [ ] For UI changes: included screenshot or recording (n/a)

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7) via /fix-github-issue

**Any Additional AI Details you'd like to share:** AI drafted the patch and tests after I described the symptom and the release+debug repro hypothesis. I directed the scope decisions (dropping the sweep vs. patching it, no namespace split).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes a bug that could freeze the TUI when agent hooks failed to write per-session status. It makes the hook command resilient to transient filesystem failures, removes an unsafe global cleanup sweep, and adds regression tests and docs.

What changed (high-level)
- Refactored hook command generation into a testable helper: hook_command_with_base(status, base).
- Made the installed hook command tolerant of transient /tmp failures so it never returns a nonzero exit:
  - suppresses stderr for mkdir and status write, uses sequential execution instead of conditional AND, and appends `exit 0`.
- Removed the unsafe sweep_orphaned_hook_dirs behavior and its one-shot invocation during HomeView startup.
- Added two regression tests under hooks::tests covering an unwritable base path and the normal write path.
- Updated documentation/comments for the hook command and its rationale.

Why this matters / benefits
- Prevents a single transient filesystem hiccup (e.g., /tmp cleanup or mount issue) from causing hooks to exit nonzero and block subsequent tool calls, avoiding TUI freezes.
- Eliminates risky cross-namespace deletion that could remove sibling-session directories.
- Keeps per-session cleanup local (perform_deletion / Instance::stop) and relies on OS tmp cleanup for rare external-kill cases.
- Improves testability and clarity of the hook-generation logic.

Technical details
- New helper: hook_command_with_base(status, base) used by hook_command(status).
- Hook command changed from:
  sh -c '[ -n "$AOE_INSTANCE_ID" ] || exit 0; mkdir -p /tmp/aoe-hooks/$AOE_INSTANCE_ID && printf {status} > /tmp/aoe-hooks/$AOE_INSTANCE_ID/status'
  to:
  sh -c '[ -n "$AOE_INSTANCE_ID" ] || exit 0; mkdir -p {base}/$AOE_INSTANCE_ID 2>/dev/null; printf {status} > {base}/$AOE_INSTANCE_ID/status 2>/dev/null; exit 0'
- Removed: pub fn sweep_orphaned_hook_dirs(...) and the call that invoked it from HomeView::new.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->