### PR TITLE
fix(web): bump @assistant-ui to pick up tap out-of-bounds fix

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -8,8 +8,8 @@
       "name": "web",
       "version": "0.0.0",
       "dependencies": {
-        "@assistant-ui/react": "^0.12.28",
-        "@assistant-ui/react-markdown": "^0.12.11",
+        "@assistant-ui/react": "^0.14.7",
+        "@assistant-ui/react-markdown": "^0.14.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
@@ -108,19 +108,19 @@
       "license": "MIT"
     },
     "node_modules/@assistant-ui/core": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.1.17.tgz",
-      "integrity": "sha512-IWIP98UVQ9W+oF0yz8XqFRtaX8HtozWVUWt6D/BSV6cyKwLfJ8niHtLG74bSnllTnGcreU2El3GR/tIodR1XuA==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ct3FyWfo5iIA6y0AXg41oLGRJRGTY4Z8UcYnimQZPyRfpsxI0QggjfGzL/MploSJuOb4p+jE3XZIg2wB6p1rjw==",
       "license": "MIT",
       "dependencies": {
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9"
+        "assistant-stream": "^0.3.15",
+        "nanoid": "^5.1.11"
       },
       "peerDependencies": {
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
+        "@assistant-ui/store": "^0.2.11",
+        "@assistant-ui/tap": "^0.5.11",
         "@types/react": "*",
-        "assistant-cloud": "^0.1.27",
+        "assistant-cloud": "^0.1.28",
         "react": "^18 || ^19",
         "zustand": "^5.0.11"
       },
@@ -140,27 +140,28 @@
       }
     },
     "node_modules/@assistant-ui/react": {
-      "version": "0.12.28",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.12.28.tgz",
-      "integrity": "sha512-czjpexLK1lKnNDNM1YMJi8SufeKUWBICqiVUtiHMV+86PYGCwJykOZKkchI8MVbSQ62xZ8A1LfPO5W2IDjed3A==",
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react/-/react-0.14.7.tgz",
+      "integrity": "sha512-GiEF4tYyU9uuBxUhGxy65kw54mtHS/L5zC6PyJpVUUFyGTjzprTqaFGZLhQuVFwJWqqGIzuHotYrfKZRgU9cCQ==",
       "license": "MIT",
       "dependencies": {
-        "@assistant-ui/core": "^0.1.17",
-        "@assistant-ui/store": "^0.2.9",
-        "@assistant-ui/tap": "^0.5.10",
+        "@assistant-ui/core": "^0.2.4",
+        "@assistant-ui/store": "^0.2.11",
+        "@assistant-ui/tap": "^0.5.11",
         "@radix-ui/primitive": "^1.1.3",
         "@radix-ui/react-compose-refs": "^1.1.2",
         "@radix-ui/react-context": "^1.1.3",
         "@radix-ui/react-primitive": "^2.1.4",
         "@radix-ui/react-use-callback-ref": "^1.1.1",
         "@radix-ui/react-use-escape-keydown": "^1.1.1",
-        "assistant-cloud": "^0.1.27",
-        "assistant-stream": "^0.3.12",
-        "nanoid": "^5.1.9",
+        "assistant-cloud": "^0.1.28",
+        "assistant-stream": "^0.3.15",
+        "nanoid": "^5.1.11",
         "radix-ui": "^1.4.3",
         "react-textarea-autosize": "^8.5.9",
-        "zod": "^4.3.6",
-        "zustand": "^5.0.12"
+        "safe-content-frame": "^0.0.19",
+        "zod": "^4.4.3",
+        "zustand": "^5.0.13"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -178,9 +179,9 @@
       }
     },
     "node_modules/@assistant-ui/react-markdown": {
-      "version": "0.12.11",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.12.11.tgz",
-      "integrity": "sha512-gYu4XVI2lX3lp9UG7V5VWP1+eO7SZomiBKsAZOKUOeuwn/hoL+J0vFY52FUgJixdF2R8NPPto2lb98DmJE70lA==",
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/react-markdown/-/react-markdown-0.14.0.tgz",
+      "integrity": "sha512-G29cz4UHnQFyxTXCHsloMfyqHSuKSiPhkaAa069tWdf/Px3ZKCyhcP0TENCnsjqsw2iTFMVm8/Nqa0d5OwsdYw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "^2.1.4",
@@ -189,7 +190,7 @@
         "react-markdown": "^10.1.0"
       },
       "peerDependencies": {
-        "@assistant-ui/react": "^0.12.26",
+        "@assistant-ui/react": "^0.14.0",
         "@types/react": "*",
         "react": "^18 || ^19"
       },
