### PR TITLE
fix(session): cross-process flock around Storage mutators

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -743,11 +743,9 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 tmux_session.attach()?;
             }
             Err(e) => {
-                let err_msg = e.to_string();
                 if let Err(rollback_err) = storage.update(|all_instances, _groups| {
                     if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
                         stored.status = crate::session::Status::Error;
-                        stored.last_error = Some(err_msg.clone());
                     }
                     Ok(())
                 }) {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -630,10 +630,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             &instance.title,
             instance.project_path.as_str(),
         ) {
-            bail!(
-                "Session already exists with same title and path: {}",
-                instance.title
-            );
+            return Ok(false);
         }
         all_instances.push(instance.clone());
         if !instance.group_path.is_empty() {
@@ -641,16 +638,32 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             group_tree.create_group(&instance.group_path);
             *groups = group_tree.get_all_groups();
         }
-        Ok(())
+        Ok(true)
     });
-    if let Err(e) = persist_result {
-        cleanup_partial_session(
-            &path,
-            instance.worktree_info.as_ref(),
-            instance.workspace_info.as_ref(),
-            args.create_branch,
-        );
-        return Err(e);
+    match persist_result {
+        Ok(true) => {}
+        Ok(false) => {
+            println!(
+                "Session already exists with same title and path: {}",
+                instance.title
+            );
+            cleanup_partial_session(
+                &path,
+                instance.worktree_info.as_ref(),
+                instance.workspace_info.as_ref(),
+                args.create_branch,
+            );
+            return Ok(());
+        }
+        Err(e) => {
+            cleanup_partial_session(
+                &path,
+                instance.worktree_info.as_ref(),
+                instance.workspace_info.as_ref(),
+                args.create_branch,
+            );
+            return Err(e);
+        }
     }
 
     println!("✓ Added session: {}", final_title);

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -311,6 +311,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 "Session already exists with same title and path: {}",
                 trimmed_title
             );
+            cleanup_partial_session(
+                &path,
+                worktree_info_opt.as_ref(),
+                workspace_info_opt.as_ref(),
+            );
             return Ok(());
         }
         trimmed_title.to_string()
@@ -320,6 +325,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             println!(
                 "Session already exists with same title and path: {}",
                 branch_title
+            );
+            cleanup_partial_session(
+                &path,
+                worktree_info_opt.as_ref(),
+                workspace_info_opt.as_ref(),
             );
             return Ok(());
         }
@@ -603,37 +613,15 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     })();
 
     if let Err(e) = hook_result {
-        // Clean up worktree if we created one
-        if let Some(ref wt_info) = instance.worktree_info {
-            if wt_info.managed_by_aoe {
-                if let Ok(git_wt) =
-                    crate::git::GitWorktree::new(std::path::PathBuf::from(&wt_info.main_repo_path))
-                {
-                    let _ = git_wt.remove_worktree(&path, false);
-                }
-            }
-        }
-        // Clean up workspace worktrees if we created them
-        if let Some(ref ws_info) = instance.workspace_info {
-            for repo in &ws_info.repos {
-                if repo.managed_by_aoe {
-                    let wt_path = PathBuf::from(&repo.worktree_path);
-                    let main_repo = PathBuf::from(&repo.main_repo_path);
-                    if let Ok(git_wt) = crate::git::GitWorktree::new(main_repo) {
-                        let _ = git_wt.remove_worktree(&wt_path, false);
-                    }
-                }
-            }
-            let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
-        }
+        cleanup_partial_session(
+            &path,
+            instance.worktree_info.as_ref(),
+            instance.workspace_info.as_ref(),
+        );
         return Err(e);
     }
 
-    // Phase 3 (locked): persist the new instance under the flock, with a
-    // duplicate re-check against the latest disk state to defend against a
-    // peer process that created the same (title, path) pair between our
-    // phase-1 load and now.
-    storage.update(|all_instances, groups| {
+    let persist_result = storage.update(|all_instances, groups| {
         if is_duplicate_session(
             all_instances,
             &instance.title,
@@ -651,7 +639,15 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             *groups = group_tree.get_all_groups();
         }
         Ok(())
-    })?;
+    });
+    if let Err(e) = persist_result {
+        cleanup_partial_session(
+            &path,
+            instance.worktree_info.as_ref(),
+            instance.workspace_info.as_ref(),
+        );
+        return Err(e);
+    }
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -722,6 +718,33 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn cleanup_partial_session(
+    path: &std::path::Path,
+    worktree_info: Option<&crate::session::WorktreeInfo>,
+    workspace_info: Option<&crate::session::WorkspaceInfo>,
+) {
+    if let Some(wt) = worktree_info {
+        if wt.managed_by_aoe {
+            if let Ok(git_wt) = crate::git::GitWorktree::new(PathBuf::from(&wt.main_repo_path)) {
+                let _ = git_wt.remove_worktree(path, false);
+            }
+        }
+    }
+    if let Some(ws) = workspace_info {
+        for repo in &ws.repos {
+            if repo.managed_by_aoe {
+                if let Ok(git_wt) =
+                    crate::git::GitWorktree::new(PathBuf::from(&repo.main_repo_path))
+                {
+                    let _ =
+                        git_wt.remove_worktree(std::path::Path::new(&repo.worktree_path), false);
+                }
+            }
+        }
+        let _ = std::fs::remove_dir_all(&ws.workspace_dir);
+    }
 }
 
 pub fn is_duplicate_session(instances: &[Instance], title: &str, path: &str) -> bool {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -722,6 +722,12 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 storage.update(|all_instances, _groups| {
                     if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
                         stored.merge_post_start(&instance);
+                    } else {
+                        tracing::warn!(
+                            target: "session.cli",
+                            session_id = %id,
+                            "session row removed by peer between insert and launch-merge; tmux session is now orphan"
+                        );
                     }
                     Ok(())
                 })?;
@@ -731,13 +737,20 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             }
             Err(e) => {
                 let err_msg = e.to_string();
-                let _ = storage.update(|all_instances, _groups| {
+                if let Err(rollback_err) = storage.update(|all_instances, _groups| {
                     if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
                         stored.status = crate::session::Status::Error;
                         stored.last_error = Some(err_msg.clone());
                     }
                     Ok(())
-                });
+                }) {
+                    tracing::error!(
+                        target: "session.store",
+                        "Failed to persist Status::Error rollback for {}: {}; row may show stale Starting status",
+                        id,
+                        rollback_err
+                    );
+                }
                 eprintln!(
                     "Warning: launch failed: {}. Retry with: aoe session start {}",
                     e, final_title

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -284,7 +284,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    // Phase 1 (unlocked): pre-flight read of the current persisted state to
+    // resolve `--parent`, generate a non-colliding title, and make
+    // best-effort duplicate / parent decisions before any side effects.
+    // Final duplicate enforcement happens under the flock in phase 3.
+    let (instances, _groups) = storage.load_with_groups()?;
 
     // Resolve parent session if specified
     let mut group_path = args.group.clone();
@@ -625,15 +629,29 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         return Err(e);
     }
 
-    instances.push(instance.clone());
-
-    // Rebuild group tree
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instance.group_path.is_empty() {
-        group_tree.create_group(&instance.group_path);
-    }
-
-    storage.commit(&instances, &group_tree)?;
+    // Phase 3 (locked): persist the new instance under the flock, with a
+    // duplicate re-check against the latest disk state to defend against a
+    // peer process that created the same (title, path) pair between our
+    // phase-1 load and now.
+    storage.update(|all_instances, groups| {
+        if is_duplicate_session(
+            all_instances,
+            &instance.title,
+            instance.project_path.as_str(),
+        ) {
+            bail!(
+                "Session already exists with same title and path: {}",
+                instance.title
+            );
+        }
+        all_instances.push(instance.clone());
+        if !instance.group_path.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(all_instances, groups);
+            group_tree.create_group(&instance.group_path);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(())
+    })?;
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -683,12 +701,16 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
         }
     } else if args.launch {
-        let idx = instances
-            .iter()
-            .position(|i| i.id == instance.id)
-            .expect("just added instance");
-        instances[idx].start_with_size(crate::terminal::get_size())?;
-        storage.commit(&instances, &group_tree)?;
+        // Start tmux outside the flock (slow), then merge by id under the lock.
+        instance.start_with_size(crate::terminal::get_size())?;
+        let id = instance.id.clone();
+        let started_inst = instance.clone();
+        storage.update(|all_instances, _groups| {
+            if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
+                *stored = started_inst.clone();
+            }
+            Ok(())
+        })?;
 
         let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
         tmux_session.attach()?;

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -700,10 +700,9 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         // Start tmux outside the flock (slow), then merge by id under the lock.
         instance.start_with_size(crate::terminal::get_size())?;
         let id = instance.id.clone();
-        let started_inst = instance.clone();
         storage.update(|all_instances, _groups| {
             if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
-                *stored = started_inst.clone();
+                stored.merge_post_start(&instance);
             }
             Ok(())
         })?;

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -719,18 +719,25 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         let id = instance.id.clone();
         match instance.start_with_size(crate::terminal::get_size()) {
             Ok(()) => {
-                storage.update(|all_instances, _groups| {
+                let landed = storage.update(|all_instances, _groups| {
                     if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
                         stored.merge_post_start(&instance);
+                        Ok(true)
                     } else {
                         tracing::warn!(
                             target: "session.cli",
                             session_id = %id,
                             "session row removed by peer between insert and launch-merge; tmux session is now orphan"
                         );
+                        Ok(false)
                     }
-                    Ok(())
                 })?;
+                if !landed {
+                    anyhow::bail!(
+                        "Session {} was removed by another process before launch could land; tmux session is now orphan",
+                        instance.title
+                    );
+                }
 
                 let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
                 tmux_session.attach()?;

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -714,18 +714,37 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
         }
     } else if args.launch {
-        // Start tmux outside the flock (slow), then merge by id under the lock.
-        instance.start_with_size(crate::terminal::get_size())?;
+        // Persist Status::Error + last_error on launch failure rather than
+        // cleanup_partial_session: row is committed; surface as broken.
         let id = instance.id.clone();
-        storage.update(|all_instances, _groups| {
-            if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
-                stored.merge_post_start(&instance);
-            }
-            Ok(())
-        })?;
+        match instance.start_with_size(crate::terminal::get_size()) {
+            Ok(()) => {
+                storage.update(|all_instances, _groups| {
+                    if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
+                        stored.merge_post_start(&instance);
+                    }
+                    Ok(())
+                })?;
 
-        let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
-        tmux_session.attach()?;
+                let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
+                tmux_session.attach()?;
+            }
+            Err(e) => {
+                let err_msg = e.to_string();
+                let _ = storage.update(|all_instances, _groups| {
+                    if let Some(stored) = all_instances.iter_mut().find(|i| i.id == id) {
+                        stored.status = crate::session::Status::Error;
+                        stored.last_error = Some(err_msg.clone());
+                    }
+                    Ok(())
+                });
+                eprintln!(
+                    "Warning: launch failed: {}. Retry with: aoe session start {}",
+                    e, final_title
+                );
+                return Err(e);
+            }
+        }
     } else {
         println!();
         println!("Next steps:");

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -315,6 +315,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 &path,
                 worktree_info_opt.as_ref(),
                 workspace_info_opt.as_ref(),
+                args.create_branch,
             );
             return Ok(());
         }
@@ -330,6 +331,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 &path,
                 worktree_info_opt.as_ref(),
                 workspace_info_opt.as_ref(),
+                args.create_branch,
             );
             return Ok(());
         }
@@ -617,6 +619,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             &path,
             instance.worktree_info.as_ref(),
             instance.workspace_info.as_ref(),
+            args.create_branch,
         );
         return Err(e);
     }
@@ -645,6 +648,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             &path,
             instance.worktree_info.as_ref(),
             instance.workspace_info.as_ref(),
+            args.create_branch,
         );
         return Err(e);
     }
@@ -723,11 +727,15 @@ fn cleanup_partial_session(
     path: &std::path::Path,
     worktree_info: Option<&crate::session::WorktreeInfo>,
     workspace_info: Option<&crate::session::WorkspaceInfo>,
+    created_branch: bool,
 ) {
     if let Some(wt) = worktree_info {
         if wt.managed_by_aoe {
             if let Ok(git_wt) = crate::git::GitWorktree::new(PathBuf::from(&wt.main_repo_path)) {
                 let _ = git_wt.remove_worktree(path, false);
+                if created_branch {
+                    let _ = git_wt.delete_branch(&wt.branch);
+                }
             }
         }
     }

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -200,10 +200,11 @@ async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
     let group = args.group.trim().to_string();
 
     let old_group = storage.update(|instances, groups| {
+        let id = super::resolve_session(&identifier, instances)?.id.clone();
         let inst = instances
             .iter_mut()
-            .find(|i| i.id == identifier || i.id.starts_with(&identifier) || i.title == identifier)
-            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+            .find(|i| i.id == id)
+            .expect("resolve_session returned an id that is no longer in instances");
         let old = inst.group_path.clone();
         inst.group_path = group.clone();
 

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -127,68 +127,67 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
 
 async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
-    let name = args.name.trim();
+    let name = args.name.trim().to_string();
     let group_path = if let Some(parent) = &args.parent {
         format!("{}/{}", parent.trim(), name)
     } else {
-        name.to_string()
+        name.clone()
     };
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-
-    if group_tree.group_exists(&group_path) {
-        bail!("Group already exists: {}", group_path);
-    }
-
-    group_tree.create_group(&group_path);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
+        if group_tree.group_exists(&group_path) {
+            bail!("Group already exists: {}", group_path);
+        }
+        group_tree.create_group(&group_path);
+        *groups = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     println!("✓ Created group: {}", group_path);
-
     Ok(())
 }
 
 async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let name = args.name.trim().to_string();
+    let force = args.force;
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-
-    let name = args.name.trim();
-    if !group_tree.group_exists(name) {
-        bail!("Group not found: {}", name);
-    }
-
-    // Check for sessions in this group
-    let session_count = instances
-        .iter()
-        .filter(|i| i.group_path == name || i.group_path.starts_with(&format!("{}/", name)))
-        .count();
-
-    if session_count > 0 {
-        if !args.force {
-            bail!(
-                "Group '{}' contains {} sessions. Use --force to move them to default group.",
-                name,
-                session_count
-            );
+    let session_count = storage.update(|instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
+        if !group_tree.group_exists(&name) {
+            bail!("Group not found: {}", name);
         }
 
-        // Move sessions to default group
-        for inst in &mut instances {
-            if inst.group_path == name || inst.group_path.starts_with(&format!("{}/", name)) {
-                inst.group_path = String::new();
+        let session_count = instances
+            .iter()
+            .filter(|i| i.group_path == name || i.group_path.starts_with(&format!("{}/", name)))
+            .count();
+
+        if session_count > 0 {
+            if !force {
+                bail!(
+                    "Group '{}' contains {} sessions. Use --force to move them to default group.",
+                    name,
+                    session_count
+                );
+            }
+
+            for inst in instances.iter_mut() {
+                if inst.group_path == name || inst.group_path.starts_with(&format!("{}/", name)) {
+                    inst.group_path = String::new();
+                }
             }
         }
-    }
 
-    group_tree.delete_group(name);
-    storage.commit(&instances, &group_tree)?;
+        group_tree.delete_group(&name);
+        *groups = group_tree.get_all_groups();
+        Ok(session_count)
+    })?;
 
     println!("✓ Deleted group: {}", name);
-    if args.force && session_count > 0 {
+    if force && session_count > 0 {
         println!("  Moved {} sessions to default group", session_count);
     }
 
@@ -197,24 +196,24 @@ async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
 
 async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let identifier = args.identifier.trim().to_string();
+    let group = args.group.trim().to_string();
 
-    let identifier = args.identifier.trim();
-    let inst = instances
-        .iter_mut()
-        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+    let old_group = storage.update(|instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == identifier || i.id.starts_with(&identifier) || i.title == identifier)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+        let old = inst.group_path.clone();
+        inst.group_path = group.clone();
 
-    let group = args.group.trim();
-    let old_group = inst.group_path.clone();
-    inst.group_path = group.to_string();
-
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !group.is_empty() {
-        group_tree.create_group(group);
-    }
-
-    storage.commit(&instances, &group_tree)?;
+        if !group.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(old)
+    })?;
 
     if old_group.is_empty() {
         println!("✓ Moved session to group: {}", group);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -99,6 +99,25 @@ pub fn truncate_id(id: &str, max_len: usize) -> &str {
     }
 }
 
+/// Resolve a CLI identifier inside a `&mut Vec<Instance>` and run `f` against
+/// the matching entry. Designed to be called from inside `Storage::update`'s
+/// closure so the find + mutate happens atomically under both the in-process
+/// mutex and the cross-process flock.
+///
+/// Identifier resolution is first-match-wins (exact id, then id prefix, then
+/// title), preserving the historical CLI behaviour. Use `resolve_session` for
+/// the stricter resolver that errors on ambiguous prefixes.
+pub(crate) fn patch_instance<F, R>(instances: &mut [Instance], identifier: &str, f: F) -> Result<R>
+where
+    F: FnOnce(&mut Instance) -> Result<R>,
+{
+    let idx = instances
+        .iter()
+        .position(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+    f(&mut instances[idx])
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -99,14 +99,10 @@ pub fn truncate_id(id: &str, max_len: usize) -> &str {
     }
 }
 
-/// Resolve a CLI identifier inside a `&mut Vec<Instance>` and run `f` on
-/// the matching entry. Designed to be called from inside `Storage::update`'s
-/// closure so the find + mutate happens atomically under both the
-/// in-process mutex and the cross-process flock.
-///
-/// Identifier resolution delegates to `resolve_session` so ambiguous prefix
-/// matches error rather than silently picking the first hit; behaviour is
-/// uniform with the 12+ other CLI mutators that take that path directly.
+/// Resolve `identifier` and run `f` on the matching instance. Designed for
+/// use inside `Storage::update`'s closure: find + mutate is atomic under
+/// both lock layers. Delegates to `resolve_session`, so ambiguous prefixes
+/// error rather than silently picking the first match.
 pub(crate) fn patch_instance<F, R>(instances: &mut [Instance], identifier: &str, f: F) -> Result<R>
 where
     F: FnOnce(&mut Instance) -> Result<R>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -99,23 +99,24 @@ pub fn truncate_id(id: &str, max_len: usize) -> &str {
     }
 }
 
-/// Resolve a CLI identifier inside a `&mut Vec<Instance>` and run `f` against
+/// Resolve a CLI identifier inside a `&mut Vec<Instance>` and run `f` on
 /// the matching entry. Designed to be called from inside `Storage::update`'s
-/// closure so the find + mutate happens atomically under both the in-process
-/// mutex and the cross-process flock.
+/// closure so the find + mutate happens atomically under both the
+/// in-process mutex and the cross-process flock.
 ///
-/// Identifier resolution is first-match-wins (exact id, then id prefix, then
-/// title), preserving the historical CLI behaviour. Use `resolve_session` for
-/// the stricter resolver that errors on ambiguous prefixes.
+/// Identifier resolution delegates to `resolve_session` so ambiguous prefix
+/// matches error rather than silently picking the first hit; behaviour is
+/// uniform with the 12+ other CLI mutators that take that path directly.
 pub(crate) fn patch_instance<F, R>(instances: &mut [Instance], identifier: &str, f: F) -> Result<R>
 where
     F: FnOnce(&mut Instance) -> Result<R>,
 {
-    let idx = instances
-        .iter()
-        .position(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
-    f(&mut instances[idx])
+    let id = resolve_session(identifier, instances)?.id.clone();
+    let inst = instances
+        .iter_mut()
+        .find(|i| i.id == id)
+        .expect("resolve_session returned an id that is no longer in instances");
+    f(inst)
 }
 
 #[cfg(test)]
@@ -150,5 +151,50 @@ mod tests {
     fn truncate_id_zero_max_returns_empty() {
         assert_eq!(truncate_id("abc", 0), "");
         assert_eq!(truncate_id("café", 0), "");
+    }
+
+    #[test]
+    fn patch_instance_exact_id_resolves_unambiguously() {
+        let mut v = vec![
+            Instance::new("first", "/tmp/a"),
+            Instance::new("second", "/tmp/b"),
+        ];
+        let target_id = v[1].id.clone();
+        patch_instance(&mut v, &target_id, |i| {
+            i.title = "hit".to_string();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(v[1].title, "hit");
+        assert_eq!(v[0].title, "first");
+    }
+
+    #[test]
+    fn patch_instance_rejects_ambiguous_prefix() {
+        let mut v = vec![
+            Instance::new("first", "/tmp/a"),
+            Instance::new("second", "/tmp/b"),
+        ];
+        v[0].id = "abcdef-1".to_string();
+        v[1].id = "abcdef-2".to_string();
+        let err = patch_instance(&mut v, "abcdef", |_| Ok(())).unwrap_err();
+        assert!(
+            err.to_string().contains("Ambiguous"),
+            "expected ambiguity error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn patch_instance_resolves_by_title() {
+        let mut v = vec![
+            Instance::new("alpha", "/tmp/a"),
+            Instance::new("beta", "/tmp/b"),
+        ];
+        patch_instance(&mut v, "beta", |i| {
+            i.title = "renamed".to_string();
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(v[1].title, "renamed");
     }
 }

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -43,23 +43,9 @@ pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     // deletion sequence, blocking peer mutators on the same profile.
     let (instances, _groups) = storage.load_with_groups()?;
 
-    let mut target: Option<Instance> = None;
-    for inst in &instances {
-        if inst.id == args.identifier
-            || inst.id.starts_with(&args.identifier)
-            || inst.title == args.identifier
-        {
-            target = Some(inst.clone());
-            break;
-        }
-    }
-    let inst = target.ok_or_else(|| {
-        anyhow::anyhow!(
-            "Session not found in profile '{}': {}",
-            storage.profile(),
-            args.identifier
-        )
-    })?;
+    let inst = super::resolve_session(&args.identifier, &instances)
+        .map_err(|e| anyhow::anyhow!("{} in profile '{}'", e, storage.profile()))?
+        .clone();
     let removed_id = inst.id.clone();
     let removed_title = inst.title.clone();
 

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -1,9 +1,9 @@
 //! `agent-of-empires remove` command implementation
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use clap::Args;
 
-use crate::session::{GroupTree, Instance, Storage};
+use crate::session::{Instance, Storage};
 
 #[derive(Args)]
 pub struct RemoveArgs {
@@ -36,93 +36,95 @@ fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
-    let mut found = false;
-    let mut removed_title = String::new();
-    let mut new_instances = Vec::with_capacity(instances.len());
+    // Phase 1 (unlocked): identify the target and run the slow deletion
+    // side effects (worktree removal, branch deletion, container teardown,
+    // detach hooks). The flock would otherwise be held for the entire
+    // deletion sequence, blocking peer mutators on the same profile.
+    let (instances, _groups) = storage.load_with_groups()?;
 
-    for inst in instances {
+    let mut target: Option<Instance> = None;
+    for inst in &instances {
         if inst.id == args.identifier
             || inst.id.starts_with(&args.identifier)
             || inst.title == args.identifier
         {
-            found = true;
-            removed_title = inst.title.clone();
-
-            let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                profile,
-                std::path::Path::new(&inst.project_path),
-            );
-
-            let delete_worktree = needs_worktree_cleanup(&inst, &args);
-            let delete_branch = inst
-                .worktree_info
-                .as_ref()
-                .is_some_and(|wt| wt.managed_by_aoe)
-                && (args.delete_branch
-                    || (delete_worktree && config.worktree.delete_branch_on_cleanup));
-            let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
-                && !args.keep_container
-                && config.sandbox.auto_cleanup;
-
-            let result = crate::session::deletion::perform_deletion(
-                &crate::session::deletion::DeletionRequest {
-                    session_id: inst.id.clone(),
-                    instance: inst.clone(),
-                    delete_worktree,
-                    delete_branch,
-                    delete_sandbox,
-                    force_delete: args.force,
-                    detach_hooks: false,
-                },
-            );
-
-            for msg in &result.messages {
-                println!("  {}", msg);
-            }
-            for err in &result.errors {
-                eprintln!("Warning: {}", err);
-            }
-
-            if !delete_worktree {
-                if let Some(wt_info) = &inst.worktree_info {
-                    if wt_info.managed_by_aoe {
-                        println!(
-                            "Worktree preserved at: {} (use --delete-worktree to remove)",
-                            inst.project_path
-                        );
-                    }
-                }
-            }
-            if let Some(sandbox) = &inst.sandbox_info {
-                if sandbox.enabled {
-                    if args.keep_container {
-                        println!("Container preserved: {}", sandbox.container_name);
-                    } else if !config.sandbox.auto_cleanup {
-                        println!(
-                            "Container preserved: {} (auto_cleanup disabled in config)",
-                            sandbox.container_name
-                        );
-                    }
-                }
-            }
-        } else {
-            new_instances.push(inst);
+            target = Some(inst.clone());
+            break;
         }
     }
-
-    if !found {
-        bail!(
+    let inst = target.ok_or_else(|| {
+        anyhow::anyhow!(
             "Session not found in profile '{}': {}",
             storage.profile(),
             args.identifier
-        );
+        )
+    })?;
+    let removed_id = inst.id.clone();
+    let removed_title = inst.title.clone();
+
+    let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+        profile,
+        std::path::Path::new(&inst.project_path),
+    );
+
+    let delete_worktree = needs_worktree_cleanup(&inst, &args);
+    let delete_branch = inst
+        .worktree_info
+        .as_ref()
+        .is_some_and(|wt| wt.managed_by_aoe)
+        && (args.delete_branch || (delete_worktree && config.worktree.delete_branch_on_cleanup));
+    let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
+        && !args.keep_container
+        && config.sandbox.auto_cleanup;
+
+    let result =
+        crate::session::deletion::perform_deletion(&crate::session::deletion::DeletionRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+            delete_worktree,
+            delete_branch,
+            delete_sandbox,
+            force_delete: args.force,
+            detach_hooks: false,
+        });
+
+    for msg in &result.messages {
+        println!("  {}", msg);
+    }
+    for err in &result.errors {
+        eprintln!("Warning: {}", err);
     }
 
-    // Rebuild group tree and save
-    let group_tree = GroupTree::new_with_groups(&new_instances, &groups);
-    storage.commit(&new_instances, &group_tree)?;
+    if !delete_worktree {
+        if let Some(wt_info) = &inst.worktree_info {
+            if wt_info.managed_by_aoe {
+                println!(
+                    "Worktree preserved at: {} (use --delete-worktree to remove)",
+                    inst.project_path
+                );
+            }
+        }
+    }
+    if let Some(sandbox) = &inst.sandbox_info {
+        if sandbox.enabled {
+            if args.keep_container {
+                println!("Container preserved: {}", sandbox.container_name);
+            } else if !config.sandbox.auto_cleanup {
+                println!(
+                    "Container preserved: {} (auto_cleanup disabled in config)",
+                    sandbox.container_name
+                );
+            }
+        }
+    }
+
+    // Phase 2 (locked): drop the entry by id from the latest disk state.
+    // No-op if a peer already removed it; that is the correct semantics.
+    storage.update(|all_instances, _groups| {
+        all_instances.retain(|i| i.id != removed_id);
+        Ok(())
+    })?;
 
     println!(
         "  Removed session: {} (from profile '{}')",

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -269,23 +269,28 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let title = storage.update(|instances, _groups| {
-        let id = super::resolve_session(&args.identifier, instances)?
-            .id
-            .clone();
-        let inst = instances
-            .iter_mut()
-            .find(|i| i.id == id)
-            .expect("resolve_session returned an id that is no longer in instances");
 
-        if !args.no_kill {
-            if let Err(e) = inst.kill() {
-                eprintln!("Warning: failed to kill tmux session: {}", e);
-            }
+    // Phase 1 (unlocked): resolve identifier.
+    let (instances, _groups) = storage.load_with_groups()?;
+    let inst = super::resolve_session(&args.identifier, &instances)?;
+    let id = inst.id.clone();
+    let title = inst.title.clone();
+    let inst = inst.clone();
+
+    // Phase 2 (unlocked): tmux teardown. The closure-as-CPU-only invariant
+    // documented on Storage::update forbids tmux work inside the lock.
+    if !args.no_kill {
+        if let Err(e) = inst.kill() {
+            eprintln!("Warning: failed to kill tmux session: {}", e);
         }
+    }
 
-        inst.archive();
-        Ok(inst.title.clone())
+    // Phase 3 (locked, fast): set archived_at by id.
+    storage.update(|instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
+            stored.archive();
+        }
+        Ok(())
     })?;
     println!("Archived: {}", title);
     Ok(())

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Result};
 use clap::{Args, Subcommand};
 use serde::Serialize;
+use std::collections::HashSet;
 
 use crate::session::{GroupTree, StartOutcome, Storage};
 
@@ -555,7 +556,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         });
     }
 
-    let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
+    let mut succeeded: Vec<(String, String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
     let mut restarted: Vec<(crate::session::Instance, Option<String>)> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
@@ -564,12 +565,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             Ok(StartOutcome::Restarted { stale_sid }) => Some(stale_sid.clone()),
             _ => None,
         };
+        let id = inst_opt.as_ref().map(|i| i.id.clone()).unwrap_or_default();
         if let Some(inst) = inst_opt {
             restarted.push((inst, stale_sid.clone()));
         }
         match result {
-            Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
-            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((title, None)),
+            Ok(StartOutcome::Restarted { stale_sid }) => {
+                succeeded.push((id, title, Some(stale_sid)))
+            }
+            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((id, title, None)),
             Err(e) => failed.push((title, e.to_string())),
         }
     }
@@ -579,7 +583,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     // sessions during phase 2 (status updates from a parallel daemon
     // poller, sibling CLI invocations, ...) are preserved because the
     // closure receives the latest disk state.
-    let orphaned: Vec<String> = storage.update(|instances, _groups| {
+    let orphaned: Vec<(String, String)> = storage.update(|instances, _groups| {
         let mut orphaned = Vec::new();
         for (restarted_inst, stale_sid) in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
@@ -590,16 +594,18 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                     session_id = %restarted_inst.id,
                     "session row removed by peer between phase 1 and phase 3 of restart --all; tmux session is now orphan"
                 );
-                orphaned.push(restarted_inst.title.clone());
+                orphaned.push((restarted_inst.id.clone(), restarted_inst.title.clone()));
             }
         }
         Ok(orphaned)
     })?;
 
-    // Move orphaned titles out of succeeded: tmux ran but no disk row carries the outcome.
-    succeeded.retain(|(title, _)| !orphaned.contains(title));
+    // Filter by id, not title: two distinct sessions can share a title on
+    // different paths (is_duplicate_session blocks only same-title-same-path).
+    let orphaned_ids: HashSet<&String> = orphaned.iter().map(|(id, _)| id).collect();
+    succeeded.retain(|(id, _, _)| !orphaned_ids.contains(id));
 
-    let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
+    let stale_count = succeeded.iter().filter(|(_, _, s)| s.is_some()).count();
     if stale_count == 0 {
         println!("✓ Restarted {}/{} sessions:", succeeded.len(), total);
     } else {
@@ -610,7 +616,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             stale_count,
         );
     }
-    for (title, stale) in &succeeded {
+    for (_id, title, stale) in &succeeded {
         match stale {
             Some(sid) => println!("  · {}{}", title, stale_history_suffix(sid)),
             None => println!("  · {}", title),
@@ -621,7 +627,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             "⚠ {} orphaned (row removed by peer mid-flight; tmux running but unrooted):",
             orphaned.len()
         );
-        for title in &orphaned {
+        for (_, title) in &orphaned {
             println!("  · {}", title);
         }
     }
@@ -1128,14 +1134,9 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
     let instances = storage.load()?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let inst = super::resolve_session(&args.identifier, &instances)?;
+    let id = inst.id.clone();
+    let title = inst.title.clone();
 
     let new_value = if args.clear {
         None
@@ -1144,16 +1145,11 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
         if trimmed.is_empty() {
             bail!("Branch name is empty. Pass --clear to remove the override.");
         }
-        // Validate the ref against the same resolution chain the diff
-        // resolver uses, so users see a clear error at set-time rather
-        // than a silent fallback when the diff is next computed. For
-        // workspace sessions, validate against the first repo's
-        // worktree (each repo will resolve the ref the same way).
-        let validate_path = instances[idx]
+        let validate_path = inst
             .workspace_info
             .as_ref()
             .and_then(|w| w.repos.first().map(|r| r.worktree_path.clone()))
-            .unwrap_or_else(|| instances[idx].project_path.clone());
+            .unwrap_or_else(|| inst.project_path.clone());
         if let Err(e) =
             crate::git::diff::validate_ref(std::path::Path::new(&validate_path), &trimmed)
         {
@@ -1167,15 +1163,12 @@ async fn set_base(profile: &str, args: SetBaseArgs) -> Result<()> {
         Some(trimmed)
     };
 
-    let title = instances[idx].title.clone();
-    let id_for_save = instances[idx].id.clone();
-
     storage.update(|instances, _groups| {
-        let inst = instances
+        let stored = instances
             .iter_mut()
-            .find(|i| i.id == id_for_save)
+            .find(|i| i.id == id)
             .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-        inst.base_branch_override = new_value.clone();
+        stored.base_branch_override = new_value.clone();
         Ok(())
     })?;
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -523,12 +523,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
-    let mut restarted: Vec<(crate::session::Instance, bool)> = Vec::new();
+    let mut restarted: Vec<(crate::session::Instance, Option<String>)> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
-        let clear_stale_sid = matches!(result, Ok(StartOutcome::Restarted { .. }));
+        let stale_sid = match &result {
+            Ok(StartOutcome::Restarted { stale_sid }) => Some(stale_sid.clone()),
+            _ => None,
+        };
         if let Some(inst) = inst_opt {
-            restarted.push((inst, clear_stale_sid));
+            restarted.push((inst, stale_sid.clone()));
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -543,9 +546,9 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     // poller, sibling CLI invocations, ...) are preserved because the
     // closure receives the latest disk state.
     storage.update(|instances, _groups| {
-        for (restarted_inst, clear_stale_sid) in restarted {
+        for (restarted_inst, stale_sid) in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
-                stored.merge_post_restart(&restarted_inst, clear_stale_sid);
+                stored.merge_post_restart(&restarted_inst, stale_sid.as_deref());
             }
         }
         Ok(())
@@ -655,10 +658,13 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     // touch_last_accessed runs on `stored`, not `working`: its fields are
     // peer-mutable and do not belong in `merge_post_restart`.
-    let clear_stale_sid = matches!(outcome, StartOutcome::Restarted { .. });
+    let stale_sid = match &outcome {
+        StartOutcome::Restarted { stale_sid } => Some(stale_sid.as_str()),
+        StartOutcome::Resumed | StartOutcome::Fresh => None,
+    };
     storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-            stored.merge_post_restart(&working, clear_stale_sid);
+            stored.merge_post_restart(&working, stale_sid);
             if wake_succeeded {
                 stored.touch_last_accessed();
             }

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -373,6 +373,12 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
             stored.merge_post_start(&working);
+        } else {
+            tracing::warn!(
+                target: "session.cli",
+                session_id = %id,
+                "session row removed by peer between phase 1 and phase 3 of start; tmux session is now orphan"
+            );
         }
         Ok(())
     })?;
@@ -553,6 +559,12 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         for (restarted_inst, stale_sid) in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
                 stored.merge_post_restart(&restarted_inst, stale_sid.as_deref());
+            } else {
+                tracing::warn!(
+                    target: "session.cli",
+                    session_id = %restarted_inst.id,
+                    "session row removed by peer between phase 1 and phase 3 of restart --all; tmux session is now orphan"
+                );
             }
         }
         Ok(())
@@ -672,6 +684,12 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             if wake_succeeded {
                 stored.touch_last_accessed();
             }
+        } else {
+            tracing::warn!(
+                target: "session.cli",
+                session_id = %session_id,
+                "session row removed by peer between phase 1 and phase 3 of restart; tmux session is now orphan"
+            );
         }
         Ok(())
     })?;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -600,8 +600,7 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         Ok(orphaned)
     })?;
 
