### PR TITLE
fix(sandbox): inject git safe.directory via env vars to fix dubious ownership error

### DIFF
--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -401,6 +401,31 @@ pub(crate) fn collect_environment(
         }
     }
 
+    // Git's safe-directory check fails when the container user (root) does not
+    // match the file owner (host UID 1000, shown as "ubuntu" inside the
+    // aoe-dev-sandbox image). Bind-mounted repos trigger:
+    //   fatal: detected dubious ownership in repository at '...'
+    // We inject safe.directory=* via Git's env-var config API (Git 2.31+),
+    // which overrides the check without modifying any files.
+    if seen_keys.insert("GIT_CONFIG_COUNT".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_COUNT".to_string(),
+            value: "1".to_string(),
+        });
+    }
+    if seen_keys.insert("GIT_CONFIG_KEY_0".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_KEY_0".to_string(),
+            value: "safe.directory".to_string(),
+        });
+    }
+    if seen_keys.insert("GIT_CONFIG_VALUE_0".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_VALUE_0".to_string(),
+            value: "*".to_string(),
+        });
+    }
+
     for entry in entries {
         if let Some((key, value)) = entry.split_once('=') {
             if seen_keys.insert(key.to_string()) {
@@ -882,6 +907,33 @@ environment = ["GH_TOKEN=write_token"]
         let entry = find_entry(&result, "MY_KEY").expect("MY_KEY not found");
         assert_eq!(entry.value(), "my_value");
         assert!(matches!(entry, EnvEntry::Literal { .. }));
+    }
+
+    #[test]
+    fn test_collect_environment_includes_git_safe_directory() {
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: None,
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        let count = find_entry(&result, "GIT_CONFIG_COUNT").expect("GIT_CONFIG_COUNT not found");
+        assert_eq!(count.value(), "1");
+        assert!(matches!(count, EnvEntry::Literal { .. }));
+
+        let key = find_entry(&result, "GIT_CONFIG_KEY_0").expect("GIT_CONFIG_KEY_0 not found");
+        assert_eq!(key.value(), "safe.directory");
+        assert!(matches!(key, EnvEntry::Literal { .. }));
+
+        let value =
+            find_entry(&result, "GIT_CONFIG_VALUE_0").expect("GIT_CONFIG_VALUE_0 not found");
+        assert_eq!(value.value(), "*");
+        assert!(matches!(value, EnvEntry::Literal { .. }));
     }
 
     #[test]

--- a/src/session/environment.rs
+++ b/src/session/environment.rs
@@ -401,31 +401,6 @@ pub(crate) fn collect_environment(
         }
     }
 
-    // Git's safe-directory check fails when the container user (root) does not
-    // match the file owner (host UID 1000, shown as "ubuntu" inside the
-    // aoe-dev-sandbox image). Bind-mounted repos trigger:
-    //   fatal: detected dubious ownership in repository at '...'
-    // We inject safe.directory=* via Git's env-var config API (Git 2.31+),
-    // which overrides the check without modifying any files.
-    if seen_keys.insert("GIT_CONFIG_COUNT".to_string()) {
-        result.push(EnvEntry::Literal {
-            key: "GIT_CONFIG_COUNT".to_string(),
-            value: "1".to_string(),
-        });
-    }
-    if seen_keys.insert("GIT_CONFIG_KEY_0".to_string()) {
-        result.push(EnvEntry::Literal {
-            key: "GIT_CONFIG_KEY_0".to_string(),
-            value: "safe.directory".to_string(),
-        });
-    }
-    if seen_keys.insert("GIT_CONFIG_VALUE_0".to_string()) {
-        result.push(EnvEntry::Literal {
-            key: "GIT_CONFIG_VALUE_0".to_string(),
-            value: "*".to_string(),
-        });
-    }
-
     for entry in entries {
         if let Some((key, value)) = entry.split_once('=') {
             if seen_keys.insert(key.to_string()) {
@@ -471,6 +446,33 @@ pub(crate) fn collect_environment(
                 }
             }
         }
+    }
+
+    // Git's safe-directory check fails when the container user (root) does not
+    // match the file owner (host UID 1000, shown as "ubuntu" inside the
+    // aoe-dev-sandbox image). Bind-mounted repos trigger:
+    //   fatal: detected dubious ownership in repository at '...'
+    // We inject safe.directory=* via Git's env-var config API (Git 2.31+),
+    // which overrides the check without modifying any files.
+    // Placed after the user entries loop so caller-provided GIT_CONFIG_*
+    // values take precedence (first-wins deduplication via seen_keys).
+    if seen_keys.insert("GIT_CONFIG_COUNT".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_COUNT".to_string(),
+            value: "1".to_string(),
+        });
+    }
+    if seen_keys.insert("GIT_CONFIG_KEY_0".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_KEY_0".to_string(),
+            value: "safe.directory".to_string(),
+        });
+    }
+    if seen_keys.insert("GIT_CONFIG_VALUE_0".to_string()) {
+        result.push(EnvEntry::Literal {
+            key: "GIT_CONFIG_VALUE_0".to_string(),
+            value: "*".to_string(),
+        });
     }
 
     result
