### PR TITLE
feat: add web project aliases and colors

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -220,7 +220,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     sweepOrphanDrafts(new Set(sessions.map((s) => s.id)));
   }, [sessionsLoaded, sessions]);
 
-  const { groups, toggleRepoCollapsed } = useRepoGroups(
+  const { groups, toggleRepoCollapsed, updateRepoAppearance } = useRepoGroups(
     workspaces,
     workspaceOrdering,
   );
@@ -867,6 +867,7 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onToggle={() => setSidebarOpen(false)}
             onSelect={handleSelectWorkspace}
             onToggleRepo={toggleRepoCollapsed}
+            onUpdateRepoAppearance={updateRepoAppearance}
             onNew={() => { setWizardPrefill(undefined); setShowSessionWizard(true); }}
             onCreateSession={handleCreateSession}
             onSettings={handleOpenSettings}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -37,6 +37,10 @@ import type {
 import { MULTI_REPO_GROUP_ID } from "../hooks/useRepoGroups";
 import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import {
+  REPO_COLOR_OPTIONS,
+  type RepoAppearanceUpdate,
+} from "../lib/repoAppearance";
+import {
   STATUS_DOT_CLASS,
   getStatusTextClass,
   isSessionActive,
@@ -72,6 +76,7 @@ interface Props {
   onToggle: () => void;
   onSelect: (workspaceId: string) => void;
   onToggleRepo: (repoId: string) => void;
+  onUpdateRepoAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
   onNew: () => void;
   onCreateSession: (repoPath: string) => void;
   onSettings: () => void;
@@ -733,63 +738,202 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   hasActiveChild,
   onClick,
   onNewSession,
+  onUpdateAppearance,
   offline,
 }: {
   group: RepoGroup;
   hasActiveChild: boolean;
   onClick: () => void;
   onNewSession: () => void;
+  onUpdateAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
   offline: boolean;
 }) {
+  const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
+  const [renaming, setRenaming] = useState(false);
+  const [renameValue, setRenameValue] = useState(group.alias ?? group.displayName);
+  const renameRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const dotClass =
     STATUS_DOT_CLASS[
       group.status === "active" ? "Running" : "Idle"
     ] ?? "bg-status-idle";
+  const colorClass =
+    REPO_COLOR_OPTIONS.find((option) => option.id === group.color)?.headerClass ??
+    "hover:bg-surface-800/50";
+
+  useEffect(() => {
+    if (renaming) renameRef.current?.select();
+  }, [renaming]);
+
+  useEffect(() => {
+    if (!contextMenu) return;
+    const close = () => setContextMenu(null);
+    const onDocClick = (e: MouseEvent) => {
+      if (menuRef.current?.contains(e.target as Node)) return;
+      close();
+    };
+    const id = requestAnimationFrame(() => {
+      document.addEventListener("click", onDocClick);
+      document.addEventListener("contextmenu", close);
+    });
+    menuBus.addEventListener("close", close);
+    return () => {
+      cancelAnimationFrame(id);
+      document.removeEventListener("click", onDocClick);
+      document.removeEventListener("contextmenu", close);
+      menuBus.removeEventListener("close", close);
+    };
+  }, [contextMenu]);
+
+  const commitRename = () => {
+    setRenaming(false);
+    const trimmed = renameValue.trim();
+    onUpdateAppearance(group.id, { alias: trimmed || null });
+  };
+
+  if (renaming) {
+    return (
+      <div
+        data-testid="sidebar-group-header"
+        data-group-id={group.id}
+        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary ${colorClass} ${
+          hasActiveChild ? "border-l-2 border-brand-600" : ""
+        }`}
+      >
+        <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
+        <input
+          ref={renameRef}
+          type="text"
+          value={renameValue}
+          onChange={(e) => setRenameValue(e.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commitRename();
+            if (e.key === "Escape") setRenaming(false);
+          }}
+          data-testid="sidebar-group-rename-input"
+          className="min-w-0 flex-1 rounded border border-brand-600 bg-surface-900 px-2 py-1 text-[13px] md:text-[14px] font-mono text-text-primary focus:outline-none"
+        />
+      </div>
+    );
+  }
 
   return (
-    <div
-      data-testid="sidebar-group-header"
-      data-group-id={group.id}
-      className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary hover:bg-surface-800/50 ${
-        hasActiveChild ? "border-l-2 border-brand-600" : ""
-      }`}
-    >
-      <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
-      <button
-        onClick={onClick}
-        aria-expanded={!group.collapsed}
-        className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
+    <>
+      <div
+        data-testid="sidebar-group-header"
+        data-group-id={group.id}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          closeOtherContextMenus();
+          setContextMenu({ x: e.clientX, y: e.clientY });
+        }}
+        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary ${colorClass} ${
+          hasActiveChild ? "border-l-2 border-brand-600" : ""
+        }`}
       >
-        <svg
-          width="10"
-          height="10"
-          viewBox="0 0 10 10"
-          fill="currentColor"
-          className={`shrink-0 text-text-dim transition-transform duration-75 ${
-            group.collapsed ? "-rotate-90" : ""
-          }`}
-        >
-          <path d="M2 3 L5 6.5 L8 3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
-        </svg>
-        <OwnerAvatar owner={group.remoteOwner} size={16} />
-        <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={group.repoPath}>
-          {group.displayName}
-        </span>
-      </button>
-      <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>
+        <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
-          onClick={onNewSession}
-          disabled={offline}
-          className="w-8 h-8 flex items-center justify-center shrink-0 rounded-md transition-colors text-text-muted hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted disabled:hover:bg-transparent"
-          aria-label={`New session in ${group.displayName}`}
+          onClick={onClick}
+          aria-expanded={!group.collapsed}
+          className="flex items-center gap-2 flex-1 min-w-0 text-left cursor-pointer"
         >
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
-            <line x1="12" y1="5" x2="12" y2="19" />
-            <line x1="5" y1="12" x2="19" y2="12" />
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="currentColor"
+            className={`shrink-0 text-text-dim transition-transform duration-75 ${
+              group.collapsed ? "-rotate-90" : ""
+            }`}
+          >
+            <path d="M2 3 L5 6.5 L8 3" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
           </svg>
+          <OwnerAvatar owner={group.remoteOwner} size={16} />
+          <span className="text-[13px] md:text-[14px] font-medium truncate flex-1" title={group.repoPath}>
+            {group.displayName}
+          </span>
         </button>
-      </Tooltip>
-    </div>
+        <Tooltip text={offline ? OFFLINE_TITLE : "New session"}>
+          <button
+            onClick={onNewSession}
+            disabled={offline}
+            className="w-8 h-8 flex items-center justify-center shrink-0 rounded-md transition-colors text-text-muted hover:text-text-secondary hover:bg-surface-700/50 cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted disabled:hover:bg-transparent"
+            aria-label={`New session in ${group.displayName}`}
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+              <line x1="12" y1="5" x2="12" y2="19" />
+              <line x1="5" y1="12" x2="19" y2="12" />
+            </svg>
+          </button>
+        </Tooltip>
+      </div>
+      {contextMenu && createPortal(
+        <div
+          ref={menuRef}
+          data-testid="sidebar-group-context-menu"
+          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px]"
+          style={{ left: contextMenu.x, top: contextMenu.y }}
+        >
+          <button
+            onClick={() => {
+              setContextMenu(null);
+              setRenameValue(group.alias ?? group.defaultDisplayName);
+              setRenaming(true);
+            }}
+            data-testid="sidebar-group-context-menu-rename"
+            className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+          >
+            Rename
+          </button>
+          {group.alias && (
+            <button
+              onClick={() => {
+                setContextMenu(null);
+                onUpdateAppearance(group.id, { alias: null });
+              }}
+              className="w-full text-left px-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            >
+              Clear alias
+            </button>
+          )}
+          <div className="border-t border-surface-700/20 my-1" />
+          <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+            Background
+          </div>
+          <div className="grid grid-cols-4 gap-1 px-3 py-1.5">
+            {REPO_COLOR_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => {
+                  setContextMenu(null);
+                  onUpdateAppearance(group.id, { color: option.id });
+                }}
+                data-testid={`sidebar-group-color-${option.id}`}
+                aria-label={`Set ${option.label} background`}
+                className={`h-7 rounded-md border cursor-pointer transition-transform hover:scale-105 ${
+                  group.color === option.id ? "border-text-primary" : "border-surface-700"
+                } ${option.swatchClass}`}
+              />
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                setContextMenu(null);
+                onUpdateAppearance(group.id, { color: null });
+              }}
+              data-testid="sidebar-group-color-clear"
+              aria-label="Clear background"
+              className="h-7 rounded-md border border-surface-700 bg-surface-900 text-[10px] font-mono text-text-dim cursor-pointer hover:bg-surface-700/40"
+            >
+              None
+            </button>
+          </div>
+        </div>,
+        document.body,
+      )}
+    </>
   );
 });
 
@@ -822,6 +966,7 @@ export function WorkspaceSidebar({
   onToggle,
   onSelect,
   onToggleRepo,
+  onUpdateRepoAppearance,
   onNew,
   onCreateSession,
   onSettings,
@@ -1050,6 +1195,7 @@ export function WorkspaceSidebar({
                     group={{ ...group, collapsed: !showExpanded }}
                     hasActiveChild={!showExpanded && hasActiveChild}
                     onClick={() => !q && onToggleRepo(group.id)}
+                    onUpdateAppearance={onUpdateRepoAppearance}
                     onNewSession={() =>
                       group.id === MULTI_REPO_GROUP_ID
                         ? onNew()

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -39,6 +39,7 @@ import { safeGetItem, safeSetItem } from "../lib/safeStorage";
 import {
   REPO_COLOR_OPTIONS,
   type RepoAppearanceUpdate,
+  type RepoColor,
 } from "../lib/repoAppearance";
 import {
   STATUS_DOT_CLASS,
@@ -259,6 +260,27 @@ function useDragSuppressRef(): MutableRefObject<number> {
     throw new Error("DragSuppressContext used outside provider");
   }
   return ref;
+}
+
+const REPO_COLOR_TOKENS: Record<RepoColor, string> = {
+  amber: "--color-status-waiting",
+  teal: "--color-terminal-active",
+  sky: "--color-sandbox",
+  violet: "--color-diff-header",
+  rose: "--color-status-error",
+  slate: "--color-surface-700",
+};
+
+function repoColorStyle(color: RepoColor | null): React.CSSProperties | undefined {
+  if (!color) return undefined;
+  const token = REPO_COLOR_TOKENS[color];
+  return {
+    backgroundColor: `color-mix(in srgb, var(${token}) 14%, transparent)`,
+  };
+}
+
+function repoSwatchStyle(color: RepoColor): React.CSSProperties {
+  return { backgroundColor: `var(${REPO_COLOR_TOKENS[color]})` };
 }
 
 function useSuppressClickAfterDrag(ref: MutableRefObject<number>) {
@@ -757,9 +779,27 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
     STATUS_DOT_CLASS[
       group.status === "active" ? "Running" : "Idle"
     ] ?? "bg-status-idle";
-  const colorClass =
-    REPO_COLOR_OPTIONS.find((option) => option.id === group.color)?.headerClass ??
-    "hover:bg-surface-800/50";
+  const headerStyle = repoColorStyle(group.color);
+  const headerHoverClass = group.color ? "" : "hover:bg-surface-800/50";
+
+  const openMenuAt = useCallback((x: number, y: number) => {
+    closeOtherContextMenus();
+    setContextMenu({ x, y });
+  }, []);
+
+  const handleHeaderKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (
+      e.key !== "Enter" &&
+      e.key !== " " &&
+      e.key !== "ContextMenu" &&
+      !(e.shiftKey && e.key === "F10")
+    ) {
+      return;
+    }
+    e.preventDefault();
+    const rect = e.currentTarget.getBoundingClientRect();
+    openMenuAt(rect.left + 12, rect.bottom + 4);
+  };
 
   useEffect(() => {
     if (renaming) renameRef.current?.select();
@@ -796,9 +836,10 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
       <div
         data-testid="sidebar-group-header"
         data-group-id={group.id}
-        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary ${colorClass} ${
+        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
+        style={headerStyle}
       >
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <input
@@ -823,14 +864,18 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
       <div
         data-testid="sidebar-group-header"
         data-group-id={group.id}
+        tabIndex={0}
+        aria-haspopup="menu"
+        aria-label={`Project actions for ${group.displayName}`}
         onContextMenu={(e) => {
           e.preventDefault();
-          closeOtherContextMenus();
-          setContextMenu({ x: e.clientX, y: e.clientY });
+          openMenuAt(e.clientX, e.clientY);
         }}
-        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary ${colorClass} ${
+        onKeyDown={handleHeaderKeyDown}
+        className={`flex items-center gap-2 px-3 py-2 transition-colors duration-75 text-text-secondary focus:outline-none focus:ring-2 focus:ring-brand-600 ${headerHoverClass} ${
           hasActiveChild ? "border-l-2 border-brand-600" : ""
         }`}
+        style={headerStyle}
       >
         <span className={`w-2 h-2 rounded-full shrink-0 ${dotClass}`} />
         <button
@@ -912,9 +957,10 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
                 }}
                 data-testid={`sidebar-group-color-${option.id}`}
                 aria-label={`Set ${option.label} background`}
-                className={`h-7 rounded-md border cursor-pointer transition-transform hover:scale-105 ${
+                className={`h-7 rounded-md border cursor-pointer transition-colors ${
                   group.color === option.id ? "border-text-primary" : "border-surface-700"
-                } ${option.swatchClass}`}
+                }`}
+                style={repoSwatchStyle(option.id)}
               />
             ))}
             <button

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -788,6 +788,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   }, []);
 
   const handleHeaderKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.target !== e.currentTarget) return;
     if (
       e.key !== "Enter" &&
       e.key !== " " &&
@@ -957,7 +958,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
                 }}
                 data-testid={`sidebar-group-color-${option.id}`}
                 aria-label={`Set ${option.label} background`}
-                className={`h-7 rounded-md border cursor-pointer transition-colors ${
+                className={`h-8 rounded-md border cursor-pointer transition-colors ${
                   group.color === option.id ? "border-text-primary" : "border-surface-700"
                 }`}
                 style={repoSwatchStyle(option.id)}
@@ -971,7 +972,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
               }}
               data-testid="sidebar-group-color-clear"
               aria-label="Clear background"
-              className="h-7 rounded-md border border-surface-700 bg-surface-900 text-[10px] font-mono text-text-dim cursor-pointer hover:bg-surface-700/40"
+              className="h-8 rounded-md border border-surface-700 bg-surface-900 text-[10px] font-mono text-text-dim cursor-pointer hover:bg-surface-700/40"
             >
               None
             </button>

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -1,6 +1,12 @@
 import { useCallback, useMemo, useState } from "react";
 import type { Workspace, RepoGroup } from "../lib/types";
 import { safeGetItem, safeRemoveItem, safeSetItem } from "../lib/safeStorage";
+import {
+  applyRepoAppearanceUpdate,
+  loadRepoAppearances,
+  persistRepoAppearances,
+  type RepoAppearanceUpdate,
+} from "../lib/repoAppearance";
 
 const COLLAPSED_KEY_PREFIX = "aoe-repo-collapsed-";
 export const MULTI_REPO_GROUP_ID = "__multi_repo__";
@@ -24,8 +30,10 @@ export function useRepoGroups(
 ): {
   groups: RepoGroup[];
   toggleRepoCollapsed: (repoId: string) => void;
+  updateRepoAppearance: (repoId: string, update: RepoAppearanceUpdate) => void;
 } {
   const [collapsedMap, setCollapsedMap] = useState<Record<string, boolean>>({});
+  const [appearanceMap, setAppearanceMap] = useState(loadRepoAppearances);
 
   const groups = useMemo(() => {
     const rank = new Map(workspaceOrdering.map((id, i) => [id, i] as const));
@@ -53,11 +61,16 @@ export function useRepoGroups(
       const hasActive = sorted.some((ws) => ws.status === "active");
       const collapsed = collapsedMap[repoPath] ?? loadCollapsed(repoPath);
       const remoteOwner = sorted[0]?.sessions[0]?.remote_owner ?? null;
+      const appearance = appearanceMap[repoPath];
+      const defaultDisplayName = repoPath.split("/").pop() ?? repoPath;
 
       repoGroups.push({
         id: repoPath,
         repoPath,
-        displayName: repoPath.split("/").pop() ?? repoPath,
+        displayName: appearance?.alias ?? defaultDisplayName,
+        defaultDisplayName,
+        alias: appearance?.alias ?? null,
+        color: appearance?.color ?? null,
         remoteOwner,
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
@@ -70,10 +83,15 @@ export function useRepoGroups(
       const hasActive = sorted.some((ws) => ws.status === "active");
       const collapsed =
         collapsedMap[MULTI_REPO_GROUP_ID] ?? loadCollapsed(MULTI_REPO_GROUP_ID);
+      const appearance = appearanceMap[MULTI_REPO_GROUP_ID];
+      const defaultDisplayName = "Multi-repo";
       repoGroups.push({
         id: MULTI_REPO_GROUP_ID,
         repoPath: MULTI_REPO_GROUP_ID,
-        displayName: "Multi-repo",
+        displayName: appearance?.alias ?? defaultDisplayName,
+        defaultDisplayName,
+        alias: appearance?.alias ?? null,
+        color: appearance?.color ?? null,
         remoteOwner: null,
         workspaces: sorted,
         status: hasActive ? "active" : "idle",
@@ -91,7 +109,7 @@ export function useRepoGroups(
     });
 
     return repoGroups;
-  }, [workspaces, workspaceOrdering, collapsedMap]);
+  }, [workspaces, workspaceOrdering, collapsedMap, appearanceMap]);
 
   const toggleRepoCollapsed = useCallback((repoId: string) => {
     setCollapsedMap((prev) => {
@@ -106,5 +124,16 @@ export function useRepoGroups(
     });
   }, []);
 
-  return { groups, toggleRepoCollapsed };
+  const updateRepoAppearance = useCallback(
+    (repoId: string, update: RepoAppearanceUpdate) => {
+      setAppearanceMap((prev) => {
+        const next = applyRepoAppearanceUpdate(prev, repoId, update);
+        persistRepoAppearances(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  return { groups, toggleRepoCollapsed, updateRepoAppearance };
 }

--- a/web/src/lib/repoAppearance.test.ts
+++ b/web/src/lib/repoAppearance.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  REPO_COLOR_OPTIONS,
+  applyRepoAppearanceUpdate,
+  loadRepoAppearances,
+  persistRepoAppearances,
+  type RepoAppearance,
+} from "./repoAppearance";
+
+const STORAGE_KEY = "aoe-repo-appearance-v1";
+
+describe("applyRepoAppearanceUpdate", () => {
+  it("sets a trimmed alias", () => {
+    const next = applyRepoAppearanceUpdate({}, "/repo/a", { alias: "  Alpha  " });
+    expect(next).toEqual({ "/repo/a": { alias: "Alpha" } });
+  });
+
+  it("clears the alias when null is passed and prunes the entry if color is also absent", () => {
+    const next = applyRepoAppearanceUpdate(
+      { "/repo/a": { alias: "Alpha" } },
+      "/repo/a",
+      { alias: null },
+    );
+    expect(next).toEqual({});
+  });
+
+  it("treats whitespace-only alias as a clear", () => {
+    const next = applyRepoAppearanceUpdate(
+      { "/repo/a": { alias: "Alpha", color: "amber" } },
+      "/repo/a",
+      { alias: "   " },
+    );
+    expect(next).toEqual({ "/repo/a": { color: "amber" } });
+  });
+
+  it("sets a valid color and keeps an existing alias", () => {
+    const next = applyRepoAppearanceUpdate(
+      { "/repo/a": { alias: "Alpha" } },
+      "/repo/a",
+      { color: "teal" },
+    );
+    expect(next).toEqual({ "/repo/a": { alias: "Alpha", color: "teal" } });
+  });
+
+  it("clears the color when null is passed and prunes the entry if alias is also absent", () => {
+    const next = applyRepoAppearanceUpdate(
+      { "/repo/a": { color: "rose" } },
+      "/repo/a",
+      { color: null },
+    );
+    expect(next).toEqual({});
+  });
+
+  it("rejects an unknown color string", () => {
+    const next = applyRepoAppearanceUpdate(
+      { "/repo/a": { alias: "Alpha" } },
+      "/repo/a",
+      // @ts-expect-error intentionally bad color
+      { color: "bogus" },
+    );
+    expect(next).toEqual({ "/repo/a": { alias: "Alpha" } });
+  });
+
+  it("does not mutate the input map", () => {
+    const current: Record<string, RepoAppearance> = {
+      "/repo/a": { alias: "Alpha" },
+    };
+    const snapshot = JSON.parse(JSON.stringify(current));
+    applyRepoAppearanceUpdate(current, "/repo/a", { alias: "Beta" });
+    expect(current).toEqual(snapshot);
+  });
+});
+
+describe("persistRepoAppearances / loadRepoAppearances", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("round-trips a populated map", () => {
+    const map: Record<string, RepoAppearance> = {
+      "/repo/a": { alias: "Alpha", color: "amber" },
+      "/repo/b": { color: "violet" },
+    };
+    persistRepoAppearances(map);
+    expect(loadRepoAppearances()).toEqual(map);
+  });
+
+  it("removes the storage entry when the map is empty", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ stale: true }));
+    persistRepoAppearances({});
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("returns an empty map for invalid JSON", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not json");
+    expect(loadRepoAppearances()).toEqual({});
+  });
+
+  it("drops entries that have neither alias nor a known color", () => {
+    window.localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        "/repo/a": { alias: "Alpha" },
+        "/repo/b": { color: "rainbow" },
+        "/repo/c": {},
+      }),
+    );
+    expect(loadRepoAppearances()).toEqual({
+      "/repo/a": { alias: "Alpha" },
+    });
+  });
+});
+
+describe("REPO_COLOR_OPTIONS", () => {
+  it("has unique ids", () => {
+    const ids = REPO_COLOR_OPTIONS.map((o) => o.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/web/src/lib/repoAppearance.ts
+++ b/web/src/lib/repoAppearance.ts
@@ -17,45 +17,13 @@ export type RepoAppearanceUpdate = {
 export const REPO_COLOR_OPTIONS: Array<{
   id: RepoColor;
   label: string;
-  swatchClass: string;
-  headerClass: string;
 }> = [
-  {
-    id: "amber",
-    label: "Amber",
-    swatchClass: "bg-amber-500",
-    headerClass: "bg-amber-950/30 hover:bg-amber-900/30",
-  },
-  {
-    id: "teal",
-    label: "Teal",
-    swatchClass: "bg-teal-500",
-    headerClass: "bg-teal-950/30 hover:bg-teal-900/30",
-  },
-  {
-    id: "sky",
-    label: "Sky",
-    swatchClass: "bg-sky-500",
-    headerClass: "bg-sky-950/30 hover:bg-sky-900/30",
-  },
-  {
-    id: "violet",
-    label: "Violet",
-    swatchClass: "bg-violet-500",
-    headerClass: "bg-violet-950/30 hover:bg-violet-900/30",
-  },
-  {
-    id: "rose",
-    label: "Rose",
-    swatchClass: "bg-rose-500",
-    headerClass: "bg-rose-950/30 hover:bg-rose-900/30",
-  },
-  {
-    id: "slate",
-    label: "Slate",
-    swatchClass: "bg-slate-500",
-    headerClass: "bg-slate-700/30 hover:bg-slate-700/40",
-  },
+  { id: "amber", label: "Amber" },
+  { id: "teal", label: "Teal" },
+  { id: "sky", label: "Sky" },
+  { id: "violet", label: "Violet" },
+  { id: "rose", label: "Rose" },
+  { id: "slate", label: "Slate" },
 ];
 
 const validColors = new Set(REPO_COLOR_OPTIONS.map((option) => option.id));

--- a/web/src/lib/repoAppearance.ts
+++ b/web/src/lib/repoAppearance.ts
@@ -1,0 +1,121 @@
+import { safeGetItem, safeRemoveItem, safeSetItem } from "./safeStorage";
+
+const STORAGE_KEY = "aoe-repo-appearance-v1";
+
+export type RepoColor = "amber" | "teal" | "sky" | "violet" | "rose" | "slate";
+
+export interface RepoAppearance {
+  alias?: string;
+  color?: RepoColor;
+}
+
+export type RepoAppearanceUpdate = {
+  alias?: string | null;
+  color?: RepoColor | null;
+};
+
+export const REPO_COLOR_OPTIONS: Array<{
+  id: RepoColor;
+  label: string;
+  swatchClass: string;
+  headerClass: string;
+}> = [
+  {
+    id: "amber",
+    label: "Amber",
+    swatchClass: "bg-amber-500",
+    headerClass: "bg-amber-950/30 hover:bg-amber-900/30",
+  },
+  {
+    id: "teal",
+    label: "Teal",
+    swatchClass: "bg-teal-500",
+    headerClass: "bg-teal-950/30 hover:bg-teal-900/30",
+  },
+  {
+    id: "sky",
+    label: "Sky",
+    swatchClass: "bg-sky-500",
+    headerClass: "bg-sky-950/30 hover:bg-sky-900/30",
+  },
+  {
+    id: "violet",
+    label: "Violet",
+    swatchClass: "bg-violet-500",
+    headerClass: "bg-violet-950/30 hover:bg-violet-900/30",
+  },
+  {
+    id: "rose",
+    label: "Rose",
+    swatchClass: "bg-rose-500",
+    headerClass: "bg-rose-950/30 hover:bg-rose-900/30",
+  },
+  {
+    id: "slate",
+    label: "Slate",
+    swatchClass: "bg-slate-500",
+    headerClass: "bg-slate-700/30 hover:bg-slate-700/40",
+  },
+];
+
+const validColors = new Set(REPO_COLOR_OPTIONS.map((option) => option.id));
+
+function normalizeAppearance(value: unknown): RepoAppearance | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as { alias?: unknown; color?: unknown };
+  const alias = typeof raw.alias === "string" ? raw.alias.trim() : "";
+  const color =
+    typeof raw.color === "string" && validColors.has(raw.color as RepoColor)
+      ? (raw.color as RepoColor)
+      : undefined;
+  if (!alias && !color) return null;
+  return {
+    ...(alias ? { alias } : {}),
+    ...(color ? { color } : {}),
+  };
+}
+
+export function loadRepoAppearances(): Record<string, RepoAppearance> {
+  const raw = safeGetItem(STORAGE_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    const entries = Object.entries(parsed)
+      .map(([repoId, value]) => [repoId, normalizeAppearance(value)] as const)
+      .filter((entry): entry is readonly [string, RepoAppearance] => entry[1] !== null);
+    return Object.fromEntries(entries);
+  } catch {
+    return {};
+  }
+}
+
+export function persistRepoAppearances(map: Record<string, RepoAppearance>): void {
+  if (Object.keys(map).length === 0) {
+    safeRemoveItem(STORAGE_KEY);
+    return;
+  }
+  safeSetItem(STORAGE_KEY, JSON.stringify(map));
+}
+
+export function applyRepoAppearanceUpdate(
+  current: Record<string, RepoAppearance>,
+  repoId: string,
+  update: RepoAppearanceUpdate,
+): Record<string, RepoAppearance> {
+  const nextForRepo: RepoAppearance = { ...(current[repoId] ?? {}) };
+  if ("alias" in update) {
+    const alias = update.alias?.trim() ?? "";
+    if (alias) nextForRepo.alias = alias;
+    else delete nextForRepo.alias;
+  }
+  if ("color" in update) {
+    if (update.color && validColors.has(update.color)) nextForRepo.color = update.color;
+    else delete nextForRepo.color;
+  }
+
+  const next = { ...current };
+  if (nextForRepo.alias || nextForRepo.color) next[repoId] = nextForRepo;
+  else delete next[repoId];
+  return next;
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -1,3 +1,5 @@
+import type { RepoColor } from "./repoAppearance";
+
 /** Session data returned by the API */
 export interface SessionResponse {
   id: string;
@@ -209,6 +211,9 @@ export interface RepoGroup {
   id: string;
   repoPath: string;
   displayName: string;
+  defaultDisplayName: string;
+  alias: string | null;
+  color: RepoColor | null;
   remoteOwner: string | null;
   workspaces: Workspace[];
   status: WorkspaceStatus;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -208,7 +208,10 @@
       "id": "sidebar.groups",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/sidebar-groups.spec.ts"],
+      "specs": [
+        "tests/live/sidebar-groups.spec.ts",
+        "tests/sidebar-multi-session.spec.ts"
+      ],
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -212,10 +212,14 @@
       "id": "sidebar.groups",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": [
-        "tests/live/sidebar-groups.spec.ts",
-        "tests/sidebar-multi-session.spec.ts"
-      ],
+      "specs": ["tests/live/sidebar-groups.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
+      "id": "sidebar.repo-appearance",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": ["tests/sidebar-multi-session.spec.ts"],
       "components": ["web/src/components/WorkspaceSidebar.tsx"]
     },
     {

--- a/web/tests/sidebar-multi-session.spec.ts
+++ b/web/tests/sidebar-multi-session.spec.ts
@@ -134,4 +134,65 @@ test.describe("Sidebar multi-session (#956)", () => {
     await expect(page.getByRole("link", { name: /feature\/a/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /feature\/b/i })).toBeVisible();
   });
+
+  test("project group context menu stores alias and background color", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+      {
+        id: "sess-b",
+        title: "Celts",
+        project_path: "/tmp/other-repo",
+        branch: null,
+      },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const projectHeader = page.locator(
+      '[data-testid="sidebar-group-header"][data-group-id="/tmp/agent-of-empires"]',
+    );
+    await expect(projectHeader).toBeVisible();
+
+    await projectHeader.click({ button: "right" });
+    const menu = page.locator("[data-testid='sidebar-group-context-menu']");
+    await expect(menu).toBeVisible();
+    await menu.locator("[data-testid='sidebar-group-context-menu-rename']").click();
+
+    const input = page.locator("[data-testid='sidebar-group-rename-input']");
+    await input.fill("Client Alpha");
+    await input.press("Enter");
+    await expect(projectHeader.getByText("Client Alpha")).toBeVisible();
+
+    await page.getByLabel("Filter sessions").click();
+    const filter = page.locator("[data-testid='sidebar-filter-input']");
+    await filter.fill("client alpha");
+    await expect(page.locator("[data-testid='sidebar-group-header']")).toHaveCount(1);
+    await filter.fill("");
+
+    await projectHeader.click({ button: "right" });
+    await page.locator("[data-testid='sidebar-group-color-amber']").click();
+    await expect(projectHeader).toHaveClass(/bg-amber-950\/30/);
+
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("aoe-repo-appearance-v1"),
+    );
+    expect(JSON.parse(stored ?? "{}")).toMatchObject({
+      "/tmp/agent-of-empires": { alias: "Client Alpha", color: "amber" },
+    });
+
+    await page.reload();
+    const restoredHeader = page.locator(
+      '[data-testid="sidebar-group-header"][data-group-id="/tmp/agent-of-empires"]',
+    );
+    await expect(restoredHeader.getByText("Client Alpha")).toBeVisible();
+    await expect(restoredHeader).toHaveClass(/bg-amber-950\/30/);
+  });
 });

--- a/web/tests/sidebar-multi-session.spec.ts
+++ b/web/tests/sidebar-multi-session.spec.ts
@@ -179,7 +179,7 @@ test.describe("Sidebar multi-session (#956)", () => {
 
     await projectHeader.click({ button: "right" });
     await page.locator("[data-testid='sidebar-group-color-amber']").click();
-    await expect(projectHeader).toHaveClass(/bg-amber-950\/30/);
+    await expect(projectHeader).toHaveAttribute("style", /color-mix/);
 
     const stored = await page.evaluate(() =>
       window.localStorage.getItem("aoe-repo-appearance-v1"),
@@ -193,6 +193,32 @@ test.describe("Sidebar multi-session (#956)", () => {
       '[data-testid="sidebar-group-header"][data-group-id="/tmp/agent-of-empires"]',
     );
     await expect(restoredHeader.getByText("Client Alpha")).toBeVisible();
-    await expect(restoredHeader).toHaveClass(/bg-amber-950\/30/);
+    await expect(restoredHeader).toHaveAttribute("style", /color-mix/);
+  });
+
+  test("project group appearance menu opens from keyboard", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      {
+        id: "sess-a",
+        title: "Ethiopians",
+        project_path: "/tmp/agent-of-empires",
+        branch: null,
+      },
+    ]);
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const projectHeader = page.locator(
+      '[data-testid="sidebar-group-header"][data-group-id="/tmp/agent-of-empires"]',
+    );
+    await projectHeader.focus();
+    await page.keyboard.press("Shift+F10");
+
+    const menu = page.locator("[data-testid='sidebar-group-context-menu']");
+    await expect(menu).toBeVisible();
+    await expect(menu.locator("[data-testid='sidebar-group-context-menu-rename']")).toBeVisible();
   });
 });


### PR DESCRIPTION
## Description
Adds web-only project display customization for sidebar project groups. Users can right-click a project group header, rename it with a local alias, and assign a background color. The data is persisted in localStorage by repo path, so it does not mutate the registered project list, TUI state, or TOML config.

The alias is also included in sidebar filtering, so projects that are hard to distinguish by folder name can be found by the label the user actually sees.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate a focused web sidebar customization feature.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npx eslint src/components/WorkspaceSidebar.tsx src/hooks/useRepoGroups.ts src/lib/repoAppearance.ts src/lib/types.ts tests/sidebar-multi-session.spec.ts`
- `npx playwright test sidebar-multi-session.spec.ts`
- `npm run build`
- `node tests/validate-coverage-matrix.mjs && git -C .. diff --check`
- `cargo fmt --check`
- `cargo clippy -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Was Added
A web-only feature allowing per-repository, local-only customization of workspace sidebar project groups:
- Right-click or keyboard-open a project group header to set a local alias and assign a background color (amber, teal, sky, violet, rose, slate, or None).
- Inline rename (commit on blur/Enter), clear-alias action, and color swatches.
- Customizations persist to localStorage under aoe-repo-appearance-v1 keyed by repo path; they do not modify registered projects, TUI state, or TOML config.
- Aliases are included in sidebar filtering so renamed groups are searchable by displayed label.
- Playwright UI tests and Vitest unit tests added to validate rename, color selection, persistence, restoration, keyboard access, and persistence logic.

## What Changed (high level)
- App.tsx: Wires an updateRepoAppearance callback through useRepoGroups into WorkspaceSidebar.
- WorkspaceSidebar / RepoGroupHeader: Converted headers to stateful components with a context/appearance menu supporting alias and color edits, auto-dismiss behavior, shared menu bus to prevent multiple open menus, increased swatch/clear button sizes, and reduced swatch motion.
- useRepoGroups hook: Loads per-repo appearance map, surfaces defaultDisplayName/alias/color on RepoGroup objects, and exposes updateRepoAppearance(repoId, update) that persists changes.
- repoAppearance module: New logic and types for RepoAppearance, RepoAppearanceUpdate, RepoColor, color options, load/persist functions, and an applyRepoAppearanceUpdate helper that trims aliases, validates colors, prunes empty entries, and tolerates malformed storage JSON.
- Types: RepoGroup extended with defaultDisplayName, alias, and color fields.
- Tests/config: Added web/tests/sidebar-multi-session.spec.ts (mocked Playwright flow), vitest tests for repoAppearance logic, and updated coverage-matrix.json to include the new surface entry.

## Benefits
- Non-invasive, local-only personalization improves visual scanning and discoverability of project groups.
- Searchable aliases make finding groups easier.
- Preferences persist per repo path across reloads.
- Keyboard accessibility and motion reduction improve usability and accessibility.

## Technical notes
- Persistence key: aoe-repo-appearance-v1; stored data contains only stable ids/labels (framework-agnostic), mapping to CSS tokens at render time.
- New exports/types: RepoColor, RepoAppearance, RepoAppearanceUpdate, REPO_COLOR_OPTIONS.
- Key functions: loadRepoAppearances(), persistRepoAppearances(), applyRepoAppearanceUpdate().
- Validation performed: ESLint on affected files, npm build, targeted Playwright spec (mocked), vitest for logic, and CI coverage-matrix update.
- Accessibility: added tabIndex/aria-haspopup and handlers for Enter/Space/ContextMenu/Shift+F10; keyboard handlers scoped to avoid nested-control conflicts.

## Potential areas for enhancement
- Optional sync/export for team-shared appearance presets (currently strictly local).
- Repo-level or admin defaults to seed appearances across machines.
- Support for custom color picker or expanded token-driven theming.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->