### PR TITLE
fix(cli): convert remaining commit() sites in group/remove/worktree

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -603,29 +603,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     })();
 
     if let Err(e) = hook_result {
-        // Clean up worktree if we created one
-        if let Some(ref wt_info) = instance.worktree_info {
-            if wt_info.managed_by_aoe {
-                if let Ok(git_wt) =
-                    crate::git::GitWorktree::new(std::path::PathBuf::from(&wt_info.main_repo_path))
-                {
-                    let _ = git_wt.remove_worktree(&path, false);
-                }
-            }
-        }
-        // Clean up workspace worktrees if we created them
-        if let Some(ref ws_info) = instance.workspace_info {
-            for repo in &ws_info.repos {
-                if repo.managed_by_aoe {
-                    let wt_path = PathBuf::from(&repo.worktree_path);
-                    let main_repo = PathBuf::from(&repo.main_repo_path);
-                    if let Ok(git_wt) = crate::git::GitWorktree::new(main_repo) {
-                        let _ = git_wt.remove_worktree(&wt_path, false);
-                    }
-                }
-            }
-            let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
-        }
+        cleanup_partial_create(&instance, &path);
         return Err(e);
     }
 
@@ -655,6 +633,12 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     })?;
 
     if duplicate {
+        // Race-loser path: another `aoe add` with the same (title, path)
+        // committed first while we were creating worktrees / running
+        // on_create hooks. Roll back our side effects so we don't leave
+        // an orphan worktree or workspace dir behind with no session row
+        // to own it. (CodeRabbit feedback on PR #1436.)
+        cleanup_partial_create(&instance, &path);
         println!(
             "Session already exists with same title and path: {}",
             final_title
@@ -719,7 +703,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         let launched_id = launched.id.clone();
         storage.update(move |instances, _groups| {
             if let Some(slot) = instances.iter_mut().find(|i| i.id == launched_id) {
-                *slot = launched;
+                slot.adopt_lifecycle_from(&launched);
             }
             Ok(())
         })?;
@@ -861,4 +845,35 @@ fn resolve_named_tool(tool: &str, config: &crate::session::Config) -> Result<Nam
         "Unknown tool: {name}\nSupported built-in and configured custom agents: {}",
         safe_names.join(", ")
     )
+}
+
+/// Best-effort cleanup of side effects from a partial `aoe add` that
+/// can't go forward: either an `on_create` hook errored, or the closure
+/// re-check inside `Storage::update` discovered a concurrently-created
+/// duplicate row and we now have a worktree / workspace dir but no
+/// session row to own it. Errors here are ignored — the caller has
+/// already decided to give up on this add, and leaving a stray dir is
+/// preferable to a hard error mid-rollback.
+fn cleanup_partial_create(instance: &Instance, path: &std::path::Path) {
+    if let Some(ref wt_info) = instance.worktree_info {
+        if wt_info.managed_by_aoe {
+            if let Ok(git_wt) =
+                crate::git::GitWorktree::new(std::path::PathBuf::from(&wt_info.main_repo_path))
+            {
+                let _ = git_wt.remove_worktree(path, false);
+            }
+        }
+    }
+    if let Some(ref ws_info) = instance.workspace_info {
+        for repo in &ws_info.repos {
+            if repo.managed_by_aoe {
+                let wt_path = PathBuf::from(&repo.worktree_path);
+                let main_repo = PathBuf::from(&repo.main_repo_path);
+                if let Ok(git_wt) = crate::git::GitWorktree::new(main_repo) {
+                    let _ = git_wt.remove_worktree(&wt_path, false);
+                }
+            }
+        }
+        let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
+    }
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -284,7 +284,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    // This snapshot is read-only: used for parent resolution, title
+    // generation, and the pre-flight duplicate check. The authoritative
+    // write happens later via `storage.update`, which re-loads under the
+    // cross-process lock so a concurrently-added row is never clobbered.
+    let instances = storage.load()?;
 
     // Resolve parent session if specified
     let mut group_path = args.group.clone();
@@ -625,15 +629,38 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         return Err(e);
     }
 
-    instances.push(instance.clone());
+    // Persist the new row through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. The `instances` snapshot loaded above
+    // may be stale (another `aoe add` could have committed between then
+    // and now); a wholesale `commit` of that snapshot would clobber the
+    // concurrently-added row. The closure re-checks for a duplicate
+    // against the fresh load so a racing identical add still no-ops.
+    let group_path_for_save = instance.group_path.clone();
+    let instance_for_save = instance.clone();
+    let duplicate = storage.update(move |instances, groups| {
+        if is_duplicate_session(
+            instances,
+            &instance_for_save.title,
+            &instance_for_save.project_path,
+        ) {
+            return Ok(true);
+        }
+        instances.push(instance_for_save);
+        if !group_path_for_save.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path_for_save);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(false)
+    })?;
 
