### PR TITLE
feat(tui): full-screen multi-column help overlay

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -1,19 +1,34 @@
-//! Help overlay component
+//! Help overlay component.
+//!
+//! The overlay claims most of the viewport, flows the shortcut sections
+//! across as many columns as the width allows, and scrolls vertically
+//! when even a single column does not fit. Sizing is driven by viewport
+//! dimensions so the same render path works on a 24-row phone and a
+//! 60-row desktop.
 
 use ratatui::prelude::*;
 use ratatui::widgets::*;
+use unicode_width::UnicodeWidthStr;
 
 use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
-const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 50;
-#[cfg(test)]
-const BORDER_HEIGHT: u16 = 2;
-#[cfg(test)]
-const BORDER_WIDTH: u16 = 2;
-#[cfg(test)]
-const KEY_COLUMN_WIDTH: usize = 13; // 2 spaces indent + 11 chars for key
+/// Width of the key column, in cells. 11 fits the longest key strings
+/// in either keymap (`Home/End/G`, `Shift+drag` = 10 cells) with one
+/// cell of padding before the description.
+const KEY_FIELD_WIDTH: usize = 11;
+/// Cells of left indent before each shortcut row.
+const ROW_INDENT: usize = 2;
+/// Space between adjacent columns.
+const COLUMN_GAP: u16 = 3;
+/// Horizontal padding inside the dialog border.
+const INNER_PADDING_X: u16 = 1;
+/// Below this viewport width the overlay drops its margins and uses the
+/// whole area; otherwise a tiny phone viewport loses too many cells to
+/// chrome.
+const SMALL_VIEWPORT_WIDTH: u16 = 40;
+/// Same idea for height: drop top/bottom margin below this.
+const SMALL_VIEWPORT_HEIGHT: u16 = 16;
 
 fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
     if strict {
@@ -27,7 +42,6 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("l/→", "Expand group"),
                     ("Home/End/G", "Go to top / bottom"),
                     ("PgUp/Dn", "Move 10 (also Shift+↑/↓, { })"),
-                    ("w", "Next waiting/idle session"),
                 ],
             ),
             (
@@ -40,13 +54,19 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("Ctrl+N", "New from selection"),
                     ("X", "Stop session"),
                     ("D", "Delete session/group"),
-                    ("Z", "Archive (toggle)"),
                     ("R", "Rename session/group"),
                     ("M", "Send message to agent"),
-                    ("F", "Toggle favorite"),
-                    ("H", "Snooze (toggle)"),
                     ("E", "Restart session"),
                     ("F5", "Restart session"),
+                ],
+            ),
+            (
+                "Attention",
+                vec![
+                    ("w", "Jump to next waiting/idle"),
+                    ("F", "Toggle favorite"),
+                    ("H", "Snooze (toggle)"),
+                    ("Z", "Archive (toggle)"),
                 ],
             ),
             (
@@ -89,7 +109,6 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("l/→", "Expand group"),
                     ("Home/End/G", "Go to top / bottom"),
                     ("PgUp/Dn", "Move 10 (also Shift+↑/↓, { })"),
-                    ("w", "Next waiting/idle session"),
                 ],
             ),
             (
@@ -102,13 +121,19 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("N", "New from selection"),
                     ("x", "Stop session"),
                     ("d", "Delete session/group"),
-                    ("z", "Archive (toggle)"),
                     ("r", "Rename session/group"),
                     ("m", "Send message to agent"),
-                    ("f", "Toggle favorite"),
-                    ("h", "Snooze (toggle)"),
                     ("e", "Restart session"),
                     ("F5", "Restart session"),
+                ],
+            ),
+            (
+                "Attention",
+                vec![
+                    ("w", "Jump to next waiting/idle"),
+                    ("f", "Toggle favorite"),
+                    ("h", "Snooze (toggle)"),
+                    ("z", "Archive (toggle)"),
                 ],
             ),
             (
@@ -144,48 +169,183 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
     }
 }
 
