### PR TITLE
fix: let directory browser load more entries

### DIFF
--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -354,6 +354,7 @@ pub async fn list_profiles(State(state): State<Arc<AppState>>) -> Json<Vec<Profi
 pub struct BrowseQuery {
     pub path: String,
     pub limit: Option<usize>,
+    pub filter: Option<String>,
 }
 
 #[derive(Serialize)]
@@ -390,6 +391,7 @@ pub async fn browse_filesystem(
 ) -> impl IntoResponse {
     let result = tokio::task::spawn_blocking(move || {
         let limit = query.limit.unwrap_or(100);
+        let filter = query.filter.map(|f| f.trim().to_lowercase());
         let path = std::path::Path::new(&query.path);
         let canonical = path.canonicalize().map_err(|_| "Path does not exist")?;
 
@@ -416,6 +418,11 @@ pub async fn browse_filesystem(
             let is_dir = entry_path.is_dir();
             if !is_dir {
                 continue;
+            }
+            if let Some(filter) = filter.as_deref() {
+                if !filter.is_empty() && !name.to_lowercase().contains(filter) {
+                    continue;
+                }
             }
             let is_git_repo = entry_path.join(".git").exists();
             entries.push(DirEntry {

--- a/web/src/components/DirectoryBrowser.tsx
+++ b/web/src/components/DirectoryBrowser.tsx
@@ -4,6 +4,7 @@ import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import type { DirEntry } from "../lib/types";
 
 const LAST_DIR_KEY = "aoe-last-browse-dir";
+const BROWSE_PAGE_SIZE = 100;
 
 function loadLastDir(): string | null {
   return safeGetItem(LAST_DIR_KEY);
@@ -22,28 +23,88 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
   const [currentPath, setCurrentPath] = useState(initialPath || "");
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [hasMore, setHasMore] = useState(false);
+  const [entryLimit, setEntryLimit] = useState(BROWSE_PAGE_SIZE);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
   const initialized = useRef(false);
+  const loadSeq = useRef(0);
+  const loadedFilter = useRef("");
+  const filterDebounceHandle = useRef<number | null>(null);
 
-  const navigate = useCallback(async (path: string): Promise<boolean> => {
-    setLoading(true);
-    setError(null);
-    setFilter("");
-    const resp = await browseFilesystem(path, 100);
-    if (!resp.ok) {
-      setError("Can't access this folder. It may not exist or is outside the home directory.");
-      setLoading(false);
-      return false;
-    }
-    // Success: update state even if empty (empty dir is valid)
-    setEntries(resp.entries);
-    setHasMore(resp.has_more);
-    setCurrentPath(path);
-    setLoading(false);
-    return true;
+  const clearFilterDebounce = useCallback(() => {
+    if (filterDebounceHandle.current == null) return;
+    window.clearTimeout(filterDebounceHandle.current);
+    filterDebounceHandle.current = null;
   }, []);
+
+  const loadPath = useCallback(
+    async (
+      path: string,
+      limit: number,
+      options: { filter?: string; resetFilter?: boolean } = {},
+    ): Promise<boolean> => {
+      const seq = loadSeq.current + 1;
+      loadSeq.current = seq;
+      setLoading(true);
+      setError(null);
+      if (options.resetFilter) {
+        clearFilterDebounce();
+        loadedFilter.current = "";
+        setFilter("");
+      }
+      try {
+        const resp = await browseFilesystem(path, limit, options.filter);
+        if (seq !== loadSeq.current) return false;
+        if (!resp.ok) {
+          setError("Can't access this folder. It may not exist or is outside the home directory.");
+          return false;
+        }
+        // Success: update state even if empty (empty dir is valid)
+        setEntries(resp.entries);
+        setHasMore(resp.has_more);
+        setEntryLimit(limit);
+        setCurrentPath(path);
+        loadedFilter.current = options.filter ?? "";
+        return true;
+      } catch {
+        if (seq === loadSeq.current) {
+          setError("Can't access this folder. It may not exist or is outside the home directory.");
+        }
+        return false;
+      } finally {
+        if (seq === loadSeq.current) setLoading(false);
+      }
+    },
+    [clearFilterDebounce],
+  );
+
+  const navigate = useCallback(
+    async (path: string): Promise<boolean> =>
+      loadPath(path, BROWSE_PAGE_SIZE, { resetFilter: true }),
+    [loadPath],
+  );
+
+  const loadMore = useCallback(() => {
+    if (loading) return;
+    clearFilterDebounce();
+    void loadPath(currentPath, entryLimit + BROWSE_PAGE_SIZE, {
+      filter: filter.trim(),
+    });
+  }, [clearFilterDebounce, currentPath, entryLimit, filter, loadPath, loading]);
+
+  useEffect(() => {
+    if (!currentPath) return;
+    const nextFilter = filter.trim();
+    if (nextFilter === loadedFilter.current) return;
+    clearFilterDebounce();
+    filterDebounceHandle.current = window.setTimeout(() => {
+      filterDebounceHandle.current = null;
+      if (nextFilter === loadedFilter.current) return;
+      void loadPath(currentPath, BROWSE_PAGE_SIZE, { filter: nextFilter });
+    }, 150);
+    return clearFilterDebounce;
+  }, [clearFilterDebounce, currentPath, filter, loadPath]);
 
   // Discover and navigate to a starting dir on mount.
   // Priority: explicit initialPath -> last-used dir from localStorage -> home -> "/".
@@ -51,17 +112,13 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
     if (initialized.current) return;
     initialized.current = true;
 
-    if (initialPath) {
-      navigate(initialPath);
-      return;
-    }
-
-    (async () => {
+    queueMicrotask(async () => {
+      if (initialPath && (await navigate(initialPath))) return;
       const lastDir = loadLastDir();
       if (lastDir && (await navigate(lastDir))) return;
       const home = await getHomePath();
       await navigate(home || "/");
-    })();
+    });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const pathSegments = currentPath.split("/").filter(Boolean);
@@ -87,10 +144,6 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
       navigate(entry.path);
     }
   };
-
-  const filtered = filter
-    ? entries.filter((e) => e.name.toLowerCase().includes(filter.toLowerCase()))
-    : entries;
 
   // Breadcrumb truncation for mobile: show first + "..." + last 2
   const renderBreadcrumbs = () => {
@@ -191,7 +244,7 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
             )}
 
             {/* Empty state */}
-            {filtered.length === 0 && (
+            {entries.length === 0 && (
               <div className="px-4 py-6 text-center">
                 <p className="text-sm text-text-dim">
                   {filter ? "No folders match your filter" : "No visible subfolders here"}
@@ -205,7 +258,7 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
             )}
 
             {/* Directory entries */}
-            {filtered.map((entry) => (
+            {entries.map((entry) => (
               <button
                 key={entry.path}
                 onClick={() => handleEntryClick(entry)}
@@ -235,8 +288,18 @@ export function DirectoryBrowser({ initialPath, onSelect }: Props) {
             ))}
 
             {hasMore && (
-              <div className="px-3 py-2 text-center text-xs text-text-dim border-t border-surface-800">
-                Showing first 100 entries. Use the filter to narrow results.
+              <div className="px-3 py-3 text-center border-t border-surface-800">
+                <p className="text-xs text-text-dim mb-2">
+                  Showing first {entries.length} entries.
+                </p>
+                <button
+                  type="button"
+                  onClick={loadMore}
+                  disabled={loading}
+                  className="h-8 px-3 text-xs font-sans text-text-secondary border border-surface-700 rounded-md hover:bg-surface-700/40 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+                >
+                  Load {BROWSE_PAGE_SIZE} more
+                </button>
               </div>
             )}
           </>

--- a/web/src/components/__tests__/DirectoryBrowser.test.tsx
+++ b/web/src/components/__tests__/DirectoryBrowser.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import type { BrowseResponse } from "../../lib/types";
+
+const browseFilesystem = vi.fn();
+const getHomePath = vi.fn();
+
+vi.mock("../../lib/api", () => ({
+  browseFilesystem: (...args: unknown[]) => browseFilesystem(...args),
+  getHomePath: () => getHomePath(),
+}));
+
+import { DirectoryBrowser } from "../DirectoryBrowser";
+
+function response(entries: BrowseResponse["entries"]): BrowseResponse & { ok: boolean } {
+  return { entries, has_more: false, ok: true };
+}
+
+function dir(name: string, path = `/home/user/${name}`) {
+  return { name, path, is_dir: true, is_git_repo: false };
+}
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+  browseFilesystem.mockReset();
+  getHomePath.mockReset();
+});
+
+describe("DirectoryBrowser", () => {
+  it("falls back to home when the initial path cannot be loaded", async () => {
+    getHomePath.mockResolvedValue("/home/user");
+    browseFilesystem.mockImplementation(async (path: string) => {
+      if (path === "/missing") return { entries: [], has_more: false, ok: false };
+      return response([dir("project")]);
+    });
+
+    render(<DirectoryBrowser initialPath="/missing" onSelect={vi.fn()} />);
+
+    await expect(screen.findByRole("option", { name: /project/i })).resolves.toBeTruthy();
+    expect(browseFilesystem).toHaveBeenNthCalledWith(1, "/missing", 100, undefined);
+    expect(browseFilesystem).toHaveBeenNthCalledWith(2, "/home/user", 100, undefined);
+  });
+
+  it("ignores stale browse responses after a newer navigation finishes", async () => {
+    getHomePath.mockResolvedValue("/home/user");
+    let resolveSlow: ((value: BrowseResponse & { ok: boolean }) => void) | undefined;
+    browseFilesystem.mockImplementation((path: string) => {
+      if (path === "/home/user/slow") {
+        return new Promise<BrowseResponse & { ok: boolean }>((resolve) => {
+          resolveSlow = resolve;
+        });
+      }
+      return Promise.resolve(response([dir("slow", "/home/user/slow")]));
+    });
+
+    render(<DirectoryBrowser onSelect={vi.fn()} />);
+
+    await screen.findByRole("option", { name: /slow/i });
+    fireEvent.click(screen.getByRole("option", { name: /slow/i }));
+    fireEvent.click(screen.getByRole("button", { name: "user" }));
+
+    await waitFor(() => {
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, undefined);
+    });
+
+    expect(resolveSlow).toBeDefined();
+    resolveSlow!(response([dir("stale-child", "/home/user/slow/stale-child")]));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("option", { name: /stale-child/i })).toBeNull();
+      expect(screen.getByRole("option", { name: /slow/i })).toBeTruthy();
+    });
+  });
+
+  it("requests filtered results from the server so entries past the first page can be found", async () => {
+    getHomePath.mockResolvedValue("/home/user");
+    const firstPage = Array.from({ length: 100 }, (_, i) => dir(`project-${i + 1}`));
+    browseFilesystem.mockImplementation(async (_path: string, _limit: number, filter?: string) => {
+      if (filter === "z") return response([dir("z-project")]);
+      return { entries: firstPage, has_more: true, ok: true };
+    });
+
+    render(<DirectoryBrowser onSelect={vi.fn()} />);
+
+    await screen.findByRole("option", { name: "project-1" });
+    expect(screen.queryByRole("option", { name: /z-project/i })).toBeNull();
+
+    fireEvent.change(screen.getByPlaceholderText("Type to filter..."), {
+      target: { value: "z" },
+    });
+
+    await waitFor(() => {
+      expect(browseFilesystem).toHaveBeenCalledWith("/home/user", 100, "z");
+    });
+    await expect(screen.findByRole("option", { name: /z-project/i })).resolves.toBeTruthy();
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -506,9 +506,11 @@ export async function getHomePath(): Promise<string | null> {
 export async function browseFilesystem(
   path: string,
   limit?: number,
+  filter?: string,
 ): Promise<BrowseResponse & { ok: boolean }> {
   const params = new URLSearchParams({ path });
   if (limit != null) params.set("limit", String(limit));
+  if (filter) params.set("filter", filter);
   const data = await fetchJson<BrowseResponse>(`/api/filesystem/browse?${params}`);
   if (!data) return { entries: [], has_more: false, ok: false };
   return { ...data, ok: true };

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -167,6 +167,7 @@
         "tests/wizard-custom-agent.spec.ts"
       ],
       "components": [
+        "web/src/components/DirectoryBrowser.tsx",
         "web/src/components/session-wizard/SessionWizard.tsx",
         "web/src/components/session-wizard/StepIndicator.tsx",
         "web/src/components/session-wizard/steps/AgentStep.tsx",

--- a/web/tests/wizard-project-step.spec.ts
+++ b/web/tests/wizard-project-step.spec.ts
@@ -141,6 +141,102 @@ test.describe("Wizard project step (#1219)", () => {
     await expect(page.getByText("/home/user/my-repo", { exact: false })).toBeVisible();
   });
 
+  test("Browse tab can load entries beyond the first page", async ({ page }) => {
+    await mockBaseApis(page);
+    await page.route("**/api/sessions", (r) =>
+      r.fulfill({ json: { sessions: [], workspace_ordering: [] } }),
+    );
+    const entries = Array.from({ length: 125 }, (_, i) => {
+      const n = String(i + 1).padStart(3, "0");
+      return {
+        name: `project-${n}`,
+        path: `/home/user/project-${n}`,
+        is_dir: true,
+        is_git_repo: i === 124,
+      };
+    });
+    await page.route("**/api/filesystem/browse**", (r) => {
+      const limit = Number(new URL(r.request().url()).searchParams.get("limit") ?? "100");
+      r.fulfill({
+        json: {
+          entries: entries.slice(0, limit),
+          has_more: entries.length > limit,
+        },
+      });
+    });
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openWizard(page);
+
+    await expect(page.getByRole("option").filter({ hasText: "project-001" })).toBeVisible();
+    await expect(page.getByRole("option").filter({ hasText: "project-125" })).toHaveCount(0);
+    await expect(page.getByText("Showing first 100 entries.")).toBeVisible();
+
+    await page.getByRole("button", { name: "Load 100 more" }).click();
+
+    const finalEntry = page.getByRole("option").filter({ hasText: "project-125" });
+    await expect(finalEntry).toBeVisible();
+    await expect(page.getByText("Load 100 more")).toHaveCount(0);
+    await finalEntry.click();
+    await expect(page.getByText("Selected project")).toBeVisible();
+    await expect(page.getByText("/home/user/project-125", { exact: false })).toBeVisible();
+  });
+
+  test("Browse tab filters entries beyond the first page on the server", async ({ page }) => {
+    await mockBaseApis(page);
+    await page.route("**/api/sessions", (r) =>
+      r.fulfill({ json: { sessions: [], workspace_ordering: [] } }),
+    );
+    const entries = [
+      ...Array.from({ length: 124 }, (_, i) => {
+        const n = String(i + 1).padStart(3, "0");
+        return {
+          name: `project-${n}`,
+          path: `/home/user/project-${n}`,
+          is_dir: true,
+          is_git_repo: false,
+        };
+      }),
+      {
+        name: "z-project",
+        path: "/home/user/z-project",
+        is_dir: true,
+        is_git_repo: true,
+      },
+    ];
+    await page.route("**/api/filesystem/browse**", (r) => {
+      const params = new URL(r.request().url()).searchParams;
+      const limit = Number(params.get("limit") ?? "100");
+      const filter = params.get("filter")?.toLowerCase() ?? "";
+      const filtered = filter
+        ? entries.filter((e) => e.name.toLowerCase().includes(filter))
+        : entries;
+      r.fulfill({
+        json: {
+          entries: filtered.slice(0, limit),
+          has_more: filtered.length > limit,
+        },
+      });
+    });
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/");
+    await openWizard(page);
+
+    await expect(page.getByRole("option").filter({ hasText: "project-001" })).toBeVisible();
+    await expect(page.getByRole("option").filter({ hasText: "z-project" })).toHaveCount(0);
+
+    await page.getByPlaceholder("Type to filter...").fill("z");
+
+    const zProject = page.getByRole("option").filter({ hasText: "z-project" });
+    await expect(zProject).toBeVisible();
+    await expect(page.getByRole("button", { name: "Load 100 more" })).toHaveCount(0);
+    await zProject.click();
+    await expect(page.getByText("Selected project")).toBeVisible();
+    await expect(page.getByText("/home/user/z-project", { exact: false })).toBeVisible();
+  });
+
   test("Clone tab: clone button disabled until URL non-empty", async ({ page }) => {
     await mockBaseApis(page);
     await page.route("**/api/sessions", (r) =>


### PR DESCRIPTION
## Description
Fixes the web directory browser's hard 100-entry ceiling by adding an explicit "Load 100 more" control when the filesystem browse API reports more entries.

Previously, directories with more than 100 visible subfolders showed "Showing first 100 entries. Use the filter to narrow results.", but filtering only searched the already-loaded first page. Entries after the first 100 could not be selected from the web UI.

The browser now:
- loads the first 100 entries as before
- shows the current loaded count when more entries exist
- lets users request the next page by increasing the browse limit
- keeps navigation resets at the first page for each new directory

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate a focused web directory-browser pagination fix.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npx eslint src/components/DirectoryBrowser.tsx tests/wizard-project-step.spec.ts`
- `npx playwright test wizard-project-step.spec.ts`
- `npm run build`
- `node tests/validate-coverage-matrix.mjs`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Removes the web directory browser's hard 100-entry ceiling by adding explicit paging and server-side filtering so users can find and select entries beyond the first page.

## What changed (high level)

- The directory browser still loads the first page initially, and now shows how many entries are loaded with a "Load 100 more" control to fetch additional pages.
- Filtering is performed server-side so search queries can match entries not yet loaded on the client.
- Navigation initialization improved: tries initialPath → last-used directory → home.
- Async navigation is hardened so slow/stale responses can't overwrite newer results, and loading/errors no longer leave the UI stuck.
- Tests added/updated (unit and Playwright) and coverage updated for DirectoryBrowser.

## What moved / was added / was removed

- Added BROWSE_PAGE_SIZE constant and entryLimit state; replaced hard-coded "100" with the constant.
- Replaced single-page fetch logic with a new loadPath(path, limit, options) loader that manages entries, hasMore, loading, error, and filter state.
- Added loadMore() to increase the loaded limit and request the next page.
- Debounce/filter logic refined to avoid regressions when loading more pages and to prevent unnecessary reloads.
- Server: browse API accepts an optional filter and applies case-insensitive substring matching.
- Client API: browseFilesystem signature extended to accept an optional filter parameter.
- Unit and Playwright tests added to cover pagination, server-filtered search, stale-response handling, and startup fallback behavior.
- No breaking changes to exported component signatures.

## Technical notes

- Uses a numeric loadSeq token to ignore out-of-order async responses; setLoading(false) is called only for the latest request.
- Mount initialization uses a microtask sequence to select the first available path (initial → last-used → home).
- Filter is trimmed/lowercased before sending to the server; server-side filtering skips entries that don't contain the normalized filter substring.
- Debounce race conditions addressed with a clearable debounce handle and checks that the requested filter differs from the currently loaded filter.

## Benefits

- Users can load and select directories beyond the previous 100-entry limit without client-side workarounds.
- Searches can find matches anywhere in a large directory without loading all pages.
- Clearer UI feedback about loaded entries and more reliable navigation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->