### PR TITLE
fix(ci): restore contributor attribution in release notes

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,50 @@
+name: PR Title Check
+
+# Enforce Conventional Commits on the PR title. AoE squash-merges PRs, so the
+# PR title becomes the commit subject git-cliff consumes when generating
+# CHANGELOG.md and the GitHub release body. A non-conventional title is what
+# put three commits in v1.8.0's release notes under the "Other" catch-all
+# instead of their real Bug Fixes / Features group.
+#
+# Defense in depth pairs with cliff.toml: the catch-all parser keeps non-
+# conventional commits visible (no silent drop), the release workflow fails
+# loudly if git-cliff ever emits a parse-error warning, and this check
+# refuses the merge before it can happen.
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Lint PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Mirror the prefixes wired up in cliff.toml's commit_parsers so the
+          # set of accepted PR titles matches the set that renders into the
+          # changelog. Any addition here must be mirrored there.
+          types: |
+            feat
+            fix
+            perf
+            security
+            revert
+            chore
+            build
+            ci
+            docs
+            style
+            refactor
+            test
+          requireScope: false
+          subjectPattern: ^[^A-Z].+$
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            should start with a lowercase character (Conventional Commits style).

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,10 +59,24 @@ jobs:
           grep '^version = ' Cargo.toml | head -1
 
       - name: Update CHANGELOG.md
+        env:
+          # See release.yml for context: git-cliff needs an auth token to
+          # resolve PR + author metadata, otherwise contributor attribution
+          # silently drops on large releases.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git cliff --config cliff.toml --tag "v$VERSION" --output CHANGELOG.md
+          git cliff --config cliff.toml --tag "v$VERSION" --output CHANGELOG.md 2> cliff-stderr.log
           echo "=== CHANGELOG.md head ==="
           head -40 CHANGELOG.md
+          echo "=== cliff stderr ==="
+          cat cliff-stderr.log
+          # Mirror the release.yml guard. cliff.toml's catch-all parser
+          # routes unmatched commits to "Other"; if git-cliff still skips
+          # any due to parse errors, fail the release prep.
+          if grep -q "skipped due to parse error" cliff-stderr.log; then
+            echo "::error::git-cliff skipped commits due to parse errors. Either fix the offending commit messages or extend cliff.toml's catch-all parser."
+            exit 1
+          fi
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,28 @@ jobs:
           fi
 
       - name: Generate release notes
+        env:
+          # git-cliff hits the GitHub API to resolve commit -> PR -> author
+          # for the "by @user in #N" lines and the "New Contributors" section.
+          # Without a token the calls are unauthenticated and rate-limited to
+          # 60/hr, which silently strips attribution when a release has many
+          # commits.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git cliff --config cliff.toml --current --strip header > release-notes.md
+          git cliff --config cliff.toml --current --strip header > release-notes.md 2> cliff-stderr.log
           echo "=== release-notes.md ==="
           cat release-notes.md
+          echo "=== cliff stderr ==="
+          cat cliff-stderr.log
+          # Belt-and-braces: cliff.toml already routes unmatched commits to
+          # the "Other" group via a catch-all parser. If git-cliff still
+          # flags a parse-error skip, something fell through the safety net
+          # (regex change, parser-order regression, etc.) and we want the
+          # release to fail loudly rather than silently lose commits.
+          if grep -q "skipped due to parse error" cliff-stderr.log; then
+            echo "::error::git-cliff skipped commits due to parse errors. Either fix the offending commit messages or extend cliff.toml's catch-all parser."
+            exit 1
+          fi
 
       - name: Create Release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ Routine maintenance is intentionally hidden:
 
 For web-dashboard changes, scope visibility via the prefix: `feat(web): ...` / `fix(web): ...` show up; `refactor(web):` / `chore(web):` / `test(web):` stay out. Same pattern for `cockpit`, `serve`, `tui`.
 
