### PR TITLE
feat(cockpit): align with claude-agent-acp v0.37.0 (pin, version check, memory_recall, native cancelled)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "reqwest",
  "rusqlite",
  "rust-embed",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,9 @@ getrandom = { version = "0.4", optional = true }
 agent-client-protocol = { version = "0.11", optional = true, features = ["unstable_session_usage"] }
 agent-client-protocol-tokio = { version = "0.11", optional = true }
 
+# Semver parsing for ACP adapter compatibility checks (see src/cockpit/agent_compat.rs).
+semver = { version = "1", optional = true }
+
 # Node tarball download + extraction for the cockpit's bundled-Node
 # fallback. xz2 needs the system liblzma; we use it for tar.xz
 # extraction. The `tar` crate handles the tarball stream. Hex used
@@ -179,6 +182,7 @@ serve = [
     # under src/cockpit/).
     "agent-client-protocol",
     "agent-client-protocol-tokio",
+    "semver",
     "tar",
     "xz2",
     "tokio-tungstenite",

--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -42,6 +42,10 @@ class ShimAgent {
       agentCapabilities: {
         loadSession: false,
       },
+      agentInfo: {
+        name: "@agentclientprotocol/claude-agent-acp",
+        version: "0.37.0",
+      },
     };
   }
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@0.37.0 \
+    @agentclientprotocol/claude-agent-acp@^0.37.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp \
+    @agentclientprotocol/claude-agent-acp@0.37.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -33,7 +33,7 @@ The wizard greys out the cockpit option for tools not in this set.
 
 | aoe tool   | Substrate B (cockpit)                                      | Auth                                   |
 |------------|------------------------------------------------------------|----------------------------------------|
-| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK)        | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
+| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK, requires >=0.37.0) | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
 | `opencode` | `opencode acp` (native, SST)                               | `OPENCODE_API_KEY` env var; or provider-specific env (set up via `opencode auth`) |
 | `gemini`   | `gemini --acp` (native, Google)                            | `GEMINI_API_KEY` env var, OAuth via `gemini auth`, or Vertex `GOOGLE_API_KEY` |
 | `codex`    | `codex-acp` (Zed adapter, npm `@zed-industries/codex-acp`) | `OPENAI_API_KEY` env var, or ChatGPT login (local-only) |
@@ -635,13 +635,35 @@ manager (e.g., `brew reinstall aoe`).
 
 ### `aoe cockpit doctor` says claude-code adapter is missing
 
-Install the official adapter once:
+Install the official adapter once. aoe requires v0.37.0 or newer; the
+cockpit refuses to enter a session with an older adapter and surfaces a
+dedicated remediation screen with the exact install command:
 
 ```bash
-npm install -g @agentclientprotocol/claude-agent-acp
+npm install -g @agentclientprotocol/claude-agent-acp@0.37.0
 ```
 
 Then run `claude login` if you haven't already.
