### PR TITLE
docs: add Playwright + TUI e2e test coverage analysis to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,17 +13,34 @@
 ## Checklist
 <!-- If you delete this checklist, your PR will be immediately closed -->
 
-- [ ] I understand the code I am submitting
 - [ ] New and existing tests pass
 - [ ] Documentation was updated where necessary
 - [ ] For UI changes: included screenshot or recording
+
+## Test Coverage Analysis
+
+<!--
+For user-facing changes we prefer to land the test alongside the code rather
+than file a follow-up issue. Think of each new behavior or bug fix as a "user
+story" that deserves a regression test. Pick one option per surface; if you
+think a test isn't warranted, say why so reviewers can sanity-check.
+-->
+
+**Web dashboard / cockpit (Playwright user story)**
+- [ ] N/A: this PR doesn't change a user-facing dashboard flow
+- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
+- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->
+
+**TUI / CLI (e2e test)**
+- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
+- [ ] Added or updated an e2e test under `tests/e2e/`
+- [ ] Skipped a test, because: <!-- explain -->
 
 ## AI Usage
 
 <!-- Check one -->
 - [ ] No AI was used
-- [ ] AI was used for drafting/refactoring
-- [ ] This is fully AI-generated
+- [ ] AI was used (any amount, from light assist to fully generated)
 
 <!-- If AI was used, please share details -->
 **AI Model/Tool used:**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,7 +40,7 @@ think a test isn't warranted, say why so reviewers can sanity-check.
 
 <!-- Check one -->
 - [ ] No AI was used
-- [ ] AI was used (any amount, from light assist to fully generated)
+- [ ] AI was used
 
 <!-- If AI was used, please share details -->
 **AI Model/Tool used:**


### PR DESCRIPTION
## Description

Updates the PR template based on the Discord discussion about #1419 and #875: instead of routinely filing follow-up issues to track new tests for each user story, prompt the PR author to either land the test alongside the change or explicitly justify why a test was skipped.

## PR Type

- [x] Documentation

## Checklist

- [x] New and existing tests pass (no code changes)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## What changed

- Added a **Test Coverage Analysis** section with two surfaces (web/cockpit Playwright user-story, TUI/CLI e2e). Each is a 3-way pick: N/A, added a test, or explicitly skipped with a reason.
- Removed the low-signal "I understand the code I am submitting" checkbox (everyone ticks it without thinking).
- Collapsed the AI Usage radio from three options to a simple yes/no, kept the "I am an AI Agent filling out this form" checkbox.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Claude drafted the template prose and this PR body via back-and-forth. The structure (which checkboxes to keep, drop, and add) was my call based on the linked Discord thread.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates the repository's pull request template to improve contributor guidance around test coverage and AI usage declarations.

### Changes Made

**Removed:**
- The "I understand the code I am submitting" checkbox, which was identified as low-signal

**Added:**
- New "Test Coverage Analysis" section that requires contributors to indicate test coverage for two key areas:
  - **Playwright tests** for web dashboard/cockpit functionality
  - **e2e tests** for TUI/CLI functionality
- Each test surface includes a 3-way choice: mark as N/A, confirm tests were added, or explicitly skip with a reason
- Encourages landing tests alongside code changes or providing justification when tests are deferred

**Simplified:**
- AI Usage declaration now uses a simple yes/no binary choice instead of three detailed options
- Retains the "I am an AI Agent filling out this form" checkbox for transparency

### Technical Details

- File modified: `.github/pull_request_template.md`
- Lines changed: +20 / -3

### Benefits

- **Improves test discipline:** Makes test coverage expectations explicit and discourages deferring tests to follow-up issues without justification
- **Clarifies testing surfaces:** Distinguishes between different testing approaches (Playwright for UI, e2e for terminal) rather than generic "tests added" declarations
- **Reduces friction:** Simplifies the AI usage section to a straightforward yes/no while maintaining transparency about AI-assisted contributions
- **Raises signal quality:** Removes checkbox items that weren't actionable, focusing the template on meaningful contributor commitments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1421?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->