### PR TITLE
fix(web): kill trackpad scroll momentum when cursor leaves the preview pane

### DIFF
--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -623,6 +623,89 @@ describe("useTerminal lifecycle", () => {
     }
   });
 
+  it("kills macOS trackpad momentum once the cursor leaves the preview pane", async () => {
+    // After a flick on the terminal, macOS keeps dispatching wheel
+    // events for the decaying momentum to whatever element the cursor
+    // is currently over. If the user moves the cursor onto the session
+    // list mid-flick, the sidebar (overflow-y-auto) would scroll. The
+    // hook installs a window-level capture wheel listener that blocks
+    // off-pane wheels while a momentum window from an in-pane wheel is
+    // still open.
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-momentum", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+
+      // Arm the guard with a wheel inside the terminal. The custom
+      // wheel handler also re-arms it, but in the jsdom mock that path
+      // requires the handler to be invoked directly; dispatching a real
+      // event on the xterm element exercises the capture-phase
+      // listener that the hook wires up.
+      const term = document.querySelector(".xterm") as HTMLElement;
+      expect(term).not.toBeNull();
+      act(() => {
+        term.dispatchEvent(
+          new WheelEvent("wheel", {
+            deltaY: -120,
+            bubbles: true,
+            cancelable: true,
+          }),
+        );
+      });
+
+      // Within the momentum window, a wheel event landing outside the
+      // terminal must be cancelled and prevented from bubbling.
+      const offPane = new WheelEvent("wheel", {
+        deltaY: -120,
+        bubbles: true,
+        cancelable: true,
+      });
+      let outsideReachedBubble = false;
+      const bubbleSpy = () => {
+        outsideReachedBubble = true;
+      };
+      outside.addEventListener("wheel", bubbleSpy);
+      try {
+        act(() => {
+          outside.dispatchEvent(offPane);
+        });
+      } finally {
+        outside.removeEventListener("wheel", bubbleSpy);
+      }
+      expect(offPane.defaultPrevented).toBe(true);
+      expect(outsideReachedBubble).toBe(false);
+
+      // After the guard window expires, a fresh wheel on the same
+      // outside element is allowed through.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200);
+      });
+      const fresh = new WheelEvent("wheel", {
+        deltaY: -120,
+        bubbles: true,
+        cancelable: true,
+      });
+      act(() => {
+        outside.dispatchEvent(fresh);
+      });
+      expect(fresh.defaultPrevented).toBe(false);
+    } finally {
+      div.remove();
+      outside.remove();
+    }
+  });
+
   it("re-reads --term-* CSS vars when aoe:theme-changed fires", async () => {
     const div = document.createElement("div");
     document.body.appendChild(div);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -1093,19 +1093,55 @@ export function useTerminal(
     let scrollWheelAccum = 0;
     let wheelPersistTimer: ReturnType<typeof setTimeout> | null = null;
     let lastCapturedWheelCell: { col: number; row: number } | null = null;
+
+    // macOS trackpad post-flick momentum is dispatched by the OS to
+    // whichever element the cursor is over. Without this guard, a flick
+    // started in the terminal would silently jump the session list the
+    // moment the cursor moved off the pane while momentum was still
+    // decaying. We arm a short-lived guard on every wheel inside the
+    // terminal, then a window-level capture listener kills any wheel
+    // event landing outside the terminal while the guard is active.
+    // Each blocked event re-arms the guard, so a continuous momentum
+    // chain stays blocked until the OS lets it die. A fresh, intentional
+    // scroll on the sidebar arrives with a >MOMENTUM_GUARD_MS gap and
+    // passes through.
+    const MOMENTUM_GUARD_MS = 150;
+    let momentumGuardTimer: ReturnType<typeof setTimeout> | null = null;
+    const armMomentumGuard = () => {
+      if (momentumGuardTimer) clearTimeout(momentumGuardTimer);
+      momentumGuardTimer = setTimeout(() => {
+        momentumGuardTimer = null;
+      }, MOMENTUM_GUARD_MS);
+    };
+
     const onWheelCapture = (e: WheelEvent) => {
       lastCapturedWheelCell = cellFromClientPoint(
         e.clientX,
         e.clientY,
         e.currentTarget ?? e.target,
       );
+      armMomentumGuard();
     };
     viewport.addEventListener("wheel", onWheelCapture, {
       capture: true,
       passive: true,
     });
+    const onWindowWheelGuard = (e: WheelEvent) => {
+      // Allow wheels targeting the terminal viewport; the terminal's own
+      // handler will re-arm the guard via onWheelCapture.
+      if (viewport.contains(e.target as Node)) return;
+      if (momentumGuardTimer === null) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      armMomentumGuard();
+    };
+    window.addEventListener("wheel", onWindowWheelGuard, {
+      capture: true,
+      passive: false,
+    });
     term.attachCustomWheelEventHandler((e: WheelEvent) => {
       e.preventDefault();
+      armMomentumGuard();
 
       if (e.ctrlKey) {
         // Trackpad pinch fires wheel events with ctrlKey=true
@@ -1224,6 +1260,8 @@ export function useTerminal(
       viewport.removeEventListener("touchcancel", onTouchEnd, touchOpts);
       viewport.removeEventListener("click", onClickCapture, true);
       viewport.removeEventListener("wheel", onWheelCapture, true);
+      window.removeEventListener("wheel", onWindowWheelGuard, true);
+      if (momentumGuardTimer) clearTimeout(momentumGuardTimer);
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);


### PR DESCRIPTION
## Description

After a flick on the terminal preview, macOS keeps dispatching wheel events to whichever element the cursor is over. If you flick the preview pane and then move the mouse onto the session list while momentum is still decaying, the scroll silently switches targets and starts scrolling the sidebar.

Root cause: the xterm custom wheel handler in `useTerminal.ts` only sees events whose target is the terminal viewport. The moment the cursor moves off, OS-level momentum wheel events bypass that handler entirely and the browser natively scrolls whatever overflow container the cursor now sits over (`WorkspaceSidebar` is `overflow-y-auto`).

Fix: a window-level capture-phase wheel listener with a 150ms guard timer that gets armed by every in-pane wheel. While the guard is active, any wheel landing outside the terminal viewport is `preventDefault`'d and its propagation stopped. Each blocked event re-arms the timer, so a continuous momentum chain stays blocked until the OS lets it die. A fresh, intentional scroll on the sidebar arrives after the guard expires and passes through normally.

Counterpart on the web side to the recent TUI fix #1367.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- `npx vitest run src/hooks` -> 84/84 pass (10 files), including the new regression test in `useTerminal.lifecycle.test.ts`: arms the guard with an in-pane wheel, asserts an off-pane wheel is cancelled + stops propagation, advances 200ms, asserts a fresh off-pane wheel passes through.
- `npx tsc --noEmit` clean.
- Manual: jsdom cannot drive real OS-level momentum, so a Mac/trackpad smoke is still needed. Steps: `cargo build --features serve && aoe serve`, open the dashboard in Chrome on macOS, attach to a session with output history, two-finger flick scroll the preview, move the cursor onto the session list before momentum dies, confirm the sidebar does not scroll.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Investigation and fix drafted via back-and-forth with Claude; reasoning, decisions, and the manual macOS validation step are mine.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes an issue where scrolling momentum from a two-finger trackpad flick on macOS would unintentionally scroll the sidebar after the cursor moved away from the preview pane.

### What Changed

**Code Implementation (useTerminal.ts)**
- Added a "momentum guard" mechanism that temporarily blocks wheel scroll events when they occur outside the terminal viewport
- The guard activates for 150 milliseconds whenever a scroll happens within the terminal, then automatically resets
- During the guard period, scroll events that land outside the terminal are blocked from propagating to other page elements (like the sidebar)
- Once the guard period expires, normal scrolling on other elements works as expected

**Testing (useTerminal.lifecycle.test.ts)**
- Added a comprehensive regression test to verify the momentum guard works correctly
- The test confirms that out-of-pane wheel events are properly blocked while the guard is active
- The test also verifies that events can pass through normally once the guard expires

### Benefits

- **Prevents accidental sidebar scrolling**: Users can no longer accidentally scroll the sidebar when moving the cursor away from the preview pane while momentum is still active
- **Minimal disruption**: The solution uses a short, fixed timer window that automatically expires, so normal scrolling behavior is preserved
- **Cross-platform safe**: The implementation applies broadly and doesn't break existing scroll behavior on other elements

### Technical Details

The fix implements a window-level capture-phase wheel event listener that:
- Arms a momentum guard timer (150ms) on any wheel event originating from within the terminal viewport
- While the guard is armed, prevents and stops propagation of wheel events occurring outside the terminal viewport
- Re-arms the guard each time a blocked event occurs (keeping the guard active during momentum chains)
- Automatically disarms after the timeout expires, allowing normal wheel scrolling on other page elements to resume

The implementation is validated with unit tests confirming the guard arms/disarms correctly and blocks momentum events as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1408?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->