### PR TITLE
feat: throwaway-directory toggle for new sessions

### DIFF
--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -130,9 +130,7 @@ Add a new session
 
 ###### **Arguments:**
 
-* `<PATH>` — Project directory (defaults to current directory)
-
-  Default value: `.`
+* `<PATH>` — Project directory (defaults to current directory). Omit when using `--throwaway`
 
 ###### **Options:**
 
@@ -158,6 +156,7 @@ Add a new session
 * `--no-cockpit` — Force terminal/PTY mode for this session, overriding the default-for-claude cockpit setting
 * `--agent <AGENT>` — Pick a specific cockpit agent (e.g., aoe-agent, claude-code). Implies --cockpit
 * `--model <MODEL>` — Override the model used by aoe-agent (e.g., claude-opus-4-7, gpt-5, gemini-2.5-pro). Forwarded to the agent at session start
+* `-T`, `--throwaway` — Create the session in a fresh temporary directory instead of a project path. The directory is removed when the session is deleted. Mutually exclusive with worktree-related flags
 
 
 

--- a/docs/guides/throwaway-sessions.md
+++ b/docs/guides/throwaway-sessions.md
@@ -1,0 +1,105 @@
+# Throwaway sessions
+
+A throwaway session is a session that does not belong to any project on
+disk. When you start one, AoE provisions a fresh temporary directory
+under your system's temp folder, attaches the session to it, and
+removes the directory when you delete the session.
+
+Use throwaway sessions for one-off questions, quick investigations, or
+ad-hoc agent runs where you do not want a session record tied to a
+specific repo or to keep stray files around afterwards.
+
+## When to use it
+
+* You want to ask the agent a question that does not depend on a
+  particular codebase.
+* You want a clean, empty scratch directory for the agent to write
+  files into without polluting an existing project.
+* You want to investigate something quickly and have the directory
+  go away automatically when you are done.
+
+## Three ways to start one
+
+### Command line
+
+```bash
+aoe add --throwaway -t "Quick question" -c claude
+# or the short flag
+aoe add -T -t "Quick question" -c claude
+```
+
+The session prints its resolved `Path:` line pointing at
+`/tmp/aoe-throwaway-<id>` (Linux) or `$TMPDIR/aoe-throwaway-<id>`
+(macOS). You do not pass a project path; it is provisioned for you.
+
+Trying to pass a path alongside `--throwaway` is rejected:
+
+```bash
+aoe add /Users/me/repo --throwaway
+# error: Cannot specify a project path with --throwaway
+```
+
+`--throwaway` is mutually exclusive with all worktree-related flags
+(`-w`, `--new-branch`, `--base-branch`, `--repo`, `--project`,
+`--no-submodules`). Mixing them fails at parse time with a clear
+conflict message.
+
+### Web dashboard
+
+In the new-session wizard, the **Project** step has a toggle labeled
+**Skip project folder** above the Recent / Browse / Clone URL tabs.
+Turning it on hides the path picker and the worktree controls on the
+Session step. The Review step shows
+"Temporary directory (provisioned on create)" in place of the path.
+
+Selecting a real project (Recent / Browse / Clone) turns the toggle
+back off, so the wizard never submits a request with both a real path
+and the throwaway flag set.
+
+### TUI new-session dialog
+
+Press `Ctrl+T` inside the new-session dialog from any field. The Path
+input is replaced with a `(throwaway directory, Ctrl+T to undo)`
+marker, the Worktree toggle is forced off, and submitting creates the
+session in a fresh temp directory. Press `Ctrl+T` again to revert.
+
+## What happens at delete
+
+When you delete a throwaway session via `aoe rm`, the web dashboard
+delete flow, or the TUI delete dialog, the deletion path also runs
+`fs::remove_dir_all` on the session's temp directory. The cleanup is
+guarded: it only runs when the session's `throwaway` flag is true AND
+the path is under your OS temp dir AND its basename starts with
+`aoe-throwaway-`. A session record with a tampered `project_path`
+pointing at, say, `/etc` is left alone.
+
+The wizard's **Recent projects** tab filters throwaway sessions out
+once they exist, so a deleted throwaway directory does not appear as a
+reusable recent project.
+
+## Compatibility
+
+* **Cockpit mode**: throwaway sessions work with `--cockpit` and the
+  bundled ACP agents. The ACP worker spawns with the temp directory
+  as its current working directory.
+* **Sandboxes**: throwaway sessions can run in a container sandbox
+  (`-s` or `--sandbox-image`); the container mounts the temp
+  directory the same way it mounts a real project path.
+* **Worktrees**: not supported. A throwaway directory is not a git
+  repo, so the worktree concept does not apply. Use a regular project
+  path with `-w` if you want a worktree.
+* **Hooks**: a throwaway directory has no `.agent-of-empires/config.toml`,
+  so the per-repo hook trust prompt never fires. Global and profile
+  `on_create` hooks still run, with the temp directory as their `cwd`.
+
+## Limits
+
+If `aoe serve` (or your shell session) dies before you delete a
+throwaway session, the directory is left on disk. Operating systems
+clean their temp folders periodically, but a daemon-side orphan sweep
+on `aoe serve` startup is tracked as a follow-up.
+
+If you need the session to outlive its temp directory (rename, move,
+keep the files), the recommended pattern is to copy whatever you need
+out of the temp directory and recreate the session against a real path
+with `aoe add <path>`.

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -11,9 +11,9 @@ use crate::session::{civilizations, GroupTree, Instance, SandboxInfo, Storage};
 
 #[derive(Args)]
 pub struct AddArgs {
-    /// Project directory (defaults to current directory)
-    #[arg(default_value = ".")]
-    path: PathBuf,
+    /// Project directory (defaults to current directory). Omit when
+    /// using `--throwaway`.
+    path: Option<PathBuf>,
 
     /// Session title (defaults to folder name)
     #[arg(short = 't', long)]
@@ -117,22 +117,55 @@ pub struct AddArgs {
     #[cfg(feature = "serve")]
     #[arg(long = "model")]
     model: Option<String>,
+
+    /// Create the session in a fresh temporary directory instead of a
+    /// project path. The directory is removed when the session is deleted.
+    /// Mutually exclusive with worktree-related flags.
+    #[arg(
+        short = 'T',
+        long = "throwaway",
+        conflicts_with_all = [
+            "worktree_branch",
+            "create_branch",
+            "base_branch",
+            "extra_repos",
+            "projects",
+            "no_submodules",
+        ]
+    )]
+    throwaway: bool,
 }
 
 #[tracing::instrument(target = "cli.add", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
-    let mut path = if args.path.as_os_str() == "." {
-        std::env::current_dir()?
+    // Throwaway sessions have no project path; the temp dir is provisioned
+    // below once we know the instance id. Reject an explicitly-passed path
+    // loudly so `aoe add /some/repo --throwaway` does not silently drop the
+    // path arg.
+    if args.throwaway && args.path.is_some() {
+        bail!(
+            "Cannot specify a project path with --throwaway\nTip: drop the path argument, the session runs in a fresh temp directory"
+        );
+    }
+
+    let mut path = if args.throwaway {
+        // Placeholder; the real path is set after `Instance::new` runs and
+        // `throwaway::provision_throwaway_dir` returns a fresh temp dir.
+        PathBuf::new()
     } else {
-        if !args.path.exists() {
-            bail!("Path does not exist: {}", args.path.display());
+        let raw = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
+        if raw.as_os_str() == "." {
+            std::env::current_dir()?
+        } else {
+            if !raw.exists() {
+                bail!("Path does not exist: {}", raw.display());
+            }
+            raw.canonicalize()
+                .with_context(|| format!("Failed to resolve path: {}", raw.display()))?
         }
-        args.path
-            .canonicalize()
-            .with_context(|| format!("Failed to resolve path: {}", args.path.display()))?
     };
 
-    if !path.is_dir() {
+    if !args.throwaway && !path.is_dir() {
         bail!("Path is not a directory: {}", path.display());
     }
 
@@ -316,6 +349,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 worktree_info_opt.as_ref(),
                 workspace_info_opt.as_ref(),
                 args.create_branch,
+                None,
             );
             return Ok(());
         }
@@ -332,6 +366,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 worktree_info_opt.as_ref(),
                 workspace_info_opt.as_ref(),
                 args.create_branch,
+                None,
             );
             return Ok(());
         }
@@ -343,6 +378,16 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
 
     let mut instance = Instance::new(&final_title, path.to_str().unwrap_or(""));
     instance.source_profile = profile.to_string();
+
+    // Throwaway sessions: provision a fresh temp directory keyed on the
+    // freshly-generated instance id. The session layer owns the naming
+    // contract (`aoe-throwaway-<id>`) and the deletion guard.
+    if args.throwaway {
+        let dir = crate::session::throwaway::provision_throwaway_dir(&instance.id)?;
+        path = dir;
+        instance.project_path = path.to_string_lossy().to_string();
+        instance.throwaway = true;
+    }
 
     if let Some(group) = &group_path {
         instance.group_path = group.trim().to_string();
@@ -620,6 +665,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             instance.worktree_info.as_ref(),
             instance.workspace_info.as_ref(),
             args.create_branch,
+            if instance.throwaway {
+                Some(std::path::Path::new(&instance.project_path))
+            } else {
+                None
+            },
         );
         return Err(e);
     }
@@ -652,6 +702,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 instance.worktree_info.as_ref(),
                 instance.workspace_info.as_ref(),
                 args.create_branch,
+                if instance.throwaway {
+                    Some(std::path::Path::new(&instance.project_path))
+                } else {
+                    None
+                },
             );
             return Ok(());
         }
@@ -661,6 +716,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
                 instance.worktree_info.as_ref(),
                 instance.workspace_info.as_ref(),
                 args.create_branch,
+                if instance.throwaway {
+                    Some(std::path::Path::new(&instance.project_path))
+                } else {
+                    None
+                },
             );
             return Err(e);
         }
