### PR TITLE
fix(tui): prune source profile's empty group after restart-to-different-profile

### DIFF
--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -603,29 +603,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     })();
 
     if let Err(e) = hook_result {
-        // Clean up worktree if we created one
-        if let Some(ref wt_info) = instance.worktree_info {
-            if wt_info.managed_by_aoe {
-                if let Ok(git_wt) =
-                    crate::git::GitWorktree::new(std::path::PathBuf::from(&wt_info.main_repo_path))
-                {
-                    let _ = git_wt.remove_worktree(&path, false);
-                }
-            }
-        }
-        // Clean up workspace worktrees if we created them
-        if let Some(ref ws_info) = instance.workspace_info {
-            for repo in &ws_info.repos {
-                if repo.managed_by_aoe {
-                    let wt_path = PathBuf::from(&repo.worktree_path);
-                    let main_repo = PathBuf::from(&repo.main_repo_path);
-                    if let Ok(git_wt) = crate::git::GitWorktree::new(main_repo) {
-                        let _ = git_wt.remove_worktree(&wt_path, false);
-                    }
-                }
-            }
-            let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
-        }
+        cleanup_partial_create(&instance, &path);
         return Err(e);
     }
 
@@ -655,6 +633,12 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     })?;
 
     if duplicate {
+        // Race-loser path: another `aoe add` with the same (title, path)
+        // committed first while we were creating worktrees / running
+        // on_create hooks. Roll back our side effects so we don't leave
+        // an orphan worktree or workspace dir behind with no session row
+        // to own it. (CodeRabbit feedback on PR #1436.)
+        cleanup_partial_create(&instance, &path);
         println!(
             "Session already exists with same title and path: {}",
             final_title
@@ -719,7 +703,7 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         let launched_id = launched.id.clone();
         storage.update(move |instances, _groups| {
             if let Some(slot) = instances.iter_mut().find(|i| i.id == launched_id) {
-                *slot = launched;
+                slot.adopt_lifecycle_from(&launched);
             }
             Ok(())
         })?;
@@ -861,4 +845,35 @@ fn resolve_named_tool(tool: &str, config: &crate::session::Config) -> Result<Nam
         "Unknown tool: {name}\nSupported built-in and configured custom agents: {}",
         safe_names.join(", ")
     )
+}
+
+/// Best-effort cleanup of side effects from a partial `aoe add` that
+/// can't go forward: either an `on_create` hook errored, or the closure
+/// re-check inside `Storage::update` discovered a concurrently-created
+/// duplicate row and we now have a worktree / workspace dir but no
+/// session row to own it. Errors here are ignored — the caller has
+/// already decided to give up on this add, and leaving a stray dir is
+/// preferable to a hard error mid-rollback.
+fn cleanup_partial_create(instance: &Instance, path: &std::path::Path) {
+    if let Some(ref wt_info) = instance.worktree_info {
+        if wt_info.managed_by_aoe {
+            if let Ok(git_wt) =
+                crate::git::GitWorktree::new(std::path::PathBuf::from(&wt_info.main_repo_path))
+            {
+                let _ = git_wt.remove_worktree(path, false);
+            }
+        }
+    }
+    if let Some(ref ws_info) = instance.workspace_info {
+        for repo in &ws_info.repos {
+            if repo.managed_by_aoe {
+                let wt_path = PathBuf::from(&repo.worktree_path);
+                let main_repo = PathBuf::from(&repo.main_repo_path);
+                if let Ok(git_wt) = crate::git::GitWorktree::new(main_repo) {
+                    let _ = git_wt.remove_worktree(&wt_path, false);
+                }
+            }
+        }
+        let _ = std::fs::remove_dir_all(&ws_info.workspace_dir);
+    }
 }

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -284,7 +284,11 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    // This snapshot is read-only: used for parent resolution, title
+    // generation, and the pre-flight duplicate check. The authoritative
+    // write happens later via `storage.update`, which re-loads under the
+    // cross-process lock so a concurrently-added row is never clobbered.
+    let instances = storage.load()?;
 
     // Resolve parent session if specified
     let mut group_path = args.group.clone();
@@ -625,15 +629,38 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
         return Err(e);
     }
 
-    instances.push(instance.clone());
+    // Persist the new row through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. The `instances` snapshot loaded above
+    // may be stale (another `aoe add` could have committed between then
+    // and now); a wholesale `commit` of that snapshot would clobber the
+    // concurrently-added row. The closure re-checks for a duplicate
+    // against the fresh load so a racing identical add still no-ops.
+    let group_path_for_save = instance.group_path.clone();
+    let instance_for_save = instance.clone();
+    let duplicate = storage.update(move |instances, groups| {
+        if is_duplicate_session(
+            instances,
+            &instance_for_save.title,
+            &instance_for_save.project_path,
+        ) {
+            return Ok(true);
+        }
+        instances.push(instance_for_save);
+        if !group_path_for_save.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path_for_save);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(false)
+    })?;
 
-    // Rebuild group tree
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instance.group_path.is_empty() {
-        group_tree.create_group(&instance.group_path);
+    if duplicate {
+        println!(
+            "Session already exists with same title and path: {}",
+            final_title
+        );
+        return Ok(());
     }
-
-    storage.commit(&instances, &group_tree)?;
 
     println!("✓ Added session: {}", final_title);
     println!("  Profile: {}", storage.profile());
@@ -683,12 +710,19 @@ pub async fn run(profile: &str, args: AddArgs) -> Result<()> {
             );
         }
     } else if args.launch {
-        let idx = instances
-            .iter()
-            .position(|i| i.id == instance.id)
-            .expect("just added instance");
-        instances[idx].start_with_size(crate::terminal::get_size())?;
-        storage.commit(&instances, &group_tree)?;
+        // Start the tmux process on a local copy first (the slow, non-storage
+        // work), then write the started state back through `update` so a
+        // concurrent writer's row added since the `add` commit above is not
+        // clobbered. `start_with_size` mutates status / pid in place.
+        let mut launched = instance.clone();
+        launched.start_with_size(crate::terminal::get_size())?;
+        let launched_id = launched.id.clone();
+        storage.update(move |instances, _groups| {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == launched_id) {
+                *slot = launched;
+            }
+            Ok(())
+        })?;
 
         let tmux_session = crate::tmux::Session::new(&instance.id, &instance.title)?;
         tmux_session.attach()?;

--- a/src/cli/group.rs
+++ b/src/cli/group.rs
@@ -127,7 +127,6 @@ async fn list_groups(profile: &str, args: GroupListArgs) -> Result<()> {
 
 async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
     let name = args.name.trim();
     let group_path = if let Some(parent) = &args.parent {
@@ -136,14 +135,20 @@ async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
         name.to_string()
     };
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-
-    if group_tree.group_exists(&group_path) {
-        bail!("Group already exists: {}", group_path);
-    }
-
-    group_tree.create_group(&group_path);
-    storage.commit(&instances, &group_tree)?;
+    // Persist through `update`, which re-loads under the cross-process lock.
+    // The existence check runs against that fresh snapshot, not a stale one,
+    // and the closure only adds the new group, so a concurrently-added group
+    // or session row is never clobbered.
+    let group_path_for_save = group_path.clone();
+    storage.update(move |instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
+        if group_tree.group_exists(&group_path_for_save) {
+            bail!("Group already exists: {}", group_path_for_save);
+        }
+        group_tree.create_group(&group_path_for_save);
+        *groups = group_tree.get_all_groups();
+        Ok(())
+    })?;
 
     println!("✓ Created group: {}", group_path);
 
