### PR TITLE
fix(tui): collapse E/F5 help row, restore strict-mode h and Ctrl+G

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -14,7 +14,7 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
     | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
     && apt-get update \
-    && apt-get install -y gh \
+    && apt-get install -y gh tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Continue as root (base image sets IS_SANDBOX=1)

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -45,8 +45,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("M", "Send message to agent"),
                     ("F", "Toggle favorite"),
                     ("H", "Snooze (toggle)"),
-                    ("E", "Restart session"),
-                    ("F5", "Restart session"),
+                    ("E", "Restart session (also F5)"),
                 ],
             ),
             (
@@ -107,8 +106,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("m", "Send message to agent"),
                     ("f", "Toggle favorite"),
                     ("h", "Snooze (toggle)"),
-                    ("e", "Restart session"),
-                    ("F5", "Restart session"),
+                    ("e", "Restart session (also F5)"),
                 ],
             ),
             (

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -749,7 +749,9 @@ impl HomeView {
         //   Shift+letter actions -> pass through unchanged: each has its own
         //     `Char('UPPER') if self.strict_hotkeys` arm in the main match.
         //   Ctrl+letter relocated bindings -> uppercase: Ctrl+T->T, Ctrl+D->D, Ctrl+R->R, Ctrl+P->P, Ctrl+N->N
-        //   Ctrl+G -> g (group toggle was lowercase)
+        //   Ctrl+G, Ctrl+O -> pass through with CTRL intact (the dispatch
+        //     table matches them with their modifier; stripping CTRL would
+        //     collide with the bare-lowercase typing-guard).
         //   Bare lowercase action letters -> blocked (return None)
         let key = if self.strict_hotkeys {
             self.normalize_strict_key(key)
@@ -1745,7 +1747,12 @@ impl HomeView {
             KeyCode::Char('>') => {
                 self.grow_list();
             }
-            KeyCode::Left => {
+            // Bare `h` collapses only in strict mode; in non-strict the
+            // earlier `Char('h') if !self.strict_hotkeys` arm catches it
+            // for Snooze, so we'd never reach here. Pairing it with Left
+            // keeps the help overlay's "h/←" claim honest and mirrors the
+            // unconditional `l`/Right binding below.
+            KeyCode::Left | KeyCode::Char('h') => {
                 if let Some(Item::Group {
                     path, collapsed, ..
                 }) = self.flat_items.get(self.cursor)
@@ -2750,11 +2757,12 @@ impl HomeView {
                 KeyCode::Char(c.to_ascii_uppercase()),
                 KeyModifiers::NONE,
             )),
-            // Ctrl+G -> g (toggle group by)
-            KeyCode::Char('g') if ctrl => {
-                Some(KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE))
-            }
-            // Ctrl+O stays as-is (cycle sort backward, already handled by its own arm)
+            // Ctrl+G and Ctrl+O stay as-is. The dispatch table already has
+            // strict-mode arms that match `Char('g')`/`Char('o')` *with*
+            // the CTRL modifier; stripping CTRL here would make the
+            // post-normalize key indistinguishable from bare lowercase
+            // input and route Ctrl+G into the typing-guard catch-all.
+            KeyCode::Char('g') if ctrl => Some(key),
             KeyCode::Char('o') if ctrl => Some(key),
             // Shifted action letters pass through unchanged. Each letter has its
             // own `Char('UPPER') if self.strict_hotkeys` arm in the main match.

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1744,6 +1744,148 @@ fn test_bare_lowercase_o_does_not_cycle_sort_in_strict_mode() {
 
 #[test]
 #[serial]
+fn test_strict_mode_h_collapses_group() {
+    // Regression guard: the help overlay lists "h/←" for Collapse group in
+    // strict mode. Bare lowercase `h` must walk through the dispatch and
+    // collapse the cursor's group, mirroring `l`/Right for expand. Without
+    // the explicit `Char('h')` arm next to `KeyCode::Left`, `h` would fall
+    // into the strict-mode typing-guard catch-all and the advertised
+    // navigation hotkey would silently open the compose dialog.
+    let mut env = create_test_env_with_groups();
+    env.view.strict_hotkeys = true;
+
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { .. }))
+        .expect("setup should produce a group");
+
+    if let Item::Group { collapsed, .. } = &env.view.flat_items[group_idx] {
+        assert!(!collapsed, "group should start expanded");
+    }
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('h')), None);
+
+    if let Item::Group { collapsed, .. } = &env.view.flat_items[group_idx] {
+        assert!(
+            *collapsed,
+            "bare 'h' in strict mode must collapse the group"
+        );
+    }
+    assert!(
+        env.view.pending_paste.is_none(),
+        "bare 'h' in strict mode must not leak into the typing-guard catch-all"
+    );
+}
+
+#[test]
+#[serial]
+fn test_strict_mode_h_still_snoozes_in_non_strict() {
+    // Companion guard for the strict-mode `h` collapse fix: making `h` an
+    // unconditional navigation key would steal the lowercase Snooze binding
+    // in default (non-strict) mode. The earlier `Char('h') if !strict` arm
+    // catches first, so the collapse arm only fires in strict mode.
+    let mut env = create_test_env_with_groups();
+    env.view.strict_hotkeys = false;
+
+    let group_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Group { .. }))
+        .expect("setup should produce a group");
+    env.view.cursor = group_idx;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('h')), None);
+
+    if let Item::Group { collapsed, .. } = &env.view.flat_items[group_idx] {
+        assert!(
+            !collapsed,
+            "non-strict 'h' must remain bound to snooze, not collapse"
+        );
+    }
+}
+
+#[test]
+#[serial]
+fn test_strict_mode_ctrl_g_toggles_group_by() {
+    // Regression guard: the help overlay lists "Ctrl+G" for Toggle group by
+    // project in strict mode. Previously normalize_strict_key stripped CTRL
+    // and routed the result into the typing-guard catch-all, so the
+    // advertised hotkey was a no-op (the bare 'g' landed in pending_paste).
+    // Ctrl+G must now keep its modifier and toggle group-by, while bare 'g'
+    // continues to fall into the typing-guard catch-all.
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_with_sessions(3);
+    env.view.strict_hotkeys = true;
+    env.view.group_by = GroupByMode::Manual;
+
+    env.view.handle_key(
+        KeyEvent::new(KeyCode::Char('g'), KeyModifiers::CONTROL),
+        None,
+    );
+    assert_eq!(
+        env.view.group_by,
+        GroupByMode::Project,
+        "Ctrl+G in strict mode should toggle group-by"
+    );
+    assert!(
+        env.view.pending_paste.is_none(),
+        "Ctrl+G must not leak into the typing-guard catch-all"
+    );
+
+    env.view.handle_key(key(KeyCode::Char('g')), None);
+    assert_eq!(
+        env.view.group_by,
+        GroupByMode::Project,
+        "bare 'g' in strict mode must NOT toggle group-by (typing-guard contract)"
+    );
+    assert_eq!(
+        env.view.pending_paste.as_deref(),
+        Some("g"),
+        "bare 'g' in strict mode falls through to the typing-guard catch-all"
+    );
+}
+
+#[test]
+#[serial]
+fn test_f5_and_e_both_open_restart_dialog() {
+    // Pin the equivalence: F5 and `e`/`E` all open the restart dialog. The
+    // help overlay collapses them onto one row as "Restart session (also
+    // F5)", which is only honest if both bindings keep hitting the same
+    // dispatch (open_restart_dialog).
+    let mut env = create_test_env_with_sessions(1);
+    env.view.cursor = 0;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::F(5)), None);
+    let f5_opened = env.view.restart_dialog.is_some();
+    env.view.restart_dialog = None;
+
+    env.view.strict_hotkeys = false;
+    env.view.handle_key(key(KeyCode::Char('e')), None);
+    let lower_e_opened = env.view.restart_dialog.is_some();
+    env.view.restart_dialog = None;
+
+    env.view.strict_hotkeys = true;
+    env.view.handle_key(key(KeyCode::Char('E')), None);
+    let upper_e_opened = env.view.restart_dialog.is_some();
+
+    assert!(f5_opened, "F5 should open the restart dialog");
+    assert!(
+        lower_e_opened,
+        "non-strict 'e' should open the restart dialog"
+    );
+    assert!(upper_e_opened, "strict 'E' should open the restart dialog");
+}
+
+#[test]
+#[serial]
 fn test_ctrl_o_key_cycles_sort_order_backward() {
     use crate::session::config::SortOrder;
 


### PR DESCRIPTION
## Description

While answering a help-overlay question I noticed `E` and `F5` were rendered on two consecutive rows ("Restart session" / "Restart session"). Pulling the thread surfaced two more real bugs in strict-hotkey mode:

1. **Help advertised a binding that didn't exist.** Strict-mode help listed `h/←` for *Collapse group*, but only `KeyCode::Left` was bound. Bare `h` in strict mode fell into the typing-guard catch-all and silently routed into the compose flow.
2. **Strict-mode `Ctrl+G` was a no-op.** `normalize_strict_key` mapped `Ctrl+G` to bare `g`/NONE, but every `Char('g')` dispatch arm requires either CTRL or `!strict`, so the normalized key landed in the catch-all and `g` ended up in `pending_paste` instead of toggling group-by.

### Fixes

- `src/tui/components/help.rs`: merge the two restart rows into `"Restart session (also F5)"` in both keymaps.
- `src/tui/home/input.rs`: pair `Char('h')` with `KeyCode::Left` so strict-mode `h` collapses the cursor's group (mirroring `l`/Right for expand). The earlier `Char('h') if !strict` Snooze arm catches first in default mode, so non-strict behavior is unchanged.
- `src/tui/home/input.rs`: stop stripping CTRL from `Ctrl+G` in `normalize_strict_key`. Ctrl+O already passed through with its modifier intact; lifting Ctrl+G the same way lets the existing strict-mode dispatch arm fire while keeping bare `g` in the typing-guard.

### Drive-by

- `docker/Dockerfile.dev`: add `tmux` to the existing apt-get install layer so the dev sandbox can run `aoe` from source and the e2e suite without a manual install. Single layer, no extra `apt-get update`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

### Tests

Three regression guards added in `tui::home::tests`, plus a companion test pinning that non-strict `h` still snoozes:

- `test_strict_mode_h_collapses_group` — strict-mode `h` collapses the cursor's group, doesn't leak into `pending_paste`.
- `test_strict_mode_h_still_snoozes_in_non_strict` — guards against accidentally stealing the Snooze binding in default mode.
- `test_strict_mode_ctrl_g_toggles_group_by` — `Ctrl+G` toggles, bare `g` still falls into the typing-guard.
- `test_f5_and_e_both_open_restart_dialog` — pins the merged help row's equivalence claim.

Verified locally with:

- `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`
- `cargo test --lib` (1964 pass; one unrelated tmux test is flaky under parallel load, passes in isolation)
- `cargo test --test e2e` (67 pass, 2 Docker-only ignored)

No web dashboard changes, so no `web/tests/coverage-matrix.json` update needed.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** I noticed the E/F5 quirk in the help overlay and asked Claude to look for other inconsistencies; it identified the strict-mode `h` and `Ctrl+G` dispatch holes, drafted regression tests that confirmed both were broken, then applied the fixes above. The Dockerfile.dev tmux addition came out of installing tmux to actually run the e2e suite while validating the fix.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes TUI help layout and strict-mode hotkey handling, and improves the dev Docker image:

- Merged duplicate help entries so "Restart session" shows as a single row "Restart session (also F5)" instead of separate E and F5 lines.
- Restored strict-mode behavior for two hotkeys:
  - Bare h now collapses/expands groups in strict mode (paired with Left arrow); non-strict snooze behavior remains unchanged.
  - Ctrl+G retains its CTRL modifier in strict mode so it toggles the group-by filter; bare g still goes to the typing guard.
- Added tmux to docker/Dockerfile.dev so the development sandbox can run the app and e2e tests without a separate tmux install.
- Added regression tests to lock in these behaviors.

## Benefits

- Cleaner, less cluttered help overlay.
- Strict-mode navigation and grouping work correctly again, improving keyboard usability.
- Easier onboarding for devs running the app and tests in Docker.
- Regressions protected by tests.

## Technical details (short)

- docker/Dockerfile.dev: install tmux alongside gh.
- src/tui/components/help.rs: combined Restart session help entry so it reads “(also F5)” in both keymaps.
- src/tui/home/input.rs:
  - Pair Char('h') with KeyCode::Left in strict-mode dispatch so h collapses groups.
  - Stop stripping CTRL in normalize_strict_key so Ctrl+G remains distinct.
- src/tui/home/tests.rs: added tests:
  - test_strict_mode_h_collapses_group
  - test_strict_mode_h_still_snoozes_in_non_strict
  - test_strict_mode_ctrl_g_toggles_group_by
  - test_f5_and_e_both_open_restart_dialog

All relevant checks were run locally: cargo fmt, clippy, lib tests (1964 passing), and e2e tests (67 passing; two Docker-only ignored).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1409?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->