### PR TITLE
fix(cli): convert session restart/stop/add to Storage::update()

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -284,7 +284,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    // This snapshot is read-only: used for parent resolution, title
+    // generation, and the pre-flight duplicate check. The authoritative
+    // write happens later via `storage.update`, which re-loads under the
+    // cross-process lock so a concurrently-added row is never clobbered.
+    let instances = storage.load()?;
 
     // Resolve parent session if specified
     let mut group_path = args.group.clone();
@@ -625,15 +629,38 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         return Err(e);
     }
 
-    instances.push(instance.clone());
+    // Persist the new row through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. The `instances` snapshot loaded above
+    // may be stale (another `aoe add` could have committed between then
+    // and now); a wholesale `commit` of that snapshot would clobber the
+    // concurrently-added row. The closure re-checks for a duplicate
+    // against the fresh load so a racing identical add still no-ops.
+    let group_path_for_save = instance.group_path.clone();
+    let instance_for_save = instance.clone();
+    let duplicate = storage.update(move |instances, groups| {
+        if is_duplicate_session(
+            instances,
+            &instance_for_save.title,
+            &instance_for_save.project_path,
+        ) {
+            return Ok(true);
+        }
+        instances.push(instance_for_save);
+        if !group_path_for_save.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path_for_save);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(false)
+    })?;
 
-    // Rebuild group tree
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instance.group_path.is_empty() {
-        group_tree.create_group(&instance.group_path);
+    if duplicate {
+        println!(
+            "Session already exists with same title and path: {}",
+            final_title
+        );
+        return Ok(());
     }
-
-    storage.commit(&instances, &group_tree)?;
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -683,12 +710,19 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
         }
     } else if args.launch {
-        let idx = instances
-            .iter()
-            .position(|i| i.id == instance.id)
-            .expect("just added instance");
-        instances[idx].start_with_size(crate::terminal::get_size())?;
-        storage.commit(&instances, &group_tree)?;
+        // Start the tmux process on a local copy first (the slow, non-storage
+        // work), then write the started state back through `update` so a
+        // concurrent writer's row added since the `add` commit above is not
+        // clobbered. `start_with_size` mutates status / pid in place.
+        let mut launched = instance.clone();
+        launched.start_with_size(crate::terminal::get_size())?;
+        let launched_id = launched.id.clone();
+        storage.update(move |instances, _groups| {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == launched_id) {
+                *slot = launched;
+            }
+            Ok(())
+        })?;
 
         let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
         tmux_session.attach()?;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -247,12 +247,44 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
 /// snapshot, returning its full id. Used to resolve the `identifier` CLI arg
 /// to a stable key before the `Storage::update` closure re-loads a fresh
 /// snapshot; the closure then matches on that id, never on a stale index.
+///
+/// Mirrors the disambiguation rules of `crate::cli::resolve_session`: exact
+/// id wins (unique by construction), an ambiguous id-prefix fails loudly
+/// rather than silently mutating the first match, exact title is a fallback.
+/// A too-short prefix on a mutating command (archive, snooze, restart, ...)
+/// must not silently act on the wrong session.
 fn resolve_session_id(instances: &[crate::session::Instance], identifier: &str) -> Result<String> {
-    instances
+    if let Some(inst) = instances.iter().find(|i| i.id == identifier) {
+        return Ok(inst.id.clone());
+    }
+
+    let prefix_matches: Vec<&crate::session::Instance> = instances
         .iter()
-        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
-        .map(|i| i.id.clone())
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))
+        .filter(|i| i.id.starts_with(identifier))
+        .collect();
+    match prefix_matches.len() {
+        0 => {}
+        1 => return Ok(prefix_matches[0].id.clone()),
+        _ => {
+            let mut candidates: Vec<String> = prefix_matches
+                .iter()
+                .map(|i| format!("  {} ({})", i.id, i.title))
+                .collect();
+            candidates.sort();
+            anyhow::bail!(
+                "Ambiguous session identifier {:?} matches {} sessions:\n{}\nUse a longer prefix or the full ID.",
+                identifier,
+                prefix_matches.len(),
+                candidates.join("\n")
+            );
+        }
+    }
+
+    if let Some(inst) = instances.iter().find(|i| i.title == identifier) {
+        return Ok(inst.id.clone());
+    }
+
+    anyhow::bail!("Session not found: {}", identifier)
 }
 
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -243,24 +243,30 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
     }
 }
 