-    // Rebuild group tree
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instance.group_path.is_empty() {
-        group_tree.create_group(&instance.group_path);
+    if duplicate {
+        println!(
+            "Session already exists with same title and path: {}",
+            final_title
+        );
+        return Ok(());
     }
-
-    storage.commit(&instances, &group_tree)?;
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -683,12 +710,19 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
         }
     } else if args.launch {
-        let idx = instances
-            .iter()
-            .position(|i| i.id == instance.id)
-            .expect("just added instance");
-        instances[idx].start_with_size(crate::terminal::get_size())?;
-        storage.commit(&instances, &group_tree)?;
+        // Start the tmux process on a local copy first (the slow, non-storage
+        // work), then write the started state back through `update` so a
+        // concurrent writer's row added since the `add` commit above is not
+        // clobbered. `start_with_size` mutates status / pid in place.
+        let mut launched = instance.clone();
+        launched.start_with_size(crate::terminal::get_size())?;
+        let launched_id = launched.id.clone();
+        storage.update(move |instances, _groups| {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == launched_id) {
+                *slot = launched;
+            }
+            Ok(())
+        })?;
 
         let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
         tmux_session.attach()?;

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -127,7 +127,6 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
 
 async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
     let name = args.name.trim();
     let group_path = if let Some(parent) = &args.parent {
@@ -136,14 +135,20 @@ async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
         name.to_string()
     };
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-
-    if group_tree.group_exists(&group_path) {
-        bail!("Group already exists: {}", group_path);
-    }
-
-    group_tree.create_group(&group_path);
-    storage.commit(&instances, &group_tree)?;
+    // Persist through `update`, which re-loads under the cross-process lock.
+    // The existence check runs against that fresh snapshot, not a stale one,
+    // and the closure only adds the new group, so a concurrently-added group
+    // or session row is never clobbered.
+    let group_path_for_save = group_path.clone();
+    storage.update(move |instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
+        if group_tree.group_exists(&group_path_for_save) {
+            bail!("Group already exists: {}", group_path_for_save);
+        }
+        group_tree.create_group(&group_path_for_save);
+        *groups = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     println!("✓ Created group: {}", group_path);
 
@@ -152,43 +157,53 @@ async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
 
 async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
+    let name = args.name.trim().to_string();
+    let force = args.force;
 
-    let name = args.name.trim();
-    if !group_tree.group_exists(name) {
-        bail!("Group not found: {}", name);
-    }
+    // Persist through `update`: the existence check, the session count, and
+    // the deletion all run against a fresh snapshot loaded under the
+    // cross-process lock. The closure mutates only the target group and its
+    // sessions, so a row another process added concurrently is preserved.
+    // The count is returned so the post-update messages stay accurate.
+    let name_for_save = name.clone();
+    let session_count = storage.update(move |instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
 
-    // Check for sessions in this group
-    let session_count = instances
-        .iter()
-        .filter(|i| i.group_path == name || i.group_path.starts_with(&format!("{}/", name)))
-        .count();
-
-    if session_count > 0 {
-        if !args.force {
-            bail!(
-                "Group '{}' contains {} sessions. Use --force to move them to default group.",
-                name,
-                session_count
-            );
+        if !group_tree.group_exists(&name_for_save) {
+            bail!("Group not found: {}", name_for_save);
         }
 
-        // Move sessions to default group
-        for inst in &mut instances {
-            if inst.group_path == name || inst.group_path.starts_with(&format!("{}/", name)) {
-                inst.group_path = String::new();
+        let prefix = format!("{}/", name_for_save);
+        let session_count = instances
+            .iter()
+            .filter(|i| i.group_path == name_for_save || i.group_path.starts_with(&prefix))
+            .count();
+
+        if session_count > 0 {
+            if !force {
+                bail!(
+                    "Group '{}' contains {} sessions. Use --force to move them to default group.",
+                    name_for_save,
+                    session_count
+                );
+            }
+
+            // Move sessions to default group
+            for inst in instances.iter_mut() {
+                if inst.group_path == name_for_save || inst.group_path.starts_with(&prefix) {
+                    inst.group_path = String::new();
+                }
             }
         }
-    }
 
-    group_tree.delete_group(name);
-    storage.commit(&instances, &group_tree)?;
+        group_tree.delete_group(&name_for_save);
+        *groups = group_tree.get_all_groups();
+        Ok(session_count)
+    })?;
 
     println!("✓ Deleted group: {}", name);
-    if args.force && session_count > 0 {
+    if force && session_count > 0 {
         println!("  Moved {} sessions to default group", session_count);
     }
 
@@ -197,24 +212,37 @@ async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
 
 async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let identifier = args.identifier.trim();
-    let inst = instances
-        .iter_mut()
-        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+    let identifier = args.identifier.trim().to_string();
+    let group = args.group.trim().to_string();
 
-    let group = args.group.trim();
-    let old_group = inst.group_path.clone();
-    inst.group_path = group.to_string();
+    // Persist through `update`: the session lookup and the group reassignment
+    // both run against a fresh snapshot loaded under the cross-process lock.
+    // The closure touches only the target row's `group_path` and adds the
+    // destination group, so a concurrently-added row is never clobbered. The
+    // previous group is returned so the post-update message stays accurate.
+    let identifier_for_save = identifier.clone();
+    let group_for_save = group.clone();
+    let old_group = storage.update(move |instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| {
+                i.id == identifier_for_save
+                    || i.id.starts_with(&identifier_for_save)
+                    || i.title == identifier_for_save
+            })
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier_for_save))?;
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !group.is_empty() {
-        group_tree.create_group(group);
-    }
+        let old_group = inst.group_path.clone();
+        inst.group_path = group_for_save.clone();
 
-    storage.commit(&instances, &group_tree)?;
+        if !group_for_save.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_for_save);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(old_group)
+    })?;
 
     if old_group.is_empty() {
         println!("✓ Moved session to group: {}", group);

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -3,7 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::session::{GroupTree, Instance, Storage};
+use crate::session::{Instance, Storage};
 
 #[derive(Args)]
 pub struct RemoveArgs {
@@ -36,93 +36,96 @@ fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
-    let mut found = false;
-    let mut removed_title = String::new();
-    let mut new_instances = Vec::with_capacity(instances.len());
+    // This snapshot is read-only: it locates the target row so its worktree
+    // and container teardown can run before any storage write. The
+    // authoritative removal happens later via `storage.update`, which
+    // re-loads under the cross-process lock; a wholesale `commit` of this
+    // snapshot would clobber a row another process added during the
+    // teardown (`perform_deletion` removes a worktree and a container, a
+    // real staleness window).
+    let instances = storage.load()?;
 
-    for inst in instances {
-        if inst.id == args.identifier
+    let target: Option<Instance> = instances.into_iter().find(|inst| {
+        inst.id == args.identifier
             || inst.id.starts_with(&args.identifier)
             || inst.title == args.identifier
-        {
-            found = true;
-            removed_title = inst.title.clone();
+    });
 
-            let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                profile,
-                std::path::Path::new(&inst.project_path),
-            );
-
-            let delete_worktree = needs_worktree_cleanup(&inst, &args);
-            let delete_branch = inst
-                .worktree_info
-                .as_ref()
-                .is_some_and(|wt| wt.managed_by_aoe)
-                && (args.delete_branch
-                    || (delete_worktree && config.worktree.delete_branch_on_cleanup));
-            let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
-                && !args.keep_container
-                && config.sandbox.auto_cleanup;
-
-            let result = crate::session::deletion::perform_deletion(
-                &crate::session::deletion::DeletionRequest {
-                    session_id: inst.id.clone(),
-                    instance: inst.clone(),
-                    delete_worktree,
-                    delete_branch,
-                    delete_sandbox,
-                    force_delete: args.force,
-                    detach_hooks: false,
-                },
-            );
-
-            for msg in &result.messages {
-                println!("  {}", msg);
-            }
-            for err in &result.errors {
-                eprintln!("Warning: {}", err);
-            }
-
-            if !delete_worktree {
-                if let Some(wt_info) = &inst.worktree_info {
-                    if wt_info.managed_by_aoe {
-                        println!(
-                            "Worktree preserved at: {} (use --delete-worktree to remove)",
-                            inst.project_path
-                        );
-                    }
-                }
-            }
-            if let Some(sandbox) = &inst.sandbox_info {
-                if sandbox.enabled {
-                    if args.keep_container {
-                        println!("Container preserved: {}", sandbox.container_name);
-                    } else if !config.sandbox.auto_cleanup {
-                        println!(
-                            "Container preserved: {} (auto_cleanup disabled in config)",
-                            sandbox.container_name
-                        );
-                    }
-                }
-            }
-        } else {
-            new_instances.push(inst);
-        }
-    }
-
-    if !found {
+    let Some(inst) = target else {
         bail!(
             "Session not found in profile '{}': {}",
             storage.profile(),
             args.identifier
         );
+    };
+
+    let removed_title = inst.title.clone();
+    let removed_id = inst.id.clone();
+
+    let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+        profile,
+        std::path::Path::new(&inst.project_path),
+    );
+
+    let delete_worktree = needs_worktree_cleanup(&inst, &args);
+    let delete_branch = inst
+        .worktree_info
+        .as_ref()
+        .is_some_and(|wt| wt.managed_by_aoe)
+        && (args.delete_branch || (delete_worktree && config.worktree.delete_branch_on_cleanup));
+    let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
+        && !args.keep_container
+        && config.sandbox.auto_cleanup;
+
+    let result =
+        crate::session::deletion::perform_deletion(&crate::session::deletion::DeletionRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+            delete_worktree,
+            delete_branch,
+            delete_sandbox,
+            force_delete: args.force,
+            detach_hooks: false,
+        });
+
+    for msg in &result.messages {
+        println!("  {}", msg);
+    }
+    for err in &result.errors {
+        eprintln!("Warning: {}", err);
     }
 