@@ -200,9 +201,9 @@
       }
     },
     "node_modules/@assistant-ui/store": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.10.tgz",
-      "integrity": "sha512-cgbSFIv0Ovu6yls4GQy7brLVx6qwUyLTf1Ki/lkj3UFJrO6oktxstosWvQBwk5mNgH6t3DOIrGSBDJSKRfCW5Q==",
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@assistant-ui/store/-/store-0.2.11.tgz",
+      "integrity": "sha512-thImx0rsaBiiDG00qaXcNlvo1SLQse19rFoVra7xCfWrj91FGVGbwwMV5h4/h6ifbMx+BcbUUgzLIf8BJBKGdQ==",
       "license": "MIT",
       "dependencies": {
         "use-effect-event": "^2.0.3"
@@ -1115,9 +1116,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1136,9 +1134,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1157,9 +1152,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1178,9 +1170,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1199,9 +1188,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1220,9 +1206,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1241,9 +1224,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1262,9 +1242,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1283,9 +1260,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1310,9 +1284,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1337,9 +1308,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1364,9 +1332,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1391,9 +1356,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1418,9 +1380,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1445,9 +1404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1472,9 +1428,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1919,9 +1872,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1940,9 +1890,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1961,9 +1908,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1982,9 +1926,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5715,9 +5656,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5733,9 +5671,6 @@
       "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5753,9 +5688,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5771,9 +5703,6 @@
       "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5791,9 +5720,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5809,9 +5735,6 @@
       "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6135,9 +6058,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6153,9 +6073,6 @@
       "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6173,9 +6090,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6191,9 +6105,6 @@
       "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7109,18 +7020,18 @@
       }
     },
     "node_modules/assistant-cloud": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.27.tgz",
-      "integrity": "sha512-BGfVnx7YFN5xtB/kbrgGxRI0TfSWq4yxB3MwYn6RDPlv4JvdtPupvDC1Y6An0EhAe42Z0AYtSmDSsR6p6eeBng==",
+      "version": "0.1.28",
+      "resolved": "https://registry.npmjs.org/assistant-cloud/-/assistant-cloud-0.1.28.tgz",
+      "integrity": "sha512-6cn+TPFRLwLyi5P/cOfyEtIGG2lfFy26VAJ+Rk+1pni3LTunDzBuLKpwoxMxNCFB4GhqBfAlzTiay7QI2qsJfw==",
       "license": "MIT",
       "dependencies": {
-        "assistant-stream": "^0.3.12"
+        "assistant-stream": "^0.3.15"
       }
     },
     "node_modules/assistant-stream": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.14.tgz",
-      "integrity": "sha512-LWJt+6cjukoEKaN3LHwx40QbnODnoMmGCPkF4Tjg3fwTjgUTWsYnNJ5H2dnRmJFbxVgKTNMdJHjkCIOSemE2tg==",
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/assistant-stream/-/assistant-stream-0.3.15.tgz",
+      "integrity": "sha512-gVFIhJ8FyITMd7RU11EckNEXJOocjohNB0XltcWNbKeWmTEKKaF62dkhKwXWjEJdvHtp29XaEjusiey/LCi7Bg==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
@@ -8902,9 +8813,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8924,9 +8832,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -8948,9 +8853,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8970,9 +8872,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -11069,6 +10968,12 @@
       "version": "1.0.0-rc.12",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
       "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