-`filter_unconventional = true` means PR titles without a recognized prefix are dropped from release notes entirely. If you land a title like "Fix stuff" it will not appear; reword the squash-merge title to `fix: <thing>` before merging.
+A non-conventional PR title no longer disappears silently from the changelog: `cliff.toml`'s catch-all parser routes anything without a recognized prefix into a generic "Other" group, and the release workflow fails if git-cliff still flags a parse-error skip. Even so, the **PR Title Check** workflow runs on every PR and refuses to pass until the title parses as `<type>(<scope>)?: <subject>` with a lowercase subject, so "Other" should only ever catch direct pushes to `main`. Reword titles like "Fix stuff" to `fix: <thing>` before merging.
 
 ## Testing
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -25,20 +25,60 @@ body = """
 ### {{ group }}
 
 {% for commit in commits %}\
-- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/njbrake/agent-of-empires/commit/{{ commit.id }}))
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}\
+{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/njbrake/agent-of-empires/pull/{{ commit.remote.pr_number }}){% endif %}\
+{% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){% endif %} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/njbrake/agent-of-empires/commit/{{ commit.id }}))
 {% endfor %}
 {% endfor %}
+{%- if github.contributors | filter(attribute="is_first_time", value=true) | length > 0 %}
+
+### New Contributors
+
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) -%}
+- [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution in [#{{ contributor.pr_number }}](https://github.com/njbrake/agent-of-empires/pull/{{ contributor.pr_number }})
+{% endfor %}
+{%- endif %}
+{% if previous and previous.version and version -%}
+
+**Full Changelog**: https://github.com/njbrake/agent-of-empires/compare/{{ previous.version }}...{{ version }}
+{% endif %}
 """
 trim = true
 footer = ""
 
+[remote.github]
+owner = "njbrake"
+repo = "agent-of-empires"
+
 [git]
 conventional_commits = true
-filter_unconventional = true
+# Don't drop commits that fail conventional-commit parsing. We surface them
+# under the "Other" group via the catch-all parser below, and the release
+# workflow additionally fails when git-cliff still emits a parse-error
+# warning. That combo guarantees no commit is ever silently lost.
+filter_unconventional = false
 filter_commits = true
 tag_pattern = "v[0-9]*"
 sort_commits = "oldest"
 protect_breaking_commits = true