+/// Locate a session by exact id, id-prefix, or exact title within a loaded
+/// snapshot, returning its full id. Used to resolve the `identifier` CLI arg
+/// to a stable key before the `Storage::update` closure re-loads a fresh
+/// snapshot; the closure then matches on that id, never on a stale index.
+fn resolve_session_id(instances: &[crate::session::Instance], identifier: &str) -> Result<String> {
+    instances
+        .iter()
+        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
+        .map(|i| i.id.clone())
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))
+}
+
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].favorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.favorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Favorited: {}", title);
     Ok(())
@@ -268,22 +274,16 @@ async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unfavorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unfavorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unfavorited: {}", title);
     Ok(())
@@ -291,27 +291,29 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
-    let id = super::resolve_session(&args.identifier, &instances)?
-        .id
-        .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
+    // Resolve and kill the pane before touching storage: killing the tmux
+    // session is a syscall that does not need the registry, and doing it
+    // outside the `update` closure keeps the lock held only for the brief
+    // load-mutate-write.
+    let resolved = super::resolve_session(&args.identifier, &instances)?;
+    let id = resolved.id.clone();
 
     if !args.no_kill {
-        if let Err(e) = instances[idx].kill() {
+        if let Err(e) = resolved.kill() {
             eprintln!("Warning: failed to kill tmux session: {}", e);
         }
     }
 
-    instances[idx].archive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.archive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Archived: {}", title);
     Ok(())
@@ -319,21 +321,18 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let id = super::resolve_session(&args.identifier, &instances)?
+    let id = super::resolve_session(&args.identifier, &storage.load()?)?
         .id
         .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
 
-    instances[idx].unarchive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unarchive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unarchived: {}", title);
     Ok(())
@@ -341,7 +340,6 @@ async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
     let config = crate::session::profile_config::resolve_config(profile)?;
 
@@ -355,20 +353,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     crate::session::validate_snooze_duration(raw_minutes).map_err(|e| anyhow::anyhow!("{}", e))?;
     let minutes = raw_minutes as u32;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    instances[idx].snooze(minutes);
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.snooze(minutes);
+        Ok(inst.title.clone())
+    })?;
 
     println!("Snoozed for {}m: {}", minutes, title);
     Ok(())
@@ -376,22 +370,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
 
 async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unsnooze();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unsnooze();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Woke: {}", title);
     Ok(())
@@ -399,7 +387,7 @@ async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -410,16 +398,25 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // Start the tmux process on a local copy first (the slow, non-storage
+    // work), then persist the started state via `update` so a row another
+    // process added in the meantime is not clobbered.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "start")?;
-    instances[idx].start_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
+    let mut started = instances[idx].clone();
+    started.source_profile = profile.to_string();
+    bail_if_cockpit(&started, "start")?;
+    started.start_with_size(crate::terminal::get_size())?;
+    let title = started.title.clone();
+    let started_id = started.id.clone();
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == started_id) {
+            *slot = started;
+        }
+        Ok(())
+    })?;
 
     println!("✓ Started session: {}", title);
     Ok(())
@@ -455,7 +452,7 @@ fn bail_if_cockpit(_inst: &crate::session::Instance, _verb: &str) -> Result<()> 
 
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
     bail_if_cockpit(inst, "stop")?;
@@ -473,14 +470,19 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Stop the process before touching storage: it is a tmux/container
+    // syscall path independent of the registry.
     inst.stop()?;
 