+      "license": "MIT"
+    },
+    "node_modules/safe-content-frame": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/safe-content-frame/-/safe-content-frame-0.0.19.tgz",
+      "integrity": "sha512-+R0IHHjvghT5O8bc8itf9AoS9MvzhUcD0p+hNINLgyEuFQJug3wt3ZuhLFZFG3bUzHi8UfQED4p6J3/Ft9oCtg==",
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/web/package.json
+++ b/web/package.json
@@ -15,8 +15,8 @@
     "coverage:all": "rm -rf coverage && AOE_COVERAGE=1 npm run test:unit -- --coverage && AOE_COVERAGE=1 npx playwright test && npm run coverage:merge"
   },
   "dependencies": {
-    "@assistant-ui/react": "^0.12.28",
-    "@assistant-ui/react-markdown": "^0.12.11",
+    "@assistant-ui/react": "^0.14.7",
+    "@assistant-ui/react-markdown": "^0.14.0",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Picks up the upstream fix for the `tapClientLookup: Index N out of bounds (length: N)` crash that occasionally blanked the cockpit (#1119).

Bumps:

- `@assistant-ui/react` `^0.12.28` → `^0.14.7`
- `@assistant-ui/react-markdown` `^0.12.11` → `^0.14.0`

The matching transitives lift to `@assistant-ui/core@0.2.4`, `@assistant-ui/store@0.2.11`, `@assistant-ui/tap@0.5.11`.

Upstream landed two PRs to close the zombie-fiber pattern behind the crash:

- assistant-ui/assistant-ui#4069: derived scopes re-keying on meta change (closed the actual throw path).
- assistant-ui/assistant-ui#4077: keyed part fibers by absolute index (closed the underlying reuse-across-reshape pattern).

Upstream tracking issue `assistant-ui/assistant-ui#4051` (filed from #1119) was closed with both PRs in.

No AoE-side code changes were needed: `tsc -b` clean, the full vitest suite passes (777/777), `vite build` succeeds.

Closes #1119

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [ ] Open the cockpit on a session with a long assistant message containing many parts (text + tools + reasoning), switch to another session in the sidebar, then switch back. Cockpit renders without throwing `tapClientLookup: Index N out of bounds` and without going blank.
- [ ] Repeat the switch a few times on a subagent-heavy session (the original repro from #1119, session `d6dcb681bbf649d5` shape). No blank screen, no console error.
- [ ] Trigger a WS reconnect during an active turn (kill the daemon, let it come back). Replayed events apply without the out-of-bounds throw.
- [ ] Normal cockpit flows still work end-to-end: send a prompt, watch tool cards render, approve / reject an approval, `/clear`, `/compact`.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and prose drafted by Claude under my direction. The actual change is two version strings plus the regenerated lockfile; I made the version-pick decisions and verified the build / tests pass locally.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request updates the `@assistant-ui` library dependencies to versions that include an upstream fix for an intermittent cockpit crash. The crash manifested as a blank screen with a "tapClientLookup: Index out of bounds" error in the browser console, caused by a race condition in the subscriber bookkeeping logic of the `@assistant-ui/tap` module.

## What Changed

**Dependencies Updated:**
- `@assistant-ui/react`: bumped from `^0.12.28` to `^0.14.7`
- `@assistant-ui/react-markdown`: bumped from `^0.12.11` to `^0.14.0`

These changes pull in transitive updates to `@assistant-ui/core@0.2.4`, `@assistant-ui/store@0.2.11`, and `@assistant-ui/tap@0.5.11` from upstream.

**No application code changes.** Only `web/package.json` was modified (2 lines added, 2 removed).

## Benefits

- **Fixes intermittent crash:** Resolves a race condition in subscriber management that could blank the cockpit during rapid message rebuilds, session switches, or WebSocket reconnections.
- **Zero risk upgrade:** No application code changes required; the fix is purely upstream dependency upgrades.
- **Validated:** All tests pass (777/777), TypeScript compilation is clean, and the build succeeds.

## Technical Details

The upstream fix addresses the derived-scope rekeying and keyed fiber tracking in `@assistant-ui/tap`'s `notifySubscribers` function, which was iterating over a subscriber list that could change (due to unsubscribes or resets during notification), resulting in out-of-bounds index access. The upstream pull requests (assistant-ui/assistant-ui#4069 and `#4077`) contain the detailed fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->