+
+The minimum version is enforced at the ACP `initialize` handshake; the
+check reads `agent_info.version` from the adapter's initialize response
+and rejects anything below 0.37.0 with a structured `StartupError`
+event. Newer versions are accepted. The minimum exists because aoe
+relies on behavior that only landed in v0.37.0:
+
+- `memory_recall` tool calls (upstream
+  agentclientprotocol/claude-agent-acp#703), so session-start memory
+  loads render in the cockpit instead of disappearing into a dropped
+  SDK event.
+- Native `stopReason: "cancelled"` (upstream
+  agentclientprotocol/claude-agent-acp#694), so cancel acknowledgement
+  surfaces as a distinct turn outcome rather than collapsing into
+  `end_turn`.
+
+If you have an older version pinned by an internal mirror, set up the
+mirror to ship 0.37.0 or override the global install with
+`npm install -g @agentclientprotocol/claude-agent-acp@latest` before
+starting `aoe serve`.
 
 ### "Failed to start cockpit agent" while the adapter is installed
 

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -9,7 +9,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter) | `npm install -g @agentclientprotocol/claude-agent-acp` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.37.0) | `npm install -g @agentclientprotocol/claude-agent-acp@0.37.0` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -132,7 +132,7 @@ Example: `aoe-sandbox-a1b2c3d4`
 
 Cockpit-mode sessions can run inside the sandbox container. When both are enabled, the cockpit runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters for this:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@0.37.0`, pinned)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.37.0`, floor pin)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -132,7 +132,7 @@ Example: `aoe-sandbox-a1b2c3d4`
 
 Cockpit-mode sessions can run inside the sandbox container. When both are enabled, the cockpit runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters for this:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp`)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@0.37.0`, pinned)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -191,7 +191,10 @@ struct AgentDoctorEntry {
 /// The doctor's `--fix` path runs `npm install -g <package>` for each
 /// entry whose binary isn't already on PATH.
 const NPM_INSTALLABLE_ACP: &[(&str, &str)] = &[
-    ("claude-agent-acp", "@agentclientprotocol/claude-agent-acp"),
+    (
+        "claude-agent-acp",
+        "@agentclientprotocol/claude-agent-acp@0.37.0",
+    ),
     ("codex-acp", "@zed-industries/codex-acp"),
     ("pi-acp", "pi-acp"),
 ];

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -827,6 +827,7 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::Stopped { .. } => "stopped",
         Event::AgentStartupError { .. } => "agent_startup_error",
+        Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -33,6 +33,7 @@ use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use tracing::{debug, error, info, trace, warn};
 
+use super::agent_compat::{self, ExpectedAgent};
 use super::agent_profiles;
 use super::agent_registry::AgentSpec;
 use super::approvals::{is_destructive, ApprovalDecision, Nonce};
@@ -40,7 +41,8 @@ use super::fs_handler::{self, FsPolicy, SandboxPathMap};
 use super::permissions::build_approval;
 use super::state::{
     AvailableCommand, CockpitSessionId, DiffPreview, Event, ModeInfo, Plan, PlanStep,
-    PlanStepStatus, RateLimitInfo, SessionMode, SessionUsage, ToolCall, UsageCost,
+    PlanStepStatus, RateLimitInfo, SessionMode, SessionUsage, StartupErrorDetail, ToolCall,
+    UsageCost,
 };
 use super::terminal_handler::TerminalManager;
 use crate::session::SandboxInfo;
@@ -760,6 +762,7 @@ impl AcpClient {
         let session_label = session_id.0.clone();
         let child_for_task = child.clone();
         let pending_for_task = pending_responders.clone();
+        let expected_agent = ExpectedAgent::from_command(&install_binary);
 
         // Allowed fs roots: cwd + any explicit additional directories.
         let mut roots = vec![cwd.clone()];
@@ -794,6 +797,7 @@ impl AcpClient {
             mode,
             Some(ready_tx),
             profile,
+            expected_agent,
             source_profile,
         ));
 
@@ -858,6 +862,7 @@ impl AcpClient {
 
         let session_label = session_id.0.clone();
         let pending_for_task = pending_responders.clone();
+        let expected_agent = ExpectedAgent::from_command(&install_binary);
 
         let (ready_tx, ready_rx) = oneshot::channel::<Result<(), AcpError>>();
 
@@ -874,6 +879,7 @@ impl AcpClient {
             mode,
             Some(ready_tx),
             profile,
+            expected_agent,
             source_profile,
         ));
 
@@ -2369,6 +2375,7 @@ async fn run_connection_task<W, R>(
     mode: ConnectMode,
     ready_tx: Option<oneshot::Sender<Result<(), AcpError>>>,
     profile: &'static agent_profiles::AgentProfile,
+    expected_agent: ExpectedAgent,
     source_profile: Option<String>,
 ) where
     W: futures_util::AsyncWrite + Send + 'static,
@@ -2607,6 +2614,39 @@ async fn run_connection_task<W, R>(
                 )
                 .block_task()
                 .await?;
+
+            // Per-adapter compatibility check (see src/cockpit/agent_compat.rs).
+            // Currently only gates claude-agent-acp at >=0.37.0; other
+            // adapters pass through. On rejection: emit a structured
+            // IncompatibleAgent event for the dedicated startup-error UI,
+            // plus a parallel AgentStartupError message so the legacy
+            // status-derivation paths still flip the session into Error
+            // state. Then signal ready_tx with the failure so the
+            // supervisor surfaces a typed error to the caller and kills
+            // the child (handled by the outer Drop path).
+            if let Err(err) = agent_compat::validate(expected_agent, &init) {
+                let user_message = err.user_message();
+                warn!(
+                    target: "cockpit.acp",
+                    session = %session_label,
+                    kind = err.kind(),
+                    message = %user_message,
+                    "agent compatibility check failed; refusing to enter session"
+                );
+                let detail = StartupErrorDetail::from(&err);
+                let _ = event_tx_for_block
+                    .send(Event::IncompatibleAgent { detail })
+                    .await;
+                let _ = event_tx_for_block
+                    .send(Event::AgentStartupError {
+                        message: user_message.clone(),
+                    })
+                    .await;
+                if let Some(tx) = ready_for_block.lock().await.take() {
+                    let _ = tx.send(Err(AcpError::Spawn(user_message)));
+                }
+                return Ok(());
+            }
 
             let load_session_capable = init.agent_capabilities.load_session;
             // Snapshot the watchdog-arming flag before `mode` is moved

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -23,9 +23,9 @@ use agent_client_protocol::schema::{
     PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionId,
-    SessionNotification, SessionUpdate, SetSessionModeRequest, TerminalId, TerminalOutputRequest,
-    TerminalOutputResponse, TextContent, WaitForTerminalExitRequest, WaitForTerminalExitResponse,
-    WriteTextFileRequest, WriteTextFileResponse,
+    SessionNotification, SessionUpdate, SetSessionModeRequest, StopReason, TerminalId,
+    TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
+    WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
 use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, Responder};
 use thiserror::Error;
@@ -249,7 +249,17 @@ const RESUME_IDLE_GRACE_DEFAULT: std::time::Duration = std::time::Duration::from
 /// long enough for claude-agent-acp to resolve a real cancel through
 /// the SDK message boundary but short enough that a user who clicked
 /// "Force end turn" isn't watching a frozen UI for 30s while the
-/// daemon waits. See #1196.
+/// daemon waits.
+///
+/// claude-agent-acp >=0.37.0 (upstream #694) now resolves cancel by
+/// returning `PromptResponse { stop_reason: StopReason::Cancelled }`
+/// promptly; in that path the watchdog never fires and the terminal
+/// Stopped reason is `cancelled` (set by `prompt_cancelled` in the
+/// prompt loop) instead of `agent_unresponsive`. The 10s watchdog
+/// stays as a transport-wedge defense: native cancel only protects
+/// against the adapter ignoring the signal, not against socket /
+/// stdout / process-level wedges that prevent the PromptResponse from
+/// reaching the daemon at all. See #1196.
 const CANCEL_ESCALATION_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
 
 /// Vendor-agnostic silent-orphan grace fallback used when no config
@@ -3019,6 +3029,19 @@ async fn run_connection_task<W, R>(
                         // follow-up prompt is silently dropped. See #1196.
                         let mut agent_unresponsive = false;
                         let mut rate_limited = false;
+                        // True when the adapter resolves the in-flight
+                        // session/prompt with `StopReason::Cancelled`,
+                        // i.e. the user cancelled and the adapter
+                        // acknowledged cleanly. claude-agent-acp >=0.37.0
+                        // emits this natively per upstream #694; older
+                        // adapters surfaced cancellation as `EndTurn` so
+                        // the cancel-escalation watchdog was aoe's only
+                        // signal. The 10s watchdog still runs as a
+                        // transport-wedge defense; this flag only
+                        // affects the terminal Stopped reason string so
+                        // the reducer can distinguish a user-driven
+                        // stop from a clean turn completion.
+                        let mut prompt_cancelled = false;
                         let mut cancelling = false;
                         let cancel_grace = tokio::time::sleep(CANCEL_ESCALATION_GRACE);
                         tokio::pin!(cancel_grace);
@@ -3027,7 +3050,23 @@ async fn run_connection_task<W, R>(
                             tokio::select! {
                                 res = &mut prompt_fut, if !simulate_orphan => {
                                     match res {
-                                        Ok(_) => {}
+                                        Ok(resp) => {
+                                            // Capture the native stop reason so
+                                            // the terminal emission downstream
+                                            // can distinguish a cancelled turn
+                                            // (StopReason::Cancelled, claude-agent-acp
+                                            // >=0.37.0 per upstream #694) from a
+                                            // clean turn completion. EndTurn /
+                                            // MaxTokens / MaxTurnRequests / Refusal
+                                            // all collapse to `prompt_complete`
+                                            // for compatibility with the existing
+                                            // reducer; we only surface
+                                            // `cancelled` because it has a
+                                            // distinct UI implication.
+                                            if matches!(resp.stop_reason, StopReason::Cancelled) {
+                                                prompt_cancelled = true;
+                                            }
+                                        }
                                         Err(e) => {
                                             // Rate-limit on session/prompt is not
                                             // a worker crash. Emit a typed
@@ -3374,6 +3413,14 @@ async fn run_connection_task<W, R>(
                             "agent_unresponsive"
                         } else if shutdown {
                             "shutdown"
+                        } else if prompt_cancelled {
+                            // The adapter resolved cancel cleanly with
+                            // StopReason::Cancelled (upstream #694). The
+                            // 10s cancel-escalation watchdog never
+                            // promoted this to `agent_unresponsive`, so
+                            // surface the cleanly-cancelled signal
+                            // distinctly from `prompt_complete`.
+                            "cancelled"
                         } else {
                             "prompt_complete"
                         };

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -40,7 +40,7 @@ use super::approvals::{is_destructive, ApprovalDecision, Nonce};
 use super::fs_handler::{self, FsPolicy, SandboxPathMap};
 use super::permissions::build_approval;
 use super::state::{
-    AvailableCommand, CockpitSessionId, DiffPreview, Event, ModeInfo, Plan, PlanStep,
+    AvailableCommand, CockpitSessionId, DiffPreview, Event, MemoryRecall, ModeInfo, Plan, PlanStep,
     PlanStepStatus, RateLimitInfo, SessionMode, SessionUsage, StartupErrorDetail, ToolCall,
     UsageCost,
 };
@@ -2027,6 +2027,11 @@ fn map_update_to_events(
                     "subagent child tool_call linked to parent via _meta.claudeCode.parentToolUseId"
                 );
             }
+            let memory_recall = if profile.supports_memory_recall_tool() {
+                extract_memory_recall(&tc.meta, &tc.locations, &tc.content)
+            } else {
+                None
+            };
             let tool_call = ToolCall {
                 id: tc.tool_call_id.0.to_string(),
                 name: tc.title.clone(),
@@ -2034,6 +2039,7 @@ fn map_update_to_events(
                 args_preview: args_preview.clone(),
                 started_at: chrono::Utc::now(),
                 parent_tool_call_id,
+                memory_recall,
             };
             let mut events = vec![Event::ToolCallStarted { tool_call }];
             if is_destructive(&tc.title, &args_preview) {
@@ -2202,6 +2208,7 @@ fn map_update_to_events(
                         args_preview,
                         started_at: now,
                         parent_tool_call_id: None,
+                        memory_recall: None,
                     },
                 },
                 Event::PlanUpdated {
@@ -2360,6 +2367,53 @@ fn extract_tool_content_text(blocks: &[agent_client_protocol::schema::ToolCallCo
         }
     }
     out
+}
+
+/// Inspect a `tool_call` payload for the `memory_recall` shape
+/// claude-agent-acp v0.37.0 routes through the tool channel (upstream
+/// #703). The adapter sends `_meta.claudeCode.toolName == "memory_recall"`
+/// plus either `locations` (recall mode, one entry per loaded memory
+/// file) or `content` (synthesize mode, one text block with the
+/// synthesised reply). Returns `None` when the meta marker is absent.
+/// Caller gates this on `AgentProfile::supports_memory_recall_tool`
+/// so unrelated agents that happen to share field shapes don't trip
+/// the classifier.
+fn extract_memory_recall(
+    meta: &Option<serde_json::Map<String, serde_json::Value>>,
+    locations: &[agent_client_protocol::schema::ToolCallLocation],
+    content: &[agent_client_protocol::schema::ToolCallContent],
+) -> Option<MemoryRecall> {
+    let map = meta.as_ref()?;
+    let claude_code = map.get("claudeCode")?;
+    let tool_name = claude_code.get("toolName").and_then(|v| v.as_str())?;
+    if tool_name != "memory_recall" {
+        return None;
+    }
+    let mode = claude_code
+        .get("toolResponse")
+        .and_then(|tr| tr.get("mode"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("recall")
+        .to_string();
+    let paths: Vec<String> = locations
+        .iter()
+        .map(|loc| loc.path.to_string_lossy().to_string())
+        .collect();
+    let synthesized_text = if mode == "synthesize" {
+        let text = extract_tool_content_text(content);
+        if text.is_empty() {
+            None
+        } else {
+            Some(text)
+        }
+    } else {
+        None
+    };
+    Some(MemoryRecall {
+        mode,
+        paths,
+        synthesized_text,
+    })
 }
 
 fn extract_diff_from_locations(
@@ -3991,6 +4045,7 @@ async fn handle_permission_request(
         args_preview,
         started_at: chrono::Utc::now(),
         parent_tool_call_id: profile.parent_tool_use_id_from_meta(&request.tool_call.meta),
+        memory_recall: None,
     };
     let approval = build_approval(tool_call);
     let nonce = approval.nonce.clone();

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -59,6 +59,17 @@ pub enum AcpError {
     /// adapter" copy. See issue #1089.
     #[error("project path no longer exists: {path}")]
     ProjectPathMissing { path: PathBuf },
+    /// The ACP `initialize` handshake completed but the adapter failed
+    /// the per-adapter compatibility policy (see
+    /// `src/cockpit/agent_compat.rs`). Carries the structured detail so
+    /// the supervisor can publish a matching `Event::IncompatibleAgent`
+    /// through the broadcast sink (the in-process event_tx the failed
+    /// `AcpClient::spawn` opened is never delivered, so the structured
+    /// payload has to ride out of band on the typed error). The payload
+    /// is boxed to keep `AcpError` small on the Ok hot path (clippy's
+    /// `result_large_err`).
+    #[error("incompatible agent: {0}")]
+    IncompatibleAgent(Box<IncompatibleAgentError>),
     #[error("transport error: {0}")]
     Transport(String),
     #[error("protocol violation: {0}")]
@@ -71,6 +82,23 @@ pub enum AcpError {
     UnknownNonce,
     #[error("agent did not offer a {0:?} option")]
     NoMatchingOption(ApprovalDecision),
+}
+
+/// Boxed payload for `AcpError::IncompatibleAgent`. Carries the
+/// structured `StartupErrorDetail` plus a pre-formatted free-form
+/// summary the supervisor mirrors into the legacy
+/// `Event::AgentStartupError { message }` channel for status-derivation
+/// callers that don't yet read the structured detail.
+#[derive(Debug)]
+pub struct IncompatibleAgentError {
+    pub detail: super::state::StartupErrorDetail,
+    pub message: String,
+}
+
+impl std::fmt::Display for IncompatibleAgentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.message)
+    }
 }
 
 impl AcpError {
@@ -945,10 +973,19 @@ impl AcpClient {
             in_flight_turn,
         };
         let profile = agent_profiles::resolve(&agent_key);
-        // Resume path has no install hint to surface: the agent is
-        // already running. Pass an empty string; the install hint is
-        // only consulted on handshake-failure timeouts, which the resume
-        // path treats as a different fault.
+        // Resolve the binary name from the registry so the resume path
+        // still routes through the per-adapter compatibility gate
+        // (`agent_compat::ExpectedAgent::from_command`). Reattaching to
+        // a stale claude-agent-acp@0.32.0 worker that survived an aoe
+        // serve restart should re-trigger the >=0.37.0 check, not
+        // silently skip it just because the resume path has no install
+        // hint to surface. Empty fallback only when the agent key is
+        // not in the registry (an unknown user-configured agent);
+        // policy maps that to Other anyway.
+        let install_binary = super::AgentRegistry::with_defaults()
+            .get(&agent_key)
+            .map(|spec| spec.command.clone())
+            .unwrap_or_default();
         Self::connect_via_socket(
             socket_path,
             cwd,
@@ -962,7 +999,7 @@ impl AcpClient {
             event_rx,
             sandbox,
             profile,
-            String::new(),
+            install_binary,
             source_profile,
         )
         .await
@@ -2681,13 +2718,18 @@ async fn run_connection_task<W, R>(
 
             // Per-adapter compatibility check (see src/cockpit/agent_compat.rs).
             // Currently only gates claude-agent-acp at >=0.37.0; other
-            // adapters pass through. On rejection: emit a structured
-            // IncompatibleAgent event for the dedicated startup-error UI,
-            // plus a parallel AgentStartupError message so the legacy
-            // status-derivation paths still flip the session into Error
-            // state. Then signal ready_tx with the failure so the
-            // supervisor surfaces a typed error to the caller and kills
-            // the child (handled by the outer Drop path).
+            // adapters pass through. On rejection: route the structured
+            // detail through the typed `AcpError::IncompatibleAgent`
+            // variant on ready_tx so the supervisor sees it on the
+            // spawn-failure path. The supervisor mirrors the detail into
+            // `Event::IncompatibleAgent` + `Event::AgentStartupError`
+            // through the broadcast sink (the in-process `event_tx`
+            // here is dropped on the floor when spawn() returns Err, so
+            // any events emitted from this closure would never reach the
+            // reducer). The supervisor also terminates the detached
+            // runner; we close the connection cleanly via `return Ok(())`
+            // so the outer cleanup at line ~3500 doesn't double-emit an
+            // AgentStartupError on top of the structured one.
             if let Err(err) = agent_compat::validate(expected_agent, &init) {
                 let user_message = err.user_message();
                 warn!(
@@ -2698,16 +2740,13 @@ async fn run_connection_task<W, R>(
                     "agent compatibility check failed; refusing to enter session"
                 );
                 let detail = StartupErrorDetail::from(&err);
-                let _ = event_tx_for_block
-                    .send(Event::IncompatibleAgent { detail })
-                    .await;
-                let _ = event_tx_for_block
-                    .send(Event::AgentStartupError {
-                        message: user_message.clone(),
-                    })
-                    .await;
                 if let Some(tx) = ready_for_block.lock().await.take() {
-                    let _ = tx.send(Err(AcpError::Spawn(user_message)));
+                    let _ = tx.send(Err(AcpError::IncompatibleAgent(Box::new(
+                        IncompatibleAgentError {
+                            detail,
+                            message: user_message,
+                        },
+                    ))));
                 }
                 return Ok(());
             }

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -49,22 +49,33 @@ impl ExpectedAgent {
     /// `claude-agent-acp` would land in `Other` and silently bypass the
     /// >=0.37.0 gate.
     pub fn from_command(command: &str) -> Self {
-        let token = command.split_whitespace().next().unwrap_or(command);
-        let basename = token.rsplit(['/', '\\']).next().unwrap_or(token);
-        let stem = basename
-            .strip_suffix(".exe")
-            .or_else(|| basename.strip_suffix(".cmd"))
-            .or_else(|| basename.strip_suffix(".bat"))
-            .unwrap_or(basename);
-        match stem {
-            "claude-agent-acp" => Self::ClaudeAgentAcp,
-            "codex-acp" => Self::CodexAcp,
-            "opencode" => Self::OpenCode,
-            "aoe-agent" => Self::AoeAgent,
-            "gemini" => Self::Gemini,
-            "pi-acp" => Self::PiAcp,
-            _ => Self::Other,
-        }
+        // Scan every whitespace-separated token. The actual binary can
+        // be the first token (`/usr/local/bin/claude-agent-acp`) but
+        // also a later one when a wrapper prefixes the command line
+        // (`bash claude-agent-acp`, `env -u FOO claude-agent-acp`,
+        // `npx claude-agent-acp`, etc.). Match against the first token
+        // that classifies as a known adapter so wrappers don't bypass
+        // the >=0.37.0 gate.
+        command
+            .split_whitespace()
+            .find_map(|token| {
+                let basename = token.rsplit(['/', '\\']).next().unwrap_or(token);
+                let stem = basename
+                    .strip_suffix(".exe")
+                    .or_else(|| basename.strip_suffix(".cmd"))
+                    .or_else(|| basename.strip_suffix(".bat"))
+                    .unwrap_or(basename);
+                match stem {
+                    "claude-agent-acp" => Some(Self::ClaudeAgentAcp),
+                    "codex-acp" => Some(Self::CodexAcp),
+                    "opencode" => Some(Self::OpenCode),
+                    "aoe-agent" => Some(Self::AoeAgent),
+                    "gemini" => Some(Self::Gemini),
+                    "pi-acp" => Some(Self::PiAcp),
+                    _ => None,
+                }
+            })
+            .unwrap_or(Self::Other)
     }
 }
 
@@ -472,7 +483,10 @@ mod tests {
         // string (e.g. `aoe cockpit doctor --json` output, log lines
         // round-tripped through user config). Tolerate the joined form
         // so the gate doesn't silently flip to `Other` and skip the
-        // claude check.
+        // claude check. Wrapper-prefixed commands count too: the
+        // classifier scans every whitespace-separated token so
+        // `bash claude-agent-acp` or `npx claude-agent-acp` is gated
+        // on the wrapped binary, not on the wrapper.
         assert_eq!(
             ExpectedAgent::from_command("claude-agent-acp --some-flag"),
             ExpectedAgent::ClaudeAgentAcp
@@ -481,5 +495,19 @@ mod tests {
             ExpectedAgent::from_command("  /usr/local/bin/claude-agent-acp  "),
             ExpectedAgent::ClaudeAgentAcp
         );
+        assert_eq!(
+            ExpectedAgent::from_command("bash claude-agent-acp"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("env FOO=bar /usr/local/bin/claude-agent-acp"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        // `npx`-style npm-package-spec invocations are out of scope:
+        // npx itself resolves the package and the spawned binary's
+        // argv[0] is `claude-agent-acp`, not `claude-agent-acp@0.37.0`.
+        // The version-suffixed form would only show up if a user wired
+        // it manually into AgentSpec.command, which is not a supported
+        // configuration today.
     }
 }

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -1,0 +1,342 @@
+//! Per-adapter compatibility policy for ACP agents.
+//!
+//! aoe spawns several ACP adapters (claude-agent-acp, codex-acp,
+//! opencode, aoe-agent, gemini, pi-acp). Some require a minimum upstream
+//! version because aoe relies on behavior that only landed past a known
+//! release. This module centralizes those rules so `acp_client` has a
+//! single hook to call after `initialize` succeeds, instead of scattering
+//! ad-hoc semver checks at every spawn site.
+//!
+//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.37.0,
+//! required for `memory_recall` tool-call emission, native `cancelled`
+//! stop reason, and several other behaviors aoe builds on). Other agents
+//! get a permissive policy (protocol check only). Long-term aoe should
+//! prefer ACP capability flags over package-version gating; until upstream
+//! exposes those, package versions are the only precise contract.
+//!
+//! Failure mode: missing `agent_info`, missing version, parse failure, or
+//! version below the floor all reject for adapters with a minimum. Other
+//! adapters are passed through. The supervisor's known spawn intent is
+//! the gate, not the self-reported `agent_info.name` on the wire.
+
+use agent_client_protocol::schema::{InitializeResponse, ProtocolVersion};
+
+/// The adapter aoe is trying to launch. Drives which `CompatibilityPolicy`
+/// is applied at initialize-time.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExpectedAgent {
+    ClaudeAgentAcp,
+    CodexAcp,
+    OpenCode,
+    AoeAgent,
+    Gemini,
+    PiAcp,
+    /// Unknown / user-configured agent. Permissive policy.
+    Other,
+}
+
+impl ExpectedAgent {
+    /// Resolve from the binary name as configured in `AgentRegistry`. Maps
+    /// the string the supervisor is about to spawn to the matching policy
+    /// enum so the supervisor can call this once and pass the result down.
+    pub fn from_command(command: &str) -> Self {
+        let bin = command.rsplit('/').next().unwrap_or(command);
+        match bin {
+            "claude-agent-acp" => Self::ClaudeAgentAcp,
+            "codex-acp" => Self::CodexAcp,
+            "opencode" => Self::OpenCode,
+            "aoe-agent" => Self::AoeAgent,
+            "gemini" => Self::Gemini,
+            "pi-acp" => Self::PiAcp,
+            _ => Self::Other,
+        }
+    }
+}
+
+/// What the policy requires from the adapter's `InitializeResponse`.
+struct CompatibilityPolicy {
+    /// If set, the adapter must report this exact `agent_info.name`.
+    expected_name: Option<&'static str>,
+    /// If set, the adapter's `agent_info.version` must parse as semver
+    /// and be at least this value.
+    min_version: Option<semver::Version>,
+    /// The protocol version the client requested. Adapter must match.
+    required_protocol: ProtocolVersion,
+    /// If `true`, missing `agent_info` or empty/unparseable version
+    /// rejects. `false` means we tolerate adapters that don't advertise.
+    fail_on_missing_agent_info: bool,
+}
+
+impl ExpectedAgent {
+    fn policy(self) -> CompatibilityPolicy {
+        match self {
+            Self::ClaudeAgentAcp => CompatibilityPolicy {
+                expected_name: Some("@agentclientprotocol/claude-agent-acp"),
+                min_version: Some(semver::Version::new(0, 37, 0)),
+                required_protocol: ProtocolVersion::V1,
+                fail_on_missing_agent_info: true,
+            },
+            // Other adapters: protocol check only. aoe doesn't yet
+            // depend on a version-gated behavior in any of them.
+            Self::CodexAcp
+            | Self::OpenCode
+            | Self::AoeAgent
+            | Self::Gemini
+            | Self::PiAcp
+            | Self::Other => CompatibilityPolicy {
+                expected_name: None,
+                min_version: None,
+                required_protocol: ProtocolVersion::V1,
+                fail_on_missing_agent_info: false,
+            },
+        }
+    }
+}
+
+/// Reasons aoe refuses to enter a session after a successful `initialize`
+/// handshake. Surfaced to the user via the cockpit StartupErrorScreen.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StartupError {
+    /// Adapter reported a version below the minimum aoe requires.
+    IncompatibleAgentVersion {
+        package_name: String,
+        installed: String,
+        required: String,
+        install_command: String,
+    },
+    /// Adapter passed name/version checks but reported a protocol version
+    /// aoe does not speak.
+    UnsupportedProtocolVersion { expected: String, received: String },
+    /// Adapter omitted `agent_info` (or `agent_info.version`) entirely,
+    /// and the policy for this adapter kind requires it.
+    MissingAgentInfo {
+        expected_package: String,
+        install_command: String,
+    },
+    /// Adapter advertised a different package name than aoe expected for
+    /// this `ExpectedAgent`. Probably a wrapper or stale install.
+    MismatchedAgentName {
+        expected: String,
+        received: String,
+        install_command: String,
+    },
+    /// `agent_info.version` was present but did not parse as semver.
+    UnparseableAgentVersion {
+        package_name: String,
+        raw_version: String,
+        required: String,
+        install_command: String,
+    },
+}
+
+impl StartupError {
+    /// Short, machine-stable identifier used by tests, logs, and the
+    /// frontend reducer's discriminator.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::IncompatibleAgentVersion { .. } => "incompatible_agent_version",
+            Self::UnsupportedProtocolVersion { .. } => "unsupported_protocol_version",
+            Self::MissingAgentInfo { .. } => "missing_agent_info",
+            Self::MismatchedAgentName { .. } => "mismatched_agent_name",
+            Self::UnparseableAgentVersion { .. } => "unparseable_agent_version",
+        }
+    }
+}
+
+/// Validate an `InitializeResponse` against the policy for the adapter
+/// aoe was launching. Returns `Ok(())` on success; `Err(StartupError)`
+/// surfaces a structured failure the supervisor can route into the
+/// startup-error UI path.
+pub fn validate(expected: ExpectedAgent, init: &InitializeResponse) -> Result<(), StartupError> {
+    let policy = expected.policy();
+
+    if init.protocol_version != policy.required_protocol {
+        return Err(StartupError::UnsupportedProtocolVersion {
+            expected: format!("{:?}", policy.required_protocol),
+            received: format!("{:?}", init.protocol_version),
+        });
+    }
+
+    // Fast path for adapters with no name/version requirement.
+    if policy.min_version.is_none() && policy.expected_name.is_none() {
+        return Ok(());
+    }
+
+    let install_command =
+        install_command_for(expected).unwrap_or_else(|| "(see project docs)".to_string());
+
+    let Some(info) = init.agent_info.as_ref() else {
+        if policy.fail_on_missing_agent_info {
+            return Err(StartupError::MissingAgentInfo {
+                expected_package: policy.expected_name.unwrap_or("(unspecified)").to_string(),
+                install_command,
+            });
+        }
+        return Ok(());
+    };
+
+    if let Some(expected_name) = policy.expected_name {
+        if info.name != expected_name {
+            return Err(StartupError::MismatchedAgentName {
+                expected: expected_name.to_string(),
+                received: info.name.clone(),
+                install_command,
+            });
+        }
+    }
+
+    if let Some(min) = policy.min_version {
+        let raw = info.version.trim();
+        if raw.is_empty() {
+            if policy.fail_on_missing_agent_info {
+                return Err(StartupError::MissingAgentInfo {
+                    expected_package: policy
+                        .expected_name
+                        .unwrap_or(info.name.as_str())
+                        .to_string(),
+                    install_command,
+                });
+            }
+            return Ok(());
+        }
+        let parsed = match semver::Version::parse(raw) {
+            Ok(v) => v,
+            Err(_) => {
+                return Err(StartupError::UnparseableAgentVersion {
+                    package_name: info.name.clone(),
+                    raw_version: raw.to_string(),
+                    required: min.to_string(),
+                    install_command,
+                });
+            }
+        };
+        if parsed < min {
+            return Err(StartupError::IncompatibleAgentVersion {
+                package_name: info.name.clone(),
+                installed: parsed.to_string(),
+                required: min.to_string(),
+                install_command,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Lookup table for the install commands surfaced in startup errors.
+/// Kept in sync with `install_hints::install_hint_for` so the error UI
+/// shows the exact command the doctor would run.
+fn install_command_for(expected: ExpectedAgent) -> Option<String> {
+    let bin = match expected {
+        ExpectedAgent::ClaudeAgentAcp => "claude-agent-acp",
+        ExpectedAgent::CodexAcp => "codex-acp",
+        ExpectedAgent::OpenCode => "opencode",
+        ExpectedAgent::AoeAgent => return None,
+        ExpectedAgent::Gemini => "gemini",
+        ExpectedAgent::PiAcp => "pi-acp",
+        ExpectedAgent::Other => return None,
+    };
+    crate::cockpit::install_hints::install_hint_for(bin).map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agent_client_protocol::schema::Implementation;
+
+    fn make_init(name: &str, version: &str) -> InitializeResponse {
+        InitializeResponse::new(ProtocolVersion::V1).agent_info(Implementation::new(name, version))
+    }
+
+    fn make_init_no_info() -> InitializeResponse {
+        InitializeResponse::new(ProtocolVersion::V1)
+    }
+
+    #[test]
+    fn claude_below_minimum_rejected() {
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.32.0");
+        let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "incompatible_agent_version");
+        let StartupError::IncompatibleAgentVersion {
+            installed,
+            required,
+            ..
+        } = err
+        else {
+            panic!()
+        };
+        assert_eq!(installed, "0.32.0");
+        assert_eq!(required, "0.37.0");
+    }
+
+    #[test]
+    fn claude_at_minimum_accepted() {
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.37.0");
+        validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
+    }
+
+    #[test]
+    fn claude_above_minimum_accepted() {
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.38.1");
+        validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
+    }
+
+    #[test]
+    fn claude_missing_agent_info_rejected() {
+        let init = make_init_no_info();
+        let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "missing_agent_info");
+    }
+
+    #[test]
+    fn claude_empty_version_rejected() {
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "");
+        let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "missing_agent_info");
+    }
+
+    #[test]
+    fn claude_unparseable_version_rejected() {
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "not-semver");
+        let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "unparseable_agent_version");
+    }
+
+    #[test]
+    fn claude_mismatched_name_rejected() {
+        let init = make_init("some-other-package", "0.37.0");
+        let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
+        assert_eq!(err.kind(), "mismatched_agent_name");
+    }
+
+    #[test]
+    fn non_claude_permissive_on_missing_info() {
+        let init = make_init_no_info();
+        validate(ExpectedAgent::CodexAcp, &init).unwrap();
+        validate(ExpectedAgent::OpenCode, &init).unwrap();
+        validate(ExpectedAgent::AoeAgent, &init).unwrap();
+        validate(ExpectedAgent::Other, &init).unwrap();
+    }
+
+    #[test]
+    fn non_claude_permissive_on_old_version() {
+        let init = make_init("@zed-industries/codex-acp", "0.0.1");
+        validate(ExpectedAgent::CodexAcp, &init).unwrap();
+    }
+
+    #[test]
+    fn from_command_recognises_path_prefixed_binary() {
+        assert_eq!(
+            ExpectedAgent::from_command("/usr/local/bin/claude-agent-acp"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("claude-agent-acp"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("unknown-bin"),
+            ExpectedAgent::Other
+        );
+    }
+}

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -41,9 +41,22 @@ impl ExpectedAgent {
     /// Resolve from the binary name as configured in `AgentRegistry`. Maps
     /// the string the supervisor is about to spawn to the matching policy
     /// enum so the supervisor can call this once and pass the result down.
+    ///
+    /// Robust to surface variations seen in the wild: a wrapper command
+    /// string ("bash claude-agent-acp"), POSIX or Windows path
+    /// separators, and the `.exe` / `.cmd` suffixes Windows shims add.
+    /// Without this normalization a wrapped or Windows-installed
+    /// `claude-agent-acp` would land in `Other` and silently bypass the
+    /// >=0.37.0 gate.
     pub fn from_command(command: &str) -> Self {
-        let bin = command.rsplit('/').next().unwrap_or(command);
-        match bin {
+        let token = command.split_whitespace().next().unwrap_or(command);
+        let basename = token.rsplit(['/', '\\']).next().unwrap_or(token);
+        let stem = basename
+            .strip_suffix(".exe")
+            .or_else(|| basename.strip_suffix(".cmd"))
+            .or_else(|| basename.strip_suffix(".bat"))
+            .unwrap_or(basename);
+        match stem {
             "claude-agent-acp" => Self::ClaudeAgentAcp,
             "codex-acp" => Self::CodexAcp,
             "opencode" => Self::OpenCode,
@@ -431,6 +444,42 @@ mod tests {
         assert_eq!(
             ExpectedAgent::from_command("unknown-bin"),
             ExpectedAgent::Other
+        );
+    }
+
+    #[test]
+    fn from_command_handles_windows_paths_and_extensions() {
+        assert_eq!(
+            ExpectedAgent::from_command(
+                "C:\\Users\\u\\AppData\\Roaming\\npm\\claude-agent-acp.cmd"
+            ),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("claude-agent-acp.exe"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("D:\\bin\\claude-agent-acp.bat"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+    }
+
+    #[test]
+    fn from_command_handles_wrapper_token_prefix() {
+        // `AgentRegistry` exposes `command` plus a separate `args`
+        // vector, but defensive code paths sometimes hand us the joined
+        // string (e.g. `aoe cockpit doctor --json` output, log lines
+        // round-tripped through user config). Tolerate the joined form
+        // so the gate doesn't silently flip to `Other` and skip the
+        // claude check.
+        assert_eq!(
+            ExpectedAgent::from_command("claude-agent-acp --some-flag"),
+            ExpectedAgent::ClaudeAgentAcp
+        );
+        assert_eq!(
+            ExpectedAgent::from_command("  /usr/local/bin/claude-agent-acp  "),
+            ExpectedAgent::ClaudeAgentAcp
         );
     }
 }

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -21,6 +21,8 @@
 
 use agent_client_protocol::schema::{InitializeResponse, ProtocolVersion};
 
+use super::state::StartupErrorDetail;
+
 /// The adapter aoe is trying to launch. Drives which `CompatibilityPolicy`
 /// is applied at initialize-time.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -139,6 +141,98 @@ impl StartupError {
             Self::MissingAgentInfo { .. } => "missing_agent_info",
             Self::MismatchedAgentName { .. } => "mismatched_agent_name",
             Self::UnparseableAgentVersion { .. } => "unparseable_agent_version",
+        }
+    }
+
+    /// User-facing one-liner suitable for the legacy
+    /// `AgentStartupError { message }` event channel. Lets the existing
+    /// status-derivation paths flip the session into Error state without
+    /// having to teach every consumer about the structured variant.
+    pub fn user_message(&self) -> String {
+        match self {
+            Self::IncompatibleAgentVersion {
+                package_name,
+                installed,
+                required,
+                install_command,
+            } => format!(
+                "{package_name} {installed} installed; aoe requires >={required}. Run: {install_command}",
+            ),
+            Self::MissingAgentInfo {
+                expected_package,
+                install_command,
+            } => format!(
+                "Adapter did not report its package version. aoe requires {expected_package} >=0.37.0. Run: {install_command}",
+            ),
+            Self::MismatchedAgentName {
+                expected,
+                received,
+                install_command,
+            } => format!(
+                "Adapter reported package name `{received}` but aoe expected `{expected}`. Run: {install_command}",
+            ),
+            Self::UnparseableAgentVersion {
+                package_name,
+                raw_version,
+                required,
+                install_command,
+            } => format!(
+                "{package_name} reported version `{raw_version}` which is not valid semver. aoe requires >={required}. Run: {install_command}",
+            ),
+            Self::UnsupportedProtocolVersion { expected, received } => format!(
+                "Adapter speaks ACP protocol {received}; aoe requires {expected}.",
+            ),
+        }
+    }
+}
+
+impl From<&StartupError> for StartupErrorDetail {
+    fn from(err: &StartupError) -> Self {
+        match err {
+            StartupError::IncompatibleAgentVersion {
+                package_name,
+                installed,
+                required,
+                install_command,
+            } => StartupErrorDetail::IncompatibleAgentVersion {
+                package_name: package_name.clone(),
+                installed: installed.clone(),
+                required: required.clone(),
+                install_command: install_command.clone(),
+            },
+            StartupError::MissingAgentInfo {
+                expected_package,
+                install_command,
+            } => StartupErrorDetail::MissingAgentInfo {
+                expected_package: expected_package.clone(),
+                install_command: install_command.clone(),
+            },
+            StartupError::MismatchedAgentName {
+                expected,
+                received,
+                install_command,
+            } => StartupErrorDetail::MismatchedAgentName {
+                expected: expected.clone(),
+                received: received.clone(),
+                install_command: install_command.clone(),
+            },
+            StartupError::UnparseableAgentVersion {
+                package_name,
+                raw_version,
+                required,
+                install_command,
+            } => StartupErrorDetail::UnparseableAgentVersion {
+                package_name: package_name.clone(),
+                raw_version: raw_version.clone(),
+                required: required.clone(),
+                install_command: install_command.clone(),
+            },
+            StartupError::UnsupportedProtocolVersion { expected, received } => {
+                StartupErrorDetail::UnsupportedProtocolVersion {
+                    expected: expected.clone(),
+                    received: received.clone(),
+                }
+            }
         }
     }
 }

--- a/src/cockpit/agent_profiles.rs
+++ b/src/cockpit/agent_profiles.rs
@@ -77,6 +77,16 @@ impl AgentProfile {
         }
         None
     }
+
+    /// True iff the agent surfaces session-start memory recall through
+    /// the tool channel with the `_meta.claudeCode.toolName` namespace
+    /// claude-agent-acp adopted in v0.37.0 (upstream #703). Other
+    /// agents don't emit this shape today; gating the classifier off
+    /// the profile prevents accidental matches against unrelated
+    /// custom tool metadata.
+    pub fn supports_memory_recall_tool(&self) -> bool {
+        self.parent_meta_namespaces.contains(&"claudeCode")
+    }
 }
 
 /// Claude via `claude-agent-acp`. Reference profile; verified against

--- a/src/cockpit/agent_registry.rs
+++ b/src/cockpit/agent_registry.rs
@@ -61,7 +61,7 @@ impl AgentRegistry {
                 command: "claude-agent-acp".into(),
                 args: vec![],
                 description:
-                    "Anthropic Claude via the official ACP adapter (npm i -g @agentclientprotocol/claude-agent-acp)"
+                    "Anthropic Claude via the official ACP adapter (npm i -g @agentclientprotocol/claude-agent-acp@0.37.0)"
                         .into(),
                 env_allowlist: None,
             },

--- a/src/cockpit/context_primer.rs
+++ b/src/cockpit/context_primer.rs
@@ -732,6 +732,7 @@ mod tests {
                     args_preview: args.to_string(),
                     started_at: Utc::now(),
                     parent_tool_call_id: None,
+                    memory_recall: None,
                 },
             },
         )
@@ -930,6 +931,7 @@ mod tests {
                             args_preview: "{}".into(),
                             started_at: Utc::now(),
                             parent_tool_call_id: None,
+                            memory_recall: None,
                         },
                         destructive: false,
                         requested_at: Utc::now(),

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -1505,6 +1505,7 @@ mod tests {
             args_preview: "ls".into(),
             started_at: Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         };
         let nonce_a = Nonce("aaaa".into());
         let nonce_b = Nonce("bbbb".into());

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -836,6 +836,7 @@ fn event_kind(event: &Event) -> &'static str {
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::Stopped { .. } => "stopped",
         Event::AgentStartupError { .. } => "agent_startup_error",
+        Event::IncompatibleAgent { .. } => "incompatible_agent",
         Event::UserPromptSent { .. } => "user_prompt_sent",
         Event::AcpSessionAssigned { .. } => "acp_session_assigned",
         Event::SessionContextReset { .. } => "session_context_reset",

--- a/src/cockpit/install_hints.rs
+++ b/src/cockpit/install_hints.rs
@@ -8,7 +8,7 @@
 /// unknown commands so callers can fall through to a generic message.
 pub fn install_hint_for(binary: &str) -> Option<&'static str> {
     Some(match binary {
-        "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp",
+        "claude-agent-acp" => "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
         "codex-acp" => "npm install -g @zed-industries/codex-acp",
         "pi-acp" => {
             "npm install -g pi-acp (also requires `npm install -g @earendil-works/pi-coding-agent`)"

--- a/src/cockpit/mod.rs
+++ b/src/cockpit/mod.rs
@@ -13,6 +13,8 @@
 //!   `state::apply_event`.
 
 pub mod acp_client;
+#[cfg(feature = "serve")]
+pub mod agent_compat;
 pub mod agent_profiles;
 pub mod agent_registry;
 pub mod approvals;

--- a/src/cockpit/permissions.rs
+++ b/src/cockpit/permissions.rs
@@ -54,6 +54,7 @@ mod tests {
             args_preview: r#"{"command":"rm -rf /tmp/x"}"#.into(),
             started_at: Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         };
         let a = build_approval(tc);
         assert!(a.destructive);
@@ -70,6 +71,7 @@ mod tests {
             args_preview: "{}".into(),
             started_at: Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         };
         let mut a = build_approval(tc);
         resolve(&mut a, ApprovalDecision::Allow, None);

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -642,7 +642,14 @@ impl CockpitState {
                 self.startup_error = Some(detail);
             }
             Event::UserPromptSent { .. } => {}
-            Event::AcpSessionAssigned { .. } => {}
+            Event::AcpSessionAssigned { .. } => {
+                // A fresh agent that passed the compatibility check
+                // has come online; heal any sticky startup error so a
+                // post-upgrade respawn unblocks the UI without a hard
+                // reload. Mirrors the frontend reducer's
+                // `incompatibleAgent = null` clear on the same event.
+                self.startup_error = None;
+            }
             Event::SessionContextReset { .. } => {
                 // Agent's stored context is gone; clear the cached
                 // usage snapshot so the composer footer doesn't keep

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -786,6 +786,7 @@ mod tests {
             args_preview: "{\"path\":\"x\"}".into(),
             started_at: Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         };
         s.apply_event(Event::ToolCallStarted {
             tool_call: tc.clone(),

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -71,6 +71,32 @@ pub struct ToolCall {
     /// stream. None for top-level tool calls. See #1041.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_tool_call_id: Option<String>,
+    /// Populated when claude-agent-acp routes a session-start memory
+    /// recall through the tool channel
+    /// (`_meta.claudeCode.toolName == "memory_recall"`, upstream
+    /// agentclientprotocol/claude-agent-acp#703 in v0.37.0). Carries
+    /// the file paths the SDK loaded into the agent's context (recall
+    /// mode) or the synthesized memory text (synthesize mode) so the
+    /// cockpit can render a dedicated card instead of treating it as a
+    /// generic read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_recall: Option<MemoryRecall>,
+}
+
+/// Structured payload for a `memory_recall` tool call. `mode` mirrors
+/// the adapter's `_meta.claudeCode.toolResponse.mode` field:
+/// `"recall"` populates `paths` (one per loaded memory file);
+/// `"synthesize"` populates `synthesized_text` with the SDK's
+/// summarised reply. Either field may be empty when the adapter
+/// reports the mode but no entries; the renderer falls back to the
+/// title in that case.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct MemoryRecall {
+    pub mode: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub paths: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub synthesized_text: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -160,6 +160,43 @@ pub struct AvailableCommand {
     pub accepts_input: bool,
 }
 
+/// Structured detail about why aoe refused to enter the session after
+/// the ACP `initialize` handshake completed. Distinct from the runtime
+/// `Stopped` taxonomy: a startup error means the session never reached
+/// the Running state. The cockpit UI short-circuits its normal render
+/// when this field is populated and shows a dedicated screen with the
+/// exact remediation command. Populated by the per-adapter compatibility
+/// check (see `src/cockpit/agent_compat.rs`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum StartupErrorDetail {
+    IncompatibleAgentVersion {
+        package_name: String,
+        installed: String,
+        required: String,
+        install_command: String,
+    },
+    MissingAgentInfo {
+        expected_package: String,
+        install_command: String,
+    },
+    MismatchedAgentName {
+        expected: String,
+        received: String,
+        install_command: String,
+    },
+    UnparseableAgentVersion {
+        package_name: String,
+        raw_version: String,
+        required: String,
+        install_command: String,
+    },
+    UnsupportedProtocolVersion {
+        expected: String,
+        received: String,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CockpitState {
     pub session_id: CockpitSessionId,
@@ -190,6 +227,13 @@ pub struct CockpitState {
     /// until the session has ever moved backends. See #1282.
     #[serde(default)]
     pub last_agent_switch: Option<AgentSwitchInfo>,
+    /// Structured startup error from the per-adapter compatibility
+    /// check. When `Some`, the cockpit UI replaces its normal session
+    /// view with a dedicated remediation screen. `None` for healthy
+    /// sessions and for legacy `AgentStartupError` failures (those
+    /// only carry a free-form message; see `Event::AgentStartupError`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_error: Option<StartupErrorDetail>,
 
     pub last_seq: u64,
     pub updated_at: DateTime<Utc>,
@@ -216,6 +260,7 @@ impl CockpitState {
             usage: None,
             available_commands: Vec::new(),
             last_agent_switch: None,
+            startup_error: None,
             last_seq: 0,
             updated_at: Utc::now(),
         }
@@ -384,6 +429,17 @@ pub enum Event {
     /// an empty conversation.
     AgentStartupError {
         message: String,
+    },
+    /// The ACP `initialize` handshake completed but the adapter failed
+    /// the per-adapter compatibility policy. Structured payload so the
+    /// cockpit UI can render an actionable remediation screen with the
+    /// exact install command. Emitted by the connection task right
+    /// before it closes; the connection drops, the child is killed, and
+    /// a parallel `AgentStartupError { message }` is published so legacy
+    /// status-derivation paths still flip the session into Error state.
+    /// See `src/cockpit/agent_compat.rs`.
+    IncompatibleAgent {
+        detail: StartupErrorDetail,
     },
     /// Echo of a user-submitted prompt. Published synchronously by the
     /// `POST /cockpit/prompt` handler before the text is forwarded to
@@ -556,6 +612,9 @@ impl CockpitState {
             Event::AgentMessageChunk { .. } => {}
             Event::Stopped { .. } => {}
             Event::AgentStartupError { .. } => {}
+            Event::IncompatibleAgent { detail } => {
+                self.startup_error = Some(detail);
+            }
             Event::UserPromptSent { .. } => {}
             Event::AcpSessionAssigned { .. } => {}
             Event::SessionContextReset { .. } => {

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -429,6 +429,40 @@ impl<S: BroadcastSink> Supervisor<S> {
             .publish(session_id, seq, &Event::AgentStartupError { message });
     }
 
+    /// Mirror an `AcpError::IncompatibleAgent` onto the broadcast sink
+    /// and tear down the detached runner. Called from every spawn-
+    /// failure site so the structured detail reaches the reducer (the
+    /// in-process event_tx on the failed AcpClient never delivers) and
+    /// socket-mode workers don't survive a compatibility rejection. On
+    /// non-compat errors this is a no-op.
+    fn publish_compat_rejection(&self, session_id: &str, err: &AcpError) {
+        let AcpError::IncompatibleAgent(payload) = err else {
+            return;
+        };
+        let detail_seq = next_seq(&self.next_seqs, session_id);
+        self.sink.publish(
+            session_id,
+            detail_seq,
+            &Event::IncompatibleAgent {
+                detail: payload.detail.clone(),
+            },
+        );
+        let msg_seq = next_seq(&self.next_seqs, session_id);
+        self.sink.publish(
+            session_id,
+            msg_seq,
+            &Event::AgentStartupError {
+                message: payload.message.clone(),
+            },
+        );
+        // SIGTERM the detached runner so a stale claude-agent-acp@0.32.0
+        // child doesn't keep the worker socket alive. `terminate_runner_for_session`
+        // also deletes the registry entry so a retry via the API doesn't
+        // hit AlreadyRunning. Idempotent: it's a no-op if the registry
+        // entry is missing or the PID is dead. No-op on non-unix.
+        terminate_runner_for_session(session_id);
+    }
+
     /// Publish a synthetic `AgentSwitched` event after a successful
     /// `/cockpit/switch-agent` operation. Carries the prior and new
     /// agent registry keys plus the reason (e.g. `"rate_limited"`).
@@ -762,7 +796,13 @@ impl<S: BroadcastSink> Supervisor<S> {
         );
 
         let cockpit_session_id = CockpitSessionId(session_id.clone());
-        let mut client = AcpClient::spawn(config.clone(), cockpit_session_id.clone()).await?;
+        let mut client = match AcpClient::spawn(config.clone(), cockpit_session_id.clone()).await {
+            Ok(c) => c,
+            Err(err) => {
+                self.publish_compat_rejection(&session_id, &err);
+                return Err(SupervisorError::Acp(err));
+            }
+        };
 
         // First spawn for this agent succeeded; record it in
         // `warmed_up_agents` so subsequent concurrent callers skip the
@@ -1167,14 +1207,42 @@ impl<S: BroadcastSink> Supervisor<S> {
                                     session = %session_id,
                                     "respawn failed: {e}"
                                 );
-                                let seq = next_seq(&next_seqs, &session_id);
-                                sink.publish(
-                                    &session_id,
-                                    seq,
-                                    &Event::AgentStartupError {
-                                        message: format!("ACP agent respawn failed: {e}"),
-                                    },
-                                );
+                                // If the respawn was rejected by the
+                                // compatibility check (e.g. operator
+                                // downgraded the adapter under us), surface
+                                // the structured detail so the UI lands on
+                                // the StartupErrorScreen instead of the
+                                // generic red banner. Then tear down the
+                                // stale runner before dropping the worker
+                                // entry.
+                                if let AcpError::IncompatibleAgent(payload) = &e {
+                                    let seq = next_seq(&next_seqs, &session_id);
+                                    sink.publish(
+                                        &session_id,
+                                        seq,
+                                        &Event::IncompatibleAgent {
+                                            detail: payload.detail.clone(),
+                                        },
+                                    );
+                                    let seq = next_seq(&next_seqs, &session_id);
+                                    sink.publish(
+                                        &session_id,
+                                        seq,
+                                        &Event::AgentStartupError {
+                                            message: payload.message.clone(),
+                                        },
+                                    );
+                                    terminate_runner_for_session(&session_id);
+                                } else {
+                                    let seq = next_seq(&next_seqs, &session_id);
+                                    sink.publish(
+                                        &session_id,
+                                        seq,
+                                        &Event::AgentStartupError {
+                                            message: format!("ACP agent respawn failed: {e}"),
+                                        },
+                                    );
+                                }
                                 // Drop the dead WorkerHandle so the user can
                                 // retry via POST /api/sessions/:id/cockpit/spawn
                                 // without hitting AlreadyRunning. Without this

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -2414,6 +2414,7 @@ mod tests {
             args_preview: "{}".into(),
             started_at: chrono::Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         };
         assert_eq!(
             derive_cockpit_status(&Event::UserPromptSent { text: "hi".into() }),

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -276,7 +276,13 @@ pub struct CockpitConfig {
     /// `session/cancel` and arms the existing cancel-escalation grace.
     /// Closes the gap where claude-agent-acp finishes streaming but
     /// never sends `PromptResponse` (upstream
-    /// agentclientprotocol/claude-agent-acp#688). Default 120s; raised
+    /// agentclientprotocol/claude-agent-acp#688). Upstream
+    /// agentclientprotocol/claude-agent-acp#706 (shipped in 0.37.0)
+    /// recovers the prompt stream after a failed turn for some cases,
+    /// reducing the false-positive rate, but cannot rescue every wedge
+    /// (transport-level stalls, child process hangs, lost terminal
+    /// frames), so the watchdog stays as the vendor-agnostic floor.
+    /// Default 120s; raised
     /// from 60s in #1360 so async-agent flows (Claude SDK `Agent` tool
     /// with `isAsync: true`) get a longer wait window before the
     /// watchdog cancels them. `0` disables the watchdog. Long-running

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -423,6 +423,7 @@ mod tests {
             args_preview: "ls".into(),
             started_at: Utc::now(),
             parent_tool_call_id: None,
+            memory_recall: None,
         }
     }
 

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -319,6 +319,12 @@ impl CockpitTranscript {
                     text: format!("agent startup failed: {message}"),
                 });
             }
+            Event::IncompatibleAgent { .. } => {
+                // Structured detail for the web cockpit's StartupErrorScreen.
+                // The TUI mirrors the textual signal via the parallel
+                // AgentStartupError event the connection task emits, so the
+                // reducer has nothing to do here.
+            }
             Event::SessionContextReset { reason } => {
                 self.flush_pending_chunk();
                 self.context_primer_pending = true;

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1542,7 +1542,7 @@ function StartupErrorBanner({
             Run <code className="rounded bg-rose-900/60 px-1">aoe cockpit doctor --fix</code>{" "}
             from a terminal, or install the adapter manually:
             <pre className="mt-1 whitespace-pre-wrap rounded bg-rose-900/40 p-2 text-xs">
-              npm install -g @agentclientprotocol/claude-agent-acp
+              npm install -g @agentclientprotocol/claude-agent-acp@0.37.0
             </pre>
           </>
         )}

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -45,6 +45,7 @@ import {
   isQueuedPromptLong,
   queuedStripLayout,
 } from "./queuedPromptsLayout";
+import { StartupErrorScreen } from "./StartupErrorScreen";
 import { SubagentCard, ToolCard, ToolGroupCard } from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
@@ -233,6 +234,19 @@ function CockpitChrome({
       vp.removeEventListener("scroll", sampleAtBottom);
     };
   }, []);
+  // Short-circuit: when the per-adapter compatibility check rejected
+  // the adapter, replace the chat layout with a dedicated screen that
+  // renders the exact remediation command. We never reach Running, so
+  // dropping the chat/composer prevents the user from typing into a
+  // session that has no live agent. Cleared on AcpSessionAssigned once
+  // the user reinstalls and a fresh worker spawns. See agent_compat.rs.
+  if (state.incompatibleAgent) {
+    return (
+      <div className="flex h-full flex-col bg-surface-900 text-text-primary">
+        <StartupErrorScreen detail={state.incompatibleAgent} />
+      </div>
+    );
+  }
   return (
     <div className="flex h-full flex-col bg-surface-900 text-text-primary">
       <PlanStrip plan={state.plan} />

--- a/web/src/components/cockpit/StartupErrorScreen.tsx
+++ b/web/src/components/cockpit/StartupErrorScreen.tsx
@@ -21,23 +21,23 @@ export function StartupErrorScreen({ detail }: Props) {
       role="alert"
       aria-live="assertive"
       data-testid="startup-error-screen"
-      className="flex h-full flex-1 items-center justify-center bg-rose-950/30 px-4 py-12"
+      className="flex h-full flex-1 items-center justify-center bg-surface-900 px-4 py-12"
     >
-      <div className="w-full max-w-xl rounded-lg border border-rose-900/60 bg-rose-950/60 p-6 text-rose-100 shadow-lg">
-        <div className="text-xs font-semibold uppercase tracking-wide text-rose-300/80">
+      <div className="w-full max-w-xl rounded-lg border border-status-error/60 bg-surface-850 p-6 text-text-primary shadow-lg">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-status-error">
           Adapter compatibility check failed
         </div>
-        <h2 className="mt-2 text-lg font-semibold text-rose-50">{heading}</h2>
-        <p className="mt-3 text-sm text-rose-100/90">{summary}</p>
+        <h2 className="mt-2 text-lg font-semibold text-text-primary">{heading}</h2>
+        <p className="mt-3 text-sm text-text-secondary">{summary}</p>
 
         {installCommand && (
           <div className="mt-4">
-            <div className="text-xs font-medium uppercase tracking-wide text-rose-300/80">
+            <div className="text-[11px] font-medium uppercase tracking-wide text-text-dim">
               Run this, then restart the session
             </div>
             <pre
               data-testid="startup-error-install-command"
-              className="mt-1 overflow-x-auto rounded-md border border-rose-900/60 bg-rose-900/40 p-2 text-xs text-rose-50"
+              className="mt-1 overflow-x-auto rounded-md border border-surface-700 bg-surface-950 p-2 font-mono text-[12px] text-text-primary"
             >
               {installCommand}
             </pre>
@@ -46,12 +46,13 @@ export function StartupErrorScreen({ detail }: Props) {
 
         <DetailRows detail={detail} />
 
-        <div className="mt-4 text-xs text-rose-200/80">
+        <div className="mt-4 text-xs text-text-dim">
           The session is paused until the adapter satisfies the required
           version. Once you have run the command above, restart{" "}
-          <code className="rounded bg-rose-900/60 px-1">aoe serve</code> (or
-          spawn a fresh cockpit session) and the check re-runs at the next
-          ACP <code className="rounded bg-rose-900/60 px-1">initialize</code>{" "}
+          <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">aoe serve</code>{" "}
+          (or spawn a fresh cockpit session) and the check re-runs at the next
+          ACP{" "}
+          <code className="rounded bg-surface-950 px-1 font-mono text-[12px]">initialize</code>{" "}
           handshake.
         </div>
       </div>
@@ -127,11 +128,11 @@ function DetailRows({ detail }: { detail: IncompatibleAgentDetail }) {
       break;
   }
   return (
-    <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs text-rose-100/90">
+    <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 font-mono text-[11px] text-text-secondary">
       {rows.map(([label, value]) => (
         <div key={label} className="contents">
-          <dt className="font-medium text-rose-200/80">{label}</dt>
-          <dd className="break-all font-mono">{value}</dd>
+          <dt className="font-medium text-text-dim">{label}</dt>
+          <dd className="break-all">{value}</dd>
         </div>
       ))}
     </dl>

--- a/web/src/components/cockpit/StartupErrorScreen.tsx
+++ b/web/src/components/cockpit/StartupErrorScreen.tsx
@@ -1,0 +1,139 @@
+import type { IncompatibleAgentDetail } from "../../lib/cockpitTypes";
+
+interface Props {
+  detail: IncompatibleAgentDetail;
+}
+
+/** Dedicated full-region replacement for the cockpit chat layout when
+ *  the per-adapter compatibility check refuses the session. Distinct
+ *  from `StartupErrorBanner`, which is a smaller text-based hint
+ *  layered on top of the chat for free-form handshake failures. This
+ *  screen surfaces the structured detail (installed vs required
+ *  version, the exact remediation command) so the user can copy-paste
+ *  it into a shell without parsing prose. */
+export function StartupErrorScreen({ detail }: Props) {
+  const heading = headingFor(detail);
+  const summary = summaryFor(detail);
+  const installCommand = installCommandFor(detail);
+
+  return (
+    <div
+      role="alert"
+      aria-live="assertive"
+      data-testid="startup-error-screen"
+      className="flex h-full flex-1 items-center justify-center bg-rose-950/30 px-4 py-12"
+    >
+      <div className="w-full max-w-xl rounded-lg border border-rose-900/60 bg-rose-950/60 p-6 text-rose-100 shadow-lg">
+        <div className="text-xs font-semibold uppercase tracking-wide text-rose-300/80">
+          Adapter compatibility check failed
+        </div>
+        <h2 className="mt-2 text-lg font-semibold text-rose-50">{heading}</h2>
+        <p className="mt-3 text-sm text-rose-100/90">{summary}</p>
+
+        {installCommand && (
+          <div className="mt-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-rose-300/80">
+              Run this, then restart the session
+            </div>
+            <pre
+              data-testid="startup-error-install-command"
+              className="mt-1 overflow-x-auto rounded-md border border-rose-900/60 bg-rose-900/40 p-2 text-xs text-rose-50"
+            >
+              {installCommand}
+            </pre>
+          </div>
+        )}
+
+        <DetailRows detail={detail} />
+
+        <div className="mt-4 text-xs text-rose-200/80">
+          The session is paused until the adapter satisfies the required
+          version. Once you have run the command above, restart{" "}
+          <code className="rounded bg-rose-900/60 px-1">aoe serve</code> (or
+          spawn a fresh cockpit session) and the check re-runs at the next
+          ACP <code className="rounded bg-rose-900/60 px-1">initialize</code>{" "}
+          handshake.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function headingFor(detail: IncompatibleAgentDetail): string {
+  switch (detail.kind) {
+    case "incompatible_agent_version":
+      return `${detail.package_name} ${detail.installed} is below the required ${detail.required}`;
+    case "missing_agent_info":
+      return "Adapter did not report its package version";
+    case "mismatched_agent_name":
+      return `Adapter package name does not match the expected agent`;
+    case "unparseable_agent_version":
+      return `Adapter reported an invalid version string`;
+    case "unsupported_protocol_version":
+      return `Adapter speaks an unsupported ACP protocol version`;
+  }
+}
+
+function summaryFor(detail: IncompatibleAgentDetail): string {
+  switch (detail.kind) {
+    case "incompatible_agent_version":
+      return `aoe requires ${detail.package_name} version ${detail.required} or newer. The installed adapter is ${detail.installed}. Updating the adapter unblocks the session; aoe relies on behavior (memory_recall tool calls, native cancelled stop reason, others) that older versions do not emit.`;
+    case "missing_agent_info":
+      return `aoe expected ${detail.expected_package} to report a package version in its ACP initialize response. The adapter returned an empty agent_info block, which usually means a stale install or a wrapper that strips metadata. Reinstall to the pinned version.`;
+    case "mismatched_agent_name":
+      return `aoe expected the adapter to identify itself as ${detail.expected} but it reported ${detail.received}. This usually means a wrapper script or a stale binary is on PATH. Reinstall the official adapter at the pinned version.`;
+    case "unparseable_agent_version":
+      return `aoe expected ${detail.package_name} to report a semver-compatible version string but received ${detail.raw_version}. Required minimum is ${detail.required}. Reinstall the official build to recover.`;
+    case "unsupported_protocol_version":
+      return `aoe negotiated ACP protocol ${detail.expected} but the adapter reported ${detail.received}. The session cannot proceed. This usually means an older or newer adapter generation than aoe currently supports.`;
+  }
+}
+
+function installCommandFor(detail: IncompatibleAgentDetail): string | null {
+  switch (detail.kind) {
+    case "incompatible_agent_version":
+    case "missing_agent_info":
+    case "mismatched_agent_name":
+    case "unparseable_agent_version":
+      return detail.install_command;
+    case "unsupported_protocol_version":
+      return null;
+  }
+}
+
+function DetailRows({ detail }: { detail: IncompatibleAgentDetail }) {
+  const rows: Array<[string, string]> = [];
+  switch (detail.kind) {
+    case "incompatible_agent_version":
+      rows.push(["Package", detail.package_name]);
+      rows.push(["Installed", detail.installed]);
+      rows.push(["Required", `>=${detail.required}`]);
+      break;
+    case "missing_agent_info":
+      rows.push(["Expected package", detail.expected_package]);
+      break;
+    case "mismatched_agent_name":
+      rows.push(["Expected", detail.expected]);
+      rows.push(["Received", detail.received]);
+      break;
+    case "unparseable_agent_version":
+      rows.push(["Package", detail.package_name]);
+      rows.push(["Raw version", detail.raw_version]);
+      rows.push(["Required", `>=${detail.required}`]);
+      break;
+    case "unsupported_protocol_version":
+      rows.push(["Expected protocol", detail.expected]);
+      rows.push(["Received protocol", detail.received]);
+      break;
+  }
+  return (
+    <dl className="mt-4 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs text-rose-100/90">
+      {rows.map(([label, value]) => (
+        <div key={label} className="contents">
+          <dt className="font-medium text-rose-200/80">{label}</dt>
+          <dd className="break-all font-mono">{value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/web/src/components/cockpit/ToolCards.render.test.tsx
+++ b/web/src/components/cockpit/ToolCards.render.test.tsx
@@ -13,7 +13,7 @@
 // a plain <pre> and the test doesn't depend on async theme loading.
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render } from "@testing-library/react";
+import { cleanup, fireEvent, render } from "@testing-library/react";
 import type { ReactNode } from "react";
 
 vi.mock("../../lib/highlighter", () => ({
@@ -185,6 +185,40 @@ describe("ToolCards profile-gated dispatch (claude)", () => {
       </Wrap>,
     );
     expect(container.textContent).toContain("checking deploy");
+  });
+});
+
+describe("ToolCards memory_recall (claude-agent-acp v0.37.0)", () => {
+  it("renders recall mode with the loaded memory paths after expansion", () => {
+    const { container, getByRole, getByTestId } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.memoryRecallList} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("Memory recall");
+    expect(container.textContent).toContain("Recalled");
+    expect(container.textContent).toContain("2 memories");
+    // Body renders only after the toggle is clicked (matches the
+    // existing CardChrome pattern). Open it to assert the paths land.
+    fireEvent.click(getByRole("button"));
+    const list = getByTestId("memory-recall-paths");
+    expect(list.textContent).toContain("user_role.md");
+    expect(list.textContent).toContain("feedback_no_em_dashes.md");
+  });
+
+  it("renders synthesize mode with the synthesized text body after expansion", () => {
+    const { container, getByRole, getByTestId } = render(
+      <Wrap toolKey="claude">
+        <ToolCard tool={fixtures.memoryRecallSynthesize} result={undefined} />
+      </Wrap>,
+    );
+    expect(container.textContent).toContain("Memory recall");
+    expect(container.textContent).toContain("Synthesised memory");
+    fireEvent.click(getByRole("button"));
+    const body = getByTestId("memory-recall-synthesized");
+    expect(body.textContent).toContain(
+      "User is a senior engineer working on agent-of-empires.",
+    );
   });
 });
 

--- a/web/src/components/cockpit/ToolCards.tsx
+++ b/web/src/components/cockpit/ToolCards.tsx
@@ -108,6 +108,14 @@ function renderToolCard(
   result: ActivityRow | undefined,
   profile: AgentProfile,
 ) {
+  // claude-agent-acp v0.37.0+ routes session-start memory recall
+  // through the tool channel with structured metadata (upstream #703).
+  // Render the dedicated card before falling through to the path-sniff
+  // MemoryCard so adapters that emit the structured shape don't end up
+  // double-classified.
+  if (tool.memory_recall) {
+    return <MemoryRecallCard tool={tool} result={result} />;
+  }
   const memory = classifyMemory(tool);
   if (memory.isMemory) {
     return <MemoryCard tool={tool} result={result} hit={memory} />;
@@ -1534,6 +1542,91 @@ function MemoryCard({ tool, result, hit }: MemoryCardProps) {
               />
             )}
           </div>
+          ) : null}
+        </ToolErrorBody>
+      }
+    />
+  );
+}
+
+/* ── memory_recall (session-start memory load) ──────────────────── */
+
+/** Dedicated card for the session-start memory recall claude-agent-acp
+ *  routes through the tool channel in v0.37.0 (upstream
+ *  agentclientprotocol/claude-agent-acp#703). Two modes:
+ *
+ *  - recall: SDK loaded one or more memory files into the agent's
+ *    context. Render the list of paths so the user sees what the
+ *    agent already knows about them.
+ *  - synthesize: SDK summarised the memories into a single text body.
+ *    Render the body verbatim.
+ *
+ *  Replaces the aoe#1071 path-sniff workaround that inferred memory
+ *  loads from subsequent Read tool calls; that path only caught
+ *  user-driven reads of memory files, never the session-start load
+ *  the agent received before any prompt was sent. The structured tool
+ *  call now makes the load visible. */
+function MemoryRecallCard({ tool, result }: Props) {
+  const status = statusFor(result);
+  const recall = tool.memory_recall;
+  const [open, setOpen] = useState(false);
+
+  if (!recall) {
+    // Defensive: dispatcher only enters this branch when memory_recall
+    // is set, but type narrowing requires the check.
+    return <GenericToolCard tool={tool} result={result} />;
+  }
+  const paths = recall.paths ?? [];
+  const synthesized = recall.synthesized_text ?? "";
+  const isSynthesize = recall.mode === "synthesize";
+
+  const primary = isSynthesize ? (
+    <span>Synthesised memory</span>
+  ) : (
+    <>
+      <span>Recalled</span>
+      <span className="ml-2 text-text-dim">
+        · {paths.length} {paths.length === 1 ? "memory" : "memories"}
+      </span>
+    </>
+  );
+
+  const hasBody = isSynthesize ? synthesized.length > 0 : paths.length > 0;
+
+  return (
+    <CardChrome
+      status={status}
+      startedAt={tool.started_at}
+      endedAt={result?.at}
+      icon={<Brain className="h-3.5 w-3.5" />}
+      label="Memory recall"
+      primary={primary}
+      expanded={open || status === "err"}
+      onToggle={hasBody ? () => setOpen((v) => !v) : undefined}
+      body={
+        <ToolErrorBody status={status} errorText={result?.text}>
+          {status !== "err" && hasBody ? (
+            <div className="border-t border-surface-800 bg-surface-950 px-3 py-2">
+              {isSynthesize ? (
+                <pre
+                  data-testid="memory-recall-synthesized"
+                  className="whitespace-pre-wrap break-words text-[11px] text-text-secondary"
+                >
+                  {synthesized}
+                </pre>
+              ) : (
+                <ul
+                  data-testid="memory-recall-paths"
+                  className="space-y-0.5 text-[11px] text-text-secondary"
+                >
+                  {paths.map((p) => (
+                    <li key={p} className="break-all font-mono">
+                      {p}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
           ) : null}
         </ToolErrorBody>
       }

--- a/web/src/components/cockpit/__fixtures__/toolCalls.ts
+++ b/web/src/components/cockpit/__fixtures__/toolCalls.ts
@@ -127,4 +127,33 @@ export const fixtures = {
     kind: "other",
     args_preview: JSON.stringify({ x: 1 }),
   }),
+  // claude-agent-acp v0.37.0+ session-start memory recall (recall mode).
+  // Adapter sends kind=read with structured _meta.claudeCode payload;
+  // the cockpit serializer surfaces the structured data on
+  // tool.memory_recall so renderToolCard dispatches to MemoryRecallCard.
+  memoryRecallList: makeToolCall({
+    id: "mem-1",
+    name: "Recalled 2 memories",
+    kind: "read",
+    args_preview: "{}",
+    memory_recall: {
+      mode: "recall",
+      paths: [
+        "/Users/test/.claude/projects/foo/memory/user_role.md",
+        "/Users/test/.claude/projects/foo/memory/feedback_no_em_dashes.md",
+      ],
+    },
+  }),
+  // Synthesize mode: adapter packed the summary into ToolCall.content
+  // instead of locations. Renderer shows the body verbatim.
+  memoryRecallSynthesize: makeToolCall({
+    id: "mem-2",
+    name: "Recalled synthesized memory",
+    kind: "read",
+    args_preview: "{}",
+    memory_recall: {
+      mode: "synthesize",
+      synthesized_text: "User is a senior engineer working on agent-of-empires.",
+    },
+  }),
 };

--- a/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+//
+// Smoke-coverage for the dedicated startup-error screen. The screen
+// only renders when the per-adapter compatibility check rejects the
+// adapter; we exercise each variant so a future schema change to
+// `IncompatibleAgentDetail` surfaces here loudly.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+import { StartupErrorScreen } from "../StartupErrorScreen";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("StartupErrorScreen", () => {
+  it("renders incompatible_agent_version with installed/required + install command", () => {
+    const { container, getByTestId } = render(
+      <StartupErrorScreen
+        detail={{
+          kind: "incompatible_agent_version",
+          package_name: "@agentclientprotocol/claude-agent-acp",
+          installed: "0.32.0",
+          required: "0.37.0",
+          install_command:
+            "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("0.32.0");
+    expect(container.textContent).toContain("0.37.0");
+    expect(container.textContent).toContain(
+      "@agentclientprotocol/claude-agent-acp",
+    );
+    const cmd = getByTestId("startup-error-install-command");
+    expect(cmd.textContent).toContain(
+      "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+    );
+  });
+
+  it("renders missing_agent_info with the expected package", () => {
+    const { container } = render(
+      <StartupErrorScreen
+        detail={{
+          kind: "missing_agent_info",
+          expected_package: "@agentclientprotocol/claude-agent-acp",
+          install_command:
+            "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("did not report its package version");
+    expect(container.textContent).toContain(
+      "@agentclientprotocol/claude-agent-acp",
+    );
+  });
+
+  it("renders mismatched_agent_name with both expected and received", () => {
+    const { container } = render(
+      <StartupErrorScreen
+        detail={{
+          kind: "mismatched_agent_name",
+          expected: "@agentclientprotocol/claude-agent-acp",
+          received: "some-wrapper-script",
+          install_command:
+            "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain(
+      "@agentclientprotocol/claude-agent-acp",
+    );
+    expect(container.textContent).toContain("some-wrapper-script");
+  });
+
+  it("renders unparseable_agent_version with the raw version string", () => {
+    const { container } = render(
+      <StartupErrorScreen
+        detail={{
+          kind: "unparseable_agent_version",
+          package_name: "@agentclientprotocol/claude-agent-acp",
+          raw_version: "not-semver",
+          required: "0.37.0",
+          install_command:
+            "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("not-semver");
+    expect(container.textContent).toContain("0.37.0");
+  });
+
+  it("renders unsupported_protocol_version without an install command", () => {
+    const { container, queryByTestId } = render(
+      <StartupErrorScreen
+        detail={{
+          kind: "unsupported_protocol_version",
+          expected: "V1",
+          received: "V2",
+        }}
+      />,
+    );
+    expect(container.textContent).toContain("ACP protocol");
+    expect(container.textContent).toContain("V1");
+    expect(container.textContent).toContain("V2");
+    expect(queryByTestId("startup-error-install-command")).toBeNull();
+  });
+});

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1861,3 +1861,56 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
     expect(state.workerRestarting).toBe(true);
   });
 });
+
+describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
+  it("sets state.incompatibleAgent from the structured detail", () => {
+    const next = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        IncompatibleAgent: {
+          detail: {
+            kind: "incompatible_agent_version",
+            package_name: "@agentclientprotocol/claude-agent-acp",
+            installed: "0.32.0",
+            required: "0.37.0",
+            install_command:
+              "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+          },
+        },
+      },
+    });
+    expect(next.incompatibleAgent).not.toBeNull();
+    expect(next.incompatibleAgent?.kind).toBe("incompatible_agent_version");
+    if (next.incompatibleAgent?.kind === "incompatible_agent_version") {
+      expect(next.incompatibleAgent.installed).toBe("0.32.0");
+      expect(next.incompatibleAgent.required).toBe("0.37.0");
+    }
+  });
+
+  it("clears incompatibleAgent on AcpSessionAssigned (respawn healed)", () => {
+    let state: CockpitState = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        IncompatibleAgent: {
+          detail: {
+            kind: "incompatible_agent_version",
+            package_name: "@agentclientprotocol/claude-agent-acp",
+            installed: "0.32.0",
+            required: "0.37.0",
+            install_command:
+              "npm install -g @agentclientprotocol/claude-agent-acp@0.37.0",
+          },
+        },
+      },
+    });
+    expect(state.incompatibleAgent).not.toBeNull();
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { AcpSessionAssigned: { acp_session_id: "acp-1" } },
+    });
+    expect(state.incompatibleAgent).toBeNull();
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -46,6 +46,24 @@ export interface ToolCall {
    *  sub-tools under their parent Task. Undefined for top-level
    *  calls. See #1041. */
   parent_tool_call_id?: string;
+  /** Populated when claude-agent-acp v0.37.0+ routes a session-start
+   *  memory recall through the tool channel (upstream #703). The
+   *  cockpit renders a dedicated MemoryRecallCard instead of treating
+   *  it as a generic read. `recall` mode carries the list of file
+   *  paths the SDK loaded into the agent's context; `synthesize`
+   *  mode carries the synthesised memory text. */
+  memory_recall?: MemoryRecall | null;
+}
+
+export interface MemoryRecall {
+  /** "recall" (file list) or "synthesize" (text body). */
+  mode: string;
+  /** Absolute paths of the memory files loaded into the agent's
+   *  context. Empty in synthesize mode. */
+  paths?: string[];
+  /** Synthesised summary the SDK produced from the loaded memories.
+   *  Present in synthesize mode only. */
+  synthesized_text?: string | null;
 }
 
 export interface DiffPreview {

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -839,11 +839,15 @@ export function applyEvent(
       // Cancel-escalation watchdog in the daemon fired: claude-agent-acp
       // ignored `session/cancel` for the grace window, the supervisor
       // is SIGTERMing the runner and respawning via `session/load` to
-      // preserve transcript continuity. Reuse `workerRestarting`'s
-      // composer-lockdown semantics; the `agentUnresponsive` flag lets
-      // the banner render the specific cause. Cleared on
-      // `AcpSessionAssigned` (respawn finished) or `UserPromptSent`.
-      // See #1196.
+      // preserve transcript continuity. claude-agent-acp >=0.37.0
+      // (upstream #694) returns StopReason::Cancelled natively when it
+      // resolves the cancel; in that path the daemon surfaces
+      // `cancelled` instead and this branch only fires when the adapter
+      // does not respond at all (transport wedge, child hang). Reuse
+      // `workerRestarting`'s composer-lockdown semantics; the
+      // `agentUnresponsive` flag lets the banner render the specific
+      // cause. Cleared on `AcpSessionAssigned` (respawn finished) or
+      // `UserPromptSent`. See #1196.
       next.workerRestarting = true;
       next.workerStopped = false;
       next.agentUnresponsive = true;

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -96,6 +96,42 @@ export interface Approval {
   } | null;
 }
 
+/** Mirror of `StartupErrorDetail` in src/cockpit/state.rs. Serde's
+ *  default for `#[serde(tag = "kind", ...)]` is internal tagging keyed
+ *  on `kind`. Carries the structured remediation data the
+ *  `StartupErrorScreen` renders. */
+export type IncompatibleAgentDetail =
+  | {
+      kind: "incompatible_agent_version";
+      package_name: string;
+      installed: string;
+      required: string;
+      install_command: string;
+    }
+  | {
+      kind: "missing_agent_info";
+      expected_package: string;
+      install_command: string;
+    }
+  | {
+      kind: "mismatched_agent_name";
+      expected: string;
+      received: string;
+      install_command: string;
+    }
+  | {
+      kind: "unparseable_agent_version";
+      package_name: string;
+      raw_version: string;
+      required: string;
+      install_command: string;
+    }
+  | {
+      kind: "unsupported_protocol_version";
+      expected: string;
+      received: string;
+    };
+
 // One variant per Event::* in src/cockpit/state.rs. All variants carry
 // a discriminant key matching the serde representation: serde defaults
 // to externally-tagged JSON for an enum, e.g.
@@ -171,6 +207,7 @@ export type CockpitEvent =
   | { AgentMessageChunk: { text: string } }
   | { Stopped: { reason: string } }
   | { AgentStartupError: { message: string } }
+  | { IncompatibleAgent: { detail: IncompatibleAgentDetail } }
   | { UserPromptSent: { text: string } }
   | { AcpSessionAssigned: { acp_session_id: string } }
   | { SessionContextReset: { reason: string } }
@@ -227,6 +264,16 @@ export interface CockpitState {
   /** Latest agent startup failure message, if any. Cleared when a new
    *  prompt is sent or the worker successfully connects. */
   startupError: string | null;
+  /** Structured detail from the per-adapter compatibility check (see
+   *  `src/cockpit/agent_compat.rs`). When set, the cockpit UI replaces
+   *  its normal session view with a full-region `StartupErrorScreen`
+   *  that renders the exact remediation command. Distinct from
+   *  `startupError` (string) which legacy callers still populate for
+   *  free-form handshake failures; `incompatibleAgent` carries
+   *  installed/required versions + install command in structured form.
+   *  Cleared on a fresh `AcpSessionAssigned` so a respawned worker
+   *  that satisfies the policy unblocks the UI. */
+  incompatibleAgent: IncompatibleAgentDetail | null;
   /** Latest interaction error (failed sendPrompt / resolveApproval /
    *  cancel POST). Surfaces as a dismissible banner so users don't
    *  silently lose actions to a network blip. Cleared on the next
@@ -436,6 +483,7 @@ export function emptyCockpitState(): CockpitState {
     lastSeq: 0,
     lagged: false,
     startupError: null,
+    incompatibleAgent: null,
     lastError: null,
     turnActive: false,
     pendingUserPromptSeq: 0,
@@ -841,6 +889,23 @@ export function applyEvent(
     }
     return next;
   }
+  if ("IncompatibleAgent" in event) {
+    // The cockpit refused to enter the session because the adapter
+    // failed the per-adapter compatibility check (see
+    // src/cockpit/agent_compat.rs). The structured payload powers the
+    // dedicated StartupErrorScreen which short-circuits normal session
+    // rendering. The parallel AgentStartupError event populates
+    // `startupError` so legacy status logic still flips into Error.
+    next.incompatibleAgent = event.IncompatibleAgent.detail;
+    next.inFlightTool = null;
+    next.agentUnresponsive = false;
+    next.lastStoppedSeq = Math.min(
+      next.lastStoppedSeq + 1,
+      next.pendingUserPromptSeq,
+    );
+    next.turnActive = isTurnActive(next);
+    return next;
+  }
   if ("AgentStartupError" in event) {
     next.startupError = event.AgentStartupError.message;
     next.inFlightTool = null;
@@ -953,6 +1018,10 @@ export function applyEvent(
     // its own once the respawn completes the handshake.
     next.startupError = null;
     next.lastError = null;
+    // A fresh agent that passed the compatibility check has come
+    // online; the structured incompatibility banner heals so the
+    // session can resume.
+    next.incompatibleAgent = null;
     // A fresh agent (via POST /cockpit/spawn after `aoe cockpit stop`
     // or via the reconciler's auto-respawn after `aoe cockpit restart`)
     // is online; clear both transient worker banners.

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -502,6 +502,13 @@
       "components": ["web/src/components/cockpit/ToolErrorBody.tsx"]
     },
     {
+      "id": "cockpit.startup-error-screen",
+      "kind": "vitest",
+      "risk": "high",
+      "specs": ["src/components/cockpit/__tests__/StartupErrorScreen.test.tsx"],
+      "components": ["web/src/components/cockpit/StartupErrorScreen.tsx"]
+    },
+    {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -204,6 +204,10 @@ const INITIALIZE_RESULT = {
       sse: false,
     },
   },
+  agentInfo: {
+    name: "@agentclientprotocol/claude-agent-acp",
+    version: "0.37.0",
+  },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none
   // available", which surfaces as AuthRequired on the next call.

--- a/website/src/pages/docs/cockpit/multi-agent.md
+++ b/website/src/pages/docs/cockpit/multi-agent.md
@@ -13,7 +13,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter) | `npm install -g @agentclientprotocol/claude-agent-acp` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.37.0) | `npm install -g @agentclientprotocol/claude-agent-acp@0.37.0` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Aligns aoe with `@agentclientprotocol/claude-agent-acp` v0.37.0 (was floating against v0.32.0 via lazy install). Five user-visible changes:

1. **Pin claude-agent-acp to 0.37.0 exact** across docker, install hints, doctor `--fix`, agent registry description, and the manual-install banner. Users land on a known-compatible build instead of whatever npm `latest` happens to be.
2. **Runtime adapter compatibility check.** New `src/cockpit/agent_compat.rs` module runs after the ACP `initialize` handshake. Reads `agent_info.version` from the adapter's initialize response and rejects anything below 0.37.0 with a structured `StartupError`. Gated on the configured adapter kind (the supervisor's known spawn intent), not on the self-reported `agent_info.name` on the wire, so spoofing or wrapper scripts can't bypass the check. Codex / OpenCode / Gemini / aoe-agent / pi-acp pass through with a permissive policy.
3. **Dedicated `StartupErrorScreen`** replaces the cockpit chat layout when the compatibility check rejects the adapter. Renders the package name, installed version, required version, and a copy-pasteable install command. Distinct from the existing `StartupErrorBanner` (which stays for free-form handshake failures) so users see a full-region remediation screen instead of a small banner over a stale chat surface.
4. **Native `cancelled` stop reason.** claude-agent-acp v0.37.0 (upstream [agentclientprotocol/claude-agent-acp#694](https://github.com/agentclientprotocol/claude-agent-acp/pull/694)) returns `PromptResponse { stop_reason: StopReason::Cancelled }` when the user cancels via `session/cancel`. Captured in the prompt loop's terminal-reason precedence so the turn surfaces as `cancelled` instead of `prompt_complete`, distinct from `agent_unresponsive` which remains the wedge-detection signal. Watchdog stays at 10s as a transport-wedge defense.
5. **`memory_recall` tool card.** claude-agent-acp v0.37.0 (upstream [agentclientprotocol/claude-agent-acp#703](https://github.com/agentclientprotocol/claude-agent-acp/pull/703)) routes session-start memory loads through the tool channel with `_meta.claudeCode.toolName == "memory_recall"`. New `MemoryRecallCard` renders recall mode (path list) and synthesize mode (text body). Replaces the path-sniff workaround we were tracking in [#1071](https://github.com/njbrake/agent-of-empires/issues/1071); the session-start memory load is now visible in the cockpit transcript.

The plan was stress-tested via `/debate` between gpt-5.5 and gemini-3.1-pro-preview before implementation; both converged on contextual fail-closed for Claude, dedicated startup-error state, post-initialize validation, and native `cancelled` handling with the watchdog retained.

Discovered during the v0.32 → v0.37 alignment pass. Other adapter changes (`/clear` no longer advertised, model picker / effort selector hooks, additionalDirectories, Bedrock auth, session-delete RPC, prompt stream recovery) are surveyed in the commit messages and tracked in followup issues; they touch separate surfaces and don't belong in this PR.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## How to test

Each step is a user-observable behavior; run them before marking ready for review.

- [ ] Install an older adapter (`npm install -g @agentclientprotocol/claude-agent-acp@0.32.0`), start `aoe serve`, open the cockpit, and create a Claude session. Confirm the `StartupErrorScreen` shows package name, installed `0.32.0`, required `0.37.0`, and the install command `npm install -g @agentclientprotocol/claude-agent-acp@0.37.0` in a copy-block.
- [ ] Run that exact command from the screen, restart `aoe serve`, reopen the session. Confirm the screen is gone and the cockpit chat renders normally.
- [ ] In a Claude session loaded with at least one entry under `~/.claude/projects/<slug>/memory/`, start a fresh session and confirm a `Memory recall` card appears in the cockpit transcript at session start. Expand it; the loaded file paths are listed.
- [ ] In a Claude session that produces a synthesised memory reply, confirm the synthesize-mode card renders the synthesised text body.
- [ ] Start a Claude prompt that takes >5s, then click the cancel button. Confirm the turn ends quickly (under a couple of seconds) and the cockpit surfaces a clean `cancelled` stop instead of the `agent_unresponsive` restart banner.
- [ ] Spawn a Codex / OpenCode / Gemini / aoe-agent / pi-acp session. Confirm the compatibility check does not gate on these adapters (they should open normally, even if pinned at an older version).
- [ ] Open `aoe cockpit doctor --fix` from a shell with no `claude-agent-acp` on PATH. Confirm the install command it runs pins `@0.37.0`.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill). The plan was stress-tested with `/debate` against gpt-5.5 and gemini-3.1-pro-preview.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (single PR, dedicated banner, exact docker pin, centralized compatibility module, run /debate before implementing), and ran the manual verification steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR aligns agent-of-empires with `@agentclientprotocol/claude-agent-acp` v0.37.0 and adds runtime compatibility enforcement, clearer startup UX for incompatible adapters, first-class memory-recall handling, and improved prompt cancellation semantics.

### What changed (high level)
- Version pinning: pinned claude-agent-acp to 0.37.0 across Docker, docs, install hints, CLI doctor, agent registry, and banners so users land on a known-compatible adapter.
- Runtime compatibility gate: new post‑initialize validator rejects adapters that fail policy (Claude requires semver ≥0.37.0). The gate uses the configured adapter kind and permits other adapter names per policy.
- Structured error flow: incompatibility produces a typed error that propagates from ACP client → supervisor spawn/respawn/attach paths; supervisor publishes an IncompatibleAgent event and terminates stale runners so older workers can't remain alive.
- Dedicated UX: added StartupErrorScreen that replaces the chat layout for compatibility rejections, showing installed vs required versions and a copyable install command; StartupErrorBanner remains for other handshake failures.
- Prompt cancellation: handles native StopReason::Cancelled (claude-agent-acp v0.37.0) so sessions can end with reason "cancelled" while retaining the 10s watchdog for transport unresponsiveness.
- Memory recall: introduces structured memory_recall tool payload and a MemoryRecallCard that renders recalled paths or synthesized memory (replaces previous path‑sniff workaround).
- Tests & CI: updated/added Rust and web tests (unit and UI), sandbox loosened to ^0.37.0 for images; cargo fmt/clippy/tests and web tsc/vitest reported passing.

### Benefits
- Predictable installs and troubleshooting via pinned adapter version and clear remediation.
- Safer runtime: explicit semver gating and termination of stale workers prevent mixed-version failures.
- Clear, actionable UX when adapters are incompatible.
- Accurate handling of native cancellations and first-class display for session memory recalls.

### Notable technical highlights (concise)
- New Rust module src/cockpit/agent_compat.rs: ExpectedAgent parsing, CompatibilityPolicy, StartupError variants, install_command_for helper, and validate() using semver (semver added behind the serve feature).
- Acp client changes: AcpError::IncompatibleAgent(IncompatibleAgentError) introduced; compatibility rejection sent via ready_tx.
- Supervisor and attach hardening: Supervisor publishes Event::IncompatibleAgent and AgentStartupError and terminates runners; attach() resolves binary from AgentRegistry so reattaches re-trigger the compat gate.
- State and wire changes: ToolCall.memory_recall and MemoryRecall types; CockpitState startup_error/incompatibleAgent and Event::IncompatibleAgent; frontend types/reducers short-circuit chat UI and clear on AcpSessionAssigned.
- Frontend components/tests: StartupErrorScreen, MemoryRecallCard, associated fixtures and tests, and reducer lifecycle tests ensuring the compatibility screen clears after successful respawn.

### Potential follow-ups
- Consider configurable upgrade strategies (auto-update/opt-in channels) or rollout guidance.
- Add telemetry for compatibility rejections to measure upgrade friction.
- Extend compatibility policy for finer-grained backward-compat support if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->