### PR TITLE
feat(tui): drag list/preview divider, click preview to send, click Yes/No on delete dialog

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -626,15 +626,44 @@ impl App {
                             // a bool. The single-click selection always
                             // mutates `cursor` so we redraw unconditionally
                             // before dispatching the action.
+                            //
+                            // Priority order for `Down(Left)`:
+                            //   1. modal dialog click (e.g. delete Yes/No)
+                            //   2. divider drag-start (between list/preview)
+                            //   3. preview-pane click (open Send Message)
+                            //   4. list row click (existing select/activate)
+                            // Earlier branches short-circuit so a click on
+                            // the divider never opens a dialog, and a
+                            // click on the preview never selects a row.
                             let click_action = if matches!(
                                 mouse.kind,
                                 MouseEventKind::Down(MouseButton::Left)
-                            ) && hit_list
-                            {
-                                let action =
-                                    self.home.handle_click(mouse.column, mouse.row);
-                                self.draw(terminal)?;
-                                action
+                            ) {
+                                if self.home.handle_dialog_click(mouse.column, mouse.row)
+                                {
+                                    self.sync_mouse_capture(terminal)?;
+                                    self.draw(terminal)?;
+                                    None
+                                } else if self
+                                    .home
+                                    .handle_drag_start(mouse.column, mouse.row)
+                                {
+                                    None
+                                } else if hit_preview {
+                                    if self.home.handle_preview_click() {
+                                        self.sync_mouse_capture(terminal)?;
+                                        self.draw(terminal)?;
+                                    }
+                                    None
+                                } else if hit_list {
+                                    let action = self
+                                        .home
+                                        .handle_click(mouse.column, mouse.row);
+                                    self.draw(terminal)?;
+                                    action
+                                } else {
+                                    None
+                                }
                             } else {
                                 None
                             };
@@ -644,6 +673,15 @@ impl App {
                                 }
                                 MouseEventKind::ScrollDown if hit_scroll_target => {
                                     self.home.handle_scroll_down(mouse.column, mouse.row)
+                                }
+                                // Drag(Left) without a matching drag_state
+                                // is a no-op inside the handler; we don't
+                                // need a separate guard here.
+                                MouseEventKind::Drag(MouseButton::Left) => {
+                                    self.home.handle_drag_move(mouse.column)
+                                }
+                                MouseEventKind::Up(MouseButton::Left) => {
+                                    self.home.handle_drag_end()
                                 }
                                 // Moved events are dispatched unconditionally
                                 // (no `hit_list` guard) so the handler can

--- a/src/tui/components/buttons.rs
+++ b/src/tui/components/buttons.rs
@@ -8,9 +8,23 @@ use ratatui::widgets::Paragraph;
 
 use crate::tui::styles::Theme;
 
+/// Width of the rendered "[Yes]    [No]" row: 5 (Yes) + 4 spaces + 4
+/// (No) = 13 cells. Kept as a constant so the click hit-test math
+/// stays in lockstep with the renderer.
+const YES_NO_ROW_WIDTH: u16 = 13;
+
 /// Render a centered `[Yes]    [No]` row. Yes uses `theme.error`, No uses
-/// `theme.running`; the unfocused button uses `theme.dimmed`.
-pub fn render_yes_no(frame: &mut Frame, area: Rect, theme: &Theme, yes_focused: bool) {
+/// `theme.running`; the unfocused button uses `theme.dimmed`. Returns
+/// `(yes_rect, no_rect)` covering the visible glyphs, so callers that
+/// want mouse-clickable buttons can hit-test the same cells the user
+/// sees. Both rects collapse to zero-width if the row doesn't fit in
+/// `area` (a degenerate render the caller can ignore).
+pub fn render_yes_no(
+    frame: &mut Frame,
+    area: Rect,
+    theme: &Theme,
+    yes_focused: bool,
+) -> (Rect, Rect) {
     let yes_style = if yes_focused {
         Style::default().fg(theme.error).bold()
     } else {
@@ -27,4 +41,18 @@ pub fn render_yes_no(frame: &mut Frame, area: Rect, theme: &Theme, yes_focused: 
         Span::styled("[No]", no_style),
     ]);
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
+
+    if area.width < YES_NO_ROW_WIDTH || area.height == 0 {
+        return (Rect::default(), Rect::default());
+    }
+    // Ratatui centers with `(width - line_len) / 2` for the left
+    // offset; mirror that here so the rects line up with the actual
+    // glyphs, not just the row.
+    let left_pad = (area.width - YES_NO_ROW_WIDTH) / 2;
+    let yes_x = area.x + left_pad;
+    let no_x = yes_x + 9; // "[Yes]" + 4 spaces
+    (
+        Rect::new(yes_x, area.y, 5, 1),
+        Rect::new(no_x, area.y, 4, 1),
+    )
 }

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -83,7 +83,7 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        render_yes_no(frame, chunks[1], theme, self.selected);
+        let _ = render_yes_no(frame, chunks[1], theme, self.selected);
     }
 }
 

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -45,6 +45,14 @@ pub struct UnifiedDeleteDialog {
     options: DeleteOptions,
     focus: FocusElement,
     focusable_elements: Vec<FocusElement>,
+    /// Screen rect of the rendered `[Yes]` button. Captured during
+    /// `render` so `handle_click` can hit-test the same cells the user
+    /// sees. `Rect::default()` until the dialog has been rendered at
+    /// least once.
+    yes_button_area: Rect,
+    /// Screen rect of the rendered `[No]` button, paired with
+    /// `yes_button_area`.
+    no_button_area: Rect,
 }
 
 impl UnifiedDeleteDialog {
@@ -81,7 +89,26 @@ impl UnifiedDeleteDialog {
             options,
             focus: initial_focus,
             focusable_elements,
+            yes_button_area: Rect::default(),
+            no_button_area: Rect::default(),
         }
+    }
+
+    /// Route a left-click. Returns `Some(Submit)` when the user clicked
+    /// the `[Yes]` button, `Some(Cancel)` for `[No]`, and `None` for
+    /// clicks that landed elsewhere inside the dialog (those are
+    /// silently absorbed by the modal — no fall-through to the list).
+    /// Rects are written during `render`; before the first render both
+    /// rects are zero-sized so `contains()` returns false.
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<DeleteOptions>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.yes_button_area.contains(pos) {
+            return Some(DialogResult::Submit(self.options.clone()));
+        }
+        if self.no_button_area.contains(pos) {
+            return Some(DialogResult::Cancel);
+        }
+        None
     }
 
     fn build_focusable_elements(
@@ -228,7 +255,7 @@ impl UnifiedDeleteDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let has_worktree = self.config.worktree_branch.is_some();
         let has_sandbox = self.config.has_sandbox;
         let show_force = has_worktree && self.options.delete_worktree;
@@ -398,8 +425,10 @@ impl UnifiedDeleteDialog {
         frame.render_widget(Paragraph::new(line), area);
     }
 
-    fn render_buttons(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        render_yes_no(frame, area, theme, self.focus == FocusElement::YesButton);
+    fn render_buttons(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let (yes, no) = render_yes_no(frame, area, theme, self.focus == FocusElement::YesButton);
+        self.yes_button_area = yes;
+        self.no_button_area = no;
     }
 
     fn render_hints(&self, frame: &mut Frame, area: Rect, theme: &Theme, has_checkboxes: bool) {
@@ -591,6 +620,46 @@ mod tests {
         dialog.focus = FocusElement::YesButton;
         dialog.handle_key(key(KeyCode::Right));
         assert_eq!(dialog.focus, FocusElement::NoButton);
+    }
+
+    #[test]
+    fn test_click_before_render_is_noop() {
+        // Both button rects default to Rect::default() (zero-sized) so
+        // the contains() check returns false until the dialog has been
+        // painted at least once.
+        let dialog = simple_dialog();
+        assert!(dialog.handle_click(5, 5).is_none());
+    }
+
+    #[test]
+    fn test_click_on_yes_button_submits() {
+        let mut dialog = simple_dialog();
+        // Stage the button rects manually since the real coordinates
+        // come from render(), which a unit test can't easily invoke.
+        dialog.yes_button_area = Rect::new(10, 8, 5, 1);
+        dialog.no_button_area = Rect::new(19, 8, 4, 1);
+
+        let result = dialog.handle_click(12, 8).expect("yes hit");
+        assert!(matches!(result, DialogResult::Submit(_)));
+    }
+
+    #[test]
+    fn test_click_on_no_button_cancels() {
+        let mut dialog = simple_dialog();
+        dialog.yes_button_area = Rect::new(10, 8, 5, 1);
+        dialog.no_button_area = Rect::new(19, 8, 4, 1);
+
+        let result = dialog.handle_click(20, 8).expect("no hit");
+        assert!(matches!(result, DialogResult::Cancel));
+    }
+
+    #[test]
+    fn test_click_between_buttons_misses() {
+        let mut dialog = simple_dialog();
+        dialog.yes_button_area = Rect::new(10, 8, 5, 1);
+        dialog.no_button_area = Rect::new(19, 8, 4, 1);
+        // The four-space gap between "[Yes]" and "[No]" is dead space.
+        assert!(dialog.handle_click(16, 8).is_none());
     }
 
     #[test]

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -97,7 +97,7 @@ impl UnifiedDeleteDialog {
     /// Route a left-click. Returns `Some(Submit)` when the user clicked
     /// the `[Yes]` button, `Some(Cancel)` for `[No]`, and `None` for
     /// clicks that landed elsewhere inside the dialog (those are
-    /// silently absorbed by the modal — no fall-through to the list).
+    /// silently absorbed by the modal, no fall-through to the list).
     /// Rects are written during `render`; before the first render both
     /// rects are zero-sized so `contains()` returns false.
     pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<DeleteOptions>> {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5,7 +5,7 @@ use ratatui::prelude::Position;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
-use super::{HomeView, TerminalMode, ViewMode};
+use super::{DragKind, HomeView, TerminalMode, ViewMode};
 use crate::session::config::{load_config, save_config, GroupByMode, SortOrder};
 use crate::session::{list_profiles, repo_config, resolve_config_or_warn, Item, Status};
 use crate::tui::app::Action;
@@ -19,6 +19,7 @@ use crate::tui::dialogs::{
     SendMessageDialog, UnifiedDeleteDialog,
 };
 use crate::tui::diff::{DiffAction, DiffView};
+use crate::tui::responsive;
 use crate::tui::settings::{SettingsAction, SettingsView};
 
 /// Maximum gap between two left-clicks on the same row that still
@@ -130,6 +131,155 @@ impl HomeView {
 
     pub fn hit_list(&self, col: u16, row: u16) -> bool {
         self.list_area.contains(Position::from((col, row)))
+    }
+
+    /// True when `(col, row)` lands on the side-by-side list/preview
+    /// divider. The divider is the preview's left border column (one
+    /// past `list_area.right()` is exclusive, so this *is* a valid hit
+    /// target that hit_list / hit_preview both miss by design). Returns
+    /// `false` in stacked mode, in the diff/settings/serve takeover
+    /// views (which clear `divider_col`), and while any modal dialog is
+    /// open — a dialog over the divider should swallow stray clicks
+    /// rather than start a hidden drag.
+    pub fn hit_divider(&self, col: u16, row: u16) -> bool {
+        if self.has_dialog() {
+            return false;
+        }
+        let Some(div_col) = self.divider_col else {
+            return false;
+        };
+        if col != div_col {
+            return false;
+        }
+        let list_y = self.list_area.y;
+        let list_bottom = self.list_area.bottom();
+        row >= list_y && row < list_bottom
+    }
+
+    /// Begin a drag if `(col, row)` is on the divider. Records the start
+    /// column and the current requested `list_width` so subsequent
+    /// `Drag` events can compute deltas without re-reading the divider's
+    /// (possibly clamped) position. Returns true when a drag actually
+    /// started, so the caller can mark the event handled and skip the
+    /// row-click path.
+    pub fn handle_drag_start(&mut self, col: u16, row: u16) -> bool {
+        if !self.hit_divider(col, row) {
+            return false;
+        }
+        self.drag_state = Some(DragKind::ListDivider {
+            start_col: col,
+            start_width: self.list_width,
+        });
+        true
+    }
+
+    /// Apply a drag-in-progress event. For the list divider, recompute
+    /// the requested width from `(start_width + delta)` and clamp to
+    /// `[10, main_area_width - PREVIEW_MIN_WIDTH]` so the preview keeps
+    /// its usability floor and the value never wraps `u16`. Returns true
+    /// when `list_width` actually changed (so the caller redraws). The
+    /// drag does NOT persist on every tick; `handle_drag_end` saves once
+    /// on release.
+    pub fn handle_drag_move(&mut self, col: u16) -> bool {
+        let Some(DragKind::ListDivider {
+            start_col,
+            start_width,
+        }) = self.drag_state
+        else {
+            return false;
+        };
+        // i32 arithmetic so a leftward drag past the start column doesn't
+        // underflow u16 before the clamp.
+        let delta = col as i32 - start_col as i32;
+        let proposed = start_width as i32 + delta;
+
+        // Clamp ceiling tracks the live viewport width; if the user
+        // resized the terminal mid-drag, the new width is honored. The
+        // floor of 10 matches the keyboard `<` shrink limit.
+        let ceiling = self
+            .main_area_width
+            .saturating_sub(responsive::PREVIEW_MIN_WIDTH);
+        let max_width = ceiling.max(10);
+        let clamped = proposed.clamp(10, max_width as i32) as u16;
+
+        if clamped == self.list_width {
+            return false;
+        }
+        self.list_width = clamped;
+        true
+    }
+
+    /// End any active drag. For the list divider, persist the final
+    /// `list_width` to config so the new layout survives a restart.
+    /// Returns true when a drag was actually in progress, so the caller
+    /// can avoid a spurious redraw on every `Up(Left)` that wasn't part
+    /// of a drag.
+    pub fn handle_drag_end(&mut self) -> bool {
+        let Some(state) = self.drag_state.take() else {
+            return false;
+        };
+        match state {
+            DragKind::ListDivider { .. } => {
+                self.save_list_width();
+            }
+        }
+        true
+    }
+
+    /// Route a left-click into whichever modal dialog supports mouse
+    /// input. Returns true when the click was consumed (the dialog
+    /// either acted on it or absorbed it as a no-op inside its bounds),
+    /// in which case the caller must NOT fall through to divider /
+    /// preview / list handlers. The `&` in the return is enough for the
+    /// caller to redraw.
+    ///
+    /// Only the destructive delete dialog wires Yes/No clicks today;
+    /// the existing modals continue to swallow mouse events implicitly
+    /// via `has_dialog()` gates in the other handlers.
+    pub fn handle_dialog_click(&mut self, col: u16, row: u16) -> bool {
+        if let Some(dialog) = &mut self.unified_delete_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.unified_delete_dialog = None;
+                    }
+                    DialogResult::Submit(options) => {
+                        self.unified_delete_dialog = None;
+                        if let Err(e) = self.delete_selected(&options) {
+                            tracing::error!(target: "tui.input", "Failed to delete session: {}", e);
+                        }
+                    }
+                }
+                return true;
+            }
+            // Click landed inside the dialog area but missed both
+            // buttons (e.g. on a checkbox or the title): swallow it so
+            // the underlying list doesn't shift selection out from
+            // under the modal.
+            return true;
+        }
+        // Other dialogs also need to swallow clicks while open — the
+        // existing `has_dialog()` gates inside list / preview / divider
+        // handlers already do this, so no extra work here.
+        false
+    }
+
+    /// Route a left-click that landed inside the preview pane. Opens
+    /// the Send Message dialog targeting the currently-selected running
+    /// session. No-op (returns false) when there's no valid target —
+    /// `open_send_message_dialog` already gates on `resolve_paste_target`,
+    /// so an empty list, a non-running selection, or a group-row
+    /// selection silently does nothing instead of opening an empty
+    /// dialog. The bool return tells the caller whether dialog state
+    /// changed so it can redraw + re-sync mouse capture.
+    pub fn handle_preview_click(&mut self) -> bool {
+        if self.has_dialog() {
+            return false;
+        }
+        let had_dialog = self.send_message_dialog.is_some();
+        self.open_send_message_dialog();
+        self.send_message_dialog.is_some() != had_dialog
     }
 
     pub fn handle_key(

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -139,8 +139,8 @@ impl HomeView {
     /// target that hit_list / hit_preview both miss by design). Returns
     /// `false` in stacked mode, in the diff/settings/serve takeover
     /// views (which clear `divider_col`), and while any modal dialog is
-    /// open — a dialog over the divider should swallow stray clicks
-    /// rather than start a hidden drag.
+    /// open, so a dialog over the divider swallows stray clicks rather
+    /// than starting a hidden drag.
     pub fn hit_divider(&self, col: u16, row: u16) -> bool {
         if self.has_dialog() {
             return false;
@@ -181,6 +181,17 @@ impl HomeView {
     /// drag does NOT persist on every tick; `handle_drag_end` saves once
     /// on release.
     pub fn handle_drag_move(&mut self, col: u16) -> bool {
+        // A dialog opened mid-drag (e.g. a hotkey pressed while the
+        // mouse button is still held) shouldn't keep updating the
+        // sidebar invisibly under the modal. End the drag here so the
+        // next `Up(Left)` is a no-op, persisting whatever width the
+        // user dragged to before the dialog covered it (handle_drag_end
+        // is the normal save site, so we mirror its behavior).
+        if self.has_dialog() && self.drag_state.is_some() {
+            self.drag_state = None;
+            self.save_list_width();
+            return false;
+        }
         let Some(DragKind::ListDivider {
             start_col,
             start_width,
@@ -227,11 +238,11 @@ impl HomeView {
     }
 
     /// Route a left-click into whichever modal dialog supports mouse
-    /// input. Returns true when the click was consumed (the dialog
-    /// either acted on it or absorbed it as a no-op inside its bounds),
-    /// in which case the caller must NOT fall through to divider /
-    /// preview / list handlers. The `&` in the return is enough for the
-    /// caller to redraw.
+    /// input. Returns true when the click was consumed, in which case
+    /// the caller must NOT fall through to the divider / preview / list
+    /// handlers. Two cases both count as consumed: the dialog acted on
+    /// the click (Yes/No), and the click landed elsewhere on screen
+    /// while a modal is open (the modal absorbs it).
     ///
     /// Only the destructive delete dialog wires Yes/No clicks today;
     /// the existing modals continue to swallow mouse events implicitly
@@ -259,7 +270,7 @@ impl HomeView {
             // under the modal.
             return true;
         }
-        // Other dialogs also need to swallow clicks while open — the
+        // Other dialogs also need to swallow clicks while open. The
         // existing `has_dialog()` gates inside list / preview / divider
         // handlers already do this, so no extra work here.
         false
@@ -267,12 +278,13 @@ impl HomeView {
 
     /// Route a left-click that landed inside the preview pane. Opens
     /// the Send Message dialog targeting the currently-selected running
-    /// session. No-op (returns false) when there's no valid target —
-    /// `open_send_message_dialog` already gates on `resolve_paste_target`,
-    /// so an empty list, a non-running selection, or a group-row
-    /// selection silently does nothing instead of opening an empty
-    /// dialog. The bool return tells the caller whether dialog state
-    /// changed so it can redraw + re-sync mouse capture.
+    /// session. No-op (returns false) when there's no valid target,
+    /// because `open_send_message_dialog` already gates on
+    /// `resolve_paste_target`, so an empty list, a non-running
+    /// selection, or a group-row selection silently does nothing
+    /// instead of opening an empty dialog. The bool return tells the
+    /// caller whether dialog state changed so it can redraw + re-sync
+    /// mouse capture.
     pub fn handle_preview_click(&mut self) -> bool {
         if self.has_dialog() {
             return false;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -57,6 +57,18 @@ fn project_group_name(inst: &Instance) -> String {
         })
 }
 
+/// Kinds of in-progress mouse drags. Today only the list/preview divider
+/// is draggable; the enum keeps future drag targets (diff split, group
+/// reorder) from churning the `Option<...>` shape on `HomeView`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DragKind {
+    /// Resizing the side-by-side list/preview divider. `start_col` is the
+    /// column where the user pressed; `start_width` is the requested
+    /// `list_width` at that moment. The new requested width is
+    /// `start_width + (current_col - start_col)`, clamped on apply.
+    ListDivider { start_col: u16, start_width: u16 },
+}
+
 pub(super) struct GroupRenameContext {
     pub(super) old_path: String,
     pub(super) old_profile: String,
@@ -317,6 +329,21 @@ pub struct HomeView {
     // Resizable list column width (percentage-like units)
     pub(super) list_width: u16,
 
+    /// Visible column of the list/preview divider in side-by-side mode,
+    /// `None` in stacked layout or while the diff view is open. Set in
+    /// `render()` after the layout split; read by mouse handlers to
+    /// hit-test divider clicks and clamp drag updates.
+    pub(super) divider_col: Option<u16>,
+    /// Width of the main horizontal area (list + preview) captured at the
+    /// last render. Used as the clamp ceiling when a divider drag updates
+    /// `list_width`, so the new width can't push the preview below
+    /// `PREVIEW_MIN_WIDTH`.
+    pub(super) main_area_width: u16,
+    /// Active mouse-drag state, `None` when no button is held. Set on
+    /// `Down(Left)` over a draggable target (the list/preview divider
+    /// today), updated on each `Drag(Left)`, cleared on `Up(Left)`.
+    pub(super) drag_state: Option<DragKind>,
+
     /// Show the info header (profile/tool/path/status/sandbox/worktree) at
     /// the top of the preview pane. Toggled with `i` and persisted to
     /// `app_state.show_preview_info`.
@@ -528,6 +555,9 @@ impl HomeView {
                 .as_ref()
                 .and_then(|c| c.app_state.home_list_width)
                 .unwrap_or(35),
+            divider_col: None,
+            main_area_width: 0,
+            drag_state: None,
             show_preview_info: user_config
                 .as_ref()
                 .and_then(|c| c.app_state.show_preview_info)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -454,7 +454,7 @@ impl HomeView {
                 .split(main_chunks[0]);
 
             // Layout chunks are contiguous, so chunks[1].x is the first
-            // column of the preview block — i.e., the visible left border
+            // column of the preview block, i.e. the visible left border
             // that the user perceives as the divider. Hit-test uses the
             // list's y-range (matches preview's y-range in side-by-side).
             self.divider_col = Some(chunks[1].x);
@@ -488,7 +488,7 @@ impl HomeView {
         // `&mut self.$field` so dialogs whose `render` captures screen
         // rects on the struct (currently `unified_delete_dialog` for
         // clickable Yes/No buttons) can mutate self. Dialogs with
-        // `&self` render methods still work — Rust auto-derefs the
+        // `&self` render methods still work; Rust auto-derefs the
         // mutable borrow.
         macro_rules! render_dialogs {
             ($($field:ident),* $(,)?) => {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -355,6 +355,8 @@ impl HomeView {
     ) {
         // Settings view takes over the whole screen
         if let Some(ref mut settings) = self.settings_view {
+            self.divider_col = None;
+            self.main_area_width = 0;
             settings.render(frame, area, theme);
             // Render unsaved changes confirmation dialog over settings
             if self.settings_close_confirm {
@@ -374,6 +376,12 @@ impl HomeView {
             // Compute diff for selected file if not cached
             let _ = diff.get_current_diff();
 
+            // No list/preview divider exists while the diff takeover owns
+            // the screen; clear it so a stale value from the previous frame
+            // can't hit-test as draggable.
+            self.divider_col = None;
+            self.main_area_width = 0;
+
             diff.render(frame, area, theme);
             return;
         }
@@ -381,6 +389,8 @@ impl HomeView {
         // Serve view takes over the whole screen
         #[cfg(feature = "serve")]
         if let Some(ref serve) = self.serve_view {
+            self.divider_col = None;
+            self.main_area_width = 0;
             serve.render(frame, area, theme);
             return;
         }
@@ -410,6 +420,7 @@ impl HomeView {
         // ~45 cols (with default list_width 35), too cramped for output;
         // stacking gives the preview the full width.
         let available_width = main_chunks[0].width;
+        self.main_area_width = available_width;
         if available_width < responsive::STACKED_BREAKPOINT {
             let main_height = main_chunks[0].height;
             let list_height = responsive::stacked_list_height(main_height);
@@ -420,6 +431,10 @@ impl HomeView {
                     Constraint::Min(responsive::STACKED_PREVIEW_MIN),
                 ])
                 .split(main_chunks[0]);
+
+            // Stacked layout has no vertical divider; only the side-by-side
+            // path exposes the resize-by-drag affordance.
+            self.divider_col = None;
 
             self.render_list(frame, chunks[0], theme);
             self.render_preview(frame, chunks[1], theme);
@@ -437,6 +452,12 @@ impl HomeView {
                     Constraint::Min(responsive::PREVIEW_MIN_WIDTH),
                 ])
                 .split(main_chunks[0]);
+
+            // Layout chunks are contiguous, so chunks[1].x is the first
+            // column of the preview block — i.e., the visible left border
+            // that the user perceives as the divider. Hit-test uses the
+            // list's y-range (matches preview's y-range in side-by-side).
+            self.divider_col = Some(chunks[1].x);
 
             self.render_list(frame, chunks[0], theme);
             self.render_preview(frame, chunks[1], theme);
@@ -464,10 +485,15 @@ impl HomeView {
         // the list of active dialog types in one place — adding a new dialog
         // means adding one line here, not stamping out another five-line
         // if-let block.
+        // `&mut self.$field` so dialogs whose `render` captures screen
+        // rects on the struct (currently `unified_delete_dialog` for
+        // clickable Yes/No buttons) can mutate self. Dialogs with
+        // `&self` render methods still work — Rust auto-derefs the
+        // mutable borrow.
         macro_rules! render_dialogs {
             ($($field:ident),* $(,)?) => {
                 $(
-                    if let Some(dialog) = &self.$field {
+                    if let Some(dialog) = &mut self.$field {
                         dialog.render(frame, area, theme);
                     }
                 )*

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5113,10 +5113,38 @@ mod divider_drag {
         let mut env = create_test_env_empty();
         stage_side_by_side(&mut env);
         env.view.handle_drag_start(35, 5);
-        // Drag far to the left of column 0 — the i32 math must absorb the
-        // negative without wrapping u16.
+        // Drag far to the left of column 0; the i32 math must absorb
+        // the negative without wrapping u16.
         env.view.handle_drag_move(0);
         assert_eq!(env.view.list_width, 10);
+    }
+
+    #[test]
+    #[serial]
+    fn dialog_opening_mid_drag_ends_drag_and_persists() {
+        // If a modal opens while the user is still holding the mouse
+        // (e.g. a hotkey was pressed mid-drag), further Drag events must
+        // not keep updating list_width invisibly under the modal. The
+        // width achieved up to that point is persisted so the user's
+        // work isn't silently lost on Up.
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        env.view.handle_drag_start(35, 5);
+        env.view.handle_drag_move(50);
+        // Open a modal.
+        env.view.info_dialog = Some(InfoDialog::new("title", "body"));
+        // Next drag event sees the dialog and bails.
+        let changed = env.view.handle_drag_move(60);
+        assert!(!changed);
+        assert!(env.view.drag_state.is_none());
+        assert_eq!(
+            env.view.list_width, 50,
+            "width frozen at last pre-dialog value"
+        );
+        let config = load_config().unwrap().expect("config saved");
+        assert_eq!(config.app_state.home_list_width, Some(50));
+        // Subsequent Up is now a no-op (drag_state was cleared early).
+        assert!(!env.view.handle_drag_end());
     }
 
     #[test]

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5039,6 +5039,165 @@ mod click_to_select {
     }
 }
 
+mod divider_drag {
+    //! Click-and-drag on the list/preview divider resizes `list_width`.
+    //! Persistence is checked via `load_config()` (the same path the
+    //! keyboard `<`/`>` tests exercise indirectly via save_list_width).
+
+    use super::*;
+    use crate::session::config::load_config;
+    use ratatui::layout::Rect;
+
+    /// Stage the geometry a real side-by-side render would produce: a
+    /// list at column 0, divider at column 35, terminal 100 wide. The
+    /// list area mirrors what `render_list` would assign.
+    fn stage_side_by_side(env: &mut TestEnv) {
+        env.view.list_area = Rect::new(0, 0, 35, 20);
+        env.view.divider_col = Some(35);
+        env.view.main_area_width = 100;
+        env.view.list_width = 35;
+    }
+
+    #[test]
+    #[serial]
+    fn hit_divider_matches_only_the_divider_column() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        assert!(env.view.hit_divider(35, 5));
+        assert!(!env.view.hit_divider(34, 5), "list inner shouldn't hit");
+        assert!(!env.view.hit_divider(36, 5), "preview shouldn't hit");
+        assert!(!env.view.hit_divider(35, 99), "row past list_area is out");
+    }
+
+    #[test]
+    #[serial]
+    fn hit_divider_is_false_in_stacked_mode() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        // Stacked layout clears divider_col at render time; emulate.
+        env.view.divider_col = None;
+        assert!(!env.view.hit_divider(35, 5));
+    }
+
+    #[test]
+    #[serial]
+    fn drag_updates_list_width_relative_to_start() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        assert!(
+            env.view.handle_drag_start(35, 5),
+            "divider click starts drag"
+        );
+        // Drag 10 cols right.
+        assert!(env.view.handle_drag_move(45));
+        assert_eq!(env.view.list_width, 45);
+        // Drag back 5 cols (from start).
+        assert!(env.view.handle_drag_move(40));
+        assert_eq!(env.view.list_width, 40);
+    }
+
+    #[test]
+    #[serial]
+    fn drag_clamps_at_preview_min_width_ceiling() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        // main_area_width=100, PREVIEW_MIN_WIDTH=40 -> ceiling=60.
+        env.view.handle_drag_start(35, 5);
+        env.view.handle_drag_move(200);
+        assert_eq!(env.view.list_width, 60);
+    }
+
+    #[test]
+    #[serial]
+    fn drag_clamps_at_floor_without_underflow() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        env.view.handle_drag_start(35, 5);
+        // Drag far to the left of column 0 — the i32 math must absorb the
+        // negative without wrapping u16.
+        env.view.handle_drag_move(0);
+        assert_eq!(env.view.list_width, 10);
+    }
+
+    #[test]
+    #[serial]
+    fn drag_end_persists_list_width_once() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        env.view.handle_drag_start(35, 5);
+        env.view.handle_drag_move(50);
+        assert!(env.view.handle_drag_end());
+        let config = load_config().unwrap().expect("config saved");
+        assert_eq!(config.app_state.home_list_width, Some(50));
+        // Subsequent Up with no active drag is a no-op.
+        assert!(!env.view.handle_drag_end());
+    }
+
+    #[test]
+    #[serial]
+    fn drag_move_without_drag_start_is_noop() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        assert!(!env.view.handle_drag_move(50));
+        assert_eq!(env.view.list_width, 35);
+    }
+
+    #[test]
+    #[serial]
+    fn drag_start_misses_off_divider_column() {
+        let mut env = create_test_env_empty();
+        stage_side_by_side(&mut env);
+        assert!(!env.view.handle_drag_start(34, 5));
+        assert!(env.view.drag_state.is_none());
+    }
+}
+
+mod preview_click {
+    //! Left-click on the preview pane opens the Send Message dialog
+    //! targeting the currently-selected running session. No-op when no
+    //! valid target exists (group selected, non-running session, empty
+    //! list).
+
+    use super::*;
+
+    #[test]
+    #[serial]
+    fn click_with_no_session_does_not_open_dialog() {
+        let mut env = create_test_env_empty();
+        let changed = env.view.handle_preview_click();
+        assert!(!changed);
+        assert!(env.view.send_message_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn click_with_non_running_session_does_not_open_dialog() {
+        // Created via create_test_env_with_sessions: instances default to
+        // Status::Creating, which resolve_paste_target rejects.
+        let mut env = create_test_env_with_sessions(1);
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let changed = env.view.handle_preview_click();
+        assert!(!changed);
+        assert!(env.view.send_message_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn click_while_dialog_open_is_swallowed() {
+        // has_dialog() must short-circuit so a stray click on the preview
+        // never opens a second dialog on top of an existing one. Use the
+        // info dialog as a stand-in modal so this test doesn't depend on
+        // tmux state (the actual send-message path needs a live tmux
+        // session, which unit tests can't stage).
+        let mut env = create_test_env_empty();
+        env.view.info_dialog = Some(InfoDialog::new("title", "body"));
+        let changed = env.view.handle_preview_click();
+        assert!(!changed);
+        assert!(env.view.send_message_dialog.is_none());
+    }
+}
+
 mod save_field_merge {
     use super::*;
     use chrono::Utc;


### PR DESCRIPTION
## Description

Three new mouse affordances on top of the existing click + scroll support in the home view.

**1. Click-and-drag the list/preview divider to resize the sidebar.** Side-by-side mode only. Mirrors the existing `<` / `>` keyboard shortcut, persists `home_list_width` once on mouse-up, clamped to `[10, main_area_width - PREVIEW_MIN_WIDTH]` so the preview keeps its usability floor. Stacked mode (terminals under 80 cols) is unchanged.

**2. Single-click the preview pane to open Send Message.** Targets the currently-selected running session. No-op when there's no runnable target (group selected, non-running session, empty list) -- same gating as the `m` keybind.

**3. Click `[Yes]` / `[No]` on the delete-session dialog.** Shared `render_yes_no` helper now returns the button rects so the hit-test stays in lockstep with the renderer; the confirm dialog is unchanged on the surface (rects are computed but ignored) and ready to opt in later.

Routing priority on `Down(Left)`: dialog -> divider -> preview -> list, so a click on the divider never opens a dialog and a click on the preview never selects a row.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (n/a -- behaviors are discoverable in the same way the existing click + scroll were)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/` (n/a -- added unit-level tests instead; the new behaviors live in `HomeView` and `UnifiedDeleteDialog` and are covered without spinning up tmux)

11 new unit tests in this PR:
- 7 in `tui::home::tests::divider_drag` (hit-test, clamp ceiling, floor without u16 underflow, persistence once on mouse-up, no-op when drag wasn't started, miss off-column, stacked-mode disable)
- 2 in `tui::home::tests::preview_click` (no-op with no selection / non-running selection, swallowed while another modal is open)
- 4 in `tui::dialogs::delete_options::tests` (Yes hit, No hit, dead space between buttons, no-op before first render)

Full sweep: 2049 lib tests + 120 integration tests pass; `cargo fmt` + `cargo clippy --all-targets` clean.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (Claude Code)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds three mouse affordances to the TUI home view: dragging the list/preview divider to resize the sidebar, single-clicking the preview pane to open the Send Message dialog for a running session, and clicking the [Yes]/[No] buttons on the delete-session confirmation dialog. It refactors mouse routing so interactions are handled in a clear priority order (dialogs → divider → preview → list).

## What changed (high level)

- Mouse event routing: Left-clicks are routed by priority to prevent conflicts (dialogs first, then divider drag, then preview, then list).
- Divider dragging: Click-and-drag to resize the side-by-side list/preview layout; width is clamped to valid bounds and persisted on mouse-up. Stacked mode (<80 cols) is unchanged.
- Preview click: Single-clicking the preview opens the Send Message dialog when the selected target is runnable (same gating as the 'm' key).
- Delete dialog clicks: Yes/No buttons are now hit-testable; clicking them returns confirm/cancel as expected.
- State & rendering: HomeView tracks divider column, main area width, and active drag state; render path sets/clears these so hit-testing matches visible UI.
- Tests: 11 new unit tests (7 divider drag, 2 preview click, 4 delete dialog hit-tests). Reported full test sweep passes; formatting and lint clean. AI-assisted (Claude Opus 4.7).

## Additions

- New HomeView methods: hit_divider, handle_drag_start/move/end, handle_dialog_click, handle_preview_click.
- New DragKind enum and HomeView fields: divider_col, main_area_width, drag_state.
- render_yes_no now returns exact Rects for Yes/No button areas.
- UnifiedDeleteDialog stores button rects and exposes handle_click for hit-testing.

## Modifications

- Mouse handling in the main TUI loop extended to handle Drag(Left) and Up(Left) and to follow the new routing order.
- Confirm dialog rendering updated to accept the returned button rects (discarded where not needed).
- Dialog rendering macro updated to borrow dialogs mutably so they can update view state during render.

## Technical details (concise)

- Divider drag clamps width to [10, main_area_width - PREVIEW_MIN_WIDTH] and persists final width on mouse-up.
- Drag lifecycle ends if a modal opens mid-drag; the last visible width is persisted.
- render_yes_no uses a YES_NO_ROW_WIDTH constant and returns two Rects used for precise hit-testing.
- Click routing returns early when a handler consumes the event to avoid overlapping effects.

## Benefits

- More discoverable and ergonomic mouse-driven resizing and actions.
- Faster Send Message access via preview click.
- Clearer, consistent dialog click behavior that matches rendered UI.
- Respect for responsive layouts and existing keyboard shortcuts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->