### PR TITLE
feat(tui): toggle preview info header with i

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -473,6 +473,12 @@ pub struct AppStateConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub diff_file_list_width: Option<u16>,
 
+    /// Show the info header (profile/tool/path/status/sandbox/worktree) at
+    /// the top of the home preview pane. Defaults to `true` when absent;
+    /// users hide it with `i` when they want the full pane for live output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub show_preview_info: Option<bool>,
+
     #[serde(default)]
     pub has_seen_custom_instruction_warning: bool,
 

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -7,7 +7,7 @@ use crate::session::config::SortOrder;
 use crate::tui::styles::Theme;
 
 const DIALOG_WIDTH: u16 = 50;
-const DIALOG_HEIGHT: u16 = 50;
+const DIALOG_HEIGHT: u16 = 51;
 #[cfg(test)]
 const BORDER_HEIGHT: u16 = 2;
 #[cfg(test)]
@@ -56,6 +56,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("C", "Toggle container/host (sandbox)"),
                     ("Ctrl+D", "Diff view (git changes)"),
                     ("< >", "Resize list panel"),
+                    ("I", "Toggle preview info header"),
                     ("O", "Cycle sort forward"),
                     ("Ctrl+O", "Cycle sort backward"),
                     ("Ctrl+G", "Toggle group by project"),
@@ -118,6 +119,7 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                     ("c", "Toggle container/host (sandbox)"),
                     ("D", "Diff view (git changes)"),
                     ("< >", "Resize list panel"),
+                    ("i", "Toggle preview info header"),
                     ("o", "Cycle sort forward"),
                     ("Ctrl+o", "Cycle sort backward"),
                     ("g", "Toggle group by project"),

--- a/src/tui/components/mod.rs
+++ b/src/tui/components/mod.rs
@@ -14,7 +14,7 @@ pub use cycler::{profile_cycler_spans, tool_cycler_spans};
 pub use dir_picker::{DirPicker, DirPickerResult};
 pub use help::HelpOverlay;
 pub use list_picker::{ListPicker, ListPickerResult};
