### PR TITLE
test(web): mobile + diff + approval + delete + cockpit-mode user-story specs (#1383)

### DIFF
--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -966,6 +966,175 @@
       "components": [
         "web/src/components/WorkspaceSidebar.tsx"
       ]
+    },
+    {
+      "id": "cockpit.story.approval-allow",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/approval-allow.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/ApprovalCard.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.story.approval-deny",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/approval-deny.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/ApprovalCard.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.story.mode-picker",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/cockpit-mode-picker.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
+      "id": "story.diff-base-picker",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/diff-base-picker.spec.ts"
+      ],
+      "components": [
+        "web/src/components/diff/DiffFileList.tsx"
+      ]
+    },
+    {
+      "id": "story.delete-session-with-worktree",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/delete-session-with-worktree.spec.ts"
+      ],
+      "components": [
+        "web/src/components/DeleteSessionDialog.tsx"
+      ]
+    },
+    {
+      "id": "story.delete-active-session",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/delete-active-session.spec.ts"
+      ],
+      "components": [
+        "web/src/components/DeleteSessionDialog.tsx",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-arrow-up",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-arrow-up.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-tab",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-tab.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-escape",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-escape.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-ctrl-modifier",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-ctrl-modifier.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-ctrl-c",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-ctrl-c.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "story.mobile-toolbar-hidden-on-desktop",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/mobile-toolbar-hidden-on-desktop.spec.ts"
+      ],
+      "components": [
+        "web/src/components/MobileTerminalToolbar.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.story.plan-strip",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/cockpit-plan-strip.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
+    },
+    {
+      "id": "story.diff-viewer-shows-files",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/diff-viewer-shows-files.spec.ts"
+      ],
+      "components": [
+        "web/src/components/diff/DiffFileList.tsx"
+      ]
+    },
+    {
+      "id": "story.diff-hunk-comment",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/diff-hunk-comment.spec.ts"
+      ],
+      "components": [
+        "web/src/components/diff/DiffFileViewer.tsx",
+        "web/src/components/diff/DiffLine.tsx",
+        "web/src/components/diff/comments/CommentForm.tsx",
+        "web/src/components/diff/comments/CommentsBanner.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/live/cockpit-stories/approval-allow.spec.ts
+++ b/web/tests/live/cockpit-stories/approval-allow.spec.ts
@@ -78,12 +78,18 @@ base("ApprovalCard Allow resolves and the turn continues", async ({ page }, test
     });
     await expect(approvalDialog).toBeVisible({ timeout: 10_000 });
 
+    // The fake script gates the post-approval chunk on the user's
+    // Allow click. Prove the gate works by asserting the
+    // post-approval text is absent BEFORE clicking; otherwise this
+    // spec would pass even if the dialog were a no-op and the chunk
+    // emitted unconditionally.
+    const postApprovalChunk = page.getByText("Write complete.");
+    await expect(postApprovalChunk).toHaveCount(0);
+
     await approvalDialog.getByRole("button", { name: "Allow" }).click();
 
     // Fake awaits the decision; once Allow lands, the next chunk emits.
-    await expect(page.getByText("Write complete.")).toBeVisible({
-      timeout: 10_000,
-    });
+    await expect(postApprovalChunk).toBeVisible({ timeout: 10_000 });
     // Approval card is dismissed after resolution.
     await expect(approvalDialog).toBeHidden({ timeout: 10_000 });
   } finally {

--- a/web/tests/live/cockpit-stories/approval-allow.spec.ts
+++ b/web/tests/live/cockpit-stories/approval-allow.spec.ts
@@ -1,0 +1,93 @@
+// User story: clicking Allow on an ApprovalCard resolves the request
+// and the turn continues.
+//
+// Script emits a permission_request mid-turn (the fake translates this
+// into a real session/request_permission JSON-RPC outbound) then a
+// post-approval chunk. The fake awaits the client decision before
+// emitting the second chunk, so seeing the post-approval text in the
+// transcript proves the click round-tripped through the cockpit.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+const ALLOW_SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "About to write a file..." },
+        },
+        {
+          sessionUpdate: "permission_request",
+          toolCall: {
+            toolCallId: "fake-tool-call-allow",
+            title: "Write file",
+            kind: "edit",
+          },
+        },
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Write complete." },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("ApprovalCard Allow resolves and the turn continues", async ({ page }, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-story-allow-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(ALLOW_SCRIPT));
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-allow" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-allow");
+    if (!seeded) throw new Error("seeded session 'story-allow' missing");
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("please write something");
+    await composer.press("Enter");
+
+    const approvalDialog = page.getByRole("alertdialog", {
+      name: /Approval needed/i,
+    });
+    await expect(approvalDialog).toBeVisible({ timeout: 10_000 });
+
+    await approvalDialog.getByRole("button", { name: "Allow" }).click();
+
+    // Fake awaits the decision; once Allow lands, the next chunk emits.
+    await expect(page.getByText("Write complete.")).toBeVisible({
+      timeout: 10_000,
+    });
+    // Approval card is dismissed after resolution.
+    await expect(approvalDialog).toBeHidden({ timeout: 10_000 });
+  } finally {
+    await serve.stop();
+    rmSync(scriptDir, { recursive: true, force: true });
+  }
+});