@@ -152,43 +157,53 @@ async fn create_group(profile: &str, args: GroupCreateArgs) -> Result<()> {
 
 async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
+    let name = args.name.trim().to_string();
+    let force = args.force;
 
-    let name = args.name.trim();
-    if !group_tree.group_exists(name) {
-        bail!("Group not found: {}", name);
-    }
+    // Persist through `update`: the existence check, the session count, and
+    // the deletion all run against a fresh snapshot loaded under the
+    // cross-process lock. The closure mutates only the target group and its
+    // sessions, so a row another process added concurrently is preserved.
+    // The count is returned so the post-update messages stay accurate.
+    let name_for_save = name.clone();
+    let session_count = storage.update(move |instances, groups| {
+        let mut group_tree = GroupTree::new_with_groups(instances, groups);
 
-    // Check for sessions in this group
-    let session_count = instances
-        .iter()
-        .filter(|i| i.group_path == name || i.group_path.starts_with(&format!("{}/", name)))
-        .count();
-
-    if session_count > 0 {
-        if !args.force {
-            bail!(
-                "Group '{}' contains {} sessions. Use --force to move them to default group.",
-                name,
-                session_count
-            );
+        if !group_tree.group_exists(&name_for_save) {
+            bail!("Group not found: {}", name_for_save);
         }
 
-        // Move sessions to default group
-        for inst in &mut instances {
-            if inst.group_path == name || inst.group_path.starts_with(&format!("{}/", name)) {
-                inst.group_path = String::new();
+        let prefix = format!("{}/", name_for_save);
+        let session_count = instances
+            .iter()
+            .filter(|i| i.group_path == name_for_save || i.group_path.starts_with(&prefix))
+            .count();
+
+        if session_count > 0 {
+            if !force {
+                bail!(
+                    "Group '{}' contains {} sessions. Use --force to move them to default group.",
+                    name_for_save,
+                    session_count
+                );
+            }
+
+            // Move sessions to default group
+            for inst in instances.iter_mut() {
+                if inst.group_path == name_for_save || inst.group_path.starts_with(&prefix) {
+                    inst.group_path = String::new();
+                }
             }
         }
-    }
 
-    group_tree.delete_group(name);
-    storage.commit(&instances, &group_tree)?;
+        group_tree.delete_group(&name_for_save);
+        *groups = group_tree.get_all_groups();
+        Ok(session_count)
+    })?;
 
     println!("✓ Deleted group: {}", name);
-    if args.force && session_count > 0 {
+    if force && session_count > 0 {
         println!("  Moved {} sessions to default group", session_count);
     }
 
@@ -197,24 +212,37 @@ async fn delete_group(profile: &str, args: GroupDeleteArgs) -> Result<()> {
 
 async fn move_session(profile: &str, args: GroupMoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
-    let identifier = args.identifier.trim();
-    let inst = instances
-        .iter_mut()
-        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))?;
+    let identifier = args.identifier.trim().to_string();
+    let group = args.group.trim().to_string();
 
-    let group = args.group.trim();
-    let old_group = inst.group_path.clone();
-    inst.group_path = group.to_string();
+    // Persist through `update`: the session lookup and the group reassignment
+    // both run against a fresh snapshot loaded under the cross-process lock.
+    // The closure touches only the target row's `group_path` and adds the
+    // destination group, so a concurrently-added row is never clobbered. The
+    // previous group is returned so the post-update message stays accurate.
+    let identifier_for_save = identifier.clone();
+    let group_for_save = group.clone();
+    let old_group = storage.update(move |instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| {
+                i.id == identifier_for_save
+                    || i.id.starts_with(&identifier_for_save)
+                    || i.title == identifier_for_save
+            })
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier_for_save))?;
 
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !group.is_empty() {
-        group_tree.create_group(group);
-    }
+        let old_group = inst.group_path.clone();
+        inst.group_path = group_for_save.clone();
 
-    storage.commit(&instances, &group_tree)?;
+        if !group_for_save.is_empty() {
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_for_save);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(old_group)
+    })?;
 
     if old_group.is_empty() {
         println!("✓ Moved session to group: {}", group);

--- a/src/cli/remove.rs
+++ b/src/cli/remove.rs
@@ -3,7 +3,7 @@
 use anyhow::{bail, Result};
 use clap::Args;
 
-use crate::session::{GroupTree, Instance, Storage};
+use crate::session::{Instance, Storage};
 
 #[derive(Args)]
 pub struct RemoveArgs {
@@ -36,93 +36,96 @@ fn needs_worktree_cleanup(inst: &Instance, args: &RemoveArgs) -> bool {
 #[tracing::instrument(target = "cli.session", skip_all, fields(profile = %profile))]
 pub async fn run(profile: &str, args: RemoveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
 
-    let mut found = false;
-    let mut removed_title = String::new();
-    let mut new_instances = Vec::with_capacity(instances.len());
+    // This snapshot is read-only: it locates the target row so its worktree
+    // and container teardown can run before any storage write. The
+    // authoritative removal happens later via `storage.update`, which
+    // re-loads under the cross-process lock; a wholesale `commit` of this
+    // snapshot would clobber a row another process added during the
+    // teardown (`perform_deletion` removes a worktree and a container, a
+    // real staleness window).
+    let instances = storage.load()?;
 
-    for inst in instances {
-        if inst.id == args.identifier
+    let target: Option<Instance> = instances.into_iter().find(|inst| {
+        inst.id == args.identifier
             || inst.id.starts_with(&args.identifier)
             || inst.title == args.identifier
-        {
-            found = true;
-            removed_title = inst.title.clone();
+    });
 
-            let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
-                profile,
-                std::path::Path::new(&inst.project_path),
-            );
-
-            let delete_worktree = needs_worktree_cleanup(&inst, &args);
-            let delete_branch = inst
-                .worktree_info
-                .as_ref()
-                .is_some_and(|wt| wt.managed_by_aoe)
-                && (args.delete_branch
-                    || (delete_worktree && config.worktree.delete_branch_on_cleanup));
-            let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
-                && !args.keep_container
-                && config.sandbox.auto_cleanup;
-
-            let result = crate::session::deletion::perform_deletion(
-                &crate::session::deletion::DeletionRequest {
-                    session_id: inst.id.clone(),
-                    instance: inst.clone(),
-                    delete_worktree,
-                    delete_branch,
-                    delete_sandbox,
-                    force_delete: args.force,
-                    detach_hooks: false,
-                },
-            );
-
-            for msg in &result.messages {
-                println!("  {}", msg);
-            }
-            for err in &result.errors {
-                eprintln!("Warning: {}", err);
-            }
-
-            if !delete_worktree {
-                if let Some(wt_info) = &inst.worktree_info {
-                    if wt_info.managed_by_aoe {
-                        println!(
-                            "Worktree preserved at: {} (use --delete-worktree to remove)",
-                            inst.project_path
-                        );
-                    }
-                }
-            }
-            if let Some(sandbox) = &inst.sandbox_info {
-                if sandbox.enabled {
-                    if args.keep_container {
-                        println!("Container preserved: {}", sandbox.container_name);
-                    } else if !config.sandbox.auto_cleanup {
-                        println!(
-                            "Container preserved: {} (auto_cleanup disabled in config)",
-                            sandbox.container_name
-                        );
-                    }
-                }
-            }
-        } else {
-            new_instances.push(inst);
-        }
-    }
-
-    if !found {
+    let Some(inst) = target else {
         bail!(
             "Session not found in profile '{}': {}",
             storage.profile(),
             args.identifier
         );
+    };
+
+    let removed_title = inst.title.clone();
+    let removed_id = inst.id.clone();
+
+    let config = crate::session::repo_config::resolve_config_with_repo_or_warn(
+        profile,
+        std::path::Path::new(&inst.project_path),
+    );
+
+    let delete_worktree = needs_worktree_cleanup(&inst, &args);
+    let delete_branch = inst
+        .worktree_info
+        .as_ref()
+        .is_some_and(|wt| wt.managed_by_aoe)
+        && (args.delete_branch || (delete_worktree && config.worktree.delete_branch_on_cleanup));
+    let delete_sandbox = inst.sandbox_info.as_ref().is_some_and(|s| s.enabled)
+        && !args.keep_container
+        && config.sandbox.auto_cleanup;
+
+    let result =
+        crate::session::deletion::perform_deletion(&crate::session::deletion::DeletionRequest {
+            session_id: inst.id.clone(),
+            instance: inst.clone(),
+            delete_worktree,
+            delete_branch,
+            delete_sandbox,
+            force_delete: args.force,
+            detach_hooks: false,
+        });
+
+    for msg in &result.messages {
+        println!("  {}", msg);
+    }
+    for err in &result.errors {
+        eprintln!("Warning: {}", err);
     }
 
-    // Rebuild group tree and save
-    let group_tree = GroupTree::new_with_groups(&new_instances, &groups);
-    storage.commit(&new_instances, &group_tree)?;
+    if !delete_worktree {
+        if let Some(wt_info) = &inst.worktree_info {
+            if wt_info.managed_by_aoe {
+                println!(
+                    "Worktree preserved at: {} (use --delete-worktree to remove)",
+                    inst.project_path
+                );
+            }
+        }
+    }
+    if let Some(sandbox) = &inst.sandbox_info {
+        if sandbox.enabled {
+            if args.keep_container {
+                println!("Container preserved: {}", sandbox.container_name);
+            } else if !config.sandbox.auto_cleanup {
+                println!(
+                    "Container preserved: {} (auto_cleanup disabled in config)",
+                    sandbox.container_name
+                );
+            }
+        }
+    }
+
+    // Remove the target row through `update`, which re-loads `sessions.json`
+    // under the cross-process lock and retains by `Instance.id`, so any row
+    // a concurrent writer added during the teardown above survives.
+    storage.update(move |instances, _groups| {
+        instances.retain(|inst| inst.id != removed_id);
+        Ok(())
+    })?;
 
     println!(
         "  Removed session: {} (from profile '{}')",

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -413,7 +413,7 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     storage.update(move |instances, _groups| {
         if let Some(slot) = instances.iter_mut().find(|i| i.id == started_id) {
-            *slot = started;
+            slot.adopt_lifecycle_from(&started);
         }
         Ok(())
     })?;
@@ -572,20 +572,32 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
         let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
-        if let Some(inst) = inst_opt {
-            restarted.push(inst);
-        }
+        // Only persist workers whose restart actually succeeded. A failed
+        // worker's `inst` still carries the mutations made before the
+        // failure point; writing those back to sessions.json would leave
+        // disk reflecting a partial restart for a session that never
+        // came up. (CodeRabbit feedback on PR #1436.)
         match result {
-            Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
-            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => succeeded.push((title, None)),
+            Ok(StartOutcome::Restarted { stale_sid }) => {
+                if let Some(inst) = inst_opt {
+                    restarted.push(inst);
+                }
+                succeeded.push((title, Some(stale_sid)));
+            }
+            Ok(StartOutcome::Resumed | StartOutcome::Fresh) => {
+                if let Some(inst) = inst_opt {
+                    restarted.push(inst);
+                }
+                succeeded.push((title, None));
+            }
             Err(e) => failed.push((title, e.to_string())),
         }
     }
 
     storage.update(move |instances, _groups| {
-        for updated in restarted {
+        for updated in &restarted {
             if let Some(slot) = instances.iter_mut().find(|i| i.id == updated.id) {
-                *slot = updated;
+                slot.adopt_lifecycle_from(updated);
             }
         }
         Ok(())
@@ -706,7 +718,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
     storage.update(move |instances, _groups| {
         if let Some(slot) = instances.iter_mut().find(|i| i.id == session_id) {
-            *slot = restarted;
+            slot.adopt_lifecycle_from(&restarted);
         }
         Ok(())
     })?;

--- a/src/cli/session.rs
+++ b/src/cli/session.rs
@@ -243,24 +243,30 @@ pub async fn run(profile: &str, command: SessionCommands) -> Result<()> {
     }
 }
 
+/// Locate a session by exact id, id-prefix, or exact title within a loaded
+/// snapshot, returning its full id. Used to resolve the `identifier` CLI arg
+/// to a stable key before the `Storage::update` closure re-loads a fresh
+/// snapshot; the closure then matches on that id, never on a stale index.
+fn resolve_session_id(instances: &[crate::session::Instance], identifier: &str) -> Result<String> {
+    instances
+        .iter()
+        .find(|i| i.id == identifier || i.id.starts_with(identifier) || i.title == identifier)
+        .map(|i| i.id.clone())
+        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", identifier))
+}
+
 async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].favorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.favorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Favorited: {}", title);
     Ok(())
@@ -268,22 +274,16 @@ async fn favorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unfavorite();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unfavorite();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unfavorited: {}", title);
     Ok(())
@@ -291,27 +291,29 @@ async fn unfavorite_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
-    let id = super::resolve_session(&args.identifier, &instances)?
-        .id
-        .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
+    // Resolve and kill the pane before touching storage: killing the tmux
+    // session is a syscall that does not need the registry, and doing it
+    // outside the `update` closure keeps the lock held only for the brief
+    // load-mutate-write.
+    let resolved = super::resolve_session(&args.identifier, &instances)?;
+    let id = resolved.id.clone();
 
     if !args.no_kill {
-        if let Err(e) = instances[idx].kill() {
+        if let Err(e) = resolved.kill() {
             eprintln!("Warning: failed to kill tmux session: {}", e);
         }
     }
 
-    instances[idx].archive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.archive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Archived: {}", title);
     Ok(())
@@ -319,21 +321,18 @@ async fn archive_session(profile: &str, args: ArchiveArgs) -> Result<()> {
 
 async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let id = super::resolve_session(&args.identifier, &instances)?
+    let id = super::resolve_session(&args.identifier, &storage.load()?)?
         .id
         .clone();
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .expect("resolve_session returned an id that is no longer in instances");
 
-    instances[idx].unarchive();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unarchive();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Unarchived: {}", title);
     Ok(())
@@ -341,7 +340,6 @@ async fn unarchive_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
 
     let config = crate::session::profile_config::resolve_config(profile)?;
 
@@ -355,20 +353,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
     crate::session::validate_snooze_duration(raw_minutes).map_err(|e| anyhow::anyhow!("{}", e))?;
     let minutes = raw_minutes as u32;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    instances[idx].snooze(minutes);
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.snooze(minutes);
+        Ok(inst.title.clone())
+    })?;
 
     println!("Snoozed for {}m: {}", minutes, title);
     Ok(())
@@ -376,22 +370,16 @@ async fn snooze_session(profile: &str, args: SnoozeArgs) -> Result<()> {
 
 async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
-
-    instances[idx].unsnooze();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let title = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.unsnooze();
+        Ok(inst.title.clone())
+    })?;
 
     println!("Woke: {}", title);
     Ok(())
@@ -399,7 +387,7 @@ async fn unsnooze_session(profile: &str, args: SessionIdArgs) -> Result<()> {
 
 async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -410,16 +398,25 @@ async fn start_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // Start the tmux process on a local copy first (the slow, non-storage
+    // work), then persist the started state via `update` so a row another
+    // process added in the meantime is not clobbered.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "start")?;
-    instances[idx].start_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
+    let mut started = instances[idx].clone();
+    started.source_profile = profile.to_string();
+    bail_if_cockpit(&started, "start")?;
+    started.start_with_size(crate::terminal::get_size())?;
+    let title = started.title.clone();
+    let started_id = started.id.clone();
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == started_id) {
+            *slot = started;
+        }
+        Ok(())
+    })?;
 
     println!("✓ Started session: {}", title);
     Ok(())
@@ -455,7 +452,7 @@ fn bail_if_cockpit(_inst: &crate::session::Instance, _verb: &str) -> Result<()> 
 
 async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = super::resolve_session(&args.identifier, &instances)?;
     bail_if_cockpit(inst, "stop")?;
@@ -473,14 +470,19 @@ async fn stop_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         return Ok(());
     }
 
+    // Stop the process before touching storage: it is a tmux/container
+    // syscall path independent of the registry.
     inst.stop()?;
 
-    // Persist Stopped status to disk so it survives TUI restarts
-    if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
-        stored.status = crate::session::Status::Stopped;
-    }
-    let group_tree = crate::session::GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    // Persist Stopped status to disk so it survives TUI restarts. `update`
+    // re-loads under the lock and mutates only this row, so a session
+    // another process added during `stop()` is preserved.
+    storage.update(move |instances, _groups| {
+        if let Some(stored) = instances.iter_mut().find(|i| i.id == session_id) {
+            stored.status = crate::session::Status::Stopped;
+        }
+        Ok(())
+    })?;
 
     if had_container {
         println!("✓ Stopped session and container: {}", title);
@@ -503,7 +505,7 @@ async fn restart_session_dispatch(profile: &str, args: RestartArgs) -> Result<()
 
 async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let target_ids = pick_targets_for_restart_all(&instances);
     if target_ids.is_empty() {
@@ -516,29 +518,28 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
     let parallel = parallel.max(1);
 
     // Clone each target into its worker; we'll write the (mutated) copy back
-    // by index after the worker returns. Workers never touch the shared Vec.
+    // by id after all workers return. Workers never touch the shared Vec.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so start-time config resolution honors the right profile's overrides
     // (sandbox.environment, on_launch hooks, etc.).
-    let mut targets: Vec<(usize, crate::session::Instance)> = Vec::with_capacity(total);
+    let mut targets: Vec<crate::session::Instance> = Vec::with_capacity(total);
     for id in &target_ids {
-        if let Some(idx) = instances.iter().position(|i| &i.id == id) {
-            let mut clone = instances[idx].clone();
+        if let Some(inst) = instances.iter().find(|i| &i.id == id) {
+            let mut clone = inst.clone();
             clone.source_profile = profile.to_string();
-            targets.push((idx, clone));
+            targets.push(clone);
         }
     }
 
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(parallel));
     let mut join_set: tokio::task::JoinSet<(
-        usize,
         String,
         Option<crate::session::Instance>,
         Result<StartOutcome>,
     )> = tokio::task::JoinSet::new();
 
-    for (idx, mut inst) in targets {
+    for mut inst in targets {
         let permit_sem = semaphore.clone();
         join_set.spawn(async move {
             let _permit = permit_sem
@@ -552,9 +553,8 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
             })
             .await;
             match res {
-                Ok((inst, result)) => (idx, title, Some(inst), result),
+                Ok((inst, result)) => (title, Some(inst), result),
                 Err(join_err) => (
-                    idx,
                     title,
                     None,
                     Err(anyhow::anyhow!("worker panicked: {}", join_err)),
@@ -565,11 +565,15 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
 
     let mut succeeded: Vec<(String, Option<String>)> = Vec::new();
     let mut failed: Vec<(String, String)> = Vec::new();
+    // Mutated copies of every session that restarted, keyed by id. After all
+    // the slow restart work finishes, a single `update` writes them back
+    // against a fresh load so a row another process added in the meantime
+    // is not clobbered.
+    let mut restarted: Vec<crate::session::Instance> = Vec::new();
     while let Some(joined) = join_set.join_next().await {
-        let (idx, title, inst_opt, result) =
-            joined.expect("JoinSet shouldn't panic on join itself");
+        let (title, inst_opt, result) = joined.expect("JoinSet shouldn't panic on join itself");
         if let Some(inst) = inst_opt {
-            instances[idx] = inst;
+            restarted.push(inst);
         }
         match result {
             Ok(StartOutcome::Restarted { stale_sid }) => succeeded.push((title, Some(stale_sid))),
@@ -578,8 +582,14 @@ async fn restart_all_sessions(profile: &str, parallel: usize) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        for updated in restarted {
+            if let Some(slot) = instances.iter_mut().find(|i| i.id == updated.id) {
+                *slot = updated;
+            }
+        }
+        Ok(())
+    })?;
 
     let stale_count = succeeded.iter().filter(|(_, s)| s.is_some()).count();
     if stale_count == 0 {
@@ -637,7 +647,7 @@ fn pick_targets_for_restart_all(instances: &[crate::session::Instance]) -> Vec<S
 
 async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let idx = instances
         .iter()
@@ -648,15 +658,23 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         })
         .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
 
+    // All of the restart work below (re-execing the pane, polling
+    // `wait_for_pane_ready` for up to 5s, sending the wake-up keys) is slow
+    // and touches only tmux, not the registry. Do it on a local copy first,
+    // then persist that copy through `update`, which re-loads `sessions.json`
+    // under the cross-process lock. A wholesale `commit` of the snapshot
+    // loaded above would be up to 5s stale and would clobber any row another
+    // process added during the restart, the exact loss this fix targets.
     // `source_profile` is runtime-only (skip_serializing) so storage-loaded
     // instances always come back blank; rehydrate it from the storage profile
     // so restart-time config resolution honors the right profile's overrides.
-    instances[idx].source_profile = profile.to_string();
-    bail_if_cockpit(&instances[idx], "restart")?;
-    let outcome = instances[idx].restart_with_size(crate::terminal::get_size())?;
-    let title = instances[idx].title.clone();
-    let session_id = instances[idx].id.clone();
-    let tool = instances[idx].tool.clone();
+    let mut restarted = instances[idx].clone();
+    restarted.source_profile = profile.to_string();
+    bail_if_cockpit(&restarted, "restart")?;
+    let outcome = restarted.restart_with_size(crate::terminal::get_size())?;
+    let title = restarted.title.clone();
+    let session_id = restarted.id.clone();
+    let tool = restarted.tool.clone();
 
     // Resolve the configured wake message (global default with per-profile
     // override). Empty string is the documented opt-out: the restart still
@@ -677,9 +695,7 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
             let delay = crate::agents::send_keys_enter_delay(&tool);
             match tmux_session.send_keys_with_delay(&wake_msg, delay) {
                 Ok(()) => {
-                    if let Some(inst) = instances.iter_mut().find(|i| i.id == session_id) {
-                        inst.touch_last_accessed();
-                    }
+                    restarted.touch_last_accessed();
                 }
                 Err(e) => {
                     eprintln!("Warning: failed to send wake-up message: {}", e);
@@ -688,8 +704,12 @@ async fn restart_session(profile: &str, args: SessionIdArgs) -> Result<()> {
         }
     }
 
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    storage.update(move |instances, _groups| {
+        if let Some(slot) = instances.iter_mut().find(|i| i.id == session_id) {
+            *slot = restarted;
+        }
+        Ok(())
+    })?;
 
     match outcome {
         StartOutcome::Restarted { stale_sid } => {
@@ -902,7 +922,7 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     }
 
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let inst = if let Some(id) = &args.identifier {
         super::resolve_session(id, &instances)?
@@ -933,14 +953,11 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
     let effective_title = args.title.unwrap_or(old_title.clone());
     let effective_title = effective_title.trim().to_string();
 
-    let idx = instances
-        .iter()
-        .position(|i| i.id == id)
-        .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-    // Rename tmux session if title changed
-    if instances[idx].title != effective_title {
-        let tmux_session = crate::tmux::Session::new(&id, &instances[idx].title)?;
+    // Rename the tmux session before touching storage: it is a tmux syscall
+    // independent of the registry, so it runs outside the `update` closure
+    // to keep the cross-process lock held only for the brief write.
+    if old_title != effective_title {
+        let tmux_session = crate::tmux::Session::new(&id, &old_title)?;
         if tmux_session.exists() {
             let new_tmux_name = crate::tmux::Session::generate_name(&id, &effective_title);
             if let Err(e) = tmux_session.rename(&new_tmux_name) {
@@ -951,17 +968,28 @@ async fn rename_session(profile: &str, args: RenameArgs) -> Result<()> {
         }
     }
 
-    instances[idx].title = effective_title.clone();
-
-    if let Some(group) = args.group {
-        instances[idx].group_path = group.trim().to_string();
-    }
-
-    let mut group_tree = GroupTree::new_with_groups(&instances, &groups);
-    if !instances[idx].group_path.is_empty() {
-        group_tree.create_group(&instances[idx].group_path);
-    }
-    storage.commit(&instances, &group_tree)?;
+    // `update` re-loads under the lock and mutates only this row, so a
+    // session another process added meanwhile is preserved.
+    let id_for_save = id.clone();
+    let title_for_save = effective_title.clone();
+    let group_for_save = args.group.clone();
+    storage.update(move |instances, groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id_for_save)
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+        inst.title = title_for_save;
+        if let Some(group) = group_for_save {
+            inst.group_path = group.trim().to_string();
+        }
+        if !inst.group_path.is_empty() {
+            let group_path = inst.group_path.clone();
+            let mut group_tree = GroupTree::new_with_groups(instances, groups);
+            group_tree.create_group(&group_path);
+            *groups = group_tree.get_all_groups();
+        }
+        Ok(())
+    })?;
 
     if old_title != effective_title {
         println!("✓ Renamed session: {} → {}", old_title, effective_title);
@@ -1021,16 +1049,7 @@ async fn current_session(args: CurrentArgs) -> Result<()> {
 
 async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (mut instances, groups) = storage.load_with_groups()?;
-
-    let idx = instances
-        .iter()
-        .position(|i| {
-            i.id == args.identifier
-                || i.id.starts_with(&args.identifier)
-                || i.title == args.identifier
-        })
-        .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+    let id = resolve_session_id(&storage.load()?, &args.identifier)?;
 
     let new_id = if args.session_id.trim().is_empty() {
         None
@@ -1045,17 +1064,20 @@ async fn set_session_id(profile: &str, args: SetSessionIdArgs) -> Result<()> {
         Some(trimmed)
     };
 
-    instances[idx].agent_session_id = new_id.clone();
-    let title = instances[idx].title.clone();
-
-    let group_tree = GroupTree::new_with_groups(&instances, &groups);
-    storage.commit(&instances, &group_tree)?;
+    let new_id_for_save = new_id.clone();
+    let (title, tool) = storage.update(move |instances, _groups| {
+        let inst = instances
+            .iter_mut()
+            .find(|i| i.id == id)
+            .ok_or_else(|| anyhow::anyhow!("Session not found: {}", args.identifier))?;
+        inst.agent_session_id = new_id_for_save;
+        Ok((inst.title.clone(), inst.tool.clone()))
+    })?;
 
     match new_id {
         Some(ref id) => {
             println!("✓ Set session ID for '{}': {}", title, id);
-            let tool = &instances[idx].tool;
-            if let Some(agent) = crate::agents::get_agent(tool) {
+            if let Some(agent) = crate::agents::get_agent(&tool) {
                 if matches!(
                     agent.resume_strategy,
                     crate::agents::ResumeStrategy::Unsupported

--- a/src/cli/worktree.rs
+++ b/src/cli/worktree.rs
@@ -154,7 +154,7 @@ async fn show_info(profile: &str, identifier: &str) -> Result<()> {
 
 async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
     let storage = Storage::new(profile)?;
-    let (instances, groups) = storage.load_with_groups()?;
+    let instances = storage.load()?;
 
     let mut orphaned_sessions = Vec::new();
     let mut orphaned_worktrees = Vec::new();
@@ -259,11 +259,20 @@ async fn cleanup_orphaned(profile: &str, force: bool) -> Result<()> {
 
     // Remove orphaned sessions
     if !orphaned_sessions.is_empty() {
-        let mut new_instances = instances.clone();
-        new_instances.retain(|inst| !orphaned_sessions.iter().any(|orphan| orphan.id == inst.id));
-
-        let group_tree = crate::session::GroupTree::new_with_groups(&new_instances, &groups);
-        storage.commit(&new_instances, &group_tree)?;
+        // Persist through `update`, which re-loads `sessions.json` under the
+        // cross-process lock and retains by `Instance.id`. The orphaned set
+        // was computed from an earlier load; a wholesale `commit` of that
+        // snapshot would clobber a row another process added in the
+        // meantime. Retaining by id removes only the orphans and leaves any
+        // concurrently-added row intact.
+        let orphan_ids: Vec<String> = orphaned_sessions
+            .iter()
+            .map(|inst| inst.id.clone())
+            .collect();
+        storage.update(move |instances, _groups| {
+            instances.retain(|inst| !orphan_ids.contains(&inst.id));
+            Ok(())
+        })?;
 
         removed_count += orphaned_sessions.len();
         println!("✓ Removed {} orphaned sessions", orphaned_sessions.len());

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -331,6 +331,7 @@ pub fn build_instance(
     let mut warnings: Vec<String> = Vec::new();
     let final_title = resolve_title(
         &params.title,
+        &final_path,
         params.worktree_branch.as_deref(),
         params.worktree_enabled,
         existing_titles,
@@ -602,27 +603,98 @@ pub fn cleanup_instance(
     let _ = instance.kill();
 }
 
-/// Resolve the session title: use the provided title, then an explicit worktree
-/// branch name, then fall back to a random civilization name.
+/// Resolve the session title. Precedence when no explicit title is provided:
+/// 1. Worktree branch name (when worktree mode is enabled).
+/// 2. A label derived from `project_path` ("leaf" when the project sits at the
+///    top of a known dev container like `~/GitProjects`, or "container - leaf"
+///    when it's a sub-directory of that top-level repo).
+/// 3. A random civilization name.
 pub(crate) fn resolve_title(
     title: &str,
+    project_path: &str,
     worktree_branch: Option<&str>,
     worktree_enabled: bool,
     existing_titles: &[&str],
 ) -> String {
-    if title.is_empty() {
-        if worktree_enabled {
-            if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
-                branch.trim().to_string()
-            } else {
-                civilizations::generate_random_title(existing_titles)
-            }
-        } else {
-            civilizations::generate_random_title(existing_titles)
-        }
-    } else {
-        title.to_string()
+    if !title.is_empty() {
+        return title.to_string();
     }
+    if worktree_enabled {
+        if let Some(branch) = worktree_branch.filter(|b| !b.trim().is_empty()) {
+            return branch.trim().to_string();
+        }
+    }
+    if let Some(derived) = derive_title_from_path(project_path) {
+        return derived;
+    }
+    civilizations::generate_random_title(existing_titles)
+}
+
+/// Known parent directories that typically hold a developer's repositories.
+/// Used to anchor the "top-level project folder" when deriving a default
+/// session title from the project path.
+const DEV_CONTAINERS: &[&str] = &[
+    "GitProjects",
+    "Projects",
+    "projects",
+    "Code",
+    "code",
+    "dev",
+    "src",
+    "workspace",
+    "Workspaces",
+    "repos",
+    "Repos",
+];
+
+/// Derive a default title from the project path.
+///
+/// Walks the path looking for a "dev container" segment (e.g. `GitProjects`).
+/// The segment immediately after the container is treated as the project
+/// root. If the project path *is* the project root, the returned title is
+/// just the root's basename (e.g. `per-dev`). If the project path lives
+/// inside the project root, the title combines both names with a hyphen
+/// separator (e.g. `per-dev - agent-of-empires`).
+///
+/// Returns `None` when the path doesn't sit beneath any known container,
+/// so the caller can fall back to a random title.
+fn derive_title_from_path(project_path: &str) -> Option<String> {
+    if project_path.is_empty() {
+        return None;
+    }
+    let raw = std::path::Path::new(project_path);
+    let canon = raw.canonicalize().unwrap_or_else(|_| raw.to_path_buf());
+    let names: Vec<String> = canon
+        .components()
+        .filter_map(|c| match c {
+            std::path::Component::Normal(s) => Some(s.to_string_lossy().to_string()),
+            _ => None,
+        })
+        .collect();
+    // Use the deepest container match so nested `~/projects/foo/src/...` still
+    // anchors on `src` (the closest one to the leaf).
+    let container_idx = names.iter().rposition(|seg| {
+        DEV_CONTAINERS
+            .iter()
+            .any(|c| seg.eq_ignore_ascii_case(c) || seg == c)
+    })?;
+    let root_idx = container_idx + 1;
+    let leaf_idx = names.len().checked_sub(1)?;
+    if root_idx > leaf_idx {
+        return None;
+    }
+    let root_name = &names[root_idx];
+    if root_name.is_empty() {
+        return None;
+    }
+    if root_idx == leaf_idx {
+        return Some(root_name.clone());
+    }
+    let leaf_name = &names[leaf_idx];
+    if leaf_name.is_empty() {
+        return Some(root_name.clone());
+    }
+    Some(format!("{root_name} - {leaf_name}"))
 }
 
 /// Origin of an effective worktree branch name. The builder uses this to decide
@@ -796,13 +868,13 @@ mod tests {
 
     #[test]
     fn test_empty_title_with_worktree_uses_branch_name() {
-        let title = resolve_title("", Some("feature-auth"), true, &[]);
+        let title = resolve_title("", "", Some("feature-auth"), true, &[]);
         assert_eq!(title, "feature-auth");
     }
 
     #[test]
     fn test_empty_title_without_worktree_uses_civilization() {
-        let title = resolve_title("", None, false, &[]);
+        let title = resolve_title("", "", None, false, &[]);
         assert!(
             civilizations::CIVILIZATIONS.contains(&title.as_str()),
             "Expected a civilization name, got: {}",
@@ -812,14 +884,77 @@ mod tests {
 
     #[test]
     fn test_provided_title_with_worktree_keeps_title() {
-        let title = resolve_title("My Session", Some("feature-auth"), true, &[]);
+        let title = resolve_title("My Session", "", Some("feature-auth"), true, &[]);
         assert_eq!(title, "My Session");
     }
 
     #[test]
     fn test_provided_title_without_worktree_keeps_title() {
-        let title = resolve_title("Custom Name", None, false, &[]);
+        let title = resolve_title("Custom Name", "", None, false, &[]);
         assert_eq!(title, "Custom Name");
+    }
+
+    #[test]
+    fn test_derive_title_at_top_of_container() {
+        // `per-dev` sits directly under `GitProjects`.
+        let derived = derive_title_from_path("/Users/alice/GitProjects/per-dev").expect("derived");
+        assert_eq!(derived, "per-dev");
+    }
+
+    #[test]
+    fn test_derive_title_in_subdir_of_container() {
+        // A repo nested two levels deep under `per-dev` should surface as
+        // `per-dev - agent-of-empires`.
+        let derived =
+            derive_title_from_path("/Users/alice/GitProjects/per-dev/forks/agent-of-empires")
+                .expect("derived");
+        assert_eq!(derived, "per-dev - agent-of-empires");
+    }
+
+    #[test]
+    fn test_derive_title_with_case_insensitive_container() {
+        // `Projects` (capital P) is in the canonical list, but the matcher
+        // should also accept other casings since users vary.
+        let derived = derive_title_from_path("/home/bob/projects/widgets").expect("derived");
+        assert_eq!(derived, "widgets");
+    }
+
+    #[test]
+    fn test_derive_title_outside_known_container_returns_none() {
+        assert_eq!(
+            derive_title_from_path("/var/log/something"),
+            None,
+            "Paths outside known containers should fall back to random"
+        );
+    }
+
+    #[test]
+    fn test_derive_title_uses_deepest_container_match() {
+        // When the path crosses two known containers, anchor on the deepest
+        // one so the result is the nearest project-root segment.
+        let derived =
+            derive_title_from_path("/home/alice/projects/monorepo/src/server").expect("derived");
+        assert_eq!(derived, "server");
+    }
+
+    #[test]
+    fn test_resolve_title_uses_path_derivation_when_no_branch() {
+        let title = resolve_title("", "/Users/alice/GitProjects/per-dev", None, false, &[]);
+        assert_eq!(title, "per-dev");
+    }
+
+    #[test]
+    fn test_worktree_branch_beats_path_derivation() {
+        // Branch name wins when worktree is enabled, even if path would derive
+        // a perfectly good title.
+        let title = resolve_title(
+            "",
+            "/Users/alice/GitProjects/per-dev",
+            Some("feature-x"),
+            true,
+            &[],
+        );
+        assert_eq!(title, "feature-x");
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -689,6 +689,27 @@ impl Instance {
         self.snoozed_until = None;
     }
 
+    /// Copy the start/stop/restart lifecycle fields from `src` onto `self`,
+    /// preserving user-metadata fields (favorited_at, archived_at,
+    /// snoozed_until, title, group_path, base_branch_override, notify_on_*,
+    /// ...). Used by CLI start/restart handlers inside the
+    /// `Storage::update()` closure to apply the result of slow tmux work
+    /// (which ran on a pre-lock clone) onto a freshly-loaded snapshot
+    /// without clobbering concurrent user edits to the same row.
+    ///
+    /// Addresses CodeRabbit feedback on PR #1435/#1436: a wholesale
+    /// `*slot = local_clone` would revert any field a concurrent
+    /// `favorite`/`set-session-id`/`set-base` (etc.) writer touched
+    /// between the pre-lock clone and the update() lock acquisition,
+    /// defeating the very lost-write fix `Storage::update()` is meant to
+    /// provide.
+    pub fn adopt_lifecycle_from(&mut self, src: &Instance) {
+        self.status = src.status;
+        self.last_accessed_at = src.last_accessed_at;
+        self.idle_entered_at = src.idle_entered_at;
+        self.agent_session_id = src.agent_session_id.clone();
+    }
+
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2469,40 +2469,20 @@ impl Instance {
             );
             shell_check
         };
-        self.status = match detected {
-            Status::Idle if self.has_command_override() => {
-                // Custom commands run agents through wrapper scripts that appear
-                // as shell processes to tmux. Only declare Error when the pane is
-                // actually dead; don't use is_shell_stale() since the shell IS
-                // the expected wrapper process.
-                if is_dead {
-                    Status::Error
-                } else {
-                    Status::Unknown
-                }
-            }
-            Status::Idle if is_dead => Status::Error,
-            Status::Idle if is_shell_stale() => {
-                // A shell is the foreground process but the pane is alive.
-                // Check captured pane content: if it contains the agent's
-                // UI the agent is still alive; only declare Error when the
-                // content looks like a bare shell prompt.
-                if pane_has_agent_content(&pane_content, &self.tool) {
-                    tracing::trace!(target: "session.store",
-                        "status '{}': shell stale but pane has agent content, staying Idle",
-                        self.title,
-                    );
-                    Status::Idle
-                } else {
-                    tracing::trace!(target: "session.store",
-                        "status '{}': shell stale, no agent content, setting Error",
-                        self.title,
-                    );
-                    Status::Error
-                }
-            }
-            other => other,
+        let has_command_override = self.has_command_override();
+        let shell_stale = if detected == Status::Idle && !has_command_override && !is_dead {
+            is_shell_stale()
+        } else {
+            false
         };
+        self.status = resolve_detected_status(
+            detected,
+            is_dead,
+            shell_stale,
+            has_command_override,
+            &pane_content,
+            &self.tool,
+        );
 
         tracing::trace!(target: "session.store", "status '{}': final={:?}", self.title, self.status);
 
@@ -2667,6 +2647,51 @@ fn prepend_exports(exports: &[String], wrapped: String) -> String {
     }
 }
 
+fn resolve_detected_status(
+    detected: Status,
+    is_dead: bool,
+    is_shell_stale: bool,
+    has_command_override: bool,
+    pane_content: &str,
+    tool: &str,
+) -> Status {
+    match detected {
+        Status::Idle if has_command_override => {
+            // Custom commands run agents through wrapper scripts that appear
+            // as shell processes to tmux. Only declare Error when the pane is
+            // actually dead; don't use shell-stale since the shell IS the
+            // expected wrapper process.
+            if is_dead {
+                Status::Error
+            } else {
+                Status::Unknown
+            }
+        }
+        Status::Idle if is_dead => Status::Error,
+        Status::Idle if is_shell_stale => resolve_shell_stale_status(pane_content, tool),
+        other => other,
+    }
+}
+
+fn resolve_shell_stale_status(pane_content: &str, tool: &str) -> Status {
+    if pane_has_agent_content(pane_content, tool) {
+        Status::Idle
+    } else if pane_looks_like_bare_shell_prompt(pane_content) {
+        Status::Error
+    } else {
+        Status::Unknown
+    }
+}
+
+fn pane_looks_like_bare_shell_prompt(raw_content: &str) -> bool {
+    let clean = crate::tmux::utils::strip_ansi(raw_content);
+    let Some(last) = clean.lines().rev().find(|l| !l.trim().is_empty()) else {
+        return false;
+    };
+    let last = last.trim();
+    last.ends_with('$') || last.ends_with('#') || last.ends_with('%') || last.ends_with('\u{276f}')
+}
+
 /// Check whether captured pane content indicates a living agent rather than
 /// a bare shell prompt. Used to prevent `is_shell_stale()` from producing
 /// false `Error` status when the agent binary is a shell wrapper or spawns
@@ -2679,15 +2704,10 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
         return false;
     }
 
-    // If the last visible line looks like a shell prompt, the agent
-    // likely exited and the shell took over. This catches servers with
-    // verbose MOTD that would otherwise exceed the line-count threshold.
-    let last = non_empty.last().unwrap().trim();
-    if last.ends_with('$')
-        || last.ends_with('#')
-        || last.ends_with('%')
-        || last.ends_with('\u{276f}')
-    {
+    // If the last visible line looks like a shell prompt, the agent likely
+    // exited and the shell took over. This catches servers with verbose MOTD
+    // that would otherwise exceed the line-count threshold.
+    if pane_looks_like_bare_shell_prompt(raw_content) {
         return false;
     }
 
@@ -2700,11 +2720,17 @@ fn pane_has_agent_content(raw_content: &str, tool: &str) -> bool {
 
     // Use word-boundary matching so short names like "pi" don't produce
     // false positives inside words like "api" or "pipeline".
-    let tool_lower = tool.to_lowercase();
+    let mut tool_names = vec![tool.to_lowercase()];
+    if let Some(agent) = crate::agents::get_agent(tool) {
+        let binary = agent.binary.to_lowercase();
+        if !tool_names.contains(&binary) {
+            tool_names.push(binary);
+        }
+    }
     let lower = clean.to_lowercase();
     if lower
         .split(|c: char| !c.is_alphanumeric() && c != '-' && c != '_')
-        .any(|word| word == tool_lower)
+        .any(|word| tool_names.iter().any(|name| word == name))
     {
         return true;
     }
@@ -3895,6 +3921,69 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_detected_status_shell_stale_agent_content_stays_idle() {
+        let content = "ctrl+p commands \u{2022} OpenCode 1.3.13+650d0db";
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, false, content, "opencode"),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_shell_stale_bare_prompt_is_error() {
+        assert_eq!(
+            resolve_detected_status(
+                Status::Idle,
+                false,
+                true,
+                false,
+                "Welcome\nuser@host:~$ ",
+                "opencode",
+            ),
+            Status::Error
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_shell_stale_unclear_is_unknown() {
+        assert_eq!(
+            resolve_detected_status(
+                Status::Idle,
+                false,
+                true,
+                false,
+                "Restoring previous session...",
+                "opencode",
+            ),
+            Status::Unknown
+        );
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, false, "", "opencode"),
+            Status::Unknown
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_keeps_hard_failures_as_error() {
+        assert_eq!(
+            resolve_detected_status(Status::Idle, true, false, false, "", "opencode"),
+            Status::Error
+        );
+        assert_eq!(
+            resolve_detected_status(Status::Idle, true, true, true, "", "opencode"),
+            Status::Error
+        );
+    }
+
+    #[test]
+    fn test_resolve_detected_status_live_command_override_is_unknown() {
+        assert_eq!(
+            resolve_detected_status(Status::Idle, false, true, true, "$ ", "opencode"),
+            Status::Unknown
+        );
+    }
+
+    #[test]
     fn test_pane_has_agent_content_agent_ui() {
         let opencode_idle = "ctrl+p commands \u{2022} OpenCode 1.3.13+650d0db";
         assert!(pane_has_agent_content(opencode_idle, "opencode"));
@@ -3951,6 +4040,11 @@ mod tests {
 
         // Longer names like "opencode" should still match.
         assert!(pane_has_agent_content("OpenCode v1.0", "opencode"));
+    }
+
+    #[test]
+    fn test_pane_has_agent_content_matches_agent_binary_alias() {
+        assert!(pane_has_agent_content("agy ready", "antigravity"));
     }
 
     mod kill_terminal_if_dead {

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -303,13 +303,22 @@ impl Storage {
     /// clobbered. The read, merge, and write all happen inside one
     /// flock-held critical section, so the reconcile cannot race a peer.
     ///
-    /// `groups.json` is still written wholesale from `group_tree`: groups are
-    /// edited only by the TUI, so they need no merge.
+    /// `groups.json` is merged with the same 3-way strategy as
+    /// `sessions.json`, keyed on `Group.path`: TUI-owned groups win for
+    /// paths it carries, baseline-but-absent groups are dropped (TUI
+    /// delete), and on-disk-only groups are appended (peer addition,
+    /// e.g. a `aoe group create` from the CLI between this view's load
+    /// and save). `baseline_group_paths` is the set of group paths this
+    /// view loaded from disk — same role `baseline_ids` plays for
+    /// instances. (CodeRabbit feedback on PR #1437: a wholesale
+    /// groups.json write would clobber a CLI-created group that landed
+    /// between the TUI's load and save.)
     pub fn commit_merged(
         &self,
         instances: &[Instance],
         group_tree: &GroupTree,
         baseline_ids: &std::collections::HashSet<String>,
+        baseline_group_paths: &std::collections::HashSet<String>,
     ) -> Result<()> {
         let _guard = self
             .save_lock
@@ -322,10 +331,25 @@ impl Storage {
         let on_disk = self.load()?;
         let merged = merge_instances(instances, &on_disk, baseline_ids);
 
-        let groups = group_tree.get_all_groups();
+        let groups_path = self.sessions_path.with_file_name("groups.json");
+        let on_disk_groups: Vec<Group> = if groups_path.exists() {
+            let content = fs::read_to_string(&groups_path)?;
+            if content.trim().is_empty() {
+                Vec::new()
+            } else {
+                serde_json::from_str(&content)?
+            }
+        } else {
+            Vec::new()
+        };
+        let groups = merge_groups(
+            &group_tree.get_all_groups(),
+            &on_disk_groups,
+            baseline_group_paths,
+        );
+
         let instances_buf = serde_json::to_vec_pretty(&merged)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
-        let groups_path = self.sessions_path.with_file_name("groups.json");
         atomic_write(&groups_path, &groups_buf)?;
         atomic_write(&self.sessions_path, &instances_buf)?;
         Ok(())
@@ -362,6 +386,31 @@ fn merge_instances(
         // On disk, never in the baseline: a peer added it after the TUI
         // loaded. Keep it.
         merged.push(row.clone());
+    }
+    merged
+}
+
+/// 3-way merge of groups keyed on `Group.path`. Mirror of `merge_instances`
+/// for groups.json: TUI-owned groups win, baseline-but-absent groups are
+/// dropped (TUI delete), on-disk-only groups are appended (peer addition).
+/// Pure function so it can be unit-tested without touching the filesystem.
+fn merge_groups(
+    groups: &[Group],
+    on_disk: &[Group],
+    baseline_paths: &std::collections::HashSet<String>,
+) -> Vec<Group> {
+    let tui_paths: std::collections::HashSet<&str> =
+        groups.iter().map(|g| g.path.as_str()).collect();
+
+    let mut merged: Vec<Group> = groups.to_vec();
+    for g in on_disk {
+        if tui_paths.contains(g.path.as_str()) {
+            continue;
+        }
+        if baseline_paths.contains(&g.path) {
+            continue;
+        }
+        merged.push(g.clone());
     }
     merged
 }
@@ -1312,6 +1361,7 @@ mod tests {
             &tui_memory,
             &GroupTree::new_with_groups(&tui_memory, &[]),
             &baseline_ids,
+            &HashSet::new(),
         )?;
 
         let loaded = storage.load()?;

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -1,27 +1,34 @@
-//! Session storage - JSON file persistence with in-process per-profile locking.
+//! Session storage - JSON file persistence with two-tier write locking.
 //!
 //! `Storage` serialises read-modify-write cycles inside the same process via a
 //! per-profile mutex (one `Arc<Mutex<()>>` per profile name, registered process-
-//! wide). Mutators use `update` (load -> mutate -> save under the lock) or
-//! `commit` (locked wholesale write, for callers that already own the
-//! authoritative in-memory state, e.g. the TUI's `HomeView`). The
-//! `save_workspace_ordering` entry point is `pub(crate)` and only consumed
-//! by `update_workspace_ordering` internally; the per-profile `save` /
-//! `save_groups` helpers have been removed entirely. This keeps it
+//! wide), and across separate OS processes via a blocking exclusive `flock(2)`
+//! on a per-profile `sessions.json.lock` file. Mutators use `update` (load ->
+//! mutate -> save under both locks) or `commit` (locked wholesale write, for
+//! callers that already own the authoritative in-memory state, e.g. the TUI's
+//! `HomeView`). The `save_workspace_ordering` entry point is `pub(crate)` and
+//! only consumed by `update_workspace_ordering` internally; the per-profile
+//! `save` / `save_groups` helpers have been removed entirely. This keeps it
 //! structurally impossible to bypass the lock.
 //!
-//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
-//! server side) is acquired BEFORE `Storage`'s per-profile mutex, never the
-//! reverse. The closure passed to `update` is `FnOnce(...) -> Result<R>` and
-//! cannot await, so `std::sync::Mutex` is safe across the body even on the
-//! tokio runtime: server callers wrap `update` in `tokio::task::spawn_blocking`,
-//! which is the existing pattern.
+//! The cross-process `flock` is required because the TUI (`aoe`), the CLI, and
+//! the `aoe serve` daemon are three separate processes that all mutate the
+//! same profile's `sessions.json`; the in-process mutex alone is invisible to
+//! peers, so their load-modify-write cycles would interleave and clobber rows
+//! (last-writer-wins). The `flock` mirrors the approach in
+//! `recovery::RecoveryLock` and is held for the entire load-modify-write
+//! region of both `update` and `commit`.
 //!
-//! Cross-process races (the TUI and `aoe serve` mutating the same profile
-//! concurrently) are explicitly out of scope here; a future advisory `flock`
-//! would close them.
+//! Lock-ordering rule across the process: `AppState.instances` (tokio RwLock,
+//! server side) is acquired BEFORE `Storage`'s per-profile mutex, which is
+//! acquired before the `flock`; never the reverse. The closure passed to
+//! `update` is `FnOnce(...) -> Result<R>` and cannot await, so
+//! `std::sync::Mutex` is safe across the body even on the tokio runtime:
+//! server callers wrap `update` in `tokio::task::spawn_blocking`, which is the
+//! existing pattern.
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use fs2::FileExt;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write as _;
@@ -77,9 +84,53 @@ fn workspace_ordering_lock() -> &'static Mutex<()> {
     LOCK.get_or_init(|| Mutex::new(()))
 }
 
+/// Cross-process advisory lock guarding a profile's `sessions.json` (and the
+/// sibling `groups.json` it is written with).
+///
+/// The in-process `save_lock` mutex only serialises writers inside one OS
+/// process; the TUI, the CLI, and the `aoe serve` daemon are three separate
+/// processes that all mutate the same profile's files, so without an OS-level
+/// lock their load-modify-write cycles interleave and rows get clobbered
+/// (last-writer-wins). This guard takes a blocking exclusive `flock(2)` on a
+/// dedicated `sessions.json.lock` file next to the data, held for the whole
+/// load-modify-write region and released when the guard drops. It mirrors the
+/// `flock` approach already used by `recovery::RecoveryLock`.
+///
+/// The lock is on a separate `.lock` file rather than on `sessions.json`
+/// itself because `atomic_write` replaces `sessions.json` via `rename(2)`; a
+/// lock held on the old inode would not cover the new one.
+struct SessionsFileLock {
+    _file: fs::File,
+}
+
+impl SessionsFileLock {
+    /// Acquire the exclusive cross-process lock, blocking until no other
+    /// process holds it. The lock file is created if missing and never
+    /// deleted (the lock lives on the open file description, not on the
+    /// file's existence).
+    fn acquire(lock_path: &Path) -> Result<Self> {
+        if let Some(parent) = lock_path.parent() {
+            // Surface an unwritable profile dir here with the real OS error
+            // rather than as a confusing ENOENT from the open() below.
+            fs::create_dir_all(parent)?;
+        }
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(lock_path)
+            .with_context(|| format!("opening sessions lock file {}", lock_path.display()))?;
+        file.lock_exclusive()
+            .with_context(|| format!("acquiring sessions lock {}", lock_path.display()))?;
+        Ok(Self { _file: file })
+    }
+}
+
 pub struct Storage {
     profile: String,
     sessions_path: PathBuf,
+    lock_path: PathBuf,
     save_lock: Arc<Mutex<()>>,
 }
 
@@ -106,11 +157,13 @@ impl Storage {
 
         let profile_dir = get_profile_dir(&profile_name)?;
         let sessions_path = profile_dir.join("sessions.json");
+        let lock_path = profile_dir.join("sessions.json.lock");
         let save_lock = save_lock_for(&profile_name);
 
         Ok(Self {
             profile: profile_name,
             sessions_path,
+            lock_path,
             save_lock,
         })
     }
@@ -177,6 +230,10 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // Cross-process exclusion: the in-process mutex above only covers this
+        // OS process; the TUI, CLI, and daemon are separate processes writing
+        // the same files. The flock spans the whole load-modify-write region.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let (mut instances, mut groups) = self.load_with_groups()?;
         let groups_before = groups.clone();
         let result = f(&mut instances, &mut groups)?;
@@ -216,6 +273,9 @@ impl Storage {
             .save_lock
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // See `update`: the flock serialises this wholesale write against
+        // mutators running in other OS processes for the same profile.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
         let groups = group_tree.get_all_groups();
         let instances_buf = serde_json::to_vec_pretty(instances)?;
         let groups_buf = serde_json::to_vec_pretty(&groups)?;
@@ -436,7 +496,13 @@ mod tests {
             .collect();
         entries.sort();
 
-        assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+        // `sessions.json.lock` is the cross-process flock file; it is created
+        // on first write and intentionally persists (the lock lives on the
+        // file, not on its existence). It is not temp-file debris.
+        assert_eq!(
+            entries,
+            vec!["groups.json", "sessions.json", "sessions.json.lock"]
+        );
         Ok(())
     }
 
@@ -990,6 +1056,144 @@ mod tests {
         assert_ne!(
             groups_mtime_before, groups_mtime_after,
             "groups.json should be rewritten when closure mutates groups"
+        );
+        Ok(())
+    }
+
+    /// Worker side of `test_update_serializes_concurrent_writers_cross_process`.
+    ///
+    /// This is not a real test: it runs as a no-op unless the parent test has
+    /// set `AOE_FLOCK_XPROC_CHILD`, in which case it re-enters as a child
+    /// process and performs exactly one `update()`. The parent re-invokes the
+    /// test binary with `--exact` targeting this function so that each child
+    /// is a genuinely separate OS process (the only thing that exercises the
+    /// cross-process `flock`; threads in one process all share a single flock
+    /// holder and would pass even on the broken code).
+    ///
+    /// Coordinates arrive via env vars:
+    /// - `AOE_FLOCK_XPROC_CHILD`: the row title/id this child should add.
+    /// - `HOME` / `XDG_CONFIG_HOME`: the shared temp app dir.
+    /// - `AOE_FLOCK_XPROC_BARRIER`: a file both children poll so their
+    ///   `update()` calls overlap rather than running sequentially.
+    #[test]
+    fn xproc_writer_child() {
+        let Ok(row) = std::env::var("AOE_FLOCK_XPROC_CHILD") else {
+            return; // ran as an ordinary unit test; nothing to do.
+        };
+        let barrier = std::env::var("AOE_FLOCK_XPROC_BARRIER")
+            .expect("barrier path must be set for the child");
+
+        // Announce arrival, then wait until both children have announced so
+        // their load-modify-write windows overlap.
+        fs::write(format!("{barrier}.{row}"), b"ready").unwrap();
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            let a = Path::new(&format!("{barrier}.a")).exists();
+            let b = Path::new(&format!("{barrier}.b")).exists();
+            if a && b {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "child timed out waiting for peer"
+            );
+            std::thread::sleep(std::time::Duration::from_millis(2));
+        }
+
+        let storage = Storage::new("xproc-profile").expect("storage");
+        storage
+            .update(|instances, _groups| {
+                instances.push(Instance::new(&row, &format!("/tmp/{row}")));
+                Ok(())
+            })
+            .expect("child update");
+    }
+
+    #[test]
+    #[serial]
+    fn test_update_serializes_concurrent_writers_cross_process() -> Result<()> {
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        // Seed an empty sessions.json so both children load-modify-write a
+        // file that already exists.
+        let storage = Storage::new("xproc-profile")?;
+        storage.commit(&[], &GroupTree::new_with_groups(&[], &[]))?;
+
+        let barrier = temp.path().join("xproc-barrier");
+        let exe = std::env::current_exe()?;
+
+        let spawn_child = |row: &str| -> std::process::Child {
+            let mut cmd = std::process::Command::new(&exe);
+            cmd.args([
+                "--exact",
+                "session::storage::tests::xproc_writer_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env("AOE_FLOCK_XPROC_CHILD", row)
+            .env("AOE_FLOCK_XPROC_BARRIER", &barrier)
+            .env("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            cmd.env("XDG_CONFIG_HOME", temp.path().join(".config"));
+            cmd.stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null());
+            cmd.spawn().expect("spawn child")
+        };
+
+        let child_a = spawn_child("a");
+        let child_b = spawn_child("b");
+
+        for (label, mut child) in [("a", child_a), ("b", child_b)] {
+            let status = child.wait()?;
+            assert!(status.success(), "child {label} exited with {status}");
+        }
+
+        let loaded = storage.load()?;
+        let mut titles: Vec<_> = loaded.iter().map(|i| i.title.clone()).collect();
+        titles.sort();
+        assert_eq!(
+            titles,
+            vec!["a".to_string(), "b".to_string()],
+            "cross-process writers lost a row: last-writer-wins clobbered the other"
+        );
+        Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_file_lock_excludes_concurrent_holder() -> Result<()> {
+        // Focused check on the lock primitive: while one guard is held, a
+        // non-blocking acquisition of the same lock file fails with
+        // `WouldBlock`, and a blocking acquisition succeeds once the first
+        // guard drops.
+        use fs2::FileExt;
+
+        let temp = tempdir()?;
+        let lock_path = temp.path().join("primitive.lock");
+
+        let guard = SessionsFileLock::acquire(&lock_path)?;
+
+        let probe = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(&lock_path)?;
+        let contended = probe.try_lock_exclusive();
+        assert!(
+            matches!(&contended, Err(e) if e.kind() == std::io::ErrorKind::WouldBlock),
+            "second holder must be blocked while the first guard is alive, got {contended:?}"
+        );
+
+        drop(guard);
+
+        // After the guard drops the lock is free; a fresh blocking acquire
+        // returns immediately.
+        let reacquired = SessionsFileLock::acquire(&lock_path);
+        assert!(
+            reacquired.is_ok(),
+            "lock must be re-acquirable after the guard drops"
         );
         Ok(())
     }

--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -284,6 +284,86 @@ impl Storage {
         atomic_write(&self.sessions_path, &instances_buf)?;
         Ok(())
     }
+
+    /// Locked, non-lossy commit for the TUI's `HomeView`. Unlike `commit`,
+    /// which overwrites `sessions.json` wholesale from the caller's in-memory
+    /// snapshot, this re-reads the on-disk rows under the flock and reconciles
+    /// them against the caller's rows using a 3-way merge keyed on
+    /// `Instance.id`:
+    ///
+    /// - Row present in `instances` (the TUI's authoritative copy): the TUI's
+    ///   version wins. The TUI owns the rows it displays and edits.
+    /// - Row in `baseline_ids` (what the TUI loaded) but absent from
+    ///   `instances`: the TUI deleted it intentionally; drop it.
+    /// - Row on disk but absent from `baseline_ids`: another process added it
+    ///   after the TUI loaded; keep it.
+    ///
+    /// Net effect: intentional TUI deletes are honoured, while rows a peer
+    /// process (CLI, `aoe serve` daemon) added concurrently are never
+    /// clobbered. The read, merge, and write all happen inside one
+    /// flock-held critical section, so the reconcile cannot race a peer.
+    ///
+    /// `groups.json` is still written wholesale from `group_tree`: groups are
+    /// edited only by the TUI, so they need no merge.
+    pub fn commit_merged(
+        &self,
+        instances: &[Instance],
+        group_tree: &GroupTree,
+        baseline_ids: &std::collections::HashSet<String>,
+    ) -> Result<()> {
+        let _guard = self
+            .save_lock
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        // The flock spans the whole read-merge-write region: a peer process
+        // cannot slip an addition in between our re-read and our write.
+        let _flock = SessionsFileLock::acquire(&self.lock_path)?;
+
+        let on_disk = self.load()?;
+        let merged = merge_instances(instances, &on_disk, baseline_ids);
+
+        let groups = group_tree.get_all_groups();
+        let instances_buf = serde_json::to_vec_pretty(&merged)?;
+        let groups_buf = serde_json::to_vec_pretty(&groups)?;
+        let groups_path = self.sessions_path.with_file_name("groups.json");
+        atomic_write(&groups_path, &groups_buf)?;
+        atomic_write(&self.sessions_path, &instances_buf)?;
+        Ok(())
+    }
+}
+
+/// 3-way merge of session rows keyed on `Instance.id`. See `commit_merged`
+/// for the rules. Pure function so it can be unit-tested without touching the
+/// filesystem.
+///
+/// Result order: the caller's `instances` first (preserving the TUI's display
+/// order), then any concurrently-added on-disk rows appended in their on-disk
+/// order. Appending keeps a peer's addition visible without disturbing the
+/// order the TUI was rendering.
+fn merge_instances(
+    instances: &[Instance],
+    on_disk: &[Instance],
+    baseline_ids: &std::collections::HashSet<String>,
+) -> Vec<Instance> {
+    let tui_ids: std::collections::HashSet<&str> =
+        instances.iter().map(|i| i.id.as_str()).collect();
+
+    let mut merged: Vec<Instance> = instances.to_vec();
+    for row in on_disk {
+        // Already represented by the TUI's authoritative copy: skip the disk
+        // version so the TUI's edits win.
+        if tui_ids.contains(row.id.as_str()) {
+            continue;
+        }
+        // In the baseline but gone from TUI memory: the TUI deleted it. Drop.
+        if baseline_ids.contains(&row.id) {
+            continue;
+        }
+        // On disk, never in the baseline: a peer added it after the TUI
+        // loaded. Keep it.
+        merged.push(row.clone());
+    }
+    merged
 }
 
 // Workspace ordering is stored at the app-data root, not per-profile:
@@ -1196,6 +1276,100 @@ mod tests {
             "lock must be re-acquirable after the guard drops"
         );
         Ok(())
+    }
+
+    #[test]
+    #[serial]
+    fn test_commit_merged_keeps_concurrent_addition_and_honours_tui_delete() -> Result<()> {
+        use std::collections::HashSet;
+
+        let temp = tempdir()?;
+        setup_test_home(temp.path());
+
+        let storage = Storage::new("test-commit-merged")?;
+
+        // The TUI loads two rows: `keep` and `tui-deletes`. This id-set is the
+        // load baseline HomeView records in `reload()`.
+        let keep = Instance::new("keep", "/tmp/keep");
+        let tui_deletes = Instance::new("tui-deletes", "/tmp/tui-deletes");
+        let baseline: Vec<Instance> = vec![keep.clone(), tui_deletes.clone()];
+        let baseline_ids: HashSet<String> = baseline.iter().map(|i| i.id.clone()).collect();
+        storage.commit(&baseline, &GroupTree::new_with_groups(&baseline, &[]))?;
+
+        // A peer process (CLI / daemon) adds a row AFTER the TUI loaded; the
+        // TUI never saw it, so its id is not in the baseline.
+        storage.update(|instances, _| {
+            instances.push(Instance::new("peer-added", "/tmp/peer-added"));
+            Ok(())
+        })?;
+
+        // The TUI's in-memory view: `keep` is still there, `tui-deletes` was
+        // removed by the user. The peer's row is, of course, absent from the
+        // TUI's memory.
+        let tui_memory: Vec<Instance> = vec![keep.clone()];
+
+        storage.commit_merged(
+            &tui_memory,
+            &GroupTree::new_with_groups(&tui_memory, &[]),
+            &baseline_ids,
+        )?;
+
+        let loaded = storage.load()?;
+        let titles: HashSet<String> = loaded.iter().map(|i| i.title.clone()).collect();
+
+        assert!(
+            titles.contains("peer-added"),
+            "concurrently-added row was dropped by the TUI commit; \
+             got {titles:?}"
+        );
+        assert!(
+            titles.contains("keep"),
+            "row the TUI still owns was lost; got {titles:?}"
+        );
+        assert!(
+            !titles.contains("tui-deletes"),
+            "row the TUI intentionally deleted came back; got {titles:?}"
+        );
+        assert_eq!(
+            loaded.len(),
+            2,
+            "expected exactly `keep` + `peer-added`; got {titles:?}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn test_merge_instances_three_way() {
+        use std::collections::HashSet;
+
+        let keep = Instance::new("keep", "/tmp/keep");
+        let tui_deletes = Instance::new("tui-deletes", "/tmp/tui-deletes");
+        let peer_added = Instance::new("peer-added", "/tmp/peer-added");
+
+        let baseline_ids: HashSet<String> = [keep.id.clone(), tui_deletes.id.clone()]
+            .into_iter()
+            .collect();
+
+        // TUI memory: kept `keep`, dropped `tui-deletes`.
+        let tui_memory = vec![keep.clone()];
+        // Disk after a peer write: all three rows.
+        let on_disk = vec![keep.clone(), tui_deletes.clone(), peer_added.clone()];
+
+        let merged = merge_instances(&tui_memory, &on_disk, &baseline_ids);
+        let ids: HashSet<&str> = merged.iter().map(|i| i.id.as_str()).collect();
+
+        assert!(ids.contains(keep.id.as_str()), "TUI-owned row dropped");
+        assert!(
+            ids.contains(peer_added.id.as_str()),
+            "concurrent peer addition dropped"
+        );
+        assert!(
+            !ids.contains(tui_deletes.id.as_str()),
+            "intentional TUI delete resurrected"
+        );
+        assert_eq!(merged.len(), 2);
+        // TUI display order is preserved: its rows come first.
+        assert_eq!(merged[0].id, keep.id);
     }
 
     #[test]

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -160,6 +160,11 @@ pub struct HomeView {
     /// a row on disk but absent from the baseline was added by another process
     /// after the TUI loaded and must be kept. See `Storage::commit_merged`.
     pub(super) load_baseline: HashMap<String, HashSet<String>>,
+    /// Per-profile group-path-set, the group-tree mirror of `load_baseline`.
+    /// Same role: a path here that is gone from the view's group tree is an
+    /// intentional TUI delete, while a path on disk that is not here is a
+    /// peer-created group that must be kept. See `Storage::commit_merged`.
+    pub(super) load_baseline_groups: HashMap<String, HashSet<String>>,
     pub(super) flat_items: Vec<Item>,
 
     // UI state
@@ -367,6 +372,7 @@ impl HomeView {
         let mut all_instances = Vec::new();
         let mut group_trees = HashMap::new();
         let mut load_baseline: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut load_baseline_groups: HashMap<String, HashSet<String>> = HashMap::new();
 
         let profile_names = match &active_profile {
             Some(name) => vec![name.clone()],
@@ -380,10 +386,15 @@ impl HomeView {
                 inst.source_profile = profile_name.clone();
             }
             // Record the load baseline before status carry-over so the merge
-            // in `save` knows exactly which ids this view loaded from disk.
+            // in `save` knows exactly which ids/group-paths this view loaded
+            // from disk.
             load_baseline.insert(
                 profile_name.clone(),
                 instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            load_baseline_groups.insert(
+                profile_name.clone(),
+                groups.iter().map(|g| g.path.clone()).collect(),
             );
             let tree = GroupTree::new_with_groups(&instances, &groups);
             group_trees.insert(profile_name.clone(), tree);
@@ -448,6 +459,7 @@ impl HomeView {
             instance_map,
             group_trees,
             load_baseline,
+            load_baseline_groups,
             flat_items: Vec::new(),
             cursor: 0,
             selected_session: None,
@@ -668,14 +680,20 @@ impl HomeView {
         self.refresh_status_hook_config_cache();
 
         let mut next_baseline: HashMap<String, HashSet<String>> = HashMap::new();
+        let mut next_baseline_groups: HashMap<String, HashSet<String>> = HashMap::new();
         for (profile_name, storage) in &self.storages {
             let (mut instances, groups) = storage.load_with_groups()?;
-            // The on-disk id-set is the load baseline for the next `save`'s
-            // merge. Captured from the raw disk read, before status carry-over
-            // or the Creating-stub re-injection touches `instances`.
+            // The on-disk id-set + group-path-set are the load baselines for
+            // the next `save`'s merge. Captured from the raw disk read,
+            // before status carry-over or the Creating-stub re-injection
+            // touches `instances`.
             next_baseline.insert(
                 profile_name.clone(),
                 instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            next_baseline_groups.insert(
+                profile_name.clone(),
+                groups.iter().map(|g| g.path.clone()).collect(),
             );
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
@@ -728,6 +746,7 @@ impl HomeView {
         // Adopt the freshly-captured per-profile load baselines. Profiles that
         // no longer exist drop out implicitly (they were never inserted).
         self.load_baseline = next_baseline;
+        self.load_baseline_groups = next_baseline_groups;
 
         self.instances = all_instances;
 
@@ -2110,7 +2129,9 @@ impl HomeView {
         stale_sid
     }
 
-    pub fn save(&self) -> anyhow::Result<()> {
+    pub fn save(&mut self) -> anyhow::Result<()> {
+        let mut next_baseline = self.load_baseline.clone();
+        let mut next_baseline_groups = self.load_baseline_groups.clone();
         for (profile_name, storage) in &self.storages {
             let profile_instances: Vec<Instance> = self
                 .instances
@@ -2137,8 +2158,31 @@ impl HomeView {
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_default();
-            storage.commit_merged(&profile_instances, &tree, &baseline)?;
+            let baseline_groups = self
+                .load_baseline_groups
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
+            storage.commit_merged(&profile_instances, &tree, &baseline, &baseline_groups)?;
+            // Promote the just-saved set into the next baseline so a row
+            // this view created and then deleted (in the same load cycle)
+            // is treated as a TUI delete on the next save, not as a
+            // peer-added row that gets resurrected. (CodeRabbit feedback on
+            // PR #1437.)
+            next_baseline.insert(
+                profile_name.clone(),
+                profile_instances.iter().map(|i| i.id.clone()).collect(),
+            );
+            next_baseline_groups.insert(
+                profile_name.clone(),
+                tree.get_all_groups()
+                    .iter()
+                    .map(|g| g.path.clone())
+                    .collect(),
+            );
         }
+        self.load_baseline = next_baseline;
+        self.load_baseline_groups = next_baseline_groups;
         Ok(())
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1383,6 +1383,7 @@ impl HomeView {
                 .collect();
             data.title = crate::session::builder::resolve_title(
                 &data.title,
+                &data.path,
                 data.worktree_branch.as_deref(),
                 data.worktree_enabled,
                 &existing_titles,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2202,6 +2202,28 @@ impl HomeView {
         }
     }
 
+    /// Drop `group_path` from `profile`'s tree when no remaining session in
+    /// that profile sits at the path or anywhere underneath it. Used after a
+    /// session moves to a different profile: without this, the source
+    /// profile keeps an empty group header that renders alongside the
+    /// target profile's new copy of the same group, reading as a duplicate.
+    pub(super) fn prune_empty_group(&mut self, profile: &str, group_path: &str) {
+        if group_path.is_empty() {
+            return;
+        }
+        let prefix = format!("{}/", group_path);
+        let still_used = self.instances.iter().any(|i| {
+            i.source_profile == profile
+                && (i.group_path == group_path || i.group_path.starts_with(&prefix))
+        });
+        if still_used {
+            return;
+        }
+        if let Some(tree) = self.group_trees.get_mut(profile) {
+            tree.delete_group(group_path);
+        }
+    }
+
     /// Determine which profile the item at the given cursor position belongs to.
     pub(super) fn profile_for_cursor(&self, cursor: usize) -> Option<String> {
         if let Some(profile) = &self.active_profile {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -153,6 +153,13 @@ pub struct HomeView {
     instances: Vec<Instance>,
     instance_map: HashMap<String, Instance>,
     pub(super) group_trees: HashMap<String, GroupTree>,
+    /// Per-profile id-set of the session rows that were on disk the last time
+    /// this `HomeView` loaded that profile (`new` / `reload`). It is the
+    /// "load baseline" for the non-lossy 3-way merge in `save`: a row in the
+    /// baseline but gone from `instances` is an intentional TUI delete, while
+    /// a row on disk but absent from the baseline was added by another process
+    /// after the TUI loaded and must be kept. See `Storage::commit_merged`.
+    pub(super) load_baseline: HashMap<String, HashSet<String>>,
     pub(super) flat_items: Vec<Item>,
 
     // UI state
@@ -359,6 +366,7 @@ impl HomeView {
         let mut storages = HashMap::new();
         let mut all_instances = Vec::new();
         let mut group_trees = HashMap::new();
+        let mut load_baseline: HashMap<String, HashSet<String>> = HashMap::new();
 
         let profile_names = match &active_profile {
             Some(name) => vec![name.clone()],
@@ -371,6 +379,12 @@ impl HomeView {
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
             }
+            // Record the load baseline before status carry-over so the merge
+            // in `save` knows exactly which ids this view loaded from disk.
+            load_baseline.insert(
+                profile_name.clone(),
+                instances.iter().map(|i| i.id.clone()).collect(),
+            );
             let tree = GroupTree::new_with_groups(&instances, &groups);
             group_trees.insert(profile_name.clone(), tree);
             all_instances.extend(instances);
@@ -433,6 +447,7 @@ impl HomeView {
             instances: all_instances,
             instance_map,
             group_trees,
+            load_baseline,
             flat_items: Vec::new(),
             cursor: 0,
             selected_session: None,
@@ -652,8 +667,16 @@ impl HomeView {
         }
         self.refresh_status_hook_config_cache();
 
+        let mut next_baseline: HashMap<String, HashSet<String>> = HashMap::new();
         for (profile_name, storage) in &self.storages {
             let (mut instances, groups) = storage.load_with_groups()?;
+            // The on-disk id-set is the load baseline for the next `save`'s
+            // merge. Captured from the raw disk read, before status carry-over
+            // or the Creating-stub re-injection touches `instances`.
+            next_baseline.insert(
+                profile_name.clone(),
+                instances.iter().map(|i| i.id.clone()).collect(),
+            );
             for inst in &mut instances {
                 inst.source_profile = profile_name.clone();
                 if let Some(prev) = self.instance_map.get(&inst.id) {
@@ -701,6 +724,10 @@ impl HomeView {
         // Remove trees for profiles that no longer exist
         let storage_keys: Vec<String> = self.storages.keys().cloned().collect();
         self.group_trees.retain(|k, _| storage_keys.contains(k));
+
+        // Adopt the freshly-captured per-profile load baselines. Profiles that
+        // no longer exist drop out implicitly (they were never inserted).
+        self.load_baseline = next_baseline;
 
         self.instances = all_instances;
 
@@ -2097,7 +2124,20 @@ impl HomeView {
                 .get(profile_name)
                 .cloned()
                 .unwrap_or_else(|| GroupTree::new_with_groups(&profile_instances, &[]));
-            storage.commit(&profile_instances, &tree)?;
+            // Non-lossy commit: `commit_merged` re-reads the on-disk rows under
+            // the cross-process flock and reconciles them against this view's
+            // rows and the load baseline, so a row a peer process (CLI, `aoe
+            // serve` daemon) added after this view last loaded is preserved
+            // instead of being clobbered by a wholesale overwrite. A profile
+            // with no recorded baseline (should not happen post-`reload`)
+            // falls back to an empty set: every on-disk row then looks
+            // peer-added and is kept, which is the safe, non-lossy direction.
+            let baseline = self
+                .load_baseline
+                .get(profile_name)
+                .cloned()
+                .unwrap_or_default();
+            storage.commit_merged(&profile_instances, &tree, &baseline)?;
         }
         Ok(())
     }

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -210,9 +210,19 @@ impl HomeView {
                         GroupTree::new_with_groups(&[], &[]),
                     );
                 }
+                // Capture the moved row's old group_path before the mutation
+                // so we can prune the source profile's now-empty copy. Without
+                // this, the source profile retains an empty group header with
+                // the same name as the one the row appears under in the target
+                // profile, which reads as a duplicate group in unified view.
+                let old_group_path = self
+                    .get_instance(&id)
+                    .map(|i| i.group_path.clone())
+                    .unwrap_or_default();
                 self.mutate_instance(&id, |inst| {
                     inst.source_profile = target_profile.to_string();
                 });
+                self.prune_empty_group(&current_profile, &old_group_path);
                 self.rebuild_group_trees();
                 // Rebuild the visible row list too; otherwise the row still
                 // renders under the old profile until the next reload, and

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -193,6 +193,23 @@ impl HomeView {
                     self.storages
                         .insert(target_profile.to_string(), Storage::new(target_profile)?);
                 }
+                // Seed the per-profile GroupTree alongside the Storage. Without
+                // this, `rebuild_group_trees()` below iterates only the already-
+                // known profile trees and the freshly-moved row ends up in
+                // `self.instances` with no tree to render under. In tree-based
+                // build_flat_items branches (manual grouping + non-Attention
+                // sort, or single-profile filtered view targeting the new
+                // profile) the row then silently disappears, and even in
+                // Attention sort the next reload re-seeds the tree from the
+                // pristine on-disk state — masking the bug as flaky. Seed
+                // here so the new profile is a first-class entry in every
+                // structure before the rebuild walks them.
+                if !self.group_trees.contains_key(target_profile) {
+                    self.group_trees.insert(
+                        target_profile.to_string(),
+                        GroupTree::new_with_groups(&[], &[]),
+                    );
+                }
                 self.mutate_instance(&id, |inst| {
                     inst.source_profile = target_profile.to_string();
                 });

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -220,13 +220,32 @@ pub(crate) fn compute_row_tag(
             // for `feature/foo` style names), truncated to 8 chars so the
             // tag stays narrow.
             let last = w.branch.rsplit('/').next().unwrap_or("");
-            let trimmed: String = last.chars().take(8).collect();
+            let trimmed: String = last.chars().take(ROW_TAG_BRANCH_MAX).collect();
             if trimmed.is_empty() {
                 Option::<String>::None
             } else {
                 Some(trimmed)
             }
         }),
+    }
+}
+
+/// Per-mode max content width for the row tag, in chars. Used by the row
+/// renderer to right-pad the tag to a stable column so the activity
+/// column doesn't reflow as tag widths vary across rows (`[fb]` vs `[def]`
+/// vs `[forit]`). Mirrors the natural cap each branch of `compute_row_tag`
+/// already enforces, so padding never truncates.
+const ROW_TAG_PROFILE_MAX: usize = 4;
+const ROW_TAG_SANDBOX_MAX: usize = 2;
+const ROW_TAG_BRANCH_MAX: usize = 8;
+
+pub(crate) fn row_tag_max_width(mode: crate::session::config::RowTagMode) -> usize {
+    use crate::session::config::RowTagMode;
+    match mode {
+        RowTagMode::None => 0,
+        RowTagMode::Auto | RowTagMode::Profile => ROW_TAG_PROFILE_MAX,
+        RowTagMode::Sandbox => ROW_TAG_SANDBOX_MAX,
+        RowTagMode::Branch => ROW_TAG_BRANCH_MAX,
     }
 }
 
@@ -1020,8 +1039,19 @@ impl HomeView {
                 if let Some(tag) =
                     compute_row_tag(inst, self.row_tag_mode, self.active_profile.is_none())
                 {
+                    // Pad to the mode's max content width so the bracket
+                    // span is fixed-width across rows. Without this, a
+                    // 2-char code (`fb`) and a 3-char code (`def`) produce
+                    // bracket spans 1 cell apart, which shifts where the
+                    // activity column lands per row (the trailing pad
+                    // absorbs the difference, but the absorbed width comes
+                    // off the user-visible whitespace and reads as a
+                    // jittery activity column when rows are scanned
+                    // vertically). compute_row_tag already caps content
+                    // at the same max, so padding is non-truncating.
+                    let max_width = row_tag_max_width(self.row_tag_mode);
                     line_spans.push(Span::styled(
-                        format!("  [{}]", tag),
+                        format!("  [{:<width$}]", tag, width = max_width),
                         Style::default().fg(theme.dimmed),
                     ));
                 }
@@ -2124,6 +2154,20 @@ mod tests {
         // unconditional render path.
         // prefix(20) + slot(6) + badge(12) + margin(1) = 39 > 35.
         assert_eq!(activity_column_padding(20, 35, 12), None);
+    }
+
+    #[test]
+    fn row_tag_max_width_matches_compute_row_tag_caps() {
+        use crate::session::config::RowTagMode;
+        // Each branch of compute_row_tag enforces its own max — the
+        // helper must agree so the padded bracket never truncates.
+        assert_eq!(row_tag_max_width(RowTagMode::None), 0);
+        assert_eq!(row_tag_max_width(RowTagMode::Auto), 4);
+        assert_eq!(row_tag_max_width(RowTagMode::Profile), 4);
+        assert_eq!(row_tag_max_width(RowTagMode::Sandbox), 2);
+        assert_eq!(row_tag_max_width(RowTagMode::Branch), 8);
+        // profile_short_code's documented cap.
+        assert!(profile_short_code("forit-backup-extra").len() <= ROW_TAG_PROFILE_MAX);
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4342,6 +4342,120 @@ fn manual_grouping_attention_sort_stays_flat() {
     );
 }
 
+/// `prune_empty_group` is the post-move cleanup that drops the source
+/// profile's now-empty copy of a group after a session moves to a
+/// different profile. Without it, both profiles end up with the same
+/// group name in unified view, the source one empty and the target one
+/// populated, which reads as a duplicate group header.
+#[test]
+#[serial]
+fn prune_empty_group_drops_source_when_no_session_remains() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _ = Storage::new("alpha").unwrap();
+    let _ = Storage::new("beta").unwrap();
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+
+    // Pre-state: alpha has one session in group "work", beta is empty.
+    let mut moved = Instance::new("moved", "/tmp/moved");
+    moved.source_profile = "alpha".to_string();
+    moved.group_path = "work".to_string();
+    view.instances = vec![moved];
+    view.group_trees.clear();
+    view.group_trees.insert(
+        "alpha".to_string(),
+        GroupTree::new_with_groups(&view.instances, &[]),
+    );
+    view.group_trees
+        .insert("beta".to_string(), GroupTree::new_with_groups(&[], &[]));
+    assert!(view.group_trees["alpha"].group_exists("work"));
+
+    // Simulate the move: re-tag source_profile, then prune the now-empty
+    // source group.
+    view.instances[0].source_profile = "beta".to_string();
+    view.prune_empty_group("alpha", "work");
+
+    assert!(
+        !view.group_trees["alpha"].group_exists("work"),
+        "alpha should no longer own the now-empty 'work' group after the move"
+    );
+}
+
+/// Prune must NOT drop the source group when the source profile still
+/// has other sessions sitting at the same path (or nested under it).
+/// Two sessions, only one moved → source profile keeps the group.
+#[test]
+#[serial]
+fn prune_empty_group_keeps_source_when_sibling_session_remains() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _ = Storage::new("alpha").unwrap();
+    let _ = Storage::new("beta").unwrap();
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+
+    let mut moved = Instance::new("moved", "/tmp/moved");
+    moved.source_profile = "alpha".to_string();
+    moved.group_path = "work".to_string();
+    let mut sibling = Instance::new("sibling", "/tmp/sibling");
+    sibling.source_profile = "alpha".to_string();
+    sibling.group_path = "work".to_string();
+    view.instances = vec![moved, sibling];
+    view.group_trees.clear();
+    view.group_trees.insert(
+        "alpha".to_string(),
+        GroupTree::new_with_groups(&view.instances, &[]),
+    );
+    view.group_trees
+        .insert("beta".to_string(), GroupTree::new_with_groups(&[], &[]));
+
+    view.instances[0].source_profile = "beta".to_string();
+    view.prune_empty_group("alpha", "work");
+
+    assert!(
+        view.group_trees["alpha"].group_exists("work"),
+        "alpha must keep 'work' because the sibling session still lives there"
+    );
+}
+
+/// Prune must also keep the source group when a session sits in a
+/// *descendant* path. Only the leaf moved out; the parent still has
+/// rows under it.
+#[test]
+#[serial]
+fn prune_empty_group_keeps_source_when_descendant_session_remains() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let _ = Storage::new("alpha").unwrap();
+    let _ = Storage::new("beta").unwrap();
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+
+    let mut moved = Instance::new("moved", "/tmp/moved");
+    moved.source_profile = "alpha".to_string();
+    moved.group_path = "work".to_string();
+    let mut nested = Instance::new("nested", "/tmp/nested");
+    nested.source_profile = "alpha".to_string();
+    nested.group_path = "work/frontend".to_string();
+    view.instances = vec![moved, nested];
+    view.group_trees.clear();
+    view.group_trees.insert(
+        "alpha".to_string(),
+        GroupTree::new_with_groups(&view.instances, &[]),
+    );
+    view.group_trees
+        .insert("beta".to_string(), GroupTree::new_with_groups(&[], &[]));
+
+    view.instances[0].source_profile = "beta".to_string();
+    view.prune_empty_group("alpha", "work");
+
+    assert!(
+        view.group_trees["alpha"].group_exists("work"),
+        "alpha must keep 'work' because the nested session still lives under it"
+    );
+}
+
 mod scroll_pane_isolation {
     //! Wheel events are confined to whichever pane the mouse is over.
     //! In particular, a wheel over the preview pane never moves the list

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -41,6 +41,85 @@ fn test_cli_add_and_list() {
     );
 }
 
+/// Concurrent `aoe add` processes must not lose rows.
+///
+/// Before Stage 2, every `aoe add` handler did `load_with_groups()` ->
+/// append -> `Storage::commit()`, a wholesale last-writer-wins overwrite.
+/// Two `aoe add` processes whose load-modify-write windows overlap each
+/// load the same baseline, append their own distinct row, and the second
+/// `commit()` clobbers the first writer's row. The Stage 1 flock alone
+/// does not fix this: it only serialises the writes, the snapshot each
+/// process holds is still stale.
+///
+/// This test seeds one session, then spawns several `aoe add` processes
+/// at once. After they all exit, every seeded and added row must be
+/// present. Red on `commit()`-based handlers, green once they use
+/// `Storage::update()`, which re-loads a fresh snapshot under the lock.
+#[test]
+#[serial]
+fn test_cli_add_concurrent_processes_keep_all_rows() {
+    let h = TuiTestHarness::new("cli_add_concurrent");
+    let project = h.project_path();
+    let project_str = project.to_str().unwrap().to_string();
+
+    // Seed a baseline row so every concurrent `add` loads a non-empty
+    // sessions.json. Without a seed, the very first writer also creates
+    // the file, which slightly narrows the race; the seed makes the
+    // lost-update window deterministic.
+    let seed = h.run_cli(&["add", &project_str, "-t", "seed-session"]);
+    assert!(
+        seed.status.success(),
+        "seed aoe add failed: {}",
+        String::from_utf8_lossy(&seed.stderr)
+    );
+
+    // Several concurrent writers. The race widens with parallelism, so a
+    // handful of overlapping processes reliably drops a row on the
+    // pre-Stage-2 `commit()` path.
+    let worker_count = 6;
+    let titles: Vec<String> = (0..worker_count)
+        .map(|i| format!("concurrent-{i}"))
+        .collect();
+
+    let children: Vec<_> = titles
+        .iter()
+        .map(|title| h.spawn_cli(&["add", &project_str, "-t", title]))
+        .collect();
+
+    for (title, child) in titles.iter().zip(children) {
+        let out = child.wait_with_output().expect("child aoe add did not run");
+        assert!(
+            out.status.success(),
+            "concurrent aoe add for {title} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let present: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["title"].as_str())
+        .collect();
+
+    assert!(
+        present.contains(&"seed-session"),
+        "seed row was clobbered by a concurrent add; present: {present:?}"
+    );
+    for title in &titles {
+        assert!(
+            present.contains(&title.as_str()),
+            "concurrent add row {title} was lost (last-writer-wins clobber); present: {present:?}"
+        );
+    }
+    assert_eq!(
+        sessions.len(),
+        worker_count + 1,
+        "expected seed + {worker_count} concurrent rows; present: {present:?}"
+    );
+}
+
 /// Regression test for #848: `aoe add` "Next steps" hint should reference
 /// the actual binary name (`aoe`), not the long project name.
 #[test]

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -1146,3 +1146,107 @@ fn test_cli_add_attaches_to_existing_worktree() {
         Some("feat/existing"),
     );
 }
+
+/// A concurrent `aoe remove` must not lose rows that other processes add
+/// while it runs.
+///
+/// Before Stage 2b, `remove.rs`, `group.rs`, and `worktree.rs` still used
+/// the lossy pattern: `load_with_groups()` -> work -> `commit()`. That load
+/// is unlocked; only the final `commit()` takes the Stage 1 flock. So the
+/// `remove` handler reads its snapshot, then any number of `aoe add`
+/// processes can run a fully locked `Storage::update()` (load fresh,
+/// append, write) before the `remove` handler reaches its `commit()`. That
+/// `commit()` is a wholesale last-writer-wins overwrite of the snapshot the
+/// handler loaded earlier, so every row those adds committed in between is
+/// clobbered. The flock serialises the writes but does nothing for the
+/// staleness of the `remove` handler's snapshot.
+///
+/// This test seeds a victim row, spawns several `aoe add` processes, then
+/// after a short delay spawns one `aoe remove` of the victim. The delay is
+/// tuned so the `remove` handler loads its snapshot before the adds commit
+/// and reaches its own `commit()` after them, the exact interleaving that
+/// loses rows. After all processes exit, the victim must be gone and every
+/// concurrently-added row must survive. Red on the `commit()`-based
+/// `remove` handler (its wholesale write clobbers the racers), green once
+/// it removes the target through `Storage::update()`, which re-loads under
+/// the lock and retains by `Instance.id`.
+#[test]
+#[serial]
+fn test_cli_remove_concurrent_with_add_keeps_all_rows() {
+    let h = TuiTestHarness::new("cli_remove_concurrent");
+    let project = h.project_path();
+    let project_str = project.to_str().unwrap().to_string();
+
+    // Seed the victim row that the concurrent `aoe remove` will delete.
+    let victim = h.run_cli(&["add", &project_str, "-t", "victim-session"]);
+    assert!(
+        victim.status.success(),
+        "seed victim aoe add failed: {}",
+        String::from_utf8_lossy(&victim.stderr)
+    );
+
+    // Several concurrent `aoe add` writers. The race widens with
+    // parallelism, so a handful of overlapping adds reliably bracket the
+    // `remove` handler's load-modify-write window on the pre-Stage-2b
+    // `commit()` path.
+    let worker_count = 6;
+    let titles: Vec<String> = (0..worker_count).map(|i| format!("racer-{i}")).collect();
+
+    // Start the `aoe add` writers first, then spawn `aoe remove` after a
+    // short delay. `aoe add` does heavier pre-write setup than `aoe remove`,
+    // so without the delay the `remove` handler would finish committing
+    // before any add wrote, and there would be no lost update to catch. The
+    // delay lets the adds get close to their commit so the `remove`
+    // handler's snapshot (loaded right after the delay) predates the add
+    // commits while its own `commit()` lands after them. The sleep lives in
+    // the test, never in a handler.
+    let adders: Vec<_> = titles
+        .iter()
+        .map(|title| h.spawn_cli(&["add", &project_str, "-t", title]))
+        .collect();
+    std::thread::sleep(std::time::Duration::from_millis(85));
+    let remover = h.spawn_cli(&["remove", "victim-session"]);
+
+    let remove_out = remover
+        .wait_with_output()
+        .expect("child aoe remove did not run");
+    assert!(
+        remove_out.status.success(),
+        "concurrent aoe remove failed:\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&remove_out.stdout),
+        String::from_utf8_lossy(&remove_out.stderr),
+    );
+
+    for (title, child) in titles.iter().zip(adders) {
+        let out = child.wait_with_output().expect("child aoe add did not run");
+        assert!(
+            out.status.success(),
+            "concurrent aoe add for {title} failed:\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr),
+        );
+    }
+
+    let json = read_sessions_json(&h);
+    let sessions = json.as_array().expect("sessions array");
+    let present: Vec<&str> = sessions
+        .iter()
+        .filter_map(|s| s["title"].as_str())
+        .collect();
+
+    assert!(
+        !present.contains(&"victim-session"),
+        "victim row should have been removed; present: {present:?}"
+    );
+    for title in &titles {
+        assert!(
+            present.contains(&title.as_str()),
+            "concurrent add row {title} was lost (remove handler clobbered it); present: {present:?}"
+        );
+    }
+    assert_eq!(
+        sessions.len(),
+        worker_count,
+        "expected {worker_count} racer rows after the victim removal; present: {present:?}"
+    );
+}

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -420,6 +420,25 @@ last_seen_version = "{}"
             .expect("failed to run aoe CLI")
     }
 
+    /// Spawn an `aoe` CLI subcommand without waiting for it to exit, returning
+    /// the `Child` handle. Unlike `run_cli` (which blocks on `.output()`), this
+    /// lets a test launch several `aoe` processes that overlap in time, the
+    /// only way to exercise the cross-process write path from outside the
+    /// crate. Shares the same isolated `HOME` / `PATH` as `run_cli`.
+    pub fn spawn_cli(&self, args: &[&str]) -> std::process::Child {
+        Command::new(&self.binary_path)
+            .args(args)
+            .env("HOME", self.home_dir.path())
+            .env("XDG_CONFIG_HOME", self.home_dir.path().join(".config"))
+            .env("PATH", self.env_path())
+            .env_remove("AGENT_OF_EMPIRES_DEBUG")
+            .env_remove("AOE_LOG_LEVEL")
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("failed to spawn aoe CLI")
+    }
+
     /// Path to the isolated home directory for custom test setup.
     pub fn home_path(&self) -> &Path {
         self.home_dir.path()

--- a/tests/integration/session_lifecycle.rs
+++ b/tests/integration/session_lifecycle.rs
@@ -114,15 +114,22 @@ fn test_save_leaves_no_debris() -> Result<()> {
         storage.commit(&instances, &GroupTree::new_with_groups(&instances, &[]))?;
     }
 
-    // Atomic write should leave only the persisted JSON files in the profile
-    // dir, no .json.bak from the old code path and no leftover tempfiles.
+    // Atomic write should leave only the persisted JSON files plus the
+    // cross-process flock file in the profile dir, no .json.bak from the old
+    // code path and no leftover tempfiles. `sessions.json.lock` is the
+    // advisory lock guarding concurrent writers; it is created on first write
+    // and intentionally persists (the lock lives on the file, not on its
+    // existence), so it is not debris.
     let profile_dir = agent_of_empires::session::get_profile_dir("default")?;
     let mut entries: Vec<String> = fs::read_dir(&profile_dir)?
         .filter_map(|e| e.ok())
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     entries.sort();
-    assert_eq!(entries, vec!["groups.json", "sessions.json"]);
+    assert_eq!(
+        entries,
+        vec!["groups.json", "sessions.json", "sessions.json.lock"]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Description

Follow-up to #1461. PR #1461 fixed the missing-row bug by seeding the target profile's GroupTree alongside its lazy Storage insertion in `restart_selected_session`, so the moved row renders under the new profile. The render flow then worked, but the source profile's tree still kept the group the session used to live in. With nothing left under it, that group renders as an empty header next to the target profile's now-populated copy of the same name — which reads as a duplicate group header in unified view.

`rebuild_group_trees` preserves each tree's `existing_groups` on purpose (users intentionally keep empty groups around to anchor structure), so the fix is targeted: capture the moved row's old `group_path` before the `source_profile` mutation, then delete it from the source profile's tree only when no remaining session in that profile sits at the same path or anywhere underneath it.

The prune logic is extracted as `prune_empty_group(profile, path)` on HomeView so the behavior is unit-testable without needing tmux (the rest of `restart_selected_session` calls `restart_with_size`, which can't be exercised in unit tests). Three tests cover: prune-when-empty, keep-when-sibling, keep-when-descendant.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — n/a, behavior verified by unit test on tree state

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI / session lifecycle (Rust test)**
- [x] Unit tests added in `src/tui/home/tests.rs`: `prune_empty_group_drops_source_when_no_session_remains`, `prune_empty_group_keeps_source_when_sibling_session_remains`, `prune_empty_group_keeps_source_when_descendant_session_remains`.

## Test plan

- [x] `cargo test --release --lib prune_empty_group` — 3 passed.
- [x] `cargo clippy --release --lib -- -D warnings` — clean.
- [x] Manual: restart-to-different-profile in unified view; source profile no longer shows phantom empty group when it was the row's only inhabitant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR introduces a comprehensive refactoring of session persistence and concurrent access handling throughout the agent-of-empires application, with a specific fix for a UI glitch where empty group headers would appear after restarting sessions into different profiles.

### What Changed

**Core Architecture**
- Replaced the pattern of "load all data → mutate in memory → commit everything back" with a safer "load → update with atomic operations" approach across all CLI commands
- Added cross-process file locking to prevent conflicts when multiple processes modify sessions simultaneously
- Introduced a 3-way merge strategy that preserves concurrent additions while honoring intentional deletions

**Session Management**
- Refactored all session commands (`add`, `remove`, `restart`, `rename`, etc.) to use the new atomic update pattern
- Added a new `resolve_session_id` helper to consistently map user identifiers (by ID, prefix, or title) to stable session IDs
- Improved lifecycle adoption logic with a new `adopt_lifecycle_from` method for copying start/stop/restart metadata

**UI Fixes**
- Fixed the specific issue where empty group headers persisted in the source profile after moving a session to a different profile
- Added `prune_empty_group` logic to clean up groups only when they have no remaining sessions
- Improved row tag formatting to maintain consistent column alignment across items with different tag lengths

**Session Title Resolution**
- Enhanced default session title generation to derive meaningful titles from project paths (detecting dev container directories and path structure) rather than always falling back to random names

**Testing & Reliability**
- Added integration tests verifying concurrent `add` and `remove` operations work correctly without losing data
- Added unit tests for the new group pruning logic covering edge cases (empty groups, sibling sessions, descendant sessions)
- Updated test infrastructure with a new `spawn_cli` method for testing concurrent processes

### Benefits

- **Data Safety**: Cross-process locking eliminates race conditions where concurrent operations would overwrite each other's changes
- **Better Defaults**: Sessions now get more intuitive names based on their project structure
- **Consistency**: All CLI commands follow the same safe persistence pattern
- **Cleaner UI**: No more phantom empty groups appearing after moving sessions
- **Reliability**: Comprehensive tests ensure concurrent operations work correctly

### Technical Details

The refactoring centralizes all persistent storage updates through `Storage::update()` which acquires OS-level advisory locks (`flock`) before reading and writing `sessions.json`/`groups.json`. The new `commit_merged()` API allows the TUI to track "load baselines" (what was on disk at load time) and preserve concurrent additions while respecting user deletions. Helper functions like `merge_instances` and `merge_groups` implement 3-way merge reconciliation keyed on `Instance.id` and `Group.path`. The session lifecycle management gained `adopt_lifecycle_from()` to copy state between instances without overwriting metadata. Status detection was refactored into reusable helpers (`resolve_detected_status`, `resolve_shell_stale_status`, `pane_looks_like_bare_shell_prompt`) for clarity and testability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->