### PR TITLE
fix(session): soften stale shell status detection

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2572,40 +2572,20 @@ impl Instance {
             );
             shell_check
         };
-        self.status = match detected {
-            Status::Idle if self.has_command_override() => {
-                // Custom commands run agents through wrapper scripts that appear
-                // as shell processes to tmux. Only declare Error when the pane is
-                // actually dead; don't use is_shell_stale() since the shell IS
-                // the expected wrapper process.
-                if is_dead {
-                    Status::Error
-                } else {
-                    Status::Unknown
-                }
-            }
-            Status::Idle if is_dead => Status::Error,
-            Status::Idle if is_shell_stale() => {
-                // A shell is the foreground process but the pane is alive.
-                // Check captured pane content: if it contains the agent's
-                // UI the agent is still alive; only declare Error when the
-                // content looks like a bare shell prompt.
-                if pane_has_agent_content(&pane_content, &self.tool) {
-                    tracing::trace!(target: "session.store",
-                        "status '{}': shell stale but pane has agent content, staying Idle",
-                        self.title,
-                    );
-                    Status::Idle
-                } else {
-                    tracing::trace!(target: "session.store",
-                        "status '{}': shell stale, no agent content, setting Error",
-                        self.title,
-                    );
-                    Status::Error
-                }
-            }
-            other => other,
+        let has_command_override = self.has_command_override();
+        let shell_stale = if detected == Status::Idle && !has_command_override && !is_dead {
+            is_shell_stale()
+        } else {
+            false
         };
+        self.status = resolve_detected_status(
+            detected,
+            is_dead,
+            shell_stale,
+            has_command_override,
+            &pane_content,
+            &self.tool,
+        );
 
         tracing::trace!(target: "session.store", "status '{}': final={:?}", self.title, self.status);
 
@@ -2770,6 +2750,51 @@ fn prepend_exports(exports: &[String], wrapped: String) -> String {
     }
 }
 
+fn resolve_detected_status(
+    detected: Status,
+    is_dead: bool,
+    is_shell_stale: bool,
+    has_command_override: bool,
+    pane_content: &str,
+    tool: &str,
+) -> Status {
+    match detected {
+        Status::Idle if has_command_override => {
+            // Custom commands run agents through wrapper scripts that appear
+            // as shell processes to tmux. Only declare Error when the pane is
+            // actually dead; don't use shell-stale since the shell IS the
+            // expected wrapper process.
+            if is_dead {
+                Status::Error
+            } else {
+                Status::Unknown
+            }
+        }
+        Status::Idle if is_dead => Status::Error,
+        Status::Idle if is_shell_stale => resolve_shell_stale_status(pane_content, tool),
+        other => other,
+    }
+}
+
+fn resolve_shell_stale_status(pane_content: &str, tool: &str) -> Status {
+    if pane_has_agent_content(pane_content, tool) {
+        Status::Idle
+    } else if pane_looks_like_bare_shell_prompt(pane_content) {
+        Status::Error
+    } else {
+        Status::Unknown
+    }
+}
+
+fn pane_looks_like_bare_shell_prompt(raw_content: &str) -> bool {
+    let clean = crate::tmux::utils::strip_ansi(raw_content);
+    let Some(last) = clean.lines().rev().find(|l| !l.trim().is_empty()) else {
+        return false;
+    };
+    let last = last.trim();
+    last.ends_with('$') || last.ends_with('#') || last.ends_with('%') || last.ends_with('\u{276f}')
+}
+
 /// Check whether captured pane content indicates a living agent rather than
 /// a bare shell prompt. Used to prevent `is_shell_stale()` from producing
 /// false `Error` status when the agent binary is a shell wrapper or spawns
@@ -2782,15 +2807,10 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
         return false;
     }
 