+struct HelpSection {
+    title: &'static str,
+    rows: Vec<(String, String)>,
+}
+
+fn build_sections(strict: bool, sort_order: SortOrder) -> Vec<HelpSection> {
+    let raw = shortcuts(strict);
+    let sort_label = format!("(current sort: {})", sort_order.label());
+    raw.into_iter()
+        .map(|(title, keys)| {
+            let mut rows: Vec<(String, String)> = keys
+                .into_iter()
+                .map(|(k, d)| (k.to_string(), d.to_string()))
+                .collect();
+            if title == "Views" {
+                rows.push((String::new(), sort_label.clone()));
+            }
+            HelpSection { title, rows }
+        })
+        .collect()
+}
+
 #[cfg(test)]
-fn content_line_count(strict: bool) -> usize {
-    let sections = shortcuts(strict);
-    let last_idx = sections.len().saturating_sub(1);
-    let mut count = 0;
-    for (idx, (section, keys)) in sections.iter().enumerate() {
-        count += 1; // section header
-        count += keys.len(); // shortcut lines
+fn section_height(section: &HelpSection) -> usize {
+    1 + section.rows.len()
+}
 
-        // Add extra line for sort label after Views section
-        if *section == "Views" {
-            count += 1;
-        }
+/// Minimum width a column needs to render every row of every section
+/// without truncating the description.
+fn min_column_width(sections: &[HelpSection]) -> u16 {
+    let row_width = sections
+        .iter()
+        .flat_map(|s| s.rows.iter().map(|(_, d)| d.width()))
+        .max()
+        .unwrap_or(0)
+        + ROW_INDENT
+        + KEY_FIELD_WIDTH;
+    let title_width = sections.iter().map(|s| s.title.width()).max().unwrap_or(0);
+    row_width.max(title_width) as u16
+}
 
-        if idx != last_idx {
-            count += 1; // blank separator between sections
+/// Pick a column count that fits `inner_width` while giving each column
+/// at least `min_col` cells. Capped at `max_cols` so we never produce
+/// more columns than there are sections.
+fn pick_columns(inner_width: u16, min_col: u16, max_cols: usize) -> usize {
+    if max_cols == 0 {
+        return 0;
+    }
+    let mut n = 1usize;
+    while n < max_cols {
+        let candidate = (n + 1) as u16;
+        let gaps = COLUMN_GAP.saturating_mul(candidate - 1);
+        let total = candidate.saturating_mul(min_col).saturating_add(gaps);
+        if total <= inner_width {
+            n += 1;
+        } else {
+            break;
         }
     }
-    count
+    n
+}
+
+/// Spread `n` sections across `n_cols` columns, preserving reading
+/// order. Returns one Vec of section indices per column.
+///
+/// The split is by section count rather than by height: with the small
+/// number of sections in the help (currently 4) and similar densities,
+/// count-based balancing keeps left-to-right reading intact and
+/// produces close-to-equal column heights in practice. Height-based
+/// bin-packing would have to reorder sections to do better.
+fn distribute_sections(n: usize, n_cols: usize) -> Vec<Vec<usize>> {
+    if n == 0 {
+        return vec![Vec::new(); n_cols.max(1)];
+    }
+    let n_cols = n_cols.clamp(1, n);
+    let per_col = n / n_cols;
+    let extra = n % n_cols;
+    let mut cols: Vec<Vec<usize>> = Vec::with_capacity(n_cols);
+    let mut idx = 0;
+    for c in 0..n_cols {
+        let count = per_col + if c < extra { 1 } else { 0 };
+        cols.push((idx..idx + count).collect());
+        idx += count;
+    }
+    cols
+}
+
+fn render_column_lines(
+    sections: &[HelpSection],
+    indices: &[usize],
+    theme: &Theme,
+) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line> = Vec::new();
+    for (i, &si) in indices.iter().enumerate() {
+        let section = &sections[si];
+        lines.push(Line::from(Span::styled(
+            section.title.to_string(),
+            Style::default().fg(theme.accent).bold(),
+        )));
+        for (key, desc) in &section.rows {
+            let pad = KEY_FIELD_WIDTH.saturating_sub(key.width());
+            let key_cell = format!("{}{}{}", " ".repeat(ROW_INDENT), key, " ".repeat(pad));
+            lines.push(Line::from(vec![
+                Span::styled(key_cell, Style::default().fg(theme.waiting)),
+                Span::styled(desc.clone(), Style::default().fg(theme.text)),
+            ]));
+        }
+        if i + 1 != indices.len() {
+            lines.push(Line::from(""));
+        }
+    }
+    lines
+}
+
+fn compute_dialog_area(area: Rect) -> Rect {
+    // Reserve a small constant margin so the overlay almost fills the
+    // viewport but still leaves a visual frame around it on every
+    // sensible terminal size. On a 100-cell-wide terminal that leaves
+    // 96 cells for the dialog, which is enough for the canonical 2-col
+    // layout (two ~43-cell columns plus borders and gap).
+    let margin_x = if area.width < SMALL_VIEWPORT_WIDTH {
+        0
+    } else {
+        (area.width / 40).clamp(1, 4)
+    };
+    let margin_y = if area.height < SMALL_VIEWPORT_HEIGHT {
+        0
+    } else {
+        (area.height / 30).clamp(1, 2)
+    };
+    Rect {
+        x: area.x + margin_x,
+        y: area.y + margin_y,
+        width: area.width.saturating_sub(2 * margin_x),
+        height: area.height.saturating_sub(2 * margin_y),
+    }
+}
+
+fn split_footer(inner: Rect) -> (Rect, Option<Rect>) {
+    if inner.height < 3 {
+        return (inner, None);
+    }
+    let lines_area = Rect {
+        height: inner.height - 1,
+        ..inner
+    };
+    let footer = Rect {
+        x: inner.x,
+        y: inner.y + inner.height - 1,
+        width: inner.width,
+        height: 1,
+    };
+    (lines_area, Some(footer))
 }
 
 pub struct HelpOverlay;
 
 impl HelpOverlay {
+    /// Render the help overlay. `scroll` is mutated in place: it is
+    /// clamped to the valid range so that overshoot from input handlers
+    /// (for example, treating `End` as `u16::MAX`) is naturally
+    /// corrected on the next paint.
     pub fn render(
         frame: &mut Frame,
         area: Rect,
         theme: &Theme,
         sort_order: SortOrder,
         strict_hotkeys: bool,
+        scroll: &mut u16,
     ) {
-        let x = area.x + (area.width.saturating_sub(DIALOG_WIDTH)) / 2;
-        let y = area.y + (area.height.saturating_sub(DIALOG_HEIGHT)) / 2;
-
-        let dialog_area = Rect {
-            x,
-            y,
-            width: DIALOG_WIDTH.min(area.width),
-            height: DIALOG_HEIGHT.min(area.height),
-        };
-
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        let dialog_area = compute_dialog_area(area);
         frame.render_widget(Clear, dialog_area);
+
+        let sections = build_sections(strict_hotkeys, sort_order);
 
         let version = format!(" Agent of Empires v{} ", env!("CARGO_PKG_VERSION"));
         let block = Block::default()
@@ -202,38 +362,65 @@ impl HelpOverlay {
         let inner = block.inner(dialog_area);
         frame.render_widget(block, dialog_area);
 
-        let mut lines: Vec<Line> = Vec::new();
-        let sort_label = format!("(current sort: {})", sort_order.label());
+        let (content_area, footer_area) = split_footer(inner);
+        let usable_width = content_area.width.saturating_sub(2 * INNER_PADDING_X);
 
-        let sections = shortcuts(strict_hotkeys);
-        let last_idx = sections.len().saturating_sub(1);
-        for (idx, (section, keys)) in sections.iter().enumerate() {
-            lines.push(Line::from(Span::styled(
-                *section,
-                Style::default().fg(theme.accent).bold(),
-            )));
-            for (key, desc) in keys {
-                lines.push(Line::from(vec![
-                    Span::styled(format!("  {:11}", key), Style::default().fg(theme.waiting)),
-                    Span::styled(*desc, Style::default().fg(theme.text)),
-                ]));
-            }
+        let min_col = min_column_width(&sections);
+        let n_cols = pick_columns(usable_width, min_col, sections.len()).max(1);
+        let distribution = distribute_sections(sections.len(), n_cols);
+        let columns: Vec<Vec<Line>> = distribution
+            .iter()
+            .map(|idxs| render_column_lines(&sections, idxs, theme))
+            .collect();
 
-            // Add sort label after "Views" section
-            if *section == "Views" {
-                lines.push(Line::from(vec![
-                    Span::styled(format!("  {:11}", ""), Style::default().fg(theme.waiting)),
-                    Span::styled(sort_label.as_str(), Style::default().fg(theme.text)),
-                ]));
-            }
+        let max_col_height = columns.iter().map(|c| c.len()).max().unwrap_or(0) as u16;
+        let max_scroll = max_col_height.saturating_sub(content_area.height);
+        *scroll = (*scroll).min(max_scroll);
+        let scroll_offset = *scroll;
 
-            if idx != last_idx {
-                lines.push(Line::from(""));
+        if n_cols > 0 && usable_width > 0 {
+            let total_gap = COLUMN_GAP.saturating_mul(n_cols as u16 - 1);
+            let base = usable_width.saturating_sub(total_gap) / n_cols as u16;
+            let extra = usable_width.saturating_sub(total_gap) % n_cols as u16;
+
+            let mut x = content_area.x + INNER_PADDING_X;
+            for (i, lines) in columns.into_iter().enumerate() {
+                let w = base + if (i as u16) < extra { 1 } else { 0 };
+                if w == 0 {
+                    continue;
+                }
+                let col_area = Rect {
+                    x,
+                    y: content_area.y,
+                    width: w,
+                    height: content_area.height,
+                };
+                let paragraph = Paragraph::new(lines).scroll((scroll_offset, 0));
+                frame.render_widget(paragraph, col_area);
+                x = x.saturating_add(w).saturating_add(COLUMN_GAP);
             }
         }
 
-        let paragraph = Paragraph::new(lines);
-        frame.render_widget(paragraph, inner);
+        if let Some(footer) = footer_area {
+            let mut hint = String::from("?/q/Esc close");
+            if max_scroll > 0 {
+                hint.push_str(&format!(
+                    "    ↑/↓ scroll  PgUp/PgDn page  g/G top/bottom  [{}/{}]",
+                    scroll_offset, max_scroll
+                ));
+            }
+            let footer_para = Paragraph::new(Line::from(Span::styled(
+                hint,
+                Style::default().fg(theme.dimmed),
+            )));
+            let footer_inner = Rect {
+                x: footer.x + INNER_PADDING_X,
+                y: footer.y,
+                width: footer.width.saturating_sub(2 * INNER_PADDING_X),
+                height: footer.height,
+            };
+            frame.render_widget(footer_para, footer_inner);
+        }
     }
 }
 
@@ -262,16 +449,49 @@ mod tests {
         // listing in so a future binding rename keeps the docs honest.
         for (strict, expected_key) in [(false, "h"), (true, "H")] {
             let all = shortcuts(strict);
-            let actions = all
+            let attention = all
                 .iter()
-                .find(|(name, _)| name.starts_with("Actions"))
-                .expect("Actions section should exist");
-            let (_, keys) = actions;
+                .find(|(name, _)| *name == "Attention")
+                .expect("Attention section should exist");
+            let (_, keys) = attention;
             assert!(
                 keys.iter()
                     .any(|(k, desc)| *k == expected_key && desc.contains("Snooze")),
-                "Actions section should contain {expected_key} Snooze entry (strict={strict})"
+                "Attention section should contain {expected_key} Snooze entry (strict={strict})"
             );
+        }
+    }
+
+    #[test]
+    fn attention_section_groups_triage_bindings() {
+        // The Attention section bundles snooze/archive/favorite/next-waiting
+        // so users see them together instead of scattered across Navigation
+        // and Actions.
+        for strict in [false, true] {
+            let all = shortcuts(strict);
+            let attention = all
+                .iter()
+                .find(|(name, _)| *name == "Attention")
+                .expect("Attention section should exist");
+            let (_, keys) = attention;
+            for needle in ["favorite", "Snooze", "Archive", "waiting"] {
+                assert!(
+                    keys.iter().any(|(_, desc)| desc.contains(needle)),
+                    "Attention section should mention {needle} (strict={strict})"
+                );
+            }
+            // And those should no longer live in Actions or Navigation.
+            for other_section in ["Navigation", "Actions", "Actions (strict mode)"] {
+                if let Some((_, other)) = all.iter().find(|(n, _)| *n == other_section) {
+                    for needle in ["favorite", "Snooze", "Archive", "waiting"] {
+                        assert!(
+                            !other.iter().any(|(_, desc)| desc.contains(needle)),
+                            "{other_section} should not still contain {needle} \
+                             (strict={strict})"
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -295,28 +515,183 @@ mod tests {
     }
 
     #[test]
-    fn help_content_fits_in_dialog() {
-        let available_height = (DIALOG_HEIGHT - BORDER_HEIGHT) as usize;
-        let available_width = (DIALOG_WIDTH - BORDER_WIDTH) as usize;
-        for strict in [false, true] {
-            let content_lines = content_line_count(strict);
-            assert!(
-                content_lines <= available_height,
-                "Help content ({content_lines} lines, strict={strict}) exceeds dialog inner height ({available_height} lines)"
-            );
-            for (section, keys) in shortcuts(strict) {
-                assert!(
-                    section.len() <= available_width,
-                    "Section header '{section}' exceeds dialog width ({available_width} chars)"
-                );
-                for (key, desc) in keys {
-                    let line_width = KEY_COLUMN_WIDTH + desc.len();
+    fn pick_columns_grows_with_width() {
+        // 40 cells per column is enough for the canonical help rows; verify
+        // the picker scales with viewport width.
+        let min = 40;
+        assert_eq!(pick_columns(30, min, 4), 1);
+        assert_eq!(pick_columns(80, min, 4), 1);
+        assert_eq!(pick_columns(85, min, 4), 2);
+        assert_eq!(pick_columns(130, min, 4), 3);
+        assert_eq!(pick_columns(180, min, 4), 4);
+        assert_eq!(pick_columns(300, min, 4), 4);
+    }
+
+    #[test]
+    fn pick_columns_capped_at_section_count() {
+        assert_eq!(pick_columns(1000, 10, 2), 2);
+        assert_eq!(pick_columns(1000, 10, 0), 0);
+    }
+
+    #[test]
+    fn distribute_preserves_reading_order() {
+        // For 4 sections across 1..=4 columns the partition must be
+        // contiguous so the user reads top-to-bottom, left-to-right.
+        for n_cols in 1..=4 {
+            let cols = distribute_sections(4, n_cols);
+            let mut prev = -1i32;
+            for c in &cols {
+                for &i in c {
                     assert!(
-                        line_width <= available_width,
-                        "Shortcut '{key}' description '{desc}' exceeds dialog width ({line_width} > {available_width})"
+                        (i as i32) > prev,
+                        "section {i} out of order in {n_cols}-col layout"
                     );
+                    prev = i as i32;
+                }
+            }
+            let total: usize = cols.iter().map(|c| c.len()).sum();
+            assert_eq!(total, 4, "every section must be placed");
+        }
+    }
+
+    #[test]
+    fn distribute_balances_section_counts() {
+        // 4 sections into 3 columns should give [2, 1, 1] (extras at the
+        // front), keeping column heights as close as possible.
+        let cols = distribute_sections(4, 3);
+        assert_eq!(cols.len(), 3);
+        assert_eq!(cols[0].len(), 2);
+        assert_eq!(cols[1].len(), 1);
+        assert_eq!(cols[2].len(), 1);
+    }
+
+    #[test]
+    fn render_keeps_max_col_height_balanced() {
+        // Sanity check: the chosen 4 → 3 split keeps max column height
+        // below the naive [1, 3, 0] alternative that would happen if we
+        // pushed all extras to one column.
+        let sections = build_sections(false, SortOrder::Newest);
+        let heights: Vec<usize> = sections.iter().map(section_height).collect();
+        let cols = distribute_sections(sections.len(), 3);
+        let max_h = cols
+            .iter()
+            .map(|c| c.iter().map(|&i| heights[i]).sum::<usize>())
+            .max()
+            .unwrap_or(0);
+        // Sum of the two largest sections is an upper bound on the
+        // tallest 3-column slot; assert we land at or below it.
+        let mut sorted = heights.clone();
+        sorted.sort_unstable_by(|a, b| b.cmp(a));
+        let bound = sorted[0] + sorted.get(1).copied().unwrap_or(0);
+        assert!(
+            max_h <= bound,
+            "3-col layout produced max column {max_h} > top-two sum {bound}"
+        );
+    }
+
+    fn render_to_buffer(width: u16, height: u16, scroll: &mut u16) -> ratatui::buffer::Buffer {
+        use ratatui::backend::TestBackend;
+        use ratatui::Terminal;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let theme = crate::tui::styles::Theme::default();
+        terminal
+            .draw(|frame| {
+                let area = frame.area();
+                HelpOverlay::render(frame, area, &theme, SortOrder::Newest, false, scroll);
+            })
+            .unwrap();
+        terminal.backend().buffer().clone()
+    }
+
+    fn buffer_contains(buf: &ratatui::buffer::Buffer, needle: &str) -> bool {
+        for y in 0..buf.area.height {
+            let mut row = String::new();
+            for x in 0..buf.area.width {
+                row.push_str(buf[(x, y)].symbol());
+            }
+            if row.contains(needle) {
+                return true;
+            }
+        }
+        false
+    }
+
+    #[test]
+    fn render_fills_wide_viewport_with_multiple_columns() {
+        // A 140x40 viewport leaves enough room for at least 2 side-by-side
+        // sections; the Actions header must land on the same row as
+        // Navigation if columns are working.
+        let mut scroll = 0;
+        let buf = render_to_buffer(140, 40, &mut scroll);
+        // Find Navigation row and check that Actions / Views / Other
+        // start on the same line in another column.
+        let mut nav_row = None;
+        for y in 0..buf.area.height {
+            let mut row = String::new();
+            for x in 0..buf.area.width {
+                row.push_str(buf[(x, y)].symbol());
+            }
+            if row.contains("Navigation") {
+                nav_row = Some((y, row));
+                break;
+            }
+        }
+        let (y, row) = nav_row.expect("Navigation header should render");
+        let has_second_section = ["Actions", "Views", "Other"]
+            .iter()
+            .any(|s| row.contains(s));
+        assert!(
+            has_second_section,
+            "expected a second section header on row {y}, got: {row:?}"
+        );
+        assert!(buf_dialog_takes_most_of_area(&buf, 140, 40));
+    }
+
+    fn buf_dialog_takes_most_of_area(buf: &ratatui::buffer::Buffer, w: u16, h: u16) -> bool {
+        // The rounded border uses '╭'/'╮'/'╰'/'╯' corners; find the
+        // top-left corner and assert it sits within the outer two cells
+        // so the dialog is "nearly fullscreen".
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                if buf[(x, y)].symbol() == "╭" {
+                    return x <= 4 && y <= 2 && x + 1 < w && y + 1 < h;
                 }
             }
         }
+        false
+    }
+
+    #[test]
+    fn render_shows_scroll_hint_when_overflowing() {
+        // 60x14 is too small to fit all rows; the footer should show the
+        // scroll position.
+        let mut scroll = 0;
+        let buf = render_to_buffer(60, 14, &mut scroll);
+        assert!(
+            buffer_contains(&buf, "scroll"),
+            "scroll hint should be visible when content overflows"
+        );
+    }
+
+    #[test]
+    fn render_clamps_scroll_to_max() {
+        // u16::MAX overshoot must be clamped after render so 'g' /
+        // 'Home' from that state actually lands on something sensible.
+        let mut scroll = u16::MAX;
+        let _buf = render_to_buffer(60, 14, &mut scroll);
+        assert!(
+            scroll < u16::MAX,
+            "scroll should be clamped to the layout max"
+        );
+    }
+
+    #[test]
+    fn render_with_no_overflow_keeps_scroll_zero() {
+        // A roomy viewport fits all content; scroll stays at 0 even if
+        // we pass a positive value in (it gets clamped to max=0).
+        let mut scroll = 5;
+        let _buf = render_to_buffer(200, 60, &mut scroll);
+        assert_eq!(scroll, 0, "no overflow should clamp scroll to 0");
     }
 }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -344,11 +344,32 @@ impl HomeView {
 
         // Handle other dialog input
         if self.show_help {
-            if matches!(
-                key.code,
-                KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q')
-            ) {
-                self.show_help = false;
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
+                    self.show_help = false;
+                    self.help_scroll = 0;
+                }
+                KeyCode::Down | KeyCode::Char('j') => {
+                    self.help_scroll = self.help_scroll.saturating_add(1);
+                }
+                KeyCode::Up | KeyCode::Char('k') => {
+                    self.help_scroll = self.help_scroll.saturating_sub(1);
+                }
+                KeyCode::PageDown | KeyCode::Char(' ') => {
+                    self.help_scroll = self.help_scroll.saturating_add(10);
+                }
+                KeyCode::PageUp => {
+                    self.help_scroll = self.help_scroll.saturating_sub(10);
+                }
+                KeyCode::Home | KeyCode::Char('g') => {
+                    self.help_scroll = 0;
+                }
+                KeyCode::End | KeyCode::Char('G') => {
+                    // u16::MAX overshoots intentionally; HelpOverlay::render
+                    // clamps to the actual max scroll for the current layout.
+                    self.help_scroll = u16::MAX;
+                }
+                _ => {}
             }
             return None;
         }
@@ -867,6 +888,7 @@ impl HomeView {
             }
             KeyCode::Char('?') => {
                 self.show_help = true;
+                self.help_scroll = 0;
             }
             KeyCode::Char('e') if !self.strict_hotkeys => {
                 self.open_restart_dialog();

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -174,6 +174,7 @@ pub struct HomeView {
 
     // Dialogs
     pub(super) show_help: bool,
+    pub(super) help_scroll: u16,
     pub(super) new_dialog: Option<NewSessionDialog>,
     pub(super) confirm_dialog: Option<ConfirmDialog>,
     pub(super) unified_delete_dialog: Option<UnifiedDeleteDialog>,
@@ -438,6 +439,7 @@ impl HomeView {
             row_tag_mode: resolved.session.row_tag,
             project_group_collapsed: HashMap::new(),
             show_help: false,
+            help_scroll: 0,
             new_dialog: None,
             confirm_dialog: None,
             unified_delete_dialog: None,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -447,7 +447,14 @@ impl HomeView {
 
         // Render dialogs on top
         if self.show_help {
-            HelpOverlay::render(frame, area, theme, self.sort_order, self.strict_hotkeys);
+            HelpOverlay::render(
+                frame,
+                area,
+                theme,
+                self.sort_order,
+                self.strict_hotkeys,
+                &mut self.help_scroll,
+            );
         }
 
         // Each Option<Dialog> field on HomeView gets the same render dispatch:


### PR DESCRIPTION
## Description

The keyboard-shortcut overlay (`?`) was a fixed 50x50 popup that clipped
content on narrower terminals and had no way to see anything that did
not fit. This PR:

- Sizes the overlay to almost the full viewport (small margin, falls
  back to zero margin on tiny phone viewports).
- Flows the sections across 1-4 columns based on inner width, choosing
  the column count so each column stays wide enough to render its
  longest description without truncation.
- Distributes sections contiguously so reading order stays top-to-bottom,
  left-to-right.
- Adds vertical scrolling (j/k, arrows, PgUp/PgDn/Space, g/G, Home/End)
  for the case where even one column does not fit. The render path
  clamps the scroll value in place, so overshoot from `End` self-corrects
  on the next paint.
- Adds a footer hint inside the dialog: close keys plus, when relevant,
  scroll keys and `[pos/max]`.
- Pulls the triage bindings (next waiting/idle, favorite, snooze,
  archive) out of Navigation/Actions into a dedicated `Attention`
  section in both keymaps so they read as one group.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(UI screenshots: this is a TUI-only change visible by pressing `?`
in the home view; the layout adapts to the running terminal size.
A recording can be produced with `RECORD_E2E=1 cargo test --test e2e`
if reviewers want one.)

### Test plan

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test --lib` (1966 passed), `cargo test --test '*'` (116 passed).
- New unit tests for column-picker, section distribution, near-fullscreen
  sizing, multi-column render against a `TestBackend`, scroll-hint
  visibility, and scroll clamping.
- Manual: open the TUI, press `?`, resize the terminal between ~60x14
  and ~250x60, verify the dialog scales and the column count changes.

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-7, 1M context)

**Any Additional AI Details you'd like to share:** Drafted via
back-and-forth with @njbrake; design and scope decisions are his.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request transforms the help overlay from a fixed-size 50x50 dialog into a responsive, full-screen interface that intelligently adapts to terminal dimensions. The help system now provides better readability and navigation for users, especially on larger displays.

## What Changed

**Help Dialog Layout**
- Replaced fixed-size dialog with a dynamic layout that uses nearly the full viewport (with small margins that scale down on very small terminals)
- Dialog now intelligently chooses between 1–4 columns based on available width and content width requirements
- Sections flow across columns preserving reading order (top-to-bottom, left-to-right)

**Content Organization**
- Created a new "Attention" section for triage-related keybindings (next waiting/idle, favorite, snooze, archive)
- Moved these bindings from Navigation/Actions into the dedicated Attention section
- Layout adapts differently for strict vs non-strict hotkey modes

**Scrolling & Navigation**
- Added full scrolling support for when content exceeds viewport:
  - Navigation keys: `j`/`k`, arrow keys, `PgUp`/`PgDn`, `Space`, `g`/`G`, `Home`/`End`
  - Scroll position shows in footer with current position/maximum
  - Smart scroll clamping prevents overshooting content bounds
- Footer hint displays available keys and current scroll position when relevant
- Closing still works via `Esc`, `?`, or `q`

**State Management**
- Added `help_scroll` field to track vertical scroll position in the help view
- Scroll state resets when help is opened

## Benefits

- **Better UX**: Users with large terminals get full use of screen space instead of a cramped 50x50 box
- **Improved Readability**: Multi-column layout organizes content more logically and reduces excessive vertical scrolling
- **Responsive Design**: Dialog gracefully adapts from small terminals (~60x14) to large ones (~250x60)
- **Enhanced Navigation**: Multiple scrolling methods accommodate different user preferences
- **Content Organization**: New "Attention" section clearly separates triage operations from general actions

## Technical Details

**Code Changes**
- `HelpOverlay::render()` now accepts a `scroll: &mut u16` parameter for state management
- Rendering logic implements:
  - Dynamic margin calculation based on viewport size
  - Column-width computation to fit content naturally
  - Optimal column-count selection algorithm
  - Section distribution across columns while maintaining reading order
  - Per-column line wrapping and independent rendering
  - Scroll position clamping on each render
  - Conditional footer scroll hint rendering
- Input handling expanded with saturating arithmetic for scroll bounds
- Unit tests cover: column selection, section distribution, sizing, multi-column rendering, scroll-hint visibility, and scroll clamping
- All changes pass cargo fmt, clippy, and test suite (unit + integration)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1410?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->