### PR TITLE
fix(tui): honor project grouping under Attention sort

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2107,14 +2107,37 @@ impl HomeView {
         }
     }
 
+    /// Put the cursor back on `selected_session` after a `flat_items` rebuild
+    /// (sort toggle, group_by toggle). Mode flips reshape the list, especially
+    /// when Attention sort is involved, so index-based clamping lands the
+    /// cursor on whatever happened to slide into the old slot. Seeking by
+    /// session id keeps focus on the row the user was actually looking at.
+    /// Falls back to the legacy clamp when there was no prior selection or
+    /// the session is no longer in the flat list (e.g., collapsed under a
+    /// group header).
+    pub(super) fn reseat_cursor_after_rebuild(&mut self) {
+        if let Some(sid) = self.selected_session.clone() {
+            for (idx, item) in self.flat_items.iter().enumerate() {
+                if let Item::Session { id, .. } = item {
+                    if *id == sid {
+                        self.cursor = idx;
+                        self.update_selected();
+                        return;
+                    }
+                }
+            }
+        }
+        self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
+        self.update_selected();
+    }
+
     fn apply_sort_order(&mut self, new_order: SortOrder) {
         self.sort_order = new_order;
         self.flat_items = self.build_flat_items();
         if self.search_active && !self.search_query.value().is_empty() {
             self.update_search();
         } else {
-            self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
-            self.update_selected();
+            self.reseat_cursor_after_rebuild();
         }
         if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
             config.app_state.sort_order = Some(self.sort_order);
@@ -2127,8 +2150,7 @@ impl HomeView {
     fn apply_group_by(&mut self, new_mode: GroupByMode) {
         self.group_by = new_mode;
         self.flat_items = self.build_flat_items();
-        self.cursor = self.cursor.min(self.flat_items.len().saturating_sub(1));
-        self.update_selected();
+        self.reseat_cursor_after_rebuild();
         match load_config().map(|c| c.unwrap_or_default()) {
             Ok(mut config) => {
                 config.app_state.group_by = Some(self.group_by);

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1834,9 +1834,22 @@ impl HomeView {
     }
 
     pub(super) fn build_flat_items(&self) -> Vec<Item> {
-        // Attention sort is a flat priority view: skip groups entirely so
-        // Waiting/Error rows from different groups can interleave by tier
-        // instead of being walled off behind group headers.
+        // Project grouping is honored across every sort order. Combined with
+        // Attention sort, sessions sort by tier within each project and the
+        // project headers float by their top-attention member (driven by
+        // sort_groups + attention_group_key in flatten_tree). Check this
+        // first so Project + Attention doesn't fall through to the flat
+        // Attention branch and lose the project headers.
+        if self.group_by == GroupByMode::Project {
+            return self.build_flat_items_by_project();
+        }
+
+        // Manual grouping + Attention sort is the cross-cutting flat
+        // priority view: skip groups entirely so Waiting/Error rows from
+        // different groups can interleave by tier instead of being walled
+        // off behind group headers. Project grouping above opts into a
+        // different shape on purpose (attention triage within explicit
+        // project boundaries).
         if self.sort_order == SortOrder::Attention {
             let filtered: Vec<Instance> = if let Some(profile) = &self.active_profile {
                 self.instances
@@ -1848,10 +1861,6 @@ impl HomeView {
                 self.instances.clone()
             };
             return flatten_sessions_by_attention(&filtered);
-        }
-
-        if self.group_by == GroupByMode::Project {
-            return self.build_flat_items_by_project();
         }
 
         if let Some(profile) = &self.active_profile {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4063,6 +4063,171 @@ fn restart_selected_session_debounces_via_cooldown_map() {
     );
 }
 
+/// Build a HomeView seeded with two distinct projects, each containing
+/// sessions with different attention statuses. Helper for the Project +
+/// Attention combination tests below.
+fn create_test_env_two_projects_mixed_attention() -> TestEnv {
+    use crate::session::Status;
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let mut alpha_waiting = Instance::new("alpha-waiting", "/repos/alpha");
+    alpha_waiting.status = Status::Waiting;
+    let mut alpha_running = Instance::new("alpha-running", "/repos/alpha");
+    alpha_running.status = Status::Running;
+
+    let mut beta_running = Instance::new("beta-running", "/repos/beta");
+    beta_running.status = Status::Running;
+    let mut beta_error = Instance::new("beta-error", "/repos/beta");
+    beta_error.status = Status::Error;
+
+    let instances = vec![alpha_waiting, alpha_running, beta_running, beta_error];
+    storage
+        .commit(&instances, &GroupTree::new_with_groups(&instances, &[]))
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    TestEnv { _temp: temp, view }
+}
+
+/// Project grouping must survive Attention sort. Previously `build_flat_items`
+/// short-circuited on `SortOrder::Attention` before checking `GroupByMode`,
+/// flattening the list and dropping project headers. The headers are the
+/// whole point of project mode; users want attention triage WITHIN their
+/// project boundaries, not a flat firehose across projects.
+#[test]
+#[serial]
+fn project_grouping_survives_attention_sort() {
+    use crate::session::config::{GroupByMode, SortOrder};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let group_count = env
+        .view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .count();
+    assert_eq!(
+        group_count, 2,
+        "Project + Attention must keep both project headers (alpha, beta), \
+         got flat_items: {:?}",
+        env.view.flat_items
+    );
+
+    let group_names: Vec<String> = env
+        .view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        group_names.iter().any(|n| n == "alpha") && group_names.iter().any(|n| n == "beta"),
+        "expected alpha and beta project headers, got {group_names:?}"
+    );
+}
+
+/// Within a project group under Attention sort, sessions must order by
+/// attention tier: Waiting (tier 0) above Running (tier 4). Confirms that
+/// the existing `sort_sessions` helper, already reached by the project
+/// flatten path via `flatten_tree`, is doing its job once we stopped
+/// short-circuiting it.
+#[test]
+#[serial]
+fn project_grouping_sorts_sessions_by_attention_within_group() {
+    use crate::session::config::{GroupByMode, SortOrder};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let mut current_group: Option<String> = None;
+    let mut alpha_session_order: Vec<String> = Vec::new();
+    for item in &env.view.flat_items {
+        match item {
+            Item::Group { name, .. } => current_group = Some(name.clone()),
+            Item::Session { id, .. } => {
+                if current_group.as_deref() == Some("alpha") {
+                    if let Some(inst) = env.view.instances.iter().find(|i| &i.id == id) {
+                        alpha_session_order.push(inst.title.clone());
+                    }
+                }
+            }
+        }
+    }
+    assert_eq!(
+        alpha_session_order,
+        vec!["alpha-waiting".to_string(), "alpha-running".to_string()],
+        "Waiting session must rank above Running within the alpha group"
+    );
+}
+
+/// The most-attention-urgent project floats to the top. `attention_group_key`
+/// scores groups by their best member's tier; beta has an Error (tier 1)
+/// while alpha's best is Waiting (tier 0), so alpha sorts first. This
+/// confirms that the existing group-sort path is reached for project mode
+/// under Attention sort.
+#[test]
+#[serial]
+fn project_groups_sort_by_top_attention_member() {
+    use crate::session::config::{GroupByMode, SortOrder};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let group_order: Vec<String> = env
+        .view
+        .flat_items
+        .iter()
+        .filter_map(|i| match i {
+            Item::Group { name, .. } => Some(name.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        group_order,
+        vec!["alpha".to_string(), "beta".to_string()],
+        "alpha (Waiting=tier 0) must sort above beta (Error=tier 1)"
+    );
+}
+
+/// Manual grouping + Attention sort must still flatten. The cross-cutting
+/// flat priority view is the original Attention design and is the right
+/// behavior when the user has not opted into project grouping. Guards
+/// against an over-eager refactor flipping both modes to grouped.
+#[test]
+#[serial]
+fn manual_grouping_attention_sort_stays_flat() {
+    use crate::session::config::{GroupByMode, SortOrder};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Manual;
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let group_count = env
+        .view
+        .flat_items
+        .iter()
+        .filter(|i| matches!(i, Item::Group { .. }))
+        .count();
+    assert_eq!(
+        group_count, 0,
+        "Manual + Attention should produce a flat list, no group headers"
+    );
+}
+
 mod scroll_pane_isolation {
     //! Wheel events are confined to whichever pane the mouse is over.
     //! In particular, a wheel over the preview pane never moves the list

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4202,6 +4202,120 @@ fn project_groups_sort_by_top_attention_member() {
     );
 }
 
+/// Pressing `g` to flip `group_by` keeps the cursor on the previously
+/// selected session, even when the list reshapes (Manual flat list →
+/// Project grouped list). Previously `apply_group_by` clamped by index,
+/// which landed the cursor on whatever row slid into the old slot once
+/// project headers got inserted. The fix seeks `selected_session` by id
+/// after the rebuild.
+#[test]
+#[serial]
+fn group_by_toggle_preserves_selected_session() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Manual;
+    env.view.sort_order = crate::session::config::SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+
+    // Pick the last session in the Manual flat list; that's the row whose
+    // index is most likely to be invalidated when project headers get
+    // inserted in front of it.
+    let target_id = env
+        .view
+        .flat_items
+        .iter()
+        .rev()
+        .find_map(|i| match i {
+            Item::Session { id, .. } => Some(id.clone()),
+            _ => None,
+        })
+        .expect("manual flat list should contain at least one session");
+    env.view.select_session_by_id(&target_id);
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(target_id.as_str())
+    );
+
+    env.view.handle_key(key(KeyCode::Char('g')), None);
+    assert_eq!(env.view.group_by, GroupByMode::Project);
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(target_id.as_str()),
+        "cursor must stay on the same session after group_by flip"
+    );
+    let cursor_item = env
+        .view
+        .flat_items
+        .get(env.view.cursor)
+        .expect("cursor must point into flat_items");
+    match cursor_item {
+        Item::Session { id, .. } => assert_eq!(id, &target_id),
+        Item::Group { .. } => panic!("cursor landed on a group header, not the session"),
+    }
+}
+
+/// Pressing `o` to flip `sort_order` keeps the cursor on the previously
+/// selected session. Most visible when going Newest → Attention with
+/// Project grouping on, since Attention reorders both groups (by top
+/// member) and sessions within each group, so the target session is very
+/// unlikely to keep its index across the rebuild.
+#[test]
+#[serial]
+fn sort_order_toggle_preserves_selected_session() {
+    use crate::session::config::{GroupByMode, SortOrder};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+
+    // Pin the Running session inside alpha. Under Attention sort it sinks
+    // below alpha-waiting, so its index will shift on the rebuild.
+    let target_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "alpha-running")
+        .map(|i| i.id.clone())
+        .expect("fixture provides alpha-running");
+    env.view.select_session_by_id(&target_id);
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(target_id.as_str())
+    );
+
+    env.view.handle_key(key(KeyCode::Char('o')), None);
+    assert_eq!(env.view.sort_order, SortOrder::Attention);
+    assert_eq!(
+        env.view.selected_session.as_deref(),
+        Some(target_id.as_str()),
+        "cursor must stay on the same session after sort_order flip"
+    );
+}
+
+/// `reseat_cursor_after_rebuild` falls back to index clamping when there
+/// is no prior session selection. Guards against the helper accidentally
+/// regressing the empty-or-group-only path, where the original clamp
+/// logic was correct.
+#[test]
+#[serial]
+fn reseat_cursor_clamps_when_no_session_selected() {
+    use crate::session::config::GroupByMode;
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    env.view.flat_items = env.view.build_flat_items();
+    env.view.selected_session = None;
+    env.view.cursor = env.view.flat_items.len() + 50; // intentionally out of range
+
+    env.view.reseat_cursor_after_rebuild();
+    assert!(
+        env.view.cursor < env.view.flat_items.len(),
+        "cursor must be clamped into the flat_items range"
+    );
+}
+
 /// Manual grouping + Attention sort must still flatten. The cross-cutting
 /// flat priority view is the original Attention design and is the right
 /// behavior when the user has not opted into project grouping. Guards


### PR DESCRIPTION
## Description

Group-by-project + Attention sort don't play nicely together: toggling Attention sort while `group_by=Project` silently flattens the list and drops the project headers, defeating the whole point of project mode for users who want to triage attention *within* their project boundaries.

**Root cause:** `build_flat_items()` in `src/tui/home/mod.rs:1836` checks `SortOrder::Attention` BEFORE `GroupByMode::Project` and early-returns the flat attention list. The downstream helpers (`flatten_tree`, `sort_sessions`, `sort_groups`, `attention_group_key` in `src/session/groups.rs`) already handle attention-within-groups correctly; this was purely a top-level branch-order bug.

**Fix:** Swap the two checks. When `group_by=Project`, always route through `build_flat_items_by_project()`, and `flatten_tree` inside it sorts sessions by attention tier within each project and floats the most-urgent project to the top via `attention_group_key`. Manual + Attention keeps its original cross-cutting flat priority view.

After the fix: with `group_by=Project` and `sort_order=Attention`, project headers stay visible, sessions inside each project sort by tier (Waiting > Error > Idle > Running > ...), and the project with the top-priority session floats to the top. The `z` / `f` / `h` footer hints (already gated on `sort_order == Attention`) now show up in this combined mode as expected.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How tested

- `cargo test --lib -- tui::home::` → 241 passed, 0 failed
- `cargo test --lib -- session::groups` → 62 passed, 0 failed
- `cargo clippy --lib --tests -- -D warnings` → clean
- `cargo fmt -- --check` → clean
- Confirmed the 3 new regression tests fail without the fix by stashing the production change and re-running.

Four tests added in `src/tui/home/tests.rs`:
- `project_grouping_survives_attention_sort` — both project headers stay visible.
- `project_grouping_sorts_sessions_by_attention_within_group` — Waiting > Running inside the same project.
- `project_groups_sort_by_top_attention_member` — the project with the top-tier session floats up.
- `manual_grouping_attention_sort_stays_flat` — no-regression guard for the cross-cutting flat view in Manual mode.

## AI Usage

- [ ] No AI was used
- [ ] AI was used for drafting/refactoring
- [x] This is fully AI-generated

**AI Model/Tool used:** Claude Code (Opus 4.7) via the `/investigate` skill

**Any Additional AI Details you'd like to share:**

Diagnosis, fix, and tests all produced by Claude Code working from a one-line bug report ("group-by-project + z/f attention features don't play nice"). The fix is a 7-line logical change inside one function; the test additions are the bulk of the diff. The investigation traced the bad branch order in `build_flat_items()` by reading the call chain through `flatten_sessions_by_attention`, `flatten_tree`, `sort_sessions`, `sort_groups`, and `attention_group_key`, then confirmed the downstream helpers already supported the desired behavior, so no changes outside `src/tui/home/` were needed.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a UI bug where enabling Attention sort while grouping by Project flattened the list and hid project headers. The control flow in the item-building logic was reordered so Project grouping is honored when Attention sorting is active.

## What Changed

- src/tui/home/mod.rs
  - Reordered logic in HomeView::build_flat_items so GroupByMode::Project is handled before the special-case SortOrder::Attention branch. Project grouping now goes through build_flat_items_by_project(), preserving headers while still sorting by attention within projects.
  - Removed the redundant late-project early-return that caused the flattened view when Attention was active.

- src/tui/home/input.rs
  - Added reseat_cursor_after_rebuild() and wired it into apply_sort_order and apply_group_by so the selected session is preserved (by id) across sort/group toggles; falls back to index clamping if the session is gone.

- src/tui/home/tests.rs
  - Added fixture create_test_env_two_projects_mixed_attention() and four regression tests covering:
    - Project headers remain visible with GroupByMode::Project + SortOrder::Attention
    - Sessions inside each project are ordered by attention tier (Waiting > Error > Idle > Running > ...)
    - Projects are ordered by their highest-attention session (top-priority project floats)
    - Cursor/selection preserved across toggles and clamped correctly when needed
  - Also asserts Manual + Attention still produces the original flat priority list.

## What Was Added

- New cursor reseating helper (reseat_cursor_after_rebuild).
- Four regression tests and a test fixture seeding two projects with mixed session statuses.

## What Was Removed

- The earlier redundant early-return branch that caused project headers to be dropped when Attention sorting was active.

## Benefits

- Restores project boundaries when sorting by urgency, improving triage within project contexts.
- Keeps attention-based ordering inside each project and brings the most-urgent project to the top.
- Preserves selection across view reshapes, improving UX when toggling sort/group modes.
- Regression tests reduce risk of future regressions.

## Technical Details

- Root cause: build_flat_items checked SortOrder::Attention before GroupByMode::Project and returned a flattened attention list; downstream helpers already supported attention-within-groups.
- Fix: swap checks so project grouping uses build_flat_items_by_project(), which sorts sessions by attention tier and uses attention_group_key to float the highest-priority project. Manual + Attention retains original flat view via its dedicated branch.
- Tests & validation: Added tests in src/tui/home/tests.rs; local runs reported tui::home tests (241 passed) and session::groups (62 passed). Regression tests fail on the old behavior.
- Diff footprint: small code changes in mod.rs and input.rs; ~4 new tests and a fixture in tests.rs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1414?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->