@@ -679,6 +739,9 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
     if instance.sandbox_info.is_some() {
         println!("  Sandbox: enabled");
+    }
+    if instance.throwaway {
+        println!("  Throwaway: yes");
     }
     if instance.yolo_mode {
         println!("  YOLO:    enabled");
@@ -778,6 +841,7 @@ fn cleanup_partial_session(
     worktree_info: Option<&crate::session::WorktreeInfo>,
     workspace_info: Option<&crate::session::WorkspaceInfo>,
     created_branch: bool,
+    throwaway_dir: Option<&std::path::Path>,
 ) {
     if let Some(wt) = worktree_info {
         if wt.managed_by_aoe {
@@ -801,6 +865,14 @@ fn cleanup_partial_session(
             }
         }
         let _ = std::fs::remove_dir_all(&ws.workspace_dir);
+    }
+    // Remove the throwaway directory provisioned earlier in this run.
+    // Guarded by `is_throwaway_path` (same check the deletion path uses),
+    // so a tampered or unexpected `project_path` is a no-op.
+    if let Some(throwaway) = throwaway_dir {
+        if crate::session::throwaway::is_throwaway_path(throwaway) {
+            let _ = std::fs::remove_dir_all(throwaway);
+        }
     }
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -46,6 +46,11 @@ pub struct SessionResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub base_branch_override: Option<String>,
     pub is_sandboxed: bool,
+    /// True when the session was created with `--throwaway`; the
+    /// `project_path` points at an auto-provisioned temp directory that
+    /// the deletion path removes. The web wizard filters these out of
+    /// the Recent-projects list.
+    pub throwaway: bool,
     /// True when the session is marked as a user favorite. Mirrors
     /// `Instance::is_favorited()`; surfaced so the web sidebar can pin
     /// favorited rows and render the `*` marker without re-implementing
@@ -191,6 +196,7 @@ impl SessionResponse {
                 .and_then(|w| w.base_branch.clone()),
             base_branch_override: inst.base_branch_override.clone(),
             is_sandboxed: inst.is_sandboxed(),
+            throwaway: inst.throwaway,
             favorited: inst.is_favorited(),
             has_managed_worktree: inst
                 .worktree_info
@@ -1113,6 +1119,11 @@ pub struct CreateSessionBody {
     #[cfg(feature = "serve")]
     #[serde(default)]
     pub cockpit_model: Option<String>,
+    /// Throwaway session: server provisions a fresh directory under
+    /// `std::env::temp_dir()` and ignores `path`. Mutually exclusive with
+    /// `worktree_branch`; the handler returns 400 on the combination.
+    #[serde(default)]
+    pub throwaway: bool,
 }
 
 fn validate_session_tool_identity(
@@ -1158,13 +1169,33 @@ pub async fn create_session(
         Err(rej) => return rej.into_response(),
     };
 
-    // Validate user inputs for shell injection
-    for (value, name) in [
+    // Throwaway sessions are server-provisioned; the worktree path is the
+    // wrong model for them. Reject the combination before reaching the
+    // builder so misbehaving clients get a clear 400 instead of a
+    // less-specific builder bail surfaced as 500.
+    if body.throwaway && body.worktree_branch.is_some() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "validation_failed",
+                "message": "Cannot combine throwaway with worktree_branch"
+            })),
+        )
+            .into_response();
+    }
+
+    // Validate user inputs for shell injection. For throwaway sessions the
+    // `path` field is server-provisioned (and clients typically send an
+    // empty string), so skip the path entry in that case.
+    let mut shell_checks: Vec<(&str, &str)> = vec![
         (body.extra_args.as_str(), "extra_args"),
         (body.tool.as_str(), "tool"),
         (body.group.as_str(), "group"),
-        (body.path.as_str(), "path"),
-    ] {
+    ];
+    if !body.throwaway {
+        shell_checks.push((body.path.as_str(), "path"));
+    }
+    for (value, name) in shell_checks {
         if let Err(msg) = validate_no_shell_injection(value, name) {
             return (
                 StatusCode::BAD_REQUEST,
@@ -1326,6 +1357,7 @@ pub async fn create_session(
             extra_args: body.extra_args,
             command_override: body.command_override,
             extra_repo_paths,
+            throwaway: body.throwaway,
         };
 
         let build_result = builder::build_instance(params, &title_refs, &branch_refs, &profile)?;
@@ -3523,6 +3555,7 @@ mod workspace_ordering_tests {
             base_branch: None,
             base_branch_override: None,
             is_sandboxed: false,
+            throwaway: false,
             has_managed_worktree: false,
             has_terminal: false,
             profile: "default".to_string(),

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -42,6 +42,11 @@ pub struct InstanceParams {
     pub command_override: String,
     /// Additional repository paths for multi-repo workspace mode
     pub extra_repo_paths: Vec<String>,
+    /// Throwaway session: ignore `path`, provision a fresh directory under
+    /// `std::env::temp_dir()`, and persist `instance.throwaway = true` so
+    /// the deletion path removes the directory. Mutually exclusive with
+    /// worktree/workspace and with non-empty `extra_repo_paths`.
+    pub throwaway: bool,
 }
 
 /// Result of building an instance, tracking what was created for cleanup purposes.
@@ -300,6 +305,15 @@ pub fn build_instance(
         bail!("{} does not support worktree mode.", params.tool);
     }
 
+    if params.throwaway {
+        if params.worktree_enabled {
+            bail!("Cannot combine --throwaway with worktree mode");
+        }
+        if !params.extra_repo_paths.is_empty() {
+            bail!("Cannot combine --throwaway with extra repository paths");
+        }
+    }
+
     if params.sandbox {
         let runtime = containers::get_container_runtime();
         if !runtime.is_available() {
@@ -310,19 +324,32 @@ pub fn build_instance(
         }
     }
 
-    let config = super::repo_config::resolve_config_with_repo(
-        profile,
-        std::path::Path::new(&params.path),
-    )
-    .unwrap_or_else(|e| {
-        tracing::warn!(target: "session.create", "Failed to load config, using defaults: {}", e);
-        Config::default()
-    });
+    // Throwaway sessions have no project repo, so config resolution falls
+    // back to global+profile defaults (`Path::new("")` makes
+    // `resolve_config_with_repo` skip the repo-config layer cleanly).
+    let config_path = if params.throwaway {
+        std::path::PathBuf::new()
+    } else {
+        std::path::PathBuf::from(&params.path)
+    };
+    let config =
+        super::repo_config::resolve_config_with_repo(profile, &config_path).unwrap_or_else(|e| {
+            tracing::warn!(target: "session.create", "Failed to load config, using defaults: {}", e);
+            Config::default()
+        });
 
-    let mut final_path = PathBuf::from(&params.path)
-        .canonicalize()
-        .map(|p| p.to_string_lossy().to_string())
-        .unwrap_or_else(|_| params.path.clone());
+    let mut final_path = if params.throwaway {
+        // Provisioning happens after `Instance::new` so we can use the
+        // generated instance id as the directory's basename suffix. Leave
+        // `final_path` empty for now; the worktree/workspace and
+        // path-existence blocks below are gated on the same flag.
+        String::new()
+    } else {
+        PathBuf::from(&params.path)
+            .canonicalize()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| params.path.clone())
+    };
 
     let mut worktree_info = None;
     let mut created_worktree = None;
@@ -470,18 +497,27 @@ pub fn build_instance(
         }
     }
 
-    // Validate that the final path exists and is a directory.
-    // This catches cases where the user typed a non-existent path in the TUI;
-    // without this check tmux silently falls back to the home directory.
-    let final_path_buf = PathBuf::from(&final_path);
-    if !final_path_buf.exists() {
-        bail!("Project path does not exist: {}", final_path);
-    }
-    if !final_path_buf.is_dir() {
-        bail!("Project path is not a directory: {}", final_path);
+    // For throwaway sessions, `final_path` is intentionally empty here; the
+    // temp directory is provisioned below after `Instance::new` runs (we
+    // need the instance id to name the directory). For all other sessions,
+    // catch the typed-a-bad-path case before tmux silently falls back to
+    // the home directory.
+    if !params.throwaway {
+        let final_path_buf = PathBuf::from(&final_path);
+        if !final_path_buf.exists() {
+            bail!("Project path does not exist: {}", final_path);
+        }
+        if !final_path_buf.is_dir() {
+            bail!("Project path is not a directory: {}", final_path);
+        }
     }
 
     let mut instance = Instance::new(&final_title, &final_path);
+    if params.throwaway {
+        let dir = super::throwaway::provision_throwaway_dir(&instance.id)?;
+        instance.project_path = dir.to_string_lossy().to_string();
+        instance.throwaway = true;
+    }
     instance.group_path = params.group;
     instance.tool = params.tool.clone();
     instance.detect_as = config
@@ -1093,6 +1129,7 @@ mod tests {
             extra_args: String::new(),
             command_override: String::new(),
             extra_repo_paths: Vec::new(),
+            throwaway: false,
         }
     }
 
@@ -1218,6 +1255,62 @@ mod tests {
         assert!(
             err.to_string()
                 .contains("No launch command resolved for custom agent 'whitespace-agent'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn build_instance_throwaway_provisions_temp_dir() {
+        let temp_home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        let app_dir = isolated_app_dir(temp_home.path());
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(app_dir.join("config.toml"), "").unwrap();
+
+        let mut params = custom_agent_params(std::path::Path::new(""), "claude");
+        params.tool = "claude".to_string();
+        params.path = String::new();
+        params.throwaway = true;
+        params.sandbox = false;
+
+        let result = build_instance(params, &[], &[], "default")
+            .expect("throwaway build must succeed without a project path");
+
+        assert!(
+            result.instance.throwaway,
+            "throwaway flag must be persisted on the instance"
+        );
+        let provisioned = std::path::PathBuf::from(&result.instance.project_path);
+        assert!(provisioned.exists());
+        assert!(provisioned.starts_with(std::env::temp_dir()));
+        assert!(super::super::throwaway::is_throwaway_path(&provisioned));
+
+        let _ = std::fs::remove_dir_all(&provisioned);
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn build_instance_rejects_throwaway_with_worktree() {
+        let temp_home = tempfile::tempdir().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        let app_dir = isolated_app_dir(temp_home.path());
+        std::fs::create_dir_all(&app_dir).unwrap();
+        std::fs::write(app_dir.join("config.toml"), "").unwrap();
+
+        let mut params = custom_agent_params(std::path::Path::new(""), "claude");
+        params.tool = "claude".to_string();
+        params.throwaway = true;
+        params.worktree_enabled = true;
+        params.worktree_branch = Some("feat".to_string());
+
+        let err = match build_instance(params, &[], &[], "default") {
+            Ok(_) => panic!("throwaway + worktree must error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("Cannot combine --throwaway with worktree mode"),
             "unexpected error: {err}"
         );
     }

--- a/src/session/deletion.rs
+++ b/src/session/deletion.rs
@@ -311,6 +311,39 @@ pub fn perform_deletion(request: &DeletionRequest) -> DeletionResult {
         }
     }
 
+    // Throwaway directory cleanup. Runs unconditionally for throwaway
+    // sessions regardless of `request.delete_worktree`, since the temp
+    // directory is the entire reason the session has any on-disk state.
+    // Guarded by `is_throwaway_path` to refuse to follow a tampered or
+    // corrupted `project_path` (e.g. JSON edited by hand to claim
+    // `throwaway: true` while pointing at `/etc`).
+    if request.instance.throwaway {
+        let path = PathBuf::from(&request.instance.project_path);
+        if super::throwaway::is_throwaway_path(&path) {
+            tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "throwaway_remove", "perform_deletion: stage");
+            match std::fs::remove_dir_all(&path) {
+                Ok(()) => messages.push("Throwaway directory removed".to_string()),
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    tracing::debug!(target: "session.delete",
+                        session_id = %request.session_id,
+                        path = %path.display(),
+                        "perform_deletion: throwaway dir already gone, treating as success"
+                    );
+                }
+                Err(e) => {
+                    errors.push(format!("Throwaway directory: {}", e));
+                }
+            }
+        } else {
+            tracing::warn!(
+                target: "session.delete",
+                session_id = %request.session_id,
+                path = %path.display(),
+                "throwaway flag set but project_path failed the guard; refusing to remove"
+            );
+        }
+    }
+
     // Stage 6: hook status cleanup
     tracing::debug!(target: "session.delete", session_id = %request.session_id, stage = "hook_status_cleanup", "perform_deletion: stage");
     crate::hooks::cleanup_hook_status_dir(&request.instance.id);
@@ -1054,6 +1087,139 @@ mod tests {
                 "unsandboxed deletion must not emit sandbox preclean stage: stages={:?}",
                 stages
             );
+        }
+    }
+
+    mod throwaway_cleanup {
+        use super::*;
+        use std::fs;
+
+        fn throwaway_instance() -> (Instance, PathBuf) {
+            let id = format!("delete-test-{}", uuid::Uuid::new_v4());
+            let dir = crate::session::throwaway::provision_throwaway_dir(&id)
+                .expect("provision throwaway dir for test");
+            let mut instance = Instance::new("Throwaway", dir.to_str().unwrap());
+            instance.throwaway = true;
+            (instance, dir)
+        }
+
+        #[test]
+        fn throwaway_session_removes_temp_dir() {
+            let (instance, dir) = throwaway_instance();
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+                detach_hooks: true,
+            };
+
+            let result = perform_deletion(&request);
+            assert!(result.success, "deletion errors: {:?}", result.errors);
+            assert!(
+                !dir.exists(),
+                "throwaway directory must be gone after perform_deletion"
+            );
+            assert!(
+                result
+                    .messages
+                    .iter()
+                    .any(|m| m.contains("Throwaway directory removed")),
+                "expected throwaway-removed message, got {:?}",
+                result.messages
+            );
+        }
+
+        #[test]
+        fn throwaway_session_with_missing_dir_still_succeeds() {
+            let (instance, dir) = throwaway_instance();
+            // Simulate the "directory already gone" race (OS-level temp
+            // cleaner ran, user deleted manually, etc.). Deletion must
+            // not fail.
+            fs::remove_dir_all(&dir).unwrap();
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+                detach_hooks: true,
+            };
+            let result = perform_deletion(&request);
+            assert!(
+                result.success,
+                "missing throwaway dir must not fail deletion: {:?}",
+                result.errors
+            );
+        }
+
+        #[test]
+        fn tampered_project_path_does_not_get_removed() {
+            // Defense against an edited or corrupted session JSON that
+            // sets `throwaway: true` while pointing project_path at
+            // something the guard would reject. The directory must
+            // survive deletion.
+            let bystander =
+                std::env::temp_dir().join(format!("important-data-{}", uuid::Uuid::new_v4()));
+            fs::create_dir(&bystander).expect("create bystander");
+            fs::write(bystander.join("file.txt"), b"keep me").unwrap();
+
+            let mut instance = Instance::new("Tampered", bystander.to_str().unwrap());
+            instance.throwaway = true;
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+                detach_hooks: true,
+            };
+            let _ = perform_deletion(&request);
+
+            assert!(
+                bystander.exists(),
+                "guard must refuse to remove a temp-dir path that lacks the aoe-throwaway- prefix"
+            );
+            assert!(
+                bystander.join("file.txt").exists(),
+                "bystander contents must survive"
+            );
+            let _ = fs::remove_dir_all(&bystander);
+        }
+
+        #[test]
+        fn non_throwaway_session_under_temp_dir_is_untouched() {
+            // A regular session whose project_path happens to be under
+            // temp_dir (e.g. a test fixture) must not be removed.
+            let dir =
+                std::env::temp_dir().join(format!("aoe-non-throwaway-{}", uuid::Uuid::new_v4()));
+            fs::create_dir(&dir).expect("create non-throwaway test dir");
+
+            let instance = Instance::new("Regular", dir.to_str().unwrap());
+            // throwaway is false by default.
+
+            let request = DeletionRequest {
+                session_id: instance.id.clone(),
+                instance,
+                delete_worktree: false,
+                delete_branch: false,
+                delete_sandbox: false,
+                force_delete: false,
+                detach_hooks: true,
+            };
+            let _ = perform_deletion(&request);
+
+            assert!(
+                dir.exists(),
+                "non-throwaway session must never trip the throwaway cleanup branch"
+            );
+            let _ = fs::remove_dir_all(&dir);
         }
     }
 }

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -325,6 +325,13 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snoozed_until: Option<DateTime<Utc>>,
 