@@ -934,6 +936,43 @@ environment = ["GH_TOKEN=write_token"]
             find_entry(&result, "GIT_CONFIG_VALUE_0").expect("GIT_CONFIG_VALUE_0 not found");
         assert_eq!(value.value(), "*");
         assert!(matches!(value, EnvEntry::Literal { .. }));
+    }
+
+    #[test]
+    fn test_collect_environment_git_safe_directory_user_override() {
+        // If the user already provides GIT_CONFIG_* entries (e.g. via
+        // sandbox.environment or extra_env), their values must take
+        // precedence over the built-in safe.directory defaults.
+        let config = SandboxConfig::default();
+        let info = SandboxInfo {
+            enabled: true,
+            container_id: None,
+            image: "test".to_string(),
+            container_name: "test".to_string(),
+            extra_env: Some(vec![
+                "GIT_CONFIG_COUNT=2".to_string(),
+                "GIT_CONFIG_KEY_0=safe.directory".to_string(),
+                "GIT_CONFIG_VALUE_0=/workspace/custom".to_string(),
+                "GIT_CONFIG_KEY_1=safe.directory".to_string(),
+                "GIT_CONFIG_VALUE_1=/workspace/other".to_string(),
+            ]),
+            custom_instruction: None,
+        };
+
+        let result = collect_environment(&config, &info);
+        let count = find_entry(&result, "GIT_CONFIG_COUNT").expect("GIT_CONFIG_COUNT not found");
+        assert_eq!(count.value(), "2");
+        assert!(matches!(count, EnvEntry::Literal { .. }));
+
+        let value0 =
+            find_entry(&result, "GIT_CONFIG_VALUE_0").expect("GIT_CONFIG_VALUE_0 not found");
+        assert_eq!(value0.value(), "/workspace/custom");
+        assert!(matches!(value0, EnvEntry::Literal { .. }));
+
+        let value1 =
+            find_entry(&result, "GIT_CONFIG_VALUE_1").expect("GIT_CONFIG_VALUE_1 not found");
+        assert_eq!(value1.value(), "/workspace/other");
+        assert!(matches!(value1, EnvEntry::Literal { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Description

Sandbox containers run as `root`, but bind-mounted repositories are owned by the host user (UID 1000, shown as `ubuntu` inside the `aoe-dev-sandbox` image). Git's safe-directory check (introduced in Git 2.35.2 as a hardening measure against CVE-2022-24765) sees `root != ubuntu` and aborts with:

```
fatal: detected dubious ownership in repository at '/workspace/...'
```

This breaks **all** git operations inside the container, including `gh` CLI commands that shell out to git to resolve repository context (e.g., `gh issue view` fails with a GraphQL error because it cannot determine the current repo).

The fix injects `safe.directory=*` via Git's environment-variable config API (`GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_0`, `GIT_CONFIG_VALUE_0`; supported since Git 2.31). This overrides the ownership check without modifying any files and applies to all sandbox containers automatically, regardless of user config.

The change is localized to `collect_environment()` in `src/session/environment.rs`, the single chokepoint that builds env vars for both `docker run` (container creation) and `docker exec` (tmux session respawn).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**
OpenCode (Kimi k2.6) — used for investigation, code analysis, and drafting the fix and PR description.

**Any Additional AI Details you'd like to share:**
The AI helped trace the root cause from the `gh issue view` GraphQL error down to Git's safe-directory check, analyzed the container ownership model, and identified the `GIT_CONFIG_*` env-var API as the cleanest fix. I validated the fix manually inside a running sandbox container before submitting.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

**Moved, not Added**: The Git `safe.directory` injection code block was repositioned in the `collect_environment()` function in `src/session/environment.rs`. It was moved from **before** the user-supplied environment entries loop to **after** it.

**Why This Matters**: The original placement meant that Git config defaults (GIT_CONFIG_COUNT, GIT_CONFIG_KEY_0, GIT_CONFIG_VALUE_0) were being injected first, then when user-provided entries were processed, the first-wins deduplication logic in `seen_keys` would silently discard any user-supplied GIT_CONFIG_* values. This was a critical bug—users couldn't override the defaults.

**The Fix**: By moving the defaults injection to **after** processing user entries, user-provided GIT_CONFIG_* values from `extra_env` or `sandbox.environment` now take precedence as intended.

**Updated Comment**: The code comment was expanded to explicitly note: "Placed after the user entries loop so caller-provided GIT_CONFIG_* values take precedence (first-wins deduplication via seen_keys)."

**New Test**: Added `test_collect_environment_git_safe_directory_user_override()` which verifies that user-provided GIT_CONFIG_* entries (GIT_CONFIG_COUNT=2 with custom safe.directory paths) correctly override the built-in defaults.

**Code Changes**: +89/-25 lines in `src/session/environment.rs` (net: +64 lines)

## Benefits

- **Restores user override capability**: Users can now provide their own Git configuration values without them being silently discarded
- **Preserves sensible defaults**: The built-in `safe.directory=*` still applies automatically when users don't provide custom configuration
- **Increased predictability**: Behavior now follows expected "user values override defaults" pattern
- **Better testability**: New test ensures this behavior is maintained across future changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1458?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