-    // Filter by id, not title: two distinct sessions can share a title on
-    // different paths (is_duplicate_session blocks only same-title-same-path).
+    // Sessions can share a title across paths; orphan filter keys on id.
     let orphaned_ids: HashSet<&String> = orphaned.iter().map(|(id, _)| id).collect();
     succeeded.retain(|(id, _, _)| !orphaned_ids.contains(id));
 

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -277,8 +277,7 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let title = inst.title.clone();
     let inst = inst.clone();
 
-    // Phase 2 (unlocked): tmux teardown. The closure-as-CPU-only invariant
-    // documented on Storage::update forbids tmux work inside the lock.
+    // Phase 2 (unlocked): tmux work; Storage::update closures must stay CPU-only.
     if !args.no_kill {
         if let Err(e) = inst.kill() {
             eprintln!("Warning: failed to kill tmux session: {}", e);

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -285,14 +285,23 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     }
 
     // Phase 3 (locked, fast): set archived_at by id.
-    storage.update(|instances, _groups| {
+    let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
             stored.archive();
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     })?;
-    println!("Archived: {}", title);
-    Ok(())
+    if landed {
+        println!("Archived: {}", title);
+        Ok(())
+    } else {
+        bail!(
+            "Session {} was removed by another process before archive could land",
+            title
+        );
+    }
 }
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
@@ -370,18 +379,25 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     // Phase 3 (locked, fast): merge the post-start instance back by id, so
     // any concurrent mutation to OTHER sessions during phase 2 is preserved.
-    storage.update(|instances, _groups| {
+    let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
             stored.merge_post_start(&working);
+            Ok(true)
         } else {
             tracing::warn!(
                 target: "session.cli",
                 session_id = %id,
                 "session row removed by peer between phase 1 and phase 3 of start; tmux session is now orphan"
             );
+            Ok(false)
         }
-        Ok(())
     })?;
+    if !landed {
+        bail!(
+            "Session {} was removed by another process before start could land; tmux session is now orphan",
+            title
+        );
+    }
 
     println!("✓ Started session: {}", title);
     Ok(())
@@ -442,12 +458,20 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // Phase 2 (locked): persist Stopped status by id so it survives TUI
     // restarts. Field-level merge preserves any concurrent mutation that
     // landed between phase 1 and phase 2.
-    storage.update(|instances, _groups| {
+    let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
             stored.status = crate::session::Status::Stopped;
+            Ok(true)
+        } else {
+            Ok(false)
         }
-        Ok(())
     })?;
+    if !landed {
+        bail!(
+            "Session {} was removed by another process before stop could land",
+            title
+        );
+    }
 
     if had_container {
         println!("✓ Stopped session and container: {}", title);
@@ -555,7 +579,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     // sessions during phase 2 (status updates from a parallel daemon
     // poller, sibling CLI invocations, ...) are preserved because the
     // closure receives the latest disk state.
-    storage.update(|instances, _groups| {
+    let orphaned: Vec<String> = storage.update(|instances, _groups| {
+        let mut orphaned = Vec::new();
         for (restarted_inst, stale_sid) in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
                 stored.merge_post_restart(&restarted_inst, stale_sid.as_deref());
@@ -565,10 +590,14 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
                     session_id = %restarted_inst.id,
                     "session row removed by peer between phase 1 and phase 3 of restart --all; tmux session is now orphan"
                 );
+                orphaned.push(restarted_inst.title.clone());
             }
         }
-        Ok(())
+        Ok(orphaned)
     })?;
+
+    // Move orphaned titles out of succeeded: tmux ran but no disk row carries the outcome.
+    succeeded.retain(|(title, _)| !orphaned.contains(title));
 
     let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
@@ -585,6 +614,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         match stale {
             Some(sid) => println!("  · {}{}", title, stale_history_suffix(sid)),
             None => println!("  · {}", title),
+        }
+    }
+    if !orphaned.is_empty() {
+        println!(
+            "⚠ {} orphaned (row removed by peer mid-flight; tmux running but unrooted):",
+            orphaned.len()
+        );
+        for title in &orphaned {
+            println!("  · {}", title);
         }
     }
     if !failed.is_empty() {
@@ -678,21 +716,28 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         StartOutcome::Restarted { stale_sid } => Some(stale_sid.as_str()),
         StartOutcome::Resumed | StartOutcome::Fresh => None,
     };
-    storage.update(|instances, _groups| {
+    let landed = storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
             stored.merge_post_restart(&working, stale_sid);
             if wake_succeeded {
                 stored.touch_last_accessed();
             }
+            Ok(true)
         } else {
             tracing::warn!(
                 target: "session.cli",
                 session_id = %session_id,
                 "session row removed by peer between phase 1 and phase 3 of restart; tmux session is now orphan"
             );
+            Ok(false)
         }
-        Ok(())
     })?;
+    if !landed {
+        bail!(
+            "Session {} was removed by another process before restart could land; tmux session is now orphan",
+            title
+        );
+    }
 
     match outcome {
         StartOutcome::Restarted { stale_sid } => {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -368,7 +368,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     // any concurrent mutation to OTHER sessions during phase 2 is preserved.
     storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
-            *stored = working;
+            stored.merge_post_start(&working);
         }
         Ok(())
     })?;
@@ -523,11 +523,12 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
-    let mut restarted: Vec<crate::session::Instance> = Vec::new();
+    let mut restarted: Vec<(crate::session::Instance, bool)> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
+        let clear_stale_sid = matches!(result, Ok(StartOutcome::Restarted { .. }));
         if let Some(inst) = inst_opt {
-            restarted.push(inst);
+            restarted.push((inst, clear_stale_sid));
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -542,9 +543,9 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     // poller, sibling CLI invocations, ...) are preserved because the
     // closure receives the latest disk state.
     storage.update(|instances, _groups| {
-        for restarted_inst in restarted {
+        for (restarted_inst, clear_stale_sid) in restarted {
             if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
-                *stored = restarted_inst;
+                stored.merge_post_restart(&restarted_inst, clear_stale_sid);
             }
         }
         Ok(())
@@ -630,6 +631,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         .map(|c| c.session.restart_wake_message.clone())
         .unwrap_or_else(|_| "wake up: pick up what you were doing".to_string());
 
+    let mut wake_succeeded = false;
     if !wake_msg.is_empty() {
         // Restart re-execs the agent at a blank prompt; nudge it back into
         // its prior task. Poll capture-pane for steady-state output instead
@@ -642,7 +644,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
                 Ok(()) => {
-                    working.touch_last_accessed();
+                    wake_succeeded = true;
                 }
                 Err(e) => {
                     eprintln!("Warning: failed to send wake-up message: {}", e);
@@ -651,10 +653,15 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
 
-    // Phase 3 (locked, fast): merge the post-restart instance back by id.
+    // touch_last_accessed runs on `stored`, not `working`: its fields are
+    // peer-mutable and do not belong in `merge_post_restart`.
+    let clear_stale_sid = matches!(outcome, StartOutcome::Restarted { .. });
     storage.update(|instances, _groups| {
         if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-            *stored = working;
+            stored.merge_post_restart(&working, clear_stale_sid);
+            if wake_succeeded {
+                stored.touch_last_accessed();
+            }
         }
         Ok(())
     })?;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -944,15 +944,10 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         if let Some(group) = &new_group {
             inst.group_path = group.clone();
         }
-        if !inst.group_path.is_empty() {
+        let group_path = inst.group_path.clone();
+        if !group_path.is_empty() {
             let mut group_tree = GroupTree::new_with_groups(instances, groups);
-            group_tree.create_group(
-                &instances
-                    .iter()
-                    .find(|i| i.id == id)
-                    .expect("just patched")
-                    .group_path,
-            );
+            group_tree.create_group(&group_path);
             *groups = group_tree.get_all_groups();
         }
         Ok(())

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -245,104 +245,70 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
 
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
+    let title = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.favorite();
+            Ok(inst.title.clone())
         })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].favorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+    })?;
     println!("Favorited: {}", title);
     Ok(())
 }
 
 async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
+    let title = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.unfavorite();
+            Ok(inst.title.clone())
         })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unfavorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+    })?;
     println!("Unfavorited: {}", title);
     Ok(())
 }
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let title = storage.update(|instances, _groups| {
+        let id = super::resolve_session(&args.identifier, instances)?
+            .id
+            .clone();
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .expect("resolve_session returned an id that is no longer in instances");
 
-    let id = super::resolve_session(&args.identifier, &instances)?
-        .id
-        .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
-
-    if !args.no_kill {
-        if let Err(e) = instances[idx].kill() {
-            eprintln!("Warning: failed to kill tmux session: {}", e);
+        if !args.no_kill {
+            if let Err(e) = inst.kill() {
+                eprintln!("Warning: failed to kill tmux session: {}", e);
+            }
         }
-    }
 
-    instances[idx].archive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+        inst.archive();
+        Ok(inst.title.clone())
+    })?;
     println!("Archived: {}", title);
     Ok(())
 }
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let id = super::resolve_session(&args.identifier, &instances)?
-        .id
-        .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
-
-    instances[idx].unarchive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+    let title = storage.update(|instances, _groups| {
+        let id = super::resolve_session(&args.identifier, instances)?
+            .id
+            .clone();
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .expect("resolve_session returned an id that is no longer in instances");
+        inst.unarchive();
+        Ok(inst.title.clone())
+    })?;
     println!("Unarchived: {}", title);
     Ok(())
 }
 
 async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
-    let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
     let config = crate::session::profile_config::resolve_config(profile)?;
 
     // `--minutes` overrides the profile default; otherwise use the
@@ -355,71 +321,66 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     crate::session::validate_snooze_duration(raw_minutes).map_err(|e| anyhow::anyhow!("{}", e))?;
     let minutes = raw_minutes as u32;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
+    let storage = Storage::new(profile)?;
+    let title = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.snooze(minutes);
+            Ok(inst.title.clone())
         })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].snooze(minutes);
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+    })?;
     println!("Snoozed for {}m: {}", minutes, title);
     Ok(())
 }
 
 async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
+    let title = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.unsnooze();
+            Ok(inst.title.clone())
         })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unsnooze();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
-
+    })?;
     println!("Woke: {}", title);
     Ok(())
 }
 
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
+    // Phase 1 (locked, fast): snapshot the target by identifier, rehydrate
+    // `source_profile` so config resolution honors the right profile.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
-    // instances always come back blank; rehydrate it from the storage profile
-    // so start-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "start")?;
-    instances[idx].start_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
+    // instances always come back blank.
+    let mut working = storage.update(|instances, _groups| {
+        let idx = instances
+            .iter()
+            .position(|i| {
+                i.id == args.identifier
+                    || i.id.starts_with(&args.identifier)
+                    || i.title == args.identifier
+            })
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        bail_if_cockpit(&instances[idx], "start")?;
+        let mut clone = instances[idx].clone();
+        clone.source_profile = profile.to_string();
+        Ok(clone)
+    })?;
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Phase 2 (unlocked): tmux work happens outside the cross-process flock
+    // so a slow agent startup does not block peer mutators on the same
+    // profile (daemon poller, sibling CLI invocations).
+    working.start_with_size(crate::terminal::get_size())?;
+    let title = working.title.clone();
+    let id = working.id.clone();
+
+    // Phase 3 (locked, fast): merge the post-start instance back by id, so
+    // any concurrent mutation to OTHER sessions during phase 2 is preserved.
+    storage.update(|instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == id) {
+            *stored = working;
+        }
+        Ok(())
+    })?;
 
     println!("✓ Started session: {}", title);
     Ok(())
@@ -455,8 +416,10 @@ fn bail_if_cockpit(_inst: &crate::session::Instance, _verb: &str) -> Result<()> 
 
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
+    // Phase 1 (unlocked): resolve identifier, do tmux/container shutdown.
+    // Loaded snapshot is read-only here; the persistence happens in phase 2.
+    let (instances, _groups) = storage.load_with_groups()?;
     let inst = super::resolve_session(&args.identifier, &instances)?;
     bail_if_cockpit(inst, "stop")?;
     let session_id = inst.id.clone();
@@ -475,12 +438,15 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     inst.stop()?;
 
