### PR TITLE
fix(web/test): unmount React trees after each test to stop jsdom-teardown flake

### DIFF
--- a/web/src/test-setup.ts
+++ b/web/src/test-setup.ts
@@ -1,0 +1,11 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+// React 19's scheduler can leave work pending past the end of a test file.
+// When jsdom is torn down between files, any remaining work fires in a
+// setImmediate callback and crashes with "ReferenceError: window is not defined"
+// (originating in node_modules/react-dom/cjs/react-dom-client.development.js).
+// Unmounting every rendered tree after each test prevents that pending work.
+afterEach(() => {
+  cleanup();
+});

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
   test: {
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["tests/**", "node_modules/**", "dist/**"],
+    setupFiles: ["./src/test-setup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],
@@ -45,6 +46,7 @@ export default defineConfig({
       exclude: [
         "src/**/*.d.ts",
         "src/main.tsx",
+        "src/test-setup.ts",
         "src/**/__tests__/**",
         "src/**/*.test.{ts,tsx}",
       ],


### PR DESCRIPTION
## What

Adds `web/src/test-setup.ts` and wires it into vitest's `setupFiles`. The setup file calls `@testing-library/react`'s `cleanup` in a global `afterEach`.

Coverage exclude list updated so the setup file does not appear in the coverage report.

## Why

Vitest occasionally reports `Vitest caught 1 unhandled error during the test run` with `ReferenceError: window is not defined`. The stack trace originates in `node_modules/react-dom/cjs/react-dom-client.development.js` under a `setImmediate` callback, after the rest of the suite has otherwise passed (`786 passed (786)`).

What is happening: React 19's scheduler can leave work pending past the end of a test file. When jsdom is torn down between files, the next scheduled tick fires in a `setImmediate` callback that tries to read `window` and crashes.

Calling `cleanup()` after each test unmounts every rendered tree, so there is no pending React work to fire after the environment flips. RTL 16 does auto-register cleanup when vitest globals are enabled, but this project does not enable globals, so a manual setup file is the supported path.

This was first observed on the [Tests run for #1402](https://github.com/njbrake/agent-of-empires/actions/runs/26276667869); other PR runs on the same revision passed, consistent with a timing flake rather than a deterministic regression. The fix is project-wide because individual test files in `web/src/**/__tests__/` are inconsistent about calling `cleanup()` themselves, and a centralized `afterEach` removes the foot-gun.

## How to test

```
cd web && npm run test:unit -- --run
```

All 791 tests pass locally; no `Unhandled Errors` block in output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes intermittent test failures caused by React leaving pending work that executes after the test environment is torn down, causing crashes with `ReferenceError: window is not defined`.

## What Changed
- **Added**: New file `web/src/test-setup.ts` containing a global `afterEach` hook
- **Updated**: `web/vite.config.ts` to wire the setup file into Vitest's test lifecycle and exclude it from coverage reporting

## How It Works
After each test completes, the setup file calls React Testing Library's `cleanup()` function, which unmounts any rendered React trees. This prevents React 19's scheduler from leaving pending callbacks that would execute after the test environment is torn down.

## Benefits
- Eliminates intermittent "Vitest caught 1 unhandled error during the test run" failures
- Ensures all 791 tests pass consistently without unhandled errors
- Provides stable test environment by proper resource cleanup between tests

## Technical Details
- The setup file uses an explicit `afterEach` hook (rather than Vitest globals) to ensure compatibility with the project's configuration
- React 19's scheduler can leave work pending after test completion; cleanup prevents this from executing in the teardown phase
- The setup file is excluded from coverage reports to keep metrics accurate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->