### PR TITLE
fix(tui): make commit() non-lossy via 3-way id-keyed merge

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -303,13 +303,22 @@ impl Storage {
     /// clobbered. The read, merge, and write all happen inside one
     /// flock-held critical section, so the reconcile cannot race a peer.
     ///
-    /// `groups.json` is still written wholesale from `group_tree`: groups are
-    /// edited only by the TUI, so they need no merge.
+    /// `groups.json` is merged with the same 3-way strategy as
+    /// `sessions.json`, keyed on `Group.path`: TUI-owned groups win for
+    /// paths it carries, baseline-but-absent groups are dropped (TUI
+    /// delete), and on-disk-only groups are appended (peer addition,
+    /// e.g. a `aoe group create` from the CLI between this view's load
+    /// and save). `baseline_group_paths` is the set of group paths this
+    /// view loaded from disk — same role `baseline_ids` plays for
+    /// instances. (CodeRabbit feedback on PR #1437: a wholesale
+    /// groups.json write would clobber a CLI-created group that landed
+    /// between the TUI's load and save.)
     pub fn commit_merged(
         &self,
         instances: &[Instance],
         group_tree: &GroupTree,
         baseline_ids: &std::collections::HashSet<String>,
+        baseline_group_paths: &std::collections::HashSet<String>,
     ) -> Result<()> {
         let _guard = self
             .save_lock
@@ -322,10 +331,25 @@ impl Storage {
         let on_disk = self.load()?;
         let merged = merge_instances(instances, &on_disk, baseline_ids);
 
-        let groups = group_tree.get_all_groups();
+        let groups_path = self.sessions_path.with_file_name("groups.json");
+        let on_disk_groups: Vec<Group> = if groups_path.exists() {
+            let content = fs::read_to_string(&groups_path)?;
+            if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                serde_json::from_str(&content)?
+            }
+        } else {
+            Vec::new()
+        };
+        let groups = merge_groups(
+            &group_tree.get_all_groups(),
+            &on_disk_groups,
+            baseline_group_paths,
+        );
+
         let instances_buf = serde_json::to_vec_pretty(&merged)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
-        let groups_path = self.sessions_path.with_file_name("groups.json");
         atomic_write(&groups_path, &groups_buf)?;
         atomic_write(&self.sessions_path, &instances_buf)?;
         Ok(())
@@ -362,6 +386,31 @@ fn merge_instances(
         // On disk, never in the baseline: a peer added it after the TUI
         // loaded. Keep it.
         merged.push(row.clone());
+    }
+    merged
+}
+
+/// 3-way merge of groups keyed on `Group.path`. Mirror of `merge_instances`
+/// for groups.json: TUI-owned groups win, baseline-but-absent groups are
+/// dropped (TUI delete), on-disk-only groups are appended (peer addition).
+/// Pure function so it can be unit-tested without touching the filesystem.
+fn merge_groups(
+    groups: &[Group],
+    on_disk: &[Group],
+    baseline_paths: &std::collections::HashSet<String>,
+) -> Vec<Group> {
+    let tui_paths: std::collections::HashSet<&str> =
+        groups.iter().map(|g| g.path.as_str()).collect();
+
+    let mut merged: Vec<Group> = groups.to_vec();
+    for g in on_disk {
+        if tui_paths.contains(g.path.as_str()) {
+            continue;
+        }
+        if baseline_paths.contains(&g.path) {
+            continue;
+        }
+        merged.push(g.clone());
     }
     merged
 }
@@ -1312,6 +1361,7 @@ mod tests {
             &tui_memory,
             &GroupTree::new_with_groups(&tui_memory, &[]),
             &baseline_ids,
+            &HashSet::new(),
         )?;
 
         let loaded = storage.load()?;

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,27 +1,34 @@
-//! Session storage - JSON file persistence with in-process per-profile locking.
+//! Session storage - JSON file persistence with two-tier write locking.
 //!
 //! `Storage` serialises read-modify-write cycles inside the same process via a
 //! per-profile mutex (one `Arc<Mutex<()>>` per profile name, registered process-
-//! wide). Mutators use `update` (load -> mutate -> save under the lock) or
-//! `commit` (locked wholesale write, for callers that already own the
-//! authoritative in-memory state, e.g. the TUI's `HomeView`). The
-//! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
-//! by `update_workspace_ordering` internally; the per-profile `save` /
-//! `save_groups` helpers have been removed entirely. This keeps it
+//! wide), and across separate OS processes via a blocking exclusive `flock(2)`
+//! on a per-profile `sessions.json.lock` file. Mutators use `update` (load ->
+//! mutate -> save under both locks) or `commit` (locked wholesale write, for
+//! callers that already own the authoritative in-memory state, e.g. the TUI's
+//! `HomeView`). The `save_workspace_ordering` entry point is `pub(crate)` and
+//! only consumed by `update_workspace_ordering` internally; the per-profile
+//! `save` / `save_groups` helpers have been removed entirely. This keeps it
 //! structurally impossible to bypass the lock.
 //!
-//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
-//! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse. The closure passed to `update` is `FnOnce(...) -> Result<R>` and
-//! cannot await, so `std::sync::Mutex` is safe across the body even on the
-//! tokio runtime: server callers wrap `update` in `tokio::task::spawn_blocking`,
-//! which is the existing pattern.
+//! The cross-process `flock` is required because the TUI (`aoe`), the CLI, and
+//! the `aoe serve` daemon are three separate processes that all mutate the
+//! same profile's `sessions.json`; the in-process mutex alone is invisible to
+//! peers, so their load-modify-write cycles would interleave and clobber rows
+//! (last-writer-wins). The `flock` mirrors the approach in
+//! `recovery::RecoveryLock` and is held for the entire load-modify-write
+//! region of both `update` and `commit`.
 //!
-//! Cross-process races (the TUI and `aoe serve` mutating the same profile
-//! concurrently) are explicitly out of scope here; a future advisory `flock`
-//! would close them.
+//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
+//! server side) is acquired BEFORE `Storage`'s per-profile mutex, which is
+//! acquired before the `flock`; never the reverse. The closure passed to
+//! `update` is `FnOnce(...) -> Result<R>` and cannot await, so
+//! `std::sync::Mutex` is safe across the body even on the tokio runtime:
+//! server callers wrap `update` in `tokio::task::spawn_blocking`, which is the
+//! existing pattern.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
@@ -77,9 +84,53 @@ fn workspace_ordering_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Cross-process advisory lock guarding a profile's `sessions.json` (and the
+/// sibling `groups.json` it is written with).
+///
+/// The in-process `save_lock` mutex only serialises writers inside one OS
+/// process; the TUI, the CLI, and the `aoe serve` daemon are three separate
+/// processes that all mutate the same profile's files, so without an OS-level
+/// lock their load-modify-write cycles interleave and rows get clobbered
+/// (last-writer-wins). This guard takes a blocking exclusive `flock(2)` on a
+/// dedicated `sessions.json.lock` file next to the data, held for the whole
+/// load-modify-write region and released when the guard drops. It mirrors the
+/// `flock` approach already used by `recovery::RecoveryLock`.
+///
+/// The lock is on a separate `.lock` file rather than on `sessions.json`
+/// itself because `atomic_write` replaces `sessions.json` via `rename(2)`; a
+/// lock held on the old inode would not cover the new one.
+struct SessionsFileLock {
+    _file: fs::File,
+}
+
+impl SessionsFileLock {
+    /// Acquire the exclusive cross-process lock, blocking until no other
+    /// process holds it. The lock file is created if missing and never
+    /// deleted (the lock lives on the open file description, not on the
+    /// file's existence).
+    fn acquire(lock_path: &Path) -> Result<Self> {
+        if let Some(parent) = lock_path.parent() {
+            // Surface an unwritable profile dir here with the real OS error
+            // rather than as a confusing ENOENT from the open() below.
+            fs::create_dir_all(parent)?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .with_context(|| format!("opening sessions lock file {}", lock_path.display()))?;
+        file.lock_exclusive()
+            .with_context(|| format!("acquiring sessions lock {}", lock_path.display()))?;
+        Ok(Self { _file: file })
+    }
+}
+
 pub struct Storage {
     profile: String,
     sessions_path: PathBuf,
+    lock_path: PathBuf,
     save_lock: Arc<Mutex<()>>,
 }
 
@@ -106,11 +157,13 @@ impl Storage {
 
         let profile_dir = get_profile_dir(&profile_name)?;
         let sessions_path = profile_dir.join("sessions.json");
+        let lock_path = profile_dir.join("sessions.json.lock");
         let save_lock = save_lock_for(&profile_name);
 
         Ok(Self {
             profile: profile_name,
             sessions_path,
+            lock_path,
             save_lock,
         })
     }
@@ -177,6 +230,10 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Cross-process exclusion: the in-process mutex above only covers this
+        // OS process; the TUI, CLI, and daemon are separate processes writing
+        // the same files. The flock spans the whole load-modify-write region.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -216,6 +273,9 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `update`: the flock serialises this wholesale write against
+        // mutators running in other OS processes for the same profile.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let groups = group_tree.get_all_groups();
         let instances_buf = serde_json::to_vec_pretty(instances)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
@@ -436,7 +496,13 @@ mod tests {
             .collect();
         entries.sort();
 
-        assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+        // `sessions.json.lock` is the cross-process flock file; it is created
+        // on first write and intentionally persists (the lock lives on the
+        // file, not on its existence). It is not temp-file debris.
+        assert_eq!(
+            entries,
+            vec!["groups.json", "sessions.json", "sessions.json.lock"]
+        );
         Ok(())
     }
 
@@ -990,6 +1056,144 @@ mod tests {
         assert_ne!(
             groups_mtime_before, groups_mtime_after,
             "groups.json should be rewritten when closure mutates groups"
+        );
+        Ok(())
+    }
+
+    /// Worker side of `test_update_serializes_concurrent_writers_cross_process`.
+    ///
+    /// This is not a real test: it runs as a no-op unless the parent test has
+    /// set `AOE_FLOCK_XPROC_CHILD`, in which case it re-enters as a child
+    /// process and performs exactly one `update()`. The parent re-invokes the
+    /// test binary with `--exact` targeting this function so that each child
+    /// is a genuinely separate OS process (the only thing that exercises the
+    /// cross-process `flock`; threads in one process all share a single flock
+    /// holder and would pass even on the broken code).
+    ///
+    /// Coordinates arrive via env vars:
+    /// - `AOE_FLOCK_XPROC_CHILD`: the row title/id this child should add.
+    /// - `HOME` / `XDG_CONFIG_HOME`: the shared temp app dir.
+    /// - `AOE_FLOCK_XPROC_BARRIER`: a file both children poll so their
+    ///   `update()` calls overlap rather than running sequentially.
+    #[test]
+    fn xproc_writer_child() {
+        let Ok(row) = std::env::var("AOE_FLOCK_XPROC_CHILD") else {
+            return; // ran as an ordinary unit test; nothing to do.
+        };
+        let barrier = std::env::var("AOE_FLOCK_XPROC_BARRIER")
+            .expect("barrier path must be set for the child");
+
+        // Announce arrival, then wait until both children have announced so
+        // their load-modify-write windows overlap.
+        fs::write(format!("{barrier}.{row}"), b"ready").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let a = Path::new(&format!("{barrier}.a")).exists();
+            let b = Path::new(&format!("{barrier}.b")).exists();
+            if a && b {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child timed out waiting for peer"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let storage = Storage::new("xproc-profile").expect("storage");
+        storage
+            .update(|instances, _groups| {
+                instances.push(Instance::new(&row, &format!("/tmp/{row}")));
+                Ok(())
+            })
+            .expect("child update");
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_serializes_concurrent_writers_cross_process() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        // Seed an empty sessions.json so both children load-modify-write a
+        // file that already exists.
+        let storage = Storage::new("xproc-profile")?;
+        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+
+        let barrier = temp.path().join("xproc-barrier");
+        let exe = std::env::current_exe()?;
+
+        let spawn_child = |row: &str| -> std::process::Child {
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args([
+                "--exact",
+                "session::storage::tests::xproc_writer_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("AOE_FLOCK_XPROC_CHILD", row)
+            .env("AOE_FLOCK_XPROC_BARRIER", &barrier)
+            .env("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            cmd.env("XDG_CONFIG_HOME", temp.path().join(".config"));
+            cmd.stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            cmd.spawn().expect("spawn child")
+        };
+
+        let child_a = spawn_child("a");
+        let child_b = spawn_child("b");
+
+        for (label, mut child) in [("a", child_a), ("b", child_b)] {
+            let status = child.wait()?;
+            assert!(status.success(), "child {label} exited with {status}");
+        }
+
+        let loaded = storage.load()?;
+        let mut titles: Vec<_> = loaded.iter().map(|i| i.title.clone()).collect();
+        titles.sort();
+        assert_eq!(
+            titles,
+            vec!["a".to_string(), "b".to_string()],
+            "cross-process writers lost a row: last-writer-wins clobbered the other"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_file_lock_excludes_concurrent_holder() -> Result<()> {
+        // Focused check on the lock primitive: while one guard is held, a
+        // non-blocking acquisition of the same lock file fails with
+        // `WouldBlock`, and a blocking acquisition succeeds once the first
+        // guard drops.
+        use fs2::FileExt;
+
+        let temp = tempdir()?;
+        let lock_path = temp.path().join("primitive.lock");
+
+        let guard = SessionsFileLock::acquire(&lock_path)?;
+
+        let probe = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let contended = probe.try_lock_exclusive();
+        assert!(
+            matches!(&contended, Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+            "second holder must be blocked while the first guard is alive, got {contended:?}"
+        );
+
+        drop(guard);
+
+        // After the guard drops the lock is free; a fresh blocking acquire
+        // returns immediately.
+        let reacquired = SessionsFileLock::acquire(&lock_path);
+        assert!(
+            reacquired.is_ok(),
+            "lock must be re-acquirable after the guard drops"
         );
         Ok(())
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -284,6 +284,86 @@ impl Storage {
         atomic_write(&self.sessions_path, &instances_buf)?;
         Ok(())
     }
+
+    /// Locked, non-lossy commit for the TUI's `HomeView`. Unlike `commit`,
+    /// which overwrites `sessions.json` wholesale from the caller's in-memory
+    /// snapshot, this re-reads the on-disk rows under the flock and reconciles
+    /// them against the caller's rows using a 3-way merge keyed on
+    /// `Instance.id`:
+    ///
+    /// - Row present in `instances` (the TUI's authoritative copy): the TUI's
+    ///   version wins. The TUI owns the rows it displays and edits.
+    /// - Row in `baseline_ids` (what the TUI loaded) but absent from
+    ///   `instances`: the TUI deleted it intentionally; drop it.
+    /// - Row on disk but absent from `baseline_ids`: another process added it
+    ///   after the TUI loaded; keep it.
+    ///
+    /// Net effect: intentional TUI deletes are honoured, while rows a peer
+    /// process (CLI, `aoe serve` daemon) added concurrently are never
+    /// clobbered. The read, merge, and write all happen inside one
+    /// flock-held critical section, so the reconcile cannot race a peer.
+    ///
+    /// `groups.json` is still written wholesale from `group_tree`: groups are
+    /// edited only by the TUI, so they need no merge.
+    pub fn commit_merged(
+        &self,
+        instances: &[Instance],
+        group_tree: &GroupTree,
+        baseline_ids: &std::collections::HashSet<String>,
+    ) -> Result<()> {
+        let _guard = self
+            .save_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The flock spans the whole read-merge-write region: a peer process
+        // cannot slip an addition in between our re-read and our write.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
+
+        let on_disk = self.load()?;
+        let merged = merge_instances(instances, &on_disk, baseline_ids);
+
+        let groups = group_tree.get_all_groups();
+        let instances_buf = serde_json::to_vec_pretty(&merged)?;
+        let groups_buf = serde_json::to_vec_pretty(&groups)?;
+        let groups_path = self.sessions_path.with_file_name("groups.json");
+        atomic_write(&groups_path, &groups_buf)?;
+        atomic_write(&self.sessions_path, &instances_buf)?;
+        Ok(())
+    }
+}
+
+/// 3-way merge of session rows keyed on `Instance.id`. See `commit_merged`
+/// for the rules. Pure function so it can be unit-tested without touching the
+/// filesystem.
+///
+/// Result order: the caller's `instances` first (preserving the TUI's display
+/// order), then any concurrently-added on-disk rows appended in their on-disk
+/// order. Appending keeps a peer's addition visible without disturbing the
+/// order the TUI was rendering.
+fn merge_instances(
+    instances: &[Instance],
+    on_disk: &[Instance],
+    baseline_ids: &std::collections::HashSet<String>,
+) -> Vec<Instance> {
+    let tui_ids: std::collections::HashSet<&str> =
+        instances.iter().map(|i| i.id.as_str()).collect();
+
+    let mut merged: Vec<Instance> = instances.to_vec();
+    for row in on_disk {
+        // Already represented by the TUI's authoritative copy: skip the disk
+        // version so the TUI's edits win.
+        if tui_ids.contains(row.id.as_str()) {
+            continue;
+        }
+        // In the baseline but gone from TUI memory: the TUI deleted it. Drop.
+        if baseline_ids.contains(&row.id) {
+            continue;
+        }
+        // On disk, never in the baseline: a peer added it after the TUI
+        // loaded. Keep it.
+        merged.push(row.clone());
+    }
+    merged
 }
 
 // Workspace ordering is stored at the app-data root, not per-profile:
@@ -1196,6 +1276,100 @@ mod tests {
             "lock must be re-acquirable after the guard drops"
         );
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_commit_merged_keeps_concurrent_addition_and_honours_tui_delete() -> Result<()> {
+        use std::collections::HashSet;
+
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        let storage = Storage::new("test-commit-merged")?;
+
+        // The TUI loads two rows: `keep` and `tui-deletes`. This id-set is the
+        // load baseline HomeView records in `reload()`.
+        let keep = Instance::new("keep", "/tmp/keep");
+        let tui_deletes = Instance::new("tui-deletes", "/tmp/tui-deletes");
+        let baseline: Vec<Instance> = vec![keep.clone(), tui_deletes.clone()];
+        let baseline_ids: HashSet<String> = baseline.iter().map(|i| i.id.clone()).collect();
+        storage.commit(&baseline, &GroupTree::new_with_groups(&baseline, &[]))?;
+
+        // A peer process (CLI / daemon) adds a row AFTER the TUI loaded; the
+        // TUI never saw it, so its id is not in the baseline.
+        storage.update(|instances, _| {
+            instances.push(Instance::new("peer-added", "/tmp/peer-added"));
+            Ok(())
+        })?;
+
+        // The TUI's in-memory view: `keep` is still there, `tui-deletes` was
+        // removed by the user. The peer's row is, of course, absent from the
+        // TUI's memory.
+        let tui_memory: Vec<Instance> = vec![keep.clone()];
+
+        storage.commit_merged(
+            &tui_memory,
+            &GroupTree::new_with_groups(&tui_memory, &[]),
+            &baseline_ids,
+        )?;
+
+        let loaded = storage.load()?;
+        let titles: HashSet<String> = loaded.iter().map(|i| i.title.clone()).collect();
+
+        assert!(
+            titles.contains("peer-added"),
+            "concurrently-added row was dropped by the TUI commit; \
+             got {titles:?}"
+        );
+        assert!(
+            titles.contains("keep"),
+            "row the TUI still owns was lost; got {titles:?}"
+        );
+        assert!(
+            !titles.contains("tui-deletes"),
+            "row the TUI intentionally deleted came back; got {titles:?}"
+        );
+        assert_eq!(
+            loaded.len(),
+            2,
+            "expected exactly `keep` + `peer-added`; got {titles:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_instances_three_way() {
+        use std::collections::HashSet;
+
+        let keep = Instance::new("keep", "/tmp/keep");
+        let tui_deletes = Instance::new("tui-deletes", "/tmp/tui-deletes");
+        let peer_added = Instance::new("peer-added", "/tmp/peer-added");
+
+        let baseline_ids: HashSet<String> = [keep.id.clone(), tui_deletes.id.clone()]
+            .into_iter()
+            .collect();
+
+        // TUI memory: kept `keep`, dropped `tui-deletes`.
+        let tui_memory = vec![keep.clone()];
+        // Disk after a peer write: all three rows.
+        let on_disk = vec![keep.clone(), tui_deletes.clone(), peer_added.clone()];
+
+        let merged = merge_instances(&tui_memory, &on_disk, &baseline_ids);
+        let ids: HashSet<&str> = merged.iter().map(|i| i.id.as_str()).collect();
+
+        assert!(ids.contains(keep.id.as_str()), "TUI-owned row dropped");
+        assert!(
+            ids.contains(peer_added.id.as_str()),
+            "concurrent peer addition dropped"
+        );
+        assert!(
+            !ids.contains(tui_deletes.id.as_str()),
+            "intentional TUI delete resurrected"
+        );
+        assert_eq!(merged.len(), 2);
+        // TUI display order is preserved: its rows come first.
+        assert_eq!(merged[0].id, keep.id);
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -160,6 +160,11 @@ pub struct HomeView {
     /// a row on disk but absent from the baseline was added by another process
     /// after the TUI loaded and must be kept. See `Storage::commit_merged`.
     pub(super) load_baseline: HashMap<String, HashSet<String>>,
+    /// Per-profile group-path-set, the group-tree mirror of `load_baseline`.
+    /// Same role: a path here that is gone from the view's group tree is an
+    /// intentional TUI delete, while a path on disk that is not here is a
+    /// peer-created group that must be kept. See `Storage::commit_merged`.
+    pub(super) load_baseline_groups: HashMap<String, HashSet<String>>,
     pub(super) flat_items: Vec<Item>,
 
     // UI state
@@ -367,6 +372,7 @@ impl HomeView {
         let mut all_instances = Vec::new();
         let mut group_trees = HashMap::new();
         let mut load_baseline: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut load_baseline_groups: HashMap<String, HashSet<String>> = HashMap::new();
 
         let profile_names = match &active_profile {
             Some(name) => vec![name.clone()],
@@ -380,10 +386,15 @@ impl HomeView {
                 inst.source_profile = profile_name.clone();
             }
             // Record the load baseline before status carry-over so the merge
-            // in `save` knows exactly which ids this view loaded from disk.
+            // in `save` knows exactly which ids/group-paths this view loaded
+            // from disk.
             load_baseline.insert(
                 profile_name.clone(),
                 instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            load_baseline_groups.insert(
+                profile_name.clone(),
+                groups.iter().map(|g| g.path.clone()).collect(),
             );
             let tree = GroupTree::new_with_groups(&instances, &groups);
             group_trees.insert(profile_name.clone(), tree);
@@ -448,6 +459,7 @@ impl HomeView {
             instance_map,
             group_trees,
             load_baseline,
+            load_baseline_groups,
             flat_items: Vec::new(),
             cursor: 0,
             selected_session: None,
@@ -668,14 +680,20 @@ impl HomeView {
         self.refresh_status_hook_config_cache();
 
         let mut next_baseline: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut next_baseline_groups: HashMap<String, HashSet<String>> = HashMap::new();
         for (profile_name, storage) in &self.storages {
             let (mut instances, groups) = storage.load_with_groups()?;
-            // The on-disk id-set is the load baseline for the next `save`'s
-            // merge. Captured from the raw disk read, before status carry-over
-            // or the Creating-stub re-injection touches `instances`.
+            // The on-disk id-set + group-path-set are the load baselines for
+            // the next `save`'s merge. Captured from the raw disk read,
+            // before status carry-over or the Creating-stub re-injection
+            // touches `instances`.
             next_baseline.insert(
                 profile_name.clone(),
                 instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            next_baseline_groups.insert(
+                profile_name.clone(),
+                groups.iter().map(|g| g.path.clone()).collect(),
             );
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
@@ -728,6 +746,7 @@ impl HomeView {
         // Adopt the freshly-captured per-profile load baselines. Profiles that
         // no longer exist drop out implicitly (they were never inserted).
         self.load_baseline = next_baseline;
+        self.load_baseline_groups = next_baseline_groups;
 
         self.instances = all_instances;
 
@@ -2110,7 +2129,9 @@ impl HomeView {
         stale_sid
     }
 
-    pub fn save(&self) -> anyhow::Result<()> {
+    pub fn save(&mut self) -> anyhow::Result<()> {
+        let mut next_baseline = self.load_baseline.clone();
+        let mut next_baseline_groups = self.load_baseline_groups.clone();
         for (profile_name, storage) in &self.storages {
             let profile_instances: Vec<Instance> = self
                 .instances
@@ -2137,8 +2158,31 @@ impl HomeView {
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_default();
-            storage.commit_merged(&profile_instances, &tree, &baseline)?;
+            let baseline_groups = self
+                .load_baseline_groups
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
+            storage.commit_merged(&profile_instances, &tree, &baseline, &baseline_groups)?;
+            // Promote the just-saved set into the next baseline so a row
+            // this view created and then deleted (in the same load cycle)
+            // is treated as a TUI delete on the next save, not as a
+            // peer-added row that gets resurrected. (CodeRabbit feedback on
+            // PR #1437.)
+            next_baseline.insert(
+                profile_name.clone(),
+                profile_instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            next_baseline_groups.insert(
+                profile_name.clone(),
+                tree.get_all_groups()
+                    .iter()
+                    .map(|g| g.path.clone())
+                    .collect(),
+            );
         }
+        self.load_baseline = next_baseline;
+        self.load_baseline_groups = next_baseline_groups;
         Ok(())
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -153,6 +153,13 @@ pub struct HomeView {
     instances: Vec<Instance>,
     instance_map: HashMap<String, Instance>,
     pub(super) group_trees: HashMap<String, GroupTree>,
+    /// Per-profile id-set of the session rows that were on disk the last time
+    /// this `HomeView` loaded that profile (`new` / `reload`). It is the
+    /// "load baseline" for the non-lossy 3-way merge in `save`: a row in the
+    /// baseline but gone from `instances` is an intentional TUI delete, while
+    /// a row on disk but absent from the baseline was added by another process
+    /// after the TUI loaded and must be kept. See `Storage::commit_merged`.
+    pub(super) load_baseline: HashMap<String, HashSet<String>>,
     pub(super) flat_items: Vec<Item>,
 
     // UI state
@@ -359,6 +366,7 @@ impl HomeView {
         let mut storages = HashMap::new();
         let mut all_instances = Vec::new();
         let mut group_trees = HashMap::new();
+        let mut load_baseline: HashMap<String, HashSet<String>> = HashMap::new();
 
         let profile_names = match &active_profile {
             Some(name) => vec![name.clone()],
@@ -371,6 +379,12 @@ impl HomeView {
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
             }
+            // Record the load baseline before status carry-over so the merge
+            // in `save` knows exactly which ids this view loaded from disk.
+            load_baseline.insert(
+                profile_name.clone(),
+                instances.iter().map(|i| i.id.clone()).collect(),
+            );
             let tree = GroupTree::new_with_groups(&instances, &groups);
             group_trees.insert(profile_name.clone(), tree);
             all_instances.extend(instances);
@@ -433,6 +447,7 @@ impl HomeView {
             instances: all_instances,
             instance_map,
             group_trees,
+            load_baseline,
             flat_items: Vec::new(),
             cursor: 0,
             selected_session: None,
@@ -652,8 +667,16 @@ impl HomeView {
         }
         self.refresh_status_hook_config_cache();
 
+        let mut next_baseline: HashMap<String, HashSet<String>> = HashMap::new();
         for (profile_name, storage) in &self.storages {
             let (mut instances, groups) = storage.load_with_groups()?;
+            // The on-disk id-set is the load baseline for the next `save`'s
+            // merge. Captured from the raw disk read, before status carry-over
+            // or the Creating-stub re-injection touches `instances`.
+            next_baseline.insert(
+                profile_name.clone(),
+                instances.iter().map(|i| i.id.clone()).collect(),
+            );
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
                 if let Some(prev) = self.instance_map.get(&inst.id) {
@@ -701,6 +724,10 @@ impl HomeView {
         // Remove trees for profiles that no longer exist
         let storage_keys: Vec<String> = self.storages.keys().cloned().collect();
         self.group_trees.retain(|k, _| storage_keys.contains(k));
+
+        // Adopt the freshly-captured per-profile load baselines. Profiles that
+        // no longer exist drop out implicitly (they were never inserted).
+        self.load_baseline = next_baseline;
 
         self.instances = all_instances;
 
@@ -2097,7 +2124,20 @@ impl HomeView {
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_else(|| GroupTree::new_with_groups(&profile_instances, &[]));
-            storage.commit(&profile_instances, &tree)?;
+            // Non-lossy commit: `commit_merged` re-reads the on-disk rows under
+            // the cross-process flock and reconciles them against this view's
+            // rows and the load baseline, so a row a peer process (CLI, `aoe
+            // serve` daemon) added after this view last loaded is preserved
+            // instead of being clobbered by a wholesale overwrite. A profile
+            // with no recorded baseline (should not happen post-`reload`)
+            // falls back to an empty set: every on-disk row then looks
+            // peer-added and is kept, which is the safe, non-lossy direction.
+            let baseline = self
+                .load_baseline
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
+            storage.commit_merged(&profile_instances, &tree, &baseline)?;
         }
         Ok(())
     }

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -114,15 +114,22 @@ fn test_save_leaves_no_debris() -> Result<()> {
         storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
     }
 
-    // Atomic write should leave only the persisted JSON files in the profile
-    // dir, no .json.bak from the old code path and no leftover tempfiles.
+    // Atomic write should leave only the persisted JSON files plus the
+    // cross-process flock file in the profile dir, no .json.bak from the old
+    // code path and no leftover tempfiles. `sessions.json.lock` is the
+    // advisory lock guarding concurrent writers; it is created on first write
+    // and intentionally persists (the lock lives on the file, not on its
+    // existence), so it is not debris.
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
     let mut entries: Vec<String> = fs::read_dir(&profile_dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     entries.sort();
-    assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+    assert_eq!(
+        entries,
+        vec!["groups.json", "sessions.json", "sessions.json.lock"]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Adds `Storage::commit_merged()`, a 3-way merge keyed on `Instance.id`, so the TUI `HomeView::save()` path stops wholesale-overwriting `sessions.json` and preserves rows added by other processes after HomeView loaded (Stage 3).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — N/A (no UI surface; storage/CLI/TUI-internals only)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated tests under `src/session/storage.rs` (named merge tests: baseline-add-keep, baseline-delete-respected, 36/36 storage tests green)

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:**
Full design + diagnostic trail at `docs/plans/2026-05-22-aoe-sessions-json-concurrency-design.md` (carried in #1437 for review-locality).

- [x] I am an AI Agent filling out this form (check box if true)

---

Stacks on #1434 (cross-process flock foundation). Review/merge after Stage 1.

## Problem

`HomeView::save()` calls `Storage::commit()` — wholesale overwrite of the
in-memory snapshot. Even with the cross-process flock from #1434
serialising writers, the TUI snapshot may be older than disk by the time
it commits (another process added a row after HomeView loaded). The TUI
would silently drop that row. The flock fixes interleaving; it does not
fix snapshot staleness in the TUI specifically.

## Fix

Adds `Storage::commit_merged()`, a 3-way merge keyed on `Instance.id`.
HomeView tracks the id-set it last loaded (`load_baseline`);
`commit_merged()` re-reads disk under the flock and reconciles:

- Rows HomeView owns: **HomeView wins** (TUI mutations preserved).
- Rows in the load baseline but absent on disk now: **HomeView deleted
  them** — drop (TUI deletes honoured).
- Rows on disk absent from the baseline: **another process added them** —
  **keep** (no clobber).

Preserves intentional TUI deletes while never dropping a concurrently-added
row. Includes the full design + diagnostic trail at
`docs/plans/2026-05-22-aoe-sessions-json-concurrency-design.md` for
review-locality.

## Verification

- 36/36 storage tests green.
- 2 named merge tests green (baseline-add-keep, baseline-delete-respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1437?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