-    // Rebuild group tree and save
-    let group_tree = GroupTree::new_with_groups(&new_instances, &groups);
-    storage.commit(&new_instances, &group_tree)?;
+    if !delete_worktree {
+        if let Some(wt_info) = &inst.worktree_info {
+            if wt_info.managed_by_aoe {
+                println!(
+                    "Worktree preserved at: {} (use --delete-worktree to remove)",
+                    inst.project_path
+                );
+            }
+        }
+    }
+    if let Some(sandbox) = &inst.sandbox_info {
+        if sandbox.enabled {
+            if args.keep_container {
+                println!("Container preserved: {}", sandbox.container_name);
+            } else if !config.sandbox.auto_cleanup {
+                println!(
+                    "Container preserved: {} (auto_cleanup disabled in config)",
+                    sandbox.container_name
+                );
+            }
+        }
+    }
+
+    // Remove the target row through `update`, which re-loads `sessions.json`
+    // under the cross-process lock and retains by `Instance.id`, so any row
+    // a concurrent writer added during the teardown above survives.
+    storage.update(move |instances, _groups| {
+        instances.retain(|inst| inst.id != removed_id);
+        Ok(())
+    })?;
 
     println!(
         "  Removed session: {} (from profile '{}')",

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -413,7 +413,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     storage.update(move |instances, _groups| {
         if let Some(slot) = instances.iter_mut().find(|i| i.id == started_id) {
-            *slot = started;
+            slot.adopt_lifecycle_from(&started);
         }
         Ok(())
     })?;
@@ -572,20 +572,32 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
-        if let Some(inst) = inst_opt {
-            restarted.push(inst);
-        }
+        // Only persist workers whose restart actually succeeded. A failed
+        // worker's `inst` still carries the mutations made before the
+        // failure point; writing those back to sessions.json would leave
+        // disk reflecting a partial restart for a session that never
+        // came up. (CodeRabbit feedback on PR #1436.)
         match result {
-            Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
-            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((title, None)),
+            Ok(StartOutcome::Restarted { stale_sid }) => {
+                if let Some(inst) = inst_opt {
+                    restarted.push(inst);
+                }
+                succeeded.push((title, Some(stale_sid)));
+            }
+            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => {
+                if let Some(inst) = inst_opt {
+                    restarted.push(inst);
+                }
+                succeeded.push((title, None));
+            }
             Err(e) => failed.push((title, e.to_string())),
         }
     }
 
     storage.update(move |instances, _groups| {
-        for updated in restarted {
+        for updated in &restarted {
             if let Some(slot) = instances.iter_mut().find(|i| i.id == updated.id) {
-                *slot = updated;
+                slot.adopt_lifecycle_from(updated);
             }
         }
         Ok(())
@@ -706,7 +718,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     storage.update(move |instances, _groups| {
         if let Some(slot) = instances.iter_mut().find(|i| i.id == session_id) {
-            *slot = restarted;
+            slot.adopt_lifecycle_from(&restarted);
         }
         Ok(())
     })?;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -243,24 +243,30 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
     }
 }
 
+/// Locate a session by exact id, id-prefix, or exact title within a loaded
+/// snapshot, returning its full id. Used to resolve the `identifier` CLI arg
+/// to a stable key before the `Storage::update` closure re-loads a fresh
+/// snapshot; the closure then matches on that id, never on a stale index.
+fn resolve_session_id(instances: &[crate::session::Instance], identifier: &str) -> Result<String> {
+    instances
+        .iter()
+        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
+        .map(|i| i.id.clone())
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))
+}
+
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].favorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.favorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Favorited: {}", title);
     Ok(())
@@ -268,22 +274,16 @@ async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unfavorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unfavorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unfavorited: {}", title);
     Ok(())
@@ -291,27 +291,29 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
-    let id = super::resolve_session(&args.identifier, &instances)?
-        .id
-        .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
+    // Resolve and kill the pane before touching storage: killing the tmux
+    // session is a syscall that does not need the registry, and doing it
+    // outside the `update` closure keeps the lock held only for the brief
+    // load-mutate-write.
+    let resolved = super::resolve_session(&args.identifier, &instances)?;
+    let id = resolved.id.clone();
 
     if !args.no_kill {
-        if let Err(e) = instances[idx].kill() {
+        if let Err(e) = resolved.kill() {
             eprintln!("Warning: failed to kill tmux session: {}", e);
         }
     }
 
-    instances[idx].archive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.archive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Archived: {}", title);
     Ok(())
@@ -319,21 +321,18 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let id = super::resolve_session(&args.identifier, &instances)?
+    let id = super::resolve_session(&args.identifier, &storage.load()?)?
         .id
         .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
 
-    instances[idx].unarchive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unarchive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unarchived: {}", title);
     Ok(())
@@ -341,7 +340,6 @@ async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
     let config = crate::session::profile_config::resolve_config(profile)?;
 
@@ -355,20 +353,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     crate::session::validate_snooze_duration(raw_minutes).map_err(|e| anyhow::anyhow!("{}", e))?;
     let minutes = raw_minutes as u32;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    instances[idx].snooze(minutes);
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.snooze(minutes);
+        Ok(inst.title.clone())
+    })?;
 
     println!("Snoozed for {}m: {}", minutes, title);
     Ok(())
@@ -376,22 +370,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
 
 async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unsnooze();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unsnooze();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Woke: {}", title);
     Ok(())
@@ -399,7 +387,7 @@ async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -410,16 +398,25 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // Start the tmux process on a local copy first (the slow, non-storage
+    // work), then persist the started state via `update` so a row another
+    // process added in the meantime is not clobbered.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "start")?;
-    instances[idx].start_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
+    let mut started = instances[idx].clone();
+    started.source_profile = profile.to_string();
+    bail_if_cockpit(&started, "start")?;
+    started.start_with_size(crate::terminal::get_size())?;
+    let title = started.title.clone();
+    let started_id = started.id.clone();
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == started_id) {
+            *slot = started;
+        }
+        Ok(())
+    })?;
 
     println!("✓ Started session: {}", title);
     Ok(())
