### PR TITLE
docs(web): clarify terminal font size scope

### DIFF
--- a/web/src/components/TerminalSettings.tsx
+++ b/web/src/components/TerminalSettings.tsx
@@ -51,8 +51,9 @@ export function TerminalSettings() {
             </select>
           </div>
           <p className="text-[11px] text-text-muted mt-1">
-            Font size for the terminal on mobile devices. Pinch the terminal
-            with two fingers to zoom; the new size is saved here.
+            Font size for web terminal sessions on mobile devices, including
+            tmux-backed sessions. Pinch the terminal with two fingers to zoom;
+            the new size is saved here.
           </p>
         </div>
 
@@ -87,8 +88,9 @@ export function TerminalSettings() {
             </select>
           </div>
           <p className="text-[11px] text-text-muted mt-1">
-            Font size for the terminal on desktop. Hold Ctrl and scroll over the
-            terminal (or pinch on a trackpad) to zoom; the new size is saved here.
+            Font size for web terminal sessions on desktop, including
+            tmux-backed sessions. Hold Ctrl and scroll over the terminal (or
+            pinch on a trackpad) to zoom; the new size is saved here.
           </p>
         </div>
 

--- a/web/src/components/__tests__/TerminalSettings.test.tsx
+++ b/web/src/components/__tests__/TerminalSettings.test.tsx
@@ -21,6 +21,17 @@ beforeEach(() => {
 });
 
 describe("TerminalSettings localStorage contract", () => {
+  it("labels font-size controls as applying to web tmux sessions", () => {
+    const { getByText } = render(<TerminalSettings />);
+
+    expect(
+      getByText(/web terminal sessions on mobile devices, including tmux-backed sessions/i),
+    ).toBeTruthy();
+    expect(
+      getByText(/web terminal sessions on desktop, including tmux-backed sessions/i),
+    ).toBeTruthy();
+  });
+
   it("mobile font slider writes mobileFontSize into aoe-web-settings", () => {
     const { container } = render(<TerminalSettings />);
     const slider = container.querySelectorAll(

--- a/web/src/components/settings/TmuxSettings.tsx
+++ b/web/src/components/settings/TmuxSettings.tsx
@@ -24,6 +24,8 @@ export function TmuxSettings({ settings, onSaveField, onUpdate }: Props) {
     <div className="space-y-4">
       <p className="text-xs text-text-dim">
         These settings apply to the TUI (local tmux sessions), not the web dashboard.
+        tmux itself does not control font size; web session font size is in
+        Terminal settings, and local TUI font size comes from your terminal app.
       </p>
       <SelectField
         label="Status bar"

--- a/web/src/components/settings/__tests__/TmuxSettings.test.tsx
+++ b/web/src/components/settings/__tests__/TmuxSettings.test.tsx
@@ -22,6 +22,16 @@ function mount(initial: Record<string, unknown> = {}) {
 }
 
 describe("TmuxSettings contract", () => {
+  it("explains that font size is controlled outside tmux", () => {
+    const { container } = mount({});
+
+    expect(container.textContent).toContain(
+      "tmux itself does not control font size",
+    );
+    expect(container.textContent).toContain("Terminal settings");
+    expect(container.textContent).toContain("terminal app");
+  });
+
   it("status_bar select emits tmux.status_bar with the new mode", () => {
     const { onSaveField, container } = mount({
       status_bar: "auto",


### PR DESCRIPTION
## Description
Clarifies where terminal font size is controlled:

- Web terminal font-size controls now explicitly mention that they apply to tmux-backed web sessions.
- Tmux settings now explain that tmux itself does not control font size; local TUI font size comes from the user's terminal app.
- Adds unit coverage for the new settings copy so the distinction stays visible.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No screenshot included because this is explanatory settings copy only; validated with unit tests and production build.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: copy-only settings clarification covered by focused Vitest component tests.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to inspect the settings split, update explanatory copy, and run validation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npx eslint src/components/TerminalSettings.tsx src/components/settings/TmuxSettings.tsx src/components/__tests__/TerminalSettings.test.tsx src/components/settings/__tests__/TmuxSettings.test.tsx`
- `npm run test:unit -- src/components/__tests__/TerminalSettings.test.tsx src/components/settings/__tests__/TmuxSettings.test.tsx`
- `npm run build`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR clarifies the scope and responsibility of terminal font size controls across the application's settings by updating explanatory text and adding corresponding test coverage.

## What Changed

**Documentation Updates:**
- Updated helper text in Terminal Settings to explicitly clarify that font-size controls apply to web terminal sessions, including tmux-backed sessions
- Updated Tmux Settings to clarify that tmux itself does not control font size—local TUI font size is determined by the user's terminal application
- No functional behavior changes; all underlying settings logic and UI controls remain unchanged

**Test Coverage Added:**
- Added contract test in TerminalSettings test suite to verify font-size control labels are correctly described as applying to "web terminal sessions … including tmux-backed sessions"
- Added test case in TmuxSettings test suite to assert the rendered content explains that tmux does not control font size

## Files Modified
1. `web/src/components/TerminalSettings.tsx` (6 lines added, 4 removed)
2. `web/src/components/__tests__/TerminalSettings.test.tsx` (11 lines added)
3. `web/src/components/settings/TmuxSettings.tsx` (2 lines added)
4. `web/src/components/settings/__tests__/TmuxSettings.test.tsx` (10 lines added)

## Benefits
- **Clarity for users**: Removes ambiguity about where font size is controlled—web terminal vs. local terminal app
- **Prevents misconfiguration**: Users will understand that changing tmux settings won't affect their TUI font size
- **Maintainability**: Test coverage ensures the distinction between web and local font size control remains visible and doesn't regress in future updates

## Technical Details
- Changes are copy-only with no logic modifications
- Test coverage validates through component assertions
- Validated with linting (ESLint), unit tests, and production build
- No Playwright or e2e testing required as changes are explanatory only

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1426?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->