### PR TITLE
feat(web): cockpit user-story foundation (mandate + harness + app fixes)

### DIFF
--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -32,9 +32,21 @@ jobs:
             // submitting", which was removed from the template in
             // #1421 but left in this workflow, so every subsequent PR
             // was flagged.
-            const hasChecklist = body.includes('## Checklist') &&
-                                 body.includes('## Test Coverage Analysis') &&
-                                 body.includes('## AI Usage');
+            const hasAllTemplateSections =
+              body.includes('## Checklist') &&
+              body.includes('## Test Coverage Analysis') &&
+              body.includes('## AI Usage');
+
+            // Escape hatch for trusted internal automation: the
+            // nix-npm-hash bot (`.github/workflows/nix-npm-hash.yml`)
+            // emits a body with only `## Checklist` plus a
+            // `<!-- nix-npm-hash: -->` marker. Accept that shape so
+            // the bot's PRs are not auto-flagged + auto-closed.
+            const isNixNpmHashBotPr =
+              body.includes('<!-- nix-npm-hash:') &&
+              body.includes('## Checklist');
+
+            const hasChecklist = hasAllTemplateSections || isNixNpmHashBotPr;
 
             const prNumber = context.payload.pull_request.number;
             const labelName = 'missing-template';

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -40,9 +40,13 @@ jobs:
             // Escape hatch for trusted internal automation: the
             // nix-npm-hash bot (`.github/workflows/nix-npm-hash.yml`)
             // emits a body with only `## Checklist` plus a
-            // `<!-- nix-npm-hash: -->` marker. Accept that shape so
-            // the bot's PRs are not auto-flagged + auto-closed.
+            // `<!-- nix-npm-hash: -->` marker. Gate this on actor
+            // login = github-actions[bot] so a human PR cannot opt
+            // out of template enforcement by dropping the marker
+            // into its body.
+            const actor = context.payload.pull_request.user?.login;
             const isNixNpmHashBotPr =
+              actor === 'github-actions[bot]' &&
               body.includes('<!-- nix-npm-hash:') &&
               body.includes('## Checklist');
 

--- a/.github/workflows/pr-template-check.yml
+++ b/.github/workflows/pr-template-check.yml
@@ -24,10 +24,17 @@ jobs:
           script: |
             const body = context.payload.pull_request.body || '';
 
-            // Check for the checklist section with at least the required item
-            // Match both checked and unchecked boxes: - [ ] or - [x] or - [X]
+            // Check that the three required template sections are all
+            // present. This catches wholesale template stripping without
+            // depending on a single literal checklist line that may be
+            // renamed or removed when the template is updated. The
+            // previous check looked for "I understand the code I am
+            // submitting", which was removed from the template in
+            // #1421 but left in this workflow, so every subsequent PR
+            // was flagged.
             const hasChecklist = body.includes('## Checklist') &&
-                                 body.includes('I understand the code I am submitting');
+                                 body.includes('## Test Coverage Analysis') &&
+                                 body.includes('## AI Usage');
 
             const prNumber = context.payload.pull_request.number;
             const labelName = 'missing-template';

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ When deciding which suite to use:
 
 **Mandate:** any PR that changes a user-facing dashboard flow under auth, wizard / session creation, settings, profiles, sessions / sidebar, right panel / diff / notifications, directory browser, devices, git clone, connectivity, or read-only behavior must update `web/tests/coverage-matrix.json` and add or modify the appropriate test. CI fails on a missing matrix entry via `web/tests/validate-coverage-matrix.mjs`. Pure styling or copy-only changes may add a `kind: "deferred"` entry with a `reason` and a linked issue.
 
+**User-story spec mandate:** any new user-facing dashboard feature MUST land with a user-story Playwright spec that drives the React UI end-to-end (clicks, keystrokes, navigation) and asserts on rendered DOM. Component-level Vitest coverage and REST-contract live specs do not satisfy this requirement; the user-story spec is what catches reducer-to-render plumbing breakage, route gating, and multi-component focus / keyboard handling. Mocked Playwright is acceptable when the flow does not depend on real backend state; otherwise use live Playwright. Tracking issue: #1383.
+
 **Coverage reports.** Vitest uses `@vitest/coverage-v8`; Playwright uses `vite-plugin-istanbul` gated by `AOE_COVERAGE=1`. The merge script (`web/scripts/merge-coverage.mjs`, via `npm run coverage:merge`) feeds both into `monocart-coverage-reports` and writes `web/coverage/merged/` (LCOV + HTML + summary). The CI `coverage` job posts a PR comment with deltas via `davelosert/vitest-coverage-report-action`; baseline is the most recent main-branch artifact.
 
 Full recipe, harness API, and fake-ACP-agent details live in `docs/development/playwright.md`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,8 +89,6 @@ When deciding which suite to use:
 
 **Mandate:** any PR that changes a user-facing dashboard flow under auth, wizard / session creation, settings, profiles, sessions / sidebar, right panel / diff / notifications, directory browser, devices, git clone, connectivity, or read-only behavior must update `web/tests/coverage-matrix.json` and add or modify the appropriate test. CI fails on a missing matrix entry via `web/tests/validate-coverage-matrix.mjs`. Pure styling or copy-only changes may add a `kind: "deferred"` entry with a `reason` and a linked issue.
 
-**User-story spec mandate:** any new user-facing dashboard feature MUST land with a user-story Playwright spec that drives the React UI end-to-end (clicks, keystrokes, navigation) and asserts on rendered DOM. Component-level Vitest coverage and REST-contract live specs do not satisfy this requirement; the user-story spec is what catches reducer-to-render plumbing breakage, route gating, and multi-component focus / keyboard handling. Mocked Playwright is acceptable when the flow does not depend on real backend state; otherwise use live Playwright. Tracking issue: #1383.
-
 **Coverage reports.** Vitest uses `@vitest/coverage-v8`; Playwright uses `vite-plugin-istanbul` gated by `AOE_COVERAGE=1`. The merge script (`web/scripts/merge-coverage.mjs`, via `npm run coverage:merge`) feeds both into `monocart-coverage-reports` and writes `web/coverage/merged/` (LCOV + HTML + summary). The CI `coverage` job posts a PR comment with deltas via `davelosert/vitest-coverage-report-action`; baseline is the most recent main-branch artifact.
 
 Full recipe, harness API, and fake-ACP-agent details live in `docs/development/playwright.md`.

--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -160,8 +160,9 @@ Look up the seeded session by `title` rather than `sessions[0]` so the
 spec stays deterministic if seeding adds more rows later.
 
 Custom per-spec scripts go through a temp file (see
-`cockpit-approval.spec.ts` for the canonical setup); the `serveCockpit`
-fixture is for stories happy with the default chunk-then-stop script.
+`cockpit-stories/approval-allow.spec.ts` or `cockpit-approval.spec.ts`
+for the canonical setup); the `serveCockpit` fixture is for stories
+happy with the default chunk-then-stop script.
 
 ## Coverage matrix
 

--- a/docs/development/playwright.md
+++ b/docs/development/playwright.md
@@ -109,6 +109,60 @@ Script file shape:
 
 Specs that need a custom script call `spawnAoeServe({ cockpit: true, fakeAcpScript: "/tmp/script.json", ... })` directly instead of using the `serveCockpit` fixture.
 
+## Cockpit user-story specs
+
+`web/tests/live/cockpit-stories/` holds UI-driven cockpit specs that
+drive the React surface end-to-end (clicks, keystrokes, navigation) and
+assert on rendered DOM. They complement the REST-contract specs at
+`web/tests/live/cockpit-*.spec.ts`, which assert against
+`/api/sessions/:id/cockpit/replay`. The story specs catch reducer-to-render
+plumbing breakage that the REST tracers cannot see.
+
+Pattern:
+
+```ts
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions, seedSessionViaAoeAdd } from "../../helpers/aoeServe";
+import { enableCockpitAndWait, waitForCockpitView } from "../../helpers/cockpit";
+
+base("send message via Enter renders agent chunk", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story" }),
+  });
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story");
+    if (!seeded) throw new Error("seeded session 'story' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+    await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+    await waitForCockpitView(page);
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("hello");
+    await composer.press("Enter");
+    await expect(page.getByText(/Hello from fake ACP agent/)).toBeVisible();
+  } finally {
+    await serve.stop();
+  }
+});
+```
+
+`enableCockpitAndWait` posts to `/cockpit/enable`, asserts the response
+was 2xx (so a 4xx/5xx surfaces immediately rather than as a noisy
+readiness timeout), and then waits for the supervisor handshake.
+`waitForCockpitView` waits for the React tree to mount the composer.
+Together they ensure both sides are ready before any click or keystroke.
+Look up the seeded session by `title` rather than `sessions[0]` so the
+spec stays deterministic if seeding adds more rows later.
+
+Custom per-spec scripts go through a temp file (see
+`cockpit-approval.spec.ts` for the canonical setup); the `serveCockpit`
+fixture is for stories happy with the default chunk-then-stop script.
+
 ## Coverage matrix
 
 `web/tests/coverage-matrix.json` is the source of truth for "what does each spec cover". Every entry has:

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -812,6 +812,24 @@ fn resolved_cockpit_config(profile: Option<&str>) -> Option<crate::session::conf
     }
 }
 
+/// Deadline for the runner unix socket to appear after spawning the
+/// `aoe __cockpit-runner` shim. 10s is enough in production, but a
+/// debug-build cold-start under heavy CI load (v8 coverage + multiple
+/// parallel `aoe serve` binaries + a runner subprocess that re-execs
+/// the same debug binary) can blow past it deterministically. Honors
+/// `AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS` in debug builds so the
+/// Playwright harness can lift it; release builds keep the original
+/// 10s ceiling.
+fn runner_socket_deadline() -> std::time::Duration {
+    #[cfg(debug_assertions)]
+    if let Ok(raw) = std::env::var("AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS") {
+        if let Ok(ms) = raw.parse::<u64>() {
+            return std::time::Duration::from_millis(ms);
+        }
+    }
+    std::time::Duration::from_secs(10)
+}
+
 /// Read the silent-orphan watchdog grace for the given source profile.
 /// In debug builds, honors `AOE_SILENT_ORPHAN_GRACE_MS` so the
 /// integration test can drive a sub-second cadence without making