--- a/web/tests/live/cockpit-stories/approval-deny.spec.ts
+++ b/web/tests/live/cockpit-stories/approval-deny.spec.ts
@@ -1,0 +1,90 @@
+// User story: clicking Deny on an ApprovalCard resolves the request
+// and the turn ends.
+//
+// Script emits a permission_request and then end_turn. After Deny, the
+// fake's session/request_permission promise resolves with the reject
+// decision and the turn finishes with no further chunks. The composer
+// flips back to the idle "Send a message…" placeholder.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+const DENY_SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Asking permission..." },
+        },
+        {
+          sessionUpdate: "permission_request",
+          toolCall: {
+            toolCallId: "fake-tool-call-deny",
+            title: "Delete file",
+            kind: "edit",
+          },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("ApprovalCard Deny resolves and the turn ends", async ({ page }, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-story-deny-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(DENY_SCRIPT));
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-deny" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-deny");
+    if (!seeded) throw new Error("seeded session 'story-deny' missing");
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("please delete something");
+    await composer.press("Enter");
+
+    const approvalDialog = page.getByRole("alertdialog", {
+      name: /Approval needed/i,
+    });
+    await expect(approvalDialog).toBeVisible({ timeout: 10_000 });
+
+    await approvalDialog.getByRole("button", { name: "Deny" }).click();
+
+    await expect(approvalDialog).toBeHidden({ timeout: 10_000 });
+    // Turn ends; idle composer placeholder reappears, Stop button gone.
+    await expect(
+      page.getByRole("textbox", { name: /Send a message/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByRole("button", { name: "Stop" })).toBeHidden({
+      timeout: 10_000,
+    });
+  } finally {
+    await serve.stop();
+    rmSync(scriptDir, { recursive: true, force: true });
+  }
+});

