### PR TITLE
fix(tui): seed GroupTree alongside Storage on restart profile change

### DIFF
--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -193,6 +193,23 @@ impl HomeView {
                     self.storages
                         .insert(target_profile.to_string(), Storage::new(target_profile)?);
                 }
+                // Seed the per-profile GroupTree alongside the Storage. Without
+                // this, `rebuild_group_trees()` below iterates only the already-
+                // known profile trees and the freshly-moved row ends up in
+                // `self.instances` with no tree to render under. In tree-based
+                // build_flat_items branches (manual grouping + non-Attention
+                // sort, or single-profile filtered view targeting the new
+                // profile) the row then silently disappears, and even in
+                // Attention sort the next reload re-seeds the tree from the
+                // pristine on-disk state — masking the bug as flaky. Seed
+                // here so the new profile is a first-class entry in every
+                // structure before the rebuild walks them.
+                if !self.group_trees.contains_key(target_profile) {
+                    self.group_trees.insert(
+                        target_profile.to_string(),
+                        GroupTree::new_with_groups(&[], &[]),
+                    );
+                }
                 self.mutate_instance(&id, |inst| {
                     inst.source_profile = target_profile.to_string();
                 });


### PR DESCRIPTION
## Summary

When the restart dialog picks a profile that wasn't previously loaded into the TUI, `restart_selected_session` inserted a fresh `Storage` for it but did NOT add a matching entry to `self.group_trees`. The subsequent `rebuild_group_trees()` then iterates only the known profile trees, so the moved row lands in `self.instances` with `source_profile=B` but no tree under `B` to render it.

### Failure modes
- **Manual grouping + non-Attention sort, or single-profile filtered view targeting the new profile**: row silently disappears from the visible list (build_flat_items walks trees → row not found).
- **Attention sort + all-profiles view**: row stays visible (that branch walks `self.instances` directly), but the next 5s reload re-seeds the tree from disk and masks the bug as flaky.

Symptom reported as "the profile badge didn't update when restarting": the row had moved profiles in memory but `rebuild_group_trees` couldn't surface it under the new profile because the new profile's tree didn't exist yet, so the user saw stale visual state.

## Fix

Insert an empty `GroupTree` for the target profile alongside the Storage insertion. `rebuild_group_trees()` then sees the new profile as a first-class entry and the row lands under it on the rebuild.

## Test plan

- [x] `cargo build --lib --release` clean
- [x] `cargo clippy --lib --release -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Manual: restart a session via dialog with a profile selection that wasn't previously open in the TUI (binary built locally for verification)

(No unit test added — `restart_selected_session` exercises `restart_with_size` which requires tmux unavailable in the unit-test sandbox. The fix is contained to a single missing `HashMap::insert` call.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

A single conditional check and insertion were added to the `restart_selected_session` method to ensure data structure consistency when restarting a session with a different profile.

## What Was Added

When restarting a session and moving it to a different profile, the code now inserts an empty `GroupTree` for that target profile—if one doesn't already exist—at the same time it inserts the `Storage`. This happens before the `rebuild_group_trees()` call.

**Lines added:** 17 (a conditional block with comments explaining the fix)

## Why This Matters

**The Problem:** Previously, when restarting a session and switching to a profile that hadn't been loaded in the TUI yet, the code would create a `Storage` for the new profile but forget to create a corresponding `GroupTree`. This created an inconsistency where the moved session existed in memory but had nowhere to be rendered in the interface—it would either disappear from the visible list entirely or only reappear after the next automatic reload (every 5 seconds).

**The Solution:** By inserting the empty `GroupTree` alongside the `Storage`, the profile becomes a complete, first-class entry in all data structures. When `rebuild_group_trees()` runs immediately after, it can properly place the moved session under the correct profile tree, and the row renders correctly without delays.

## Benefits

- **Eliminates a frustrating bug** where restarted sessions would disappear when switching to an unloaded profile
- **Ensures immediate UI consistency** without waiting for the next background reload cycle
- **Minimal change** with just one missing `HashMap::insert` added—low risk, high impact
- **Maintains symmetry** between `Storage` and `GroupTree` creation, making the codebase more robust

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->