@@ -455,7 +452,7 @@ fn bail_if_cockpit(_inst: &crate::session::Instance, _verb: &str) -> Result<()> 
 
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
     bail_if_cockpit(inst, "stop")?;
@@ -473,14 +470,19 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Stop the process before touching storage: it is a tmux/container
+    // syscall path independent of the registry.
     inst.stop()?;
 
-    // Persist Stopped status to disk so it survives TUI restarts
-    if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-        stored.status = crate::session::Status::Stopped;
-    }
-    let group_tree = crate::session::GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Persist Stopped status to disk so it survives TUI restarts. `update`
+    // re-loads under the lock and mutates only this row, so a session
+    // another process added during `stop()` is preserved.
+    storage.update(move |instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
+            stored.status = crate::session::Status::Stopped;
+        }
+        Ok(())
+    })?;
 
     if had_container {
         println!("✓ Stopped session and container: {}", title);
@@ -503,7 +505,7 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
 
 async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let target_ids = pick_targets_for_restart_all(&instances);
     if target_ids.is_empty() {
@@ -516,29 +518,28 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let parallel = parallel.max(1);
 
     // Clone each target into its worker; we'll write the (mutated) copy back
-    // by index after the worker returns. Workers never touch the shared Vec.
+    // by id after all workers return. Workers never touch the shared Vec.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides
     // (sandbox.environment, on_launch hooks, etc.).
-    let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
+    let mut targets: Vec<crate::session::Instance> = Vec::with_capacity(total);
     for id in &target_ids {
-        if let Some(idx) = instances.iter().position(|i| &i.id == id) {
-            let mut clone = instances[idx].clone();
+        if let Some(inst) = instances.iter().find(|i| &i.id == id) {
+            let mut clone = inst.clone();
             clone.source_profile = profile.to_string();
-            targets.push((idx, clone));
+            targets.push(clone);
         }
     }
 
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
     let mut join_set: tokio::task::JoinSet<(
-        usize,
         String,
         Option<crate::session::Instance>,
         Result<StartOutcome>,
     )> = tokio::task::JoinSet::new();
 
-    for (idx, mut inst) in targets {
+    for mut inst in targets {
         let permit_sem = semaphore.clone();
         join_set.spawn(async move {
             let _permit = permit_sem
@@ -552,9 +553,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             })
             .await;
             match res {
-                Ok((inst, result)) => (idx, title, Some(inst), result),
+                Ok((inst, result)) => (title, Some(inst), result),
                 Err(join_err) => (
-                    idx,
                     title,
                     None,
                     Err(anyhow::anyhow!("worker panicked: {}", join_err)),
@@ -565,11 +565,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
+    // Mutated copies of every session that restarted, keyed by id. After all
+    // the slow restart work finishes, a single `update` writes them back
+    // against a fresh load so a row another process added in the meantime
+    // is not clobbered.
+    let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
-        let (idx, title, inst_opt, result) =
-            joined.expect("JoinSet shouldn't panic on join itself");
+        let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
         if let Some(inst) = inst_opt {
-            instances[idx] = inst;
+            restarted.push(inst);
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -578,8 +582,14 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        for updated in restarted {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == updated.id) {
+                *slot = updated;
+            }
+        }
+        Ok(())
+    })?;
 
     let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
@@ -637,7 +647,7 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -648,15 +658,23 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // All of the restart work below (re-execing the pane, polling
+    // `wait_for_pane_ready` for up to 5s, sending the wake-up keys) is slow
+    // and touches only tmux, not the registry. Do it on a local copy first,
+    // then persist that copy through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. A wholesale `commit` of the snapshot
+    // loaded above would be up to 5s stale and would clobber any row another
+    // process added during the restart, the exact loss this fix targets.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so restart-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "restart")?;
-    let outcome = instances[idx].restart_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
-    let session_id = instances[idx].id.clone();
-    let tool = instances[idx].tool.clone();
+    let mut restarted = instances[idx].clone();
+    restarted.source_profile = profile.to_string();
+    bail_if_cockpit(&restarted, "restart")?;
+    let outcome = restarted.restart_with_size(crate::terminal::get_size())?;
+    let title = restarted.title.clone();
+    let session_id = restarted.id.clone();
+    let tool = restarted.tool.clone();
 
     // Resolve the configured wake message (global default with per-profile
     // override). Empty string is the documented opt-out: the restart still
@@ -677,9 +695,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
                 Ok(()) => {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) {
-                        inst.touch_last_accessed();
-                    }
+                    restarted.touch_last_accessed();
                 }
                 Err(e) => {
                     eprintln!("Warning: failed to send wake-up message: {}", e);
@@ -688,8 +704,12 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == session_id) {
+            *slot = restarted;
+        }
+        Ok(())
+    })?;
 
     match outcome {
         StartOutcome::Restarted { stale_sid } => {
@@ -902,7 +922,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = if let Some(id) = &args.identifier {
         super::resolve_session(id, &instances)?
@@ -933,14 +953,11 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     let effective_title = args.title.unwrap_or(old_title.clone());
     let effective_title = effective_title.trim().to_string();
 
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-    // Rename tmux session if title changed
-    if instances[idx].title != effective_title {
-        let tmux_session = crate::tmux::Session::new(&id, &instances[idx].title)?;
+    // Rename the tmux session before touching storage: it is a tmux syscall
+    // independent of the registry, so it runs outside the `update` closure
+    // to keep the cross-process lock held only for the brief write.
+    if old_title != effective_title {
+        let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
         if tmux_session.exists() {
             let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
             if let Err(e) = tmux_session.rename(&new_tmux_name) {
@@ -951,17 +968,28 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
-    instances[idx].title = effective_title.clone();
-
-    if let Some(group) = args.group {
-        instances[idx].group_path = group.trim().to_string();
-    }
-
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instances[idx].group_path.is_empty() {
-        group_tree.create_group(&instances[idx].group_path);
-    }
-    storage.commit(&instances, &group_tree)?;
+    // `update` re-loads under the lock and mutates only this row, so a
+    // session another process added meanwhile is preserved.
+    let id_for_save = id.clone();
+    let title_for_save = effective_title.clone();
+    let group_for_save = args.group.clone();
+    storage.update(move |instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id_for_save)
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+        inst.title = title_for_save;
+        if let Some(group) = group_for_save {
+            inst.group_path = group.trim().to_string();
+        }
+        if !inst.group_path.is_empty() {
+            let group_path = inst.group_path.clone();
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(())
+    })?;
 
     if old_title != effective_title {
         println!("✓ Renamed session: {} → {}", old_title, effective_title);
@@ -1021,16 +1049,7 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
 
 async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
     let new_id = if args.session_id.trim().is_empty() {
         None
@@ -1045,17 +1064,20 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         Some(trimmed)
     };
 
-    instances[idx].agent_session_id = new_id.clone();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let new_id_for_save = new_id.clone();
+    let (title, tool) = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.agent_session_id = new_id_for_save;
+        Ok((inst.title.clone(), inst.tool.clone()))
+    })?;
 
     match new_id {
         Some(ref id) => {
             println!("✓ Set session ID for '{}': {}", title, id);
-            let tool = &instances[idx].tool;
-            if let Some(agent) = crate::agents::get_agent(tool) {
+            if let Some(agent) = crate::agents::get_agent(&tool) {
                 if matches!(
                     agent.resume_strategy,
                     crate::agents::ResumeStrategy::Unsupported

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -154,7 +154,7 @@ async fn show_info(profile: &str, identifier: &str) -> Result<()> {
 
 async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let mut orphaned_sessions = Vec::new();
     let mut orphaned_worktrees = Vec::new();
@@ -259,11 +259,20 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
 
     // Remove orphaned sessions
     if !orphaned_sessions.is_empty() {
-        let mut new_instances = instances.clone();
-        new_instances.retain(|inst| !orphaned_sessions.iter().any(|orphan| orphan.id == inst.id));
-
-        let group_tree = crate::session::GroupTree::new_with_groups(&new_instances, &groups);
-        storage.commit(&new_instances, &group_tree)?;
+        // Persist through `update`, which re-loads `sessions.json` under the
+        // cross-process lock and retains by `Instance.id`. The orphaned set
+        // was computed from an earlier load; a wholesale `commit` of that
+        // snapshot would clobber a row another process added in the
+        // meantime. Retaining by id removes only the orphans and leaves any
+        // concurrently-added row intact.
+        let orphan_ids: Vec<String> = orphaned_sessions
+            .iter()
+            .map(|inst| inst.id.clone())
+            .collect();
+        storage.update(move |instances, _groups| {
+            instances.retain(|inst| !orphan_ids.contains(&inst.id));
+            Ok(())
+        })?;
 
         removed_count += orphaned_sessions.len();
         println!("✓ Removed {} orphaned sessions", orphaned_sessions.len());

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -689,6 +689,27 @@ impl Instance {
         self.snoozed_until = None;
     }
 
+    /// Copy the start/stop/restart lifecycle fields from `src` onto `self`,
+    /// preserving user-metadata fields (favorited_at, archived_at,
+    /// snoozed_until, title, group_path, base_branch_override, notify_on_*,
+    /// ...). Used by CLI start/restart handlers inside the
+    /// `Storage::update()` closure to apply the result of slow tmux work
+    /// (which ran on a pre-lock clone) onto a freshly-loaded snapshot
+    /// without clobbering concurrent user edits to the same row.
+    ///
+    /// Addresses CodeRabbit feedback on PR #1435/#1436: a wholesale
+    /// `*slot = local_clone` would revert any field a concurrent
+    /// `favorite`/`set-session-id`/`set-base` (etc.) writer touched
+    /// between the pre-lock clone and the update() lock acquisition,
+    /// defeating the very lost-write fix `Storage::update()` is meant to
+    /// provide.
+    pub fn adopt_lifecycle_from(&mut self, src: &Instance) {
+        self.status = src.status;
+        self.last_accessed_at = src.last_accessed_at;
+        self.idle_entered_at = src.idle_entered_at;
+        self.agent_session_id = src.agent_session_id.clone();
+    }
+
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,27 +1,34 @@
-//! Session storage - JSON file persistence with in-process per-profile locking.
+//! Session storage - JSON file persistence with two-tier write locking.
 //!
 //! `Storage` serialises read-modify-write cycles inside the same process via a
 //! per-profile mutex (one `Arc<Mutex<()>>` per profile name, registered process-
-//! wide). Mutators use `update` (load -> mutate -> save under the lock) or
-//! `commit` (locked wholesale write, for callers that already own the
-//! authoritative in-memory state, e.g. the TUI's `HomeView`). The
-//! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
-//! by `update_workspace_ordering` internally; the per-profile `save` /
-//! `save_groups` helpers have been removed entirely. This keeps it
+//! wide), and across separate OS processes via a blocking exclusive `flock(2)`
+//! on a per-profile `sessions.json.lock` file. Mutators use `update` (load ->
+//! mutate -> save under both locks) or `commit` (locked wholesale write, for
+//! callers that already own the authoritative in-memory state, e.g. the TUI's
+//! `HomeView`). The `save_workspace_ordering` entry point is `pub(crate)` and
+//! only consumed by `update_workspace_ordering` internally; the per-profile
+//! `save` / `save_groups` helpers have been removed entirely. This keeps it
 //! structurally impossible to bypass the lock.
 //!
-//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
-//! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse. The closure passed to `update` is `FnOnce(...) -> Result<R>` and
-//! cannot await, so `std::sync::Mutex` is safe across the body even on the
-//! tokio runtime: server callers wrap `update` in `tokio::task::spawn_blocking`,
-//! which is the existing pattern.
+//! The cross-process `flock` is required because the TUI (`aoe`), the CLI, and
+//! the `aoe serve` daemon are three separate processes that all mutate the
+//! same profile's `sessions.json`; the in-process mutex alone is invisible to
+//! peers, so their load-modify-write cycles would interleave and clobber rows
+//! (last-writer-wins). The `flock` mirrors the approach in
+//! `recovery::RecoveryLock` and is held for the entire load-modify-write
+//! region of both `update` and `commit`.
 //!
-//! Cross-process races (the TUI and `aoe serve` mutating the same profile
-//! concurrently) are explicitly out of scope here; a future advisory `flock`
-//! would close them.
+//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
+//! server side) is acquired BEFORE `Storage`'s per-profile mutex, which is
+//! acquired before the `flock`; never the reverse. The closure passed to
+//! `update` is `FnOnce(...) -> Result<R>` and cannot await, so
+//! `std::sync::Mutex` is safe across the body even on the tokio runtime:
+//! server callers wrap `update` in `tokio::task::spawn_blocking`, which is the
+//! existing pattern.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
@@ -77,9 +84,53 @@ fn workspace_ordering_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Cross-process advisory lock guarding a profile's `sessions.json` (and the
+/// sibling `groups.json` it is written with).
+///
+/// The in-process `save_lock` mutex only serialises writers inside one OS
+/// process; the TUI, the CLI, and the `aoe serve` daemon are three separate
+/// processes that all mutate the same profile's files, so without an OS-level
+/// lock their load-modify-write cycles interleave and rows get clobbered
+/// (last-writer-wins). This guard takes a blocking exclusive `flock(2)` on a
+/// dedicated `sessions.json.lock` file next to the data, held for the whole
+/// load-modify-write region and released when the guard drops. It mirrors the
+/// `flock` approach already used by `recovery::RecoveryLock`.
+///
+/// The lock is on a separate `.lock` file rather than on `sessions.json`
+/// itself because `atomic_write` replaces `sessions.json` via `rename(2)`; a
+/// lock held on the old inode would not cover the new one.
+struct SessionsFileLock {
+    _file: fs::File,
+}
+
+impl SessionsFileLock {
+    /// Acquire the exclusive cross-process lock, blocking until no other
+    /// process holds it. The lock file is created if missing and never
+    /// deleted (the lock lives on the open file description, not on the
+    /// file's existence).
+    fn acquire(lock_path: &Path) -> Result<Self> {
+        if let Some(parent) = lock_path.parent() {
+            // Surface an unwritable profile dir here with the real OS error
+            // rather than as a confusing ENOENT from the open() below.
+            fs::create_dir_all(parent)?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .with_context(|| format!("opening sessions lock file {}", lock_path.display()))?;
+        file.lock_exclusive()
+            .with_context(|| format!("acquiring sessions lock {}", lock_path.display()))?;
+        Ok(Self { _file: file })
+    }
+}
+
 pub struct Storage {
     profile: String,
     sessions_path: PathBuf,
+    lock_path: PathBuf,
     save_lock: Arc<Mutex<()>>,
 }
 
@@ -106,11 +157,13 @@ impl Storage {
 
         let profile_dir = get_profile_dir(&profile_name)?;
         let sessions_path = profile_dir.join("sessions.json");
+        let lock_path = profile_dir.join("sessions.json.lock");
         let save_lock = save_lock_for(&profile_name);
 
         Ok(Self {
             profile: profile_name,
             sessions_path,
+            lock_path,
             save_lock,
         })
     }
@@ -177,6 +230,10 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Cross-process exclusion: the in-process mutex above only covers this
+        // OS process; the TUI, CLI, and daemon are separate processes writing
+        // the same files. The flock spans the whole load-modify-write region.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -216,6 +273,9 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `update`: the flock serialises this wholesale write against
+        // mutators running in other OS processes for the same profile.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let groups = group_tree.get_all_groups();
         let instances_buf = serde_json::to_vec_pretty(instances)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
@@ -436,7 +496,13 @@ mod tests {
             .collect();
         entries.sort();
 
-        assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+        // `sessions.json.lock` is the cross-process flock file; it is created
+        // on first write and intentionally persists (the lock lives on the
+        // file, not on its existence). It is not temp-file debris.
+        assert_eq!(
+            entries,
+            vec!["groups.json", "sessions.json", "sessions.json.lock"]
+        );
         Ok(())
     }
 
@@ -990,6 +1056,144 @@ mod tests {
         assert_ne!(
             groups_mtime_before, groups_mtime_after,
             "groups.json should be rewritten when closure mutates groups"
+        );
+        Ok(())
+    }
+
+    /// Worker side of `test_update_serializes_concurrent_writers_cross_process`.
+    ///
+    /// This is not a real test: it runs as a no-op unless the parent test has
+    /// set `AOE_FLOCK_XPROC_CHILD`, in which case it re-enters as a child
+    /// process and performs exactly one `update()`. The parent re-invokes the
+    /// test binary with `--exact` targeting this function so that each child
+    /// is a genuinely separate OS process (the only thing that exercises the
+    /// cross-process `flock`; threads in one process all share a single flock
+    /// holder and would pass even on the broken code).
+    ///
+    /// Coordinates arrive via env vars:
+    /// - `AOE_FLOCK_XPROC_CHILD`: the row title/id this child should add.
+    /// - `HOME` / `XDG_CONFIG_HOME`: the shared temp app dir.
+    /// - `AOE_FLOCK_XPROC_BARRIER`: a file both children poll so their
+    ///   `update()` calls overlap rather than running sequentially.
+    #[test]
+    fn xproc_writer_child() {
+        let Ok(row) = std::env::var("AOE_FLOCK_XPROC_CHILD") else {
+            return; // ran as an ordinary unit test; nothing to do.
+        };
+        let barrier = std::env::var("AOE_FLOCK_XPROC_BARRIER")
+            .expect("barrier path must be set for the child");
+
+        // Announce arrival, then wait until both children have announced so
+        // their load-modify-write windows overlap.
+        fs::write(format!("{barrier}.{row}"), b"ready").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let a = Path::new(&format!("{barrier}.a")).exists();
+            let b = Path::new(&format!("{barrier}.b")).exists();
+            if a && b {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child timed out waiting for peer"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let storage = Storage::new("xproc-profile").expect("storage");
+        storage
+            .update(|instances, _groups| {
+                instances.push(Instance::new(&row, &format!("/tmp/{row}")));
+                Ok(())
+            })
+            .expect("child update");
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_serializes_concurrent_writers_cross_process() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        // Seed an empty sessions.json so both children load-modify-write a
+        // file that already exists.
+        let storage = Storage::new("xproc-profile")?;
+        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+
+        let barrier = temp.path().join("xproc-barrier");
+        let exe = std::env::current_exe()?;
+
+        let spawn_child = |row: &str| -> std::process::Child {
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args([
+                "--exact",
+                "session::storage::tests::xproc_writer_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("AOE_FLOCK_XPROC_CHILD", row)
+            .env("AOE_FLOCK_XPROC_BARRIER", &barrier)
+            .env("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            cmd.env("XDG_CONFIG_HOME", temp.path().join(".config"));
+            cmd.stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            cmd.spawn().expect("spawn child")
+        };
+
+        let child_a = spawn_child("a");
+        let child_b = spawn_child("b");
+
+        for (label, mut child) in [("a", child_a), ("b", child_b)] {
+            let status = child.wait()?;
+            assert!(status.success(), "child {label} exited with {status}");
+        }
+
+        let loaded = storage.load()?;
+        let mut titles: Vec<_> = loaded.iter().map(|i| i.title.clone()).collect();
+        titles.sort();
+        assert_eq!(
+            titles,
+            vec!["a".to_string(), "b".to_string()],
+            "cross-process writers lost a row: last-writer-wins clobbered the other"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_file_lock_excludes_concurrent_holder() -> Result<()> {
+        // Focused check on the lock primitive: while one guard is held, a
+        // non-blocking acquisition of the same lock file fails with
+        // `WouldBlock`, and a blocking acquisition succeeds once the first
+        // guard drops.
+        use fs2::FileExt;
+
+        let temp = tempdir()?;
+        let lock_path = temp.path().join("primitive.lock");
+
+        let guard = SessionsFileLock::acquire(&lock_path)?;
+
+        let probe = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let contended = probe.try_lock_exclusive();
+        assert!(
+            matches!(&contended, Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+            "second holder must be blocked while the first guard is alive, got {contended:?}"
+        );
+
+        drop(guard);
+
+        // After the guard drops the lock is free; a fresh blocking acquire
+        // returns immediately.
+        let reacquired = SessionsFileLock::acquire(&lock_path);
+        assert!(
+            reacquired.is_ok(),
+            "lock must be re-acquirable after the guard drops"
         );
         Ok(())
     }

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -41,6 +41,85 @@ fn test_cli_add_and_list() {
     );
 }
 
+/// Concurrent `aoe add` processes must not lose rows.
+///
+/// Before Stage 2, every `aoe add` handler did `load_with_groups()` ->
+/// append -> `Storage::commit()`, a wholesale last-writer-wins overwrite.
+/// Two `aoe add` processes whose load-modify-write windows overlap each
+/// load the same baseline, append their own distinct row, and the second
+/// `commit()` clobbers the first writer's row. The Stage 1 flock alone
+/// does not fix this: it only serialises the writes, the snapshot each
+/// process holds is still stale.
+///
+/// This test seeds one session, then spawns several `aoe add` processes
+/// at once. After they all exit, every seeded and added row must be
+/// present. Red on `commit()`-based handlers, green once they use
+/// `Storage::update()`, which re-loads a fresh snapshot under the lock.
+#[test]
+#[serial]
+fn test_cli_add_concurrent_processes_keep_all_rows() {
+    let h = TuiTestHarness::new("cli_add_concurrent");
+    let project = h.project_path();
+    let project_str = project.to_str().unwrap().to_string();
+
+    // Seed a baseline row so every concurrent `add` loads a non-empty
+    // sessions.json. Without a seed, the very first writer also creates
+    // the file, which slightly narrows the race; the seed makes the
+    // lost-update window deterministic.
+    let seed = h.run_cli(&["add", &project_str, "-t", "seed-session"]);
+    assert!(
+        seed.status.success(),
+        "seed aoe add failed: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    // Several concurrent writers. The race widens with parallelism, so a
+    // handful of overlapping processes reliably drops a row on the
+    // pre-Stage-2 `commit()` path.
+    let worker_count = 6;
+    let titles: Vec<String> = (0..worker_count)
+        .map(|i| format!("concurrent-{i}"))
+        .collect();
+
+    let children: Vec<_> = titles
+        .iter()
+        .map(|title| h.spawn_cli(&["add", &project_str, "-t", title]))
+        .collect();
+
+    for (title, child) in titles.iter().zip(children) {
+        let out = child.wait_with_output().expect("child aoe add did not run");
+        assert!(
+            out.status.success(),
+            "concurrent aoe add for {title} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let present: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["title"].as_str())
+        .collect();
+
+    assert!(
+        present.contains(&"seed-session"),
+        "seed row was clobbered by a concurrent add; present: {present:?}"
+    );
+    for title in &titles {
+        assert!(
+            present.contains(&title.as_str()),
+            "concurrent add row {title} was lost (last-writer-wins clobber); present: {present:?}"
+        );
+    }
+    assert_eq!(
+        sessions.len(),
+        worker_count + 1,
+        "expected seed + {worker_count} concurrent rows; present: {present:?}"
+    );
+}
+
 /// Regression test for #848: `aoe add` "Next steps" hint should reference
 /// the actual binary name (`aoe`), not the long project name.
 #[test]

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1146,3 +1146,107 @@ fn test_cli_add_attaches_to_existing_worktree() {
         Some("feat/existing"),
     );
 }
+
+/// A concurrent `aoe remove` must not lose rows that other processes add
+/// while it runs.
+///
+/// Before Stage 2b, `remove.rs`, `group.rs`, and `worktree.rs` still used
+/// the lossy pattern: `load_with_groups()` -> work -> `commit()`. That load
+/// is unlocked; only the final `commit()` takes the Stage 1 flock. So the
+/// `remove` handler reads its snapshot, then any number of `aoe add`
+/// processes can run a fully locked `Storage::update()` (load fresh,
+/// append, write) before the `remove` handler reaches its `commit()`. That
+/// `commit()` is a wholesale last-writer-wins overwrite of the snapshot the
+/// handler loaded earlier, so every row those adds committed in between is
+/// clobbered. The flock serialises the writes but does nothing for the
+/// staleness of the `remove` handler's snapshot.
+///
+/// This test seeds a victim row, spawns several `aoe add` processes, then
+/// after a short delay spawns one `aoe remove` of the victim. The delay is
+/// tuned so the `remove` handler loads its snapshot before the adds commit
+/// and reaches its own `commit()` after them, the exact interleaving that
+/// loses rows. After all processes exit, the victim must be gone and every
+/// concurrently-added row must survive. Red on the `commit()`-based
+/// `remove` handler (its wholesale write clobbers the racers), green once
+/// it removes the target through `Storage::update()`, which re-loads under
+/// the lock and retains by `Instance.id`.
+#[test]
+#[serial]
+fn test_cli_remove_concurrent_with_add_keeps_all_rows() {
+    let h = TuiTestHarness::new("cli_remove_concurrent");
+    let project = h.project_path();
+    let project_str = project.to_str().unwrap().to_string();
+
+    // Seed the victim row that the concurrent `aoe remove` will delete.
+    let victim = h.run_cli(&["add", &project_str, "-t", "victim-session"]);
+    assert!(
+        victim.status.success(),
+        "seed victim aoe add failed: {}",
+        String::from_utf8_lossy(&victim.stderr)
+    );
+
+    // Several concurrent `aoe add` writers. The race widens with
+    // parallelism, so a handful of overlapping adds reliably bracket the
+    // `remove` handler's load-modify-write window on the pre-Stage-2b
+    // `commit()` path.
+    let worker_count = 6;
+    let titles: Vec<String> = (0..worker_count).map(|i| format!("racer-{i}")).collect();
+
+    // Start the `aoe add` writers first, then spawn `aoe remove` after a
+    // short delay. `aoe add` does heavier pre-write setup than `aoe remove`,
+    // so without the delay the `remove` handler would finish committing
+    // before any add wrote, and there would be no lost update to catch. The
+    // delay lets the adds get close to their commit so the `remove`
+    // handler's snapshot (loaded right after the delay) predates the add
+    // commits while its own `commit()` lands after them. The sleep lives in
+    // the test, never in a handler.
+    let adders: Vec<_> = titles
+        .iter()
+        .map(|title| h.spawn_cli(&["add", &project_str, "-t", title]))
+        .collect();
+    std::thread::sleep(std::time::Duration::from_millis(85));
+    let remover = h.spawn_cli(&["remove", "victim-session"]);
+
+    let remove_out = remover
+        .wait_with_output()
+        .expect("child aoe remove did not run");
+    assert!(
+        remove_out.status.success(),
+        "concurrent aoe remove failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&remove_out.stdout),
+        String::from_utf8_lossy(&remove_out.stderr),
+    );
+
+    for (title, child) in titles.iter().zip(adders) {
+        let out = child.wait_with_output().expect("child aoe add did not run");
+        assert!(
+            out.status.success(),
+            "concurrent aoe add for {title} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let present: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["title"].as_str())
+        .collect();
+
+    assert!(
+        !present.contains(&"victim-session"),
+        "victim row should have been removed; present: {present:?}"
+    );
+    for title in &titles {
+        assert!(
+            present.contains(&title.as_str()),
+            "concurrent add row {title} was lost (remove handler clobbered it); present: {present:?}"
+        );
+    }
+    assert_eq!(
+        sessions.len(),
+        worker_count,
+        "expected {worker_count} racer rows after the victim removal; present: {present:?}"
+    );
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -420,6 +420,25 @@ last_seen_version = "{}"
             .expect("failed to run aoe CLI")
     }
 
+    /// Spawn an `aoe` CLI subcommand without waiting for it to exit, returning
+    /// the `Child` handle. Unlike `run_cli` (which blocks on `.output()`), this
+    /// lets a test launch several `aoe` processes that overlap in time, the
+    /// only way to exercise the cross-process write path from outside the
+    /// crate. Shares the same isolated `HOME` / `PATH` as `run_cli`.
+    pub fn spawn_cli(&self, args: &[&str]) -> std::process::Child {
+        Command::new(&self.binary_path)
+            .args(args)
+            .env("HOME", self.home_dir.path())
+            .env("XDG_CONFIG_HOME", self.home_dir.path().join(".config"))
+            .env("PATH", self.env_path())
+            .env_remove("AGENT_OF_EMPIRES_DEBUG")
+            .env_remove("AOE_LOG_LEVEL")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn aoe CLI")
+    }
+
     /// Path to the isolated home directory for custom test setup.
     pub fn home_path(&self) -> &Path {
         self.home_dir.path()

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -114,15 +114,22 @@ fn test_save_leaves_no_debris() -> Result<()> {
         storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
     }
 
-    // Atomic write should leave only the persisted JSON files in the profile
-    // dir, no .json.bak from the old code path and no leftover tempfiles.
+    // Atomic write should leave only the persisted JSON files plus the
+    // cross-process flock file in the profile dir, no .json.bak from the old
+    // code path and no leftover tempfiles. `sessions.json.lock` is the
+    // advisory lock guarding concurrent writers; it is created on first write
+    // and intentionally persists (the lock lives on the file, not on its
+    // existence), so it is not debris.
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
     let mut entries: Vec<String> = fs::read_dir(&profile_dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     entries.sort();
-    assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+    assert_eq!(
+        entries,
+        vec!["groups.json", "sessions.json", "sessions.json.lock"]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Converts the last five `commit()` sites outside `session.rs`/`add.rs` (group, remove, worktree) to `Storage::update()` (Stage 2b / final CLI cleanup). After this, `grep '\.commit(' src/cli/*.rs` is empty.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — N/A (no UI surface; storage/CLI/TUI-internals only)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (new `test_cli_remove_concurrent_with_add_keeps_all_rows` regression test)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Full design + diagnostic trail at `docs/plans/2026-05-22-aoe-sessions-json-concurrency-design.md` (carried in #1437 for review-locality).

- [x] I am an AI Agent filling out this form (check box if true)

---

Stacks on #1434 and #1435. Review/merge after Stage 2.

## Problem

The Stage 2 survey under-counted: five more `commit()` sites lived outside
`session.rs`/`add.rs`, all equally lossy. `group.rs` (`create_group`,
`delete_group`, `move_session`), `remove.rs` (`run`), and `worktree.rs`
(`cleanup_orphaned`) all kept the `load → work → overwrite` pattern and
would still drop concurrently-added rows.

## Fix

Same playbook as Stage 2: convert each handler to `Storage::update()`.
Existence checks, counts, and lookups move *inside* the closure so they
run against a fresh load.

After this, `grep '\.commit(' src/cli/*.rs`` returns nothing — the CLI is
fully safe.

## Verification

Red-green confirmed: pre-Stage-2b `commit()`-based `remove.rs` loses
5-of-6 concurrently-added rows in
`test_cli_remove_concurrent_with_add_keeps_all_rows`; converted handler
keeps all. Full e2e suite 69/0/2-ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR finishes converting the remaining CLI operations from snapshot-then-commit semantics to atomic Storage::update() updates under a cross-process lock, eliminating the last sources of lost-update data races on sessions.json.

## What changed (high level)

- Converted five CLI handlers to atomic updates:
  - group.rs: create_group, delete_group, move_session
  - remove.rs: run (session removal)
  - worktree.rs: cleanup_orphaned
- Reworked several session lifecycle flows in session.rs and add.rs to:
  - perform slow or side-effectful work (tmux/container actions, hooks) on cloned instances outside the lock
  - persist only lifecycle changes back into the canonical row via update closures
- Storage layer: added per-profile filesystem advisory locking (sessions.json.lock) so update()/commit() hold a cross-process lock during load–modify–write
- New utility and cleanup:
  - Instance::adopt_lifecycle_from() to copy only lifecycle fields when persisting results of external work
  - cleanup_partial_create() to remove orphaned worktrees/workspaces on race-loss or hook failures
- Tests and harness:
  - Added e2e tests that reproduce prior lost-update failures (concurrent add, concurrent remove-with-add)
  - Added spawn_cli helper in the e2e harness
  - Integration test updated to expect persistent lock file

## Benefits

- Stronger data integrity: concurrent CLI writers no longer lose rows; update closures validate against a fresh locked snapshot before writing.
- Smaller, safer writes: handlers now mutate only targeted rows instead of rewriting entire snapshots.
- Safer lifecycle persistence: lifecycle fields are adopted instead of wholesale clobbers, preventing overwriting concurrent user edits.
- Regression coverage: e2e tests exercise the concurrent scenarios that previously failed.

## Potential areas for further improvement

- Consider documenting the lock file semantics and expectations for external tooling in the user/developer docs.
- Extend more targeted unit tests around cleanup_partial_create() and failure paths to assert filesystem cleanup behavior.
- Review any long-running update closures for latency under heavy contention; consider retry/backoff or finer-grained locking if necessary.

## Technical details (concise)

- CLI handlers now follow this pattern:
  1. Load a read-only snapshot with Storage::load() for user-facing resolution and pre-flight checks.
  2. Perform slow side effects (hooks, tmux/container ops) on clones outside the lock.
  3. Call Storage::update() where the closure re-loads the fresh state under an advisory flock, re-validates, mutates only the matching rows (or retains non-target rows), and returns the new snapshot to be written.
- Storage::update()/commit() acquire a per-profile SessionsFileLock (fs2::FileExt flock) for the whole read–modify–write window; sessions.json.lock is now persistent.
- Instance::adopt_lifecycle_from(&mut self, src) copies status, last_accessed_at, idle_entered_at, and agent_session_id to avoid overwriting metadata.
- cleanup_partial_create() centralizes removal of orphaned worktrees/workspaces for both race-loser and hook-failure paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1436?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