--- a/web/tests/live/cockpit-stories/approval-deny.spec.ts
+++ b/web/tests/live/cockpit-stories/approval-deny.spec.ts
@@ -76,10 +76,14 @@ base("ApprovalCard Deny resolves and the turn ends", async ({ page }, testInfo) 
     await approvalDialog.getByRole("button", { name: "Deny" }).click();
 
     await expect(approvalDialog).toBeHidden({ timeout: 10_000 });
-    // Turn ends; idle composer placeholder reappears, Stop button gone.
-    await expect(
-      page.getByRole("textbox", { name: /Send a message/i }),
-    ).toBeVisible({ timeout: 10_000 });
+    // Turn ends; idle composer reappears, Stop button gone. Asserting
+    // visibility alone is insufficient — the textbox is visible
+    // mid-turn too. Assert enabled (not pending) and cleared (the
+    // post-submit clear ran) so this reliably proves the turn returned
+    // to idle.
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+    await expect(composer).toBeEnabled({ timeout: 10_000 });
+    await expect(composer).toHaveValue("");
     await expect(page.getByRole("button", { name: "Stop" })).toBeHidden({
       timeout: 10_000,
     });

--- a/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
+++ b/web/tests/live/cockpit-stories/cockpit-mode-picker.spec.ts
@@ -1,0 +1,71 @@
+// User story: switch the cockpit's current mode via the ModePicker.
+//
+// ModePicker (Composer.tsx) renders a chip showing the active mode
+// and opens a menu on click; selecting an entry POSTs /cockpit/mode
+// and the fake-ACP emits current_mode_update, which the cockpit
+// reducer applies to flip the chip label.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base("ModePicker switches the cockpit mode", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mode-picker" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mode-picker");
+    if (!seeded) throw new Error("seeded session 'story-mode-picker' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+    // Explicit spawn so the supervisor has an active ACP session
+    // attached before setMode dispatches. Without this, /cockpit/mode
+    // can race the implicit spawn from enable and fail silently.
+    const spawnRes = await fetch(
+      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/spawn`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ agent: "claude" }),
+      },
+    );
+    if (![200, 202, 409].includes(spawnRes.status)) {
+      throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
+    }
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    // ModePicker's trigger shows the current mode label. Default
+    // legacy mode is "Default".
+    const trigger = page
+      .locator("button")
+      .filter({ has: page.locator(":scope > span", { hasText: /^(Default|Plan|Accept|Bypass)$/ }) })
+      .first();
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+    await trigger.click();
+
+    const planMenuItem = page
+      .locator('[role="menu"]')
+      .getByText(/^Plan$/i)
+      .first();
+    await expect(planMenuItem).toBeVisible({ timeout: 5_000 });
+    await planMenuItem.click();
+
+    // The fake-ACP emits current_mode_update on session/set_mode; the
+    // reducer applies that and the trigger label flips.
+    await expect(trigger).toContainText(/Plan/i, { timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/cockpit-plan-strip.spec.ts
+++ b/web/tests/live/cockpit-stories/cockpit-plan-strip.spec.ts
@@ -1,0 +1,85 @@
+// User story: agent-emitted plan updates render in the PlanStrip
+// above the cockpit transcript.
+//
+// ACP's `plan` session update carries `entries: [{ content, status,
+// priority? }]`. The supervisor translates it to PlanUpdated; the
+// reducer applies to state.plan and CockpitView mounts PlanStrip,
+// which shows the first in-progress step's title.
+
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+const PLAN_SCRIPT = {
+  turns: [
+    {
+      updates: [
+        {
+          sessionUpdate: "plan",
+          entries: [
+            { content: "Investigate the bug", status: "in_progress", priority: "high" },
+            { content: "Write a fix", status: "pending", priority: "medium" },
+            { content: "Add tests", status: "pending", priority: "low" },
+          ],
+        },
+        {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Planned." },
+        },
+      ],
+      stopReason: "end_turn",
+    },
+  ],
+};
+
+base("plan session update renders in PlanStrip", async ({ page }, testInfo) => {
+  const scriptDir = mkdtempSync(join(tmpdir(), "aoe-pw-story-plan-"));
+  const scriptPath = join(scriptDir, "script.json");
+  writeFileSync(scriptPath, JSON.stringify(PLAN_SCRIPT));
+
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    fakeAcpScript: scriptPath,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-plan" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-plan");
+    if (!seeded) throw new Error("seeded session 'story-plan' missing");
+    const sessionId = seeded.id;
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    const composer = page.getByRole("textbox", { name: /Send a message/i });
+    await composer.fill("plan this work");
+    await composer.press("Enter");
+
+    // PlanStrip shows the current step (first in-progress entry).
+    // The same title also appears in the expanded list below, so use
+    // `.first()` to scope to the header.
+    await expect(
+      page.getByText("Investigate the bug").first(),
+    ).toBeVisible({ timeout: 15_000 });
+    // Progress label "0/3": zero done, three total. Sidebar session
+    // row also renders the same "0/3" counter, so `.first()` scopes
+    // to the cockpit PlanStrip (which mounts before the sidebar one
+    // updates).
+    await expect(page.getByText("0/3").first()).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await serve.stop();
+    rmSync(scriptDir, { recursive: true, force: true });
+  }
+});

--- a/web/tests/live/cockpit-stories/delete-active-session.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-active-session.spec.ts
@@ -28,7 +28,10 @@ base("deleting the active session falls back to /", async ({ page }, testInfo) =
       timeout: 10_000,
     });
 
-    const row = page.locator('[data-testid="sidebar-session-row"]');
+    const row = page
+      .locator('[data-testid="sidebar-session-row"]')
+      .filter({ hasText: "story-delete-active" })
+      .first();
     await expect(row).toBeVisible({ timeout: 10_000 });
     await row.click({ button: "right" });
     await page.locator('[data-testid="sidebar-context-menu-delete"]').click();

--- a/web/tests/live/cockpit-stories/delete-active-session.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-active-session.spec.ts
@@ -1,0 +1,48 @@
+// User story: delete the session you are currently viewing. The row
+// disappears from the sidebar and the route falls back to the
+// dashboard.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("deleting the active session falls back to /", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-delete-active" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-delete-active");
+    if (!seeded) throw new Error("seeded session 'story-delete-active' missing");
+    const sessionId = seeded.id;
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await expect(page).toHaveURL(new RegExp(`/session/${sessionId}`), {
+      timeout: 10_000,
+    });
+
+    const row = page.locator('[data-testid="sidebar-session-row"]');
+    await expect(row).toBeVisible({ timeout: 10_000 });
+    await row.click({ button: "right" });
+    await page.locator('[data-testid="sidebar-context-menu-delete"]').click();
+
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+
+    await expect(row).toHaveCount(0, { timeout: 10_000 });
+    // After deleting the active session the route should leave the
+    // /session/:id URL.
+    await expect(page).not.toHaveURL(new RegExp(`/session/${sessionId}`), {
+      timeout: 10_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
@@ -65,8 +65,11 @@ base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, 
     const sessionId = seeded.id;
 
     await page.goto(serve.baseUrl);
-    const row = page.locator('[data-testid="sidebar-session-row"]');
-    await expect(row).toContainText("story-delete-wt", { timeout: 10_000 });
+    const row = page
+      .locator('[data-testid="sidebar-session-row"]')
+      .filter({ hasText: "story-delete-wt" })
+      .first();
+    await expect(row).toBeVisible({ timeout: 10_000 });
 
     await row.click({ button: "right" });
     await page.locator('[data-testid="sidebar-context-menu-delete"]').click();

--- a/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
@@ -77,11 +77,16 @@ base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, 
     const worktreeCheckbox = page.locator(
       '[data-testid="delete-session-checkbox-worktree"]',
     );
+    const branchCheckbox = page.locator(
+      '[data-testid="delete-session-checkbox-branch"]',
+    );
     await expect(worktreeCheckbox).toBeVisible({ timeout: 5_000 });
+    await expect(branchCheckbox).toBeVisible({ timeout: 5_000 });
     // Custom Checkbox component renders as a `<label data-checked="...">`,
     // not a native input, so toBeChecked() does not apply. The label
     // attribute is the source of truth.
     await expect(worktreeCheckbox).toHaveAttribute("data-checked", "true");
+    await expect(branchCheckbox).toHaveAttribute("data-checked", "true");
 
     const deletePromise = page.waitForResponse(
       (res) =>
@@ -91,7 +96,9 @@ base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, 
     await dialog.getByRole("button", { name: /^Delete$/ }).click();
     const response = await deletePromise;
     expect(response.ok()).toBeTruthy();
-    expect(response.request().postDataJSON().delete_worktree).toBe(true);
+    const payload = response.request().postDataJSON();
+    expect(payload.delete_worktree).toBe(true);
+    expect(payload.delete_branch).toBe(true);
 
     await expect(row).toHaveCount(0, { timeout: 10_000 });
   } finally {

--- a/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
@@ -85,7 +85,12 @@ base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, 
     // Custom Checkbox component renders as a `<label data-checked="...">`,
     // not a native input, so toBeChecked() does not apply. The label
     // attribute is the source of truth.
+    // Worktree defaults to true via cleanupDefaults; branch defaults
+    // to false. The user story is "opt into deleting BOTH", so click
+    // the branch checkbox to flip it on before submit.
     await expect(worktreeCheckbox).toHaveAttribute("data-checked", "true");
+    await expect(branchCheckbox).toHaveAttribute("data-checked", "false");
+    await branchCheckbox.click();
     await expect(branchCheckbox).toHaveAttribute("data-checked", "true");
 
     const deletePromise = page.waitForResponse(

--- a/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
@@ -1,0 +1,100 @@
+// User story: delete a session that has a managed worktree, opting
+// into "Delete worktree" + "Delete branch".
+//
+// Seeds the session with `aoe add -w new-branch -b` so the
+// DeleteSessionDialog renders its checkbox section. Toggling
+// delete_worktree on and confirming results in a DELETE body with
+// `delete_worktree: true`.
+
+import { mkdirSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../../helpers/aoeServe";
+
+base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      const res = spawnSync(
+        resolveAoeBinary(),
+        [
+          "add",
+          projectDir,
+          "-t",
+          "story-delete-wt",
+          "-c",
+          "claude",
+          "-w",
+          "feature/x",
+          "-b",
+        ],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    },
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-delete-wt");
+    if (!seeded) throw new Error("seeded session 'story-delete-wt' missing");
+    const sessionId = seeded.id;
+
+    await page.goto(serve.baseUrl);
+    const row = page.locator('[data-testid="sidebar-session-row"]');
+    await expect(row).toContainText("story-delete-wt", { timeout: 10_000 });
+
+    await row.click({ button: "right" });
+    await page.locator('[data-testid="sidebar-context-menu-delete"]').click();
+
+    const dialog = page.locator('[data-testid="delete-session-dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    const worktreeCheckbox = page.locator(
+      '[data-testid="delete-session-checkbox-worktree"]',
+    );
+    await expect(worktreeCheckbox).toBeVisible({ timeout: 5_000 });
+    // Custom Checkbox component renders as a `<label data-checked="...">`,
+    // not a native input, so toBeChecked() does not apply. The label
+    // attribute is the source of truth.
+    await expect(worktreeCheckbox).toHaveAttribute("data-checked", "true");
+
+    const deletePromise = page.waitForResponse(
+      (res) =>
+        res.url().endsWith(`/api/sessions/${sessionId}`) &&
+        res.request().method() === "DELETE",
+    );
+    await dialog.getByRole("button", { name: /^Delete$/ }).click();
+    const response = await deletePromise;
+    expect(response.ok()).toBeTruthy();
+    expect(response.request().postDataJSON().delete_worktree).toBe(true);
+
+    await expect(row).toHaveCount(0, { timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
+++ b/web/tests/live/cockpit-stories/delete-session-with-worktree.spec.ts
@@ -90,7 +90,12 @@ base("DeleteSessionDialog can opt into deleting the worktree", async ({ page }, 
     // the branch checkbox to flip it on before submit.
     await expect(worktreeCheckbox).toHaveAttribute("data-checked", "true");
     await expect(branchCheckbox).toHaveAttribute("data-checked", "false");
-    await branchCheckbox.click();
+    // The Checkbox renders as <label> with an inner <span> that owns
+    // the onClick (DeleteSessionDialog.tsx ~line 210). Clicking the
+    // label itself does NOT fire onChange — there is no <input>
+    // associated. Click the first inner span (the colored box) to
+    // flip state.
+    await branchCheckbox.locator("span").first().click();
     await expect(branchCheckbox).toHaveAttribute("data-checked", "true");
 
     const deletePromise = page.waitForResponse(

--- a/web/tests/live/cockpit-stories/diff-base-picker.spec.ts
+++ b/web/tests/live/cockpit-stories/diff-base-picker.spec.ts
@@ -1,0 +1,45 @@
+// User story: open the BasePicker on the diff panel and see the
+// branch-suggestions listbox render.
+//
+// The trigger renders inline next to "Changes" with aria-label "Change
+// diff base (current: <branch>)". Clicking it opens a popover with a
+// search input and a role=listbox of suggestions.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("BasePicker opens the branch suggestions listbox", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-diff-base" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-diff-base");
+    if (!seeded) throw new Error("seeded session 'story-diff-base' missing");
+    const sessionId = seeded.id;
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const trigger = page.getByRole("button", {
+      name: /Change diff base \(current: /i,
+    });
+    await expect(trigger).toBeVisible({ timeout: 10_000 });
+    await trigger.click();
+
+    await expect(page.getByPlaceholder("Search branches...")).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      page.getByRole("listbox", { name: "Branch suggestions" }),
+    ).toBeVisible();
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/diff-hunk-comment.spec.ts
+++ b/web/tests/live/cockpit-stories/diff-hunk-comment.spec.ts
@@ -1,0 +1,108 @@
+// User story: leave a comment on a diff hunk in a cockpit session.
+//
+// Cockpit-enabled session with an uncommitted file: click the file
+// row → DiffFileViewer mounts → hover a line to surface the "+"
+// gutter button → click it → CommentForm appears → write body, save.
+// The persistent CommentsBanner then shows the comment count.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base("comment on a diff hunk persists in the comments banner", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    cockpit: true,
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      writeFileSync(
+        join(projectDir, "story.txt"),
+        "line one\nline two\nline three\n",
+      );
+      const res = spawnSync(
+        resolveAoeBinary(),
+        ["add", projectDir, "-t", "story-hunk-comment", "-c", "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    },
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-hunk-comment");
+    if (!seeded) throw new Error("seeded session 'story-hunk-comment' missing");
+    const sessionId = seeded.id;
+
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await waitForCockpitView(page);
+
+    // Click the diff file row to open the file viewer.
+    const fileRow = page.getByText("story.txt").first();
+    await expect(fileRow).toBeVisible({ timeout: 15_000 });
+    await fileRow.click();
+
+    // "+" gutter buttons live behind `opacity-0 group-hover:opacity-100`
+    // on each diff line, so the click target only paints on hover.
+    // Hover the gutter cell first to reveal the button, then click.
+    // CommentForm uses a two-click range-selection model: first click
+    // sets rangeStart, second click on the same line resolves a single-
+    // line range and mounts the draft form.
+    const addBtn = page.getByRole("button", {
+      name: /Add comment on .* line/i,
+    }).first();
+    await expect(addBtn).toBeAttached({ timeout: 15_000 });
+    // Hover the surrounding diff line to trigger group-hover.
+    const lineRow = addBtn.locator("xpath=ancestor::div[contains(@class,'group')][1]");
+    await lineRow.hover();
+    await expect(addBtn).toBeVisible({ timeout: 5_000 });
+    await addBtn.click(); // sets rangeStart
+    await lineRow.hover(); // re-trigger group-hover after click
+    await addBtn.click(); // resolves single-line range -> draft form mounts
+
+    const composer = page.getByPlaceholder(/Leave a comment/i);
+    await expect(composer).toBeVisible({ timeout: 5_000 });
+    await composer.fill("looks good but rename this");
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    // The CommentsBanner / commentsCount surface should reflect one
+    // saved comment. ContentSplit renders the right pane twice (desktop
+    // `hidden md:flex` + mobile slide-in `md:hidden fixed`), so two
+    // CommentsBanner copies live in the DOM at all viewports. The
+    // desktop copy is the visible one at default Chromium width;
+    // `.first()` resolves to it deterministically and avoids the strict-
+    // mode multi-match.
+    await expect(page.getByText(/1 comment/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/diff-viewer-shows-files.spec.ts
+++ b/web/tests/live/cockpit-stories/diff-viewer-shows-files.spec.ts
@@ -1,0 +1,71 @@
+// User story: a session with uncommitted changes shows the modified
+// file in the diff panel.
+//
+// Seeds a session whose project directory has an extra file beyond
+// the base commit; the dashboard's GET /api/sessions/:id/diff/files
+// returns that file and DiffFileList renders a clickable row.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../../helpers/aoeServe";
+
+base("diff panel renders the changed file row", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, env }) => {
+      const projectDir = join(home, "project");
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+        cwd: projectDir,
+        env: {
+          ...env,
+          GIT_AUTHOR_NAME: "t",
+          GIT_AUTHOR_EMAIL: "t@t",
+          GIT_COMMITTER_NAME: "t",
+          GIT_COMMITTER_EMAIL: "t@t",
+        },
+      });
+      // Untracked file: shows up in the diff against HEAD.
+      writeFileSync(join(projectDir, "story.txt"), "hello story\n");
+      const res = spawnSync(
+        resolveAoeBinary(),
+        ["add", projectDir, "-t", "story-diff-files", "-c", "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    },
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-diff-files");
+    if (!seeded) throw new Error("seeded session 'story-diff-files' missing");
+    const sessionId = seeded.id;
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await expect(page).toHaveURL(new RegExp(`/session/${sessionId}`), {
+      timeout: 10_000,
+    });
+
+    // The diff-file row text appears twice in the DOM (file-list + the
+    // viewer header once selected). `.first()` picks the clickable row.
+    await expect(page.getByText("story.txt").first()).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-arrow-up.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-arrow-up.spec.ts
@@ -1,0 +1,71 @@
+// User story: tapping the Arrow up button on the mobile terminal
+// toolbar sends the ANSI up-arrow escape sequence to the PTY.
+//
+// Patches WebSocket.prototype.send to capture every payload, then
+// decodes the binary frames and asserts the escape "\x1b[A" is in
+// the trace.
+
+import { test as base, expect, devices } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base.use({ ...devices["iPhone 13"] });
+
+base("mobile toolbar Arrow up sends ANSI up-arrow", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mobile-arrow-up" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mobile-arrow-up");
+    if (!seeded) throw new Error("seeded session 'story-mobile-arrow-up' missing");
+    const sessionId = seeded.id;
+
+    await page.addInitScript(() => {
+      const w = window as unknown as { __WS_SENT__: string[] };
+      w.__WS_SENT__ = [];
+      const origSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function (data: BufferSource | string) {
+        try {
+          if (data instanceof ArrayBuffer) {
+            w.__WS_SENT__.push(new TextDecoder().decode(new Uint8Array(data)));
+          } else if (ArrayBuffer.isView(data)) {
+            w.__WS_SENT__.push(
+              new TextDecoder().decode(data as unknown as Uint8Array),
+            );
+          } else if (typeof data === "string") {
+            w.__WS_SENT__.push(data);
+          }
+        } catch {
+          // swallow
+        }
+        return origSend.call(this, data as never);
+      };
+    });
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const arrowUp = page.getByRole("button", { name: "Arrow up" });
+    await expect(arrowUp).toBeVisible({ timeout: 15_000 });
+    await arrowUp.click();
+
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => (window as unknown as { __WS_SENT__: string[] }).__WS_SENT__,
+          ),
+        { timeout: 5_000 },
+      )
+      .toContain("\x1b[A");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-ctrl-c.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-ctrl-c.spec.ts
@@ -1,0 +1,67 @@
+// User story: tapping the ^C button on the mobile terminal toolbar
+// sends ETX (\x03) to the PTY.
+
+import { test as base, expect, devices } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base.use({ ...devices["iPhone 13"] });
+
+base("mobile toolbar Ctrl+C button sends ETX", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mobile-ctrl-c" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mobile-ctrl-c");
+    if (!seeded) throw new Error("seeded session 'story-mobile-ctrl-c' missing");
+    const sessionId = seeded.id;
+
+    await page.addInitScript(() => {
+      const w = window as unknown as { __WS_SENT__: string[] };
+      w.__WS_SENT__ = [];
+      const origSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function (data: BufferSource | string) {
+        try {
+          if (data instanceof ArrayBuffer) {
+            w.__WS_SENT__.push(new TextDecoder().decode(new Uint8Array(data)));
+          } else if (ArrayBuffer.isView(data)) {
+            w.__WS_SENT__.push(
+              new TextDecoder().decode(data as unknown as Uint8Array),
+            );
+          } else if (typeof data === "string") {
+            w.__WS_SENT__.push(data);
+          }
+        } catch {
+          // swallow
+        }
+        return origSend.call(this, data as never);
+      };
+    });
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const ctrlC = page.getByRole("button", { name: "Ctrl+C interrupt" });
+    await expect(ctrlC).toBeVisible({ timeout: 15_000 });
+    await ctrlC.click();
+
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => (window as unknown as { __WS_SENT__: string[] }).__WS_SENT__,
+          ),
+        { timeout: 5_000 },
+      )
+      .toContain("\x03");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-ctrl-modifier.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-ctrl-modifier.spec.ts
@@ -1,0 +1,46 @@
+// User story: the Ctrl toggle on the mobile terminal toolbar latches
+// the modifier so the next keystroke combines with Ctrl.
+//
+// Tapping Ctrl flips aria-pressed to "true"; tapping again flips it
+// back. This story covers the latch UI only; the modifier-applied
+// keystroke is handled by the terminal helper textarea and is
+// exercised separately by the Ctrl+C interrupt story.
+
+import { test as base, expect, devices } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base.use({ ...devices["iPhone 13"] });
+
+base("mobile toolbar Ctrl button latches and unlatches", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mobile-ctrl" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mobile-ctrl");
+    if (!seeded) throw new Error("seeded session 'story-mobile-ctrl' missing");
+    const sessionId = seeded.id;
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const ctrl = page.getByRole("button", { name: "Ctrl", exact: true });
+    await expect(ctrl).toBeVisible({ timeout: 15_000 });
+    await expect(ctrl).toHaveAttribute("aria-pressed", "false");
+
+    await ctrl.click();
+    await expect(ctrl).toHaveAttribute("aria-pressed", "true");
+
+    await ctrl.click();
+    await expect(ctrl).toHaveAttribute("aria-pressed", "false");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-escape.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-escape.spec.ts
@@ -1,0 +1,67 @@
+// User story: tapping the Esc button on the mobile terminal toolbar
+// sends "\x1b" to the PTY.
+
+import { test as base, expect, devices } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base.use({ ...devices["iPhone 13"] });
+
+base("mobile toolbar Esc sends ESC", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mobile-esc" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mobile-esc");
+    if (!seeded) throw new Error("seeded session 'story-mobile-esc' missing");
+    const sessionId = seeded.id;
+
+    await page.addInitScript(() => {
+      const w = window as unknown as { __WS_SENT__: string[] };
+      w.__WS_SENT__ = [];
+      const origSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function (data: BufferSource | string) {
+        try {
+          if (data instanceof ArrayBuffer) {
+            w.__WS_SENT__.push(new TextDecoder().decode(new Uint8Array(data)));
+          } else if (ArrayBuffer.isView(data)) {
+            w.__WS_SENT__.push(
+              new TextDecoder().decode(data as unknown as Uint8Array),
+            );
+          } else if (typeof data === "string") {
+            w.__WS_SENT__.push(data);
+          }
+        } catch {
+          // swallow
+        }
+        return origSend.call(this, data as never);
+      };
+    });
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const esc = page.getByRole("button", { name: "Escape" });
+    await expect(esc).toBeVisible({ timeout: 15_000 });
+    await esc.click();
+
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => (window as unknown as { __WS_SENT__: string[] }).__WS_SENT__,
+          ),
+        { timeout: 5_000 },
+      )
+      .toContain("\x1b");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-hidden-on-desktop.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-hidden-on-desktop.spec.ts
@@ -1,0 +1,40 @@
+// User story: the mobile terminal toolbar must not render on a
+// desktop viewport, even when a session is open.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("mobile toolbar is hidden on a desktop viewport", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-toolbar-desktop" }),
+  });
+
+  try {
+    await page.setViewportSize({ width: 1280, height: 720 });
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-toolbar-desktop");
+    if (!seeded) throw new Error("seeded session 'story-toolbar-desktop' missing");
+    const sessionId = seeded.id;
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+    await expect(page).toHaveURL(new RegExp(`/session/${sessionId}`), {
+      timeout: 10_000,
+    });
+
+    await expect(
+      page.getByRole("button", { name: "Arrow up" }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole("button", { name: "Ctrl+C interrupt" }),
+    ).toHaveCount(0);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/mobile-toolbar-tab.spec.ts
+++ b/web/tests/live/cockpit-stories/mobile-toolbar-tab.spec.ts
@@ -1,0 +1,67 @@
+// User story: tapping the Tab button on the mobile terminal toolbar
+// sends "\t" to the PTY.
+
+import { test as base, expect, devices } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base.use({ ...devices["iPhone 13"] });
+
+base("mobile toolbar Tab sends \\t", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-mobile-tab" }),
+  });
+
+  try {
+    const sessions = await listSessions(serve.baseUrl);
+    const seeded = sessions.find((s) => s.title === "story-mobile-tab");
+    if (!seeded) throw new Error("seeded session 'story-mobile-tab' missing");
+    const sessionId = seeded.id;
+
+    await page.addInitScript(() => {
+      const w = window as unknown as { __WS_SENT__: string[] };
+      w.__WS_SENT__ = [];
+      const origSend = WebSocket.prototype.send;
+      WebSocket.prototype.send = function (data: BufferSource | string) {
+        try {
+          if (data instanceof ArrayBuffer) {
+            w.__WS_SENT__.push(new TextDecoder().decode(new Uint8Array(data)));
+          } else if (ArrayBuffer.isView(data)) {
+            w.__WS_SENT__.push(
+              new TextDecoder().decode(data as unknown as Uint8Array),
+            );
+          } else if (typeof data === "string") {
+            w.__WS_SENT__.push(data);
+          }
+        } catch {
+          // swallow
+        }
+        return origSend.call(this, data as never);
+      };
+    });
+
+    await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+
+    const tab = page.getByRole("button", { name: "Tab" });
+    await expect(tab).toBeVisible({ timeout: 15_000 });
+    await tab.click();
+
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => (window as unknown as { __WS_SENT__: string[] }).__WS_SENT__,
+          ),
+        { timeout: 5_000 },
+      )
+      .toContain("\t");
+  } finally {
+    await serve.stop();
+  }
+});


### PR DESCRIPTION
> ⚠️ **DEPENDS ON #1443.** Merge #1443 first. This PR is part of a series splitting the cockpit user-story rollout. The branch is based on #1443; once that merges to main, GitHub will narrow this diff to only this PR's commits.

## Description

Fifteen Playwright live specs:

**Mobile toolbar (6):** arrow-up, Ctrl-C, Ctrl modifier chord, Escape, Tab, hidden on desktop viewport.

**Diff (3):** base picker, hunk comment, viewer shows files.

**Approval (2):** allow + deny flows for tool-call approvals.

**Delete (2):** delete active session, delete session that owns a worktree.

**Cockpit (2):** mode picker (terminal / cockpit switch), plan strip shows the agent's current plan.

**Series:**
- #1443 — foundation
- #1444 — wizard
- #1445 — composer + queue
- #1446 — sidebar + shortcut + palette + topbar
- #1447 — settings + profile + projects + modals + misc
- **#this PR** — mobile + diff + approval + delete + cockpit-mode/plan

Closes part of #1383.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass (134 of 138 live specs passed locally; 4 skipped)
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under \`web/tests/\` and updated \`web/tests/coverage-matrix.json\`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Claude wrote the spec scaffolding from a flow checklist I provided. Decisions about which flows to cover are mine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds comprehensive Playwright E2E test coverage for the Cockpit user-story rollout: 15 new live specs plus a coverage-matrix.json update. Tests exercise mobile terminal toolbar behaviors, diff panel features, approval flows, session deletion scenarios, and cockpit mode/plan UI.

## What changed (high-level)

- Added 15 Playwright live specs under web/tests/live/cockpit-stories/ covering:
  - Mobile toolbar (6): arrow-up, Ctrl+C, Ctrl latch, Escape, Tab, and hidden-on-desktop checks.
  - Diff panel (3): base branch picker, hunk comment composer, and diff file list rendering.
  - Approval flows (2): Allow and Deny paths for tool-call approvals.
  - Session deletion (2): delete active session; delete session with a managed worktree (verifies payload flags).
  - Cockpit UI (2): mode picker (switch to Plan) and plan-strip rendering from ACP plan updates.
- Updated web/tests/coverage-matrix.json with entries mapping these specs to UI components.
- Tests include helper/refactor work and one small Rust tweak as part of the series (depends on PR `#1443`).

## Benefits

- Increases confidence across core Cockpit features with realistic server-backed E2E tests.
- Validates mobile terminal interactions and responsive behavior.
- Verifies complex flows (approval decisions, worktree-aware deletion, plan rendering) end-to-end.
- Improves safety for future refactors by mapping UI components to specs in the coverage matrix.

## Technical notes (concise)

- Playwright live tests spawn local AoE server instances, seed sessions (some git-backed), and assert UI/HTTP behaviors.
- Mobile toolbar tests intercept WebSocket.send via injected init scripts to assert terminal control sequences (e.g., \x1b[A, \x03, \t).
- Approval tests simulate ACP scripts that emit permission requests mid-turn and assert UI-driven decision outcomes.
- Deletion test for worktrees asserts delete_worktree/delete_branch payloads on DELETE /api/sessions/:id.
- Tests ensure cleanup via try/finally blocks; local run reported 134/138 live specs passing with 4 skipped.
- Author notes: Claude Code assisted in scaffolding; the author provided design decisions and test flows.

## Dependency / Context

- This PR depends on `#1443` (foundation) and is part of a multi-PR rollout (`#1444`–#1448).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1448?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->