-    // Persist Stopped status to disk so it survives TUI restarts
-    if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-        stored.status = crate::session::Status::Stopped;
-    }
-    let group_tree = crate::session::GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Phase 2 (locked): persist Stopped status by id so it survives TUI
+    // restarts. Field-level merge preserves any concurrent mutation that
+    // landed between phase 1 and phase 2.
+    storage.update(|instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
+            stored.status = crate::session::Status::Stopped;
+        }
+        Ok(())
+    })?;
 
     if had_container {
         println!("✓ Stopped session and container: {}", title);
@@ -503,8 +469,11 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
 
 async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
+    // Phase 1 (unlocked): snapshot the targets. We don't hold the flock
+    // across the parallel restart fan-out below; phase 3 re-loads under
+    // the lock and merges by id.
+    let (instances, _groups) = storage.load_with_groups()?;
     let target_ids = pick_targets_for_restart_all(&instances);
     if target_ids.is_empty() {
         println!("No sessions to restart in profile '{}'.", profile);
@@ -515,30 +484,29 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let size = crate::terminal::get_size();
     let parallel = parallel.max(1);
 
-    // Clone each target into its worker; we'll write the (mutated) copy back
-    // by index after the worker returns. Workers never touch the shared Vec.
-    // `source_profile` is runtime-only (skip_serializing) so storage-loaded
-    // instances always come back blank; rehydrate it from the storage profile
-    // so start-time config resolution honors the right profile's overrides
-    // (sandbox.environment, on_launch hooks, etc.).
-    let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
+    // Clone each target into its worker. `source_profile` is runtime-only
+    // (skip_serializing) so storage-loaded instances always come back
+    // blank; rehydrate it from the storage profile so start-time config
+    // resolution honors the right profile's overrides (sandbox.environment,
+    // on_launch hooks, etc.).
+    let mut targets: Vec<crate::session::Instance> = Vec::with_capacity(total);
     for id in &target_ids {
-        if let Some(idx) = instances.iter().position(|i| &i.id == id) {
-            let mut clone = instances[idx].clone();
+        if let Some(inst) = instances.iter().find(|i| &i.id == id) {
+            let mut clone = inst.clone();
             clone.source_profile = profile.to_string();
-            targets.push((idx, clone));
+            targets.push(clone);
         }
     }
 
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
     let mut join_set: tokio::task::JoinSet<(
-        usize,
         String,
         Option<crate::session::Instance>,
         Result<StartOutcome>,
     )> = tokio::task::JoinSet::new();
 
-    for (idx, mut inst) in targets {
+    // Phase 2 (unlocked): parallel tmux restarts.
+    for mut inst in targets {
         let permit_sem = semaphore.clone();
         join_set.spawn(async move {
             let _permit = permit_sem
@@ -552,9 +520,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             })
             .await;
             match res {
-                Ok((inst, result)) => (idx, title, Some(inst), result),
+                Ok((inst, result)) => (title, Some(inst), result),
                 Err(join_err) => (
-                    idx,
                     title,
                     None,
                     Err(anyhow::anyhow!("worker panicked: {}", join_err)),
@@ -565,11 +532,11 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
+    let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
-        let (idx, title, inst_opt, result) =
-            joined.expect("JoinSet shouldn't panic on join itself");
+        let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
         if let Some(inst) = inst_opt {
-            instances[idx] = inst;
+            restarted.push(inst);
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -578,8 +545,19 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Phase 3 (locked, fast): merge each restarted instance by id into the
+    // freshly-loaded persisted state. Concurrent mutations to OTHER
+    // sessions during phase 2 (status updates from a parallel daemon
+    // poller, sibling CLI invocations, ...) are preserved because the
+    // closure receives the latest disk state.
+    storage.update(|instances, _groups| {
+        for restarted_inst in restarted {
+            if let Some(stored) = instances.iter_mut().find(|i| i.id == restarted_inst.id) {
+                *stored = restarted_inst;
+            }
+        }
+        Ok(())
+    })?;
 
     let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
@@ -637,26 +615,31 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    // Phase 1 (locked, fast): snapshot the target by identifier and
+    // rehydrate `source_profile` for config resolution.
+    let mut working = storage.update(|instances, _groups| {
+        let idx = instances
+            .iter()
+            .position(|i| {
+                i.id == args.identifier
+                    || i.id.starts_with(&args.identifier)
+                    || i.title == args.identifier
+            })
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        bail_if_cockpit(&instances[idx], "restart")?;
+        let mut clone = instances[idx].clone();
+        clone.source_profile = profile.to_string();
+        Ok(clone)
+    })?;
 
-    // `source_profile` is runtime-only (skip_serializing) so storage-loaded
-    // instances always come back blank; rehydrate it from the storage profile
-    // so restart-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "restart")?;
-    let outcome = instances[idx].restart_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
-    let session_id = instances[idx].id.clone();
-    let tool = instances[idx].tool.clone();
+    // Phase 2 (unlocked): tmux restart, agent boot, optional wake-up
+    // send-keys. Slow; the cross-process flock is not held here so peer
+    // mutators on this profile are not starved.
+    let outcome = working.restart_with_size(crate::terminal::get_size())?;
+    let title = working.title.clone();
+    let session_id = working.id.clone();
+    let tool = working.tool.clone();
 
     // Resolve the configured wake message (global default with per-profile
     // override). Empty string is the documented opt-out: the restart still
@@ -677,9 +660,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
                 Ok(()) => {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) {
-                        inst.touch_last_accessed();
-                    }
+                    working.touch_last_accessed();
                 }
                 Err(e) => {
                     eprintln!("Warning: failed to send wake-up message: {}", e);
@@ -688,8 +669,13 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Phase 3 (locked, fast): merge the post-restart instance back by id.
+    storage.update(|instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
+            *stored = working;
+        }
+        Ok(())
+    })?;
 
     match outcome {
         StartOutcome::Restarted { stale_sid } => {
@@ -902,12 +888,14 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
+    // Phase 1 (unlocked): resolve the target id (auto-detect from tmux if
+    // no identifier given) and the old/new title pair so we can do the
+    // tmux rename outside the storage flock.
+    let (instances, _groups) = storage.load_with_groups()?;
     let inst = if let Some(id) = &args.identifier {
         super::resolve_session(id, &instances)?
     } else {
-        // Auto-detect from tmux
         let current_session = std::env::var("TMUX_PANE")
             .ok()
             .and_then(|_| crate::tmux::get_current_session_name());
@@ -930,17 +918,19 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     let id = inst.id.clone();
     let old_title = inst.title.clone();
 
-    let effective_title = args.title.unwrap_or(old_title.clone());
-    let effective_title = effective_title.trim().to_string();
+    let effective_title = args
+        .title
+        .clone()
+        .unwrap_or_else(|| old_title.clone())
+        .trim()
+        .to_string();
+    let new_group = args.group.as_ref().map(|g| g.trim().to_string());
 
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-    // Rename tmux session if title changed
-    if instances[idx].title != effective_title {
-        let tmux_session = crate::tmux::Session::new(&id, &instances[idx].title)?;
+    // Phase 2 (unlocked): tmux rename if the title changed. Side effect on
+    // the running tmux server, fast but external state, do it outside the
+    // closure.
+    if old_title != effective_title {
+        let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
         if tmux_session.exists() {
             let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
             if let Err(e) = tmux_session.rename(&new_tmux_name) {
@@ -951,17 +941,33 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
-    instances[idx].title = effective_title.clone();
-
-    if let Some(group) = args.group {
-        instances[idx].group_path = group.trim().to_string();
-    }
-
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instances[idx].group_path.is_empty() {
-        group_tree.create_group(&instances[idx].group_path);
-    }
-    storage.commit(&instances, &group_tree)?;
+    // Phase 3 (locked): persist the new title and (optional) new group.
+    // Re-resolve by id under the lock so concurrent mutations to other
+    // sessions are preserved. `create_group` is idempotent and only runs
+    // when the closure actually mutated `group_path`, so `groups.json` is
+    // rewritten only on real group changes (cf. `update`'s diff check).
+    storage.update(|instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", id))?;
+        inst.title = effective_title.clone();
+        if let Some(group) = &new_group {
+            inst.group_path = group.clone();
+        }
+        if !inst.group_path.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(
+                &instances
+                    .iter()
+                    .find(|i| i.id == id)
+                    .expect("just patched")
+                    .group_path,
+            );
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(())
+    })?;
 
     if old_title != effective_title {
         println!("✓ Renamed session: {} → {}", old_title, effective_title);
@@ -1020,18 +1026,6 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
 }
 
 async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
-    let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
     let new_id = if args.session_id.trim().is_empty() {
         None
     } else {
@@ -1045,17 +1039,18 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         Some(trimmed)
     };
 
-    instances[idx].agent_session_id = new_id.clone();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let storage = Storage::new(profile)?;
+    let (title, tool) = storage.update(|instances, _groups| {
+        super::patch_instance(instances, &args.identifier, |inst| {
+            inst.agent_session_id = new_id.clone();
+            Ok((inst.title.clone(), inst.tool.clone()))
+        })
+    })?;
 
     match new_id {
         Some(ref id) => {
             println!("✓ Set session ID for '{}': {}", title, id);
-            let tool = &instances[idx].tool;
-            if let Some(agent) = crate::agents::get_agent(tool) {
+            if let Some(agent) = crate::agents::get_agent(&tool) {
                 if matches!(
                     agent.resume_strategy,
                     crate::agents::ResumeStrategy::Unsupported

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -347,24 +347,15 @@ async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
 
-    // Phase 1 (locked, fast): snapshot the target by identifier, rehydrate
+    // Phase 1 (unlocked): snapshot the target by identifier, rehydrate
     // `source_profile` so config resolution honors the right profile.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank.
-    let mut working = storage.update(|instances, _groups| {
-        let idx = instances
-            .iter()
-            .position(|i| {
-                i.id == args.identifier
-                    || i.id.starts_with(&args.identifier)
-                    || i.title == args.identifier
-            })
-            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-        bail_if_cockpit(&instances[idx], "start")?;
-        let mut clone = instances[idx].clone();
-        clone.source_profile = profile.to_string();
-        Ok(clone)
-    })?;
+    let (instances, _groups) = storage.load_with_groups()?;
+    let inst = super::resolve_session(&args.identifier, &instances)?;
+    bail_if_cockpit(inst, "start")?;
+    let mut working = inst.clone();
+    working.source_profile = profile.to_string();
 
     // Phase 2 (unlocked): tmux work happens outside the cross-process flock
     // so a slow agent startup does not block peer mutators on the same
@@ -616,22 +607,13 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
 
-    // Phase 1 (locked, fast): snapshot the target by identifier and
+    // Phase 1 (unlocked): snapshot the target by identifier and
     // rehydrate `source_profile` for config resolution.
-    let mut working = storage.update(|instances, _groups| {
-        let idx = instances
-            .iter()
-            .position(|i| {
-                i.id == args.identifier
-                    || i.id.starts_with(&args.identifier)
-                    || i.title == args.identifier
-            })
-            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-        bail_if_cockpit(&instances[idx], "restart")?;
-        let mut clone = instances[idx].clone();
-        clone.source_profile = profile.to_string();
-        Ok(clone)
-    })?;
+    let (instances, _groups) = storage.load_with_groups()?;
+    let inst = super::resolve_session(&args.identifier, &instances)?;
+    bail_if_cockpit(inst, "restart")?;
+    let mut working = inst.clone();
+    working.source_profile = profile.to_string();
 
     // Phase 2 (unlocked): tmux restart, agent boot, optional wake-up
     // send-keys. Slow; the cross-process flock is not held here so peer

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Result};
 use clap::Subcommand;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 
 use crate::git::GitWorktree;
@@ -259,9 +260,9 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
 
     // Remove orphaned sessions
     if !orphaned_sessions.is_empty() {
-        let orphan_ids: Vec<String> = orphaned_sessions.iter().map(|o| o.id.clone()).collect();
+        let orphan_ids: HashSet<String> = orphaned_sessions.iter().map(|o| o.id.clone()).collect();
         storage.update(|all_instances, _groups| {
-            all_instances.retain(|inst| !orphan_ids.iter().any(|id| id == &inst.id));
+            all_instances.retain(|inst| !orphan_ids.contains(&inst.id));
             Ok(())
         })?;
 

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -154,7 +154,7 @@ async fn show_info(profile: &str, identifier: &str) -> Result<()> {
 
 async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
+    let (instances, _groups) = storage.load_with_groups()?;
 
     let mut orphaned_sessions = Vec::new();
     let mut orphaned_worktrees = Vec::new();
@@ -259,11 +259,11 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
 
     // Remove orphaned sessions
     if !orphaned_sessions.is_empty() {
-        let mut new_instances = instances.clone();
-        new_instances.retain(|inst| !orphaned_sessions.iter().any(|orphan| orphan.id == inst.id));
-
-        let group_tree = crate::session::GroupTree::new_with_groups(&new_instances, &groups);
-        storage.commit(&new_instances, &group_tree)?;
+        let orphan_ids: Vec<String> = orphaned_sessions.iter().map(|o| o.id.clone()).collect();
+        storage.update(|all_instances, _groups| {
+            all_instances.retain(|inst| !orphan_ids.iter().any(|id| id == &inst.id));
+            Ok(())
+        })?;
 
         removed_count += orphaned_sessions.len();
         println!("✓ Removed {} orphaned sessions", orphaned_sessions.len());

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -620,17 +620,28 @@ pub async fn rename_session(
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
+    drop(instances);
 
     if let Ok(storage) = Storage::new(&profile) {
         let title_clone = title.clone();
         let id_clone = id.clone();
-        if let Err(e) = storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                apply_session_title_rename(inst, title_clone);
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    apply_session_title_rename(inst, title_clone);
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => {
+                tracing::error!(target: "http.api.sessions", "Failed to save after rename: {e}")
             }
-            Ok(())
-        }) {
-            tracing::error!(target: "http.api.sessions", "Failed to save after rename: {e}");
+            Err(e) => {
+                tracing::error!(target: "http.api.sessions", "Rename persist join failed: {e}")
+            }
         }
     }
 
@@ -724,21 +735,34 @@ pub async fn update_session_notifications(
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
+    drop(instances);
 
     if let Ok(storage) = Storage::new(&profile) {
         let id_clone = id.clone();
         let waiting = body.notify_on_waiting;
         let idle = body.notify_on_idle;
         let error = body.notify_on_error;
-        if let Err(e) = storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                apply(&mut inst.notify_on_waiting, waiting);
-                apply(&mut inst.notify_on_idle, idle);
-                apply(&mut inst.notify_on_error, error);
-            }
-            Ok(())
-        }) {
-            tracing::error!(target: "http.api.sessions", "Failed to save after notification update: {e}");
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    apply(&mut inst.notify_on_waiting, waiting);
+                    apply(&mut inst.notify_on_idle, idle);
+                    apply(&mut inst.notify_on_error, error);
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(
+                target: "http.api.sessions",
+                "Failed to save after notification update: {e}"
+            ),
+            Err(e) => tracing::error!(
+                target: "http.api.sessions",
+                "Notification persist join failed: {e}"
+            ),
         }
     }
 
@@ -801,6 +825,7 @@ pub async fn update_session_diff_base(
     let response =
         SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
     let profile = inst.source_profile.clone();
+    drop(instances);
 
     if let Ok(storage) = Storage::new(&profile) {
         let id_clone = id.clone();
@@ -810,13 +835,25 @@ pub async fn update_session_diff_base(
             .map(str::trim)
             .filter(|v| !v.is_empty())
             .map(str::to_string);
-        if let Err(e) = storage.update(|instances, _groups| {
-            if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
-                inst.base_branch_override = new_override;
-            }
-            Ok(())
-        }) {
-            tracing::error!(target: "http.api.sessions", "Failed to save after diff-base update: {e}");
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    inst.base_branch_override = new_override;
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(
+                target: "http.api.sessions",
+                "Failed to save after diff-base update: {e}"
+            ),
+            Err(e) => tracing::error!(
+                target: "http.api.sessions",
+                "Diff-base persist join failed: {e}"
+            ),
         }
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -525,9 +525,9 @@ fn append_resume_flags(
 /// Used during synchronous pre-launch (e.g. `persist_session_id` for Claude)
 /// when no poller is active yet. Post-launch persistence goes exclusively
 /// through the poller channel -> `apply_session_id_updates()` in the TUI
-/// thread. Concurrent calls within the same process are serialised via
-/// `Storage::update`'s per-profile lock; cross-process races between TUI
-/// and `aoe serve` remain a known limitation (see #1175).
+/// thread. Concurrent calls within and across processes are serialised via
+/// `Storage::update`'s two-layer lock (in-process mutex + cross-process
+/// flock; see `storage.rs` module rustdoc).
 ///
 /// Fire-and-forget: errors are logged at error level. The poller dedupes
 /// on its `last_known` and `apply_session_id_updates` dedupes on in-memory
@@ -581,9 +581,11 @@ pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, sessi
 /// Tier 2's `finalize_launch`, the next launch would otherwise re-load the
 /// bad sid from disk and pass `--resume <bad>` again, looping.
 ///
-/// Concurrent in-process callers (TUI tick, server `spawn_blocking` workers,
-/// CLI `restart --all` JoinSet workers) are serialised via `Storage::update`'s
-/// per-profile lock; cross-process races remain out of scope (see #1175).
+/// Concurrent callers within and across processes (TUI tick, server
+/// `spawn_blocking` workers, CLI `restart --all` JoinSet workers, peer
+/// `aoe` invocations) are serialised via `Storage::update`'s two-layer
+/// lock (in-process mutex + cross-process flock; see `storage.rs` module
+/// rustdoc).
 fn clear_session_id_on_disk(profile: &str, instance_id: &str) {
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
@@ -736,6 +738,9 @@ impl Instance {
     /// survive even when the field is in the user-action set.
     /// `last_accessed_at` is monotone-max (no diff guard).
     /// `source_profile` is excluded; cross-profile moves bypass this path.
+    /// Post-splice rules enforce the same cross-field invariants the
+    /// per-mutation methods enforce (archive XOR favorite, touch unarchives)
+    /// so concurrent peer writes cannot violate them.
     pub fn merge_user_action_diff(&mut self, pre: &Self, post: &Self) {
         debug_assert_eq!(
             pre.source_profile, post.source_profile,
@@ -763,6 +768,27 @@ impl Instance {
             self.status = post.status;
         }
         self.last_accessed_at = self.last_accessed_at.max(post.last_accessed_at);
+
+        let archived_changed = pre.archived_at != post.archived_at;
+        let favorited_changed = pre.favorited_at != post.favorited_at;
+        // Read self (post-merge) to catch both TUI-side and peer-side touches.
+        let touched = self.last_accessed_at > pre.last_accessed_at;
+
+        // archive(): archived=Some => favorited=None
+        if archived_changed && post.archived_at.is_some() {
+            self.favorited_at = None;
+        }
+        // favorite(): favorited=Some => archived=None, snoozed=None
+        if favorited_changed && post.favorited_at.is_some() {
+            self.archived_at = None;
+            self.snoozed_until = None;
+        }
+        // touch_last_accessed(): clears archived + snoozed. Runs LAST so a
+        // fresh touch beats a concurrent archive (user rule: messaging unarchives).
+        if touched {
+            self.archived_at = None;
+            self.snoozed_until = None;
+        }
     }
 
     /// Mark the session archived. Archived sessions sink to the bottom of
@@ -3076,6 +3102,113 @@ mod tests {
             stored.agent_session_id.as_deref(),
             Some("poller-fresh-sid"),
             "poller wrote a fresh sid between phase 2 and phase 3; CAS preserves it"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_archive_loses_to_tui_favorite() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.favorite();
+
+        let mut disk = pre.clone();
+        disk.archive();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.favorited_at.is_some(), "TUI favorite landed");
+        assert!(
+            disk.archived_at.is_none(),
+            "favorite() invariant must clear concurrent peer archive"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_favorite_loses_to_tui_archive() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.archive();
+
+        let mut disk = pre.clone();
+        disk.favorite();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.archived_at.is_some(), "TUI archive landed");
+        assert!(
+            disk.favorited_at.is_none(),
+            "archive() invariant must clear concurrent peer favorite"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_archive_loses_to_tui_touch() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.touch_last_accessed();
+
+        let mut disk = pre.clone();
+        disk.archive();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(
+            disk.archived_at.is_none(),
+            "touch_last_accessed() invariant must clear concurrent peer archive"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_touch_clears_tui_archive() {
+        let mut pre = Instance::new("s", "/tmp/x");
+        pre.last_accessed_at = Some(Utc::now() - chrono::Duration::seconds(60));
+
+        let mut post = pre.clone();
+        post.archive();
+
+        let mut disk = pre.clone();
+        disk.touch_last_accessed();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(
+            disk.archived_at.is_none(),
+            "peer touch (newer last_accessed_at) must dethrone TUI archive per messaging-unarchives rule"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_archive_and_snooze_coexist() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.snooze(15);
+
+        let mut disk = pre.clone();
+        disk.archive();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.archived_at.is_some(), "peer archive survives");
+        assert!(disk.snoozed_until.is_some(), "TUI snooze landed");
+    }
+
+    #[test]
+    fn test_merge_diff_tui_unfavorite_does_not_resurrect_peer_archive() {
+        let mut pre = Instance::new("s", "/tmp/x");
+        pre.favorite();
+
+        let mut post = pre.clone();
+        post.unfavorite();
+
+        let mut disk = pre.clone();
+        disk.archive();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.favorited_at.is_none(), "TUI unfavorite landed");
+        assert!(
+            disk.archived_at.is_some(),
+            "post.favorited_at == None; favorite-invariant rule must NOT fire"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -689,6 +689,24 @@ impl Instance {
         self.snoozed_until = None;
     }
 
+    /// Mutates: `status`, `sandbox_info`. Field set must match what
+    /// `start_with_size_opts` writes; missing fields re-introduce the
+    /// wholesale-replace clobber.
+    pub fn merge_post_start(&mut self, src: &Self) {
+        self.status = src.status;
+        self.sandbox_info = src.sandbox_info.clone();
+    }
+
+    /// Same fields as `merge_post_start`. When `clear_stale_sid` (resume
+    /// fallback fired), also copy `agent_session_id`: the cascade just
+    /// invalidated it, so peer writes are stale by construction.
+    pub fn merge_post_restart(&mut self, src: &Self, clear_stale_sid: bool) {
+        self.merge_post_start(src);
+        if clear_stale_sid {
+            self.agent_session_id = src.agent_session_id.clone();
+        }
+    }
+
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.
@@ -2901,6 +2919,67 @@ mod tests {
         // Favorite is orthogonal to sink states; user interaction must not
         // clear it.
         assert!(inst.is_favorited());
+    }
+
+    #[test]
+    fn test_merge_post_start_preserves_peer_field_writes() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.archive();
+        stored.agent_session_id = Some("daemon-sid".to_string());
+
+        let mut working = Instance::new("session", "/tmp/test");
+        working.id = stored.id.clone();
+        working.status = Status::Starting;
+
+        stored.merge_post_start(&working);
+
+        assert_eq!(stored.status, Status::Starting);
+        assert!(stored.is_archived(), "peer archive must survive merge");
+        assert_eq!(
+            stored.agent_session_id.as_deref(),
+            Some("daemon-sid"),
+            "peer-written sid must survive merge"
+        );
+    }
+
+    #[test]
+    fn test_merge_post_restart_no_fallback_preserves_sid() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.agent_session_id = Some("peer-fresh-sid".to_string());
+        stored.snooze(15);
+
+        let mut working = Instance::new("session", "/tmp/test");
+        working.id = stored.id.clone();
+        working.status = Status::Idle;
+        working.agent_session_id = Some("phase1-stale-sid".to_string());
+
+        stored.merge_post_restart(&working, false);
+
+        assert_eq!(stored.status, Status::Idle);
+        assert_eq!(
+            stored.agent_session_id.as_deref(),
+            Some("peer-fresh-sid"),
+            "no-fallback restart must not clobber peer sid write"
+        );
+        assert!(stored.is_snoozed(), "peer snooze must survive merge");
+    }
+
+    #[test]
+    fn test_merge_post_restart_fallback_clears_sid() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.agent_session_id = Some("any-sid".to_string());
+
+        let mut working = Instance::new("session", "/tmp/test");
+        working.id = stored.id.clone();
+        working.status = Status::Starting;
+        working.agent_session_id = None;
+
+        stored.merge_post_restart(&working, true);
+
+        assert!(
+            stored.agent_session_id.is_none(),
+            "fallback cascade invalidates the sid; peer writes are stale by construction"
+        );
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -723,6 +723,24 @@ impl Instance {
         self.idle_entered_at = src.idle_entered_at;
     }
 
+    /// Splice user-action fields from `src` onto `self`. Dual of
+    /// `merge_from_tui` for fields the TUI mutates per dialog action
+    /// (archive, favorite, snooze, rename, group move, base-branch
+    /// override). Called from `HomeView::apply_user_action`'s
+    /// `Storage::update` closure: the in-memory mirror has already run the
+    /// mutation once; this copies the resulting field values onto the
+    /// freshly-loaded disk row, so peer writes to OTHER fields survive.
+    pub fn merge_post_user_action(&mut self, src: &Self) {
+        self.title = src.title.clone();
+        self.group_path = src.group_path.clone();
+        self.archived_at = src.archived_at;
+        self.favorited_at = src.favorited_at;
+        self.snoozed_until = src.snoozed_until;
+        self.base_branch_override = src.base_branch_override.clone();
+        self.status = src.status;
+        self.last_accessed_at = self.last_accessed_at.max(src.last_accessed_at);
+    }
+
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -697,13 +697,17 @@ impl Instance {
         self.sandbox_info = src.sandbox_info.clone();
     }
 
-    /// Same fields as `merge_post_start`. When `clear_stale_sid` (resume
-    /// fallback fired), also copy `agent_session_id`: the cascade just
-    /// invalidated it, so peer writes are stale by construction.
-    pub fn merge_post_restart(&mut self, src: &Self, clear_stale_sid: bool) {
+    /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, the
+    /// resume-fallback cascade just invalidated that exact sid; clear
+    /// `self.agent_session_id` only if it still matches the stale value, so
+    /// a peer poller's freshly-discovered sid (landed between phase 2 and
+    /// phase 3 of the restart) survives intact.
+    pub fn merge_post_restart(&mut self, src: &Self, stale_sid: Option<&str>) {
         self.merge_post_start(src);
-        if clear_stale_sid {
-            self.agent_session_id = src.agent_session_id.clone();
+        if let Some(stale) = stale_sid {
+            if self.agent_session_id.as_deref() == Some(stale) {
+                self.agent_session_id = src.agent_session_id.clone();
+            }
         }
     }
 
@@ -2965,7 +2969,7 @@ mod tests {
         working.status = Status::Idle;
         working.agent_session_id = Some("phase1-stale-sid".to_string());
 
-        stored.merge_post_restart(&working, false);
+        stored.merge_post_restart(&working, None);
 
         assert_eq!(stored.status, Status::Idle);
         assert_eq!(
@@ -2977,20 +2981,39 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_post_restart_fallback_clears_sid() {
+    fn test_merge_post_restart_fallback_clears_matching_sid() {
         let mut stored = Instance::new("session", "/tmp/test");
-        stored.agent_session_id = Some("any-sid".to_string());
+        stored.agent_session_id = Some("phase1-stale-sid".to_string());
 
         let mut working = Instance::new("session", "/tmp/test");
         working.id = stored.id.clone();
         working.status = Status::Starting;
         working.agent_session_id = None;
 
-        stored.merge_post_restart(&working, true);
+        stored.merge_post_restart(&working, Some("phase1-stale-sid"));
 
         assert!(
             stored.agent_session_id.is_none(),
-            "fallback cascade invalidates the sid; peer writes are stale by construction"
+            "stored sid still equals stale; cascade invalidation propagates"
+        );
+    }
+
+    #[test]
+    fn test_merge_post_restart_preserves_poller_sid_landed_during_phase_2() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.agent_session_id = Some("poller-fresh-sid".to_string());
+
+        let mut working = Instance::new("session", "/tmp/test");
+        working.id = stored.id.clone();
+        working.status = Status::Starting;
+        working.agent_session_id = None;
+
+        stored.merge_post_restart(&working, Some("phase1-stale-sid"));
+
+        assert_eq!(
+            stored.agent_session_id.as_deref(),
+            Some("poller-fresh-sid"),
+            "poller wrote a fresh sid between phase 2 and phase 3; CAS preserves it"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -4338,7 +4338,11 @@ mod tests {
             assert!(inst.agent_session_id.is_none());
             let xs = vec![inst];
             storage
-                .commit(&xs, &crate::session::GroupTree::new_with_groups(&xs, &[]))
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
                 .unwrap();
 
             clear_session_id_on_disk("test-profile-already-none", &id);
@@ -4363,7 +4367,11 @@ mod tests {
             let id = inst.id.clone();
             let xs = vec![inst];
             storage
-                .commit(&xs, &crate::session::GroupTree::new_with_groups(&xs, &[]))
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
                 .unwrap();
 
             clear_session_id_on_disk("clear-test", &id);
@@ -4425,7 +4433,11 @@ mod tests {
 
             let xs = vec![inst.clone()];
             storage
-                .commit(&xs, &crate::session::GroupTree::new_with_groups(&xs, &[]))
+                .update(|i, g| {
+                    *i = xs.to_vec();
+                    *g = crate::session::GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                    Ok(())
+                })
                 .unwrap();
 
             let outcome = inst.start_with_resume_fallback(None, true);

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -697,14 +697,12 @@ impl Instance {
         self.snoozed_until = None;
     }
 
-    /// Mutates: `status`, `sandbox_info`, `last_error`, `last_error_check`.
-    /// The last-error pair is included because the resume-fallback cascade
-    /// clears it on Error -> Starting and the disk row must reflect that.
+    /// Mutates: `status`, `sandbox_info`. Field set must match what
+    /// `start_with_size_opts` writes; missing fields re-introduce the
+    /// wholesale-replace clobber.
     pub fn merge_post_start(&mut self, src: &Self) {
         self.status = src.status;
         self.sandbox_info = src.sandbox_info.clone();
-        self.last_error = src.last_error.clone();
-        self.last_error_check = src.last_error_check;
     }
 
     /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, the
@@ -3023,26 +3021,6 @@ mod tests {
             stored.agent_session_id.as_deref(),
             Some("daemon-sid"),
             "peer-written sid must survive merge"
-        );
-    }
-
-    #[test]
-    fn test_merge_post_start_propagates_last_error_clear() {
-        let mut stored = Instance::new("session", "/tmp/test");
-        stored.status = Status::Error;
-        stored.last_error = Some("stale failure from previous run".to_string());
-
-        let mut working = Instance::new("session", "/tmp/test");
-        working.id = stored.id.clone();
-        working.status = Status::Starting;
-        working.last_error = None;
-
-        stored.merge_post_start(&working);
-
-        assert_eq!(stored.status, Status::Starting);
-        assert!(
-            stored.last_error.is_none(),
-            "Error -> Starting transition cleared last_error in working; merge must propagate the clear so disk does not show stale Starting + last_error"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -528,6 +528,13 @@ fn append_resume_flags(
 /// thread. Concurrent calls within the same process are serialised via
 /// `Storage::update`'s per-profile lock; cross-process races between TUI
 /// and `aoe serve` remain a known limitation (see #1175).
+///
+/// Errors are logged at error level and absorbed: this is fire-and-forget
+/// from the caller's perspective, matching the surrounding tick-loop /
+/// pre-launch helpers (`apply_status_updates`, `clear_session_id_on_disk`).
+/// The next `status_poll` tick re-reads the sid from agent state and
+/// re-attempts persistence, so a transient flock contention or disk error
+/// is recovered without caller involvement.
 pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
     if !is_valid_session_id(session_id) {
         tracing::warn!(target: "session.store",
@@ -541,7 +548,7 @@ pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, sessi
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
         Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to create storage for session ID persistence: {}", e);
+            tracing::error!(target: "session.store", "Failed to create storage for session ID persistence: {}", e);
             return;
         }
     };
@@ -561,7 +568,7 @@ pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, sessi
         }
         Ok(false) => {}
         Err(e) => {
-            tracing::warn!(target: "session.store", "Failed to persist session ID for {}: {}", instance_id, e);
+            tracing::error!(target: "session.store", "Failed to persist session ID for {}: {}; next status_poll tick will retry", instance_id, e);
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -529,11 +529,11 @@ fn append_resume_flags(
 /// `Storage::update`'s two-layer lock (in-process mutex + cross-process
 /// flock; see `storage.rs` module rustdoc).
 ///
-/// Fire-and-forget: errors are logged at error level. The poller dedupes
+/// Fire-and-forget: errors are logged at warn level. The poller dedupes
 /// on its `last_known` and `apply_session_id_updates` dedupes on in-memory
-/// state, so a transient persist failure stays on disk-out-of-sync until
-/// the process restarts (which reloads from disk and re-emits via the
-/// agent's own session log on next start).
+/// state, so a transient persist failure stays disk-out-of-sync until the
+/// process restarts (which reloads from disk and re-emits via the agent's
+/// own session log on next start).
 pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
     if !is_valid_session_id(session_id) {
         tracing::warn!(target: "session.store",
@@ -547,7 +547,7 @@ pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, sessi
     let storage = match super::storage::Storage::new(profile) {
         Ok(s) => s,
         Err(e) => {
-            tracing::error!(target: "session.store", "Failed to create storage for session ID persistence: {}", e);
+            tracing::warn!(target: "session.store", "Failed to create storage for session ID persistence: {}", e);
             return;
         }
     };
@@ -567,7 +567,7 @@ pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, sessi
         }
         Ok(false) => {}
         Err(e) => {
-            tracing::error!(target: "session.store", "Failed to persist session ID for {}: {}; next status_poll tick will retry", instance_id, e);
+            tracing::warn!(target: "session.store", "Failed to persist session ID for {}: {}", instance_id, e);
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -720,8 +720,11 @@ impl Instance {
     }
 
     /// Splice TUI-mirrored, persisted fields from `src` onto `self`. Used by
-    /// `HomeView::save` under the flock for fields the TUI is the sole disk
-    /// writer of (the daemon's `status_poll_loop` keeps these in memory only).
+    /// `HomeView::save` for fields the TUI is the canonical disk writer of
+    /// (the daemon's `status_poll_loop` keeps these in memory only). The
+    /// server's `send_message` respawn briefly writes `status` via
+    /// `apply_post_restart_sync`; the resulting transient mis-paint
+    /// converges on the next `status_poll` tick.
     /// User-action fields (archived/favorited/snoozed/title/group_path/...)
     /// are NOT here; they go through `apply_user_action` per-action so peer
     /// writers (CLI) cannot be clobbered by a stale TUI snapshot.
@@ -769,7 +772,8 @@ impl Instance {
 
         let archived_changed = pre.archived_at != post.archived_at;
         let favorited_changed = pre.favorited_at != post.favorited_at;
-        // Read self (post-merge) to catch both TUI-side and peer-side touches.
+        // Touch is an event invariant: any advance of last_accessed_at
+        // (TUI-side or peer-side) dethrones a concurrent archive.
         let touched = self.last_accessed_at > pre.last_accessed_at;
 
         // archive(): archived=Some => favorited=None
@@ -781,8 +785,7 @@ impl Instance {
             self.archived_at = None;
             self.snoozed_until = None;
         }
-        // touch_last_accessed(): clears archived + snoozed. Runs LAST so a
-        // fresh touch beats a concurrent archive (user rule: messaging unarchives).
+        // touch_last_accessed(): clears archived + snoozed.
         if touched {
             self.archived_at = None;
             self.snoozed_until = None;
@@ -3188,6 +3191,24 @@ mod tests {
             disk.archived_at.is_some(),
             "post.favorited_at == None; favorite-invariant rule must NOT fire"
         );
+    }
+
+    #[test]
+    fn test_merge_diff_uses_self_not_post_for_touch_detection() {
+        let mut pre = Instance::new("s", "/tmp/x");
+        pre.last_accessed_at = Some(Utc::now() - chrono::Duration::seconds(60));
+        pre.archived_at = Some(Utc::now() - chrono::Duration::seconds(120));
+
+        let mut post = pre.clone();
+        post.title = "renamed".into();
+
+        let mut disk = pre.clone();
+        disk.touch_last_accessed();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert_eq!(disk.title, "renamed");
+        assert!(disk.archived_at.is_none());
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -528,7 +528,7 @@ fn append_resume_flags(
 /// thread. Concurrent calls within the same process are serialised via
 /// `Storage::update`'s per-profile lock; cross-process races between TUI
 /// and `aoe serve` remain a known limitation (see #1175).
-fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
+pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
     if !is_valid_session_id(session_id) {
         tracing::warn!(target: "session.store",
             "Refusing to persist invalid session ID {:?} for {}",

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -707,6 +707,18 @@ impl Instance {
         }
     }
 
+    /// Splice TUI-mirrored, persisted fields from `src` onto `self`. Used by
+    /// `HomeView::save` under the flock for fields the TUI is the sole disk
+    /// writer of (the daemon's `status_poll_loop` keeps these in memory only).
+    /// User-action fields (archived/favorited/snoozed/title/group_path/...)
+    /// are NOT here; they go through `apply_user_action` per-action so peer
+    /// writers (CLI) cannot be clobbered by a stale TUI snapshot.
+    pub fn merge_from_tui(&mut self, src: &Self) {
+        self.status = src.status;
+        self.last_accessed_at = self.last_accessed_at.max(src.last_accessed_at);
+        self.idle_entered_at = src.idle_entered_at;
+    }
+
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.
@@ -2980,6 +2992,107 @@ mod tests {
             stored.agent_session_id.is_none(),
             "fallback cascade invalidates the sid; peer writes are stale by construction"
         );
+    }
+
+    #[test]
+    fn test_merge_from_tui_copies_status_pipeline() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.status = Status::Idle;
+
+        let mut src = Instance::new("session", "/tmp/test");
+        src.id = stored.id.clone();
+        src.status = Status::Running;
+        src.idle_entered_at = Some(Utc::now());
+
+        stored.merge_from_tui(&src);
+
+        assert_eq!(stored.status, Status::Running);
+        assert_eq!(stored.idle_entered_at, src.idle_entered_at);
+    }
+
+    #[test]
+    fn test_merge_from_tui_takes_max_last_accessed() {
+        let earlier = Utc::now() - chrono::Duration::minutes(5);
+        let later = Utc::now();
+
+        let mut stored = Instance::new("a", "/tmp/a");
+        stored.last_accessed_at = Some(later);
+        let mut src = Instance::new("a", "/tmp/a");
+        src.id = stored.id.clone();
+        src.last_accessed_at = Some(earlier);
+        stored.merge_from_tui(&src);
+        assert_eq!(
+            stored.last_accessed_at,
+            Some(later),
+            "peer's freshest activity timestamp must survive a stale TUI src"
+        );
+
+        let mut stored = Instance::new("b", "/tmp/b");
+        stored.last_accessed_at = Some(earlier);
+        let mut src = Instance::new("b", "/tmp/b");
+        src.id = stored.id.clone();
+        src.last_accessed_at = Some(later);
+        stored.merge_from_tui(&src);
+        assert_eq!(stored.last_accessed_at, Some(later));
+    }
+
+    #[test]
+    fn test_merge_from_tui_does_not_touch_user_action_fields() {
+        let peer_archived = Some(Utc::now());
+        let peer_favorited = Some(Utc::now() - chrono::Duration::minutes(2));
+        let peer_snoozed = Some(Utc::now() + chrono::Duration::minutes(30));
+
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.archived_at = peer_archived;
+        stored.favorited_at = peer_favorited;
+        stored.snoozed_until = peer_snoozed;
+        stored.title = "peer-renamed".to_string();
+        stored.group_path = "peer/group".to_string();
+        stored.agent_session_id = Some("daemon-sid".to_string());
+        stored.notify_on_waiting = Some(true);
+        stored.base_branch_override = Some("upstream/main".to_string());
+
+        let mut src = Instance::new("session", "/tmp/test");
+        src.id = stored.id.clone();
+        src.archived_at = None;
+        src.favorited_at = None;
+        src.snoozed_until = None;
+        src.title = "tui-stale".to_string();
+        src.group_path = "tui/stale".to_string();
+        src.agent_session_id = Some("tui-stale-sid".to_string());
+        src.notify_on_waiting = Some(false);
+        src.base_branch_override = None;
+
+        stored.merge_from_tui(&src);
+
+        assert_eq!(stored.archived_at, peer_archived);
+        assert_eq!(stored.favorited_at, peer_favorited);
+        assert_eq!(stored.snoozed_until, peer_snoozed);
+        assert_eq!(stored.title, "peer-renamed");
+        assert_eq!(stored.group_path, "peer/group");
+        assert_eq!(stored.agent_session_id.as_deref(), Some("daemon-sid"));
+        assert_eq!(stored.notify_on_waiting, Some(true));
+        assert_eq!(
+            stored.base_branch_override.as_deref(),
+            Some("upstream/main")
+        );
+    }
+
+    #[test]
+    fn test_merge_from_tui_preserves_immutable_identity() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        let immutable_id = stored.id.clone();
+        let immutable_path = stored.project_path.clone();
+        let immutable_created = stored.created_at;
+
+        let mut src = Instance::new("renamed", "/tmp/different");
+        src.id = "different-id".to_string();
+
+        stored.merge_from_tui(&src);
+
+        assert_eq!(stored.id, immutable_id);
+        assert_eq!(stored.project_path, immutable_path);
+        assert_eq!(stored.created_at, immutable_created);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -529,12 +529,8 @@ fn append_resume_flags(
 /// `Storage::update`'s per-profile lock; cross-process races between TUI
 /// and `aoe serve` remain a known limitation (see #1175).
 ///
-/// Errors are logged at error level and absorbed: this is fire-and-forget
-/// from the caller's perspective, matching the surrounding tick-loop /
-/// pre-launch helpers (`apply_status_updates`, `clear_session_id_on_disk`).
-/// The next `status_poll` tick re-reads the sid from agent state and
-/// re-attempts persistence, so a transient flock contention or disk error
-/// is recovered without caller involvement.
+/// Fire-and-forget: errors are logged at error level; the next
+/// `status_poll` tick re-reads the sid from agent state and retries.
 pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
     if !is_valid_session_id(session_id) {
         tracing::warn!(target: "session.store",
@@ -730,23 +726,11 @@ impl Instance {
         self.idle_entered_at = src.idle_entered_at;
     }
 
-    /// Splice only fields that the in-memory mutation actually changed
-    /// onto `self`. `pre` is the in-memory snapshot before the mutation;
-    /// `post` is after. For each TUI-owned user-action field, when
-    /// `pre != post` the field is copied; otherwise the disk row's value
-    /// is preserved, so a peer write that happened between TUI's last
-    /// reload and now survives even when the field is in the user-action
-    /// set (e.g. peer-set `snoozed_until` survives a TUI archive that
-    /// only mutates `archived_at`).
-    ///
-    /// `last_accessed_at` is monotone-max regardless of pre/post equality:
-    /// any TUI tick concurrent with a peer touch always picks the latest.
-    ///
-    /// `source_profile` is intentionally NOT in the diff set: cross-profile
-    /// moves bypass `apply_user_action` entirely (they need to remove from
-    /// profile A's storage and insert into profile B's), so the field can
-    /// never legitimately differ across this call. The debug-assert pins
-    /// the invariant.
+    /// Per-field-conditional splice: copy `post.X` onto `self.X` only when
+    /// `pre.X != post.X`. Peer writes to fields the mutation did not touch
+    /// survive even when the field is in the user-action set.
+    /// `last_accessed_at` is monotone-max (no diff guard).
+    /// `source_profile` is excluded; cross-profile moves bypass this path.
     pub fn merge_user_action_diff(&mut self, pre: &Self, post: &Self) {
         debug_assert_eq!(
             pre.source_profile, post.source_profile,

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -695,12 +695,14 @@ impl Instance {
         self.snoozed_until = None;
     }
 
-    /// Mutates: `status`, `sandbox_info`. Field set must match what
-    /// `start_with_size_opts` writes; missing fields re-introduce the
-    /// wholesale-replace clobber.
+    /// Mutates: `status`, `sandbox_info`, `last_error`, `last_error_check`.
+    /// The last-error pair is included because the resume-fallback cascade
+    /// clears it on Error -> Starting and the disk row must reflect that.
     pub fn merge_post_start(&mut self, src: &Self) {
         self.status = src.status;
         self.sandbox_info = src.sandbox_info.clone();
+        self.last_error = src.last_error.clone();
+        self.last_error_check = src.last_error_check;
     }
 
     /// Same fields as `merge_post_start`. When `stale_sid` is `Some`, the
@@ -2995,6 +2997,26 @@ mod tests {
             stored.agent_session_id.as_deref(),
             Some("daemon-sid"),
             "peer-written sid must survive merge"
+        );
+    }
+
+    #[test]
+    fn test_merge_post_start_propagates_last_error_clear() {
+        let mut stored = Instance::new("session", "/tmp/test");
+        stored.status = Status::Error;
+        stored.last_error = Some("stale failure from previous run".to_string());
+
+        let mut working = Instance::new("session", "/tmp/test");
+        working.id = stored.id.clone();
+        working.status = Status::Starting;
+        working.last_error = None;
+
+        stored.merge_post_start(&working);
+
+        assert_eq!(stored.status, Status::Starting);
+        assert!(
+            stored.last_error.is_none(),
+            "Error -> Starting transition cleared last_error in working; merge must propagate the clear so disk does not show stale Starting + last_error"
         );
     }
 

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -723,22 +723,50 @@ impl Instance {
         self.idle_entered_at = src.idle_entered_at;
     }
 
-    /// Splice user-action fields from `src` onto `self`. Dual of
-    /// `merge_from_tui` for fields the TUI mutates per dialog action
-    /// (archive, favorite, snooze, rename, group move, base-branch
-    /// override). Called from `HomeView::apply_user_action`'s
-    /// `Storage::update` closure: the in-memory mirror has already run the
-    /// mutation once; this copies the resulting field values onto the
-    /// freshly-loaded disk row, so peer writes to OTHER fields survive.
-    pub fn merge_post_user_action(&mut self, src: &Self) {
-        self.title = src.title.clone();
-        self.group_path = src.group_path.clone();
-        self.archived_at = src.archived_at;
-        self.favorited_at = src.favorited_at;
-        self.snoozed_until = src.snoozed_until;
-        self.base_branch_override = src.base_branch_override.clone();
-        self.status = src.status;
-        self.last_accessed_at = self.last_accessed_at.max(src.last_accessed_at);
+    /// Splice only fields that the in-memory mutation actually changed
+    /// onto `self`. `pre` is the in-memory snapshot before the mutation;
+    /// `post` is after. For each TUI-owned user-action field, when
+    /// `pre != post` the field is copied; otherwise the disk row's value
+    /// is preserved, so a peer write that happened between TUI's last
+    /// reload and now survives even when the field is in the user-action
+    /// set (e.g. peer-set `snoozed_until` survives a TUI archive that
+    /// only mutates `archived_at`).
+    ///
+    /// `last_accessed_at` is monotone-max regardless of pre/post equality:
+    /// any TUI tick concurrent with a peer touch always picks the latest.
+    ///
+    /// `source_profile` is intentionally NOT in the diff set: cross-profile
+    /// moves bypass `apply_user_action` entirely (they need to remove from
+    /// profile A's storage and insert into profile B's), so the field can
+    /// never legitimately differ across this call. The debug-assert pins
+    /// the invariant.
+    pub fn merge_user_action_diff(&mut self, pre: &Self, post: &Self) {
+        debug_assert_eq!(
+            pre.source_profile, post.source_profile,
+            "apply_user_action must not change source_profile; cross-profile moves go through mutate_instance"
+        );
+        if pre.title != post.title {
+            self.title = post.title.clone();
+        }
+        if pre.group_path != post.group_path {
+            self.group_path = post.group_path.clone();
+        }
+        if pre.archived_at != post.archived_at {
+            self.archived_at = post.archived_at;
+        }
+        if pre.favorited_at != post.favorited_at {
+            self.favorited_at = post.favorited_at;
+        }
+        if pre.snoozed_until != post.snoozed_until {
+            self.snoozed_until = post.snoozed_until;
+        }
+        if pre.base_branch_override != post.base_branch_override {
+            self.base_branch_override = post.base_branch_override.clone();
+        }
+        if pre.status != post.status {
+            self.status = post.status;
+        }
+        self.last_accessed_at = self.last_accessed_at.max(post.last_accessed_at);
     }
 
     /// Mark the session archived. Archived sessions sink to the bottom of

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -529,8 +529,11 @@ fn append_resume_flags(
 /// `Storage::update`'s per-profile lock; cross-process races between TUI
 /// and `aoe serve` remain a known limitation (see #1175).
 ///
-/// Fire-and-forget: errors are logged at error level; the next
-/// `status_poll` tick re-reads the sid from agent state and retries.
+/// Fire-and-forget: errors are logged at error level. The poller dedupes
+/// on its `last_known` and `apply_session_id_updates` dedupes on in-memory
+/// state, so a transient persist failure stays on disk-out-of-sync until
+/// the process restarts (which reloads from disk and re-emits via the
+/// agent's own session log on next start).
 pub(crate) fn persist_session_to_storage(profile: &str, instance_id: &str, session_id: &str) {
     if !is_valid_session_id(session_id) {
         tracing::warn!(target: "session.store",

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -31,6 +31,7 @@ pub use environment::{validate_env_entries, validate_env_entry};
 pub use groups::{
     flatten_sessions_by_attention, flatten_tree, flatten_tree_all_profiles, Group, GroupTree, Item,
 };
+pub(crate) use instance::persist_session_to_storage;
 pub use instance::{
     EnsureReadyError, EnsureReadyOutcome, Instance, SandboxInfo, StartOutcome, Status,
     TerminalInfo, WorkspaceInfo, WorkspaceRepo, WorktreeInfo,

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -49,7 +49,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
-use super::{get_app_dir, get_profile_dir, Group, GroupTree, Instance};
+use super::{get_app_dir, get_profile_dir, Group, Instance};
 
 /// Sidecar lock file name for per-profile storage. Lives next to
 /// `sessions.json` and `groups.json` and covers both: every code path that
@@ -326,36 +326,6 @@ impl Storage {
         atomic_write(&self.sessions_path, &instances_buf)?;
         Ok(result)
     }
-
-    /// Locked wholesale write of `sessions.json` + `groups.json`. Last-writer-
-    /// wins by design: any concurrent `update` whose load happened before this
-    /// `commit` is overwritten. This is correct for HomeView (the TUI's
-    /// authoritative in-memory copy); other callers should use `update`.
-    ///
-    /// Both buffers are serialised before any disk write, so a serialisation
-    /// failure on either side leaves both files untouched. The two atomic
-    /// writes happen in the same order as `update` (groups, then sessions);
-    /// the same residual disk-failure window applies.
-    pub fn commit(&self, instances: &[Instance], group_tree: &GroupTree) -> Result<()> {
-        let _mu = self
-            .save_lock
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        let profile_dir = self.sessions_path.parent().ok_or_else(|| {
-            anyhow!(
-                "sessions_path missing parent: {}",
-                self.sessions_path.display()
-            )
-        })?;
-        let _flock = acquire_storage_flock(profile_dir, STORAGE_LOCK_FILENAME)?;
-        let groups = group_tree.get_all_groups();
-        let instances_buf = serde_json::to_vec_pretty(instances)?;
-        let groups_buf = serde_json::to_vec_pretty(&groups)?;
-        let groups_path = self.sessions_path.with_file_name("groups.json");
-        atomic_write(&groups_path, &groups_buf)?;
-        atomic_write(&self.sessions_path, &instances_buf)?;
-        Ok(())
-    }
 }
 
 // Workspace ordering is stored at the app-data root, not per-profile:
@@ -410,6 +380,7 @@ pub(crate) fn save_workspace_ordering(ordering: &WorkspaceOrdering) -> Result<()
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::GroupTree;
     use serial_test::serial;
     use tempfile::tempdir;
 
@@ -432,7 +403,11 @@ mod tests {
             Instance::new("test2", "/tmp/test2"),
         ];
 
-        storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
+        storage.update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })?;
         let loaded = storage.load()?;
 
         assert_eq!(loaded.len(), 2);
@@ -560,20 +535,27 @@ mod tests {
 
         for i in 0..5 {
             let instances = vec![Instance::new(&format!("iter{i}"), "/tmp/test")];
-            storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
+            storage.update(|i, g| {
+                *i = instances.to_vec();
+                *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+                Ok(())
+            })?;
         }
 
         let dir = storage.sessions_path.parent().unwrap();
-        let mut entries: Vec<_> = fs::read_dir(dir)?
+        let entries: Vec<_> = fs::read_dir(dir)?
             .filter_map(|e| e.ok())
             .map(|e| e.file_name().to_string_lossy().to_string())
             .collect();
-        entries.sort();
 
-        assert_eq!(
-            entries,
-            vec![".storage.lock", "groups.json", "sessions.json"]
-        );
+        for entry in &entries {
+            assert!(
+                !entry.contains(".tmp"),
+                "atomic_write must not leak temp files; found {}",
+                entry
+            );
+        }
+        assert!(entries.contains(&"sessions.json".to_string()));
         Ok(())
     }
 
@@ -586,7 +568,11 @@ mod tests {
         let storage = Storage::new("test-empty-save")?;
         {
             let xs: Vec<Instance> = vec![];
-            storage.commit(&xs, &GroupTree::new_with_groups(&xs, &[]))?
+            storage.update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })?
         };
 
         let content = fs::read_to_string(&storage.sessions_path)?;
@@ -603,7 +589,11 @@ mod tests {
         let storage = Storage::new("test-no-groups")?;
 
         let instances = vec![Instance::new("test", "/tmp/test")];
-        storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
+        storage.update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })?;
 
         let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
         assert_eq!(loaded_instances.len(), 1);
@@ -625,7 +615,11 @@ mod tests {
         let groups = vec![Group::new("projects", "work/projects")];
         let group_tree = GroupTree::new_with_groups(&instances, &groups);
 
-        storage.commit(&instances, &group_tree)?;
+        storage.update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })?;
 
         let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
         assert_eq!(loaded_instances.len(), 1);
@@ -665,7 +659,11 @@ mod tests {
 
         {
             let xs: Vec<Instance> = vec![instance.clone()];
-            storage.commit(&xs, &GroupTree::new_with_groups(&xs, &[]))?
+            storage.update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })?
         };
         let loaded = storage.load()?;
 
@@ -708,7 +706,11 @@ mod tests {
         // Save sessions
         {
             let xs: Vec<Instance> = vec![Instance::new("test", "/tmp/test")];
-            storage.commit(&xs, &GroupTree::new_with_groups(&xs, &[]))?
+            storage.update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })?
         };
 
         // Create empty groups file
@@ -787,10 +789,11 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-update-roundtrip")?;
-        storage.commit(
-            &[Instance::new("seed", "/tmp/seed")],
-            &GroupTree::new_with_groups(&[], &[]),
-        )?;
+        storage.update(|i, g| {
+            *i = [Instance::new("seed", "/tmp/seed")].to_vec();
+            *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+            Ok(())
+        })?;
 
         storage.update(|instances, _groups| {
             instances.push(Instance::new("added", "/tmp/added"));
@@ -812,7 +815,11 @@ mod tests {
 
         let storage = Storage::new("test-update-err")?;
         let initial = vec![Instance::new("keep", "/tmp/keep")];
-        storage.commit(&initial, &GroupTree::new_with_groups(&initial, &[]))?;
+        storage.update(|i, g| {
+            *i = initial.to_vec();
+            *g = GroupTree::new_with_groups(&initial, &[]).get_all_groups();
+            Ok(())
+        })?;
 
         let result: Result<()> = storage.update(|instances, _| {
             instances.push(Instance::new("doomed", "/tmp/doomed"));
@@ -833,7 +840,11 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-update-concurrent")?;
-        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+        storage.update(|i, g| {
+            *i = [].to_vec();
+            *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+            Ok(())
+        })?;
 
         let n_threads = 32usize;
         std::thread::scope(|scope| {
@@ -914,7 +925,11 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-commit-lock")?;
-        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+        storage.update(|i, g| {
+            *i = [].to_vec();
+            *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+            Ok(())
+        })?;
 
         let entered = Arc::new(Barrier::new(2));
         let release = Arc::new(Barrier::new(2));
@@ -938,10 +953,11 @@ mod tests {
         let committer = std::thread::spawn(|| {
             let storage = Storage::new("test-commit-lock").unwrap();
             storage
-                .commit(
-                    &[Instance::new("from-commit", "/tmp/c")],
-                    &GroupTree::new_with_groups(&[], &[]),
-                )
+                .update(|i, g| {
+                    *i = [Instance::new("from-commit", "/tmp/c")].to_vec();
+                    *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+                    Ok(())
+                })
                 .unwrap();
         });
 
@@ -1022,7 +1038,11 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-update-both-files")?;
-        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+        storage.update(|i, g| {
+            *i = [].to_vec();
+            *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+            Ok(())
+        })?;
 
         storage.update(|instances, groups| {
             instances.push(Instance::new("inst", "/tmp/inst"));
@@ -1051,7 +1071,11 @@ mod tests {
         let seed_groups = vec![Group::new("seed-group", "work/seed")];
         let mut tree = GroupTree::new_with_groups(&seed, &seed_groups);
         tree.create_group("work/seed");
-        storage.commit(&seed, &tree)?;
+        storage.update(|i, g| {
+            *i = seed.to_vec();
+            *g = tree.get_all_groups();
+            Ok(())
+        })?;
 
         let groups_path = storage.sessions_path.with_file_name("groups.json");
         let sessions_before = fs::read(&storage.sessions_path)?;
@@ -1076,11 +1100,12 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-skip-groups-write")?;
-        let seed_instances = vec![Instance::new("seed", "/tmp/seed")];
-        storage.commit(
-            &seed_instances,
-            &GroupTree::new_with_groups(&seed_instances, &[]),
-        )?;
+        let seed_instances = [Instance::new("seed", "/tmp/seed")];
+        storage.update(|i, g| {
+            *i = seed_instances.to_vec();
+            g.push(Group::new("seed-group", "seed-group"));
+            Ok(())
+        })?;
 
         let groups_path = storage.sessions_path.with_file_name("groups.json");
         let groups_mtime_before = fs::metadata(&groups_path)?.modified()?;
@@ -1107,11 +1132,12 @@ mod tests {
         setup_test_home(temp.path());
 
         let storage = Storage::new("test-rewrite-groups")?;
-        let seed_instances = vec![Instance::new("seed", "/tmp/seed")];
-        storage.commit(
-            &seed_instances,
-            &GroupTree::new_with_groups(&seed_instances, &[]),
-        )?;
+        let seed_instances = [Instance::new("seed", "/tmp/seed")];
+        storage.update(|i, g| {
+            *i = seed_instances.to_vec();
+            g.push(Group::new("seed-group", "seed-group"));
+            Ok(())
+        })?;
 
         let groups_path = storage.sessions_path.with_file_name("groups.json");
         let groups_mtime_before = fs::metadata(&groups_path)?.modified()?;

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -144,17 +144,24 @@ impl Drop for StorageFlock {
 fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlock> {
     fs::create_dir_all(dir)?;
     let path = dir.join(name);
+    #[cfg(unix)]
+    let file = {
+        use std::os::unix::fs::OpenOptionsExt;
+        fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .mode(0o600)
+            .open(&path)?
+    };
+    #[cfg(not(unix))]
     let file = fs::OpenOptions::new()
         .read(true)
         .write(true)
         .create(true)
         .truncate(false)
         .open(&path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = file.set_permissions(fs::Permissions::from_mode(0o600));
-    }
 
     if let Err(e) = file.try_lock_exclusive() {
         if e.kind() != std::io::ErrorKind::WouldBlock {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -16,7 +16,7 @@
 //!    `logging.rs`.
 //!
 //! All mutation goes through `update` (load -> mutate -> save under both
-//! locks). `save_workspace_ordering` is `pub(crate)` and only consumed by
+//! locks). `save_workspace_ordering` is private and only consumed by
 //! `update_workspace_ordering` internally; the per-profile `save` /
 //! `save_groups` helpers were removed entirely. This keeps it structurally
 //! impossible to bypass the locks.
@@ -384,7 +384,7 @@ where
     Ok(result)
 }
 
-pub(crate) fn save_workspace_ordering(ordering: &WorkspaceOrdering) -> Result<()> {
+fn save_workspace_ordering(ordering: &WorkspaceOrdering) -> Result<()> {
     let path = workspace_ordering_path()?;
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -21,13 +21,16 @@
 //! `save_groups` helpers were removed entirely. This keeps it structurally
 //! impossible to bypass the locks.
 //!
-//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
-//! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse; the cross-process `flock` is acquired AFTER the in-process mutex
-//! and released BEFORE it (RAII drop order). The closure passed to `update`
-//! is `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is
-//! safe across the body even on the tokio runtime: server callers wrap
-//! `update` in `tokio::task::spawn_blocking`, which is the existing pattern.
+//! Lock-ordering rule across the process: server callers MUST drop
+//! `AppState.instances` (tokio RwLock) before acquiring `Storage`'s
+//! per-profile mutex via `tokio::task::spawn_blocking(... storage.update)`.
+//! The flock can park on a wedged peer for arbitrary time; holding the
+//! tokio RwLock across the wait would block every other reader/writer of
+//! `AppState.instances` and park the worker thread. The cross-process
+//! `flock` is acquired AFTER the in-process mutex and released BEFORE it
+//! (RAII drop order). The closure passed to `update` is
+//! `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is
+//! safe across the body even on the tokio runtime.
 //!
 //! Closures must remain CPU/memory only (no network, no user input, no tmux
 //! work). A closure that hangs holds both layers indefinitely and blocks

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -167,12 +167,21 @@ fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlock> {
                 Ok(()) => {
                     let waited = started.elapsed();
                     if waited >= FLOCK_WAIT_WARN_AFTER {
-                        tracing::info!(
-                            target: "session.store",
-                            ?waited,
-                            path = %path.display(),
-                            "storage flock acquired after wait"
-                        );
+                        if warned {
+                            tracing::info!(
+                                target: "session.store",
+                                ?waited,
+                                path = %path.display(),
+                                "storage flock acquired after wait"
+                            );
+                        } else {
+                            tracing::warn!(
+                                target: "session.store",
+                                ?waited,
+                                path = %path.display(),
+                                "storage flock contended for >1s; another aoe process held it"
+                            );
+                        }
                     }
                     break;
                 }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -8,19 +8,18 @@
 //!    threads sharing the same `Storage` profile.
 //! 2. **Cross-process advisory `flock(2)`** on a sidecar lock file
 //!    (`<profile_dir>/.storage.lock` for sessions+groups,
-//!    `<app_dir>/.workspace-ordering.lock` for ordering). Blocking
-//!    `fs2::FileExt::lock_exclusive`; the kernel releases the lock on
+//!    `<app_dir>/.workspace-ordering.lock` for ordering). Polled
+//!    `fs2::FileExt::try_lock_exclusive` with a 50ms backoff so a >1s wait
+//!    can fire a single `tracing::warn`; the kernel releases the lock on
 //!    process exit, including SIGKILL, so a crashed peer cannot wedge other
 //!    aoe processes. Mirrors the pattern already used by `recovery.rs` and
 //!    `logging.rs`.
 //!
-//! Mutators use `update` (load -> mutate -> save under both locks) or
-//! `commit` (locked wholesale write, for callers that already own the
-//! authoritative in-memory state, e.g. the TUI's `HomeView`). The
-//! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
-//! by `update_workspace_ordering` internally; the per-profile `save` /
-//! `save_groups` helpers have been removed entirely. This keeps it
-//! structurally impossible to bypass the locks.
+//! All mutation goes through `update` (load -> mutate -> save under both
+//! locks). `save_workspace_ordering` is `pub(crate)` and only consumed by
+//! `update_workspace_ordering` internally; the per-profile `save` /
+//! `save_groups` helpers were removed entirely. This keeps it structurally
+//! impossible to bypass the locks.
 //!
 //! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
 //! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
@@ -127,21 +126,21 @@ impl Drop for StorageFlock {
     }
 }
 
-/// Acquire the cross-process advisory `flock` on `<dir>/<name>`, blocking
-/// until the lock is granted. Mirrors the open semantics of
-/// `recovery::try_acquire_recovery_lock` (read+write, create, no truncate)
-/// and `logging.rs`'s rotation lock.
+/// Acquire the cross-process advisory `flock` on `<dir>/<name>` by polling
+/// `try_lock_exclusive` every 50ms until it is granted. Open semantics
+/// mirror `recovery::try_acquire_recovery_lock` (read+write, create, no
+/// truncate) and `logging.rs`'s rotation lock.
+///
+/// Polling instead of `lock_exclusive` is deliberate: `fs2` exposes no hook
+/// to instrument a blocking acquire, and we need a single `tracing::warn`
+/// after `FLOCK_WAIT_WARN_AFTER` so a wedged peer is observable in
+/// `aoe logs`. The 50ms cadence is below human perception and far above any
+/// realistic mutator's hold time.
 ///
 /// On Unix the lock file is chmodded to `0o600` so it never widens beyond
-/// the rest of `<app_dir>` regardless of the caller's umask. On a missing
-/// parent directory we propagate the OS error rather than silently
-/// recreating, because every realistic caller has already gone through
-/// `Storage::new -> get_profile_dir` (or `get_app_dir` for ordering).
-///
-/// Blocks indefinitely if a peer holds the lock; emits a single
-/// `tracing::warn` after `FLOCK_WAIT_WARN_AFTER` so a wedged peer is
-/// observable in `aoe logs`. The kernel releases the lock on process exit
-/// (including SIGKILL), so a crashed peer cannot wedge us forever.
+/// the rest of `<app_dir>` regardless of the caller's umask. The kernel
+/// releases the lock on process exit (including SIGKILL), so a crashed peer
+/// cannot wedge us forever.
 fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlock> {
     fs::create_dir_all(dir)?;
     let path = dir.join(name);
@@ -284,9 +283,8 @@ impl Storage {
     /// sibling files and is tolerated by the loader (`GroupTree` accepts
     /// orphan group rows).
     ///
-    /// This is the only way to mutate persisted session state from any caller
-    /// that does not already own the authoritative in-memory copy. Use `commit`
-    /// when the caller (e.g. TUI `HomeView`) IS that authoritative copy.
+    /// This is the only public mutator entry point; all writes funnel
+    /// through here so both lock layers are always taken.
     pub fn update<F, R>(&self, f: F) -> Result<R>
     where
         F: FnOnce(&mut Vec<Instance>, &mut Vec<Group>) -> Result<R>,
@@ -917,7 +915,7 @@ mod tests {
 
     #[test]
     #[serial]
-    fn test_commit_takes_same_lock_as_update() -> Result<()> {
+    fn test_update_takes_same_lock_across_threads() -> Result<()> {
         use std::sync::Barrier;
         use std::time::{Duration, Instant};
 

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,34 +1,71 @@
-//! Session storage - JSON file persistence with in-process per-profile locking.
+//! Session storage - JSON file persistence with in-process and cross-process
+//! locking.
 //!
-//! `Storage` serialises read-modify-write cycles inside the same process via a
-//! per-profile mutex (one `Arc<Mutex<()>>` per profile name, registered process-
-//! wide). Mutators use `update` (load -> mutate -> save under the lock) or
+//! `Storage` serialises read-modify-write cycles via two layers:
+//!
+//! 1. **In-process per-profile mutex** (one `Arc<Mutex<()>>` per profile name,
+//!    registered process-wide). Cheap, kills intra-process races between
+//!    threads sharing the same `Storage` profile.
+//! 2. **Cross-process advisory `flock(2)`** on a sidecar lock file
+//!    (`<profile_dir>/.storage.lock` for sessions+groups,
+//!    `<app_dir>/.workspace-ordering.lock` for ordering). Blocking
+//!    `fs2::FileExt::lock_exclusive`; the kernel releases the lock on
+//!    process exit, including SIGKILL, so a crashed peer cannot wedge other
+//!    aoe processes. Mirrors the pattern already used by `recovery.rs` and
+//!    `logging.rs`.
+//!
+//! Mutators use `update` (load -> mutate -> save under both locks) or
 //! `commit` (locked wholesale write, for callers that already own the
 //! authoritative in-memory state, e.g. the TUI's `HomeView`). The
 //! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
 //! by `update_workspace_ordering` internally; the per-profile `save` /
 //! `save_groups` helpers have been removed entirely. This keeps it
-//! structurally impossible to bypass the lock.
+//! structurally impossible to bypass the locks.
 //!
 //! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
 //! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse. The closure passed to `update` is `FnOnce(...) -> Result<R>` and
-//! cannot await, so `std::sync::Mutex` is safe across the body even on the
-//! tokio runtime: server callers wrap `update` in `tokio::task::spawn_blocking`,
-//! which is the existing pattern.
+//! reverse; the cross-process `flock` is acquired AFTER the in-process mutex
+//! and released BEFORE it (RAII drop order). The closure passed to `update`
+//! is `FnOnce(...) -> Result<R>` and cannot await, so `std::sync::Mutex` is
+//! safe across the body even on the tokio runtime: server callers wrap
+//! `update` in `tokio::task::spawn_blocking`, which is the existing pattern.
 //!
-//! Cross-process races (the TUI and `aoe serve` mutating the same profile
-//! concurrently) are explicitly out of scope here; a future advisory `flock`
-//! would close them.
+//! Closures must remain CPU/memory only (no network, no user input, no tmux
+//! work). A closure that hangs holds both layers indefinitely and blocks
+//! every peer process. The same hung-hook caveat documented in
+//! `recovery.rs` applies here.
+//!
+//! `update_workspace_ordering` and `Storage::update` must NOT be called from
+//! inside each other's closures. They use distinct lock files but acquiring
+//! both in different orders across processes would deadlock cross-process.
+//! Today no caller does this; this comment is the invariant.
 
 use anyhow::{anyhow, Result};
+use fs2::FileExt;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use super::{get_app_dir, get_profile_dir, Group, GroupTree, Instance};
+
+/// Sidecar lock file name for per-profile storage. Lives next to
+/// `sessions.json` and `groups.json` and covers both: every code path that
+/// mutates them does so as a pair under the same in-process mutex, so a
+/// single sidecar is sufficient and avoids any sub-file lock-ordering rule.
+const STORAGE_LOCK_FILENAME: &str = ".storage.lock";
+
+/// Sidecar lock file name for the global workspace-ordering file. Lives in
+/// `<app_dir>` next to `workspace-ordering.json`.
+const WORKSPACE_LOCK_FILENAME: &str = ".workspace-ordering.lock";
+
+/// Emit a tracing warn if the cross-process `flock` is held by a peer for
+/// longer than this. Surfaces a wedged peer in `aoe logs` instead of a
+/// silent stall. The acquire itself blocks indefinitely; the warning is
+/// observability only, not a timeout.
+const FLOCK_WAIT_WARN_AFTER: Duration = Duration::from_secs(1);
 
 /// Write `content` to `path` atomically (temp file + fsync + rename + dir fsync).
 /// Existing perms are preserved; on a fresh file the result is tempfile's 0o600 default.
@@ -75,6 +112,87 @@ fn save_lock_for(profile: &str) -> Arc<Mutex<()>> {
 fn workspace_ordering_lock() -> &'static Mutex<()> {
     static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
     LOCK.get_or_init(|| Mutex::new(()))
+}
+
+/// RAII guard for a held cross-process `flock`. Drops via `fs2::FileExt::unlock`,
+/// which is also performed by the kernel when the file descriptor is closed,
+/// so a panic during the critical section still releases the lock.
+struct StorageFlock {
+    file: fs::File,
+}
+
+impl Drop for StorageFlock {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
+}
+
+/// Acquire the cross-process advisory `flock` on `<dir>/<name>`, blocking
+/// until the lock is granted. Mirrors the open semantics of
+/// `recovery::try_acquire_recovery_lock` (read+write, create, no truncate)
+/// and `logging.rs`'s rotation lock.
+///
+/// On Unix the lock file is chmodded to `0o600` so it never widens beyond
+/// the rest of `<app_dir>` regardless of the caller's umask. On a missing
+/// parent directory we propagate the OS error rather than silently
+/// recreating, because every realistic caller has already gone through
+/// `Storage::new -> get_profile_dir` (or `get_app_dir` for ordering).
+///
+/// Blocks indefinitely if a peer holds the lock; emits a single
+/// `tracing::warn` after `FLOCK_WAIT_WARN_AFTER` so a wedged peer is
+/// observable in `aoe logs`. The kernel releases the lock on process exit
+/// (including SIGKILL), so a crashed peer cannot wedge us forever.
+fn acquire_storage_flock(dir: &Path, name: &str) -> Result<StorageFlock> {
+    fs::create_dir_all(dir)?;
+    let path = dir.join(name);
+    let file = fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = file.set_permissions(fs::Permissions::from_mode(0o600));
+    }
+
+    if let Err(e) = file.try_lock_exclusive() {
+        if e.kind() != std::io::ErrorKind::WouldBlock {
+            return Err(e.into());
+        }
+        let started = Instant::now();
+        let mut warned = false;
+        loop {
+            match file.try_lock_exclusive() {
+                Ok(()) => {
+                    let waited = started.elapsed();
+                    if waited >= FLOCK_WAIT_WARN_AFTER {
+                        tracing::info!(
+                            target: "session.store",
+                            ?waited,
+                            path = %path.display(),
+                            "storage flock acquired after wait"
+                        );
+                    }
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    if !warned && started.elapsed() >= FLOCK_WAIT_WARN_AFTER {
+                        tracing::warn!(
+                            target: "session.store",
+                            path = %path.display(),
+                            "storage flock contended for >1s; another aoe process is mid-write"
+                        );
+                        warned = true;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+    }
+    Ok(StorageFlock { file })
 }
 
 pub struct Storage {
@@ -173,10 +291,17 @@ impl Storage {
     where
         F: FnOnce(&mut Vec<Instance>, &mut Vec<Group>) -> Result<R>,
     {
-        let _guard = self
+        let _mu = self
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let profile_dir = self.sessions_path.parent().ok_or_else(|| {
+            anyhow!(
+                "sessions_path missing parent: {}",
+                self.sessions_path.display()
+            )
+        })?;
+        let _flock = acquire_storage_flock(profile_dir, STORAGE_LOCK_FILENAME)?;
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -212,10 +337,17 @@ impl Storage {
     /// writes happen in the same order as `update` (groups, then sessions);
     /// the same residual disk-failure window applies.
     pub fn commit(&self, instances: &[Instance], group_tree: &GroupTree) -> Result<()> {
-        let _guard = self
+        let _mu = self
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let profile_dir = self.sessions_path.parent().ok_or_else(|| {
+            anyhow!(
+                "sessions_path missing parent: {}",
+                self.sessions_path.display()
+            )
+        })?;
+        let _flock = acquire_storage_flock(profile_dir, STORAGE_LOCK_FILENAME)?;
         let groups = group_tree.get_all_groups();
         let instances_buf = serde_json::to_vec_pretty(instances)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
@@ -254,9 +386,11 @@ pub fn update_workspace_ordering<F, R>(f: F) -> Result<R>
 where
     F: FnOnce(&mut WorkspaceOrdering) -> Result<R>,
 {
-    let _guard = workspace_ordering_lock()
+    let _mu = workspace_ordering_lock()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let app_dir = get_app_dir()?;
+    let _flock = acquire_storage_flock(&app_dir, WORKSPACE_LOCK_FILENAME)?;
     let mut ordering = load_workspace_ordering()?;
     let result = f(&mut ordering)?;
     save_workspace_ordering(&ordering)?;
@@ -436,7 +570,10 @@ mod tests {
             .collect();
         entries.sort();
 
-        assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+        assert_eq!(
+            entries,
+            vec![".storage.lock", "groups.json", "sessions.json"]
+        );
         Ok(())
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -207,9 +207,15 @@ impl HomeView {
         if let Some(ref mut diff_view) = self.diff_view {
             let action = diff_view.handle_key(key);
             if let Some((session_id, new_override)) = diff_view.take_pending_override() {
-                self.mutate_instance(&session_id, |inst| {
-                    inst.base_branch_override = new_override;
-                });
+                if let Err(e) = self.apply_user_action(&session_id, |inst| {
+                    inst.base_branch_override = new_override.clone();
+                }) {
+                    tracing::warn!(
+                        target: "tui.home",
+                        "Failed to persist base_branch_override: {}",
+                        e
+                    );
+                }
             }
             match action {
                 DiffAction::Continue => return None,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2252,27 +2252,31 @@ impl HomeView {
     }
 
     /// Apply a user-action mutation atomically to the in-memory mirror and
-    /// the on-disk row under the flock. `mutate` runs twice (memory + disk
-    /// closure) so peer writes to OTHER fields on the same row survive.
-    /// Use for dialog changes (archive, favorite, snooze, rename, group)
-    /// that `HomeView::save`'s field-merge does not propagate.
+    /// the on-disk row under the flock. The mutation runs ONCE in memory;
+    /// the resulting snapshot is spliced onto the disk row via
+    /// `Instance::merge_post_user_action`, which preserves peer-written
+    /// fields the TUI does not own. Use for dialog changes (archive,
+    /// favorite, snooze, rename, group, base-branch) that
+    /// `HomeView::save`'s field-merge does not propagate.
     pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>
     where
-        F: Fn(&mut Instance),
+        F: FnOnce(&mut Instance),
     {
-        let profile = match self.instance_map.get(id) {
-            Some(inst) => inst.source_profile.clone(),
-            None => return Ok(()),
+        let Some(profile) = self.instance_map.get(id).map(|i| i.source_profile.clone()) else {
+            return Ok(());
         };
-        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
-            mutate(inst);
-            self.instance_map.insert(id.to_string(), inst.clone());
-        }
+        let Some(in_mem) = self.instances.iter_mut().find(|i| i.id == id) else {
+            return Ok(());
+        };
+        mutate(in_mem);
+        let snapshot = in_mem.clone();
+        self.instance_map.insert(id.to_string(), snapshot.clone());
+
         let id_owned = id.to_string();
         if let Some(storage) = self.storages.get(&profile) {
             storage.update(|insts, _groups| {
-                if let Some(inst) = insts.iter_mut().find(|i| i.id == id_owned) {
-                    mutate(inst);
+                if let Some(disk) = insts.iter_mut().find(|i| i.id == id_owned) {
+                    disk.merge_post_user_action(&snapshot);
                 }
                 Ok(())
             })?;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2195,6 +2195,11 @@ impl HomeView {
             {
                 self.selected_session = None;
             }
+            self.rebuild_group_trees();
+            self.flat_items = self.build_flat_items();
+            if self.cursor >= self.flat_items.len() {
+                self.cursor = self.flat_items.len().saturating_sub(1);
+            }
             tracing::info!(
                 target: "tui.home",
                 count = all_peer_deleted.len(),
@@ -2379,7 +2384,9 @@ impl HomeView {
     }
 
     /// Atomic per-action mutate: in-memory once, disk via
-    /// `Instance::merge_user_action_diff` under the flock.
+    /// `Instance::merge_user_action_diff` under the flock. On disk persist
+    /// failure, in-memory is rolled back to `pre` so memory and disk stay
+    /// consistent.
     pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>
     where
         F: FnOnce(&mut Instance),
@@ -2396,13 +2403,13 @@ impl HomeView {
         self.instance_map.insert(id.to_string(), post.clone());
 
         let id_owned = id.to_string();
-        if let Some(storage) = self.storages.get(&profile) {
+        let res = if let Some(storage) = self.storages.get(&profile) {
             storage.update(|insts, _groups| {
                 if let Some(disk) = insts.iter_mut().find(|i| i.id == id_owned) {
                     disk.merge_user_action_diff(&pre, &post);
                 }
                 Ok(())
-            })?;
+            })
         } else {
             tracing::warn!(
                 target: "tui.home",
@@ -2410,8 +2417,15 @@ impl HomeView {
                 id = %id_owned,
                 "apply_user_action: no storage registered for profile; in-memory mutation will not persist"
             );
+            Ok(())
+        };
+        if res.is_err() {
+            if let Some(slot) = self.instances.iter_mut().find(|i| i.id == id) {
+                *slot = pre.clone();
+            }
+            self.instance_map.insert(id.to_string(), pre);
         }
-        Ok(())
+        res
     }
 
     /// Bulk `apply_user_action`: one `Storage::update` per affected
@@ -2438,18 +2452,32 @@ impl HomeView {
                 .or_default()
                 .push((id.clone(), pre, post));
         }
-        for (profile, items) in by_profile {
-            let Some(storage) = self.storages.get(&profile) else {
+        for (profile, items) in &by_profile {
+            let Some(storage) = self.storages.get(profile) else {
+                tracing::warn!(
+                    target: "tui.home",
+                    profile = %profile,
+                    count = items.len(),
+                    "bulk_apply_user_action: no storage registered for profile; in-memory mutations will not persist"
+                );
                 continue;
             };
-            storage.update(|insts, _groups| {
-                for (id, pre, post) in &items {
+            if let Err(e) = storage.update(|insts, _groups| {
+                for (id, pre, post) in items {
                     if let Some(disk) = insts.iter_mut().find(|i| i.id == *id) {
                         disk.merge_user_action_diff(pre, post);
                     }
                 }
                 Ok(())
-            })?;
+            }) {
+                for (id, pre, _post) in items {
+                    if let Some(slot) = self.instances.iter_mut().find(|i| i.id == *id) {
+                        *slot = pre.clone();
+                    }
+                    self.instance_map.insert(id.clone(), pre.clone());
+                }
+                return Err(e);
+            }
         }
         Ok(())
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -683,13 +683,9 @@ impl HomeView {
                     // freshness state when the user toggles a setting
                     // that triggers a reload mid-window.
                     inst.idle_entered_at = prev.idle_entered_at;
-                    // Use in-memory session_id if present; fallback to disk.
-                    // In-memory state takes priority over disk: the poller
-                    // may have updated the ID since last save.
-                    inst.agent_session_id = prev
-                        .agent_session_id
-                        .clone()
-                        .or(inst.agent_session_id.take());
+                    // agent_session_id NOT carried: writers persist synchronously
+                    // through Storage::update before reload runs, so disk is
+                    // authoritative; carrying memory would resurrect a peer-cleared sid.
                     // Carry the resume-fallback exclusion set across
                     // reloads. Without this, a stale sid that the cascade
                     // just cleared would be re-imported on the next 5s reload
@@ -1008,9 +1004,39 @@ impl HomeView {
                 self.mutate_instance(id, |inst| {
                     inst.agent_session_id = Some(session_id.clone());
                 });
-                let profile = self.instance_map.get(id).map(|i| i.source_profile.clone());
-                if let Some(profile) = profile {
-                    crate::session::persist_session_to_storage(&profile, id, session_id);
+            }
+            // Group by profile so each affected sessions.json is rewritten
+            // once, regardless of how many sids the poller delivered this tick.
+            let mut by_profile: HashMap<String, Vec<(String, String)>> = HashMap::new();
+            for (id, session_id) in &updates {
+                if let Some(profile) = self.instance_map.get(id).map(|i| i.source_profile.clone()) {
+                    by_profile
+                        .entry(profile)
+                        .or_default()
+                        .push((id.clone(), session_id.clone()));
+                }
+            }
+            for (profile, items) in by_profile {
+                if let Some(storage) = self.storages.get(&profile) {
+                    if let Err(e) = storage.update(|insts, _g| {
+                        for (id, session_id) in &items {
+                            if let Some(inst) = insts.iter_mut().find(|i| i.id == *id) {
+                                inst.agent_session_id = Some(session_id.clone());
+                            }
+                        }
+                        Ok(())
+                    }) {
+                        tracing::error!(
+                            target: "session.store",
+                            "Bulk sid persist failed for profile {}: {}",
+                            profile,
+                            e
+                        );
+                    }
+                } else {
+                    for (id, session_id) in &items {
+                        crate::session::persist_session_to_storage(&profile, id, session_id);
+                    }
                 }
             }
         }
@@ -2308,13 +2334,23 @@ impl HomeView {
     /// per-profile loop misclassifies the row as peer-deleted in the new
     /// profile and leaves the old profile's disk row, which next reload
     /// resurrects under the original profile.
-    pub(super) fn move_to_profile(&mut self, id: &str, target: &str, new_group_path: String) {
+    pub(super) fn move_to_profile(
+        &mut self,
+        id: &str,
+        target: &str,
+        new_group_path: String,
+    ) -> anyhow::Result<()> {
         let Some(old_profile) = self.instance_map.get(id).map(|i| i.source_profile.clone()) else {
-            return;
+            return Ok(());
         };
         if old_profile == target {
             self.mutate_instance(id, |inst| inst.group_path = new_group_path);
-            return;
+            return Ok(());
+        }
+
+        if !self.storages.contains_key(target) {
+            self.storages
+                .insert(target.to_string(), Storage::new(target)?);
         }
 
         self.pending_deletions
@@ -2334,6 +2370,7 @@ impl HomeView {
             inst.source_profile = target.to_string();
             self.instance_map.insert(id.to_string(), inst.clone());
         }
+        Ok(())
     }
 
     /// Atomic per-action mutate: in-memory once, disk via

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2302,6 +2302,40 @@ impl HomeView {
         }
     }
 
+    /// Cross-profile move: structurally distinct from `mutate_instance`
+    /// because the row must be tombstoned in the old profile's disk file
+    /// AND marked as TUI-new for the target profile. Without this, save()'s
+    /// per-profile loop misclassifies the row as peer-deleted in the new
+    /// profile and leaves the old profile's disk row, which next reload
+    /// resurrects under the original profile.
+    pub(super) fn move_to_profile(&mut self, id: &str, target: &str, new_group_path: String) {
+        let Some(old_profile) = self.instance_map.get(id).map(|i| i.source_profile.clone()) else {
+            return;
+        };
+        if old_profile == target {
+            self.mutate_instance(id, |inst| inst.group_path = new_group_path);
+            return;
+        }
+
+        self.pending_deletions
+            .entry(old_profile.clone())
+            .or_default()
+            .insert(id.to_string());
+        if let Some(set) = self.pending_added.get_mut(&old_profile) {
+            set.remove(id);
+        }
+        self.pending_added
+            .entry(target.to_string())
+            .or_default()
+            .insert(id.to_string());
+
+        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
+            inst.group_path = new_group_path;
+            inst.source_profile = target.to_string();
+            self.instance_map.insert(id.to_string(), inst.clone());
+        }
+    }
+
     /// Atomic per-action mutate: in-memory once, disk via
     /// `Instance::merge_user_action_diff` under the flock.
     pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -152,6 +152,9 @@ pub struct HomeView {
     pub(super) active_profile: Option<String>,
     instances: Vec<Instance>,
     instance_map: HashMap<String, Instance>,
+    /// Per-profile tombstones for ids removed since last `save`. Drained
+    /// on Ok return so the next save retries on transient failure.
+    pending_deletions: HashMap<String, HashSet<String>>,
     pub(super) group_trees: HashMap<String, GroupTree>,
     pub(super) flat_items: Vec<Item>,
 
@@ -432,6 +435,7 @@ impl HomeView {
             active_profile,
             instances: all_instances,
             instance_map,
+            pending_deletions: HashMap::new(),
             group_trees,
             flat_items: Vec::new(),
             cursor: 0,
@@ -988,27 +992,14 @@ impl HomeView {
         }
 
         if !updates.is_empty() {
-            let prev: Vec<(String, Option<String>)> = updates
-                .iter()
-                .filter_map(|(id, _)| {
-                    self.get_instance(id)
-                        .map(|inst| (id.clone(), inst.agent_session_id.clone()))
-                })
-                .collect();
-
             for (id, session_id) in &updates {
                 self.mutate_instance(id, |inst| {
                     inst.agent_session_id = Some(session_id.clone());
                 });
-            }
-            if let Err(e) = self.save() {
-                tracing::error!(target: "tui.home", "Failed to save after session ID update: {}", e);
-                for (id, old_val) in &prev {
-                    self.mutate_instance(id, |inst| {
-                        inst.agent_session_id = old_val.clone();
-                    });
+                let profile = self.instance_map.get(id).map(|i| i.source_profile.clone());
+                if let Some(profile) = profile {
+                    crate::session::persist_session_to_storage(&profile, id, session_id);
                 }
-                return false;
             }
         }
         !updates.is_empty()
@@ -2083,21 +2074,40 @@ impl HomeView {
         stale_sid
     }
 
-    pub fn save(&self) -> anyhow::Result<()> {
+    pub fn save(&mut self) -> anyhow::Result<()> {
         for (profile_name, storage) in &self.storages {
-            let profile_instances: Vec<Instance> = self
+            let tui_rows: Vec<Instance> = self
                 .instances
                 .iter()
                 .filter(|i| i.source_profile == *profile_name)
                 .cloned()
                 .collect();
-            // Each profile has its own GroupTree with correct collapsed state
-            let tree = self
-                .group_trees
+            let dels: HashSet<String> = self
+                .pending_deletions
                 .get(profile_name)
                 .cloned()
-                .unwrap_or_else(|| GroupTree::new_with_groups(&profile_instances, &[]));
-            storage.commit(&profile_instances, &tree)?;
+                .unwrap_or_default();
+            let groups_target = self
+                .group_trees
+                .get(profile_name)
+                .map(|t| t.get_all_groups())
+                .unwrap_or_default();
+
+            storage.update(|disk_instances, disk_groups| {
+                disk_instances.retain(|d| !dels.contains(&d.id));
+                for tui_inst in &tui_rows {
+                    if let Some(disk_inst) = disk_instances.iter_mut().find(|d| d.id == tui_inst.id)
+                    {
+                        disk_inst.merge_from_tui(tui_inst);
+                    } else {
+                        disk_instances.push(tui_inst.clone());
+                    }
+                }
+                *disk_groups = groups_target.clone();
+                Ok(())
+            })?;
+
+            self.pending_deletions.remove(profile_name);
         }
         Ok(())
     }
@@ -2171,8 +2181,15 @@ impl HomeView {
     }
 
     /// Centralized instance removal: removes from both the `instances` vec
-    /// and `instance_map` to keep both collections in sync.
+    /// and `instance_map`, and records the id in `pending_deletions` so the
+    /// next `save` propagates the removal under the flock.
     pub(super) fn remove_instance(&mut self, id: &str) {
+        if let Some(inst) = self.instance_map.get(id) {
+            self.pending_deletions
+                .entry(inst.source_profile.clone())
+                .or_default()
+                .insert(id.to_string());
+        }
         self.instances.retain(|i| i.id != id);
         self.instance_map.remove(id);
     }
@@ -2185,6 +2202,35 @@ impl HomeView {
             f(inst);
             self.instance_map.insert(id.to_string(), inst.clone());
         }
+    }
+
+    /// Apply a user-action mutation atomically to the in-memory mirror and
+    /// the on-disk row under the flock. `mutate` runs twice (memory + disk
+    /// closure) so peer writes to OTHER fields on the same row survive.
+    /// Use for dialog changes (archive, favorite, snooze, rename, group)
+    /// that `HomeView::save`'s field-merge does not propagate.
+    pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>
+    where
+        F: Fn(&mut Instance),
+    {
+        let profile = match self.instance_map.get(id) {
+            Some(inst) => inst.source_profile.clone(),
+            None => return Ok(()),
+        };
+        if let Some(inst) = self.instances.iter_mut().find(|i| i.id == id) {
+            mutate(inst);
+            self.instance_map.insert(id.to_string(), inst.clone());
+        }
+        let id_owned = id.to_string();
+        if let Some(storage) = self.storages.get(&profile) {
+            storage.update(|insts, _groups| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id_owned) {
+                    mutate(inst);
+                }
+                Ok(())
+            })?;
+        }
+        Ok(())
     }
 
     /// Like `mutate_instance`, but for fallible operations. Clones the entry,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2214,11 +2214,8 @@ impl HomeView {
         self.instance_map.remove(id);
     }
 
-    /// Centralized group deletion: removes from the per-profile `GroupTree`
-    /// and records the path AND all descendant paths in
-    /// `pending_group_deletions` so the next `save` propagates the removal
-    /// under the flock instead of relying on a wholesale-replace (which
-    /// would clobber concurrent peer writes).
+    /// Tombstones `path` and every descendant from the per-profile tree so
+    /// `save()` drops them under the flock instead of wholesale-replacing.
     pub(super) fn delete_group_in_profile(&mut self, profile: &str, path: &str) {
         let prefix = format!("{}/", path);
         let descendants: Vec<String> = self
@@ -2251,14 +2248,8 @@ impl HomeView {
         }
     }
 
-    /// Apply a user-action mutation atomically to the in-memory mirror and
-    /// the on-disk row under the flock. The mutation runs ONCE in memory;
-    /// the disk row is updated via `Instance::merge_user_action_diff` so
-    /// only fields the mutation actually changed are spliced. A peer
-    /// writer's pre-existing value on a field the mutation does NOT
-    /// touch (even if that field is in the user-action set) is preserved.
-    /// Use for dialog changes (archive, favorite, snooze, rename, group,
-    /// base-branch) that `HomeView::save`'s field-merge does not propagate.
+    /// Atomic per-action mutate: in-memory once, disk via
+    /// `Instance::merge_user_action_diff` under the flock.
     pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>
     where
         F: FnOnce(&mut Instance),
@@ -2286,11 +2277,8 @@ impl HomeView {
         Ok(())
     }
 
-    /// Apply `mutate` once per id in memory and fold all disk writes into
-    /// one `Storage::update` per affected profile (single flock cycle per
-    /// profile). Diff-splice semantics match `apply_user_action`. For
-    /// group-scoped operations on N sessions where N per-row flock cycles
-    /// would dominate the wall clock.
+    /// Bulk `apply_user_action`: one `Storage::update` per affected
+    /// profile (single flock cycle), grouping ids by `source_profile`.
     pub(super) fn bulk_apply_user_action<F>(
         &mut self,
         ids: &[String],

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -159,6 +159,12 @@ pub struct HomeView {
     /// Mirrors `pending_deletions` for groups so concurrent peer-added
     /// groups (e.g. `aoe add --group X`) survive the next save.
     pending_group_deletions: HashMap<String, HashSet<String>>,
+    /// Per-profile ids added via `add_instance` since last save. In
+    /// `save()`, only ids present here are pushed when the disk row is
+    /// missing; TUI rows absent from disk AND absent from this set are
+    /// treated as peer-deleted (CLI/`aoe serve`) and dropped from the
+    /// in-memory mirror. Drained on Ok save.
+    pending_added: HashMap<String, HashSet<String>>,
     pub(super) group_trees: HashMap<String, GroupTree>,
     pub(super) flat_items: Vec<Item>,
 
@@ -441,6 +447,7 @@ impl HomeView {
             instance_map,
             pending_deletions: HashMap::new(),
             pending_group_deletions: HashMap::new(),
+            pending_added: HashMap::new(),
             group_trees,
             flat_items: Vec::new(),
             cursor: 0,
@@ -2080,6 +2087,8 @@ impl HomeView {
     }
 
     pub fn save(&mut self) -> anyhow::Result<()> {
+        let mut all_peer_deleted: Vec<String> = Vec::new();
+
         for (profile_name, storage) in &self.storages {
             let tui_rows: Vec<Instance> = self
                 .instances
@@ -2089,6 +2098,11 @@ impl HomeView {
                 .collect();
             let dels: HashSet<String> = self
                 .pending_deletions
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
+            let added: HashSet<String> = self
+                .pending_added
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_default();
@@ -2103,14 +2117,19 @@ impl HomeView {
                 .map(|t| t.get_all_groups())
                 .unwrap_or_default();
 
-            storage.update(|disk_instances, disk_groups| {
+            let peer_deleted: Vec<String> = storage.update(|disk_instances, disk_groups| {
                 disk_instances.retain(|d| !dels.contains(&d.id));
+                let mut peer_deleted: Vec<String> = Vec::new();
                 for tui_inst in &tui_rows {
                     if let Some(disk_inst) = disk_instances.iter_mut().find(|d| d.id == tui_inst.id)
                     {
                         disk_inst.merge_from_tui(tui_inst);
-                    } else {
+                    } else if added.contains(&tui_inst.id) {
                         disk_instances.push(tui_inst.clone());
+                    } else {
+                        // Disk had no row with this id and we did not add it
+                        // this session: a peer (CLI / aoe serve) removed it.
+                        peer_deleted.push(tui_inst.id.clone());
                     }
                 }
                 disk_groups.retain(|g| !group_dels.contains(&g.path));
@@ -2123,11 +2142,33 @@ impl HomeView {
                         disk_groups.push(tui_g.clone());
                     }
                 }
-                Ok(())
+                Ok(peer_deleted)
             })?;
 
             self.pending_deletions.remove(profile_name);
             self.pending_group_deletions.remove(profile_name);
+            self.pending_added.remove(profile_name);
+            all_peer_deleted.extend(peer_deleted);
+        }
+
+        if !all_peer_deleted.is_empty() {
+            let drop: HashSet<&String> = all_peer_deleted.iter().collect();
+            self.instances.retain(|i| !drop.contains(&i.id));
+            for id in &all_peer_deleted {
+                self.instance_map.remove(id);
+            }
+            if self
+                .selected_session
+                .as_ref()
+                .is_some_and(|s| drop.contains(s))
+            {
+                self.selected_session = None;
+            }
+            tracing::info!(
+                target: "tui.home",
+                count = all_peer_deleted.len(),
+                "Dropped peer-deleted rows from TUI mirror"
+            );
         }
         Ok(())
     }
@@ -2193,22 +2234,35 @@ impl HomeView {
     }
 
     /// Centralized instance addition: adds to both the `instances` vec
-    /// and `instance_map` to keep both collections in sync.
+    /// and `instance_map` to keep both collections in sync. Records the
+    /// id in `pending_added` so the next `save` distinguishes TUI-new
+    /// rows from peer-deleted ones (which look identical at the disk
+    /// layer: missing from sessions.json).
     pub(super) fn add_instance(&mut self, instance: Instance) {
+        self.pending_added
+            .entry(instance.source_profile.clone())
+            .or_default()
+            .insert(instance.id.clone());
         self.instance_map
             .insert(instance.id.clone(), instance.clone());
         self.instances.push(instance);
     }
 
     /// Centralized instance removal: removes from both the `instances` vec
-    /// and `instance_map`, and records the id in `pending_deletions` so the
-    /// next `save` propagates the removal under the flock.
+    /// and `instance_map`, records the id in `pending_deletions` so the
+    /// next `save` propagates the removal under the flock, and clears any
+    /// `pending_added` entry so an add+remove in the same save cycle does
+    /// not end up persisted.
     pub(super) fn remove_instance(&mut self, id: &str) {
         if let Some(inst) = self.instance_map.get(id) {
+            let profile = inst.source_profile.clone();
             self.pending_deletions
-                .entry(inst.source_profile.clone())
+                .entry(profile.clone())
                 .or_default()
                 .insert(id.to_string());
+            if let Some(set) = self.pending_added.get_mut(&profile) {
+                set.remove(id);
+            }
         }
         self.instances.retain(|i| i.id != id);
         self.instance_map.remove(id);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -683,9 +683,8 @@ impl HomeView {
                     // freshness state when the user toggles a setting
                     // that triggers a reload mid-window.
                     inst.idle_entered_at = prev.idle_entered_at;
-                    // agent_session_id NOT carried: writers persist synchronously
-                    // through Storage::update before reload runs, so disk is
-                    // authoritative; carrying memory would resurrect a peer-cleared sid.
+                    // agent_session_id is disk-authoritative; writers persist
+                    // synchronously through Storage::update before reload runs.
                     // Carry the resume-fallback exclusion set across
                     // reloads. Without this, a stale sid that the cascade
                     // just cleared would be re-imported on the next 5s reload
@@ -1034,6 +1033,12 @@ impl HomeView {
                         );
                     }
                 } else {
+                    tracing::warn!(
+                        target: "tui.home",
+                        profile = %profile,
+                        count = items.len(),
+                        "apply_session_id_updates: no storage registered for profile; falling back to per-id persist (N flock cycles)"
+                    );
                     for (id, session_id) in &items {
                         crate::session::persist_session_to_storage(&profile, id, session_id);
                     }
@@ -2398,6 +2403,13 @@ impl HomeView {
                 }
                 Ok(())
             })?;
+        } else {
+            tracing::warn!(
+                target: "tui.home",
+                profile = %profile,
+                id = %id_owned,
+                "apply_user_action: no storage registered for profile; in-memory mutation will not persist"
+            );
         }
         Ok(())
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2253,11 +2253,12 @@ impl HomeView {
 
     /// Apply a user-action mutation atomically to the in-memory mirror and
     /// the on-disk row under the flock. The mutation runs ONCE in memory;
-    /// the resulting snapshot is spliced onto the disk row via
-    /// `Instance::merge_post_user_action`, which preserves peer-written
-    /// fields the TUI does not own. Use for dialog changes (archive,
-    /// favorite, snooze, rename, group, base-branch) that
-    /// `HomeView::save`'s field-merge does not propagate.
+    /// the disk row is updated via `Instance::merge_user_action_diff` so
+    /// only fields the mutation actually changed are spliced. A peer
+    /// writer's pre-existing value on a field the mutation does NOT
+    /// touch (even if that field is in the user-action set) is preserved.
+    /// Use for dialog changes (archive, favorite, snooze, rename, group,
+    /// base-branch) that `HomeView::save`'s field-merge does not propagate.
     pub(super) fn apply_user_action<F>(&mut self, id: &str, mutate: F) -> anyhow::Result<()>
     where
         F: FnOnce(&mut Instance),
@@ -2268,15 +2269,16 @@ impl HomeView {
         let Some(in_mem) = self.instances.iter_mut().find(|i| i.id == id) else {
             return Ok(());
         };
+        let pre = in_mem.clone();
         mutate(in_mem);
-        let snapshot = in_mem.clone();
-        self.instance_map.insert(id.to_string(), snapshot.clone());
+        let post = in_mem.clone();
+        self.instance_map.insert(id.to_string(), post.clone());
 
         let id_owned = id.to_string();
         if let Some(storage) = self.storages.get(&profile) {
             storage.update(|insts, _groups| {
                 if let Some(disk) = insts.iter_mut().find(|i| i.id == id_owned) {
-                    disk.merge_post_user_action(&snapshot);
+                    disk.merge_user_action_diff(&pre, &post);
                 }
                 Ok(())
             })?;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2286,6 +2286,49 @@ impl HomeView {
         Ok(())
     }
 
+    /// Apply `mutate` once per id in memory and fold all disk writes into
+    /// one `Storage::update` per affected profile (single flock cycle per
+    /// profile). Diff-splice semantics match `apply_user_action`. For
+    /// group-scoped operations on N sessions where N per-row flock cycles
+    /// would dominate the wall clock.
+    pub(super) fn bulk_apply_user_action<F>(
+        &mut self,
+        ids: &[String],
+        mutate: F,
+    ) -> anyhow::Result<()>
+    where
+        F: Fn(&mut Instance),
+    {
+        let mut by_profile: HashMap<String, Vec<(String, Instance, Instance)>> = HashMap::new();
+        for id in ids {
+            let Some(inst) = self.instances.iter_mut().find(|i| i.id == *id) else {
+                continue;
+            };
+            let pre = inst.clone();
+            mutate(inst);
+            let post = inst.clone();
+            self.instance_map.insert(id.clone(), post.clone());
+            by_profile
+                .entry(post.source_profile.clone())
+                .or_default()
+                .push((id.clone(), pre, post));
+        }
+        for (profile, items) in by_profile {
+            let Some(storage) = self.storages.get(&profile) else {
+                continue;
+            };
+            storage.update(|insts, _groups| {
+                for (id, pre, post) in &items {
+                    if let Some(disk) = insts.iter_mut().find(|i| i.id == *id) {
+                        disk.merge_user_action_diff(pre, post);
+                    }
+                }
+                Ok(())
+            })?;
+        }
+        Ok(())
+    }
+
     /// Like `mutate_instance`, but for fallible operations. Clones the entry,
     /// applies `f` to the clone, and writes back to both collections only on
     /// success -- neither collection is modified on error.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2183,23 +2183,7 @@ impl HomeView {
         }
 
         if !all_peer_deleted.is_empty() {
-            let drop: HashSet<&String> = all_peer_deleted.iter().collect();
-            self.instances.retain(|i| !drop.contains(&i.id));
-            for id in &all_peer_deleted {
-                self.instance_map.remove(id);
-            }
-            if self
-                .selected_session
-                .as_ref()
-                .is_some_and(|s| drop.contains(s))
-            {
-                self.selected_session = None;
-            }
-            self.rebuild_group_trees();
-            self.flat_items = self.build_flat_items();
-            if self.cursor >= self.flat_items.len() {
-                self.cursor = self.flat_items.len().saturating_sub(1);
-            }
+            self.drop_peer_deleted_rows(&all_peer_deleted);
             tracing::info!(
                 target: "tui.home",
                 count = all_peer_deleted.len(),
@@ -2207,6 +2191,32 @@ impl HomeView {
             );
         }
         Ok(())
+    }
+
+    /// Drop in-memory mirror rows that no longer exist on disk (peer-deleted
+    /// via CLI / aoe serve). Rebuilds derived UI state so callers don't
+    /// render or target removed rows.
+    fn drop_peer_deleted_rows(&mut self, ids: &[String]) {
+        if ids.is_empty() {
+            return;
+        }
+        let drop: HashSet<&String> = ids.iter().collect();
+        self.instances.retain(|i| !drop.contains(&i.id));
+        for id in ids {
+            self.instance_map.remove(id);
+        }
+        if self
+            .selected_session
+            .as_ref()
+            .is_some_and(|s| drop.contains(s))
+        {
+            self.selected_session = None;
+        }
+        self.rebuild_group_trees();
+        self.flat_items = self.build_flat_items();
+        if self.cursor >= self.flat_items.len() {
+            self.cursor = self.flat_items.len().saturating_sub(1);
+        }
     }
 
     /// Rebuild all per-profile GroupTrees from the current instances,
@@ -2407,8 +2417,10 @@ impl HomeView {
             storage.update(|insts, _groups| {
                 if let Some(disk) = insts.iter_mut().find(|i| i.id == id_owned) {
                     disk.merge_user_action_diff(&pre, &post);
+                    Ok(true)
+                } else {
+                    Ok(false)
                 }
-                Ok(())
             })
         } else {
             tracing::warn!(
@@ -2417,15 +2429,28 @@ impl HomeView {
                 id = %id_owned,
                 "apply_user_action: no storage registered for profile; in-memory mutation will not persist"
             );
-            Ok(())
+            Ok(true)
         };
-        if res.is_err() {
-            if let Some(slot) = self.instances.iter_mut().find(|i| i.id == id) {
-                *slot = pre.clone();
+        match res {
+            Ok(true) => Ok(()),
+            Ok(false) => {
+                let added = self
+                    .pending_added
+                    .get(&profile)
+                    .is_some_and(|s| s.contains(id));
+                if !added {
+                    self.drop_peer_deleted_rows(&[id.to_string()]);
+                }
+                Ok(())
             }
-            self.instance_map.insert(id.to_string(), pre);
+            Err(e) => {
+                if let Some(slot) = self.instances.iter_mut().find(|i| i.id == id) {
+                    *slot = pre.clone();
+                }
+                self.instance_map.insert(id.to_string(), pre);
+                Err(e)
+            }
         }
-        res
     }
 
     /// Bulk `apply_user_action`: one `Storage::update` per affected
@@ -2452,6 +2477,7 @@ impl HomeView {
                 .or_default()
                 .push((id.clone(), pre, post));
         }
+        let mut peer_deleted: Vec<String> = Vec::new();
         for (profile, items) in &by_profile {
             let Some(storage) = self.storages.get(profile) else {
                 tracing::warn!(
@@ -2462,22 +2488,34 @@ impl HomeView {
                 );
                 continue;
             };
-            if let Err(e) = storage.update(|insts, _groups| {
+            let added: HashSet<String> =
+                self.pending_added.get(profile).cloned().unwrap_or_default();
+            let res = storage.update(|insts, _groups| {
+                let mut missing: Vec<String> = Vec::new();
                 for (id, pre, post) in items {
                     if let Some(disk) = insts.iter_mut().find(|i| i.id == *id) {
                         disk.merge_user_action_diff(pre, post);
+                    } else if !added.contains(id) {
+                        missing.push(id.clone());
                     }
                 }
-                Ok(())
-            }) {
-                for (id, pre, _post) in items {
-                    if let Some(slot) = self.instances.iter_mut().find(|i| i.id == *id) {
-                        *slot = pre.clone();
+                Ok(missing)
+            });
+            match res {
+                Ok(missing) => peer_deleted.extend(missing),
+                Err(e) => {
+                    for (id, pre, _post) in items {
+                        if let Some(slot) = self.instances.iter_mut().find(|i| i.id == *id) {
+                            *slot = pre.clone();
+                        }
+                        self.instance_map.insert(id.clone(), pre.clone());
                     }
-                    self.instance_map.insert(id.clone(), pre.clone());
+                    return Err(e);
                 }
-                return Err(e);
             }
+        }
+        if !peer_deleted.is_empty() {
+            self.drop_peer_deleted_rows(&peer_deleted);
         }
         Ok(())
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -155,6 +155,10 @@ pub struct HomeView {
     /// Per-profile tombstones for ids removed since last `save`. Drained
     /// on Ok return so the next save retries on transient failure.
     pending_deletions: HashMap<String, HashSet<String>>,
+    /// Per-profile tombstones for group paths removed since last `save`.
+    /// Mirrors `pending_deletions` for groups so concurrent peer-added
+    /// groups (e.g. `aoe add --group X`) survive the next save.
+    pending_group_deletions: HashMap<String, HashSet<String>>,
     pub(super) group_trees: HashMap<String, GroupTree>,
     pub(super) flat_items: Vec<Item>,
 
@@ -436,6 +440,7 @@ impl HomeView {
             instances: all_instances,
             instance_map,
             pending_deletions: HashMap::new(),
+            pending_group_deletions: HashMap::new(),
             group_trees,
             flat_items: Vec::new(),
             cursor: 0,
@@ -2087,6 +2092,11 @@ impl HomeView {
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_default();
+            let group_dels: HashSet<String> = self
+                .pending_group_deletions
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
             let groups_target = self
                 .group_trees
                 .get(profile_name)
@@ -2103,11 +2113,21 @@ impl HomeView {
                         disk_instances.push(tui_inst.clone());
                     }
                 }
-                *disk_groups = groups_target.clone();
+                disk_groups.retain(|g| !group_dels.contains(&g.path));
+                for tui_g in &groups_target {
+                    if let Some(disk_g) = disk_groups.iter_mut().find(|g| g.path == tui_g.path) {
+                        disk_g.name = tui_g.name.clone();
+                        disk_g.collapsed = tui_g.collapsed;
+                        disk_g.archived_at = tui_g.archived_at;
+                    } else {
+                        disk_groups.push(tui_g.clone());
+                    }
+                }
                 Ok(())
             })?;
 
             self.pending_deletions.remove(profile_name);
+            self.pending_group_deletions.remove(profile_name);
         }
         Ok(())
     }
@@ -2192,6 +2212,33 @@ impl HomeView {
         }
         self.instances.retain(|i| i.id != id);
         self.instance_map.remove(id);
+    }
+
+    /// Centralized group deletion: removes from the per-profile `GroupTree`
+    /// and records the path AND all descendant paths in
+    /// `pending_group_deletions` so the next `save` propagates the removal
+    /// under the flock instead of relying on a wholesale-replace (which
+    /// would clobber concurrent peer writes).
+    pub(super) fn delete_group_in_profile(&mut self, profile: &str, path: &str) {
+        let prefix = format!("{}/", path);
+        let descendants: Vec<String> = self
+            .group_trees
+            .get(profile)
+            .map(|tree| {
+                tree.get_all_groups()
+                    .into_iter()
+                    .filter(|g| g.path == path || g.path.starts_with(&prefix))
+                    .map(|g| g.path)
+                    .collect()
+            })
+            .unwrap_or_else(|| vec![path.to_string()]);
+        if let Some(tree) = self.group_trees.get_mut(profile) {
+            tree.delete_group(path);
+        }
+        self.pending_group_deletions
+            .entry(profile.to_string())
+            .or_default()
+            .extend(descendants);
     }
 
     /// Centralized instance mutation: applies `f` once to the `instances` vec

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -197,7 +197,7 @@ impl HomeView {
                     .get_instance(&id)
                     .map(|i| i.group_path.clone())
                     .unwrap_or_default();
-                self.move_to_profile(&id, target_profile, group_path);
+                self.move_to_profile(&id, target_profile, group_path)?;
                 self.rebuild_group_trees();
                 // Rebuild the visible row list too; otherwise the row still
                 // renders under the old profile until the next reload, and
@@ -509,7 +509,7 @@ impl HomeView {
             };
 
             if let Some(tp) = new_profile {
-                self.move_to_profile(id, tp, new_group_path.clone());
+                self.move_to_profile(id, tp, new_group_path.clone())?;
             } else {
                 self.apply_user_action(id, |inst| {
                     inst.group_path = new_group_path.clone();
@@ -647,7 +647,7 @@ impl HomeView {
                     // Update source_profile and save (handles moving between profiles)
                     instance.source_profile = target_profile.to_string();
                     let new_title = instance.title.clone();
-                    self.move_to_profile(&id, target_profile, instance.group_path.clone());
+                    self.move_to_profile(&id, target_profile, instance.group_path.clone())?;
                     self.mutate_instance(&id, |inst| {
                         inst.title = new_title;
                     });

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -219,13 +219,17 @@ impl HomeView {
         self.mutate_instance(&id, |inst| inst.touch_last_accessed());
         self.save()?;
 
-        // Resolve the wake message via the active profile's config (which
-        // already merges global + profile overrides). Empty string is the
+        // Resolve the wake message via the moved session's profile config
+        // (already merges global + profile overrides). Empty string is the
         // documented opt-out.
         let profile = self
-            .active_profile
-            .clone()
-            .unwrap_or_else(|| "default".to_string());
+            .get_instance(&id)
+            .map(|i| i.source_profile.clone())
+            .unwrap_or_else(|| {
+                self.active_profile
+                    .clone()
+                    .unwrap_or_else(|| "default".to_string())
+            });
         let wake_msg = crate::session::resolve_config(&profile)
             .map(|c| c.session.restart_wake_message.clone())
             .unwrap_or_else(|_| "wake up: pick up what you were doing".to_string());
@@ -524,11 +528,14 @@ impl HomeView {
             }
         }
 
+        let path_changed = new_path != ctx.old_path;
+        let profile_changed = new_profile.is_some_and(|p| p != ctx.old_profile);
+
         // Capture old_path and its descendants from the pre-rebuild tree:
         // rebuild_group_trees below derives groups from instance.group_path,
         // which the loop above already migrated, so the old paths are about
         // to disappear from the in-memory tree.
-        let stale_paths: Vec<String> = if new_path != ctx.old_path {
+        let stale_paths: Vec<String> = if path_changed || profile_changed {
             let prefix = format!("{}/", ctx.old_path);
             self.group_trees
                 .get(&ctx.old_profile)
@@ -547,10 +554,12 @@ impl HomeView {
         // Rebuild trees from the updated instance list
         self.rebuild_group_trees();
 
-        if new_path != ctx.old_path {
+        if path_changed {
             if let Some(tree) = self.group_trees.get_mut(&ctx.old_profile) {
                 tree.rename_group(&ctx.old_path, new_path);
             }
+        }
+        if path_changed || profile_changed {
             self.pending_group_deletions
                 .entry(ctx.old_profile.clone())
                 .or_default()

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -313,9 +313,9 @@ impl HomeView {
                 })
                 .map(|i| i.id.clone())
                 .collect();
-            for id in &ids_to_clear {
-                self.apply_user_action(id, |inst| inst.group_path = String::new())?;
-            }
+            self.bulk_apply_user_action(&ids_to_clear, |inst| {
+                inst.group_path = String::new();
+            })?;
 
             self.rebuild_group_trees();
             if let Some(profile) = &owning_profile {
@@ -353,13 +353,13 @@ impl HomeView {
                 .map(|i| i.id.clone())
                 .collect();
 
-            for session_id in sessions_to_delete {
-                self.apply_user_action(&session_id, |inst| {
-                    inst.status = Status::Deleting;
-                    inst.group_path = String::new();
-                })?;
+            self.bulk_apply_user_action(&sessions_to_delete, |inst| {
+                inst.status = Status::Deleting;
+                inst.group_path = String::new();
+            })?;
 
-                if let Some(inst) = self.get_instance(&session_id) {
+            for session_id in &sessions_to_delete {
+                if let Some(inst) = self.get_instance(session_id) {
                     let delete_worktree = options.delete_worktrees
                         && (inst
                             .worktree_info

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -193,9 +193,11 @@ impl HomeView {
                     self.storages
                         .insert(target_profile.to_string(), Storage::new(target_profile)?);
                 }
-                self.mutate_instance(&id, |inst| {
-                    inst.source_profile = target_profile.to_string();
-                });
+                let group_path = self
+                    .get_instance(&id)
+                    .map(|i| i.group_path.clone())
+                    .unwrap_or_default();
+                self.move_to_profile(&id, target_profile, group_path);
                 self.rebuild_group_trees();
                 // Rebuild the visible row list too; otherwise the row still
                 // renders under the old profile until the next reload, and
@@ -507,10 +509,7 @@ impl HomeView {
             };
 
             if let Some(tp) = new_profile {
-                self.mutate_instance(id, |inst| {
-                    inst.group_path = new_group_path.clone();
-                    inst.source_profile = tp.to_string();
-                });
+                self.move_to_profile(id, tp, new_group_path.clone());
             } else {
                 self.apply_user_action(id, |inst| {
                     inst.group_path = new_group_path.clone();
@@ -647,10 +646,10 @@ impl HomeView {
 
                     // Update source_profile and save (handles moving between profiles)
                     instance.source_profile = target_profile.to_string();
+                    let new_title = instance.title.clone();
+                    self.move_to_profile(&id, target_profile, instance.group_path.clone());
                     self.mutate_instance(&id, |inst| {
-                        inst.title = instance.title.clone();
-                        inst.group_path = instance.group_path.clone();
-                        inst.source_profile = instance.source_profile.clone();
+                        inst.title = new_title;
                     });
 
                     self.rebuild_group_trees();

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -525,11 +525,29 @@ impl HomeView {
             }
         }
 
+        // Capture old_path and its descendants from the pre-rebuild tree:
+        // rebuild_group_trees below derives groups from instance.group_path,
+        // which the loop above already migrated, so the old paths are about
+        // to disappear from the in-memory tree.
+        let stale_paths: Vec<String> = if new_path != ctx.old_path {
+            let prefix = format!("{}/", ctx.old_path);
+            self.group_trees
+                .get(&ctx.old_profile)
+                .map(|tree| {
+                    tree.get_all_groups()
+                        .into_iter()
+                        .map(|g| g.path)
+                        .filter(|p| p == &ctx.old_path || p.starts_with(&prefix))
+                        .collect()
+                })
+                .unwrap_or_else(|| vec![ctx.old_path.clone()])
+        } else {
+            Vec::new()
+        };
+
         // Rebuild trees from the updated instance list
         self.rebuild_group_trees();
 
-        // Rename moves the node in-tree; tombstone the old path so disk
-        // drops the old row in save()'s per-row group merge.
         if new_path != ctx.old_path {
             if let Some(tree) = self.group_trees.get_mut(&ctx.old_profile) {
                 tree.rename_group(&ctx.old_path, new_path);
@@ -537,7 +555,7 @@ impl HomeView {
             self.pending_group_deletions
                 .entry(ctx.old_profile.clone())
                 .or_default()
-                .insert(ctx.old_path.clone());
+                .extend(stale_paths);
         }
 
         // When moving to a different profile, ensure the new path exists in the target tree

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -318,14 +318,12 @@ impl HomeView {
             }
 
             self.rebuild_group_trees();
-            // Delete the group only from the owning profile's tree
             if let Some(profile) = &owning_profile {
-                if let Some(tree) = self.group_trees.get_mut(profile) {
-                    tree.delete_group(&group_path);
-                }
+                self.delete_group_in_profile(profile, &group_path);
             } else {
-                for tree in self.group_trees.values_mut() {
-                    tree.delete_group(&group_path);
+                let profiles: Vec<String> = self.group_trees.keys().cloned().collect();
+                for profile in profiles {
+                    self.delete_group_in_profile(&profile, &group_path);
                 }
             }
             self.save()?;
@@ -396,12 +394,11 @@ impl HomeView {
             }
 
             if let Some(profile) = &owning_profile {
-                if let Some(tree) = self.group_trees.get_mut(profile) {
-                    tree.delete_group(&group_path);
-                }
+                self.delete_group_in_profile(profile, &group_path);
             } else {
-                for tree in self.group_trees.values_mut() {
-                    tree.delete_group(&group_path);
+                let profiles: Vec<String> = self.group_trees.keys().cloned().collect();
+                for profile in profiles {
+                    self.delete_group_in_profile(&profile, &group_path);
                 }
             }
             self.save()?;
@@ -531,12 +528,16 @@ impl HomeView {
         // Rebuild trees from the updated instance list
         self.rebuild_group_trees();
 
-        // Rename the group node in the source tree so the old path is removed
-        // and the new path is established (including all descendant nodes).
+        // Rename moves the node in-tree; tombstone the old path so disk
+        // drops the old row in save()'s per-row group merge.
         if new_path != ctx.old_path {
             if let Some(tree) = self.group_trees.get_mut(&ctx.old_profile) {
                 tree.rename_group(&ctx.old_path, new_path);
             }
+            self.pending_group_deletions
+                .entry(ctx.old_profile.clone())
+                .or_default()
+                .insert(ctx.old_path.clone());
         }
 
         // When moving to a different profile, ensure the new path exists in the target tree

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -314,7 +314,7 @@ impl HomeView {
                 .map(|i| i.id.clone())
                 .collect();
             for id in &ids_to_clear {
-                self.mutate_instance(id, |inst| inst.group_path = String::new());
+                self.apply_user_action(id, |inst| inst.group_path = String::new())?;
             }
 
             self.rebuild_group_trees();
@@ -356,10 +356,10 @@ impl HomeView {
                 .collect();
 
             for session_id in sessions_to_delete {
-                self.mutate_instance(&session_id, |inst| {
+                self.apply_user_action(&session_id, |inst| {
                     inst.status = Status::Deleting;
                     inst.group_path = String::new();
-                });
+                })?;
 
                 if let Some(inst) = self.get_instance(&session_id) {
                     let delete_worktree = options.delete_worktrees
@@ -515,9 +515,9 @@ impl HomeView {
                     inst.source_profile = tp.to_string();
                 });
             } else {
-                self.mutate_instance(id, |inst| {
+                self.apply_user_action(id, |inst| {
                     inst.group_path = new_group_path.clone();
-                });
+                })?;
             }
         }
 
@@ -667,10 +667,10 @@ impl HomeView {
                 }
             }
 
-            self.mutate_instance(&id, |inst| {
+            self.apply_user_action(&id, |inst| {
                 inst.title = effective_title.clone();
                 inst.group_path = effective_group.clone();
-            });
+            })?;
 
             // Rebuild group trees and create group if needed
             self.rebuild_group_trees();
@@ -714,8 +714,7 @@ impl HomeView {
             }
         };
         if is_snoozed {
-            self.mutate_instance(&id, |inst| inst.unsnooze());
-            self.save()?;
+            self.apply_user_action(&id, |inst| inst.unsnooze())?;
             self.flat_items = self.build_flat_items();
             return Ok(Some(format!("Woke: {}", title)));
         }
@@ -735,12 +734,12 @@ impl HomeView {
         id: &str,
         minutes: u32,
     ) -> anyhow::Result<Option<String>> {
-        let mut title = String::new();
-        self.mutate_instance(id, |inst| {
-            inst.snooze(minutes);
-            title = inst.title.clone();
-        });
-        self.save()?;
+        let title = self
+            .instance_map
+            .get(id)
+            .map(|i| i.title.clone())
+            .unwrap_or_default();
+        self.apply_user_action(id, |inst| inst.snooze(minutes))?;
         self.flat_items = self.build_flat_items();
         if self.sort_order == crate::session::config::SortOrder::Attention {
             self.select_top_attention(None);
@@ -771,11 +770,10 @@ impl HomeView {
             None => return Ok(()),
         };
         if is_fav {
-            self.mutate_instance(&id, |inst| inst.unfavorite());
+            self.apply_user_action(&id, |inst| inst.unfavorite())?;
         } else {
-            self.mutate_instance(&id, |inst| inst.favorite());
+            self.apply_user_action(&id, |inst| inst.favorite())?;
         }
-        self.save()?;
         self.flat_items = self.build_flat_items();
         Ok(())
     }
@@ -800,8 +798,7 @@ impl HomeView {
             None => return Ok(()),
         };
         if is_archived {
-            self.mutate_instance(&id, |inst| inst.unarchive());
-            self.save()?;
+            self.apply_user_action(&id, |inst| inst.unarchive())?;
             self.flat_items = self.build_flat_items();
             // Re-seat the cursor on the just-unarchived session. After the
             // flat_items rebuild the row jumps from tier 99 to its real
@@ -820,8 +817,7 @@ impl HomeView {
             }
         }
 
-        self.mutate_instance(&id, |inst| inst.archive());
-        self.save()?;
+        self.apply_user_action(&id, |inst| inst.archive())?;
         self.flat_items = self.build_flat_items();
         if self.sort_order == crate::session::config::SortOrder::Attention {
             self.select_top_attention(None);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5188,4 +5188,30 @@ mod save_field_merge {
             "peer's notify_on_waiting must survive an apply_user_action that does not touch it"
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_apply_user_action_disk_and_memory_share_one_timestamp() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        view.apply_user_action(&id, |inst| inst.archive())
+            .expect("apply_user_action must persist");
+
+        let mem_ts = view
+            .get_instance(&id)
+            .expect("in-memory row present")
+            .archived_at;
+        let disk_ts = Storage::new("test")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == id)
+            .expect("disk row present")
+            .archived_at;
+        assert_eq!(
+            mem_ts, disk_ts,
+            "single Utc::now() snapshot, no microsecond drift between memory and disk"
+        );
+    }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5357,7 +5357,8 @@ mod save_field_merge {
         view.storages
             .insert("target".to_string(), Storage::new("target").unwrap());
 
-        view.move_to_profile(&id, "target", "moved/group".to_string());
+        view.move_to_profile(&id, "target", "moved/group".to_string())
+            .unwrap();
 
         assert!(
             view.pending_deletions
@@ -5383,7 +5384,7 @@ mod save_field_merge {
         view.storages
             .insert("target".to_string(), Storage::new("target").unwrap());
 
-        view.move_to_profile(&id, "target", String::new());
+        view.move_to_profile(&id, "target", String::new()).unwrap();
         view.save().expect("save must succeed across profiles");
 
         let old_disk = Storage::new("test").unwrap().load().unwrap();
@@ -5403,7 +5404,8 @@ mod save_field_merge {
     fn test_move_to_profile_same_profile_only_updates_group_path() {
         let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
 
-        view.move_to_profile(&id, "test", "newgrp".to_string());
+        view.move_to_profile(&id, "test", "newgrp".to_string())
+            .unwrap();
 
         assert!(
             !view.pending_deletions.contains_key("test")
@@ -5411,5 +5413,37 @@ mod save_field_merge {
             "same-profile move must NOT tombstone the row"
         );
         assert_eq!(view.get_instance(&id).unwrap().group_path, "newgrp");
+    }
+
+    #[test]
+    #[serial]
+    fn test_reload_honors_peer_cleared_session_id() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/sid");
+
+        // Seed a stale sid via the in-memory mirror + persist.
+        view.mutate_instance(&id, |inst| {
+            inst.agent_session_id = Some("stale_X".to_string());
+        });
+        view.save().unwrap();
+
+        // Peer clears the sid on disk (simulates `aoe session set-session-id ""`).
+        Storage::new("test")
+            .unwrap()
+            .update(|insts, _g| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id) {
+                    inst.agent_session_id = None;
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        view.reload().unwrap();
+
+        assert!(
+            view.get_instance(&id)
+                .and_then(|i| i.agent_session_id.clone())
+                .is_none(),
+            "reload must honor peer-cleared sid; carrying memory would re-pass --resume <stale>"
+        );
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -52,7 +52,11 @@ fn create_test_env_with_sessions(count: usize) -> TestEnv {
         ));
     }
     storage
-        .commit(&instances, &GroupTree::new_with_groups(&instances, &[]))
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -82,7 +86,11 @@ fn create_test_env_with_groups() -> TestEnv {
     instances.push(inst3);
 
     storage
-        .commit(&instances, &GroupTree::new_with_groups(&instances, &[]))
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -117,7 +125,13 @@ fn create_test_env_with_mixed_sessions() -> TestEnv {
     instances.push(inst3);
 
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -386,7 +400,11 @@ fn test_enter_on_cockpit_session_opens_cockpit_view() {
     ];
     instances[1].cockpit_mode = true;
     storage
-        .commit(&instances, &GroupTree::new_with_groups(&instances, &[]))
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -1092,7 +1110,13 @@ fn create_test_env_with_group_sessions() -> TestEnv {
 
     // Build group tree from instances and save with groups
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -1128,7 +1152,11 @@ fn test_group_has_managed_worktrees() {
     {
         let xs: Vec<Instance> = vec![inst1, inst2];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -1168,7 +1196,11 @@ fn test_group_has_containers() {
     {
         let xs: Vec<Instance> = vec![inst1, inst2];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -1314,7 +1346,11 @@ fn test_delete_group_with_sessions_respects_worktree_option() {
     {
         let xs: Vec<Instance> = vec![inst1];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -1368,7 +1404,11 @@ fn test_delete_group_with_sessions_respects_container_option() {
     {
         let xs: Vec<Instance> = vec![inst1];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2087,7 +2127,11 @@ fn test_all_profiles_view_loads_from_multiple_profiles() {
     {
         let xs = vec![Instance::new("Alpha Session", "/tmp/a")];
         storage_a
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2095,7 +2139,11 @@ fn test_all_profiles_view_loads_from_multiple_profiles() {
     {
         let xs = vec![Instance::new("Beta Session", "/tmp/b")];
         storage_b
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2125,7 +2173,11 @@ fn test_filtered_view_loads_single_profile() {
     {
         let xs = vec![Instance::new("Alpha Session", "/tmp/a")];
         storage_a
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2133,7 +2185,11 @@ fn test_filtered_view_loads_single_profile() {
     {
         let xs = vec![Instance::new("Beta Session", "/tmp/b")];
         storage_b
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2158,7 +2214,11 @@ fn test_all_profiles_view_has_no_profile_headers() {
     {
         let xs = vec![Instance::new("A1", "/tmp/a")];
         storage_a
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2166,7 +2226,11 @@ fn test_all_profiles_view_has_no_profile_headers() {
     {
         let xs = vec![Instance::new("B1", "/tmp/b")];
         storage_b
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2196,7 +2260,11 @@ fn test_all_profiles_view_shows_all_sessions_flat() {
     {
         let xs = vec![Instance::new("A1", "/tmp/a")];
         storage_a
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2204,7 +2272,11 @@ fn test_all_profiles_view_shows_all_sessions_flat() {
     {
         let xs = vec![Instance::new("B1", "/tmp/b")];
         storage_b
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2244,7 +2316,13 @@ fn test_default_row_tag_mode_renders_no_tag() {
     let storage_a = Storage::new("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
     let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
-    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = instances_a.to_vec();
+            *g = group_tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2274,12 +2352,24 @@ fn test_row_tag_auto_renders_profile_in_all_profiles_view() {
     let storage_a = Storage::new("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
     let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
-    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = instances_a.to_vec();
+            *g = group_tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let storage_b = Storage::new("beta").unwrap();
     let instances_b = vec![Instance::new("B1", "/tmp/b")];
     let group_tree_b = GroupTree::new_with_groups(&instances_b, &[]);
-    storage_b.commit(&instances_b, &group_tree_b).unwrap();
+    storage_b
+        .update(|i, g| {
+            *i = instances_b.to_vec();
+            *g = group_tree_b.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2315,7 +2405,13 @@ fn test_row_tag_auto_omits_tag_in_filtered_view() {
     let storage_a = Storage::new("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
     let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
-    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = instances_a.to_vec();
+            *g = group_tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
@@ -2347,7 +2443,13 @@ fn test_row_tag_profile_renders_in_filtered_view() {
     let storage_a = Storage::new("alpha").unwrap();
     let instances_a = vec![Instance::new("A1", "/tmp/a")];
     let group_tree_a = GroupTree::new_with_groups(&instances_a, &[]);
-    storage_a.commit(&instances_a, &group_tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = instances_a.to_vec();
+            *g = group_tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("alpha".to_string()), tools).unwrap();
@@ -2395,7 +2497,13 @@ fn test_row_tag_branch_dedups_with_divergence_display() {
     });
     let instances = vec![inst];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2443,7 +2551,13 @@ fn test_row_tag_branch_renders_when_title_matches_branch() {
     });
     let instances = vec![inst];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2479,7 +2593,13 @@ fn test_row_tag_auto_skips_for_empty_source_profile() {
     inst.source_profile = String::new();
     let instances = vec![inst];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2512,7 +2632,11 @@ fn test_create_session_in_all_mode_is_findable() {
     {
         let xs = vec![Instance::new("Existing", "/tmp/a")];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2571,14 +2695,26 @@ fn test_save_preserves_per_profile_collapsed_state() {
     inst_a.group_path = "work".to_string();
     let mut tree_a = GroupTree::new_with_groups(&[inst_a.clone()], &[]);
     tree_a.toggle_collapsed("work");
-    storage_a.commit(&[inst_a], &tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = [inst_a].to_vec();
+            *g = tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     // Create beta with group "work" (expanded, the default)
     let storage_b = Storage::new("beta").unwrap();
     let mut inst_b = Instance::new("B1", "/tmp/b");
     inst_b.group_path = "work".to_string();
     let tree_b = GroupTree::new_with_groups(&[inst_b.clone()], &[]);
-    storage_b.commit(&[inst_b], &tree_b).unwrap();
+    storage_b
+        .update(|i, g| {
+            *i = [inst_b].to_vec();
+            *g = tree_b.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     // Load unified view
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -2667,14 +2803,26 @@ fn test_delete_group_scoped_to_owning_profile() {
     let mut inst_a = Instance::new("A1", "/tmp/a");
     inst_a.group_path = "work".to_string();
     let tree_a = GroupTree::new_with_groups(&[inst_a.clone()], &[]);
-    storage_a.commit(&[inst_a], &tree_a).unwrap();
+    storage_a
+        .update(|i, g| {
+            *i = [inst_a].to_vec();
+            *g = tree_a.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     // Create beta with the same group name "work"
     let storage_b = Storage::new("beta").unwrap();
     let mut inst_b = Instance::new("B1", "/tmp/b");
     inst_b.group_path = "work".to_string();
     let tree_b = GroupTree::new_with_groups(&[inst_b.clone()], &[]);
-    storage_b.commit(&[inst_b], &tree_b).unwrap();
+    storage_b
+        .update(|i, g| {
+            *i = [inst_b].to_vec();
+            *g = tree_b.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(None, tools).unwrap();
@@ -2817,7 +2965,11 @@ fn test_shift_n_prefills_main_repo_path_for_worktree_session() {
     {
         let xs: Vec<Instance> = vec![inst];
         storage
-            .commit(&xs, &GroupTree::new_with_groups(&xs, &[]))
+            .update(|i, g| {
+                *i = xs.to_vec();
+                *g = GroupTree::new_with_groups(&xs, &[]).get_all_groups();
+                Ok(())
+            })
             .unwrap();
     }
 
@@ -2933,7 +3085,13 @@ fn test_rename_selected_group_with_children() {
     inst2.group_path = "work/frontend".to_string();
     let instances = vec![inst1, inst2];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -3000,7 +3158,13 @@ fn test_rename_group_removes_old_path() {
     inst.group_path = "work".to_string();
     let instances = vec![inst];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -3032,7 +3196,13 @@ fn test_rename_group_empty_group() {
     let instances: Vec<Instance> = vec![];
     let mut group_tree = GroupTree::new_with_groups(&instances, &[]);
     group_tree.create_group("empty-group");
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -3074,7 +3244,13 @@ fn test_rename_group_duplicate_returns_error() {
     inst2.group_path = "personal".to_string();
     let instances = vec![inst1, inst2];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -3112,7 +3288,13 @@ fn test_rename_group_resort_az() {
     inst2.group_path = "mmm".to_string();
     let instances = vec![inst1, inst2];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree).unwrap();
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
     let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
@@ -4084,7 +4266,11 @@ fn create_test_env_two_projects_mixed_attention() -> TestEnv {
 
     let instances = vec![alpha_waiting, alpha_running, beta_running, beta_error];
     storage
-        .commit(&instances, &GroupTree::new_with_groups(&instances, &[]))
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let tools = AvailableTools::with_tools(&["claude"]);
@@ -4931,7 +5117,7 @@ mod save_field_merge {
         view.save().unwrap();
 
         assert!(
-            view.pending_deletions.get("test").is_none(),
+            !view.pending_deletions.contains_key("test"),
             "pending_deletions must drain on Ok save"
         );
     }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3119,6 +3119,36 @@ fn test_rename_selected_group_with_children() {
         .find(|i| i.title == "child-session")
         .unwrap();
     assert_eq!(child.group_path, "projects/frontend");
+
+    // Disk-state regression check: the rename must drop both old_path
+    // and its descendant rows, leaving only the renamed paths on disk.
+    let disk_groups: Vec<String> = storage
+        .load_with_groups()
+        .unwrap()
+        .1
+        .into_iter()
+        .map(|g| g.path)
+        .collect();
+    assert!(
+        !disk_groups.contains(&"work".to_string()),
+        "old parent path must not survive on disk: {:?}",
+        disk_groups
+    );
+    assert!(
+        !disk_groups.contains(&"work/frontend".to_string()),
+        "old descendant path must not survive on disk: {:?}",
+        disk_groups
+    );
+    assert!(
+        disk_groups.contains(&"projects".to_string()),
+        "renamed parent must be on disk: {:?}",
+        disk_groups
+    );
+    assert!(
+        disk_groups.contains(&"projects/frontend".to_string()),
+        "renamed descendant must be on disk: {:?}",
+        disk_groups
+    );
 }
 
 #[test]
@@ -5212,6 +5242,38 @@ mod save_field_merge {
         assert_eq!(
             mem_ts, disk_ts,
             "single Utc::now() snapshot, no microsecond drift between memory and disk"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_apply_user_action_preserves_peer_user_action_field() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        // Peer writes snoozed_until under the flock while the TUI's in-memory
+        // mirror still has snoozed_until = None.
+        let peer_storage = Storage::new("test").unwrap();
+        peer_storage
+            .update(|insts, _| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id) {
+                    inst.snooze(30);
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        // TUI archives the row. archive() mutates archived_at + favorited_at
+        // only; snoozed_until is in the user-action set but unchanged by this
+        // mutation, so the diff-splice must NOT clobber the peer's value.
+        view.apply_user_action(&id, |inst| inst.archive())
+            .expect("archive must persist");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+        assert!(row.archived_at.is_some(), "TUI archive landed");
+        assert!(
+            row.snoozed_until.is_some(),
+            "peer-written snoozed_until must survive a TUI archive that does not touch the field"
         );
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4822,3 +4822,161 @@ mod click_to_select {
         assert_ne!(was_collapsed, now_collapsed, "group collapsed state flips");
     }
 }
+
+mod save_field_merge {
+    use super::*;
+    use chrono::Utc;
+
+    fn boot_view_with_one_session(title: &str, path: &str) -> (TempDir, HomeView, String) {
+        let temp = TempDir::new().unwrap();
+        setup_test_home(&temp);
+        let storage = Storage::new("test").unwrap();
+        let inst = Instance::new(title, path);
+        let id = inst.id.clone();
+        storage
+            .update(|i, g| {
+                i.push(inst.clone());
+                *g = GroupTree::new_with_groups(&[inst], &[]).get_all_groups();
+                Ok(())
+            })
+            .unwrap();
+
+        let tools = AvailableTools::with_tools(&["claude"]);
+        let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+        (temp, view, id)
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_preserves_peer_field_update() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        let peer_storage = Storage::new("test").unwrap();
+        let peer_archived_at = Utc::now();
+        peer_storage
+            .update(|insts, _| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id) {
+                    inst.archived_at = Some(peer_archived_at);
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        view.save().expect("save must merge peer-owned field write");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+        assert_eq!(
+            row.archived_at,
+            Some(peer_archived_at),
+            "peer's archive must survive a TUI save with stale view"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_preserves_peer_added_row() {
+        let (_temp, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
+
+        let peer_storage = Storage::new("test").unwrap();
+        peer_storage
+            .update(|insts, _| {
+                insts.push(Instance::new("peer-added", "/tmp/peer"));
+                Ok(())
+            })
+            .unwrap();
+
+        view.save()
+            .expect("save must not delete rows the TUI does not know about");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        assert!(
+            reloaded.iter().any(|i| i.title == "peer-added"),
+            "peer-added row must survive TUI save"
+        );
+        assert!(
+            reloaded.iter().any(|i| i.title == "a"),
+            "TUI's known row must remain"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_drops_explicitly_deleted_row() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
+
+        view.remove_instance(&id);
+        view.save().expect("save must propagate the delete");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        assert!(
+            !reloaded.iter().any(|i| i.id == id),
+            "tombstoned row must be removed from disk"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_drains_pending_deletions_on_ok() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/victim");
+
+        view.remove_instance(&id);
+        assert!(
+            view.pending_deletions
+                .get("test")
+                .is_some_and(|s| s.contains(&id)),
+            "remove_instance must populate pending_deletions"
+        );
+
+        view.save().unwrap();
+
+        assert!(
+            view.pending_deletions.get("test").is_none(),
+            "pending_deletions must drain on Ok save"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_apply_user_action_persists_atomically() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        view.apply_user_action(&id, |inst| inst.archive())
+            .expect("apply_user_action must persist");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+        assert!(
+            row.archived_at.is_some(),
+            "apply_user_action must persist archived_at to disk"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_apply_user_action_does_not_clobber_peer_field() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        let peer_storage = Storage::new("test").unwrap();
+        peer_storage
+            .update(|insts, _| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id) {
+                    inst.notify_on_waiting = Some(true);
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        view.apply_user_action(&id, |inst| inst.archive())
+            .expect("archive must persist");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+        assert!(row.archived_at.is_some(), "TUI archive landed");
+        assert_eq!(
+            row.notify_on_waiting,
+            Some(true),
+            "peer's notify_on_waiting must survive an apply_user_action that does not touch it"
+        );
+    }
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5124,6 +5124,29 @@ mod save_field_merge {
 
     #[test]
     #[serial]
+    fn test_save_preserves_peer_added_group() {
+        let (_temp, mut view, _id) = boot_view_with_one_session("a", "/tmp/a");
+
+        let peer_storage = Storage::new("test").unwrap();
+        peer_storage
+            .update(|_insts, groups| {
+                groups.push(crate::session::Group::new("peer-grp", "peer-grp"));
+                Ok(())
+            })
+            .unwrap();
+
+        view.save()
+            .expect("save must not clobber groups the TUI does not know about");
+
+        let reloaded = Storage::new("test").unwrap().load_with_groups().unwrap().1;
+        assert!(
+            reloaded.iter().any(|g| g.path == "peer-grp"),
+            "peer-added group must survive TUI save"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn test_apply_user_action_persists_atomically() {
         let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5250,8 +5250,6 @@ mod save_field_merge {
     fn test_apply_user_action_preserves_peer_user_action_field() {
         let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
-        // Peer writes snoozed_until under the flock while the TUI's in-memory
-        // mirror still has snoozed_until = None.
         let peer_storage = Storage::new("test").unwrap();
         peer_storage
             .update(|insts, _| {
@@ -5262,9 +5260,8 @@ mod save_field_merge {
             })
             .unwrap();
 
-        // TUI archives the row. archive() mutates archived_at + favorited_at
-        // only; snoozed_until is in the user-action set but unchanged by this
-        // mutation, so the diff-splice must NOT clobber the peer's value.
+        // archive() touches archived_at + favorited_at only; the peer-set
+        // snoozed_until must NOT be clobbered by the diff-splice.
         view.apply_user_action(&id, |inst| inst.archive())
             .expect("archive must persist");
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5273,4 +5273,80 @@ mod save_field_merge {
             "peer-written snoozed_until must survive a TUI archive that does not touch the field"
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_save_drops_peer_deleted_row_from_mirror() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/peer-rm");
+
+        // Simulate `aoe session remove victim` from another process: peer
+        // deletes the row from disk while TUI still has it in memory.
+        Storage::new("test")
+            .unwrap()
+            .update(|insts, _g| {
+                insts.retain(|i| i.id != id);
+                Ok(())
+            })
+            .unwrap();
+
+        view.save()
+            .expect("save must not error on peer-deleted rows");
+
+        assert!(
+            !view.instances().iter().any(|i| i.id == id),
+            "peer-deleted row must be dropped from in-memory instances"
+        );
+        assert!(
+            view.get_instance(&id).is_none(),
+            "peer-deleted row must be dropped from instance_map"
+        );
+        let disk = Storage::new("test").unwrap().load().unwrap();
+        assert!(
+            !disk.iter().any(|i| i.id == id),
+            "save() must not resurrect the peer-deleted row on disk"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_pushes_tui_added_row_to_disk() {
+        let (_temp, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
+
+        let mut new_inst = Instance::new("tui-added", "/tmp/added");
+        new_inst.source_profile = "test".to_string();
+        let new_id = new_inst.id.clone();
+        view.add_instance(new_inst);
+
+        view.save().expect("save must persist TUI-added row");
+
+        let disk = Storage::new("test").unwrap().load().unwrap();
+        assert!(
+            disk.iter().any(|i| i.id == new_id),
+            "TUI-added row must be persisted to disk"
+        );
+        assert!(
+            !view.pending_added.contains_key("test"),
+            "pending_added must drain on Ok save"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_save_add_then_remove_in_same_cycle_does_not_persist() {
+        let (_temp, mut view, _) = boot_view_with_one_session("seed", "/tmp/seed");
+
+        let mut new_inst = Instance::new("ephemeral", "/tmp/ephemeral");
+        new_inst.source_profile = "test".to_string();
+        let new_id = new_inst.id.clone();
+        view.add_instance(new_inst);
+        view.remove_instance(&new_id);
+
+        view.save().expect("save must succeed");
+
+        let disk = Storage::new("test").unwrap().load().unwrap();
+        assert!(
+            !disk.iter().any(|i| i.id == new_id),
+            "add+remove in same save cycle must not leak the row to disk"
+        );
+    }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5349,4 +5349,67 @@ mod save_field_merge {
             "add+remove in same save cycle must not leak the row to disk"
         );
     }
+
+    #[test]
+    #[serial]
+    fn test_move_to_profile_marks_tombstone_and_pending_added() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+        view.storages
+            .insert("target".to_string(), Storage::new("target").unwrap());
+
+        view.move_to_profile(&id, "target", "moved/group".to_string());
+
+        assert!(
+            view.pending_deletions
+                .get("test")
+                .is_some_and(|s| s.contains(&id)),
+            "old profile must have tombstone"
+        );
+        assert!(
+            view.pending_added
+                .get("target")
+                .is_some_and(|s| s.contains(&id)),
+            "new profile must have pending_added entry"
+        );
+        let inst = view.get_instance(&id).unwrap();
+        assert_eq!(inst.source_profile, "target");
+        assert_eq!(inst.group_path, "moved/group");
+    }
+
+    #[test]
+    #[serial]
+    fn test_move_to_profile_save_roundtrip_persists_under_target() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+        view.storages
+            .insert("target".to_string(), Storage::new("target").unwrap());
+
+        view.move_to_profile(&id, "target", String::new());
+        view.save().expect("save must succeed across profiles");
+
+        let old_disk = Storage::new("test").unwrap().load().unwrap();
+        let new_disk = Storage::new("target").unwrap().load().unwrap();
+        assert!(
+            !old_disk.iter().any(|i| i.id == id),
+            "old profile disk must NOT contain the moved row"
+        );
+        assert!(
+            new_disk.iter().any(|i| i.id == id),
+            "new profile disk MUST contain the moved row"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_move_to_profile_same_profile_only_updates_group_path() {
+        let (_temp, mut view, id) = boot_view_with_one_session("victim", "/tmp/move");
+
+        view.move_to_profile(&id, "test", "newgrp".to_string());
+
+        assert!(
+            !view.pending_deletions.contains_key("test")
+                || !view.pending_deletions.get("test").unwrap().contains(&id),
+            "same-profile move must NOT tombstone the row"
+        );
+        assert_eq!(view.get_instance(&id).unwrap().group_path, "newgrp");
+    }
 }

--- a/tests/integration/group_persistence.rs
+++ b/tests/integration/group_persistence.rs
@@ -16,7 +16,11 @@ fn test_create_group_and_persist() -> Result<()> {
     let mut group_tree = GroupTree::new_with_groups(&instances, &[]);
     group_tree.create_group("work");
 
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
     let reloaded_tree = GroupTree::new_with_groups(&loaded_instances, &loaded_groups);
@@ -35,7 +39,11 @@ fn test_nested_group_persistence() -> Result<()> {
     let mut group_tree = GroupTree::new_with_groups(&instances, &[]);
     group_tree.create_group("work/frontend");
 
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
     let reloaded_tree = GroupTree::new_with_groups(&loaded_instances, &loaded_groups);
@@ -56,7 +64,11 @@ fn test_delete_group_persists() -> Result<()> {
     // Create and save a group
     let mut group_tree = GroupTree::new_with_groups(&instances, &[]);
     group_tree.create_group("temporary");
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     // Reload, delete, save again
     let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
@@ -64,7 +76,11 @@ fn test_delete_group_persists() -> Result<()> {
     assert!(reloaded_tree.group_exists("temporary"));
 
     reloaded_tree.delete_group("temporary");
-    storage.commit(&loaded_instances, &reloaded_tree)?;
+    storage.update(|i, g| {
+        *i = loaded_instances.to_vec();
+        *g = reloaded_tree.get_all_groups();
+        Ok(())
+    })?;
 
     // Reload again and verify deletion
     let (final_instances, final_groups) = storage.load_with_groups()?;
@@ -86,13 +102,21 @@ fn test_move_session_between_groups() -> Result<()> {
     let mut group_tree = GroupTree::new_with_groups(&[instance.clone()], &[]);
     group_tree.create_group("group-a");
     group_tree.create_group("group-b");
-    storage.commit(&[instance.clone()], &group_tree)?;
+    storage.update(|i, g| {
+        *i = [instance.clone()].to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     // Move the session to group-b
     let (mut loaded, loaded_groups) = storage.load_with_groups()?;
     loaded[0].group_path = "group-b".to_string();
     let new_tree = GroupTree::new_with_groups(&loaded, &loaded_groups);
-    storage.commit(&loaded, &new_tree)?;
+    storage.update(|i, g| {
+        *i = loaded.to_vec();
+        *g = new_tree.get_all_groups();
+        Ok(())
+    })?;
 
     // Reload and verify
     let (final_instances, final_groups) = storage.load_with_groups()?;
@@ -119,7 +143,11 @@ fn test_group_with_sessions_round_trip() -> Result<()> {
 
     let instances = vec![inst1, inst2, inst3];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded, loaded_groups) = storage.load_with_groups()?;
     assert_eq!(loaded.len(), 3);
@@ -151,7 +179,11 @@ fn test_empty_groups_persist() -> Result<()> {
     let mut group_tree = GroupTree::new_with_groups(&instances, &[]);
     group_tree.create_group("empty-group");
     group_tree.create_group("another-empty");
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded_instances, loaded_groups) = storage.load_with_groups()?;
     assert!(loaded_instances.is_empty());

--- a/tests/integration/profile_management.rs
+++ b/tests/integration/profile_management.rs
@@ -122,7 +122,11 @@ fn test_profile_session_isolation() -> Result<()> {
     let storage_a = Storage::new("alpha")?;
     let instance = Instance::new("Alpha Session", "/path/alpha");
     let seeded = vec![instance];
-    storage_a.commit(&seeded, &GroupTree::new_with_groups(&seeded, &[]))?;
+    storage_a.update(|i, g| {
+        *i = seeded.to_vec();
+        *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+        Ok(())
+    })?;
 
     // Load from profile beta - should be empty
     let storage_b = Storage::new("beta")?;
@@ -147,7 +151,11 @@ fn test_rename_profile() -> Result<()> {
     let storage = Storage::new("old_name")?;
     let instance = Instance::new("Test Session", "/path/test");
     let seeded = vec![instance];
-    storage.commit(&seeded, &GroupTree::new_with_groups(&seeded, &[]))?;
+    storage.update(|i, g| {
+        *i = seeded.to_vec();
+        *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+        Ok(())
+    })?;
 
     rename_profile("old_name", "new_name")?;
 

--- a/tests/integration/sandbox_integration.rs
+++ b/tests/integration/sandbox_integration.rs
@@ -85,7 +85,11 @@ fn test_sandbox_info_persists_across_save_load() {
 
     let seeded = vec![inst.clone()];
     storage
-        .commit(&seeded, &GroupTree::new_with_groups(&seeded, &[]))
+        .update(|i, g| {
+            *i = seeded.to_vec();
+            *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let loaded = storage.load().unwrap();

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -16,7 +16,11 @@ fn test_create_session_persists() -> Result<()> {
     let instance = Instance::new("My Project", "/home/user/project");
     let group_tree = GroupTree::new_with_groups(std::slice::from_ref(&instance), &[]);
 
-    storage.commit(std::slice::from_ref(&instance), &group_tree)?;
+    storage.update(|i, g| {
+        *i = vec![instance.clone()];
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded, _groups) = storage.load_with_groups()?;
     assert_eq!(loaded.len(), 1);
@@ -40,7 +44,11 @@ fn test_create_multiple_sessions() -> Result<()> {
     ];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
 
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded, _) = storage.load_with_groups()?;
     assert_eq!(loaded.len(), 3);
@@ -63,13 +71,21 @@ fn test_remove_session_by_id() -> Result<()> {
 
     let instances = vec![inst_a, inst_b];
     let group_tree = GroupTree::new_with_groups(&instances, &[]);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     // Remove by filtering
     let (mut loaded, groups) = storage.load_with_groups()?;
     loaded.retain(|i| i.id != remove_id);
     let group_tree = GroupTree::new_with_groups(&loaded, &groups);
-    storage.commit(&loaded, &group_tree)?;
+    storage.update(|i, g| {
+        *i = loaded.to_vec();
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (reloaded, _) = storage.load_with_groups()?;
     assert_eq!(reloaded.len(), 1);
@@ -90,7 +106,11 @@ fn test_create_session_with_group() -> Result<()> {
     let mut group_tree = GroupTree::new_with_groups(std::slice::from_ref(&instance), &[]);
     group_tree.create_group("work");
 
-    storage.commit(std::slice::from_ref(&instance), &group_tree)?;
+    storage.update(|i, g| {
+        *i = vec![instance.clone()];
+        *g = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     let (loaded, loaded_groups) = storage.load_with_groups()?;
     assert_eq!(loaded.len(), 1);
@@ -111,21 +131,28 @@ fn test_save_leaves_no_debris() -> Result<()> {
 
     for i in 0..5 {
         let instances = vec![Instance::new(&format!("iter{i}"), "/tmp/test")];
-        storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
+        storage.update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })?;
     }
 
     // Atomic write should leave only the persisted JSON files in the profile
     // dir, no .json.bak from the old code path and no leftover tempfiles.
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
-    let mut entries: Vec<String> = fs::read_dir(&profile_dir)?
+    let entries: Vec<String> = fs::read_dir(&profile_dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
-    entries.sort();
-    assert_eq!(
-        entries,
-        vec![".storage.lock", "groups.json", "sessions.json"]
-    );
+    for entry in &entries {
+        assert!(
+            !entry.contains(".tmp"),
+            "atomic_write must not leak temp files; found {}",
+            entry
+        );
+    }
+    assert!(entries.contains(&"sessions.json".to_string()));
 
     Ok(())
 }
@@ -141,7 +168,11 @@ fn test_source_profile_not_serialized() {
     let storage = Storage::new("default").unwrap();
     let seeded = vec![instance.clone()];
     storage
-        .commit(&seeded, &GroupTree::new_with_groups(&seeded, &[]))
+        .update(|i, g| {
+            *i = seeded.to_vec();
+            *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     // Read raw JSON -- source_profile should not appear
@@ -170,7 +201,11 @@ fn test_storage_empty_profile_resolves_to_bootstrap() -> Result<()> {
     assert_eq!(storage.profile(), "main");
 
     let instances = vec![Instance::new("Test", "/path/test")];
-    storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
+    storage.update(|i, g| {
+        *i = instances.to_vec();
+        *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+        Ok(())
+    })?;
     let loaded = storage.load()?;
     assert_eq!(loaded.len(), 1);
 

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -122,7 +122,10 @@ fn test_save_leaves_no_debris() -> Result<()> {
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     entries.sort();
-    assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+    assert_eq!(
+        entries,
+        vec![".storage.lock", "groups.json", "sessions.json"]
+    );
 
     Ok(())
 }

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -17,7 +17,11 @@ fn test_concurrent_updates_no_lost_updates() -> Result<()> {
     let _temp = setup_temp_home();
 
     let storage = Storage::new("default")?;
-    storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+    storage.update(|i, g| {
+        *i = [].to_vec();
+        *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+        Ok(())
+    })?;
 
     let n_threads = 16usize;
     let start = Arc::new(Barrier::new(n_threads));
@@ -90,7 +94,11 @@ fn test_update_with_groups_and_instances_round_trip() -> Result<()> {
     let _temp = setup_temp_home();
 
     let storage = Storage::new("default")?;
-    storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+    storage.update(|i, g| {
+        *i = [].to_vec();
+        *g = GroupTree::new_with_groups(&[], &[]).get_all_groups();
+        Ok(())
+    })?;
 
     storage.update(|instances, groups| {
         let mut inst = Instance::new("project-a", "/tmp/a");
@@ -105,60 +113,6 @@ fn test_update_with_groups_and_instances_round_trip() -> Result<()> {
     assert_eq!(loaded_instances[0].group_path, "work/clients");
     assert_eq!(loaded_groups.len(), 1);
     assert_eq!(loaded_groups[0].name, "clients");
-    Ok(())
-}
-
-#[test]
-#[serial]
-fn test_commit_overwrites_concurrent_update_by_design() -> Result<()> {
-    let _temp = setup_temp_home();
-
-    let storage = Storage::new("default")?;
-    storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
-
-    let entered = Arc::new(Barrier::new(2));
-    let release = Arc::new(Barrier::new(2));
-    let entered_clone = Arc::clone(&entered);
-    let release_clone = Arc::clone(&release);
-
-    let updater = std::thread::spawn(move || {
-        let storage = Storage::new("default").unwrap();
-        storage
-            .update(|instances, _| {
-                instances.push(Instance::new("from-update", "/tmp/u"));
-                entered_clone.wait();
-                release_clone.wait();
-                Ok(())
-            })
-            .unwrap();
-    });
-
-    entered.wait();
-    let committer = std::thread::spawn(|| {
-        let storage = Storage::new("default").unwrap();
-        storage
-            .commit(
-                &[Instance::new("from-commit", "/tmp/c")],
-                &GroupTree::new_with_groups(&[], &[]),
-            )
-            .unwrap();
-    });
-
-    std::thread::sleep(std::time::Duration::from_millis(80));
-    assert!(
-        !committer.is_finished(),
-        "commit should be blocked by update lock"
-    );
-    release.wait();
-    updater.join().unwrap();
-    committer.join().unwrap();
-
-    let loaded = storage.load()?;
-    assert_eq!(loaded.len(), 1);
-    assert_eq!(
-        loaded[0].title, "from-commit",
-        "commit semantics: last writer wins after the lock is released"
-    );
     Ok(())
 }
 
@@ -178,7 +132,11 @@ fn test_concurrent_per_field_updates_no_clobber() -> Result<()> {
 
     let storage = Storage::new("default")?;
     let seed = vec![Instance::new("session", "/tmp/session")];
-    storage.commit(&seed, &GroupTree::new_with_groups(&seed, &[]))?;
+    storage.update(|i, g| {
+        *i = seed.to_vec();
+        *g = GroupTree::new_with_groups(&seed, &[]).get_all_groups();
+        Ok(())
+    })?;
     let target_id = storage.load()?[0].id.clone();
 
     let n_iterations = 16usize;
@@ -247,7 +205,11 @@ fn test_update_propagates_disk_write_failure() -> Result<()> {
 
     let storage = Storage::new("default")?;
     let seed = vec![Instance::new("session", "/tmp/s")];
-    storage.commit(&seed, &GroupTree::new_with_groups(&seed, &[]))?;
+    storage.update(|i, g| {
+        *i = seed.to_vec();
+        *g = GroupTree::new_with_groups(&seed, &[]).get_all_groups();
+        Ok(())
+    })?;
 
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
 

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -414,7 +414,7 @@ fn test_cross_process_blocking_acquire() -> Result<()> {
 
 #[test]
 #[serial]
-fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
+fn test_lock_released_on_panic_unwind() -> Result<()> {
     let temp = setup_temp_home();
     let home = temp.path().to_path_buf();
 
@@ -425,14 +425,6 @@ fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
     })?;
     let id = storage.load()?[0].id.clone();
 
-    // Hold the flock from a spawned thread inside this process by going through
-    // the public update path with a sleeping closure. Killing a child of `aoe`
-    // is harder to time deterministically; the in-thread variant gives the
-    // same OS-level guarantee (kernel releases the flock when the holder's
-    // file descriptor is closed) because thread panic unwinds the
-    // `StorageFlock` Drop impl, which calls `fs2::FileExt::unlock`. Combined
-    // with the `kill -9` path's `exit(2)`-on-SIGKILL semantics, this asserts
-    // that an aborted holder cannot wedge peer processes.
     let storage_clone = Storage::new("default")?;
     let parent_handle = std::thread::spawn(move || {
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -443,8 +435,6 @@ fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
     });
     parent_handle.join().expect("thread joined");
 
-    // After the panicking thread has unwound, a fresh child should acquire
-    // the flock immediately.
     let started = std::time::Instant::now();
     let mut child = spawn_favorite(aoe_bin(), &home, &id);
     let status = child.wait()?;
@@ -455,6 +445,92 @@ fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
         elapsed < std::time::Duration::from_secs(2),
         "lock must be released after holder unwinds; observed {:?}",
         elapsed
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+#[serial]
+fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
+    use fs2::FileExt;
+    use nix::sys::signal::{self, Signal};
+    use nix::sys::wait::waitpid;
+    use nix::unistd::{fork, ForkResult, Pid};
+
+    let _temp = setup_temp_home();
+
+    let storage = Storage::new("default")?;
+    storage.update(|insts, _| {
+        insts.push(Instance::new("victim-kill", "/tmp/aoe-test-victim-kill"));
+        Ok(())
+    })?;
+
+    let lock_path = agent_of_empires::session::get_profile_dir("default")?.join(".storage.lock");
+    let path_c =
+        std::ffi::CString::new(lock_path.to_str().expect("utf8 path")).expect("path has no NUL");
+
+    // SAFETY: between fork() and _exit() the child only calls
+    // async-signal-safe libc routines (open, flock, pause, _exit). Cargo
+    // test runs each test on a worker thread, so the post-fork process
+    // is multithreaded; non-async-signal-safe code (allocator, std::fs)
+    // would be UB here.
+    let child = match unsafe { fork() }? {
+        ForkResult::Parent { child } => child,
+        ForkResult::Child => unsafe {
+            let fd = nix::libc::open(
+                path_c.as_ptr(),
+                nix::libc::O_RDWR | nix::libc::O_CREAT,
+                0o600,
+            );
+            if fd < 0 {
+                nix::libc::_exit(2);
+            }
+            if nix::libc::flock(fd, nix::libc::LOCK_EX) != 0 {
+                nix::libc::_exit(3);
+            }
+            nix::libc::pause();
+            nix::libc::_exit(0);
+        },
+    };
+
+    struct ChildGuard(Pid);
+    impl Drop for ChildGuard {
+        fn drop(&mut self) {
+            let _ = signal::kill(self.0, Signal::SIGKILL);
+            let _ = waitpid(self.0, None);
+        }
+    }
+    let _g = ChildGuard(child);
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    loop {
+        let probe = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        if FileExt::try_lock_exclusive(&probe).is_err() {
+            break;
+        }
+        let _ = FileExt::unlock(&probe);
+        drop(probe);
+        if std::time::Instant::now() > deadline {
+            anyhow::bail!("child did not acquire flock within deadline");
+        }
+        std::thread::sleep(std::time::Duration::from_millis(20));
+    }
+
+    signal::kill(child, Signal::SIGKILL)?;
+    waitpid(child, None)?;
+
+    let started = std::time::Instant::now();
+    storage.update(|_, _| Ok(()))?;
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(2),
+        "lock must release after SIGKILL; observed {:?}",
+        started.elapsed()
     );
     Ok(())
 }

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -519,18 +519,19 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
 
     let hold = std::time::Duration::from_millis(500);
     let storage_clone = Storage::new("profile-a")?;
-    let started = std::time::Instant::now();
+    let parent_held = Arc::new(Barrier::new(2));
+    let parent_held_inner = parent_held.clone();
     let parent_handle = std::thread::spawn(move || {
         storage_clone
             .update(|_, _| {
+                parent_held_inner.wait();
                 std::thread::sleep(hold);
                 Ok(())
             })
             .unwrap();
     });
 
-    // Give the parent thread time to take the flock on profile-a.
-    std::thread::sleep(std::time::Duration::from_millis(50));
+    parent_held.wait();
 
     // Cross-profile children must NOT be serialised by profile-a's flock.
     let aoe = aoe_bin();
@@ -540,6 +541,7 @@ fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
         .env("HOME", &home);
     #[cfg(target_os = "linux")]
     cmd_b.env("XDG_CONFIG_HOME", home.join(".config"));
+    let started = std::time::Instant::now();
     let status = cmd_b
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -1,6 +1,7 @@
-//! Integration tests for the in-process per-profile lock added in #1175.
+//! Integration tests for the two-layer per-profile lock (in-process mutex
+//! + cross-process flock).
 //!
-//! These exercise the public locked API (`Storage::update`, `commit`,
+//! These exercise the public locked API (`Storage::update`,
 //! `update_workspace_ordering`) end-to-end from outside the crate, the same
 //! surface a third-party consumer would see.
 

--- a/tests/integration/storage_concurrency.rs
+++ b/tests/integration/storage_concurrency.rs
@@ -290,3 +290,231 @@ fn test_update_propagates_disk_write_failure() -> Result<()> {
     );
     Ok(())
 }
+
+// Cross-process tests: spawn real `aoe` subprocesses that each go through
+// the full Storage::update path (in-process Mutex + cross-process flock +
+// atomic_write). They validate that two independent OS processes
+// (e.g. TUI + daemon, or two CLI invocations, or daemon + a CLI invocation)
+// cannot lose each other's updates when racing on the same profile.
+
+fn aoe_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_aoe")
+}
+
+fn spawn_favorite(aoe: &str, home: &std::path::Path, id: &str) -> std::process::Child {
+    let mut cmd = std::process::Command::new(aoe);
+    cmd.args(["session", "favorite", id])
+        .env("HOME", home)
+        .env_remove("AGENT_OF_EMPIRES_DEBUG");
+    #[cfg(target_os = "linux")]
+    cmd.env("XDG_CONFIG_HOME", home.join(".config"));
+    cmd.stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+        .expect("aoe binary failed to spawn")
+}
+
+#[test]
+#[serial]
+fn test_cross_process_no_lost_updates() -> Result<()> {
+    let temp = setup_temp_home();
+    let home = temp.path().to_path_buf();
+
+    let storage = Storage::new("default")?;
+    let n = 8usize;
+    storage.update(|instances, _groups| {
+        for i in 0..n {
+            instances.push(Instance::new(
+                &format!("session-{i}"),
+                &format!("/tmp/aoe-test-{i}"),
+            ));
+        }
+        Ok(())
+    })?;
+    let ids: Vec<String> = storage.load()?.iter().map(|i| i.id.clone()).collect();
+    assert_eq!(ids.len(), n);
+
+    let aoe = aoe_bin();
+    let children: Vec<_> = ids
+        .iter()
+        .map(|id| spawn_favorite(aoe, &home, id))
+        .collect();
+    for mut child in children {
+        let status = child.wait()?;
+        assert!(
+            status.success(),
+            "child `aoe session favorite` exited with {status:?}"
+        );
+    }
+
+    let final_state = storage.load()?;
+    let favorited = final_state
+        .iter()
+        .filter(|i| i.favorited_at.is_some())
+        .count();
+    assert_eq!(
+        favorited, n,
+        "every concurrent CLI favorite must persist (no lost updates)"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_cross_process_blocking_acquire() -> Result<()> {
+    let temp = setup_temp_home();
+    let home = temp.path().to_path_buf();
+
+    let storage = Storage::new("default")?;
+    storage.update(|instances, _groups| {
+        instances.push(Instance::new("blocked", "/tmp/aoe-test-blocked"));
+        Ok(())
+    })?;
+    let id = storage.load()?[0].id.clone();
+
+    let hold = std::time::Duration::from_millis(800);
+    let parent_held = std::sync::Arc::new(std::sync::Barrier::new(2));
+    let parent_held_in_thread = parent_held.clone();
+
+    let storage_clone = Storage::new("default")?;
+    let parent_handle = std::thread::spawn(move || {
+        storage_clone
+            .update(|_instances, _groups| {
+                parent_held_in_thread.wait();
+                std::thread::sleep(hold);
+                Ok(())
+            })
+            .unwrap();
+    });
+
+    parent_held.wait();
+    let started = std::time::Instant::now();
+    let mut child = spawn_favorite(aoe_bin(), &home, &id);
+    let status = child.wait()?;
+    let elapsed = started.elapsed();
+    parent_handle.join().unwrap();
+
+    assert!(status.success(), "child exit status: {status:?}");
+    assert!(
+        elapsed >= hold - std::time::Duration::from_millis(200),
+        "child should have blocked on the flock for ~{:?}, observed {:?}",
+        hold,
+        elapsed
+    );
+
+    let final_state = storage.load()?;
+    assert!(
+        final_state
+            .iter()
+            .any(|i| i.id == id && i.favorited_at.is_some()),
+        "child's favorite must land after parent releases"
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_cross_process_lock_released_on_child_kill() -> Result<()> {
+    let temp = setup_temp_home();
+    let home = temp.path().to_path_buf();
+
+    let storage = Storage::new("default")?;
+    storage.update(|instances, _groups| {
+        instances.push(Instance::new("victim", "/tmp/aoe-test-victim"));
+        Ok(())
+    })?;
+    let id = storage.load()?[0].id.clone();
+
+    // Hold the flock from a spawned thread inside this process by going through
+    // the public update path with a sleeping closure. Killing a child of `aoe`
+    // is harder to time deterministically; the in-thread variant gives the
+    // same OS-level guarantee (kernel releases the flock when the holder's
+    // file descriptor is closed) because thread panic unwinds the
+    // `StorageFlock` Drop impl, which calls `fs2::FileExt::unlock`. Combined
+    // with the `kill -9` path's `exit(2)`-on-SIGKILL semantics, this asserts
+    // that an aborted holder cannot wedge peer processes.
+    let storage_clone = Storage::new("default")?;
+    let parent_handle = std::thread::spawn(move || {
+        let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let _: Result<()> = storage_clone.update(|_, _| -> Result<()> {
+                panic!("simulated abort while holding the lock");
+            });
+        }));
+    });
+    parent_handle.join().expect("thread joined");
+
+    // After the panicking thread has unwound, a fresh child should acquire
+    // the flock immediately.
+    let started = std::time::Instant::now();
+    let mut child = spawn_favorite(aoe_bin(), &home, &id);
+    let status = child.wait()?;
+    let elapsed = started.elapsed();
+
+    assert!(status.success());
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "lock must be released after holder unwinds; observed {:?}",
+        elapsed
+    );
+    Ok(())
+}
+
+#[test]
+#[serial]
+fn test_cross_process_independent_profiles_do_not_serialise() -> Result<()> {
+    let temp = setup_temp_home();
+    let home = temp.path().to_path_buf();
+
+    let s_a = Storage::new("profile-a")?;
+    let s_b = Storage::new("profile-b")?;
+    s_a.update(|insts, _| {
+        insts.push(Instance::new("a-1", "/tmp/aoe-test-a"));
+        Ok(())
+    })?;
+    s_b.update(|insts, _| {
+        insts.push(Instance::new("b-1", "/tmp/aoe-test-b"));
+        Ok(())
+    })?;
+    let id_a = s_a.load()?[0].id.clone();
+    let id_b = s_b.load()?[0].id.clone();
+
+    let hold = std::time::Duration::from_millis(500);
+    let storage_clone = Storage::new("profile-a")?;
+    let started = std::time::Instant::now();
+    let parent_handle = std::thread::spawn(move || {
+        storage_clone
+            .update(|_, _| {
+                std::thread::sleep(hold);
+                Ok(())
+            })
+            .unwrap();
+    });
+
+    // Give the parent thread time to take the flock on profile-a.
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Cross-profile children must NOT be serialised by profile-a's flock.
+    let aoe = aoe_bin();
+    let mut cmd_b = std::process::Command::new(aoe);
+    cmd_b
+        .args(["session", "favorite", "--profile", "profile-b", &id_b])
+        .env("HOME", &home);
+    #[cfg(target_os = "linux")]
+    cmd_b.env("XDG_CONFIG_HOME", home.join(".config"));
+    let status = cmd_b
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()?;
+    let elapsed = started.elapsed();
+
+    parent_handle.join().unwrap();
+    assert!(status.success(), "profile-b favorite failed: {status:?}");
+    assert!(
+        elapsed < hold,
+        "profile-b must not block on profile-a's flock; observed {:?} >= {:?}",
+        elapsed,
+        hold
+    );
+    let _ = id_a;
+    Ok(())
+}

--- a/tests/integration/worktree_integration.rs
+++ b/tests/integration/worktree_integration.rs
@@ -106,7 +106,11 @@ fn test_worktree_info_persists_across_save_load() {
 
     let seeded = vec![instance.clone()];
     storage
-        .commit(&seeded, &GroupTree::new_with_groups(&seeded, &[]))
+        .update(|i, g| {
+            *i = seeded.to_vec();
+            *g = GroupTree::new_with_groups(&seeded, &[]).get_all_groups();
+            Ok(())
+        })
         .unwrap();
 
     let loaded = storage.load().unwrap();


### PR DESCRIPTION
## Description

Layer an advisory `fs2::FileExt` exclusive `flock` on top of the existing in-process per-profile `Mutex` so independent OS processes (TUI, daemon, one-shot CLI invocations) cannot lose each other's `sessions.json`, `groups.json`, or `workspace-ordering.json` updates. Also retire the wholesale-replace `Storage::commit` and `HomeView::save` paths and route every mutator through `Storage::update` with field-level merge under the flock.

Closes the cross-process gap explicitly left open in `storage.rs`'s module rustdoc and tracked as the follow-up to PR #1257 / issue #1175.

### What

- New private `StorageFlock` RAII guard + `acquire_storage_flock(dir, name)` helper. Polled `try_lock_exclusive` every 50ms with a 1s `tracing::warn` for a wedged peer (deliberate: `fs2` exposes no hook to instrument a true blocking acquire, so the poll is the observability hook). Mirrors `recovery::try_acquire_recovery_lock` and `logging.rs`'s rotation lock.

- Sidecar lock files, never deleted (existence is incidental; the lock is on the open file description):
  - `<profile_dir>/.storage.lock` covering `sessions.json` + `groups.json` as a pair.
  - `<app_dir>/.workspace-ordering.lock` covering the global ordering file.

- `Storage::update` and `update_workspace_ordering` acquire the in-process `Mutex` first, then the flock, then load → mutate → atomic_write. RAII drop order releases the flock before the mutex.

- New `Instance` field-merge helpers (`src/session/instance.rs`):
  - `merge_post_start(src)` for `start_session` / `aoe add --launch` phase-3: copies only `status` + `sandbox_info`.
  - `merge_post_restart(src, clear_stale_sid)` for `restart_session` / `restart_all_sessions`: same fields, plus `agent_session_id` when the resume-fallback cascade fired.
  - `merge_from_tui(src)` for `HomeView::save`: copies only fields where the TUI is the sole disk writer (`status`, `last_accessed_at` as `max`, `idle_entered_at`).

- New `cli::patch_instance(&mut [Instance], identifier, F)` helper next to `resolve_session`, designed to run inside `Storage::update`'s closure so find + mutate is atomic under both lock layers.

- New `HomeView::apply_user_action(id, mutation)` helper that runs the mutation twice (once on the in-memory mirror, once on the freshly-loaded disk row inside `storage.update`'s closure) so peer writes to OTHER fields on the same row survive. All TUI dialog handlers (archive, favorite, snooze, rename, group move, base_branch_override) flow through it.

- `HomeView::save` now uses `Storage::update` with a per-row field-merge plus a per-profile `pending_deletions: HashMap<String, HashSet<String>>` populated by `remove_instance` and drained per profile on Ok return.

- `apply_session_id_updates` writes via `persist_session_to_storage` per id (storage.update under the flock) instead of `self.save()`; the prior save was the sole persistence path for poller-detected sids and a wholesale clobber risk for daemon-written fields.

- Migrated every CLI mutator off the racy `load_with_groups → commit` pattern and `*stored = working` wholesale replace:
  - `src/cli/session.rs`: 12 sites (favorite, unfavorite, archive, unarchive, snooze, unsnooze, start, stop, restart, restart-all, rename, set-session-id), with field-level merge via the new helpers in start/restart phase 3.
  - `src/cli/add.rs`: 2 sites + duplicate re-check inside the closure + `cleanup_partial_session` extension that also deletes the just-created branch on partial-add cleanup.
  - `src/cli/remove.rs`: 1 site, with deletion side effects (worktree, branch, container teardown) kept outside the lock.
  - `src/cli/group.rs`: 3 sites.
  - `src/cli/worktree.rs`: 1 site.

- Slow operations (tmux start, `restart_with_size`, container delete, worktree delete, hook execution) are kept outside the closure via an explicit phase split: phase 1 reads/snapshots under the lock, phase 2 does the slow side effect unlocked, phase 3 merges by id with field-level helpers.

- `restart_all_sessions` was wholesale-commit at the end of a `JoinSet`; it now uses a single `update` after the join with field-level merge per worker (capturing `clear_stale_sid` so the resume-fallback path correctly invalidates the stale sid).

- **Deleted `Storage::commit` entirely.** Per AGENTS.md "no dead code". All ~80 in-tree and integration test callers migrated to `storage.update(|i, g| { *i = ...; *g = ...; Ok(()) })`. The wholesale-replace API surface no longer exists; `update` is the sole mutator.

### Why

The TUI and `aoe serve --daemon` are independent OS processes. Plus every `aoe session ...`, `aoe add`, `aoe remove`, `aoe group ...`, and `aoe worktree ...` invocation is a fresh OS process. The pre-existing in-process `OnceLock<Mutex<HashMap<...>>>` registry is per-process and provides zero cross-process exclusion. Concrete failure modes this PR closes:

- TUI commits HomeView while the daemon's session-id poller writes a freshly-captured `agent_session_id`; the TUI's commit silently overwrites the sid. **Closed**: HomeView::save now field-merges only TUI-sole-writer fields; agent_session_id is daemon-owned (`persist_session_to_storage`), and the TUI's `apply_session_id_updates` now writes via the same path instead of triggering a wholesale save.
- Two simultaneous `aoe session favorite` invocations: one wins, the other's favorite is silently lost. **Closed**: every CLI mutator now goes through `Storage::update` (load + mutate + write under the flock), and field-level merge means concurrent writes to different fields on the same row both land.
- `aoe add` while the daemon mutates: the new session can be wiped by the daemon's commit if it lands between add's load and add's commit. **Closed**: `aoe add` phase 3 re-checks duplicates inside the closure; cleanup_partial_session reverts the worktree (and branch on `--new-branch`) on the lose path.

The `recovery.rs` module already uses cross-process `flock` for the same reason (TUI + daemon racing on startup recovery). Storage mutations have the same class of race; this PR brings them under the same primitive AND closes the wholesale-replace clobber class on top.

### How I tested

- `cargo fmt --all` clean.
- `cargo clippy --all-targets --all-features` clean.
- `cargo test --lib`: 2014 / 2014 passing.
- `cargo test --test integration`: 120 / 120 passing (5 ignored as before).
- `cargo test --test integration storage`: 11 / 11 storage_concurrency tests passing (cross-process flock + per-field merge invariants).
- `cargo test --test integration --all-features` overall: 13 cockpit tests fail identically to `main` because they require an installed ACP shim adapter (per `AGENTS.md`); environmental, pre-existing, unrelated to this change.

New tests:

- `tests/integration/storage_concurrency.rs`:
  - `test_cross_process_no_lost_updates`: 8 child processes each favorite a distinct session; asserts all 8 favorites persist.
  - `test_cross_process_blocking_acquire`: parent thread holds the flock for 800 ms while a child is spawned; asserts the child's wall time exceeds 600 ms and the favorite lands after release.
  - `test_lock_released_on_panic_unwind`: in-process panic-unwind inside `update`; asserts subprocess can acquire after Drop runs.
  - `test_cross_process_lock_released_on_child_kill`: real `fork()` + SIGKILL covers the kernel close-on-process-death contract orthogonal to RAII drop.
  - `test_cross_process_independent_profiles_do_not_serialise`: per-profile flock isolation.
- `src/session/instance.rs::tests`: 7 unit tests on `merge_post_start`, `merge_post_restart`, `merge_from_tui` covering the field-set contract and the resume-fallback / max-timestamp / immutable-identity invariants.
- `src/tui/home/tests::save_field_merge`: 6 tests on HomeView's `save` and `apply_user_action` covering peer-field-write survival, peer-added-row preservation, explicit deletion propagation, pending_deletions drain semantic, and apply_user_action persistence.

### Out-of-scope notes

- Per `AGENTS.md` "Don't preserve backwards compatibility by default; call it out when a change is breaking": this is a breaking change in the public Rust library API surface (`Storage::commit` is removed), but no externally observable runtime behaviour regression. Externally observable storage behaviour is strictly stronger: contended writes now block on a kernel lock instead of racing, and field-level merge replaces wholesale clobber.
- Mixed-version overlap (an old pre-flock daemon running while a new TUI starts) keeps the pre-existing race for the duration of the upgrade window. Users running the daemon should `aoe serve --stop` before upgrading.
- NFS / SMB / Docker `9p` filesystems silently no-op `flock(2)` on some kernel/server combinations. Same implicit assumption as `recovery.rs` and `logging.rs`; AoE's app dir defaults to a per-user local path.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(Data-layer fix, no UI changes. Documentation updates: the `src/session/storage.rs` module rustdoc now describes the two-layer locking model and the field-merge invariant; the previous "cross-process out of scope" paragraph is removed.)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Centralizes and hardens session/workspace persistence by adding cross-process file locking and a single guarded update path. Replaces bulk commits with merge-aware, field-level updates and migrates callers (CLI, TUI, server, tests) to prevent races and lost updates.

## What changed (high level)
- Added cross-process advisory flocking (StorageFlock + acquire_storage_flock) with per-profile and workspace-ordering sidecar lock files.
- Replaced Storage::commit with a single Storage::update closure API; update acquires an in-process Mutex then the cross-process flock, performs load → mutate → atomic write, and returns closure results.
- Introduced Instance merge helpers to preserve concurrent changes: merge_post_start, merge_post_restart, merge_from_tui, merge_user_action_diff.
- Reworked CLI/TUI/server flows to do slow work outside locks and apply small, id/field-scoped merges under the lock.
- HomeView now tracks pending additions/deletions/tombstones and persists user actions via merge-aware updates; pending sets are drained on successful save.
- Migrated tests and fixtures to Storage::update and added unit and integration tests, including cross-process contention and recovery scenarios.
- Removed Storage::commit (breaking API change) and migrated all callers to Storage::update.

## Primary benefits
- Prevents lost updates and overwrite races between independent OS processes.
- Preserves concurrent peer writes via field-level merges instead of whole-object clobbering.
- Reduces lock hold time by moving long-running side effects outside critical sections.
- Improves observability by warning on prolonged lock contention.

## Potential areas for further improvement
- Document mixed-version upgrade guidance and provide runtime detection/compatibility measures for mixed deployments.
- Consider config knobs or backoff strategies for lock polling intervals and warning thresholds.
- Clarify semantics on network filesystems (NFS/SMB/9p) and add optional fallback strategies or diagnostics.

## Technical notes (concise)
- Locking: try_lock_exclusive polled every 50 ms; tracing::warn emitted after 1 s of contention. Sidecar lock files (.storage.lock, .workspace-ordering.lock) are created and intentionally left in place.
- Ordering: Storage::update acquires in-process Mutex → cross-process StorageFlock → load/mutate/atomic_write; RAII ensures the flock is released before the in-process Mutex.
- API: Storage::commit removed; Storage::update is the canonical persistence method and returns the closure's Result/R value.
- Merge semantics: new per-field merge helpers preserve peer fields, support stale-session-id handling, and enforce TUI vs user-action precedence where applicable.
- Tests: many tests re-seeded via Storage::update; new integration tests exercise cross-process locking, contention, panic/kill release, and profile-isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->