-pub use preview::Preview;
+pub use preview::{format_scroll_indicator, Preview};
 pub use text_input::{
     longest_common_prefix, render_text_field, render_text_field_with_ghost,
     set_input_cursor_position, set_prefixed_input_cursor_position, GroupGhostCompletion,

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -148,8 +148,13 @@ impl Preview {
         theme: &Theme,
         idle_decay_window: Duration,
         compact: bool,
+        show_info: bool,
     ) {
-        if compact {
+        // When the user has hidden the info header (or the viewport is too
+        // narrow for it), the output gets the whole pane and skips the inner
+        // " Output " banner. The outer block already says "Preview", so an
+        // inner banner would just be redundant chrome.
+        if compact || !show_info {
             Self::render_output_cached(
                 frame,
                 area,
@@ -379,7 +384,7 @@ fn compute_scroll(line_count: usize, visible_height: usize, user_offset: u16) ->
 
 /// Render a tmux-style ` [offset/max] ` indicator when the user has scrolled
 /// back. Returns `None` while live-following or when the content fits in view.
-fn format_scroll_indicator(
+pub fn format_scroll_indicator(
     line_count: usize,
     visible_height: usize,
     user_offset: u16,

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -227,6 +227,14 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
             payload: PaletteAction::Key(key('w')),
         },
         PaletteCommand {
+            id: "toggle-preview-info",
+            title: "Toggle preview info header".to_string(),
+            group: PaletteGroup::Views,
+            keywords: vec!["hide", "show", "info", "header", "preview"],
+            hotkey: hotkey_label("i", "I", strict_hotkeys),
+            payload: PaletteAction::Key(key('i')),
+        },
+        PaletteCommand {
             id: "settings",
             title: "Open settings".to_string(),
             group: PaletteGroup::Settings,

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1745,6 +1745,15 @@ impl HomeView {
             KeyCode::Char('>') => {
                 self.grow_list();
             }
+            // `i`/`I`: toggle the preview info header (profile/tool/path/
+            // status/sandbox/worktree). Persisted across runs. The hint
+            // rendered inside the header advertises this binding.
+            KeyCode::Char('i') if !self.strict_hotkeys => {
+                self.toggle_preview_info();
+            }
+            KeyCode::Char('I') if self.strict_hotkeys => {
+                self.toggle_preview_info();
+            }
             KeyCode::Left => {
                 if let Some(Item::Group {
                     path, collapsed, ..

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1747,7 +1747,7 @@ impl HomeView {
             }
             // `i`/`I`: toggle the preview info header (profile/tool/path/
             // status/sandbox/worktree). Persisted across runs. The hint
-            // rendered inside the header advertises this binding.
+            // rendered on the outer Preview block title advertises this.
             KeyCode::Char('i') if !self.strict_hotkeys => {
                 self.toggle_preview_info();
             }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -303,6 +303,11 @@ pub struct HomeView {
     // Resizable list column width (percentage-like units)
     pub(super) list_width: u16,
 
+    /// Show the info header (profile/tool/path/status/sandbox/worktree) at
+    /// the top of the preview pane. Toggled with `i` and persisted to
+    /// `app_state.show_preview_info`.
+    pub(super) show_preview_info: bool,
+
     /// Channel that startup-recovery workers send results back on. `None`
     /// when no recovery was attempted at construction (live tmux, daemon
     /// owns recovery, lock contended, or no candidates). Drained on every
@@ -505,6 +510,10 @@ impl HomeView {
                 .as_ref()
                 .and_then(|c| c.app_state.home_list_width)
                 .unwrap_or(35),
+            show_preview_info: user_config
+                .as_ref()
+                .and_then(|c| c.app_state.show_preview_info)
+                .unwrap_or(true),
             recovery_rx: None,
             recovery_lock: None,
             recovery_in_flight: std::collections::HashSet::new(),
@@ -1779,6 +1788,16 @@ impl HomeView {
     fn save_list_width(&self) {
         if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
             config.app_state.home_list_width = Some(self.list_width);
+            if let Err(e) = save_config(&config) {
+                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+            }
+        }
+    }
+
+    pub fn toggle_preview_info(&mut self) {
+        self.show_preview_info = !self.show_preview_info;
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.app_state.show_preview_info = Some(self.show_preview_info);
             if let Err(e) = save_config(&config) {
                 tracing::warn!(target: "tui.home", "Failed to save config: {e}");
             }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -13,7 +13,9 @@ use super::{
 };
 use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
-use crate::tui::components::{set_prefixed_input_cursor_position, HelpOverlay, Preview};
+use crate::tui::components::{
+    format_scroll_indicator, set_prefixed_input_cursor_position, HelpOverlay, Preview,
+};
 use crate::tui::responsive;
 use crate::tui::styles::{has_min_contrast, Theme};
 use crate::update::UpdateInfo;
@@ -1344,6 +1346,45 @@ impl HomeView {
             block = block
                 .title(title)
                 .title_style(Style::default().fg(title_color));
+
+            // Advertise the info-header toggle. Only meaningful in Agent view
+            // (Terminal/Tool views have their own minimal header that isn't
+            // bound to `show_preview_info`), and the compact branch above
+            // already owns the title slot.
+            if matches!(self.view_mode, ViewMode::Agent) {
+                let key = if self.strict_hotkeys { "I" } else { "i" };
+                let hint_text = if self.show_preview_info {
+                    format!(" hide info with {key} ")
+                } else {
+                    format!(" show info with {key} ")
+                };
+                let hint_style = Style::default().fg(theme.dimmed).italic();
+
+                // When the info section is hidden, the inner " Output " banner
+                // (which usually carries the scroll indicator) is also gone.
+                // Surface the indicator here so users still see how far back
+                // they've scrolled. With borders::ALL the inner is area - 2;
+                // render_output_cached then drops one more row before painting
+                // (its compact branch uses height-1 for visible_height), so we
+                // match that to keep the count stable as the user scrolls.
+                let scroll_indicator = if !self.show_preview_info {
+                    let inner_height = area.height.saturating_sub(2);
+                    let visible_height = inner_height.saturating_sub(1) as usize;
+                    format_scroll_indicator(
+                        self.preview_cache.captured_lines,
+                        visible_height,
+                        self.preview_scroll_offset,
+                    )
+                } else {
+                    None
+                };
+
+                let mut hint_spans = vec![Span::styled(hint_text, hint_style)];
+                if let Some(ind) = scroll_indicator {
+                    hint_spans.push(Span::styled(ind, hint_style));
+                }
+                block = block.title_top(Line::from(hint_spans).right_aligned());
+            }
         }
 
         let inner = block.inner(area);
@@ -1377,6 +1418,7 @@ impl HomeView {
                                 theme,
                                 self.idle_decay_window,
                                 compact,
+                                self.show_preview_info,
                             );
                         }
                     } else {


### PR DESCRIPTION
## Description

Adds a per-user toggle for the home preview pane's info header (the section showing Profile/Tool/Path/Status/Sandbox/Worktree). Press `i` (or `I` in strict-hotkey mode) to hide or show it. Default is shown; state persists to `app_state.show_preview_info`.

When info is **visible** the outer block title carries the hint right-aligned in dim italic:
```
╭ Preview ──────────────── hide info with i ─╮
│ Profile: …  Tool: …                        │
│ Path:    …                                 │
│ Status:  …                                 │
│ Sandbox: …                                 │
│ ─── Worktree ───                           │
│ Branch:  …                                 │
│ Main:    …                                 │
│──────── Output ───────────────── [12/40] ──│
│ <output …>                                 │
```

When info is **hidden** the inner ` Output ` banner is dropped (it just duplicated "Preview"), so the pane reads as one bare output surface. The scroll indicator moves up next to the hint so users still see how far they've scrolled:
```
╭ Preview ────── show info with i  [12/40] ─╮
│ <output, full height>                     │
```

Bindings, palette, and help overlay all advertise the new shortcut. The fixed-size help dialog grew by one row to fit the new "Toggle preview info header" entry.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass (`cargo test --lib`: 1962 passed)
- [x] Documentation was updated where necessary (help overlay + command palette)
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:** Interactive back-and-forth; Claude wrote the code, I directed the UX (started as an in-section hint, iterated to outer-block title + dropped redundant inner banner + relocated scroll indicator).

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

Adds a per-user toggle to hide/show the preview info header (Profile / Tool / Path / Status / Sandbox / Worktree) in the home preview pane. Toggle with `i` (or `I` in strict-hotkey mode); preference persists to app_state.show_preview_info and defaults to visible.

## What changed (high level)

- New persisted setting and runtime flag to track preview header visibility.
- New keybinding (`i` / `I`) wired into main input, command palette, and help overlay; help dialog increased by one row to include the entry.
- Preview UI changes:
  - When info shown: preview displays the info header, an inner "Output" banner, and an internal scroll indicator; outer title shows a dim italic hint ("hide info with i").
  - When info hidden: inner banner removed (single output surface); outer title shows "show info with i" and the scroll indicator is moved into the outer title hint.
- Minor public API change: scroll-indicator formatting is exposed so it can be rendered outside the preview pane.
- Tests: library tests pass locally (cargo test --lib reported 1962 passed). Help/command-palette docs updated.

## Benefits

- Lets users maximize preview output by hiding the verbose header.
- Setting persists across sessions and is discoverable via help and command palette.
- Backward-compatible default (info shown).

## Technical summary

- Config: AppStateConfig gains show_preview_info: Option<bool> (serde default + skip_serializing_if) — absent field means default visible.
- HomeView: adds show_preview_info: bool initialized from persisted config; adds pub fn toggle_preview_info() which flips the flag and saves it.
- Input: `i` / `I` key handlers call toggle_preview_info().
- Rendering:
  - Preview::render_with_cache signature now accepts show_info: bool and renders compact output when compact || !show_info.
  - fn format_scroll_indicator(...) made pub and re-exported for use by outer title rendering.
  - Home render updated to pass show_preview_info into preview renderer and to render the right-aligned hint + relocated scroll indicator when info is hidden.
- UI: command palette and help overlay include a "Toggle preview info header" entry; help dialog size adjusted.
- Tests & docs: help overlay and command palette updated; tests reported passing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1411?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->