-    // If the last visible line looks like a shell prompt, the agent
-    // likely exited and the shell took over. This catches servers with
-    // verbose MOTD that would otherwise exceed the line-count threshold.
-    let last = non_empty.last().unwrap().trim();
-    if last.ends_with('$')
-        || last.ends_with('#')
-        || last.ends_with('%')
-        || last.ends_with('\u{276f}')
-    {
+    // If the last visible line looks like a shell prompt, the agent likely
+    // exited and the shell took over. This catches servers with verbose MOTD
+    // that would otherwise exceed the line-count threshold.
+    if pane_looks_like_bare_shell_prompt(raw_content) {
         return false;
     }
 
@@ -2803,11 +2823,17 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
 
     // Use word-boundary matching so short names like "pi" don't produce
     // false positives inside words like "api" or "pipeline".
-    let tool_lower = tool.to_lowercase();
+    let mut tool_names = vec![tool.to_lowercase()];
+    if let Some(agent) = crate::agents::get_agent(tool) {
+        let binary = agent.binary.to_lowercase();
+        if !tool_names.contains(&binary) {
+            tool_names.push(binary);
+        }
+    }
     let lower = clean.to_lowercase();
     if lower
         .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
-        .any(|word| word == tool_lower)
+        .any(|word| tool_names.iter().any(|name| word == name))
     {
         return true;
     }
@@ -4304,6 +4330,69 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_detected_status_shell_stale_agent_content_stays_idle() {
+        let content = "ctrl+p commands \u{2022} OpenCode 1.3.13+650d0db";
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, false, content, "opencode"),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_shell_stale_bare_prompt_is_error() {
+        assert_eq!(
+            resolve_detected_status(
+                Status::Idle,
+                false,
+                true,
+                false,
+                "Welcome\nuser@host:~$ ",
+                "opencode",
+            ),
+            Status::Error
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_shell_stale_unclear_is_unknown() {
+        assert_eq!(
+            resolve_detected_status(
+                Status::Idle,
+                false,
+                true,
+                false,
+                "Restoring previous session...",
+                "opencode",
+            ),
+            Status::Unknown
+        );
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, false, "", "opencode"),
+            Status::Unknown
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_keeps_hard_failures_as_error() {
+        assert_eq!(
+            resolve_detected_status(Status::Idle, true, false, false, "", "opencode"),
+            Status::Error
+        );
+        assert_eq!(
+            resolve_detected_status(Status::Idle, true, true, true, "", "opencode"),
+            Status::Error
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_live_command_override_is_unknown() {
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, true, "$ ", "opencode"),
+            Status::Unknown
+        );
+    }
+
+    #[test]
     fn test_pane_has_agent_content_agent_ui() {
         let opencode_idle = "ctrl+p commands \u{2022} OpenCode 1.3.13+650d0db";
         assert!(pane_has_agent_content(opencode_idle, "opencode"));
@@ -4360,6 +4449,11 @@ mod tests {
 
         // Longer names like "opencode" should still match.
         assert!(pane_has_agent_content("OpenCode v1.0", "opencode"));
+    }
+
+    #[test]
+    fn test_pane_has_agent_content_matches_agent_binary_alias() {
+        assert!(pane_has_agent_content("agy ready", "antigravity"));
     }
 
     mod kill_terminal_if_dead {


### PR DESCRIPTION
## Description
Shell-stale status detection was treating any live pane whose foreground command looked like a shell as `Error` unless the captured pane clearly looked like agent UI. That makes wrapper-based, restoring, or otherwise ambiguous agent panes show the sidebar `x` even when the tmux pane is still alive.

This PR keeps hard failures as `Error`:

- missing/dead panes still become `Error`
- custom command overrides still only become `Error` when the pane is dead
- live shell-stale panes become `Error` only when the captured content clearly ends at a bare shell prompt
- ambiguous live shell-stale panes now become `Unknown` instead of `Error`
- agent UI detection also recognizes the agent binary alias, e.g. `agy` for Antigravity

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No documentation or screenshots were needed; this is a Rust status-classification fix with unit coverage.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: the browser-visible change is driven by Rust session status classification, not frontend behavior. The new states are covered by in-module Rust unit tests around the classifier.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: reproducing a stale foreground shell without a dead pane requires tool-specific wrapper/runtime behavior. The decision logic is now pure and covered by deterministic unit tests.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to inspect the tmux status path, implement the focused classifier change, and add regression tests.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `cargo test session::instance::tests:: -- --nocapture`
- `cargo test session::instance::tests::test_resolve_detected_status -- --nocapture`
- `cargo fmt -- --check`
- `cargo clippy -- -D warnings`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed (high-level)

This PR softens the session status classifier so live tmux panes that merely look like shells don't get incorrectly marked Error. Key changes:

- Refactored status resolution to centralize logic and reduce false-positive Error states.
- Live panes are only classified Error when there's clear evidence: the pane is dead or the captured content clearly ends at a bare shell prompt.
- Ambiguous live, shell-like panes are downgraded from Error to Unknown instead of Error.
- Agent detection expanded to recognize the agent binary alias (e.g., "agy" for Antigravity).
- Unit tests added/updated to cover the new classification behavior.

Benefits
- Fewer spurious Error statuses for wrapper-based agents and recovering TUIs.
- More accurate detection when agent executable names vary (aliases).
- Improved UX: sidebar/error glyphs appear only for dead panes or clearly bare prompts.
- Changes are narrowly scoped to stale-shell classification; hard failures remain unchanged.

Technical details (concise)
- Introduces resolve_detected_status(...) to centralize decision logic previously in update_status_with_metadata_inner.
- Adds pane_looks_like_bare_shell_prompt() which inspects the last non-empty, ANSI-stripped line for prompt suffixes ($, #, %, ❯).
- pane_has_agent_content() now reuses the prompt helper and matches either the configured tool name or the agent’s binary alias.
- Tests: new unit tests for resolve_detected_status and agent-alias matching; Playwright/e2e UI tests were skipped since logic is covered by unit tests.

Potential areas for further improvement
- Consider richer heuristics (timing, repeated captures) to distinguish short-lived TUI transitions from real failures.
- Add optional telemetry/logging when ambiguous Unknown states persist to aid tuning heuristics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1433?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->