-    // Persist Stopped status to disk so it survives TUI restarts
-    if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-        stored.status = crate::session::Status::Stopped;
-    }
-    let group_tree = crate::session::GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Persist Stopped status to disk so it survives TUI restarts. `update`
+    // re-loads under the lock and mutates only this row, so a session
+    // another process added during `stop()` is preserved.
+    storage.update(move |instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
+            stored.status = crate::session::Status::Stopped;
+        }
+        Ok(())
+    })?;
 
     if had_container {
         println!("✓ Stopped session and container: {}", title);
@@ -503,7 +505,7 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
 
 async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let target_ids = pick_targets_for_restart_all(&instances);
     if target_ids.is_empty() {
@@ -516,29 +518,28 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let parallel = parallel.max(1);
 
     // Clone each target into its worker; we'll write the (mutated) copy back
-    // by index after the worker returns. Workers never touch the shared Vec.
+    // by id after all workers return. Workers never touch the shared Vec.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides
     // (sandbox.environment, on_launch hooks, etc.).
-    let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
+    let mut targets: Vec<crate::session::Instance> = Vec::with_capacity(total);
     for id in &target_ids {
-        if let Some(idx) = instances.iter().position(|i| &i.id == id) {
-            let mut clone = instances[idx].clone();
+        if let Some(inst) = instances.iter().find(|i| &i.id == id) {
+            let mut clone = inst.clone();
             clone.source_profile = profile.to_string();
-            targets.push((idx, clone));
+            targets.push(clone);
         }
     }
 
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
     let mut join_set: tokio::task::JoinSet<(
-        usize,
         String,
         Option<crate::session::Instance>,
         Result<StartOutcome>,
     )> = tokio::task::JoinSet::new();
 
-    for (idx, mut inst) in targets {
+    for mut inst in targets {
         let permit_sem = semaphore.clone();
         join_set.spawn(async move {
             let _permit = permit_sem
@@ -552,9 +553,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             })
             .await;
             match res {
-                Ok((inst, result)) => (idx, title, Some(inst), result),
+                Ok((inst, result)) => (title, Some(inst), result),
                 Err(join_err) => (
-                    idx,
                     title,
                     None,
                     Err(anyhow::anyhow!("worker panicked: {}", join_err)),
@@ -565,11 +565,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
+    // Mutated copies of every session that restarted, keyed by id. After all
+    // the slow restart work finishes, a single `update` writes them back
+    // against a fresh load so a row another process added in the meantime
+    // is not clobbered.
+    let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
-        let (idx, title, inst_opt, result) =
-            joined.expect("JoinSet shouldn't panic on join itself");
+        let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
         if let Some(inst) = inst_opt {
-            instances[idx] = inst;
+            restarted.push(inst);
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -578,8 +582,14 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        for updated in restarted {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == updated.id) {
+                *slot = updated;
+            }
+        }
+        Ok(())
+    })?;
 
     let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
@@ -637,7 +647,7 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -648,15 +658,23 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // All of the restart work below (re-execing the pane, polling
+    // `wait_for_pane_ready` for up to 5s, sending the wake-up keys) is slow
+    // and touches only tmux, not the registry. Do it on a local copy first,
+    // then persist that copy through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. A wholesale `commit` of the snapshot
+    // loaded above would be up to 5s stale and would clobber any row another
+    // process added during the restart, the exact loss this fix targets.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so restart-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "restart")?;
-    let outcome = instances[idx].restart_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
-    let session_id = instances[idx].id.clone();
-    let tool = instances[idx].tool.clone();
+    let mut restarted = instances[idx].clone();
+    restarted.source_profile = profile.to_string();
+    bail_if_cockpit(&restarted, "restart")?;
+    let outcome = restarted.restart_with_size(crate::terminal::get_size())?;
+    let title = restarted.title.clone();
+    let session_id = restarted.id.clone();
+    let tool = restarted.tool.clone();
 
     // Resolve the configured wake message (global default with per-profile
     // override). Empty string is the documented opt-out: the restart still
@@ -677,9 +695,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
                 Ok(()) => {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) {
-                        inst.touch_last_accessed();
-                    }
+                    restarted.touch_last_accessed();
                 }
                 Err(e) => {
                     eprintln!("Warning: failed to send wake-up message: {}", e);
@@ -688,8 +704,12 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == session_id) {
+            *slot = restarted;
+        }
+        Ok(())
+    })?;
 
     match outcome {
         StartOutcome::Restarted { stale_sid } => {
@@ -902,7 +922,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = if let Some(id) = &args.identifier {
         super::resolve_session(id, &instances)?
@@ -933,14 +953,11 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     let effective_title = args.title.unwrap_or(old_title.clone());
     let effective_title = effective_title.trim().to_string();
 
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-    // Rename tmux session if title changed
-    if instances[idx].title != effective_title {
-        let tmux_session = crate::tmux::Session::new(&id, &instances[idx].title)?;
+    // Rename the tmux session before touching storage: it is a tmux syscall
+    // independent of the registry, so it runs outside the `update` closure
+    // to keep the cross-process lock held only for the brief write.
+    if old_title != effective_title {
+        let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
         if tmux_session.exists() {
             let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
             if let Err(e) = tmux_session.rename(&new_tmux_name) {
@@ -951,17 +968,28 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
-    instances[idx].title = effective_title.clone();
-
-    if let Some(group) = args.group {
-        instances[idx].group_path = group.trim().to_string();
-    }
-
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instances[idx].group_path.is_empty() {
-        group_tree.create_group(&instances[idx].group_path);
-    }
-    storage.commit(&instances, &group_tree)?;
+    // `update` re-loads under the lock and mutates only this row, so a
+    // session another process added meanwhile is preserved.
+    let id_for_save = id.clone();
+    let title_for_save = effective_title.clone();
+    let group_for_save = args.group.clone();
+    storage.update(move |instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id_for_save)
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+        inst.title = title_for_save;
+        if let Some(group) = group_for_save {
+            inst.group_path = group.trim().to_string();
+        }
+        if !inst.group_path.is_empty() {
+            let group_path = inst.group_path.clone();
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(())
+    })?;
 
     if old_title != effective_title {
         println!("✓ Renamed session: {} → {}", old_title, effective_title);
@@ -1021,16 +1049,7 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
 
 async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
     let new_id = if args.session_id.trim().is_empty() {
         None
@@ -1045,17 +1064,20 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         Some(trimmed)
     };
 
-    instances[idx].agent_session_id = new_id.clone();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let new_id_for_save = new_id.clone();
+    let (title, tool) = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.agent_session_id = new_id_for_save;
+        Ok((inst.title.clone(), inst.tool.clone()))
+    })?;
 
     match new_id {
         Some(ref id) => {
             println!("✓ Set session ID for '{}': {}", title, id);
-            let tool = &instances[idx].tool;
-            if let Some(agent) = crate::agents::get_agent(tool) {
+            if let Some(agent) = crate::agents::get_agent(&tool) {
                 if matches!(
                     agent.resume_strategy,
                     crate::agents::ResumeStrategy::Unsupported

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,27 +1,34 @@
-//! Session storage - JSON file persistence with in-process per-profile locking.
+//! Session storage - JSON file persistence with two-tier write locking.
 //!
 //! `Storage` serialises read-modify-write cycles inside the same process via a
 //! per-profile mutex (one `Arc<Mutex<()>>` per profile name, registered process-
-//! wide). Mutators use `update` (load -> mutate -> save under the lock) or
-//! `commit` (locked wholesale write, for callers that already own the
-//! authoritative in-memory state, e.g. the TUI's `HomeView`). The
-//! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
-//! by `update_workspace_ordering` internally; the per-profile `save` /
-//! `save_groups` helpers have been removed entirely. This keeps it
+//! wide), and across separate OS processes via a blocking exclusive `flock(2)`
+//! on a per-profile `sessions.json.lock` file. Mutators use `update` (load ->
+//! mutate -> save under both locks) or `commit` (locked wholesale write, for
+//! callers that already own the authoritative in-memory state, e.g. the TUI's
+//! `HomeView`). The `save_workspace_ordering` entry point is `pub(crate)` and
+//! only consumed by `update_workspace_ordering` internally; the per-profile
+//! `save` / `save_groups` helpers have been removed entirely. This keeps it
 //! structurally impossible to bypass the lock.
 //!
-//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
-//! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse. The closure passed to `update` is `FnOnce(...) -> Result<R>` and
-//! cannot await, so `std::sync::Mutex` is safe across the body even on the
-//! tokio runtime: server callers wrap `update` in `tokio::task::spawn_blocking`,
-//! which is the existing pattern.
+//! The cross-process `flock` is required because the TUI (`aoe`), the CLI, and
+//! the `aoe serve` daemon are three separate processes that all mutate the
+//! same profile's `sessions.json`; the in-process mutex alone is invisible to
+//! peers, so their load-modify-write cycles would interleave and clobber rows
+//! (last-writer-wins). The `flock` mirrors the approach in
+//! `recovery::RecoveryLock` and is held for the entire load-modify-write
+//! region of both `update` and `commit`.
 //!
-//! Cross-process races (the TUI and `aoe serve` mutating the same profile
-//! concurrently) are explicitly out of scope here; a future advisory `flock`
-//! would close them.
+//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
+//! server side) is acquired BEFORE `Storage`'s per-profile mutex, which is
+//! acquired before the `flock`; never the reverse. The closure passed to
+//! `update` is `FnOnce(...) -> Result<R>` and cannot await, so
+//! `std::sync::Mutex` is safe across the body even on the tokio runtime:
+//! server callers wrap `update` in `tokio::task::spawn_blocking`, which is the
+//! existing pattern.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
@@ -77,9 +84,53 @@ fn workspace_ordering_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Cross-process advisory lock guarding a profile's `sessions.json` (and the
+/// sibling `groups.json` it is written with).
+///
+/// The in-process `save_lock` mutex only serialises writers inside one OS
+/// process; the TUI, the CLI, and the `aoe serve` daemon are three separate
+/// processes that all mutate the same profile's files, so without an OS-level
+/// lock their load-modify-write cycles interleave and rows get clobbered
+/// (last-writer-wins). This guard takes a blocking exclusive `flock(2)` on a
+/// dedicated `sessions.json.lock` file next to the data, held for the whole
+/// load-modify-write region and released when the guard drops. It mirrors the
+/// `flock` approach already used by `recovery::RecoveryLock`.
+///
+/// The lock is on a separate `.lock` file rather than on `sessions.json`
+/// itself because `atomic_write` replaces `sessions.json` via `rename(2)`; a
+/// lock held on the old inode would not cover the new one.
+struct SessionsFileLock {
+    _file: fs::File,
+}
+
+impl SessionsFileLock {
+    /// Acquire the exclusive cross-process lock, blocking until no other
+    /// process holds it. The lock file is created if missing and never
+    /// deleted (the lock lives on the open file description, not on the
+    /// file's existence).
+    fn acquire(lock_path: &Path) -> Result<Self> {
+        if let Some(parent) = lock_path.parent() {
+            // Surface an unwritable profile dir here with the real OS error
+            // rather than as a confusing ENOENT from the open() below.
+            fs::create_dir_all(parent)?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .with_context(|| format!("opening sessions lock file {}", lock_path.display()))?;
+        file.lock_exclusive()
+            .with_context(|| format!("acquiring sessions lock {}", lock_path.display()))?;
+        Ok(Self { _file: file })
+    }
+}
+
 pub struct Storage {
     profile: String,
     sessions_path: PathBuf,
+    lock_path: PathBuf,
     save_lock: Arc<Mutex<()>>,
 }
 
@@ -106,11 +157,13 @@ impl Storage {
 
         let profile_dir = get_profile_dir(&profile_name)?;
         let sessions_path = profile_dir.join("sessions.json");
+        let lock_path = profile_dir.join("sessions.json.lock");
         let save_lock = save_lock_for(&profile_name);
 
         Ok(Self {
             profile: profile_name,
             sessions_path,
+            lock_path,
             save_lock,
         })
     }
@@ -177,6 +230,10 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Cross-process exclusion: the in-process mutex above only covers this
+        // OS process; the TUI, CLI, and daemon are separate processes writing
+        // the same files. The flock spans the whole load-modify-write region.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -216,6 +273,9 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `update`: the flock serialises this wholesale write against
+        // mutators running in other OS processes for the same profile.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let groups = group_tree.get_all_groups();
         let instances_buf = serde_json::to_vec_pretty(instances)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
@@ -436,7 +496,13 @@ mod tests {
             .collect();
         entries.sort();
 
-        assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+        // `sessions.json.lock` is the cross-process flock file; it is created
+        // on first write and intentionally persists (the lock lives on the
+        // file, not on its existence). It is not temp-file debris.
+        assert_eq!(
+            entries,
+            vec!["groups.json", "sessions.json", "sessions.json.lock"]
+        );
         Ok(())
     }
 
@@ -990,6 +1056,144 @@ mod tests {
         assert_ne!(
             groups_mtime_before, groups_mtime_after,
             "groups.json should be rewritten when closure mutates groups"
+        );
+        Ok(())
+    }
+
+    /// Worker side of `test_update_serializes_concurrent_writers_cross_process`.
+    ///
+    /// This is not a real test: it runs as a no-op unless the parent test has
+    /// set `AOE_FLOCK_XPROC_CHILD`, in which case it re-enters as a child
+    /// process and performs exactly one `update()`. The parent re-invokes the
+    /// test binary with `--exact` targeting this function so that each child
+    /// is a genuinely separate OS process (the only thing that exercises the
+    /// cross-process `flock`; threads in one process all share a single flock
+    /// holder and would pass even on the broken code).
+    ///
+    /// Coordinates arrive via env vars:
+    /// - `AOE_FLOCK_XPROC_CHILD`: the row title/id this child should add.
+    /// - `HOME` / `XDG_CONFIG_HOME`: the shared temp app dir.
+    /// - `AOE_FLOCK_XPROC_BARRIER`: a file both children poll so their
+    ///   `update()` calls overlap rather than running sequentially.
+    #[test]
+    fn xproc_writer_child() {
+        let Ok(row) = std::env::var("AOE_FLOCK_XPROC_CHILD") else {
+            return; // ran as an ordinary unit test; nothing to do.
+        };
+        let barrier = std::env::var("AOE_FLOCK_XPROC_BARRIER")
+            .expect("barrier path must be set for the child");
+
+        // Announce arrival, then wait until both children have announced so
+        // their load-modify-write windows overlap.
+        fs::write(format!("{barrier}.{row}"), b"ready").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let a = Path::new(&format!("{barrier}.a")).exists();
+            let b = Path::new(&format!("{barrier}.b")).exists();
+            if a && b {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child timed out waiting for peer"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let storage = Storage::new("xproc-profile").expect("storage");
+        storage
+            .update(|instances, _groups| {
+                instances.push(Instance::new(&row, &format!("/tmp/{row}")));
+                Ok(())
+            })
+            .expect("child update");
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_serializes_concurrent_writers_cross_process() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        // Seed an empty sessions.json so both children load-modify-write a
+        // file that already exists.
+        let storage = Storage::new("xproc-profile")?;
+        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+
+        let barrier = temp.path().join("xproc-barrier");
+        let exe = std::env::current_exe()?;
+
+        let spawn_child = |row: &str| -> std::process::Child {
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args([
+                "--exact",
+                "session::storage::tests::xproc_writer_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("AOE_FLOCK_XPROC_CHILD", row)
+            .env("AOE_FLOCK_XPROC_BARRIER", &barrier)
+            .env("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            cmd.env("XDG_CONFIG_HOME", temp.path().join(".config"));
+            cmd.stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            cmd.spawn().expect("spawn child")
+        };
+
+        let child_a = spawn_child("a");
+        let child_b = spawn_child("b");
+
+        for (label, mut child) in [("a", child_a), ("b", child_b)] {
+            let status = child.wait()?;
+            assert!(status.success(), "child {label} exited with {status}");
+        }
+
+        let loaded = storage.load()?;
+        let mut titles: Vec<_> = loaded.iter().map(|i| i.title.clone()).collect();
+        titles.sort();
+        assert_eq!(
+            titles,
+            vec!["a".to_string(), "b".to_string()],
+            "cross-process writers lost a row: last-writer-wins clobbered the other"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_file_lock_excludes_concurrent_holder() -> Result<()> {
+        // Focused check on the lock primitive: while one guard is held, a
+        // non-blocking acquisition of the same lock file fails with
+        // `WouldBlock`, and a blocking acquisition succeeds once the first
+        // guard drops.
+        use fs2::FileExt;
+
+        let temp = tempdir()?;
+        let lock_path = temp.path().join("primitive.lock");
+
+        let guard = SessionsFileLock::acquire(&lock_path)?;
+
+        let probe = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let contended = probe.try_lock_exclusive();
+        assert!(
+            matches!(&contended, Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+            "second holder must be blocked while the first guard is alive, got {contended:?}"
+        );
+
+        drop(guard);
+
+        // After the guard drops the lock is free; a fresh blocking acquire
+        // returns immediately.
+        let reacquired = SessionsFileLock::acquire(&lock_path);
+        assert!(
+            reacquired.is_ok(),
+            "lock must be re-acquirable after the guard drops"
         );
         Ok(())
     }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -41,6 +41,85 @@ fn test_cli_add_and_list() {
     );
 }
 
+/// Concurrent `aoe add` processes must not lose rows.
+///
+/// Before Stage 2, every `aoe add` handler did `load_with_groups()` ->
+/// append -> `Storage::commit()`, a wholesale last-writer-wins overwrite.
+/// Two `aoe add` processes whose load-modify-write windows overlap each
+/// load the same baseline, append their own distinct row, and the second
+/// `commit()` clobbers the first writer's row. The Stage 1 flock alone
+/// does not fix this: it only serialises the writes, the snapshot each
+/// process holds is still stale.
+///
+/// This test seeds one session, then spawns several `aoe add` processes
+/// at once. After they all exit, every seeded and added row must be
+/// present. Red on `commit()`-based handlers, green once they use
+/// `Storage::update()`, which re-loads a fresh snapshot under the lock.
+#[test]
+#[serial]
+fn test_cli_add_concurrent_processes_keep_all_rows() {
+    let h = TuiTestHarness::new("cli_add_concurrent");
+    let project = h.project_path();
+    let project_str = project.to_str().unwrap().to_string();
+
+    // Seed a baseline row so every concurrent `add` loads a non-empty
+    // sessions.json. Without a seed, the very first writer also creates
+    // the file, which slightly narrows the race; the seed makes the
+    // lost-update window deterministic.
+    let seed = h.run_cli(&["add", &project_str, "-t", "seed-session"]);
+    assert!(
+        seed.status.success(),
+        "seed aoe add failed: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    // Several concurrent writers. The race widens with parallelism, so a
+    // handful of overlapping processes reliably drops a row on the
+    // pre-Stage-2 `commit()` path.
+    let worker_count = 6;
+    let titles: Vec<String> = (0..worker_count)
+        .map(|i| format!("concurrent-{i}"))
+        .collect();
+
+    let children: Vec<_> = titles
+        .iter()
+        .map(|title| h.spawn_cli(&["add", &project_str, "-t", title]))
+        .collect();
+
+    for (title, child) in titles.iter().zip(children) {
+        let out = child.wait_with_output().expect("child aoe add did not run");
+        assert!(
+            out.status.success(),
+            "concurrent aoe add for {title} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let present: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["title"].as_str())
+        .collect();
+
+    assert!(
+        present.contains(&"seed-session"),
+        "seed row was clobbered by a concurrent add; present: {present:?}"
+    );
+    for title in &titles {
+        assert!(
+            present.contains(&title.as_str()),
+            "concurrent add row {title} was lost (last-writer-wins clobber); present: {present:?}"
+        );
+    }
+    assert_eq!(
+        sessions.len(),
+        worker_count + 1,
+        "expected seed + {worker_count} concurrent rows; present: {present:?}"
+    );
+}
+
 /// Regression test for #848: `aoe add` "Next steps" hint should reference
 /// the actual binary name (`aoe`), not the long project name.
 #[test]

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -420,6 +420,25 @@ last_seen_version = "{}"
             .expect("failed to run aoe CLI")
     }
 
+    /// Spawn an `aoe` CLI subcommand without waiting for it to exit, returning
+    /// the `Child` handle. Unlike `run_cli` (which blocks on `.output()`), this
+    /// lets a test launch several `aoe` processes that overlap in time, the
+    /// only way to exercise the cross-process write path from outside the
+    /// crate. Shares the same isolated `HOME` / `PATH` as `run_cli`.
+    pub fn spawn_cli(&self, args: &[&str]) -> std::process::Child {
+        Command::new(&self.binary_path)
+            .args(args)
+            .env("HOME", self.home_dir.path())
+            .env("XDG_CONFIG_HOME", self.home_dir.path().join(".config"))
+            .env("PATH", self.env_path())
+            .env_remove("AGENT_OF_EMPIRES_DEBUG")
+            .env_remove("AOE_LOG_LEVEL")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn aoe CLI")
+    }
+
     /// Path to the isolated home directory for custom test setup.
     pub fn home_path(&self) -> &Path {
         self.home_dir.path()

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -114,15 +114,22 @@ fn test_save_leaves_no_debris() -> Result<()> {
         storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
     }
 
-    // Atomic write should leave only the persisted JSON files in the profile
-    // dir, no .json.bak from the old code path and no leftover tempfiles.
+    // Atomic write should leave only the persisted JSON files plus the
+    // cross-process flock file in the profile dir, no .json.bak from the old
+    // code path and no leftover tempfiles. `sessions.json.lock` is the
+    // advisory lock guarding concurrent writers; it is created on first write
+    // and intentionally persists (the lock lives on the file, not on its
+    // existence), so it is not debris.
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
     let mut entries: Vec<String> = fs::read_dir(&profile_dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     entries.sort();
-    assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+    assert_eq!(
+        entries,
+        vec!["groups.json", "sessions.json", "sessions.json.lock"]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Converts the remaining `commit()`-style call sites in `src/cli/session.rs` and `src/cli/add.rs` to the safe `Storage::update()` closure pattern (Stage 2). Removes the stale-snapshot race that the foundation flock alone can't fix.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — N/A (no UI surface; storage/CLI/TUI-internals only)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (new `test_cli_add_concurrent_processes_keep_all_rows` + `TuiTestHarness::spawn_cli()` helper)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Full design + diagnostic trail at `docs/plans/2026-05-22-aoe-sessions-json-concurrency-design.md` (carried in #1437 for review-locality).

- [x] I am an AI Agent filling out this form (check box if true)

---

Stacks on #1434 (cross-process flock foundation). Review after / merge after.

## Problem

The `aoe session restart`, `aoe session stop`, and `aoe add` CLI handlers
follow a `load → slow work → commit()` pattern. The snapshot they hold goes
stale during the slow work (e.g. `restart_session` polls
`wait_for_pane_ready` for up to 5s), then `commit()` overwrites the file
from that stale snapshot — clobbering any rows another writer added in the
interim. This is the proximate trigger of the `cx-swap-bg`-induced losses
noted in the foundation PR.

## Fix

Converts every `commit()` call site in `src/cli/session.rs` and
`src/cli/add.rs` to `Storage::update(|inst, grp| …)`. The closure runs against
a fresh load under the flock, applying only the intended mutation, so no
stale-snapshot overwrite is possible. Slow work happens *before* the
closure, not between load and write.

`grep '\.commit('\ src/cli/session.rs src/cli/add.rs`` now returns nothing.

## Verification

- 0 `commit()` remain in `src/cli/session.rs` + `src/cli/add.rs`.
- New `test_cli_add_concurrent_processes_keep_all_rows` — several
  `aoe add` processes race; assert all rows present after exit. Red on
  pre-Stage-2 code, green here.
- e2e CLI suite 27/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR fixes a concurrency bug where CLI session operations could overwrite concurrent changes to sessions.json. It adds cross-process locking and refactors CLI handlers to perform slow work before persisting, then apply mutations against a fresh load under an exclusive lock via Storage::update(), eliminating stale-snapshot races.

## What changed (high-level)

- Added a persistent advisory lock file (sessions.json.lock) and integrated an exclusive flock into Storage::update() and commit().
- Reworked CLI flow: slow/non-storage work (tmux ops, polling, cloning) happens first; persistence happens inside Storage::update() closures that reload fresh data and apply only the intended mutation.
- Converted all commit() call sites in src/cli/session.rs and src/cli/add.rs to Storage::update() closures.
- Improved session identifier resolution to prefer exact IDs, allow unambiguous prefixes, and error on ambiguous prefixes to avoid accidentally mutating the wrong session.
- Added tests and test helpers: an e2e test that spawns concurrent aoe add processes to assert no rows are lost, a harness helper to spawn non-blocking CLI subprocesses, and integration tests updated to expect the lock file.

## Benefits

- Prevents data loss from concurrent CLI processes (no more last-writer-clobber).
- Ensures mutations are applied against a fresh authoritative snapshot under an OS-level lock.
- No public API changes; locking is internal to Storage.
- Verified by new e2e and integration tests.

## Technical summary (brief)

- Storage: introduced SessionsFileLock and a lock_path field; update() and commit() now acquire the flock plus existing in-process mutex for the full load→mutate→save window.
- CLI: add.rs and session.rs now defer persistence until after slow operations and use storage.update(|instances, groups| { … }) to mutate only the target row(s). start/stop/restart/rename/set-id/favorite/archive/snooze flows updated accordingly.
- Identifier resolution: resolve_session_id now prefers exact ID, accepts single prefix matches, errors on multiple prefix matches, with a fallback to exact title; final verification occurs inside the update closure.
- Tests: new e2e test test_cli_add_concurrent_processes_keep_all_rows; spawn_cli helper; integration test updated to keep sessions.json.lock.

Files of note: src/cli/add.rs, src/cli/session.rs, src/session/storage.rs, tests/e2e/cli.rs, tests/e2e/harness.rs, tests/integration/session_lifecycle.rs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1435?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