+
+# Squash-merge commits arrive as "feat(foo): subject (#1234)". The trailing
+# "(#1234)" is the same PR number that git-cliff resolves via the GitHub
+# remote integration and surfaces as `commit.remote.pr_number`. Strip it so
+# the rendered line doesn't show the PR ref twice.
+commit_preprocessors = [
+  # Strip the trailing " (#1234)" that GitHub appends to squash-merge
+  # subjects. git-cliff's GitHub remote integration resolves the same PR
+  # number and renders it as a link, so leaving the literal in the message
+  # ends up duplicating the reference on every line.
+  #
+  # (?m) so $ matches end-of-line (the subject is followed by the body).
+  # The pattern is intentionally narrow: a literal space + (#NNN) + end of
+  # line. Looser variants like \s+...\s*$ confuse git-cliff's conventional-
+  # commit parser and flip commit.conventional to false, which silently
+  # drops the scope from the rendered line.
+  { pattern = '(?m) \(#\d+\)$', replace = "" },
+]
 
 commit_parsers = [
   { message = "^feat", group = "Features" },
@@ -58,4 +98,11 @@ commit_parsers = [
   { message = "^style", skip = true },
   { message = "^refactor", skip = true },
   { message = "^test", skip = true },
+
+  # Catch-all: any commit that didn't match a typed prefix above (e.g. a
+  # squash-merge that landed without a conventional-commit type) lands in
+  # "Other" instead of being silently dropped from the changelog. The
+  # release workflow also fails when git-cliff emits a parse-error warning,
+  # so this is the second of two safety nets.
+  { message = ".*", group = "Other" },
 ]


### PR DESCRIPTION
> _AI disclosure: Drafted by Claude Opus 4.7 under my direction; I reviewed every change before pushing._

## Description

v1.8.0's GitHub Release (https://github.com/njbrake/agent-of-empires/releases/tag/v1.8.0) lost every `by @user in #N` line and the "New Contributors" section that the previous auto-generated release notes used to carry. Three commits also silently disappeared from the changelog because their PR titles weren't Conventional Commits and git-cliff was configured to drop unconventional ones.

This PR lands the fix end to end, plus a gate that prevents the same class of bug from re-occurring.

### 1. Restore contributor attribution

`cliff.toml`:
- New `[remote.github]` section so git-cliff resolves PR + author metadata.
- Template renders `**scope:** subject in #N by @user (`hash`)` per line, a `New Contributors` section, and a Full Changelog compare link.
- `commit_preprocessors` strips the squash-merge trailing `(#N)` so the PR ref is not duplicated in every rendered line.

Workflows:
- `release.yml` and `prepare-release.yml` now pass `GITHUB_TOKEN` to git-cliff. Without it the GitHub API calls run unauthenticated, hit the 60/hr anonymous limit, and silently strip attribution on a normal-sized release.

### 2. Never silently drop commits again

`cliff.toml`:
- `filter_unconventional = false` plus a catch-all parser routes any non-conventional commit into a generic `Other` group rather than dropping it. The three commits that disappeared from v1.8.0 (`e6eebd6`, `2ed20f2`, `b6d3df1`) would have surfaced under `Other`.

Workflows:
- Both release jobs `grep -q "skipped due to parse error"` against git-cliff's stderr and fail loudly if it ever fires. The catch-all should make that impossible in practice, but the guard means a future regression in `commit_parsers` cannot silently lose commits.

### 3. Enforce Conventional Commits on PR titles

- New `.github/workflows/pr-title-check.yml` uses `amannn/action-semantic-pull-request` to block merges whose title doesn't parse as `<type>(<scope>)?: <subject>` with a lowercase subject. The type set is the same one wired up in cliff.toml's `commit_parsers`, so the gate matches the renderer.

### 4. Docs

- `CONTRIBUTING.md` "Changelog visibility" section updated to point at the new gate and the safety net behind it.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test plan

- [x] Rendered v1.8.0 locally with the new `cliff.toml` against the upstream `v1.7.1..v1.8.0` range. Verified: per-line `by @user in #N`, `New Contributors` section listing @MovieHolic-Plex and @flyinghail, Full Changelog link, the three previously-dropped commits now visible under `Other`, and no duplicate `(#N)` references.
- [x] Re-ran with `-vv` and confirmed git-cliff stderr no longer contains `skipped due to parse error`. The CI guard would otherwise fail the workflow.
- [ ] A maintainer can regenerate v1.8.0's release body with `gh release edit v1.8.0 --notes-file <(git cliff --config cliff.toml --current --strip header)` to retroactively restore attribution (I cannot, no release-edit permission on njbrake/agent-of-empires).
- [ ] After merge, the next `prepare-release` run will regenerate `CHANGELOG.md` against the new template.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude Opus 4.7

**Any Additional AI Details you'd like to share:**
Claude drafted the cliff.toml template, regex, and workflow edits, then iterated on the preprocessor pattern when the first version flipped `commit.conventional` to false. I verified locally that the rendered output matches the format the v1.7.1 auto-generated release used to carry, and that the catch-all parser surfaces the three previously-dropped commits.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR restores missing contributor attribution and GitHub PR information in release notes, which was lost in v1.8.0. It also implements safeguards to prevent future silent failures when processing non-standard commit formats.

## What Changed

**New Files:**
- Added a new PR Title Check GitHub Actions workflow that validates all pull request titles follow Conventional Commits format (e.g., `fix: description`, `feat: description`)

**Workflow Updates:**
- Modified release and prepare-release workflows to provide authentication credentials (GITHUB_TOKEN) when generating release notes, ensuring GitHub API calls aren't rate-limited
- Added error detection in both workflows to catch and fail if release note generation encounters unparseable commits

**Configuration Updates:**
- Updated the release notes template (cliff.toml) to include per-commit author and PR number information alongside the commit hash
- Added preprocessing rules to prevent duplicate PR references in squash-merged commits
- Changed settings to route non-standard commits to an "Other" group instead of silently dropping them

**Documentation:**
- Updated CONTRIBUTING.md to explain the new PR title validation requirements and how non-standard commits are now handled in release notes

## Benefits

- **Restored Information**: Release notes now properly attribute changes to original authors and link to the PRs that introduced them
- **Improved Visibility**: Non-standard commits are now visible in release notes (in an "Other" section) rather than silently disappearing
- **Prevented Errors**: Workflows will fail if release generation encounters unparseable content, preventing silent data loss
- **Enforced Standards**: PR title validation ensures all contributions follow a consistent format, making release notes cleaner and more predictable

## Technical Details

The solution involves four interconnected changes:

1. **Authentication**: Release workflows now pass `GITHUB_TOKEN` to git-cliff for authenticated API access, preventing anonymous rate-limit restrictions that strip attribution metadata
2. **Template Enhancement**: The changelog template now renders per-line entries as `<scope>: <subject> in #<PR> by @<author> (<hash>)` and includes a "New Contributors" section and full changelog link
3. **Fallback Handling**: Set `filter_unconventional = false` in cliff.toml and added a catch-all parser to route commits that don't match conventional format into an "Other" group
4. **Workflow Validation**: Both release workflows capture stderr from git-cliff and fail if they detect "skipped due to parse error" messages, preventing undetected drops
5. **Preprocessor Rules**: Added commit preprocessors to strip trailing PR references (e.g., `(`#NNN`)`) from squash-merge subjects to avoid duplication in rendered output

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->