### PR TITLE
fix(test): de-flake recovery_lock test by removing env-var dependency

### DIFF
--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -42,7 +42,7 @@
 //! non-interactive and complete in <30s". Hardening is tracked as a follow-up
 //! (graceful timeout + force-kill path on the cascade).
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 #[cfg(feature = "serve")]
 use std::sync::Arc;
 #[cfg(feature = "serve")]
@@ -70,7 +70,14 @@ pub struct RecoveryLock {
 /// The lock file lives at `<app_dir>/.recovery.lock`. It is created if
 /// missing and never deleted (the lock is on the file, not its existence).
 pub fn try_acquire_recovery_lock() -> Result<Option<RecoveryLock>> {
-    let path = recovery_lock_path()?;
+    try_acquire_recovery_lock_at(&recovery_lock_path()?)
+}
+
+/// Inner helper that takes the lock-file path directly. Split out so tests
+/// can exercise the flock logic without depending on the env-var-driven
+/// `get_app_dir()` resolution, which races with non-`#[serial]` readers of
+/// `HOME` / `XDG_CONFIG_HOME` elsewhere in the suite.
+fn try_acquire_recovery_lock_at(path: &Path) -> Result<Option<RecoveryLock>> {
     if let Some(parent) = path.parent() {
         // Propagate so an unwritable app dir surfaces here with the real
         // OS error (e.g. EACCES, EROFS) rather than as a confusing
@@ -82,7 +89,7 @@ pub fn try_acquire_recovery_lock() -> Result<Option<RecoveryLock>> {
         .write(true)
         .create(true)
         .truncate(false)
-        .open(&path)?;
+        .open(path)?;
     match file.try_lock_exclusive() {
         Ok(()) => Ok(Some(RecoveryLock { _file: file })),
         Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => Ok(None),
@@ -245,18 +252,6 @@ pub fn run_recovery_for_instance(inst: &mut Instance) -> Result<StartOutcome> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
-
-    /// Point `HOME` (and `XDG_CONFIG_HOME` on Linux) at a temp dir so
-    /// `get_app_dir()` resolves into the sandbox instead of touching the
-    /// user's real app dir. Mirrors the helper in `session::tests`.
-    fn isolate_app_dir() -> tempfile::TempDir {
-        let temp_home = tempfile::TempDir::new().unwrap();
-        std::env::set_var("HOME", temp_home.path());
-        #[cfg(target_os = "linux")]
-        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
-        temp_home
-    }
 
     #[cfg(feature = "serve")]
     #[test]
@@ -352,20 +347,24 @@ mod tests {
     /// the wrapper successfully creates the lock file and acquires/
     /// releases the lock without erroring. The cross-process behavior
     /// is exercised by the e2e suite (TUI + daemon spawned together).
+    ///
+    /// Driven through `try_acquire_recovery_lock_at` rather than the
+    /// public entry point so the lock path is fixed and independent of
+    /// `HOME` / `XDG_CONFIG_HOME`. The public function reads those env
+    /// vars via `dirs::config_dir()`; `getenv` and `setenv` are not
+    /// thread-safe, and non-`#[serial]` HOME readers elsewhere in the
+    /// suite have been observed to race a `set_var` from another test
+    /// and resolve the lock path under the wrong sandbox, surfacing as
+    /// a flaky "re-acquisition after drop" failure on CI.
     #[test]
-    #[serial]
     fn recovery_lock_acquires_and_releases() {
-        // Sandbox HOME/XDG_CONFIG_HOME so this never touches the real
-        // <app_dir>/.recovery.lock, where a concurrent `aoe` / `aoe serve`
-        // would otherwise either fail the test or have its own lock
-        // hijacked. `#[serial]` against the same env-var mutators in the
-        // rest of the suite.
-        let _sandbox = isolate_app_dir();
+        let temp = tempfile::TempDir::new().unwrap();
+        let path = temp.path().join(".recovery.lock");
 
-        let first = try_acquire_recovery_lock().unwrap();
+        let first = try_acquire_recovery_lock_at(&path).unwrap();
         assert!(first.is_some(), "acquisition should succeed");
         drop(first);
-        let second = try_acquire_recovery_lock().unwrap();
+        let second = try_acquire_recovery_lock_at(&path).unwrap();
         assert!(second.is_some(), "re-acquisition after drop should succeed");
     }
 }


### PR DESCRIPTION
## Description

`session::recovery::tests::recovery_lock_acquires_and_releases` was occasionally failing on CI at the second `try_acquire_recovery_lock()` call returning `None` instead of `Some(_)`. Two recent runs:

- https://github.com/njbrake/agent-of-empires/actions/runs/26282066442/job/77360489199
- https://github.com/njbrake/agent-of-empires/actions/runs/26282410769

**Root cause.** The test sandboxed `HOME` / `XDG_CONFIG_HOME` and was `#[serial]`, but `serial_test::serial` only synchronizes against other `#[serial]` tests. Many non-`#[serial]` test threads in the same binary read `HOME` indirectly (via `dirs::config_dir()`, etc.), and `getenv` / `setenv` are not thread-safe at the libc level. Under CI contention the second acquisition could resolve under a different sandbox path that another test was already holding, surfacing as `WouldBlock`.

**Fix.** Split the flock body into a `try_acquire_recovery_lock_at(path)` helper that takes the lock path directly, and drive the unit test through that helper with a `tempfile::TempDir`-owned path. No `HOME` / `XDG_CONFIG_HOME` mutation, no `#[serial]` needed, no `isolate_app_dir()` helper. The test still verifies what its comment always said it verified, flock acquire/release semantics on a single path, without the env-var dependency that made it racy.

The public `try_acquire_recovery_lock()` is unchanged behaviorally; production callers still go through `recovery_lock_path()` and the env-var-driven app dir.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**

Diagnosed the flake from the two failing CI logs, walked through the env-var race hypothesis, then shaped the refactor and the test rewrite. I reviewed every line before committing.

- [ ] I am an AI Agent filling out this form (check box if true)

## Test plan

- [x] `cargo test --features serve --lib` (2515 passed locally)
- [x] `cargo fmt --check`
- [x] `cargo clippy --features serve --lib --no-deps`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The recovery lock acquisition logic has been refactored to support testing with isolated paths, and the flaky unit test has been rewritten.

**File Modified:** `src/session/recovery.rs`

**Changes:**
- Extracted the file-lock logic into a new internal helper function `try_acquire_recovery_lock_at(path: &Path)` that performs exclusive lock acquisition at a caller-specified path
- Updated `try_acquire_recovery_lock()` to delegate to this helper, preserving its existing behavior
- Rewrote the `recovery_lock_acquires_and_releases` unit test to use the new helper with a temporary directory-owned path, eliminating the need for environment variable sandboxing and serial test synchronization
- Updated imports to support `Path` parameter passing

**Code metrics:** +23 lines / -24 lines

## Why This Matters

The original test was intermittently failing in CI because it relied on environment variable manipulation (`HOME`, `XDG_CONFIG_HOME`) combined with `#[serial]` synchronization. However, `#[serial]` only synchronizes between other `#[serial]` tests—non-serialized test threads in the same binary could still modify those environment variables concurrently, causing thread-unsafe `libc` `getenv`/`setenv` calls and path resolution conflicts.

## Benefits

- **Eliminates test flakiness:** Removes dependency on environment variables and serial test synchronization, making the test deterministic and thread-safe
- **Simplifies test setup:** Uses a simple temporary directory instead of complex sandboxing
- **Maintains production behavior:** The public API remains unchanged; production code continues to use `recovery_lock_path()` and environment-driven app directories
- **Improves testability:** The new `try_acquire_recovery_lock_at()` helper enables more flexible path-based testing scenarios

## Technical Details

The fix addresses a thread-safety issue with POSIX environment variables in multi-threaded test environments. By moving lock path resolution out of shared environment state and into caller-controlled parameters, the test can now use deterministic temporary paths without interfering with concurrent test threads.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1413?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->