### PR TITLE
feat(session): default title from project path when no branch is set

### DIFF
--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -331,6 +331,7 @@ pub fn build_instance(
     let mut warnings: Vec<String> = Vec::new();
     let final_title = resolve_title(
         &params.title,
+        &final_path,
         params.worktree_branch.as_deref(),
         params.worktree_enabled,
         existing_titles,
@@ -602,27 +603,98 @@ pub fn cleanup_instance(
     let _ = instance.kill();
 }
 
-/// Resolve the session title: use the provided title, then an explicit worktree
-/// branch name, then fall back to a random civilization name.
+/// Resolve the session title. Precedence when no explicit title is provided:
+/// 1. Worktree branch name (when worktree mode is enabled).
+/// 2. A label derived from `project_path` ("leaf" when the project sits at the
+///    top of a known dev container like `~/GitProjects`, or "container - leaf"
+///    when it's a sub-directory of that top-level repo).
+/// 3. A random civilization name.
 pub(crate) fn resolve_title(
     title: &str,
+    project_path: &str,
     worktree_branch: Option<&str>,
     worktree_enabled: bool,
     existing_titles: &[&str],
 ) -> String {
-    if title.is_empty() {
-        if worktree_enabled {
-            if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
-                branch.trim().to_string()
-            } else {
-                civilizations::generate_random_title(existing_titles)
-            }
-        } else {
-            civilizations::generate_random_title(existing_titles)
-        }
-    } else {
-        title.to_string()
+    if !title.is_empty() {
+        return title.to_string();
     }
+    if worktree_enabled {
+        if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
+            return branch.trim().to_string();
+        }
+    }
+    if let Some(derived) = derive_title_from_path(project_path) {
+        return derived;
+    }
+    civilizations::generate_random_title(existing_titles)
+}
+
+/// Known parent directories that typically hold a developer's repositories.
+/// Used to anchor the "top-level project folder" when deriving a default
+/// session title from the project path.
+const DEV_CONTAINERS: &[&str] = &[
+    "GitProjects",
+    "Projects",
+    "projects",
+    "Code",
+    "code",
+    "dev",
+    "src",
+    "workspace",
+    "Workspaces",
+    "repos",
+    "Repos",
+];
+
+/// Derive a default title from the project path.
+///
+/// Walks the path looking for a "dev container" segment (e.g. `GitProjects`).
+/// The segment immediately after the container is treated as the project
+/// root. If the project path *is* the project root, the returned title is
+/// just the root's basename (e.g. `per-dev`). If the project path lives
+/// inside the project root, the title combines both names with a hyphen
+/// separator (e.g. `per-dev - agent-of-empires`).
+///
+/// Returns `None` when the path doesn't sit beneath any known container,
+/// so the caller can fall back to a random title.
+fn derive_title_from_path(project_path: &str) -> Option<String> {
+    if project_path.is_empty() {
+        return None;
+    }
+    let raw = std::path::Path::new(project_path);
+    let canon = raw.canonicalize().unwrap_or_else(|_| raw.to_path_buf());
+    let names: Vec<String> = canon
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+    // Use the deepest container match so nested `~/projects/foo/src/...` still
+    // anchors on `src` (the closest one to the leaf).
+    let container_idx = names.iter().rposition(|seg| {
+        DEV_CONTAINERS
+            .iter()
+            .any(|c| seg.eq_ignore_ascii_case(c) || seg == c)
+    })?;
+    let root_idx = container_idx + 1;
+    let leaf_idx = names.len().checked_sub(1)?;
+    if root_idx > leaf_idx {
+        return None;
+    }
+    let root_name = &names[root_idx];
+    if root_name.is_empty() {
+        return None;
+    }
+    if root_idx == leaf_idx {
+        return Some(root_name.clone());
+    }
+    let leaf_name = &names[leaf_idx];
+    if leaf_name.is_empty() {
+        return Some(root_name.clone());
+    }
+    Some(format!("{root_name} - {leaf_name}"))
 }
 
 /// Origin of an effective worktree branch name. The builder uses this to decide
@@ -796,13 +868,13 @@ mod tests {
 
     #[test]
     fn test_empty_title_with_worktree_uses_branch_name() {
-        let title = resolve_title("", Some("feature-auth"), true, &[]);
+        let title = resolve_title("", "", Some("feature-auth"), true, &[]);
         assert_eq!(title, "feature-auth");
     }
 
     #[test]
     fn test_empty_title_without_worktree_uses_civilization() {
-        let title = resolve_title("", None, false, &[]);
+        let title = resolve_title("", "", None, false, &[]);
         assert!(
             civilizations::CIVILIZATIONS.contains(&title.as_str()),
             "Expected a civilization name, got: {}",
@@ -812,14 +884,77 @@ mod tests {
 
     #[test]
     fn test_provided_title_with_worktree_keeps_title() {
-        let title = resolve_title("My Session", Some("feature-auth"), true, &[]);
+        let title = resolve_title("My Session", "", Some("feature-auth"), true, &[]);
         assert_eq!(title, "My Session");
     }
 
     #[test]
     fn test_provided_title_without_worktree_keeps_title() {
-        let title = resolve_title("Custom Name", None, false, &[]);
+        let title = resolve_title("Custom Name", "", None, false, &[]);
         assert_eq!(title, "Custom Name");
+    }
+
+    #[test]
+    fn test_derive_title_at_top_of_container() {
+        // `per-dev` sits directly under `GitProjects`.
+        let derived = derive_title_from_path("/Users/alice/GitProjects/per-dev").expect("derived");
+        assert_eq!(derived, "per-dev");
+    }
+
+    #[test]
+    fn test_derive_title_in_subdir_of_container() {
+        // A repo nested two levels deep under `per-dev` should surface as
+        // `per-dev - agent-of-empires`.
+        let derived =
+            derive_title_from_path("/Users/alice/GitProjects/per-dev/forks/agent-of-empires")
+                .expect("derived");
+        assert_eq!(derived, "per-dev - agent-of-empires");
+    }
+
+    #[test]
+    fn test_derive_title_with_case_insensitive_container() {
+        // `Projects` (capital P) is in the canonical list, but the matcher
+        // should also accept other casings since users vary.
+        let derived = derive_title_from_path("/home/bob/projects/widgets").expect("derived");
+        assert_eq!(derived, "widgets");
+    }
+
+    #[test]
+    fn test_derive_title_outside_known_container_returns_none() {
+        assert_eq!(
+            derive_title_from_path("/var/log/something"),
+            None,
+            "Paths outside known containers should fall back to random"
+        );
+    }
+
+    #[test]
+    fn test_derive_title_uses_deepest_container_match() {
+        // When the path crosses two known containers, anchor on the deepest
+        // one so the result is the nearest project-root segment.
+        let derived =
+            derive_title_from_path("/home/alice/projects/monorepo/src/server").expect("derived");
+        assert_eq!(derived, "server");
+    }
+
+    #[test]
+    fn test_resolve_title_uses_path_derivation_when_no_branch() {
+        let title = resolve_title("", "/Users/alice/GitProjects/per-dev", None, false, &[]);
+        assert_eq!(title, "per-dev");
+    }
+
+    #[test]
+    fn test_worktree_branch_beats_path_derivation() {
+        // Branch name wins when worktree is enabled, even if path would derive
+        // a perfectly good title.
+        let title = resolve_title(
+            "",
+            "/Users/alice/GitProjects/per-dev",
+            Some("feature-x"),
+            true,
+            &[],
+        );
+        assert_eq!(title, "feature-x");
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1337,6 +1337,7 @@ impl HomeView {
                 .collect();
             data.title = crate::session::builder::resolve_title(
                 &data.title,
+                &data.path,
                 data.worktree_branch.as_deref(),
                 data.worktree_enabled,
                 &existing_titles,


### PR DESCRIPTION
## Description

When creating a session without an explicit title and without a worktree branch, `resolve_title` currently picks a random civilization name (Babylon, Sumer, ...). For folks with several sessions pointed at the same repo, that produces a project list where every row looks like a different empire, with no anchor back to the underlying project.

This PR adds a `project_path`-aware fallback between the existing branch-name path and the random fallback. When the project path lives beneath a known "dev container" (`GitProjects`, `Projects`, `projects`, `Code`, `code`, `dev`, `src`, `workspace`, `Workspaces`, `repos`, `Repos`), the new behaviour is:

- Path is the immediate child of the container → use that name (e.g. `~/GitProjects/per-dev` → `per-dev`).
- Path sits inside that top-level project → combine both names with a hyphen (e.g. `~/GitProjects/per-dev/forks/agent-of-empires` → `per-dev - agent-of-empires`).
- Path is outside any known container → fall through to the existing random civilization name. No regression for users whose repos don't live under a familiar parent directory.

The case-insensitive matcher accepts both `Projects` and `projects` (and similar variants) so users on different OSes / conventions get the same behaviour. The deepest container wins, so something like `~/projects/monorepo/src/server` resolves to `server` (anchored on the inner `src`).

`resolve_title` gains a `project_path: &str` parameter (breaking; only two in-tree callers, both updated in this PR). The full precedence is:

1. Explicit user-supplied title (unchanged).
2. Worktree branch name when worktree mode is enabled (unchanged).
3. **NEW**: derive from project path under a known container.
4. Random civilization name (existing fallback).

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo test --lib --release session::builder`)
- [ ] Documentation was updated where necessary  — N/A, no user-facing docs cover the title default precedence
- [ ] For UI changes: included screenshot or recording — N/A, the change only affects what string the existing title slot defaults to

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle — the change is purely a string-derivation function with unit tests covering every branch (top-of-container, nested-subdir, case-insensitive, deepest-match, outside-container, worktree-branch-wins).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Implementation drafted by Claude with the author's review; the heuristic (dev-container anchor + hyphen-joined two-level title) and the chosen container list reflect the author's intent. All seven new tests were added in the same commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR enhances session title resolution to intelligently derive meaningful default titles from repository paths when no explicit title is provided and no worktree branch is available.

### What Changed

**Core functionality:**
- Enhanced `resolve_title()` function now accepts the project path as a new parameter, enabling path-based title derivation
- Added `derive_title_from_path()` helper that intelligently extracts titles from project directory structures
- Introduced a `DEV_CONTAINERS` constant containing 11 common developer directory names (GitProjects, Projects, Code, dev, src, workspace, repos, etc.)
- Updated the session title precedence order to include path-based derivation as a fallback before random civilization names

**Behavior:**
When creating a session without an explicit title and without a worktree branch:
- If the project sits directly under a known dev container directory → uses the project folder name (e.g., `~/GitProjects/my-app` → "my-app")
- If the project is nested deeper → combines the top-level project and leaf folder names (e.g., `~/GitProjects/my-app/forks/agent-of-empires` → "my-app - agent-of-empires")
- Uses the deepest matching container, supporting nested scenarios like `~/projects/monorepo/src/server` → "server"
- Gracefully falls back to random civilization names for projects outside known containers

**Testing:**
- Seven new unit tests added covering:
  - Direct child of a dev container
  - Nested subdirectories within containers
  - Case-insensitive container matching
  - Deepest container selection
  - Outside-container fallback behavior
  - Precedence rules (explicit title and worktree branch still take priority)

### Files Modified

- `src/session/builder.rs` - Core changes to title resolution logic (+152/-17 lines)
- `src/tui/home/mod.rs` - Updated session creation to pass project path to title resolver (+1/-0 lines)

### Benefits

- **More deterministic titles**: Sessions get meaningful names based on project structure instead of random civilization names
- **Better session organization**: Related projects get similar title prefixes, making them easier to identify
- **Preserves existing behavior**: User-provided titles and worktree branches still take priority
- **Backward compatible**: Sessions without paths or outside known containers fall back to the existing random naming scheme

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1459?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->