@@ -1225,7 +1243,7 @@ impl AcpClient {
         // binds before it spawns the agent so this is usually fast (a
         // few ms) but bound the wait so a wedged runner returns a typed
         // error instead of parking the supervisor.
-        let stream = wait_for_socket(&socket_path, std::time::Duration::from_secs(10)).await?;
+        let stream = wait_for_socket(&socket_path, runner_socket_deadline()).await?;
         let (read_half, write_half) = stream.into_split();
         let transport = ByteStreams::new(write_half.compat_write(), read_half.compat());
 
@@ -1869,6 +1887,18 @@ fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
     const ALWAYS_FORWARD: &[&str] = &[
         "PATH",
         "HOME",
+        // XDG_CONFIG_HOME drives `get_app_dir()` on Linux (see
+        // src/session/mod.rs). Without forwarding, the runner falls
+        // back to `$HOME/.config/agent-of-empires[-dev]`, which
+        // diverges from the daemon when the operator (or live test
+        // harness) has set XDG_CONFIG_HOME to a non-default value.
+        // The runner then writes its WorkerRecord to a path the
+        // daemon never reads, the daemon's `reap_user_stopped`
+        // observes the registry as missing on the next tick, emits
+        // `Stopped { user_stopped }`, and respawns — turning a fine
+        // worker into a respawn loop. See #1383 (CI Linux live
+        // specs under an isolated $XDG_CONFIG_HOME).
+        "XDG_CONFIG_HOME",
         "LANG",
         "LC_ALL",
         "TERM",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1900,7 +1900,7 @@ fn apply_env_filter(cmd: &mut std::process::Command, config: &SpawnConfig) {
         // The runner then writes its WorkerRecord to a path the
         // daemon never reads, the daemon's `reap_user_stopped`
         // observes the registry as missing on the next tick, emits
-        // `Stopped { user_stopped }`, and respawns — turning a fine
+        // `Stopped { user_stopped }`, and respawns, turning a fine
         // worker into a respawn loop. See #1383 (CI Linux live
         // specs under an isolated $XDG_CONFIG_HOME).
         "XDG_CONFIG_HOME",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1986,6 +1986,11 @@ fn spawn_subprocess(config: &SpawnConfig) -> Result<tokio::process::Child, AcpEr
     let always_forward = [
         "PATH",
         "HOME",
+        // Mirror the runner-mode ALWAYS_FORWARD: XDG_CONFIG_HOME drives
+        // `get_app_dir()` on Linux, so the stdio agent must see the
+        // same value the daemon resolved against (otherwise a custom
+        // XDG_CONFIG_HOME diverges between daemon and agent).
+        "XDG_CONFIG_HOME",
         "LANG",
         "LC_ALL",
         "TERM",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -824,7 +824,12 @@ fn runner_socket_deadline() -> std::time::Duration {
     #[cfg(debug_assertions)]
     if let Ok(raw) = std::env::var("AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS") {
         if let Ok(ms) = raw.parse::<u64>() {
-            return std::time::Duration::from_millis(ms);
+            // Clamp to a floor of 100ms so a typo like
+            // `AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS=0` does not make
+            // wait_for_socket fail immediately and surface as a
+            // mysterious "runner socket did not appear" without ever
+            // polling.
+            return std::time::Duration::from_millis(ms.max(100));
         }
     }
     std::time::Duration::from_secs(10)

--- a/web/playwright.live.config.ts
+++ b/web/playwright.live.config.ts
@@ -19,13 +19,24 @@ export default defineConfig({
   // Live specs do real I/O (cargo binary spawn, tmux, fetch). Give them more
   // headroom than the mocked suite's 30s.
   timeout: 60_000,
-  // Four workers on the 4-core GitHub runner. Each worker spawns its
-  // own `aoe serve` against an isolated HOME / TMUX_TMPDIR with a
-  // (workerIndex, parallelIndex)-derived port, so workers don't
-  // collide. Bumped from 2 because the live suite is mostly idle
-  // (waiting on tmux / fetch round-trips) and CPU isn't the bottleneck.
+  // Three workers on the 4-core GitHub runner. Each worker runs a real
+  // chromium, a debug-build `aoe serve`, a tmux instance, and (for
+  // cockpit specs) a fake-ACP node subprocess; with v8 coverage
+  // instrumented, 4 workers reliably starved one of them just long
+  // enough for whichever spec was waiting on a tight turnActive /
+  // WebSocket window to time out. The failing spec rotated across
+  // runs (queue follow-up, stop-during-sub-agent, profile-switch-view,
+  // etc.) because the contention bit a different worker each time, not
+  // because the spec itself was broken: all of those passed locally
+  // under the CI-matching debug+AOE_COVERAGE config at 4 workers in
+  // isolation but flaked when the full suite ran on the GH Actions
+  // runner. 6 → 4 also came from a CI-flake shrink (#1383); this is
+  // the next step on the same axis. Each worker still gets an
+  // isolated HOME / TMUX_TMPDIR and (workerIndex,
+  // parallelIndex)-derived port, so workers don't collide on port or
+  // filesystem.
   fullyParallel: true,
-  workers: 4,
+  workers: 3,
   // No retries: a flaky live spec doubles CI wall time on every flake.
   // Better to surface the flake and fix it (or quarantine via test.skip
   // until fixed) than to mask it with a retry budget.

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -123,7 +123,17 @@ export function SettingsView({
   );
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
-  const [selectedProfile, setSelectedProfile] = useState("default");
+  // Seed empty rather than "default" so the initial
+  // useEffect-gated loadSettings doesn't fire a wasted
+  // fetchSettings("default") against a profile that may not exist.
+  // Once fetchProfiles resolves the seed flips to the real default
+  // profile (e.g. "main") and a single loadSettings fires. The
+  // previous "default" seed caused two fetchSettings calls — one for
+  // the placeholder and one for the resolved name — and the second
+  // setSettings could race ahead of an optimistic user edit and
+  // clobber it. See #1383 (profile-settings-isolation / settings-
+  // tmux-* flakes).
+  const [selectedProfile, setSelectedProfile] = useState("");
   const sidebar = buildSidebar();
   const tabs = sidebar.filter(
     (s): s is { kind: "tab"; id: TabId; label: string } => s.kind === "tab",
@@ -146,6 +156,7 @@ export function SettingsView({
   };
 
   const loadSettings = useCallback(() => {
+    if (!selectedProfile) return;
     fetchSettings(selectedProfile).then((s) => {
       if (s) setSettings(s);
     });

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -128,8 +128,8 @@ export function SettingsView({
   // fetchSettings("default") against a profile that may not exist.
   // Once fetchProfiles resolves the seed flips to the real default
   // profile (e.g. "main") and a single loadSettings fires. The
-  // previous "default" seed caused two fetchSettings calls — one for
-  // the placeholder and one for the resolved name — and the second
+  // previous "default" seed caused two fetchSettings calls (one for
+  // the placeholder and one for the resolved name), and the second
   // setSettings could race ahead of an optimistic user edit and
   // clobber it. See #1383 (profile-settings-isolation / settings-
   // tmux-* flakes).

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -168,6 +168,7 @@ export function SettingsView({
 
   const sendSave = useCallback(
     async (section: string, data: Record<string, unknown>) => {
+      if (!selectedProfile) return;
       setSaving(true);
       setSaveError(null);
       const ok = await updateProfileSettings(selectedProfile, { [section]: data });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -6,7 +6,9 @@
       "id": "dashboard.golden-path",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/golden-path.spec.ts"],
+      "specs": [
+        "tests/live/golden-path.spec.ts"
+      ],
       "components": [
         "web/src/components/Dashboard.tsx",
         "web/src/components/TerminalView.tsx",
@@ -17,35 +19,52 @@
       "id": "auth.no-auth",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/auth-no-auth.spec.ts"],
+      "specs": [
+        "tests/live/auth-no-auth.spec.ts"
+      ],
       "components": []
     },
     {
       "id": "auth.passphrase-login",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/auth-login-passphrase.spec.ts"],
-      "components": ["web/src/components/LoginPage.tsx"]
+      "specs": [
+        "tests/live/auth-login-passphrase.spec.ts"
+      ],
+      "components": [
+        "web/src/components/LoginPage.tsx"
+      ]
     },
     {
       "id": "auth.token-entry",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/auth-token-entry.spec.ts"],
-      "components": ["web/src/components/TokenEntryPage.tsx", "web/src/lib/token.ts"]
+      "specs": [
+        "tests/live/auth-token-entry.spec.ts"
+      ],
+      "components": [
+        "web/src/components/TokenEntryPage.tsx",
+        "web/src/lib/token.ts"
+      ]
     },
     {
       "id": "auth.token-rotation",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/auth-token-rotation.spec.ts"],
-      "components": ["src/server/mod.rs"]
+      "specs": [
+        "tests/live/auth-token-rotation.spec.ts"
+      ],
+      "components": [
+        "src/server/mod.rs"
+      ]
     },
     {
       "id": "settings.theme-persistence",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/settings-persistence-theme.spec.ts"],
+      "specs": [
+        "tests/live/settings-persistence-theme.spec.ts"
+      ],
       "components": [
         "web/src/components/SettingsView.tsx",
         "web/src/components/settings/ThemeSettings.tsx"
@@ -55,42 +74,60 @@
       "id": "settings.sound-payload",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/settings/__tests__/SoundSettings.test.tsx"],
-      "components": ["web/src/components/settings/SoundSettings.tsx"]
+      "specs": [
+        "src/components/settings/__tests__/SoundSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/SoundSettings.tsx"
+      ]
     },
     {
       "id": "settings.update-payload",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/settings/__tests__/UpdateSettings.test.tsx"],
-      "components": ["web/src/components/settings/UpdateSettings.tsx"]
+      "specs": [
+        "src/components/settings/__tests__/UpdateSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/UpdateSettings.tsx"
+      ]
     },
     {
       "id": "settings.tmux-payload",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/settings/__tests__/TmuxSettings.test.tsx"],
-      "components": ["web/src/components/settings/TmuxSettings.tsx"]
+      "specs": [
+        "src/components/settings/__tests__/TmuxSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/TmuxSettings.tsx"
+      ]
     },
     {
       "id": "settings.tmux-persistence",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/settings-persistence-tmux.spec.ts"],
+      "specs": [
+        "tests/live/settings-persistence-tmux.spec.ts"
+      ],
       "components": []
     },
     {
       "id": "settings.theme-payload",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/settings/__tests__/ThemeSettings.test.tsx"],
+      "specs": [
+        "src/components/settings/__tests__/ThemeSettings.test.tsx"
+      ],
       "components": []
     },
     {
       "id": "settings.logging-payload",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/settings/__tests__/LoggingSettings.test.tsx"],
+      "specs": [
+        "src/components/settings/__tests__/LoggingSettings.test.tsx"
+      ],
       "components": [
         "web/src/components/settings/LoggingSettings.tsx",
         "web/src/components/settings/FormFields.tsx"
@@ -100,21 +137,31 @@
       "id": "settings.notifications",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/__tests__/NotificationSettings.test.tsx"],
-      "components": ["web/src/components/NotificationSettings.tsx"]
+      "specs": [
+        "src/components/__tests__/NotificationSettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/NotificationSettings.tsx"
+      ]
     },
     {
       "id": "settings.security-readonly",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/__tests__/SecuritySettings.test.tsx"],
-      "components": ["web/src/components/SecuritySettings.tsx"]
+      "specs": [
+        "src/components/__tests__/SecuritySettings.test.tsx"
+      ],
+      "components": [
+        "web/src/components/SecuritySettings.tsx"
+      ]
     },
     {
       "id": "settings.terminal-localstorage",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/__tests__/TerminalSettings.test.tsx"],
+      "specs": [
+        "src/components/__tests__/TerminalSettings.test.tsx"
+      ],
       "components": [
         "web/src/components/TerminalSettings.tsx",
         "web/src/components/TerminalSessionStack.tsx"
@@ -124,49 +171,67 @@
       "id": "app-shell.topbar-dev-badge",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/__tests__/TopBar.test.tsx"],
-      "components": ["web/src/components/TopBar.tsx"]
+      "specs": [
+        "src/components/__tests__/TopBar.test.tsx"
+      ],
+      "components": [
+        "web/src/components/TopBar.tsx"
+      ]
     },
     {
       "id": "app-shell.routing",
       "kind": "mocked-playwright",
       "risk": "high",
-      "specs": ["tests/routing.spec.ts"],
+      "specs": [
+        "tests/routing.spec.ts"
+      ],
       "components": []
     },
     {
       "id": "app-shell.sessions-loaded-sentinel",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/hooks/useSessions.test.ts"],
+      "specs": [
+        "src/hooks/useSessions.test.ts"
+      ],
       "components": []
     },
     {
       "id": "profiles.lifecycle",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/profile-lifecycle.spec.ts"],
-      "components": ["web/src/components/settings/ProfileSelector.tsx"]
+      "specs": [
+        "tests/live/profile-lifecycle.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ProfileSelector.tsx"
+      ]
     },
     {
       "id": "profiles.override",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/profile-override.spec.ts"],
+      "specs": [
+        "tests/live/profile-override.spec.ts"
+      ],
       "components": []
     },
     {
       "id": "profiles.name-validation",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/settings/__tests__/ProfileSelector.test.tsx"],
+      "specs": [
+        "src/components/settings/__tests__/ProfileSelector.test.tsx"
+      ],
       "components": []
     },
     {
       "id": "profiles.selection-resolve",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/__tests__/SettingsView.test.tsx"],
+      "specs": [
+        "src/components/__tests__/SettingsView.test.tsx"
+      ],
       "components": []
     },
     {
@@ -198,50 +263,76 @@
       "id": "wizard.profile-description",
       "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["tests/wizard-agent-step.spec.ts"],
-      "components": ["web/src/components/session-wizard/steps/AgentStep.tsx"]
+      "specs": [
+        "tests/wizard-agent-step.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/AgentStep.tsx"
+      ]
     },
     {
       "id": "directory-browser",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/directory-browser.spec.ts"],
-      "components": ["web/src/components/DirectoryBrowser.tsx"]
+      "specs": [
+        "tests/live/directory-browser.spec.ts"
+      ],
+      "components": [
+        "web/src/components/DirectoryBrowser.tsx"
+      ]
     },
     {
       "id": "sidebar.groups",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/sidebar-groups.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/live/sidebar-groups.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "sidebar.repo-appearance",
       "kind": "mocked-playwright",
       "risk": "low",
-      "specs": ["tests/sidebar-multi-session.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/sidebar-multi-session.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "sidebar.workspace-ordering",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/workspace-ordering.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/live/workspace-ordering.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "sidebar.client-side-navigation",
       "kind": "mocked-playwright",
       "risk": "medium",
-      "specs": ["tests/sidebar-multi-session.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/sidebar-multi-session.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "sidebar.favorite-indicator",
       "kind": "deferred",
       "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
       "risk": "low",
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "session.lifecycle",
@@ -260,8 +351,12 @@
       "id": "session.delete-dialog-keyboard",
       "kind": "vitest",
       "risk": "low",
-      "specs": ["src/components/__tests__/DeleteSessionDialog.test.tsx"],
-      "components": ["web/src/components/DeleteSessionDialog.tsx"]
+      "specs": [
+        "src/components/__tests__/DeleteSessionDialog.test.tsx"
+      ],
+      "components": [
+        "web/src/components/DeleteSessionDialog.tsx"
+      ]
     },
     {
       "id": "storage.quota-crash-regression",
@@ -320,28 +415,42 @@
       "id": "devices",
       "kind": "live-playwright",
       "risk": "low",
-      "specs": ["tests/live/devices.spec.ts"],
-      "components": ["web/src/components/ConnectedDevices.tsx"]
+      "specs": [
+        "tests/live/devices.spec.ts"
+      ],
+      "components": [
+        "web/src/components/ConnectedDevices.tsx"
+      ]
     },
     {
       "id": "connectivity.disconnect-banner",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/disconnect-banner.spec.ts"],
-      "components": ["web/src/components/DisconnectBanner.tsx"]
+      "specs": [
+        "tests/live/disconnect-banner.spec.ts"
+      ],
+      "components": [
+        "web/src/components/DisconnectBanner.tsx"
+      ]
     },
     {
       "id": "git-clone",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/git-clone.spec.ts"],
-      "components": ["web/src/components/session-wizard/steps/ProjectStep.tsx"]
+      "specs": [
+        "tests/live/git-clone.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
     },
     {
       "id": "cockpit.spawn-prompt",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/cockpit-spawn-prompt.spec.ts"],
+      "specs": [
+        "tests/live/cockpit-spawn-prompt.spec.ts"
+      ],
       "components": [
         "web/src/components/cockpit/CockpitView.tsx",
         "web/src/components/cockpit/CockpitRuntime.tsx",
@@ -355,35 +464,47 @@
       "id": "cockpit.approval",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/cockpit-approval.spec.ts"],
-      "components": ["web/src/components/cockpit/ApprovalCard.tsx"]
+      "specs": [
+        "tests/live/cockpit-approval.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/ApprovalCard.tsx"
+      ]
     },
     {
       "id": "cockpit.force-end-turn-gate",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/__tests__/WorkingSpinner.test.tsx"],
+      "specs": [
+        "src/components/cockpit/__tests__/WorkingSpinner.test.tsx"
+      ],
       "components": []
     },
     {
       "id": "cockpit.escape-no-cancel",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/cockpit-escape-no-cancel.spec.ts"],
+      "specs": [
+        "tests/live/cockpit-escape-no-cancel.spec.ts"
+      ],
       "components": []
     },
     {
       "id": "cockpit.escape-no-cancel-contract",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/Composer.escape.test.tsx"],
+      "specs": [
+        "src/components/cockpit/Composer.escape.test.tsx"
+      ],
       "components": []
     },
     {
       "id": "cockpit.mode-switch",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/cockpit-mode-switch.spec.ts"],
+      "specs": [
+        "tests/live/cockpit-mode-switch.spec.ts"
+      ],
       "components": [
         "web/src/components/cockpit/SwitchSubstrateAction.tsx",
         "web/src/components/cockpit/ContextPrimerBanner.tsx"
@@ -416,7 +537,9 @@
         "src/lib/cockpitTypes.test.ts",
         "src/components/cockpit/RateLimitRecoveryModal.test.tsx"
       ],
-      "components": ["web/src/components/cockpit/RateLimitRecoveryModal.tsx"]
+      "components": [
+        "web/src/components/cockpit/RateLimitRecoveryModal.tsx"
+      ]
     },
     {
       "id": "cockpit.silent-orphan-watchdog",
@@ -432,15 +555,23 @@
       "id": "cockpit.usage-baseline",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/cockpitTypes.test.ts"],
-      "components": ["web/src/lib/cockpitTypes.ts"]
+      "specs": [
+        "src/lib/cockpitTypes.test.ts"
+      ],
+      "components": [
+        "web/src/lib/cockpitTypes.ts"
+      ]
     },
     {
       "id": "cockpit.drafts",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/cockpitDrafts.test.ts"],
-      "components": ["web/src/lib/cockpitDrafts.ts"]
+      "specs": [
+        "src/lib/cockpitDrafts.test.ts"
+      ],
+      "components": [
+        "web/src/lib/cockpitDrafts.ts"
+      ]
     },
     {
       "id": "cockpit.queue-drain-clear-split",
@@ -460,84 +591,130 @@
       "id": "cockpit.files-index",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/useFilesIndex.test.tsx"],
-      "components": ["web/src/components/cockpit/useFilesIndex.ts"]
+      "specs": [
+        "src/components/cockpit/useFilesIndex.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/useFilesIndex.ts"
+      ]
     },
     {
       "id": "cockpit.rattle",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/cockpitRattle.test.ts"],
-      "components": ["web/src/lib/cockpitRattle.ts"]
+      "specs": [
+        "src/lib/cockpitRattle.test.ts"
+      ],
+      "components": [
+        "web/src/lib/cockpitRattle.ts"
+      ]
     },
     {
       "id": "cockpit.args",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/cockpitArgs.test.ts"],
-      "components": ["web/src/lib/cockpitArgs.ts"]
+      "specs": [
+        "src/lib/cockpitArgs.test.ts"
+      ],
+      "components": [
+        "web/src/lib/cockpitArgs.ts"
+      ]
     },
     {
       "id": "cockpit.approval-card",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/cockpit/ApprovalCard.test.tsx"],
-      "components": ["web/src/components/cockpit/ApprovalCard.tsx"]
+      "specs": [
+        "src/components/cockpit/ApprovalCard.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ApprovalCard.tsx"
+      ]
     },
     {
       "id": "cockpit.markdown",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/cockpit/Markdown.test.tsx"],
-      "components": ["web/src/components/cockpit/Markdown.tsx"]
+      "specs": [
+        "src/components/cockpit/Markdown.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/Markdown.tsx"
+      ]
     },
     {
       "id": "cockpit.tool-cards",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/cockpit/ToolCards.render.test.tsx"],
-      "components": ["web/src/components/cockpit/ToolCards.tsx"]
+      "specs": [
+        "src/components/cockpit/ToolCards.render.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ToolCards.tsx"
+      ]
     },
     {
       "id": "cockpit.context-primer-banner",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/ContextPrimerBanner.test.tsx"],
-      "components": ["web/src/components/cockpit/ContextPrimerBanner.tsx"]
+      "specs": [
+        "src/components/cockpit/ContextPrimerBanner.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ContextPrimerBanner.tsx"
+      ]
     },
     {
       "id": "cockpit.switch-substrate-action",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/SwitchSubstrateAction.test.tsx"],
-      "components": ["web/src/components/cockpit/SwitchSubstrateAction.tsx"]
+      "specs": [
+        "src/components/cockpit/SwitchSubstrateAction.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/SwitchSubstrateAction.tsx"
+      ]
     },
     {
       "id": "cockpit.tool-error-body",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/components/cockpit/ToolErrorBody.test.tsx"],
-      "components": ["web/src/components/cockpit/ToolErrorBody.tsx"]
+      "specs": [
+        "src/components/cockpit/ToolErrorBody.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/ToolErrorBody.tsx"
+      ]
     },
     {
       "id": "cockpit.startup-error-screen",
       "kind": "vitest",
       "risk": "high",
-      "specs": ["src/components/cockpit/__tests__/StartupErrorScreen.test.tsx"],
-      "components": ["web/src/components/cockpit/StartupErrorScreen.tsx"]
+      "specs": [
+        "src/components/cockpit/__tests__/StartupErrorScreen.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/StartupErrorScreen.tsx"
+      ]
     },
     {
       "id": "read-only.mode",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/read-only-mode.spec.ts"],
-      "components": ["web/src/components/MobileTerminalToolbar.tsx"]
+      "specs": [
+        "tests/live/read-only-mode.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
     },
     {
       "id": "ensure-session-restart",
       "kind": "live-playwright",
       "risk": "high",
-      "specs": ["tests/live/ensure-session-restart.spec.ts"],
+      "specs": [
+        "tests/live/ensure-session-restart.spec.ts"
+      ],
       "components": []
     },
     {
@@ -556,7 +733,44 @@
       "kind": "deferred",
       "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
       "risk": "low",
-      "components": ["web/src/components/ProjectsView.tsx"]
+      "components": [
+        "web/src/components/ProjectsView.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-tmux-select",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/settings-tmux-select.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/TmuxSettings.tsx",
+        "web/src/components/settings/FormFields.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-tmux-mouse",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/settings-tmux-mouse.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/TmuxSettings.tsx"
+      ]
+    },
+    {
+      "id": "story.profile-settings-isolation",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/profile-settings-isolation.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/ProfileSelector.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -23,7 +23,6 @@ import {
   realpathSync,
   rmSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
@@ -335,7 +334,11 @@ function writeFakeClaudeShim(binDir: string): void {
   chmodSync(path, 0o755);
 }
 
-function writeFakeAcpShim(binDir: string, fakeAcpScript: string | undefined): void {
+function writeFakeAcpShim(
+  binDir: string,
+  fakeAcpScript: string | undefined,
+  fakeAcpDebugLog: string,
+): void {
   // The cockpit supervisor resolves the agent through `AgentRegistry`
   // (src/cockpit/agent_registry.rs): the `claude` tool key maps to
   // command `claude-agent-acp`, not `claude`. `resolve_agent_command`
@@ -343,11 +346,20 @@ function writeFakeAcpShim(binDir: string, fakeAcpScript: string | undefined): vo
   // entry in the shim dir the supervisor falls through to the real
   // installed adapter, which then surfaces "Authentication required"
   // on the first prompt. Shim every name a cockpit test can land on.
+  //
+  // The shim also re-exports diagnostic env vars (FAKE_ACP_SCRIPT,
+  // FAKE_ACP_DEBUG_LOG) so they reach the node child even when the
+  // daemon -> runner spawn chain does not propagate every env from
+  // the parent (observed in CI: seedEnv vars set on `aoe serve` do
+  // not all reach the runner-spawned fake-ACP child, so relying on
+  // process.env in fakeAcpAgent.mjs alone is unreliable).
   const fakeAgentJs = resolve(__dirname, "fakeAcpAgent.mjs");
-  const scriptLine = fakeAcpScript
-    ? `export FAKE_ACP_SCRIPT=${JSON.stringify(fakeAcpScript)}\n`
-    : "";
-  const script = `#!/bin/bash\n${scriptLine}exec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
+  const scriptLines: string[] = [];
+  if (fakeAcpScript) {
+    scriptLines.push(`export FAKE_ACP_SCRIPT=${JSON.stringify(fakeAcpScript)}`);
+  }
+  scriptLines.push(`export FAKE_ACP_DEBUG_LOG=${JSON.stringify(fakeAcpDebugLog)}`);
+  const script = `#!/bin/bash\n${scriptLines.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
   for (const name of ["claude", "claude-agent-acp", "aoe-agent"]) {
     const path = join(binDir, name);
     writeFileSync(path, script);
@@ -416,8 +428,23 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   // and checks `starts_with(dirs::home_dir())`; if HOME is the un-
   // canonicalized form, that check fails on macOS and any browse call
   // against the test's HOME tree returns "outside the home directory".
+  //
+  // Use `/tmp/...` as the base instead of `tmpdir()`. On macOS,
+  // `tmpdir()` resolves to `/private/var/folders/<hash>/T/...` (~95
+  // chars). After we append `/.agent-of-empires-dev/cockpit-workers/
+  // <session_id>.sock` (~60 chars) we blow past the 104-byte
+  // `sun_path` limit on Darwin unix sockets and the runner's
+  // `UnixListener::bind` fails with ENAMETOOLONG. Because the runner
+  // writes its stderr to /dev/null, the failure surfaces as "runner
+  // socket … did not appear within Ns" (the daemon's wait_for_socket
+  // poll never sees a socket appear) instead of a typed bind error.
+  // `/tmp` is a stable, short, world-writable directory on every
+  // supported OS we target; using it caps the path well under
+  // sun_path on Darwin (104) and Linux (108). See macOS sun_path
+  // <sys/un.h>.
+  const shortBase = "/tmp";
   const home = realpathSync(
-    mkdtempSync(join(tmpdir(), `aoe-pw-w${opts.workerIndex}-p${opts.parallelIndex}-`)),
+    mkdtempSync(join(shortBase, `aoe-pw-w${opts.workerIndex}-p${opts.parallelIndex}-`)),
   );
   const xdg = join(home, "config");
   const tmp = join(home, "tmp");
@@ -426,8 +453,9 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   for (const dir of [xdg, tmp, tmuxTmp, shimBin]) {
     mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
+  const fakeAcpDebugLog = join(home, "fake-acp.log");
   if (opts.cockpit) {
-    writeFakeAcpShim(shimBin, opts.fakeAcpScript);
+    writeFakeAcpShim(shimBin, opts.fakeAcpScript, fakeAcpDebugLog);
   } else {
     writeFakeClaudeShim(shimBin);
   }
@@ -441,6 +469,31 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     TMPDIR: tmp,
     TMUX_TMPDIR: tmuxTmp,
     PATH: `${shimBin}:${process.env.PATH ?? ""}`,
+    // Lift the runner-socket appearance deadline. The `aoe
+    // __cockpit-runner` shim re-execs the debug `aoe` binary, which
+    // under v8 coverage + 3 parallel workers + tmux + a fake-ACP node
+    // subprocess can take >10s to bind its unix listener on a
+    // contended runner. The production 10s default in
+    // `runner_socket_deadline()` covers cold caches; tests need
+    // headroom or `cockpit_enable` fails with `runner socket … did
+    // not appear within 10s` (deterministic on slower local + CI
+    // machines, never on hot caches). Honored only in debug builds.
+    AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS: "60000",
+    // FAKE_ACP_DEBUG_LOG is *also* re-exported by the shim itself
+    // (see writeFakeAcpShim) because the daemon -> runner -> node
+    // spawn chain on CI Linux did not propagate this env var from
+    // process.env alone. Keeping it on seedEnv too is harmless and
+    // covers any future caller that bypasses the shim path.
+    FAKE_ACP_DEBUG_LOG: fakeAcpDebugLog,
+    // Daemon log level. AOE_LOG_LEVEL only accepts a single level
+    // string (trace|debug|info|warn|error) — see LogLevel::parse in
+    // src/logging.rs. The default `info` is sufficient for the
+    // post-mortem attachments; `trace` was used briefly to diagnose
+    // the XDG_CONFIG_HOME bug but adds enough I/O pressure on CI to
+    // cause unrelated REST flakes (e.g. settings PATCH failing
+    // under contention and triggering an optimistic-update revert).
+    // Override via process env if a future investigation needs it.
+    AOE_LOG_LEVEL: process.env.AOE_LOG_LEVEL ?? "info",
   };
 
   if (authMode === "token") {

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -23,6 +23,7 @@ import {
   realpathSync,
   rmSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { randomBytes } from "node:crypto";
@@ -444,7 +445,10 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   // supported OS we target; using it caps the path well under
   // sun_path on Darwin (104) and Linux (108). See macOS sun_path
   // <sys/un.h>.
-  const shortBase = "/tmp";
+  // Windows has no `/tmp`; fall back to `tmpdir()` there. `sun_path`
+  // is a POSIX-only limit, so the Darwin short-path workaround does
+  // not apply to win32 either.
+  const shortBase = process.platform === "win32" ? tmpdir() : "/tmp";
   const home = realpathSync(
     mkdtempSync(join(shortBase, `aoe-pw-w${opts.workerIndex}-p${opts.parallelIndex}-`)),
   );

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -357,6 +357,8 @@ function writeFakeAcpShim(
   const scriptLines: string[] = [];
   if (fakeAcpScript) {
     scriptLines.push(`export FAKE_ACP_SCRIPT=${JSON.stringify(fakeAcpScript)}`);
+  } else {
+    scriptLines.push("unset FAKE_ACP_SCRIPT");
   }
   scriptLines.push(`export FAKE_ACP_DEBUG_LOG=${JSON.stringify(fakeAcpDebugLog)}`);
   const script = `#!/bin/bash\n${scriptLines.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -492,7 +492,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
     // covers any future caller that bypasses the shim path.
     FAKE_ACP_DEBUG_LOG: fakeAcpDebugLog,
     // Daemon log level. AOE_LOG_LEVEL only accepts a single level
-    // string (trace|debug|info|warn|error) — see LogLevel::parse in
+    // string (trace|debug|info|warn|error); see LogLevel::parse in
     // src/logging.rs. The default `info` is sufficient for the
     // post-mortem attachments; `trace` was used briefly to diagnose
     // the XDG_CONFIG_HOME bug but adds enough I/O pressure on CI to

--- a/web/tests/helpers/cockpit.ts
+++ b/web/tests/helpers/cockpit.ts
@@ -1,4 +1,30 @@
-import { expect } from "@playwright/test";
+import { expect, type Locator, type Page, type TestInfo } from "@playwright/test";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+/** Best-effort read of the per-test debug.log written by `aoe serve`
+ *  and its child runners. Returns the last `tailBytes` chars or null
+ *  if the file can't be read. Used by enableCockpitAndWait to surface
+ *  supervisor + runner logs in test failure messages, since the
+ *  cockpit/enable endpoint returns 200 even when the background spawn
+ *  task wedges or fails. */
+function readDebugLogTail(
+  home: string | undefined,
+  tailBytes = 8_000,
+): string | null {
+  if (!home) return null;
+  const path = join(home, ".agent-of-empires-dev", "debug.log");
+  if (!existsSync(path)) return null;
+  try {
+    const content = readFileSync(path, "utf8");
+    return content.length > tailBytes
+      ? `... (${content.length - tailBytes} bytes elided)\n` +
+          content.slice(-tailBytes)
+      : content;
+  } catch {
+    return null;
+  }
+}
 
 /**
  * Wait for the cockpit supervisor to be ready to accept prompts after a
@@ -13,30 +39,356 @@ import { expect } from "@playwright/test";
  * `cockpit-spawn-prompt.spec.ts` used to do this with a hardcoded
  * `setTimeout(2_000)` that proved tight under CI load).
  *
- * This helper polls the disk-backed replay endpoint until any frame
- * appears, indicating the supervisor finished its handshake and is
- * emitting events. After this resolves, sending a prompt is safe.
+ * Two-phase wait:
+ *   1. Poll `/cockpit/replay` until any frame appears (proves the
+ *      worker process is up and the supervisor finished `initialize`).
+ *   2. Poll `/api/sessions` until the seeded session reports
+ *      `cockpit_worker_state === "running"` (proves the ACP
+ *      `session/new` handshake completed and the supervisor is ready
+ *      to forward prompts).
+ *
+ * Without phase 2 the React client receives `cockpit_worker_state ===
+ * "resuming"` from the initial `/api/sessions` fetch on navigation,
+ * the `useCockpit` drain effect parks the prompt, and the test races
+ * the next REST poll cycle (a few seconds at best, indefinitely under
+ * CI load) before "Send a message" Enter actually reaches the
+ * supervisor.
  *
  * Default timeout is 15s; the local happy-path completes in well under
  * 1s, so 15s only kicks in on contended CI runners.
  */
+async function fetchReplayFrames(
+  baseUrl: string,
+  sessionId: string,
+): Promise<unknown[]> {
+  const replay = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+  ).then((r) => r.json());
+  if (Array.isArray(replay)) return replay;
+  return (replay?.frames as unknown[]) ?? [];
+}
+
+/** Look for an `AgentStartupError` event in the replay buffer. The
+ *  supervisor publishes this when `cockpit_enable` succeeds but the
+ *  background `supervisor.spawn(...)` task fails (e.g. container ensure
+ *  error, agent process spawn refused, handshake timed out). Phase 1 of
+ *  waitForCockpitReady sees the error frame as "any frame present" and
+ *  resolves, but phase 2 (worker_state === "running") never will.
+ *  Returning the error string here lets the caller throw with the real
+ *  cause instead of timing out on a stale "absent". */
+function findStartupError(frames: unknown[]): string | null {
+  for (const f of frames) {
+    if (typeof f !== "object" || f == null) continue;
+    const event = (f as { event?: unknown }).event;
+    if (event && typeof event === "object" && "AgentStartupError" in event) {
+      const err = (event as { AgentStartupError?: { message?: string } })
+        .AgentStartupError;
+      return err?.message ?? "AgentStartupError (no message)";
+    }
+  }
+  return null;
+}
+
 export async function waitForCockpitReady(
   baseUrl: string,
   sessionId: string,
+  timeoutMs = 30_000,
+  home?: string,
+): Promise<void> {
+  try {
+    await expect
+      .poll(
+        async () => {
+          const frames = await fetchReplayFrames(baseUrl, sessionId);
+          const startupErr = findStartupError(frames);
+          if (startupErr) {
+            throw new Error(
+              `cockpit_enable spawn failed: ${startupErr} ` +
+                `(frames=${frames.length})`,
+            );
+          }
+          return frames.length;
+        },
+        { timeout: timeoutMs, intervals: [100, 200, 200, 200] },
+      )
+      .toBeGreaterThan(0);
+  } catch (err) {
+    const log = readDebugLogTail(home) ?? "(debug.log unavailable)";
+    throw new Error(
+      `waitForCockpitReady phase 1 (replay frames) failed after ${timeoutMs}ms.\n` +
+        `cockpit/enable returned 200 but no event ever reached the replay buffer, ` +
+        `which means the supervisor.spawn task is wedged.\n` +
+        `Original: ${err instanceof Error ? err.message : String(err)}\n` +
+        `--- debug.log tail ---\n${log}\n--- end debug.log ---`,
+    );
+  }
+  // Phase 2: wait for the supervisor to reach "running". On failure
+  // dump everything we can about the session + replay frames so the
+  // root cause is visible without re-running with debug flags.
+  try {
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(`${baseUrl}/api/sessions`);
+          if (!res.ok) return "fetch-failed";
+          const body = await res.json();
+          const sessions: Array<{ id: string; cockpit_worker_state?: string }> =
+            Array.isArray(body) ? body : (body.sessions ?? []);
+          const me = sessions.find((s) => s.id === sessionId);
+          const state = me?.cockpit_worker_state ?? "absent";
+          if (state === "absent") {
+            const frames = await fetchReplayFrames(baseUrl, sessionId);
+            const startupErr = findStartupError(frames);
+            if (startupErr) {
+              throw new Error(
+                `cockpit_enable spawn failed: ${startupErr} ` +
+                  `(frames=${frames.length})`,
+              );
+            }
+          }
+          return state;
+        },
+        { timeout: timeoutMs, intervals: [100, 200, 200, 500, 1000] },
+      )
+      .toBe("running");
+  } catch (err) {
+    // Augment the timeout error with the full replay + sessions
+    // snapshot. expect.poll's default message is just the last polled
+    // value, which makes a "stuck absent" indistinguishable from a
+    // misrouted poll. Surface what the server actually said.
+    const frames = await fetchReplayFrames(baseUrl, sessionId).catch(() => []);
+    const sessionsRes = await fetch(`${baseUrl}/api/sessions`).catch(() => null);
+    const sessionsBody = sessionsRes
+      ? await sessionsRes.json().catch(() => null)
+      : null;
+    const summary = JSON.stringify(
+      {
+        sessionId,
+        sessions: sessionsBody,
+        framesCount: frames.length,
+        firstFrames: frames.slice(0, 5),
+      },
+      null,
+      2,
+    );
+    const log = readDebugLogTail(home) ?? "(debug.log unavailable)";
+    throw new Error(
+      `waitForCockpitReady phase 2 failed: ${err instanceof Error ? err.message : String(err)}\n` +
+        `Diagnostic snapshot:\n${summary}\n` +
+        `--- debug.log tail ---\n${log}\n--- end debug.log ---`,
+    );
+  }
+}
+
+/**
+ * Enable the cockpit supervisor for a session and wait for it to be
+ * ready to accept prompts. Asserts the enable POST succeeded before
+ * polling readiness so a 4xx / 5xx surfaces as an explicit failure
+ * rather than a readiness timeout.
+ */
+export async function enableCockpitAndWait(
+  baseUrl: string,
+  sessionId: string,
+  timeoutMs = 30_000,
+  home?: string,
+): Promise<void> {
+  const res = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+    { method: "POST" },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `cockpit enable failed: status=${res.status} body=${await res.text()}`,
+    );
+  }
+  await waitForCockpitReady(baseUrl, sessionId, timeoutMs, home);
+}
+
+/**
+ * Wait for the cockpit React surface to be mounted and interactive on
+ * the current page. Resolves when the composer textarea is visible.
+ *
+ * `waitForCockpitReady` checks the server-side supervisor handshake via
+ * disk-backed replay; this checks the client side after `page.goto`. UI
+ * story specs need both: the supervisor must be alive (otherwise prompt
+ * sends drop), and the React tree must have mounted CockpitView so
+ * clicks have something to land on.
+ *
+ * Default timeout is 15s, matching `waitForCockpitReady`; the textbox
+ * appears within a few hundred ms on the local happy path. Lazy-loaded
+ * cockpit chunks (`App.tsx` dynamic `import("./components/cockpit/CockpitView")`)
+ * may add a short delay on first navigation.
+ */
+export async function waitForCockpitView(
+  page: Page,
   timeoutMs = 15_000,
 ): Promise<void> {
+  await expect(
+    page.getByRole("textbox", {
+      name: /Send a message|Queue a follow-up/i,
+    }),
+  ).toBeVisible({ timeout: timeoutMs });
+}
+
+/**
+ * Resolve the `<select>` rendered by a FormFields `SelectField` whose
+ * label text matches the given string. SelectField wraps `<label>` and
+ * `<select>` as siblings inside a single `<div>`; the cheapest
+ * unambiguous selector walks from the label up to that wrapper.
+ */
+export function settingsSelectByLabel(page: Page, labelText: string): Locator {
+  return page
+    .locator("label")
+    .filter({ hasText: labelText })
+    .locator("xpath=..")
+    .locator("select")
+    .first();
+}
+
+/**
+ * Resolve the `<input type="number">` rendered by NumberField whose
+ * label text matches the given string. Same structure as
+ * settingsSelectByLabel.
+ */
+export function settingsNumberInputByLabel(page: Page, labelText: string): Locator {
+  return page
+    .locator("label")
+    .filter({ hasText: labelText })
+    .locator("xpath=..")
+    .locator('input[type="number"]')
+    .first();
+}
+
+/** Click a top-level SettingsView tab by its visible label. */
+export async function openSettingsTab(page: Page, label: string): Promise<void> {
+  await page.getByRole("button", { name: label, exact: true }).click();
+}
+
+/**
+ * Wait for SettingsView's mount-time async chain to settle before
+ * interacting with its inputs. The component renders with seed state
+ * `selectedProfile = "default"` and `settings = null`, then fires
+ * `fetchProfiles()` + `loadSettings()` from a useEffect; when
+ * `fetchProfiles` resolves it may flip `selectedProfile` to the real
+ * default profile (e.g. "main"), which retriggers
+ * `loadSettings(<new profile>)`. A test that calls
+ * `selectOption(...)` between the optimistic local update and the
+ * second `setSettings(...)` from the refire sees its choice
+ * clobbered by the refire and the assertion sticks at the original
+ * value (observed in settings-tmux-* specs on slower CI runners).
+ *
+ * The Profile selector lives in the top-level header inside
+ * SettingsView. Waiting for it to expose a non-empty value means
+ * `fetchProfiles` has resolved, `setSelectedProfile(real)` has
+ * applied, and the subsequent `loadSettings(real)` has had a chance
+ * to populate `settings`. Cheaper than polling `/api/profiles`
+ * directly and avoids depending on an internal "loading" flag.
+ */
+export async function waitForSettingsLoaded(page: Page): Promise<void> {
+  const profileSelect = page.locator("select").first();
+  await expect(profileSelect).toBeVisible({ timeout: 10_000 });
   await expect
-    .poll(
-      async () => {
-        const replay = await fetch(
-          `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-        ).then((r) => r.json());
-        const frames: unknown[] = Array.isArray(replay)
-          ? replay
-          : (replay.frames ?? []);
-        return frames.length;
-      },
-      { timeout: timeoutMs, intervals: [100, 200, 200, 200] },
-    )
+    .poll(async () => (await profileSelect.inputValue()).length, {
+      timeout: 10_000,
+    })
     .toBeGreaterThan(0);
+}
+
+/**
+ * Attach diagnostic logs (daemon debug.log + fake-acp.log) to the
+ * Playwright test report when the test failed. Skips attaching on
+ * success to keep the report small.
+ *
+ * Call in the spec's `finally` block, BEFORE `serve.stop()` so the
+ * isolated $HOME tree still exists. The "Cockpit worker stopped"
+ * banner that ate #1383 round 4 is a downstream symptom; the actual
+ * cause (fake-ACP EPIPE, runner SIGTERM, daemon reap, etc.) shows
+ * up in those two logs but vanishes with the home dir.
+ */
+export async function attachServeDiagnostics(
+  testInfo: TestInfo,
+  serve: { home: string },
+): Promise<void> {
+  // Always attach. Both `testInfo.status` and `testInfo.errors` are
+  // populated only AFTER the test function returns and all hooks run;
+  // they are empty/undefined when called from the test body's
+  // `finally`. The cost of always attaching (~few KB on success) is
+  // worth the certainty that diagnostics actually fire on failure.
+  // Playwright's HTML reporter inlines attachments on failed tests
+  // and elides them on passes anyway, so the report size impact is
+  // bounded.
+  // App dir resolution mirrors aoeServe.ts#appDirFor: Linux uses
+  // $XDG_CONFIG_HOME (which the harness sets to `${home}/config`),
+  // macOS/Windows use `${home}/.agent-of-empires-dev`. Probe both so
+  // the diagnostic works on either runner OS without plumbing the
+  // platform through.
+  const candidates = [
+    join(serve.home, "config", "agent-of-empires-dev", "debug.log"),
+    join(serve.home, ".agent-of-empires-dev", "debug.log"),
+  ];
+  const debugLog = candidates.find((p) => existsSync(p));
+  if (debugLog) {
+    try {
+      const content = readFileSync(debugLog, "utf8");
+      const tail =
+        content.length > 64_000
+          ? `... (${content.length - 64_000} bytes elided)\n` +
+            content.slice(-64_000)
+          : content;
+      await testInfo.attach("debug.log", { body: tail, contentType: "text/plain" });
+    } catch (e) {
+      await testInfo.attach("debug.log.read-error", {
+        body: String(e),
+        contentType: "text/plain",
+      });
+    }
+  } else {
+    await testInfo.attach("debug.log.missing", {
+      body: `tried: ${candidates.join("\n       ")}`,
+      contentType: "text/plain",
+    });
+  }
+  const fakeLog = join(serve.home, "fake-acp.log");
+  if (existsSync(fakeLog)) {
+    try {
+      const content = readFileSync(fakeLog, "utf8");
+      await testInfo.attach("fake-acp.log", { body: content, contentType: "text/plain" });
+    } catch (e) {
+      await testInfo.attach("fake-acp.log.read-error", {
+        body: String(e),
+        contentType: "text/plain",
+      });
+    }
+  } else {
+    await testInfo.attach("fake-acp.log.missing", {
+      body: `expected at ${fakeLog}`,
+      contentType: "text/plain",
+    });
+  }
+}
+
+/**
+ * Locator scoped to the active SessionWizard dialog. The wizard renders
+ * a fixed-position overlay that visually covers the sidebar; without
+ * this scope, `getByRole`/`getByText` queries can match background
+ * sidebar / topbar elements behind the overlay.
+ */
+export function wizardScope(page: Page): Locator {
+  return page.locator(
+    'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+  );
+}
+
+/**
+ * Resolve the first text input that sits in the same wrapper `<div>`
+ * as a `<label>` matching the given text. Works for both the wizard's
+ * SessionStep field layout and FormFields TextField.
+ */
+export function inputByLabel(page: Page, labelText: string): Locator {
+  return page
+    .locator("label")
+    .filter({ hasText: labelText })
+    .locator("xpath=..")
+    .locator('input[type="text"]')
+    .first();
 }

--- a/web/tests/helpers/cockpit.ts
+++ b/web/tests/helpers/cockpit.ts
@@ -13,8 +13,16 @@ function readDebugLogTail(
   tailBytes = 8_000,
 ): string | null {
   if (!home) return null;
-  const path = join(home, ".agent-of-empires-dev", "debug.log");
-  if (!existsSync(path)) return null;
+  // Linux: debug.log lives under $XDG_CONFIG_HOME (the harness sets
+  // this to `${home}/config`). macOS/Windows: under
+  // `${home}/.agent-of-empires-dev`. Probe both so the tail surfaces
+  // on whichever OS the test is running.
+  const candidates = [
+    join(home, "config", "agent-of-empires-dev", "debug.log"),
+    join(home, ".agent-of-empires-dev", "debug.log"),
+  ];
+  const path = candidates.find((p) => existsSync(p));
+  if (!path) return null;
   try {
     const content = readFileSync(path, "utf8");
     return content.length > tailBytes

--- a/web/tests/helpers/cockpit.ts
+++ b/web/tests/helpers/cockpit.ts
@@ -293,7 +293,7 @@ export async function openSettingsTab(page: Page, label: string): Promise<void> 
  * directly and avoids depending on an internal "loading" flag.
  */
 export async function waitForSettingsLoaded(page: Page): Promise<void> {
-  const profileSelect = page.locator("select").first();
+  const profileSelect = settingsSelectByLabel(page, "Profile");
   await expect(profileSelect).toBeVisible({ timeout: 10_000 });
   await expect
     .poll(async () => (await profileSelect.inputValue()).length, {

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -76,11 +76,19 @@ process.stdout.on("error", (err) => {
   fakeDebug(`stdout error swallowed: ${err.code ?? err.message}`);
 });
 process.stderr.on("error", () => {});
+// Log the failure cause to fake-acp.log so post-mortems can see why
+// the agent died, then crash-fast. Default Node behavior on
+// uncaughtException is exit(1); merely registering a listener
+// suppresses that, which lets a real bug keep the fake agent
+// half-alive and surface as a confusing supervisor timeout downstream
+// instead of the actual stack trace.
 process.on("uncaughtException", (err) => {
   fakeDebug(`uncaughtException: ${err?.stack ?? err}`);
+  process.exit(1);
 });
 process.on("unhandledRejection", (reason) => {
   fakeDebug(`unhandledRejection: ${reason}`);
+  process.exit(1);
 });
 process.on("exit", (code) => {
   fakeDebug(`process.exit code=${code}`);

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -14,8 +14,12 @@
 //                          `session/request_permission` JSON-RPC
 //                          REQUEST; the fake awaits the client's
 //                          response before continuing the turn.
-//   session/setMode     -> emit current_mode_changed
-//   session/cancel      -> emit stopped { stopReason: "cancelled" }
+//   session/set_mode    -> emit current_mode_update (also accepts the
+//                          legacy camelCase `session/setMode`)
+//   session/cancel      -> notification (no response); sets a per-
+//                          session cancel flag that the in-flight
+//                          session/prompt loop polls so the prompt
+//                          returns with stopReason "cancelled"
 //
 // Script source:
 //
@@ -43,7 +47,59 @@
 // exhausted, subsequent prompts get the default happy-path turn.
 
 import { createInterface } from "node:readline";
-import { readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync, appendFileSync } from "node:fs";
+
+// Silently swallow EPIPE/EBADF on stdout/stderr writes. The fake is a
+// noisy stdout writer (one JSON line per session/update notification);
+// if the supervisor briefly stalls draining the pipe (CI under v8
+// coverage instrumentation has spent ~hundreds of ms behind the
+// runtime worker), a subsequent write can emit EPIPE — without a
+// handler, Node treats that as an uncaught exception and exits the
+// process. The runner sees the child exit, deletes the worker_registry
+// entry, the supervisor's reap pass publishes Stopped {
+// reason: "user_stopped" }, and the UI banners "Cockpit worker
+// stopped" mid-turn. That matched the symptom in #1383 (see Once /
+// upon visible but "a time." never arriving in the composer-streamed
+// trace). Swallowing the error is safe: write failures here mean the
+// peer is gone, and there is no surface in the fake that benefits
+// from observing them.
+const FAKE_DEBUG_PATH = process.env.FAKE_ACP_DEBUG_LOG;
+function fakeDebug(line) {
+  if (!FAKE_DEBUG_PATH) return;
+  try {
+    appendFileSync(FAKE_DEBUG_PATH, `[${Date.now()}] ${line}\n`);
+  } catch {
+    // ignore
+  }
+}
+process.stdout.on("error", (err) => {
+  fakeDebug(`stdout error swallowed: ${err.code ?? err.message}`);
+});
+process.stderr.on("error", () => {});
+process.on("uncaughtException", (err) => {
+  fakeDebug(`uncaughtException: ${err?.stack ?? err}`);
+});
+process.on("unhandledRejection", (reason) => {
+  fakeDebug(`unhandledRejection: ${reason}`);
+});
+process.on("exit", (code) => {
+  fakeDebug(`process.exit code=${code}`);
+});
+process.on("SIGTERM", () => {
+  fakeDebug("SIGTERM received, exiting 0");
+  process.exit(0);
+});
+process.on("SIGINT", () => {
+  fakeDebug("SIGINT received, exiting 0");
+  process.exit(0);
+});
+process.on("SIGPIPE", () => {
+  fakeDebug("SIGPIPE received (ignored)");
+});
+process.on("SIGHUP", () => {
+  fakeDebug("SIGHUP received (ignored)");
+});
+fakeDebug(`fake-acp starting pid=${process.pid} argv=${JSON.stringify(process.argv)}`);
 
 const DEFAULT_TURN = {
   updates: [
@@ -157,8 +213,37 @@ const DEFAULT_PERMISSION_OPTIONS = [
   { optionId: "reject-always", name: "Reject always", kind: "reject_always" },
 ];
 
+// Per-session cancel flags. session/cancel is a notification (no id);
+// the in-flight session/prompt loop polls this flag at each step and
+// short-circuits when set so the prompt returns with stopReason
+// "cancelled" instead of running the rest of the scripted updates.
+const cancelFlags = new Map();
+
 async function emitSessionUpdates(sessionId, updates) {
   for (const u of updates) {
+    if (cancelFlags.get(sessionId)) return;
+    if (u && u.sessionUpdate === "wait_ms") {
+      // Story-spec helper: pause emission inside a turn so the UI
+      // observes the turn as active long enough to click Stop, queue a
+      // follow-up, etc. Not part of ACP; the fake just swallows it.
+      // Clamp the raw value: NaN, Infinity, or negative numbers would
+      // make setTimeout fire immediately or behave unpredictably and
+      // mask bad fixture data. Cap at 60s so a typo can't hang CI.
+      const raw = typeof u.ms === "number" && Number.isFinite(u.ms) ? u.ms : 200;
+      const ms = Math.min(60_000, Math.max(0, Math.floor(raw)));
+      // Sleep in 50ms slices so a cancel notification arriving during
+      // a long wait_ms doesn't have to wait for the full duration
+      // before the cancel flag is observed.
+      const sliceMs = 50;
+      let remaining = ms;
+      while (remaining > 0) {
+        if (cancelFlags.get(sessionId)) return;
+        const slice = Math.min(sliceMs, remaining);
+        await new Promise((resolve) => setTimeout(resolve, slice));
+        remaining -= slice;
+      }
+      continue;
+    }
     if (u && u.sessionUpdate === "permission_request") {
       // ACP carries permissions on a separate JSON-RPC request, not on
       // session/update. Translate the scripted entry into a real
@@ -181,9 +266,12 @@ async function emitSessionUpdates(sessionId, updates) {
       continue;
     }
     sendNotification("session/update", { sessionId, update: u });
-    // Tiny tick between updates so the cockpit reducer can apply each
-    // event in order rather than batching them.
-    await new Promise((resolve) => setTimeout(resolve, 1));
+    // Inter-update tick so the cockpit reducer can apply each event in
+    // order rather than batching them. Bumped from 1ms to 5ms after
+    // CI flakes (#1383): under 6-worker contention on the 4-core CI
+    // runner, a 1ms tick didn't survive the event-loop pressure and
+    // some specs lost the first chunk before the React reducer ran.
+    await new Promise((resolve) => setTimeout(resolve, 5));
   }
 }
 
@@ -216,6 +304,7 @@ const INITIALIZE_RESULT = {
 
 async function handleRequest(msg) {
   const { id, method, params } = msg;
+  fakeDebug(`handleRequest method=${method} id=${id}`);
   if (process.env.FAKE_ACP_DEBUG) {
     try {
       const { appendFileSync } = await import("node:fs");
@@ -239,24 +328,19 @@ async function handleRequest(msg) {
       return;
     }
 
-    case "session/setMode": {
+    case "session/setMode":
+    case "session/set_mode": {
+      // ACP wire method name is `session/set_mode` (snake_case) per
+      // agent-client-protocol-schema. Accept both spellings so a future
+      // rename doesn't silently regress this fake.
       const sessionId = params?.sessionId;
       const modeId = params?.modeId;
       sendResult(id, {});
       if (sessionId && modeId) {
+        // Emit the ACP-correct variant so the supervisor translates to
+        // a server-side Event::CurrentModeChanged for the reducer.
         await emitSessionUpdates(sessionId, [
-          { sessionUpdate: "current_mode_changed", currentModeId: modeId },
-        ]);
-      }
-      return;
-    }
-
-    case "session/cancel": {
-      const sessionId = params?.sessionId;
-      sendResult(id, {});
-      if (sessionId) {
-        await emitSessionUpdates(sessionId, [
-          { sessionUpdate: "stopped", stopReason: "cancelled" },
+          { sessionUpdate: "current_mode_update", currentModeId: modeId },
         ]);
       }
       return;
@@ -265,10 +349,16 @@ async function handleRequest(msg) {
     case "session/prompt": {
       const sessionId = params?.sessionId;
       const turn = nextTurn();
+      // Reset any prior cancel flag so this turn starts clean.
+      if (sessionId) cancelFlags.set(sessionId, false);
       if (sessionId) {
         await emitSessionUpdates(sessionId, turn.updates);
       }
-      sendResult(id, { stopReason: turn.stopReason ?? "end_turn" });
+      const wasCancelled = sessionId ? cancelFlags.get(sessionId) : false;
+      if (sessionId) cancelFlags.set(sessionId, false);
+      sendResult(id, {
+        stopReason: wasCancelled ? "cancelled" : (turn.stopReason ?? "end_turn"),
+      });
       return;
     }
 
@@ -278,7 +368,11 @@ async function handleRequest(msg) {
 }
 
 async function main() {
+  fakeDebug("main() entry");
   const rl = createInterface({ input: process.stdin });
+  process.stdin.on("end", () => fakeDebug("stdin end"));
+  process.stdin.on("close", () => fakeDebug("stdin close"));
+  process.stdin.on("error", (err) => fakeDebug(`stdin error: ${err.code ?? err.message}`));
   rl.on("line", async (line) => {
     const trimmed = line.trim();
     if (!trimmed) return;
@@ -301,21 +395,27 @@ async function main() {
       // session/request_permission). Resolve the awaiting Promise.
       resolveOutbound(msg);
     } else if (msg.method) {
-      // Notification from client (e.g. fs/* response). We don't model
-      // delegated FS/terminal call results; tests that need them script
-      // their turns to avoid triggering tool calls.
-      process.stderr.write(
-        `[fakeAcpAgent] received notification: ${msg.method}\n`,
-      );
+      // Notification from client. session/cancel is the one we model:
+      // per ACP spec it's a notification (no id), and the in-flight
+      // session/prompt MUST be aborted with stopReason="cancelled".
+      // Other notifications (fs/* responses, etc) are ignored; tests
+      // that need them script their turns to avoid triggering tool
+      // calls.
+      if (msg.method === "session/cancel") {
+        const sid = msg.params?.sessionId;
+        if (sid) cancelFlags.set(sid, true);
+      } else {
+        process.stderr.write(
+          `[fakeAcpAgent] received notification: ${msg.method}\n`,
+        );
+      }
     }
   });
 
   rl.on("close", () => {
+    fakeDebug("readline close, exiting 0");
     process.exit(0);
   });
-
-  process.on("SIGTERM", () => process.exit(0));
-  process.on("SIGINT", () => process.exit(0));
 }
 
 main().catch((err) => {

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -53,7 +53,7 @@ import { readFileSync, existsSync, appendFileSync } from "node:fs";
 // noisy stdout writer (one JSON line per session/update notification);
 // if the supervisor briefly stalls draining the pipe (CI under v8
 // coverage instrumentation has spent ~hundreds of ms behind the
-// runtime worker), a subsequent write can emit EPIPE — without a
+// runtime worker), a subsequent write can emit EPIPE; without a
 // handler, Node treats that as an uncaught exception and exits the
 // process. The runner sees the child exit, deletes the worker_registry
 // entry, the supervisor's reap pass publishes Stopped {

--- a/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
+++ b/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
@@ -8,7 +8,11 @@
 
 import { test as base, expect } from "@playwright/test";
 import { spawnAoeServe } from "../../helpers/aoeServe";
-import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+import {
+  openSettingsTab,
+  settingsSelectByLabel,
+  waitForSettingsLoaded,
+} from "../../helpers/cockpit";
 
 base("per-profile settings stay isolated across profile switches", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -19,16 +23,8 @@ base("per-profile settings stay isolated across profile switches", async ({ page
 
   try {
     await page.goto(`${serve.baseUrl}/settings`);
-    const profileSelect = page.locator("select").first();
-    await expect(profileSelect).toBeVisible({ timeout: 10_000 });
-    // Default profile name varies by build (`main` on release, `default`
-    // historically). ProfileSelect renders before its initial fetch
-    // resolves, so inputValue is "" briefly; poll until populated.
-    await expect
-      .poll(async () => (await profileSelect.inputValue()).length, {
-        timeout: 10_000,
-      })
-      .toBeGreaterThan(0);
+    await waitForSettingsLoaded(page);
+    const profileSelect = settingsSelectByLabel(page, "Profile");
     const profileA = await profileSelect.inputValue();
 
     await openSettingsTab(page, "Tmux");

--- a/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
+++ b/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
@@ -1,0 +1,65 @@
+// User story: settings changed on one profile do not bleed into
+// another profile.
+//
+// SettingsView saves via updateProfileSettings(selectedProfile, ...).
+// On profile switch the panel re-fetches and re-renders against the
+// new profile's stored values; profile B should start at the default
+// regardless of edits made under profile A.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+
+base("per-profile settings stay isolated across profile switches", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    const profileSelect = page.locator("select").first();
+    await expect(profileSelect).toBeVisible({ timeout: 10_000 });
+    // Default profile name varies by build (`main` on release, `default`
+    // historically). ProfileSelect renders before its initial fetch
+    // resolves, so inputValue is "" briefly; poll until populated.
+    await expect
+      .poll(async () => (await profileSelect.inputValue()).length, {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(0);
+    const profileA = await profileSelect.inputValue();
+
+    await openSettingsTab(page, "Tmux");
+    const statusBar = settingsSelectByLabel(page, "Status bar");
+    await expect(statusBar).toBeVisible({ timeout: 10_000 });
+
+    // Change tmux status_bar on profile A to "disabled".
+    await statusBar.selectOption("disabled");
+    await expect(statusBar).toHaveValue("disabled");
+
+    // Create profile B and switch to it.
+    await page.getByRole("button", { name: "+ New" }).click();
+    await page.getByPlaceholder("Profile name").fill("isolation-b");
+    await page.getByRole("button", { name: "Create", exact: true }).click();
+    await expect(
+      profileSelect.locator("option", { hasText: "isolation-b" }),
+    ).toHaveCount(1, { timeout: 5_000 });
+    await profileSelect.selectOption("isolation-b");
+    await openSettingsTab(page, "Tmux");
+
+    // Profile B starts fresh; tmux status_bar should be the unset
+    // default ("auto"), not "disabled".
+    const statusBarB = settingsSelectByLabel(page, "Status bar");
+    await expect(statusBarB).toHaveValue("auto", { timeout: 10_000 });
+
+    // Switch back to profile A; the value set above must still hold.
+    await profileSelect.selectOption(profileA);
+    await openSettingsTab(page, "Tmux");
+    const statusBarA = settingsSelectByLabel(page, "Status bar");
+    await expect(statusBarA).toHaveValue("disabled", { timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-tmux-mouse.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-tmux-mouse.spec.ts
@@ -1,0 +1,38 @@
+// User story: change the tmux mouse-support setting and assert it
+// persists across reload.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import {
+  openSettingsTab,
+  settingsSelectByLabel,
+  waitForSettingsLoaded,
+} from "../../helpers/cockpit";
+
+base("tmux mouse SelectField round-trips through the UI", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await waitForSettingsLoaded(page);
+    await openSettingsTab(page, "Tmux");
+
+    const mouse = settingsSelectByLabel(page, "Mouse support");
+    await expect(mouse).toBeVisible({ timeout: 10_000 });
+
+    await mouse.selectOption("disabled");
+    await expect(mouse).toHaveValue("disabled");
+
+    await page.reload();
+    await waitForSettingsLoaded(page);
+    await openSettingsTab(page, "Tmux");
+    const reloaded = settingsSelectByLabel(page, "Mouse support");
+    await expect(reloaded).toHaveValue("disabled", { timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-tmux-select.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-tmux-select.spec.ts
@@ -1,0 +1,38 @@
+// User story: change a tmux setting via the SelectField and confirm
+// the new value persists across a reload.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import {
+  openSettingsTab,
+  settingsSelectByLabel,
+  waitForSettingsLoaded,
+} from "../../helpers/cockpit";
+
+base("tmux status_bar setting select round-trips through the UI", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await waitForSettingsLoaded(page);
+    await openSettingsTab(page, "Tmux");
+
+    const statusBar = settingsSelectByLabel(page, "Status bar");
+    await expect(statusBar).toBeVisible({ timeout: 10_000 });
+
+    await statusBar.selectOption("disabled");
+    await expect(statusBar).toHaveValue("disabled");
+
+    await page.reload();
+    await waitForSettingsLoaded(page);
+    await openSettingsTab(page, "Tmux");
+    const reloaded = settingsSelectByLabel(page, "Status bar");
+    await expect(reloaded).toHaveValue("disabled", { timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
## Description

First in a series of six PRs splitting the cockpit user-story spec rollout for #1383. Lands the foundation everything else depends on.

**App fixes**
- `src/cockpit/acp_client.rs`: forward `XDG_CONFIG_HOME` to the detached runner spawn so daemon and runner agree on `get_app_dir()`. Without it, an isolated `XDG_CONFIG_HOME` (CI live harness, operators with custom configs) caused the runner to write its `WorkerRecord` to a path the daemon never read, triggering a respawn loop. Adds `AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS` (debug-only) so the live test harness can lift the 10s socket-appearance deadline under heavy CI load.
- `web/src/components/SettingsView.tsx`: gate `loadSettings` on a real profile name. Initial state was `"default"`, which fired a wasted `fetchSettings` against a profile that may not exist; once `fetchProfiles` resolved to the real default (e.g. `"main"`), a second `loadSettings` raced ahead of optimistic user edits and clobbered them.

**Test harness**
- `web/tests/helpers/aoeServe.ts`: use `/tmp` as the `HOME` base so the cockpit-workers socket path stays under Darwin's 104-byte `sun_path` limit; export `FAKE_ACP_DEBUG_LOG` via the shim bash so it reaches the node child past env-clear on the runner; honor `AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS`.
- `web/tests/helpers/cockpit.ts`: add `attachServeDiagnostics` (post-mortem `debug.log` + `fake-acp.log` attachment) and `waitForSettingsLoaded`.
- `web/tests/helpers/fakeAcpAgent.mjs`: lifecycle logging (pid/argv, every `handleRequest`, stdin/readline/signal events) and explicit `SIGTERM`/`SIGINT` handlers so CI worker-death failures leave a trail.
- `web/playwright.live.config.ts`: 4 -> 3 workers (v8 coverage + tmux + fake-ACP node child was starving one worker under the 4-worker config, causing rotating flakes).

**Mandate + docs**
- `AGENTS.md`: user-story spec mandate for new user-facing dashboard features.
- `docs/development/playwright.md`: cockpit user-story spec section with pattern and helpers reference.

**Demo specs**
- `settings-tmux-mouse`, `settings-tmux-select`, `profile-settings-isolation` exercise both the SettingsView fix and the new helpers.

Follow-up PRs in this series add the remaining 79 story specs:
- #PR2 wizard (16)
- #PR3 composer + queue (15)
- #PR4 sidebar + shortcut + palette + topbar (17)
- #PR5 settings remainder + profile + projects + modals + misc (17)
- #PR6 mobile + diff + approval + delete + cockpit-mode/plan (15)

Closes part of #1383.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under \`web/tests/\` and updated \`web/tests/coverage-matrix.json\`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Claude handled investigation (CI failure diagnosis, root-cause analysis), test scaffolding, and prose. Idea, decisions, code review, and direction are mine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR introduces the foundation for the Cockpit user‑story rollout: app stability fixes, a hardened Playwright test harness and fake‑ACP agent, documentation + a mandate requiring Playwright user‑story specs, CI/test config tweaks, and three new end‑to‑end demo specs.

### High-Level Overview

- App fixes
  - Forward XDG_CONFIG_HOME into detached runner spawns so daemon and runner use the same app dir.
  - Prevent SettingsView from fetching/saving against an unresolved profile by initializing selection to empty and gating load/save.
  - Make the cockpit runner socket wait configurable in debug via AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS (clamped); release behavior unchanged.

- Test harness & fake agent
  - Use a short tmp root (e.g., /tmp) for per-test HOME on POSIX to avoid macOS unix-socket path-length failures.
  - Shim always exports FAKE_ACP_DEBUG_LOG and unsets FAKE_ACP_SCRIPT when absent; server env is seeded with FAKE_ACP_DEBUG_LOG, AOE_LOG_LEVEL, and honors socket-timeout override.
  - New cockpit helpers implement a two‑phase readiness check (replay frames + worker running), UI sync/locator helpers (e.g., waitForSettingsLoaded, waitForCockpitView), and attachServeDiagnostics to include debug.log and fake-acp.log in test reports.
  - Fake ACP agent gains lifecycle logging, signal handlers, cancellable scripted session updates, broader request/notification handling, and safer timing.
  - Reduce Playwright live workers from 4 → 3 to reduce flakiness under coverage/CI constraints.

- Documentation & mandate
  - AGENTS.md: mandate Playwright user‑story specs for new user‑facing dashboard features (guidance on mocked vs live).
  - docs/development/playwright.md: cockpit user‑story section with pattern, helper responsibilities, and an example test.

- Tests & demos
  - Added three live Playwright specs: settings-tmux-mouse, settings-tmux-select, profile-settings-isolation.
  - coverage-matrix.json updated to include the new story coverage surfaces.

- CI/template tweak
  - PR template check tightened to require three specific headings (## Checklist, ## Test Coverage Analysis, ## AI Usage) with a narrow escape hatch for the automation actor.

## Technical Details (concise)

- src/cockpit/acp_client.rs
  - Replace fixed 10s socket wait with a deadline helper; debug builds read AOE_COCKPIT_RUNNER_SOCKET_TIMEOUT_MS (clamped ≥100ms); always forward XDG_CONFIG_HOME; mirror for in‑proc stdio spawn.

- web/src/components/SettingsView.tsx
  - selectedProfile initialized to "" and loadSettings/sendSave no‑op when empty to avoid premature fetch/save.

- web/tests/helpers/aoeServe.ts
  - writeFakeAcpShim accepts debug-log path and always exports FAKE_ACP_DEBUG_LOG; uses short tmp root for HOME and forwards socket-timeout + log envs to spawned server.

- web/tests/helpers/cockpit.ts
  - Two‑phase readiness with richer failure diagnostics (debug.log tail + fake-acp.log), UI sync/locator helpers, attachServeDiagnostics, and waitForSettingsLoaded.

- web/tests/helpers/fakeAcpAgent.mjs
  - FAKE_ACP_DEBUG_LOG‑gated debug logging, signal handlers, cancellable scripted updates, session/set_mode support, and adjusted inter-update timing.

- web/playwright.live.config.ts & web/tests/coverage-matrix.json
  - Playwright workers lowered 4 → 3; new story entries added to coverage matrix.

- .github/workflows/pr-template-check.yml
  - Template detection requires three headings; escape hatch limited to github-actions[bot] with nix-npm-hash marker.

## Benefits

- Reduces flakiness and platform-specific CI failures (socket path limits, timing races).
- Prevents premature/clobbering settings fetches and accidental optimistic-save races in the UI.
- Improves post‑mortem diagnostics (log attachments) for faster CI triage.
- Establishes an enforceable user‑story testing pattern for future dashboard features.
- Provides reusable harness helpers and a more realistic fake agent to make end‑to‑end specs more reliable.

## Areas for Further Enhancement

- Expand live‑spec coverage to more dashboard flows and edge cases.
- Consider runtime metrics/telemetry for runner socket appearance and retries to aid observability.
- Centralize more automated diagnostics (snapshots, richer logs) to further shorten triage time.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1443?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->