### PR TITLE
test: stabilize flaky Playwright + cockpit integration tests

### DIFF
--- a/tests/integration/cockpit_acp_smoke.rs
+++ b/tests/integration/cockpit_acp_smoke.rs
@@ -16,33 +16,15 @@ use agent_of_empires::cockpit::agent_registry::AgentSpec;
 use agent_of_empires::cockpit::approvals::ApprovalDecision;
 use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
 
-fn node_available() -> bool {
-    std::process::Command::new("node")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn shim_path() -> std::path::PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    std::path::PathBuf::from(manifest)
-        .join("cockpit-worker")
-        .join("test-shim")
-        .join("shim.mjs")
-}
+use crate::common::{shim_path, shim_ready};
 
 #[tokio::test]
 async fn shim_agent_round_trips_prompt() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        eprintln!("skipping: shim missing at {}", shim.display());
-        return;
-    }
 
     let cwd = std::env::temp_dir();
     let config = SpawnConfig {
@@ -158,15 +140,11 @@ async fn shim_agent_round_trips_prompt() {
 /// allow, agent observes the selected option_id and reports back.
 #[tokio::test]
 async fn shim_agent_round_trips_approval_allow() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        eprintln!("skipping: shim missing at {}", shim.display());
-        return;
-    }
 
     let cwd = std::env::temp_dir();
     let config = SpawnConfig {
@@ -258,14 +236,11 @@ async fn shim_agent_round_trips_approval_allow() {
 /// shim echoes the read content back so we can assert the wire works.
 #[tokio::test]
 async fn shim_agent_round_trips_fs() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        return;
-    }
     let temp = tempfile::tempdir().expect("tempdir");
     let cwd = temp.path().to_path_buf();
     let config = SpawnConfig {
@@ -331,14 +306,11 @@ async fn shim_agent_round_trips_fs() {
 /// + TerminalManager wiring end-to-end.
 #[tokio::test]
 async fn shim_agent_round_trips_terminal() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        return;
-    }
     let temp = tempfile::tempdir().expect("tempdir");
     let cwd = temp.path().to_path_buf();
     let config = SpawnConfig {
@@ -416,15 +388,11 @@ async fn shim_agent_round_trips_terminal() {
 /// in `Supervisor::spawn` depend on.
 #[tokio::test]
 async fn shim_agent_set_mode_emits_current_mode_changed() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        eprintln!("skipping: shim missing at {}", shim.display());
-        return;
-    }
 
     let cwd = std::env::temp_dir();
     let config = SpawnConfig {
@@ -486,14 +454,11 @@ async fn shim_agent_set_mode_emits_current_mode_changed() {
 #[tokio::test]
 async fn shim_agent_emits_rate_limit_event() {
     use agent_of_empires::cockpit::state::Event;
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
     let shim = shim_path();
-    if !shim.exists() {
-        return;
-    }
 
     let cwd = std::env::temp_dir();
     let config = SpawnConfig {

--- a/tests/integration/cockpit_midturn_resume.rs
+++ b/tests/integration/cockpit_midturn_resume.rs
@@ -28,21 +28,7 @@ use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
 use tokio::net::UnixListener;
 use tokio::process::Command;
 
-fn node_available() -> bool {
-    std::process::Command::new("node")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
-
-fn shim_path() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    PathBuf::from(manifest)
-        .join("cockpit-worker")
-        .join("test-shim")
-        .join("shim.mjs")
-}
+use crate::common::{shim_path, shim_ready};
 
 /// Spawn the shim and bridge its stdio to a UNIX listener. Mimics what
 /// `aoe __cockpit-runner` does in production: byte-proxy, no protocol
@@ -116,12 +102,8 @@ async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> 
 
 #[tokio::test]
 async fn attach_in_flight_synthesizes_reattach_idle_stopped() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
-        return;
-    }
-    if !shim_path().exists() {
-        eprintln!("skipping: shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -158,12 +140,8 @@ async fn attach_in_flight_synthesizes_reattach_idle_stopped() {
 
 #[tokio::test]
 async fn attach_idle_session_does_not_synthesize_stopped() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
-        return;
-    }
-    if !shim_path().exists() {
-        eprintln!("skipping: shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -207,12 +185,8 @@ async fn attach_idle_session_does_not_synthesize_stopped() {
 /// `session/prompt` round-trip, and event mapping.
 #[tokio::test]
 async fn socket_transport_round_trips_prompt_via_attach() {
-    if !node_available() {
-        eprintln!("skipping: node not on PATH");
-        return;
-    }
-    if !shim_path().exists() {
-        eprintln!("skipping: shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 

--- a/tests/integration/cockpit_silent_orphan.rs
+++ b/tests/integration/cockpit_silent_orphan.rs
@@ -29,13 +29,7 @@ use serial_test::serial;
 use tokio::net::UnixListener;
 use tokio::process::Command;
 
-fn node_available() -> bool {
-    std::process::Command::new("node")
-        .arg("--version")
-        .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
-}
+use crate::common::{shim_path, shim_ready};
 
 /// RAII helper that snapshots env-var values on construction and
 /// restores them on drop. The watchdog tests are `#[serial]` but the
@@ -68,14 +62,6 @@ impl Drop for EnvGuard {
             }
         }
     }
-}
-
-fn shim_path() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    PathBuf::from(manifest)
-        .join("cockpit-worker")
-        .join("test-shim")
-        .join("shim.mjs")
 }
 
 async fn spawn_shim_socket_bridge_with_preseed(
@@ -132,8 +118,8 @@ async fn drain_for_stopped_reason(client: &mut AcpClient, deadline: Instant) -> 
 #[tokio::test]
 #[serial]
 async fn silent_orphan_fires_on_cost_then_silence() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -193,8 +179,8 @@ async fn silent_orphan_fires_on_cost_then_silence() {
 #[tokio::test]
 #[serial]
 async fn silent_orphan_suppressed_during_normal_turn() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -250,8 +236,8 @@ async fn silent_orphan_suppressed_during_normal_turn() {
 #[tokio::test]
 #[serial]
 async fn silent_orphan_disabled_by_zero_grace() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -313,8 +299,8 @@ async fn silent_orphan_disabled_by_zero_grace() {
 #[tokio::test]
 #[serial]
 async fn silent_orphan_suppressed_during_async_agent_wait() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -371,8 +357,8 @@ async fn silent_orphan_suppressed_during_async_agent_wait() {
 #[tokio::test]
 #[serial]
 async fn silent_orphan_suppressed_during_background_bash() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 
@@ -430,8 +416,8 @@ async fn silent_orphan_suppressed_during_background_bash() {
 #[tokio::test]
 #[serial]
 async fn silent_orphan_suppressed_during_scheduled_wakeup() {
-    if !node_available() || !shim_path().exists() {
-        eprintln!("skipping: node or shim missing");
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
         return;
     }
 

--- a/tests/integration/cockpit_silent_orphan.rs
+++ b/tests/integration/cockpit_silent_orphan.rs
@@ -171,8 +171,16 @@ async fn silent_orphan_fires_on_cost_then_silence() {
         .await
         .expect("send prompt");
 
+    // 15s budget rather than 5s: the watchdog fires at FAST_GRACE (300ms)
+    // after the cost-populated usage_update on the happy path, but
+    // ubuntu-latest under full cargo-test load occasionally schedules the
+    // shim's prompt body or the daemon's lifecycle signal pump late
+    // enough that the cancel + prompt_fut resolve + Stopped emission
+    // chain slips past a tight 5s drain. The watchdog itself is unchanged;
+    // this is a CI-scheduling headroom bump. A regression where the
+    // watchdog never fires would still fail (drain returns None).
     let stopped =
-        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(5)).await;
+        drain_for_stopped_reason(&mut client, Instant::now() + Duration::from_secs(15)).await;
     let _ = client.shutdown().await;
 
     assert_eq!(

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -3,8 +3,46 @@
 //! Declared once from `tests/integration/main.rs`; consumers import via
 //! `use crate::common::...`.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::TempDir;
+
+/// Path to the Node ACP test shim used by cockpit_* integration tests.
+#[allow(dead_code)]
+pub fn shim_path() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
+    PathBuf::from(manifest)
+        .join("cockpit-worker")
+        .join("test-shim")
+        .join("shim.mjs")
+}
+
+/// Returns `Ok(())` if the cockpit shim can be spawned (node on PATH, shim
+/// file present, shim deps installed). Otherwise returns a short reason
+/// that callers print before skipping. CI installs deps via `npm ci` in
+/// `cockpit-worker/test-shim/` before running the integration leg; local
+/// runs need the same one-shot setup, which the message points at.
+#[allow(dead_code)]
+pub fn shim_ready() -> Result<(), String> {
+    let node_ok = std::process::Command::new("node")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    if !node_ok {
+        return Err("node not on PATH".into());
+    }
+    let shim = shim_path();
+    if !shim.exists() {
+        return Err(format!("shim missing at {}", shim.display()));
+    }
+    let node_modules = shim.parent().unwrap().join("node_modules");
+    if !node_modules.exists() {
+        return Err(format!(
+            "shim deps not installed; run `cd cockpit-worker/test-shim && npm ci` first"
+        ));
+    }
+    Ok(())
+}
 
 /// Set `HOME` (and `XDG_CONFIG_HOME` on Linux) to a fresh temp dir so tests
 /// read and write to isolated state. Returns the guard; drop it to clean up.

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -8,8 +8,7 @@ use tempfile::TempDir;
 
 /// Path to the Node ACP test shim used by cockpit_* integration tests.
 pub fn shim_path() -> PathBuf {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    PathBuf::from(manifest)
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("cockpit-worker")
         .join("test-shim")
         .join("shim.mjs")

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -7,7 +7,6 @@ use std::path::{Path, PathBuf};
 use tempfile::TempDir;
 
 /// Path to the Node ACP test shim used by cockpit_* integration tests.
-#[allow(dead_code)]
 pub fn shim_path() -> PathBuf {
     let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap();
     PathBuf::from(manifest)
@@ -21,7 +20,6 @@ pub fn shim_path() -> PathBuf {
 /// that callers print before skipping. CI installs deps via `npm ci` in
 /// `cockpit-worker/test-shim/` before running the integration leg; local
 /// runs need the same one-shot setup, which the message points at.
-#[allow(dead_code)]
 pub fn shim_ready() -> Result<(), String> {
     let node_ok = std::process::Command::new("node")
         .arg("--version")

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -34,9 +34,9 @@ pub fn shim_ready() -> Result<(), String> {
     }
     let node_modules = shim.parent().unwrap().join("node_modules");
     if !node_modules.exists() {
-        return Err(format!(
-            "shim deps not installed; run `cd cockpit-worker/test-shim && npm ci` first"
-        ));
+        return Err(
+            "shim deps not installed; run `cd cockpit-worker/test-shim && npm ci` first".into(),
+        );
     }
     Ok(())
 }

--- a/web/tests/helpers/sidebar.ts
+++ b/web/tests/helpers/sidebar.ts
@@ -1,21 +1,19 @@
 import type { Page } from "@playwright/test";
 
 export async function clickSidebarSession(page: Page, title: string) {
+  // Sidebar session rows are anchor tags (see WorkspaceSidebar.tsx). The
+  // pre-link button-based fallback that used to live here was dead code by
+  // the time it ran: if the link never appeared, the button locator never
+  // did either, but its click had no timeout and would consume the rest
+  // of the 30s test budget before erroring with a confusing "page closed"
+  // message. Surfacing the link timeout directly gives a clean failure.
+  //
+  // 20s rather than 10s: at 6 mocked workers on a 4-vCPU runner with v8
+  // coverage instrumentation, sidebar slide-in + sessions fetch + render
+  // sometimes lose to scheduler contention past 10s. Two flakes in CI
+  // (pinch-zoom MIN_FONT_SIZE, scrollback scroll-down clamp) traced to
+  // exactly this race.
   const sessionLink = page.getByRole("link").filter({ hasText: title }).first();
-  try {
-    // 10s rather than 5s: at 6 mocked-suite workers on a 4-vCPU runner,
-    // the React render + sidebar slide-in can lose to scheduler contention
-    // and miss a 5s wait, which manifests as the surrounding test hitting
-    // its 30s timeout.
-    await sessionLink.waitFor({ state: "visible", timeout: 10_000 });
-    await sessionLink.click();
-    return;
-  } catch {
-    // Fall back to the pre-link sidebar implementation below.
-  }
-
-  // Older sidebar implementations rendered the repo-group header and the
-  // nested session row as buttons with the same text. The second match is the
-  // actual session row.
-  await page.locator("button").filter({ hasText: title }).nth(1).click();
+  await sessionLink.waitFor({ state: "visible", timeout: 20_000 });
+  await sessionLink.click();
 }

--- a/web/tests/live/theme-switch-live.spec.ts
+++ b/web/tests/live/theme-switch-live.spec.ts
@@ -1,107 +1,16 @@
 // Live-backend theme switching coverage. Spins up a real `aoe serve`
-// process against an isolated $HOME and drives the dashboard's theme
-// picker through actual /api/themes/:name + /api/theme/current calls.
-// This is the test that would have caught the OnceLock-via-load_theme
-// deadlock that the mock-API tests in theme-switch.spec.ts couldn't:
-// mocks bypass the resolver entirely.
+// process via the shared aoeServe harness and drives the dashboard's
+// theme picker through actual /api/themes/:name + /api/theme/current
+// calls. This is the test that would have caught the
+// OnceLock-via-load_theme deadlock that the mock-API tests in
+// theme-switch.spec.ts couldn't: mocks bypass the resolver entirely.
 
 import { test, expect, type Page } from "@playwright/test";
-import { spawn, type ChildProcess } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
-
-// Matches liveGlobalSetup's resolution: env override, then release, then
-// debug. Local dev typically only has the debug binary; CI sets
-// AOE_E2E_BINARY to a release build.
-function resolveAoeBinary(): string | null {
-  const fromEnv = process.env.AOE_E2E_BINARY;
-  if (fromEnv && existsSync(fromEnv)) return fromEnv;
-  const release = resolve(process.cwd(), "..", "target", "release", "aoe");
-  if (existsSync(release)) return release;
-  const debug = resolve(process.cwd(), "..", "target", "debug", "aoe");
-  if (existsSync(debug)) return debug;
-  return null;
-}
-
-const AOE_BINARY = resolveAoeBinary();
-const HAS_BINARY = AOE_BINARY !== null;
+import { spawnAoeServe, type ServeHandle } from "../helpers/aoeServe";
 
 // Builtin pinned to a value that visibly differs from Empire so the
 // dashboard repaint is observable.
 const SWITCH_TO = "dracula";
-
-interface Daemon {
-  proc: ChildProcess;
-  home: string;
-  base: string;
-  cleanup: () => void;
-}
-
-async function startServer(port: number): Promise<Daemon> {
-  if (!AOE_BINARY) throw new Error("aoe binary not resolved");
-  const home = mkdtempSync(join(tmpdir(), "aoe-theme-e2e-"));
-  const base = `http://127.0.0.1:${port}`;
-  // Foreground (no daemonize), no auth, no tunnel; keeps Ctrl-C
-  // semantics on Playwright shutdown.
-  const proc = spawn(
-    AOE_BINARY,
-    [
-      "serve",
-      "--no-auth",
-      "--port",
-      String(port),
-      "--host",
-      "127.0.0.1",
-    ],
-    {
-      cwd: process.cwd(),
-      env: {
-        ...process.env,
-        HOME: home,
-        // Suppress the dev-build prefix dance; let `aoe serve`'s
-        // env-driven app-dir routing pick its own dev path.
-        RUST_LOG: "warn",
-      },
-      stdio: ["ignore", "pipe", "pipe"],
-    },
-  );
-
-  // Wait until the server is listening (poll /api/themes which has no
-  // auth and no side effects).
-  const deadline = Date.now() + 20_000;
-  while (Date.now() < deadline) {
-    try {
-      const res = await fetch(`${base}/api/themes`);
-      if (res.ok) break;
-    } catch {
-      // socket not up yet
-    }
-    await new Promise((r) => setTimeout(r, 200));
-  }
-  if (Date.now() >= deadline) {
-    proc.kill("SIGKILL");
-    throw new Error("aoe serve did not start within 20s");
-  }
-
-  return {
-    proc,
-    home,
-    base,
-    cleanup: () => {
-      try {
-        proc.kill("SIGTERM");
-      } catch {
-        // already exited
-      }
-      try {
-        rmSync(home, { recursive: true, force: true });
-      } catch {
-        // best effort
-      }
-    },
-  };
-}
 
 async function readCssVar(page: Page, name: string): Promise<string> {
   return await page.evaluate(
@@ -111,29 +20,18 @@ async function readCssVar(page: Page, name: string): Promise<string> {
 }
 
 test.describe("Live aoe serve theme switching (#1189)", () => {
-  // Skip gracefully if the Rust binary hasn't been built. CI runs
-  // `cargo build --features serve` first; local runs without the
-  // binary skip these instead of failing the rest of the suite.
-  test.skip(
-    !HAS_BINARY,
-    "aoe binary missing; run `cargo build --features serve` first",
-  );
-
-  let daemon: Daemon;
+  let handle: ServeHandle;
 
   test.beforeAll(async ({}, workerInfo) => {
-    // Worker-indexed port so parallel live workers don't collide.
-    // Base 18099 keeps it away from aoeServe.ts's range (which uses
-    // workerIndex around 28000+).
-    const envPort = process.env.AOE_LIVE_TEST_PORT;
-    const port = envPort
-      ? Number(envPort)
-      : 18099 + workerInfo.workerIndex;
-    daemon = await startServer(port);
+    handle = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: workerInfo.workerIndex,
+      parallelIndex: workerInfo.parallelIndex,
+    });
   });
 
-  test.afterAll(() => {
-    daemon?.cleanup();
+  test.afterAll(async () => {
+    await handle?.stop();
   });
 
   test("GET /api/themes/:name returns within 2s and is not stuck in resolve", async () => {
@@ -143,7 +41,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
     const ctrl = new AbortController();
     const watchdog = setTimeout(() => ctrl.abort(), 2_000);
     try {
-      const res = await fetch(`${daemon.base}/api/themes/${SWITCH_TO}`, {
+      const res = await fetch(`${handle.baseUrl}/api/themes/${SWITCH_TO}`, {
         signal: ctrl.signal,
       });
       expect(res.ok).toBe(true);
@@ -172,7 +70,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
       const ctrl = new AbortController();
       const watchdog = setTimeout(() => ctrl.abort(), 2_000);
       try {
-        const res = await fetch(`${daemon.base}/api/themes/${name}`, {
+        const res = await fetch(`${handle.baseUrl}/api/themes/${name}`, {
           signal: ctrl.signal,
         });
         expect(res.ok, `${name} did not return`).toBe(true);
@@ -188,7 +86,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
   test("dashboard chrome repaints when theme switches via API", async ({
     page,
   }) => {
-    await page.goto(`${daemon.base}/`);
+    await page.goto(`${handle.baseUrl}/`);
     // Wait for the React-side fetch of /api/theme/current to land
     // and seed --color-surface-900 with the active palette.
     await expect
@@ -205,7 +103,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
     // endpoint the picker uses, then firing the same event the
     // ThemeSettings.tsx save() handler dispatches.
     const patch = await page.request.patch(
-      `${daemon.base}/api/profiles/default/settings`,
+      `${handle.baseUrl}/api/profiles/default/settings`,
       {
         data: { theme: { name: SWITCH_TO } },
       },

--- a/web/tests/live/theme-switch-live.spec.ts
+++ b/web/tests/live/theme-switch-live.spec.ts
@@ -11,11 +11,22 @@ import { existsSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
-const AOE_BINARY = resolve(process.cwd(), "..", "target", "debug", "aoe");
-const HAS_BINARY = existsSync(AOE_BINARY);
+// Matches liveGlobalSetup's resolution: env override, then release, then
+// debug. Local dev typically only has the debug binary; CI sets
+// AOE_E2E_BINARY to a release build.
+function resolveAoeBinary(): string | null {
+  const fromEnv = process.env.AOE_E2E_BINARY;
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+  const release = resolve(process.cwd(), "..", "target", "release", "aoe");
+  if (existsSync(release)) return release;
+  const debug = resolve(process.cwd(), "..", "target", "debug", "aoe");
+  if (existsSync(debug)) return debug;
+  return null;
+}
 
-const HARNESS_PORT = Number(process.env.AOE_LIVE_TEST_PORT ?? 18099);
-const HARNESS_BASE = `http://127.0.0.1:${HARNESS_PORT}`;
+const AOE_BINARY = resolveAoeBinary();
+const HAS_BINARY = AOE_BINARY !== null;
+
 // Builtin pinned to a value that visibly differs from Empire so the
 // dashboard repaint is observable.
 const SWITCH_TO = "dracula";
@@ -23,11 +34,14 @@ const SWITCH_TO = "dracula";
 interface Daemon {
   proc: ChildProcess;
   home: string;
+  base: string;
   cleanup: () => void;
 }
 
-async function startServer(): Promise<Daemon> {
+async function startServer(port: number): Promise<Daemon> {
+  if (!AOE_BINARY) throw new Error("aoe binary not resolved");
   const home = mkdtempSync(join(tmpdir(), "aoe-theme-e2e-"));
+  const base = `http://127.0.0.1:${port}`;
   // Foreground (no daemonize), no auth, no tunnel; keeps Ctrl-C
   // semantics on Playwright shutdown.
   const proc = spawn(
@@ -36,7 +50,7 @@ async function startServer(): Promise<Daemon> {
       "serve",
       "--no-auth",
       "--port",
-      String(HARNESS_PORT),
+      String(port),
       "--host",
       "127.0.0.1",
     ],
@@ -58,7 +72,7 @@ async function startServer(): Promise<Daemon> {
   const deadline = Date.now() + 20_000;
   while (Date.now() < deadline) {
     try {
-      const res = await fetch(`${HARNESS_BASE}/api/themes`);
+      const res = await fetch(`${base}/api/themes`);
       if (res.ok) break;
     } catch {
       // socket not up yet
@@ -73,6 +87,7 @@ async function startServer(): Promise<Daemon> {
   return {
     proc,
     home,
+    base,
     cleanup: () => {
       try {
         proc.kill("SIGTERM");
@@ -101,13 +116,20 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
   // binary skip these instead of failing the rest of the suite.
   test.skip(
     !HAS_BINARY,
-    `${AOE_BINARY} missing; run \`cargo build --features serve\` first`,
+    "aoe binary missing; run `cargo build --features serve` first",
   );
 
   let daemon: Daemon;
 
-  test.beforeAll(async () => {
-    daemon = await startServer();
+  test.beforeAll(async ({}, workerInfo) => {
+    // Worker-indexed port so parallel live workers don't collide.
+    // Base 18099 keeps it away from aoeServe.ts's range (which uses
+    // workerIndex around 28000+).
+    const envPort = process.env.AOE_LIVE_TEST_PORT;
+    const port = envPort
+      ? Number(envPort)
+      : 18099 + workerInfo.workerIndex;
+    daemon = await startServer(port);
   });
 
   test.afterAll(() => {
@@ -121,7 +143,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
     const ctrl = new AbortController();
     const watchdog = setTimeout(() => ctrl.abort(), 2_000);
     try {
-      const res = await fetch(`${HARNESS_BASE}/api/themes/${SWITCH_TO}`, {
+      const res = await fetch(`${daemon.base}/api/themes/${SWITCH_TO}`, {
         signal: ctrl.signal,
       });
       expect(res.ok).toBe(true);
@@ -150,7 +172,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
       const ctrl = new AbortController();
       const watchdog = setTimeout(() => ctrl.abort(), 2_000);
       try {
-        const res = await fetch(`${HARNESS_BASE}/api/themes/${name}`, {
+        const res = await fetch(`${daemon.base}/api/themes/${name}`, {
           signal: ctrl.signal,
         });
         expect(res.ok, `${name} did not return`).toBe(true);
@@ -166,7 +188,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
   test("dashboard chrome repaints when theme switches via API", async ({
     page,
   }) => {
-    await page.goto(`${HARNESS_BASE}/`);
+    await page.goto(`${daemon.base}/`);
     // Wait for the React-side fetch of /api/theme/current to land
     // and seed --color-surface-900 with the active palette.
     await expect
@@ -183,7 +205,7 @@ test.describe("Live aoe serve theme switching (#1189)", () => {
     // endpoint the picker uses, then firing the same event the
     // ThemeSettings.tsx save() handler dispatches.
     const patch = await page.request.patch(
-      `${HARNESS_BASE}/api/profiles/default/settings`,
+      `${daemon.base}/api/profiles/default/settings`,
       {
         data: { theme: { name: SWITCH_TO } },
       },

--- a/web/tests/terminal-focus-shortcut.spec.ts
+++ b/web/tests/terminal-focus-shortcut.spec.ts
@@ -75,11 +75,11 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     await expect.poll(() => focusedKind(page)).toBe("agent");
     await shot(page, "01-agent-focused.png");
 
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("paired");
     await shot(page, "02-paired-focused.png");
 
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("agent");
     await shot(page, "03-back-to-agent.png");
   });
@@ -95,7 +95,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
 
     // Semantic match for VSCode's Ctrl+` "open/focus the terminal": from
     // outside both panes, focus lands in paired (the secondary shell).
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("paired");
   });
 
@@ -106,12 +106,12 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     await page.goto("/");
     await openSession(page);
 
-    await page.keyboard.press("Control+Alt+b");
+    await page.keyboard.press("ControlOrMeta+Alt+b");
     await expect(page.locator('[data-term="paired"]')).toHaveCount(0);
     await shot(page, "04-collapsed.png");
 
     await focusKind(page, "agent");
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
     await expect.poll(() => focusedKind(page)).toBe("paired");
     await shot(page, "05-expanded-paired-focused.png");
@@ -137,7 +137,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     // state. focusSelf in PairedTerminal can't find a textarea, so the
     // listener calls setPendingTerminalFocus("paired").
     await focusKind(page, "agent");
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
 
     // Within 3s the ensureTerminal mock returns, ready flips true,
     // the consume-on-ready effect fires, focus lands in paired.
@@ -166,7 +166,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     // Agent terminal still mounted as "Starting session..." so its xterm
     // textarea doesn't exist yet. Press Cmd+` → target=agent → listener
     // sets the pending latch.
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
 
     // ensureSession resolves, ensureState flips to ready, consume effect
     // fires, focus lands on agent.
@@ -212,7 +212,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
     await expect.poll(() => focusedKind(page)).toBe("paired");
 
     // Press Cmd+` → handler clears selectedFilePath, then rAF-dispatches.
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("agent");
     await shot(page, "07-after-toggle-agent.png");
   });
@@ -225,7 +225,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
 
     // 11 toggles total = odd flips from agent → paired.
     for (let i = 0; i < 11; i++) {
-      await page.keyboard.press("Control+`");
+      await page.keyboard.press("ControlOrMeta+`");
     }
     await expect.poll(() => focusedKind(page)).toBe("paired");
   });
@@ -240,7 +240,7 @@ test.describe("Cmd/Ctrl+` desktop", () => {
       page.locator('[data-term="agent"]').first(),
     ).toHaveClass(/term-focused/);
 
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     // The visible paired panel should pick up term-focused.
     await expect(
       page.locator('[data-term="paired"]:visible').first(),
@@ -264,7 +264,7 @@ test.describe("Cmd/Ctrl+` mobile", () => {
 
     // Right panel starts collapsed on mobile; expand it via the existing
     // shortcut so the slide-in mounts.
-    await page.keyboard.press("Control+Alt+b");
+    await page.keyboard.press("ControlOrMeta+Alt+b");
     await expect(page.locator('[data-term="paired"]')).toHaveCount(2);
 
     // Focus the visible paired (mobile slide-in). On a mobile viewport
@@ -273,10 +273,10 @@ test.describe("Cmd/Ctrl+` mobile", () => {
     await focusKind(page, "paired");
     await expect.poll(() => focusedKind(page)).toBe("paired");
 
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("agent");
 
-    await page.keyboard.press("Control+`");
+    await page.keyboard.press("ControlOrMeta+`");
     await expect.poll(() => focusedKind(page)).toBe("paired");
   });
 });


### PR DESCRIPTION
> AI disclosure: this PR was authored by Claude (Opus 4.7, 1M context) with human review and direction.

## Description

Five commits, each a self-contained fix for a different flake source surfaced by local Mac runs and CI run 26342421371 on main.

- `11eafcd1` Mac modifier fix in terminal-focus-shortcut spec. `useKeyboardShortcuts.ts:35` gates the `mod` flag on `metaKey` on Mac, but the spec sent literal `Control+` presses, so the handler returned early. Linux CI passed because Ctrl satisfies `mod` there. Eight focus / panel-state assertions failed locally; swapped to Playwright's `ControlOrMeta+` per-platform shorthand to match `command-palette.spec.ts`.
- `8f5cbe31` `theme-switch-live.spec.ts` was under `tests/` so the mocked config picked it up; the three tests in the describe block ran on different workers under `fullyParallel`, each `beforeAll` spawned a real `aoe serve`, and the three daemons collided on the hardcoded 18099 port. Moved to `tests/live/`, port now derived from `workerInfo.workerIndex`, and the binary resolver tries `AOE_E2E_BINARY` then `target/release/aoe` then `target/debug/aoe` so local dev with only a debug build works.
- `bdc76d81` `clickSidebarSession` had a dead button-fallback that ran after the 10s link `waitFor` timed out, then took the remaining 30s test budget and failed with a confusing page-closed error. Two CI flakes (pinch-zoom MIN_FONT_SIZE, scrollback scroll-down clamp) traced to that exact path. Dropped the fallback, bumped the link wait to 20s for six-worker + coverage-instrumented load.
- `ec5e83aa` `silent_orphan_fires_on_cost_then_silence` flaked once on main with the same code paths that have passed many times since. Watchdog itself is correct; under full cargo-test load the cancel + prompt_fut resolve + Stopped emission chain occasionally slips past a tight 5s drain. Bumped to 15s; pure scheduling headroom, no semantic change.
- `1ec08b24` Local Mac `cargo test --features serve` failed 15 cockpit tests with a 30s ACP handshake timeout because `cockpit-worker/test-shim/node_modules` was missing. CI installs deps via `npm ci`. Added `shim_ready()` in `tests/integration/common/mod.rs` and threaded it through `cockpit_acp_smoke`, `cockpit_midturn_resume`, `cockpit_silent_orphan`; each test now skips with a one-line hint pointing at `cd cockpit-worker/test-shim && npm ci`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR fixes existing specs and helper code, no user-facing flow changes

**TUI / CLI (e2e test)**
- [x] N/A: no TUI / CLI / session-lifecycle change

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code, Opus 4.7 (1M context)

**Any Additional AI Details you'd like to share:** Diagnosis of each flake (Mac modifier gate, dead fallback, port collision, scheduler-headroom margin, missing shim deps) and the fixes were drafted by Claude under human direction; commits were reviewed before push.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR stabilizes flaky Playwright and cockpit integration tests by centralizing shim readiness checks, isolating live tests with per-worker servers, improving cross-platform key handling, removing a dead UI fallback, and increasing timeouts to avoid intermittent CI scheduling/load races.

What changed (high-level)
- Centralized cockpit shim gating: added shim_ready() and shim_path() in tests/integration/common/mod.rs so integration tests skip early with a clear, actionable reason when Node/shim prerequisites are missing.
- Updated cockpit integration tests (cockpit_acp_smoke, cockpit_midturn_resume, cockpit_silent_orphan) to call shim_ready()/shim_path() instead of duplicating node/shim checks; tests now print skip hints (e.g., how to install test-shim deps).
- Added EnvGuard in cockpit_silent_orphan to snapshot and restore AOE_SILENT_ORPHAN_* env vars and avoid cross-test leakage.
- Moved theme-switch-live.spec.ts into the live harness and replaced inline server startup with spawnAoeServe/ServeHandle so each worker derives its own port from workerIndex; binary resolution now prefers AOE_E2E_BINARY → target/release/aoe → target/debug/aoe.
- Replaced literal Control+ key events with Playwright’s platform-aware ControlOrMeta+ in terminal-focus-shortcut.spec.ts to fix macOS Cmd vs Ctrl behavior.
- Removed a dead fallback in clickSidebarSession (web/tests/helpers/sidebar.ts): now it only waits for and clicks the sidebar link (increased wait to 20s).
- Increased timing headroom for heavy CI/coverage runs:
  - silent_orphan drain/watchdog: 5s → 15s
  - sidebar link visibility wait: 10s → 20s

Benefits
- Fewer flaky CI failures and clearer, actionable skip diagnostics when local Node/shim prerequisites are missing.
- Consistent cross-platform shortcut behavior (macOS Cmd vs Ctrl).
- Safer parallel CI via per-worker server ports and reduced port-collision risk.
- Improved robustness under heavy/coverage-instrumented loads.
- Reduced duplicate test plumbing and easier maintenance via shared helpers.

Technical details (concise)
- New test helpers in tests/integration/common/mod.rs:
  - pub fn shim_path() -> PathBuf
  - pub fn shim_ready() -> Result<(), String> (checks node on PATH, shim.mjs exists, and shim/node_modules exists; returns a short skip reason)
- cockpit tests now gate with shim_ready() and use shim_path() when spawning AcpClient.
- EnvGuard RAII added to cockpit_silent_orphan.rs to restore environment variables on drop.
- web/tests/helpers/sidebar.ts: clickSidebarSession(page, title) now filters page.getByRole("link") by title, waits up to 20s for visibility, then clicks; removed 10s wait + button fallback.
- web/tests/live/theme-switch-live.spec.ts: uses spawnAoeServe({ authMode, workerIndex, parallelIndex }) and ServeHandle.baseUrl; spawn helper's waitForServer already checks process exit code/signal for fail-fast behavior.
- terminal-focus-shortcut.spec.ts: all "Control+`" invocations changed to "ControlOrMeta+`".
- Minor lint-driven change: replaced useless format!() with .into() in shim_ready error message; commits were human-reviewed (AI-assisted drafting noted).

Suggested follow-ups
- Document shim_ready() and shim install steps in CONTRIBUTING or a test README.
- Consider migrating other live specs to spawnAoeServe to reduce further port/contention flakes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->