+    /// Throwaway-session marker. When true, `project_path` points at an
+    /// auto-provisioned directory under `std::env::temp_dir()` (basename
+    /// `aoe-throwaway-<id>`) that the deletion path removes on `aoe rm`.
+    /// Mutually exclusive with worktree/workspace. See `src/session/throwaway.rs`.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub throwaway: bool,
+
     // Git worktree integration
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_info: Option<WorktreeInfo>,
@@ -651,6 +658,7 @@ impl Instance {
             archived_at: None,
             favorited_at: None,
             snoozed_until: None,
+            throwaway: false,
             worktree_info: None,
             workspace_info: None,
             sandbox_info: None,

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -16,6 +16,7 @@ pub(crate) mod recovery;
 pub mod repo_config;
 pub(crate) mod serde_helpers;
 mod storage;
+pub mod throwaway;
 
 pub use crate::sound::{SoundConfig, SoundConfigOverride};
 pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};

--- a/src/session/throwaway.rs
+++ b/src/session/throwaway.rs
@@ -1,0 +1,112 @@
+//! Throwaway-session directory provisioning and identification.
+//!
+//! A throwaway session has no associated project path. The session layer
+//! provisions a fresh directory under `std::env::temp_dir()` with the basename
+//! `aoe-throwaway-<instance-id>` and attaches the session to it. On deletion,
+//! the directory is removed; the basename prefix plus the temp-dir ancestry
+//! check guard against `remove_dir_all` being aimed at unrelated paths if a
+//! session JSON is tampered.
+
+use std::ffi::OsStr;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+/// Basename prefix for every throwaway session directory. Used by both the
+/// provisioner (to name the directory) and the deletion guard (to reject
+/// tampered `project_path` values that point at unrelated dirs under
+/// `temp_dir()`).
+pub const THROWAWAY_DIR_PREFIX: &str = "aoe-throwaway-";
+
+/// Create a fresh directory for a throwaway session and return its absolute
+/// path. Uses `fs::create_dir` (not `create_dir_all`) so a collision with a
+/// pre-existing directory surfaces as an error rather than silently reusing
+/// the directory's contents, which would violate the freshness contract.
+pub fn provision_throwaway_dir(instance_id: &str) -> Result<PathBuf> {
+    let path = std::env::temp_dir().join(format!("{THROWAWAY_DIR_PREFIX}{instance_id}"));
+    fs::create_dir(&path)
+        .with_context(|| format!("Failed to create throwaway directory at {}", path.display()))?;
+    Ok(path)
+}
+
+/// Return true iff `path` is plausibly a throwaway directory created by this
+/// crate: it lives under `std::env::temp_dir()` AND its basename starts with
+/// `THROWAWAY_DIR_PREFIX`. Used by `session::deletion::perform_deletion` to
+/// guard `fs::remove_dir_all` against accidental or malicious targeting of
+/// unrelated paths.
+pub fn is_throwaway_path(path: &Path) -> bool {
+    if !path.starts_with(std::env::temp_dir()) {
+        return false;
+    }
+    path.file_name()
+        .and_then(OsStr::to_str)
+        .is_some_and(|n| n.starts_with(THROWAWAY_DIR_PREFIX))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provisions_and_returns_temp_path() {
+        let id = format!("test-{}", uuid::Uuid::new_v4());
+        let path = provision_throwaway_dir(&id).expect("provision must succeed");
+        assert!(path.exists());
+        assert!(path.is_dir());
+        assert!(path.starts_with(std::env::temp_dir()));
+        assert!(path
+            .file_name()
+            .and_then(OsStr::to_str)
+            .unwrap()
+            .starts_with(THROWAWAY_DIR_PREFIX));
+        let _ = fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn provision_collision_errors() {
+        let id = format!("collision-{}", uuid::Uuid::new_v4());
+        let first = provision_throwaway_dir(&id).expect("first provision must succeed");
+        let second = provision_throwaway_dir(&id);
+        assert!(
+            second.is_err(),
+            "provision_throwaway_dir must error on collision rather than reuse contents",
+        );
+        let _ = fs::remove_dir_all(&first);
+    }
+
+    #[test]
+    fn is_throwaway_path_accepts_well_formed() {
+        let id = format!("accept-{}", uuid::Uuid::new_v4());
+        let path = provision_throwaway_dir(&id).expect("provision");
+        assert!(is_throwaway_path(&path));
+        let _ = fs::remove_dir_all(&path);
+    }
+
+    #[test]
+    fn is_throwaway_path_rejects_wrong_prefix_under_temp_dir() {
+        let path = std::env::temp_dir().join("important-data");
+        assert!(
+            !is_throwaway_path(&path),
+            "guard must reject paths under temp_dir without the aoe-throwaway- prefix",
+        );
+    }
+
+    #[test]
+    fn is_throwaway_path_rejects_outside_temp_dir() {
+        let path = PathBuf::from("/aoe-throwaway-anywhere");
+        assert!(
+            !is_throwaway_path(&path),
+            "guard must reject paths outside temp_dir even if basename matches",
+        );
+    }
+
+    #[test]
+    fn is_throwaway_path_rejects_root_with_matching_basename_in_other_root() {
+        // Defense against the tampered-JSON case: `throwaway: true` with
+        // `project_path: "/etc"` must NOT trip the deletion guard, even
+        // though `/etc` is a real directory.
+        let path = PathBuf::from("/etc");
+        assert!(!is_throwaway_path(&path));
+    }
+}

--- a/src/tui/creation_poller.rs
+++ b/src/tui/creation_poller.rs
@@ -124,6 +124,7 @@ impl CreationPoller {
             extra_args: data.extra_args,
             command_override: data.command_override,
             extra_repo_paths: data.extra_repo_paths,
+            throwaway: data.throwaway,
         };
 
         let build_result =

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -34,6 +34,10 @@ pub(super) const HELP_DIALOG_WIDTH: u16 = 85;
 
 pub(super) const FIELD_HELP: &[FieldHelp] = &[
     FieldHelp {
+        name: "Throwaway",
+        description: "Ctrl+T toggles a temporary working directory (no project path needed)",
+    },
+    FieldHelp {
         name: "Profile",
         description: "Settings profile for session defaults (Left/Right to cycle)",
     },
@@ -103,6 +107,9 @@ pub struct NewSessionData {
     pub extra_args: String,
     /// Command override for the agent binary (replaces the default binary)
     pub command_override: String,
+    /// Throwaway session: provision a fresh temp directory and persist
+    /// `instance.throwaway = true`. Mutually exclusive with worktree mode.
+    pub throwaway: bool,
 }
 
 pub struct NewSessionDialog {
@@ -203,6 +210,11 @@ pub struct NewSessionDialog {
     /// Inline confirmation for creating a non-existent directory.
     /// None = inactive, Some(true) = Yes selected, Some(false) = No selected.
     pub(super) confirm_create_dir: Option<bool>,
+    /// Throwaway-session marker. When true, submission skips the path
+    /// canonicalize/exists checks; the server (or `aoe add` CLI path)
+    /// provisions a fresh temp directory. Toggled with Ctrl+T from
+    /// anywhere in the form. Mutually exclusive with worktree mode.
+    pub(super) throwaway: bool,
 }
 
 /// Shared logic for handling key events in an editable list (env keys or env values).
@@ -455,6 +467,7 @@ impl NewSessionDialog {
             path_ghost: None,
             group_ghost: None,
             confirm_create_dir: None,
+            throwaway: false,
         }
     }
 
@@ -721,6 +734,7 @@ impl NewSessionDialog {
             path_ghost: None,
             group_ghost: None,
             confirm_create_dir: None,
+            throwaway: false,
         }
     }
 
@@ -785,6 +799,7 @@ impl NewSessionDialog {
             path_ghost: None,
             group_ghost: None,
             confirm_create_dir: None,
+            throwaway: false,
         }
     }
 
