### PR TITLE
fix(tui): accept uppercase Q to close help in strict mode

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -345,7 +345,7 @@ impl HomeView {
         // Handle other dialog input
         if self.show_help {
             match key.code {
-                KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') => {
+                KeyCode::Esc | KeyCode::Char('?') | KeyCode::Char('q') | KeyCode::Char('Q') => {
                     self.show_help = false;
                     self.help_scroll = 0;
                 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -180,6 +180,18 @@ fn test_help_closes_on_q() {
 
 #[test]
 #[serial]
+fn test_help_closes_on_uppercase_q_for_strict_mode() {
+    // Strict mode binds quit to uppercase Q; the help overlay must
+    // accept it too so strict-mode users can dismiss the dialog with
+    // the same key they use to quit.
+    let mut env = create_test_env_empty();
+    env.view.show_help = true;
+    env.view.handle_key(key(KeyCode::Char('Q')), None);
+    assert!(!env.view.show_help);
+}
+
+#[test]
+#[serial]
 fn test_has_dialog_returns_true_for_help() {
     let mut env = create_test_env_empty();
     assert!(!env.view.has_dialog());


### PR DESCRIPTION
## Description

Follow-up to #1410. Strict-mode binds quit to uppercase `Q`, but the
help overlay only matched lowercase `q`, so strict-mode users who
pressed the documented quit key from inside help got no response.
Accept both cases and lock the behavior in with a regression test.

## PR Type

- [x] Bug Fix

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No screenshot needed: invisible behavior change. Verified by the new
`test_help_closes_on_uppercase_q_for_strict_mode` unit test.)

### Test plan

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings`,
  `cargo test --lib test_help_closes` (4 passed).
- Manual: open the TUI in strict-hotkeys mode, press `?` to open
  help, press `Q`, verify the overlay closes.

## AI Usage

- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (claude-opus-4-7, 1M context)

**Any Additional AI Details you'd like to share:** Drafted via
back-and-forth with @njbrake; this was a follow-up suggestion from
the /rpr review of #1410.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

This PR fixes an inconsistency in the TUI help overlay where it failed to recognize the uppercase `Q` key for closing the overlay when in strict-hotkeys mode. Previously, users could only close the help overlay with lowercase `q` or `Esc`, which conflicted with the uppercase `Q` quit binding used in strict-hotkeys mode.

## Non-Technical Summary

**Input Handler Update** (`src/tui/home/input.rs`):
- Modified the help overlay dismissal logic to recognize both uppercase and lowercase `Q` as valid keys for closing the help screen

**Test Coverage** (`src/tui/home/tests.rs`):
- Added a regression test (`test_help_closes_on_uppercase_q_for_strict_mode`) to verify that the help overlay properly closes when uppercase `Q` is pressed in strict-hotkeys mode

## Benefits

- **Improved UX Consistency**: Users in strict-hotkeys mode now experience consistent behavior—the same key binding (`Q`) that quits the application also closes the help overlay
- **Bug Prevention**: The regression test locks in the expected behavior and prevents future regressions
- **Minimal Risk**: Single-line code change with corresponding test coverage ensures low complexity and high confidence

## Testing

All existing and new tests pass (`cargo test --lib test_help_closes`). Manual verification in strict-hotkeys mode confirms the fix works as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1412?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->