@@ -873,6 +888,18 @@ impl NewSessionDialog {
                 }
                 DirPickerResult::Continue => {}
             }
+            return DialogResult::Continue;
+        }
+
+        // Ctrl+T toggles the throwaway-session mode from anywhere in the
+        // form. Mutually exclusive with worktrees; turning on throwaway
+        // clears the worktree toggle.
+        if key.code == KeyCode::Char('t') && key.modifiers.contains(KeyModifiers::CONTROL) {
+            self.throwaway = !self.throwaway;
+            if self.throwaway {
+                self.worktree_enabled = false;
+            }
+            self.error_message = None;
             return DialogResult::Continue;
         }
 
@@ -972,11 +999,16 @@ impl NewSessionDialog {
             }
             KeyCode::Enter => {
                 self.error_message = None;
-                let path_str = self.path.value().trim().to_string();
-                let resolved = path_input::expand_tilde(&path_str);
-                if !std::path::Path::new(&resolved).exists() {
-                    self.confirm_create_dir = Some(false);
-                    return DialogResult::Continue;
+                // Throwaway sessions skip the path-existence check: the
+                // server (or `aoe add` CLI) provisions the temp dir on
+                // submit.
+                if !self.throwaway {
+                    let path_str = self.path.value().trim().to_string();
+                    let resolved = path_input::expand_tilde(&path_str);
+                    if !std::path::Path::new(&resolved).exists() {
+                        self.confirm_create_dir = Some(false);
+                        return DialogResult::Continue;
+                    }
                 }
                 self.build_submit_result()
             }
@@ -1617,14 +1649,20 @@ impl NewSessionDialog {
         DialogResult::Submit(NewSessionData {
             profile: self.selected_profile().to_string(),
             title: final_title,
-            path: self.path.value().trim().to_string(),
+            // Throwaway sessions send an empty path; the server / `aoe add`
+            // CLI provisions a fresh temp directory keyed on the instance id.
+            path: if self.throwaway {
+                String::new()
+            } else {
+                self.path.value().trim().to_string()
+            },
             group: self.group.value().trim().to_string(),
             tool: self.available_tools[self.tool_index].clone(),
-            worktree_enabled: self.worktree_enabled,
+            worktree_enabled: !self.throwaway && self.worktree_enabled,
             worktree_branch,
             create_new_branch: self.create_new_branch,
             base_branch,
-            extra_repo_paths: if self.worktree_enabled {
+            extra_repo_paths: if !self.throwaway && self.worktree_enabled {
                 self.workspace_repos.clone()
             } else {
                 Vec::new()
@@ -1639,6 +1677,7 @@ impl NewSessionDialog {
             },
             extra_args: self.extra_args.value().trim().to_string(),
             command_override: self.command_override.value().trim().to_string(),
+            throwaway: self.throwaway,
         })
     }
 

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -516,6 +516,19 @@ impl NewSessionDialog {
         let value = self.path.value();
         let mut spans = vec![Span::styled("Path:", label_style), Span::raw(" ")];
 
+        // When throwaway is active the path input is meaningless: the
+        // session lives in a server-provisioned temp dir. Replace the
+        // value with a dim marker so the user does not edit a value
+        // that will be discarded on submit.
+        if self.throwaway {
+            spans.push(Span::styled(
+                "(throwaway directory, Ctrl+T to undo)",
+                Style::default().fg(theme.dimmed),
+            ));
+            frame.render_widget(Paragraph::new(Line::from(spans)), area);
+            return;
+        }
+
         if value.is_empty() && !is_focused {
             if let Some(placeholder_text) = placeholder {
                 spans.push(Span::styled(placeholder_text, value_style));

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1228,3 +1228,69 @@ fn test_sandbox_config_mode_enter_on_image_returns_to_main() {
     assert!(matches!(result, DialogResult::Continue));
     assert!(!dialog.sandbox_config_mode);
 }
+
+#[test]
+fn test_throwaway_toggle_with_ctrl_t() {
+    let mut dialog = single_tool_dialog();
+    assert!(!dialog.throwaway);
+
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    assert!(dialog.throwaway, "Ctrl+T must turn throwaway on");
+
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    assert!(!dialog.throwaway, "Ctrl+T again must turn it off");
+}
+
+#[test]
+fn test_throwaway_toggle_clears_worktree() {
+    let mut dialog = single_tool_dialog();
+    dialog.worktree_enabled = true;
+
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    assert!(dialog.throwaway);
+    assert!(
+        !dialog.worktree_enabled,
+        "enabling throwaway must clear the worktree toggle"
+    );
+}
+
+#[test]
+fn test_throwaway_submit_sends_empty_path_and_no_worktree() {
+    let mut dialog = single_tool_dialog();
+    dialog.worktree_enabled = true;
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    match result {
+        DialogResult::Submit(data) => {
+            assert!(data.throwaway, "data.throwaway must be true");
+            assert_eq!(data.path, "", "throwaway submit must send an empty path");
+            assert!(
+                !data.worktree_enabled,
+                "throwaway submit must force worktree_enabled off"
+            );
+            assert!(
+                data.worktree_branch.is_none(),
+                "throwaway submit must not carry a worktree branch"
+            );
+        }
+        other => panic!("Expected Submit, got {:?}", std::mem::discriminant(&other)),
+    }
+}
+
+#[test]
+fn test_throwaway_skips_path_existence_confirmation() {
+    let mut dialog = single_tool_dialog();
+    // Use a nonexistent path; without throwaway, Enter would open the
+    // "Create dir?" confirmation.
+    dialog.path = Input::new("/does/not/exist/throwaway-test".to_string());
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    let result = dialog.handle_key(key(KeyCode::Enter));
+    assert!(
+        matches!(result, DialogResult::Submit(_)),
+        "throwaway must skip the path-exists check on Enter"
+    );
+    assert!(
+        dialog.confirm_create_dir.is_none(),
+        "create-dir confirmation must not activate for throwaway sessions"
+    );
+}

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -56,6 +56,7 @@ impl HomeView {
             extra_args: data.extra_args,
             command_override: data.command_override,
             extra_repo_paths: data.extra_repo_paths,
+            throwaway: data.throwaway,
         };
 
         let build_result = builder::build_instance(

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2666,6 +2666,7 @@ fn test_create_session_in_all_mode_is_findable() {
         extra_env: Vec::new(),
         extra_args: String::new(),
         command_override: String::new(),
+        throwaway: false,
     };
 
     let session_id = view.create_session(data).unwrap();
@@ -3422,6 +3423,7 @@ fn test_apply_creation_results_returns_session_id() {
         extra_env: Vec::new(),
         extra_args: String::new(),
         command_override: String::new(),
+        throwaway: false,
     };
 
     // Use the async CreationPoller path (pass None hooks, non-sandbox,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6513,6 +6513,7 @@ mod new_session_attach_mode {
             extra_env: Vec::new(),
             extra_args: String::new(),
             command_override: String::new(),
+            throwaway: false,
         }
     }
 

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1067,3 +1067,104 @@ fn test_cli_add_attaches_to_existing_worktree() {
         Some("feat/existing"),
     );
 }
+
+#[test]
+#[serial]
+fn test_cli_add_throwaway_provisions_temp_dir() {
+    let h = TuiTestHarness::new("cli_add_throwaway");
+
+    let add_output = h.run_cli(&["add", "--throwaway", "-t", "QuickThrowaway"]);
+    assert!(
+        add_output.status.success(),
+        "aoe add --throwaway failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&add_output.stdout),
+        String::from_utf8_lossy(&add_output.stderr),
+    );
+    let stdout = String::from_utf8_lossy(&add_output.stdout);
+    assert!(
+        stdout.contains("Throwaway: yes"),
+        "expected 'Throwaway: yes' summary line; got:\n{}",
+        stdout
+    );
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let session = sessions
+        .iter()
+        .find(|s| s["title"].as_str() == Some("QuickThrowaway"))
+        .expect("QuickThrowaway must exist");
+    assert_eq!(session["throwaway"].as_bool(), Some(true));
+    let project_path = session["project_path"]
+        .as_str()
+        .expect("project_path must be a string");
+    let path = Path::new(project_path);
+    assert!(path.exists(), "throwaway dir must exist: {}", project_path);
+    assert!(
+        path.starts_with(std::env::temp_dir()),
+        "throwaway dir must live under temp_dir(): {}",
+        project_path
+    );
+    assert!(
+        path.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("aoe-throwaway-")),
+        "throwaway dir basename must use the aoe-throwaway- prefix: {}",
+        project_path
+    );
+
+    // Capture path before rm so we can assert cleanup.
+    let captured = path.to_path_buf();
+
+    let rm_output = h.run_cli(&["rm", "QuickThrowaway"]);
+    assert!(
+        rm_output.status.success(),
+        "aoe rm failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&rm_output.stdout),
+        String::from_utf8_lossy(&rm_output.stderr),
+    );
+    assert!(
+        !captured.exists(),
+        "throwaway dir must be removed after aoe rm: {}",
+        captured.display(),
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_throwaway_rejects_explicit_path() {
+    let h = TuiTestHarness::new("cli_add_throwaway_path");
+    let project = h.project_path();
+
+    let output = h.run_cli(&["add", project.to_str().unwrap(), "--throwaway"]);
+    assert!(
+        !output.status.success(),
+        "aoe add <path> --throwaway must error"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Cannot specify a project path with --throwaway"),
+        "unexpected error output:\n{}",
+        stderr,
+    );
+}
+
+#[test]
+#[serial]
+fn test_cli_add_throwaway_conflicts_with_worktree_flag() {
+    let h = TuiTestHarness::new("cli_add_throwaway_worktree");
+
+    let output = h.run_cli(&["add", "--throwaway", "-w", "feat/x"]);
+    assert!(
+        !output.status.success(),
+        "aoe add --throwaway -w must error at clap layer"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    // clap's mutex error wording mentions one of the two flag names.
+    assert!(
+        stderr.contains("--throwaway")
+            || stderr.contains("--worktree")
+            || stderr.contains("cannot be used"),
+        "unexpected error output:\n{}",
+        stderr,
+    );
+}

--- a/web/src/components/session-wizard/SessionWizard.tsx
+++ b/web/src/components/session-wizard/SessionWizard.tsx
@@ -169,20 +169,29 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
   const handleSubmit = async () => {
     dispatch({ type: "SUBMIT_START" });
     const d = state.data;
+    // Throwaway sessions: server provisions the working directory and
+    // ignores `path`. Force-omit every worktree-related field so a
+    // stale reducer state cannot make the server return 400 on the
+    // `throwaway + worktree_branch` mutex.
     const body: CreateSessionRequest = {
-      path: d.path, tool: d.tool,
+      path: d.throwaway ? "" : d.path,
+      tool: d.tool,
       title: d.title || undefined, group: d.group || undefined,
       yolo_mode: d.yoloMode,
-      worktree_branch: d.useWorktree ? getSubmittedBranch(d.title, d.worktreeBranch) : undefined,
-      create_new_branch: d.useWorktree && !d.attachExisting,
+      worktree_branch:
+        !d.throwaway && d.useWorktree
+          ? getSubmittedBranch(d.title, d.worktreeBranch)
+          : undefined,
+      create_new_branch: !d.throwaway && d.useWorktree && !d.attachExisting,
       base_branch:
-        d.useWorktree && !d.attachExisting && d.baseBranch.trim()
+        !d.throwaway && d.useWorktree && !d.attachExisting && d.baseBranch.trim()
           ? d.baseBranch.trim()
           : undefined,
       sandbox: d.sandboxEnabled,
       sandbox_image: d.sandboxEnabled ? d.sandboxImage : undefined,
       extra_env: d.sandboxEnabled && d.extraEnv.length > 0 ? d.extraEnv.filter(Boolean) : undefined,
-      extra_repo_paths: d.extraRepoPaths.length > 0 ? d.extraRepoPaths : undefined,
+      extra_repo_paths:
+        !d.throwaway && d.extraRepoPaths.length > 0 ? d.extraRepoPaths : undefined,
       extra_args: d.extraArgs || undefined,
       command_override: d.commandOverride || undefined,
       custom_instruction: d.customInstruction || undefined,
@@ -193,6 +202,7 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
       // switch (see src/server/api/sessions.rs), so a tampered
       // client request can't escalate cockpit on.
       cockpit_mode: cockpitMasterEnabled && ACP_CAPABLE_TOOLS.has(d.tool),
+      throwaway: d.throwaway || undefined,
     };
     const result = await createSession(body);
     if (result.ok) {
@@ -235,7 +245,13 @@ export function SessionWizard({ onClose, onCreated, prefill, cockpitMasterEnable
     }
   };
 
-  const nextDisabled = currentStepDef?.id === "project" && !state.data.path;
+  // Throwaway selection satisfies the project-step "need a project" gate
+  // without a path: the server provisions the working directory on
+  // submit. Otherwise require a path as before.
+  const nextDisabled =
+    currentStepDef?.id === "project" &&
+    !state.data.throwaway &&
+    !state.data.path;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">

--- a/web/src/components/session-wizard/steps/ProjectStep.tsx
+++ b/web/src/components/session-wizard/steps/ProjectStep.tsx
@@ -7,7 +7,41 @@ import { ExtraReposPicker } from "./ExtraReposPicker";
 interface WizardData {
   path: string;
   extraRepoPaths: string[];
+  throwaway: boolean;
   [key: string]: unknown;
+}
+
+/** Toggle switch matching the one used in `SessionStep.tsx`. Local copy
+ *  rather than a shared import because exporting from `SessionStep`
+ *  would force a circular component reference; the visual contract is
+ *  the part that matters and is short. */
+function Toggle({
+  checked,
+  onChange,
+  ariaLabel,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  ariaLabel: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!checked)}
+      className={`relative inline-flex h-7 w-12 shrink-0 items-center rounded-full transition-colors duration-200 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-600 cursor-pointer ${
+        checked ? "bg-brand-600" : "bg-surface-700"
+      }`}
+    >
+      <span
+        className={`inline-block h-5 w-5 rounded-full bg-white shadow-sm transition-transform duration-200 ${
+          checked ? "translate-x-6" : "translate-x-1"
+        }`}
+      />
+    </button>
+  );
 }
 
 type Tab = "recent" | "browse" | "clone";
@@ -29,6 +63,10 @@ interface RecentProject {
 function collectRecentProjects(sessions: SessionResponse[]): RecentProject[] {
   const map = new Map<string, RecentProject>();
   for (const s of sessions) {
+    // Throwaway sessions live in transient `aoe-throwaway-*` temp dirs
+    // that get deleted with the session. They must not appear in the
+    // Recent list, where they would be re-selectable as a project.
+    if (s.throwaway) continue;
     const path = s.main_repo_path || s.project_path;
     if (!path) continue;
     const existing = map.get(path);
@@ -140,6 +178,44 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
         Pick a recent project, browse for one, or clone from a URL.
       </p>
 
+      {/* Throwaway-session toggle. Sits above the project-source tabs
+          because it is a mode (skip the path picker entirely) rather
+          than another path source. The reducer enforces mutual
+          exclusion with path/extraRepoPaths/useWorktree; see
+          `wizardReducer.ts`. */}
+      <label
+        className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-4"
+        onClick={(e) => {
+          // Avoid double-toggle when the user clicks the switch itself:
+          // both the label and the inner button fire onChange otherwise.
+          if ((e.target as HTMLElement).closest('button[role="switch"]')) return;
+          onChange("throwaway", !data.throwaway);
+        }}
+      >
+        <div className="flex-1">
+          <div className="text-sm font-medium text-text-primary">Skip project folder</div>
+          <div className="text-xs text-text-dim mt-0.5 leading-snug">
+            Run the agent in a fresh temporary directory. The folder is removed when you delete the session.
+          </div>
+        </div>
+        <Toggle
+          checked={data.throwaway}
+          onChange={(v) => onChange("throwaway", v)}
+          ariaLabel="Skip project folder"
+        />
+      </label>
+
+      {data.throwaway && (
+        <div className="px-3 py-2.5 bg-surface-900 border border-brand-600/30 rounded-md">
+          <p className="text-[10px] font-mono uppercase tracking-wider text-text-dim mb-1">Throwaway session</p>
+          <p className="text-sm text-text-primary">
+            A fresh <span className="font-mono">aoe-throwaway-&lt;id&gt;</span> directory is created when you launch this session.
+          </p>
+        </div>
+      )}
+
+      {!data.throwaway && (
+      <>
       {/* Tab bar */}
       {!loading && (
         <div className="flex gap-1 mb-4 border-b border-surface-700/30">
@@ -330,6 +406,8 @@ export function ProjectStep({ data, onChange, initialTab }: Props) {
             onChange={(paths) => onChange("extraRepoPaths", paths)}
           />
         </div>
+      )}
+      </>
       )}
     </div>
   );

--- a/web/src/components/session-wizard/steps/ReviewStep.tsx
+++ b/web/src/components/session-wizard/steps/ReviewStep.tsx
@@ -5,7 +5,7 @@ import { getReviewSummary } from "../sessionNames";
 import { useServerDown, OFFLINE_TITLE } from "../../../lib/connectionState";
 import type { AgentInfo } from "../../../lib/types";
 
-interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; attachExisting: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; [key: string]: unknown; }
+interface WizardData { path: string; title: string; worktreeBranch: string; useWorktree: boolean; attachExisting: boolean; baseBranch: string; group: string; tool: string; profile: string; profileDirty: boolean; yoloMode: boolean; sandboxEnabled: boolean; sandboxImage: string; extraArgs: string; customInstruction: string; commandOverride: string; throwaway: boolean; [key: string]: unknown; }
 interface Props { data: WizardData; onChange: (field: string, value: unknown) => void; agents: AgentInfo[]; isSubmitting: boolean; error: string | null; onSubmit: () => void; onJumpTo: (stepId: StepId) => void; steps: StepDef[]; }
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
@@ -111,7 +111,11 @@ function EditableRow({ label, value, displayValue, placeholder, onChange, accent
 export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubmit, onJumpTo, steps }: Props) {
   const hasStep = (id: StepId) => steps.some((s) => s.id === id);
   const offline = useServerDown();
-  const canSubmit = !isSubmitting && !offline && !!data.path && !!data.tool;
+  // Throwaway sessions intentionally carry no path until the server
+  // provisions one on submit; treat that as satisfying the "need a
+  // project" gate so the user can launch.
+  const canSubmit =
+    !isSubmitting && !offline && (data.throwaway || !!data.path) && !!data.tool;
   const summary = getReviewSummary(data.title, data.worktreeBranch);
   const selectedAgent = agents.find((agent) => agent.name === data.tool);
   const selectedCustomAgent = selectedAgent?.kind === "custom";
@@ -132,7 +136,16 @@ export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubm
       <h2 className="text-lg font-semibold text-text-primary mb-1">Review & Launch</h2>
       <p className="text-sm text-text-muted mb-5">Here's what will be created. Make sure everything looks right.</p>
       <div className="bg-surface-900 border border-surface-700 rounded-lg p-4 mb-5">
-        <Row label="Project" value={data.path || "(not set)"} stepId="project" onJumpTo={onJumpTo} />
+        <Row
+          label="Project"
+          value={
+            data.throwaway
+              ? "Temporary directory (provisioned on create)"
+              : data.path || "(not set)"
+          }
+          stepId="project"
+          onJumpTo={onJumpTo}
+        />
         <EditableRow
           label="Title"
           value={data.title}
@@ -140,7 +153,7 @@ export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubm
           placeholder="Auto-generated"
           onChange={(v) => onChange("title", v)}
         />
-        {data.useWorktree ? (
+        {!data.throwaway && data.useWorktree ? (
           <>
             <EditableRow
               label="Branch / worktree"
@@ -158,6 +171,8 @@ export function ReviewStep({ data, onChange, agents, isSubmitting, error, onSubm
               <Row label="Base branch" value={data.baseBranch.trim()} />
             )}
           </>
+        ) : data.throwaway ? (
+          <Row label="Worktree" value="Not applicable (throwaway session)" />
         ) : (
           <Row label="Worktree" value="None, runs in repo folder" />
         )}

--- a/web/src/components/session-wizard/steps/SessionStep.tsx
+++ b/web/src/components/session-wizard/steps/SessionStep.tsx
@@ -13,6 +13,7 @@ interface WizardData {
   baseBranch: string;
   group: string;
   tool: string;
+  throwaway: boolean;
   [key: string]: unknown;
 }
 
@@ -60,23 +61,37 @@ export function SessionStep({ data, onChange }: Props) {
         <p className="text-xs text-text-dim mt-1">Shown in the dashboard. Renaming it later does not rename the git branch.</p>
       </div>
 
-      <label
-        className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
-        onClick={() => onChange("useWorktree", !data.useWorktree)}
-      >
-        <div className="flex-1">
-          <div className="text-sm font-medium text-text-primary">Create a worktree</div>
-          <div className="text-xs text-text-dim mt-0.5 leading-snug">
-            Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
+      {/* Worktree controls are meaningless for throwaway sessions: the
+          working directory is a fresh temp dir, not a git repo. The
+          reducer also forces useWorktree to false when throwaway flips
+          on; this hide is purely a UX confirmation that the worktree
+          path is not available in throwaway mode. */}
+      {data.throwaway ? (
+        <p
+          className="text-xs text-text-dim mb-3"
+          aria-label="Worktree disabled: throwaway session"
+        >
+          Throwaway sessions do not use git worktrees.
+        </p>
+      ) : (
+        <label
+          className="flex items-center justify-between gap-3 p-3 bg-surface-900 border border-surface-700 rounded-lg cursor-pointer mb-3"
+          onClick={() => onChange("useWorktree", !data.useWorktree)}
+        >
+          <div className="flex-1">
+            <div className="text-sm font-medium text-text-primary">Create a worktree</div>
+            <div className="text-xs text-text-dim mt-0.5 leading-snug">
+              Run the agent in a new git worktree branched off the current HEAD. Off = run directly in the repo folder.
+            </div>
           </div>
-        </div>
-        <Toggle
-          checked={data.useWorktree}
-          onChange={(v) => onChange("useWorktree", v)}
-        />
-      </label>
+          <Toggle
+            checked={data.useWorktree}
+            onChange={(v) => onChange("useWorktree", v)}
+          />
+        </label>
+      )}
 
-      {data.useWorktree && (
+      {!data.throwaway && data.useWorktree && (
         <div className="mb-5">
           <label className="block text-sm text-text-dim mb-1.5">Branch / worktree name</label>
           <input

--- a/web/src/components/session-wizard/wizardReducer.test.ts
+++ b/web/src/components/session-wizard/wizardReducer.test.ts
@@ -120,6 +120,70 @@ describe("SessionWizard reducer / APPLY_PROFILE_DEFAULTS (#1142)", () => {
     expect(next.data.profileDirty).toBe(false);
   });
 
+  it("enabling throwaway clears path, extraRepoPaths, and useWorktree", () => {
+    // Mutual exclusion: switching to throwaway must not leave stale
+    // path/useWorktree state that would otherwise leak into the submit
+    // payload (the server would 400 on throwaway + worktree_branch, and
+    // the UI would render an empty path next to a "real" project marker).
+    const seeded = makeState({
+      data: {
+        ...initialData,
+        path: "/Users/me/old-project",
+        extraRepoPaths: ["/Users/me/lib-a", "/Users/me/lib-b"],
+        useWorktree: true,
+      },
+    });
+    const next = reducer(seeded, {
+      type: "SET_FIELD",
+      field: "throwaway",
+      value: true,
+    });
+    expect(next.data.throwaway).toBe(true);
+    expect(next.data.path).toBe("");
+    expect(next.data.extraRepoPaths).toEqual([]);
+    expect(next.data.useWorktree).toBe(false);
+  });
+
+  it("setting a real path clears throwaway (bidirectional reset)", () => {
+    const seeded = makeState({
+      data: { ...initialData, throwaway: true, path: "" },
+    });
+    const next = reducer(seeded, {
+      type: "SET_FIELD",
+      field: "path",
+      value: "/Users/me/picked-project",
+    });
+    expect(next.data.throwaway).toBe(false);
+    expect(next.data.path).toBe("/Users/me/picked-project");
+  });
+
+  it("setting extraRepoPaths to a non-empty array clears throwaway", () => {
+    const seeded = makeState({
+      data: { ...initialData, throwaway: true },
+    });
+    const next = reducer(seeded, {
+      type: "SET_FIELD",
+      field: "extraRepoPaths",
+      value: ["/Users/me/lib"],
+    });
+    expect(next.data.throwaway).toBe(false);
+  });
+
+  it("setting throwaway to false does NOT clear an existing path", () => {
+    // A redundant SET_FIELD throwaway=false (e.g. user toggles off and
+    // then back to a real project) must not wipe whatever path the
+    // user just picked.
+    const seeded = makeState({
+      data: { ...initialData, throwaway: false, path: "/Users/me/keep-me" },
+    });
+    const next = reducer(seeded, {
+      type: "SET_FIELD",
+      field: "throwaway",
+      value: false,
+    });
+    expect(next.data.path).toBe("/Users/me/keep-me");
+  });
+
   it("marks dirty on user toggles even without a profile selected", () => {
     // The dirty guard initially only fired when state.data.profile was
     // truthy, which left no-prefill / no-active-profile users exposed

--- a/web/src/components/session-wizard/wizardReducer.ts
+++ b/web/src/components/session-wizard/wizardReducer.ts
@@ -40,6 +40,13 @@ export interface WizardData {
   commandOverride: string;
   /** Tracks whether the user has manually edited fields after a profile selection */
   profileDirty: boolean;
+  /** Throwaway-session mode. When true, the wizard skips the project-path
+   *  picker, hides the worktree controls, and submits `path: ""` so the
+   *  server provisions a fresh temp directory. The reducer enforces
+   *  mutual exclusion bidirectionally: enabling `throwaway` clears
+   *  `path`/`useWorktree`/`extraRepoPaths`; setting any of those
+   *  back to a non-empty value clears `throwaway`. */
+  throwaway: boolean;
   [key: string]: unknown;
 }
 
@@ -86,6 +93,7 @@ export const initialData: WizardData = {
   extraRepoPaths: [],
   advancedEnabled: false, profileDirty: false,
   customInstruction: "", extraArgs: "", commandOverride: "",
+  throwaway: false,
 };
 
 export function reducer(state: WizardState, action: Action): WizardState {
@@ -102,6 +110,22 @@ export function reducer(state: WizardState, action: Action): WizardState {
         );
         newData.worktreeBranch = override.worktreeBranch;
         newData.worktreeBranchDirty = override.worktreeBranchDirty;
+      }
+      // Throwaway mutual exclusion. Enabling throwaway clears the
+      // path-source fields so a stale "Recent" selection cannot leak
+      // into the submit payload; conversely, setting a real path or
+      // extra repos turns throwaway off so the wizard can never claim
+      // both.
+      if (action.field === "throwaway" && action.value === true) {
+        newData.path = "";
+        newData.extraRepoPaths = [];
+        newData.useWorktree = false;
+      }
+      if (
+        (action.field === "path" && typeof action.value === "string" && action.value.length > 0) ||
+        (action.field === "extraRepoPaths" && Array.isArray(action.value) && action.value.length > 0)
+      ) {
+        newData.throwaway = false;
       }
       // Mark dirty whenever the user manually edits an agent-step
       // field. Guarded against `state.data.profile` previously, but the

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -29,6 +29,12 @@ export interface SessionResponse {
    *  diff header. See #970. */
   base_branch_override?: string | null;
   is_sandboxed: boolean;
+  /** True when the session was created in throwaway mode (`aoe add
+   *  --throwaway` or the wizard toggle). The `project_path` points
+   *  at an auto-provisioned `aoe-throwaway-*` directory under the OS
+   *  temp dir, and the deletion path removes it. The wizard's
+   *  Recent-projects list filters these out. */
+  throwaway: boolean;
   /** True when the session is marked as a user favorite. Mirrors
    *  `Instance::is_favorited()` server-side. The sidebar pins favorited
    *  rows and prepends a `*` marker. Toggled via the TUI `f`/`F` keybind
@@ -309,6 +315,10 @@ export interface CreateSessionRequest {
    *  false → tmux passthrough (legacy). Server defaults to true on
    *  web-created sessions; the wizard may override. */
   cockpit_mode?: boolean;
+  /** Throwaway mode: server provisions a fresh temp directory and
+   *  ignores `path` (clients send `""`). Mutually exclusive with
+   *  `worktree_branch`; the server returns 400 on the combination. */
+  throwaway?: boolean;
 }
 
 /** Live cockpit worker lifecycle, mirrored from

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -271,6 +271,55 @@
       ]
     },
     {
+      "id": "wizard.throwaway-toggle-visible",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/wizard-throwaway-toggle-visible.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
+      "id": "wizard.throwaway-enables-next",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/wizard-throwaway-enables-next.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/ProjectStep.tsx",
+        "web/src/components/session-wizard/wizardReducer.ts"
+      ]
+    },
+    {
+      "id": "wizard.throwaway-hides-worktree",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/wizard-throwaway-hides-worktree.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/steps/SessionStep.tsx"
+      ]
+    },
+    {
+      "id": "wizard.throwaway-launch",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/wizard-throwaway-launch.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/ProjectStep.tsx",
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
+      "id": "wizard.throwaway-delete-cleans-tempdir",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": ["tests/live/wizard-throwaway-delete-cleans-tempdir.spec.ts"],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx"
+      ]
+    },
+    {
       "id": "directory-browser",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/live/wizard-throwaway-delete-cleans-tempdir.spec.ts
+++ b/web/tests/live/wizard-throwaway-delete-cleans-tempdir.spec.ts
@@ -1,0 +1,78 @@
+// User story: deleting a throwaway session removes its temp directory
+// from disk so users do not accumulate dead `aoe-throwaway-*` folders.
+// Closes #1324.
+
+import { existsSync } from "node:fs";
+import { test as base, expect } from "@playwright/test";
+import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+
+base("deleting a throwaway session removes its temp dir", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    await wizard
+      .getByRole("switch", { name: "Skip project folder" })
+      .click();
+    await wizard.getByRole("button", { name: "Next" }).click();
+    await wizard.getByRole("button", { name: "Next" }).click();
+    await wizard.getByRole("button", { name: "Next" }).click();
+    await wizard.getByRole("button", { name: /Launch session/ }).click();
+
+    await expect
+      .poll(async () => (await listSessions(serve.baseUrl)).length, {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
+
+    const [created] = await listSessions(serve.baseUrl);
+    const sessionId = created!.id as string;
+    const projectPath = created!.project_path as string;
+    expect(existsSync(projectPath)).toBe(true);
+
+    // Delete via sidebar context menu.
+    const row = page.locator("[data-testid='sidebar-session-row']").first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.click({ button: "right" });
+    await page
+      .locator("[data-testid='sidebar-context-menu-delete']")
+      .click();
+    const dialog = page.locator("[data-testid='delete-session-dialog']");
+    await expect(dialog).toBeVisible();
+
+    const deletePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/api/sessions/${sessionId}`) &&
+        res.request().method() === "DELETE",
+    );
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+    const deleteRes = await deletePromise;
+    expect(deleteRes.ok()).toBe(true);
+
+    // The session row leaves the sidebar AND the throwaway dir is gone.
+    await expect
+      .poll(async () => (await listSessions(serve.baseUrl)).length, {
+        timeout: 10_000,
+      })
+      .toBe(0);
+    await expect
+      .poll(() => existsSync(projectPath), { timeout: 5_000 })
+      .toBe(false);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/wizard-throwaway-enables-next.spec.ts
+++ b/web/tests/live/wizard-throwaway-enables-next.spec.ts
@@ -1,0 +1,49 @@
+// User story: enabling the throwaway toggle makes the wizard's Next
+// button activate without picking a project path. The Recent/Browse/
+// Clone-URL tab strip and the directory browser disappear so the user
+// has no path source to choose. Closes #1324.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+base("throwaway toggle enables Next without a path", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    // Baseline: Next is disabled because no path is selected.
+    const nextButton = wizard.getByRole("button", { name: "Next" });
+    await expect(nextButton).toBeDisabled();
+
+    // Flip the toggle. The reducer also clears any prefilled path /
+    // useWorktree state, so Next must transition to enabled.
+    await wizard
+      .getByRole("switch", { name: "Skip project folder" })
+      .click();
+
+    await expect(nextButton).toBeEnabled({ timeout: 5_000 });
+
+    // The throwaway confirmation card replaces the path picker.
+    await expect(wizard.getByText(/Throwaway session/)).toBeVisible();
+    // The Browse tab button must NOT be visible while throwaway is on.
+    await expect(
+      wizard.getByRole("button", { name: "Browse" }),
+    ).toBeHidden();
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/wizard-throwaway-hides-worktree.spec.ts
+++ b/web/tests/live/wizard-throwaway-hides-worktree.spec.ts
@@ -1,0 +1,47 @@
+// User story: enabling throwaway on ProjectStep hides the worktree
+// controls on SessionStep. A throwaway directory is not a git repo, so
+// the worktree concept does not apply. Closes #1324.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+base("throwaway hides the worktree section on the Session step", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    await wizard
+      .getByRole("switch", { name: "Skip project folder" })
+      .click();
+
+    await wizard.getByRole("button", { name: "Next" }).click();
+    await expect(
+      wizard.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Explanatory note appears in place of the worktree controls.
+    await expect(
+      wizard.getByText(/Throwaway sessions do not use git worktrees/),
+    ).toBeVisible();
+    // The "Create a worktree" switch must NOT be in the DOM at all.
+    await expect(
+      wizard.getByRole("switch", { name: /Create a worktree/i }),
+    ).toHaveCount(0);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/wizard-throwaway-launch.spec.ts
+++ b/web/tests/live/wizard-throwaway-launch.spec.ts
@@ -1,0 +1,67 @@
+// User story: launching a throwaway session from the wizard creates a
+// real session on the server with `throwaway: true` and a `project_path`
+// under the OS temp directory. Closes #1324.
+
+import { tmpdir } from "node:os";
+import { test as base, expect } from "@playwright/test";
+import { listSessions, spawnAoeServe } from "../helpers/aoeServe";
+
+base("throwaway happy path: launch creates a temp-dir session", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    // ProjectStep: enable throwaway, advance.
+    await wizard
+      .getByRole("switch", { name: "Skip project folder" })
+      .click();
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // SessionStep: title is auto-generated; just advance.
+    await expect(
+      wizard.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // AgentStep: claude default; advance.
+    await wizard.getByRole("button", { name: "Next" }).click();
+
+    // ReviewStep: project label must say "Temporary directory ..."; Launch.
+    await expect(
+      wizard.getByText(/Temporary directory \(provisioned on create\)/),
+    ).toBeVisible({ timeout: 10_000 });
+    await wizard.getByRole("button", { name: /Launch session/ }).click();
+
+    // Server-side: a session exists, marked throwaway, with a project_path
+    // under tmpdir() and the aoe-throwaway- basename prefix.
+    await expect
+      .poll(async () => (await listSessions(serve.baseUrl)).length, {
+        timeout: 15_000,
+      })
+      .toBeGreaterThan(0);
+
+    const sessions = await listSessions(serve.baseUrl);
+    expect(sessions).toHaveLength(1);
+    const session = sessions[0]!;
+    expect(session.throwaway).toBe(true);
+    const projectPath = session.project_path as string;
+    expect(projectPath.startsWith(tmpdir())).toBe(true);
+    expect(projectPath).toContain("aoe-throwaway-");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/wizard-throwaway-toggle-visible.spec.ts
+++ b/web/tests/live/wizard-throwaway-toggle-visible.spec.ts
@@ -1,0 +1,35 @@
+// User story: opening the wizard shows a "Skip project folder" toggle
+// above the project-source tab bar so users can opt out of picking a
+// project path. Closes #1324.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../helpers/aoeServe";
+
+base("wizard throwaway toggle is visible above the project tabs", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await expect(wizard).toBeVisible({ timeout: 15_000 });
+
+    // The throwaway toggle uses the existing role="switch" pattern and
+    // carries the aria-label set in `ProjectStep.tsx`.
+    const toggle = wizard.getByRole("switch", { name: "Skip project folder" });
+    await expect(toggle).toBeVisible({ timeout: 10_000 });
+    await expect(toggle).toHaveAttribute("aria-checked", "false");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -89,6 +89,13 @@ const PAGES = [
     description:
       "Drive a single Agent of Empires session across several git repositories with the project registry and multi-select pickers.",
   },
+  {
+    source: "docs/guides/throwaway-sessions.md",
+    dest: "guides/throwaway-sessions.md",
+    title: "Throwaway Sessions",
+    description:
+      "Launch a session in a fresh temporary directory with no project path. The directory is removed when the session is deleted.",
+  },
 
   // --- Docs pages (docs/ → pages/docs/) ---
   {
@@ -255,6 +262,7 @@ const URL_MAP = {
   "docs/guides/agent-override.md": "/guides/agent-override/",
   "docs/guides/session-resume.md": "/guides/session-resume/",
   "docs/guides/multi-repo-workspaces.md": "/guides/multi-repo-workspaces/",
+  "docs/guides/throwaway-sessions.md": "/guides/throwaway-sessions/",
   "docs/guides/tool-sessions.md": "/guides/tool-sessions/",
   "docs/guides/podman.md": "/guides/podman/",
   "docs/guides/apple-containers.md": "/guides/apple-containers/",

--- a/website/src/data/docsNav.ts
+++ b/website/src/data/docsNav.ts
@@ -31,6 +31,7 @@ export const docsNav: NavSection[] = [
       { title: "Repo Config & Hooks", href: "/guides/repo-config/" },
       { title: "Git Worktrees", href: "/guides/worktrees/" },
       { title: "Multi-Repo Workspaces", href: "/guides/multi-repo-workspaces/" },
+      { title: "Throwaway Sessions", href: "/guides/throwaway-sessions/" },
       { title: "Diff View", href: "/guides/diff-view/" },
       { title: "tmux Status Bar", href: "/guides/tmux-status-bar/" },
       { title: "Agent Command Overrides", href: "/guides/agent-override/" },


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a "throwaway directory" toggle to new-session creation across the CLI, TUI, and web wizard. A throwaway session does not belong to any project on disk: AoE provisions a fresh directory under `std::env::temp_dir()` named `aoe-throwaway-<id>`, attaches the session to it, and unconditionally removes the directory when the session is deleted. The use case is the one in the issue: ask a question, run a quick investigation, scratch around with the agent without picking or polluting a real repo.

The feature persists as `instance.throwaway: bool` (a single `#[serde(default)]` field on `Instance`); no data migration is required. The session-layer helper at `src/session/throwaway.rs` owns the naming contract (`aoe-throwaway-<id>` basename, `fs::create_dir` so collisions surface as errors) and the deletion guard (`is_throwaway_path` checks both temp-dir ancestry AND the basename prefix, so a tampered session JSON pointing at `/etc` is left alone).

Three entry points, one persisted flag:

- **CLI:** `aoe add -T -t Quick -c claude` (also `--throwaway`). Conflicts at clap parse time with every worktree-related flag (`-w`, `--new-branch`, `--base-branch`, `--repo`, `--project`, `--no-submodules`). Passing an explicit project path alongside `--throwaway` is rejected at runtime; the historical `aoe add` no-args default still works.
- **TUI:** Ctrl+T inside the new-session dialog flips the flag, dims the Path input, force-clears the Worktree toggle, and skips the path-exists "Create dir?" prompt on Enter.
- **Web wizard:** a `Skip project folder` Toggle above the Recent / Browse / Clone-URL tabs. The reducer enforces mutual exclusion bidirectionally: enabling throwaway clears `path`/`extraRepoPaths`/`useWorktree`; selecting any real path clears `throwaway`. SessionStep hides the worktree section, ReviewStep labels the project slot "Temporary directory (provisioned on create)", and `collectRecentProjects` filters throwaway sessions out so transient temp dirs never become re-selectable Recents.

The server-side `CreateSessionBody` gains a `throwaway` field and returns 400 (`Cannot combine throwaway with worktree_branch`) before reaching the builder, so a misbehaving direct API client can't bypass the UI mutex. The shell-injection check on `body.path` is skipped only when `throwaway` is true (the client sends `""`). `SessionResponse.throwaway` is exposed so the web wizard can filter the Recents list.

Test coverage:

- Rust: 4 throwaway helper unit tests (provisioning, collision, guard-accept, guard-reject); 2 builder tests (throwaway provisions a temp dir, `throwaway + worktree` errors); 4 deletion-guard tests (accept, missing-dir, tampered path is NOT removed, non-throwaway under temp is NOT removed); 4 TUI dialog tests (toggle, mutex with worktree, empty-path-on-submit, skip-confirm-on-enter); 3 e2e tests (happy path including `aoe rm` cleanup, explicit-path rejection, clap-level worktree conflict).
- Vitest: 4 new wizardReducer cases for the bidirectional mutex; 816/816 in the full suite.
- Live Playwright: 5 user-story specs under `web/tests/live/wizard-throwaway-*.spec.ts` mirroring the canonical pattern from #1397 (toggle visible, enables-next, hides-worktree, full launch happy path, delete-cleans-tempdir). Each gets a matching `web/tests/coverage-matrix.json` entry; `validate-coverage-matrix.mjs` is green.

Local validation: `cargo fmt --check`, `cargo clippy --features serve --all-targets -- -D warnings`, `cargo test --features serve`, `cargo build --features serve`, `cargo xtask gen-docs`, `npx tsc --noEmit`, `npx vitest run`, and `node web/tests/validate-coverage-matrix.mjs` all green. (15 cockpit-ACP integration tests fail locally with `agent did not complete the ACP initialize handshake within 30s` because the local machine doesn't have `@agentclientprotocol/claude-agent-acp` installed; not introduced by this branch and unrelated to the change.)

Closes #1324

### Follow-up tracked separately

`aoe serve` startup currently does not sweep stale `aoe-throwaway-*` directories left behind when the daemon dies between session creation and explicit deletion. OS temp-cleaning policies pick most of these up, but a deliberate sweep on supervisor startup (cross-reference live session IDs, age policy, audit log) belongs in its own PR. I have NOT auto-filed the follow-up issue from this PR; happy to open one as a separate step if you want it tracked in Issues.

## PR Type

- [x] New Feature

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

User-runnable verification steps, one per acceptance criterion:

- [ ] `aoe add -T -t Quick -c claude` succeeds. The printed `Path:` line points under `$TMPDIR` (macOS) or `/tmp` (Linux), and the summary shows `Throwaway: yes`.
- [ ] `aoe add /some/real/path --throwaway` fails with `Cannot specify a project path with --throwaway`.
- [ ] `aoe add --throwaway -w foo` fails at the clap layer with a flag-conflict message.
- [ ] `aoe rm Quick` (the throwaway from step 1) succeeds; the printed directory from step 1 no longer exists on disk.
- [ ] Open the TUI new-session dialog, press Ctrl+T; the Path field swaps to `(throwaway directory, Ctrl+T to undo)` and the Worktree toggle deactivates. Enter creates the session in a fresh temp dir.
- [ ] In the web wizard, the ProjectStep shows a "Skip project folder" toggle above the Recent/Browse/Clone-URL tabs. Flipping it on hides the tabs, enables Next without a path. SessionStep hides the worktree section. ReviewStep shows "Temporary directory (provisioned on create)". Launching produces a session row whose `GET /api/sessions` entry has `throwaway: true` and a `project_path` under `os.tmpdir()`.
- [ ] Delete a throwaway session via the dashboard's sidebar context menu; the temp directory from `project_path` is removed from disk.
- [ ] In the wizard, after deleting a real project's sessions, throwaway sessions never appear in the Recent tab.

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, plan, debate-with-three-LLMs synthesis, and implementation drafted by Claude under my direction. I picked the UX shape (toggle vs tab vs checkbox), the CLI ergonomics (`-T` short flag, hard clap mutex over silent precedence), the cleanup contract (guard by temp-dir ancestry AND basename prefix), the scope cuts (orphan-sweep deferred), and reviewed each commit before pushing.

- [x] I am an AI Agent filling out this form (check box if true)