### PR TITLE
fix(update): re-check periodically inside the TUI

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -24,6 +24,16 @@ use crate::update::{check_for_update, UpdateInfo};
 /// re-evaluating well under any realistic `check_interval_hours` setting.
 const UPDATE_CHECK_THROTTLE_GAP: Duration = Duration::from_secs(60);
 
+/// Floor for the periodic re-check interval. The settings TUI validator
+/// rejects `check_interval_hours = 0`, but a user could still land in that
+/// state by hand-editing the config file. Without a floor, the periodic
+/// re-check would fire once per `UPDATE_CHECK_THROTTLE_GAP` (60s) and the
+/// underlying `check_for_update` cache TTL would also be zero, defeating
+/// the cache and hitting GitHub on every tick. One hour is generous; users
+/// who genuinely want hourly checks set `check_interval_hours = 1` and get
+/// the same effect via the normal path.
+const MIN_PERIODIC_RECHECK_INTERVAL: Duration = Duration::from_secs(3600);
+
 /// Inter-key timeout for the paste-burst detector. After any printable Char
 /// or Enter, the event loop polls for the next event with this timeout; if
 /// another burst-candidate arrives before the deadline, it joins the burst.
@@ -98,13 +108,20 @@ pub struct App {
     /// the sync `execute_action` can't lend out).
     #[cfg(feature = "serve")]
     pending_cockpit_open: Option<String>,
-    /// Version of the most recent auto-install kicked off in this process.
-    /// The running binary's compile-time `CARGO_PKG_VERSION` stays at the
-    /// old value until restart, so without this guard every periodic
-    /// re-check (#1471) would re-trigger an install for the same release,
-    /// cycling the "auto-updating…" / "update complete" status messages
-    /// and wasting bandwidth.
-    last_auto_installed_version: Option<String>,
+    /// Version of the install currently being attempted (auto or manual).
+    /// Set when the install task is spawned; transferred to
+    /// `last_installed_version_in_session` on confirmed success in
+    /// `poll_update_status`. Cleared on failure so the user can retry.
+    pending_install_version: Option<String>,
+    /// Version we successfully installed this session. The running binary's
+    /// compile-time `CARGO_PKG_VERSION` stays at the old value until
+    /// restart, so without this guard every periodic re-check (#1471) would
+    /// surface the same release again: as an auto-install loop in auto
+    /// mode, and as a re-appearing banner in notify mode. A genuinely newer
+    /// release clears the guard automatically because the version string
+    /// differs. Single-process scope; on restart the new binary's
+    /// `CARGO_PKG_VERSION` makes the underlying check return "no update".
+    last_installed_version_in_session: Option<String>,
 }
 
 /// Check if the app version changed and return the previous version if changelog should be shown.
@@ -221,7 +238,8 @@ impl App {
             mouse_captured: crate::tui::mouse_capture_requested(),
             #[cfg(feature = "serve")]
             pending_cockpit_open: None,
-            last_auto_installed_version: None,
+            pending_install_version: None,
+            last_installed_version_in_session: None,
         })
     }
 
@@ -805,11 +823,9 @@ impl App {
             if last_update_eval.elapsed() >= UPDATE_CHECK_THROTTLE_GAP {
                 last_update_eval = std::time::Instant::now();
                 let settings = get_update_settings();
-                let interval =
-                    Duration::from_secs(settings.check_interval_hours.saturating_mul(3600));
                 if should_spawn_periodic_update_check(
                     last_update_check.elapsed(),
-                    interval,
+                    periodic_recheck_interval(settings.check_interval_hours),
                     self.update_rx.is_some(),
                     settings.update_check_mode.is_enabled(),
                 ) {
@@ -926,6 +942,21 @@ impl App {
             return false;
         };
 
+        // Already installed this version this session (auto or manual). The
+        // running binary's compile-time `CARGO_PKG_VERSION` is stale until
+        // the user restarts, so every periodic re-check (#1471) would
+        // otherwise rediscover the same release: auto mode would loop the
+        // installer, notify mode would re-show the banner. Skip both.
+        if self.last_installed_version_in_session.as_deref() == Some(info.latest_version.as_str()) {
+            tracing::info!(
+                target: "update.dedup",
+                version = %info.latest_version,
+                "skipping: already installed this version this session, restart aoe to use it"
+            );
+            self.update_info = None;
+            return false;
+        }
+
         // Auto mode: install in the background and suppress the banner.
         // The new binary is picked up on next launch; we do not restart
         // the TUI mid-session (avoids racing tmux attaches and partial
@@ -970,21 +1001,6 @@ impl App {
             return;
         }
 
-        // Periodic re-checks (#1471) keep finding the same "available"
-        // version until the user restarts (the running binary's
-        // compile-time `CARGO_PKG_VERSION` is stale). Without this guard,
-        // each periodic tick would re-install the same release, cycling
-        // status messages and wasting bandwidth. A genuinely newer release
-        // clears the guard automatically because the version string differs.
-        if self.last_auto_installed_version.as_deref() == Some(version.as_str()) {
-            tracing::info!(
-                target: "update.auto",
-                version,
-                "auto mode skipped: already installed this version this session, restart aoe to use it"
-            );
-            return;
-        }
-
         let method = match detect_install_method() {
             Ok(m) => m,
             Err(e) => {
@@ -1014,11 +1030,11 @@ impl App {
         self.update_status = Some(UpdateStatus::transient(format!(
             "auto-updating to v{version} in background…"
         )));
-        // Record before spawning: if the install fails we still skip retries
-        // for this same version, since auto-install failures (disk full,
-        // corrupt download) tend to repeat. The user can press `u` from the
-        // banner, run `aoe update`, or restart aoe to retry.
-        self.last_auto_installed_version = Some(version.clone());
+        // Stash for `poll_update_status` to promote into
+        // `last_installed_version_in_session` on confirmed success. Tracking
+        // only on success preserves the user's ability to retry after a
+        // failed install (transient network issue, disk full, etc.).
+        self.pending_install_version = Some(version.clone());
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.update_status_rx = Some(rx);
         let handle = tokio::runtime::Handle::current();
@@ -1036,12 +1052,17 @@ impl App {
         };
         match rx.try_recv() {
             Ok(Ok(())) => {
+                // Promote the pending version into the per-session record so
+                // the periodic re-check (#1471) stops surfacing this release.
+                self.last_installed_version_in_session = self.pending_install_version.take();
                 self.update_status = Some(UpdateStatus::persistent(
                     "update complete. Restart aoe to use the new version.".into(),
                 ));
                 true
             }
             Ok(Err(e)) => {
+                // Clear pending so a retry is allowed.
+                self.pending_install_version = None;
                 self.update_status = Some(UpdateStatus::transient(format!("update failed: {e}")));
                 true
             }
@@ -1050,6 +1071,7 @@ impl App {
                 false
             }
             Err(tokio::sync::oneshot::error::TryRecvError::Closed) => {
+                self.pending_install_version = None;
                 self.update_status = Some(UpdateStatus::transient(
                     "update task ended unexpectedly".into(),
                 ));
@@ -1089,6 +1111,9 @@ impl App {
             })?;
             match result {
                 Ok(()) => {
+                    // Record the successful manual install so the periodic
+                    // re-check (#1471) stops re-surfacing this release.
+                    self.last_installed_version_in_session = Some(version.clone());
                     self.update_status = Some(UpdateStatus::persistent(
                         "update complete. Restart aoe to use the new version.".into(),
                     ));
@@ -1106,6 +1131,9 @@ impl App {
             // async I/O still use the existing tokio runtime while sidestepping the
             // Send constraint.
             self.update_status = Some(UpdateStatus::transient(format!("updating to v{version}…")));
+            // Stash for `poll_update_status` to promote on confirmed success
+            // (#1471). Mirrors the auto-install path.
+            self.pending_install_version = Some(version.clone());
             let (tx, rx) = tokio::sync::oneshot::channel();
             self.update_status_rx = Some(rx);
             let handle = tokio::runtime::Handle::current();
@@ -1135,11 +1163,18 @@ fn persist_dismissed_update_version(version: Option<String>) {
     }
 }
 
+/// Convert `check_interval_hours` to a `Duration` for the periodic re-check,
+/// clamped to a sane minimum. See `MIN_PERIODIC_RECHECK_INTERVAL`.
+fn periodic_recheck_interval(check_interval_hours: u64) -> Duration {
+    Duration::from_secs(check_interval_hours.saturating_mul(3600))
+        .max(MIN_PERIODIC_RECHECK_INTERVAL)
+}
+
 /// Decide whether the main loop should spawn a fresh periodic update check.
 /// Pulled out as a pure function so the throttle/in-flight/mode guards are
 /// testable without driving the tokio runtime, the config file, or the
 /// network. `elapsed` is time since the last check started; `interval` is
-/// `settings.check_interval_hours` converted to `Duration`.
+/// the value produced by `periodic_recheck_interval`.
 fn should_spawn_periodic_update_check(
     elapsed: Duration,
     interval: Duration,
@@ -1890,6 +1925,33 @@ mod tests {
             false,
             false,
         ));
+    }
+
+    #[test]
+    fn periodic_recheck_interval_honors_user_setting() {
+        assert_eq!(
+            periodic_recheck_interval(24),
+            Duration::from_secs(24 * 3600)
+        );
+        assert_eq!(
+            periodic_recheck_interval(168),
+            Duration::from_secs(168 * 3600)
+        );
+    }
+
+    #[test]
+    fn periodic_recheck_interval_floors_zero_to_minimum() {
+        // The settings TUI rejects 0, but a hand-edited config could land
+        // here. Without the floor, a 0-hour interval combined with the 0-hour
+        // cache TTL would hit GitHub on every throttle-gap tick (~60s).
+        assert_eq!(periodic_recheck_interval(0), MIN_PERIODIC_RECHECK_INTERVAL);
+    }
+
+    #[test]
+    fn periodic_recheck_interval_does_not_overflow() {
+        // `saturating_mul` keeps `u64::MAX` hours from wrapping. The result
+        // is "effectively never re-check" rather than a panic.
+        let _ = periodic_recheck_interval(u64::MAX);
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -18,6 +18,12 @@ use crate::session::{get_update_settings, save_config, Config};
 use crate::tmux::AvailableTools;
 use crate::update::{check_for_update, UpdateInfo};
 
+/// Minimum elapsed time between considering periodic update re-checks.
+/// The main loop runs at ~20Hz; gating on this gap keeps the per-iteration
+/// `get_update_settings()` config read off the hot path while still
+/// re-evaluating well under any realistic `check_interval_hours` setting.
+const UPDATE_CHECK_THROTTLE_GAP: Duration = Duration::from_secs(60);
+
 /// Inter-key timeout for the paste-burst detector. After any printable Char
 /// or Enter, the event loop polls for the next event with this timeout; if
 /// another burst-candidate arrives before the deadline, it joins the burst.
@@ -410,34 +416,11 @@ impl App {
         // Refresh tmux session cache
         crate::tmux::refresh_session_cache();
 
-        // Spawn async update check
+        // Spawn async update check at startup. The periodic re-check below
+        // covers long-running sessions (#1471).
         let settings = get_update_settings();
         if settings.update_check_mode.is_enabled() {
-            let (tx, rx) = tokio::sync::oneshot::channel();
-            self.update_rx = Some(rx);
-            tokio::spawn(async move {
-                let version = env!("CARGO_PKG_VERSION");
-                let mut result = check_for_update(version, false).await;
-                // For Homebrew installs, suppress the "update available"
-                // ribbon until the formula has caught up to the GitHub
-                // release. Otherwise users see the prompt, press 'u', and
-                // hit a no-op `brew upgrade` while the formula lags. The
-                // brew probes are sync; offload to keep the runtime free.
-                if let Ok(info) = &mut result {
-                    if info.available {
-                        let target = info.latest_version.clone();
-                        let actionable = tokio::task::spawn_blocking(move || {
-                            crate::update::install::install_method_supports_target(&target)
-                        })
-                        .await
-                        .unwrap_or(true);
-                        if !actionable {
-                            info.available = false;
-                        }
-                    }
-                }
-                let _ = tx.send(result);
-            });
+            self.spawn_update_check();
         }
 
         // SIGHUP/SIGTERM futures so we exit cleanly when the terminal
@@ -464,6 +447,12 @@ impl App {
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
+        // Tracks when the most recent update check started, so the periodic
+        // re-check in the loop body honors `check_interval_hours` (#1471).
+        // Initialized to the moment startup spawn fired (or "now" when the
+        // startup check was disabled) so the first periodic tick is one full
+        // interval away rather than firing immediately.
+        let mut last_update_check = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
@@ -794,6 +783,26 @@ impl App {
                 last_heartbeat = std::time::Instant::now();
             }
 
+            // Periodic update re-check (#1471). The startup spawn only fires
+            // once per process; long-running TUI sessions would otherwise
+            // silently miss releases that ship after the user attached. The
+            // throttle gap keeps the per-iteration `get_update_settings()`
+            // config-file read off the 20Hz hot path.
+            if last_update_check.elapsed() >= UPDATE_CHECK_THROTTLE_GAP {
+                let settings = get_update_settings();
+                let interval =
+                    Duration::from_secs(settings.check_interval_hours.saturating_mul(3600));
+                if should_spawn_periodic_update_check(
+                    last_update_check.elapsed(),
+                    interval,
+                    self.update_rx.is_some(),
+                    settings.update_check_mode.is_enabled(),
+                ) {
+                    self.spawn_update_check();
+                    last_update_check = std::time::Instant::now();
+                }
+            }
+
             // Animated spinners (rattles) need periodic redraws, but only at
             // the spinner frame rate to avoid unnecessary widget tree rebuilds
             if last_spinner_redraw.elapsed() >= SPINNER_REDRAW_INTERVAL
@@ -850,6 +859,39 @@ impl App {
                 "slow frame",
             );
         }
+    }
+
+    /// Spawn an async update check, mirroring the brew-formula-lag
+    /// suppression done at startup. Stores the receiver on `self.update_rx`
+    /// so the main loop's `poll_update_check` picks up the result. Callers
+    /// are responsible for gating on `update_check_mode.is_enabled()` and
+    /// avoiding duplicate in-flight checks via `self.update_rx.is_none()`.
+    fn spawn_update_check(&mut self) {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.update_rx = Some(rx);
+        tokio::spawn(async move {
+            let version = env!("CARGO_PKG_VERSION");
+            let mut result = check_for_update(version, false).await;
+            // For Homebrew installs, suppress the "update available" banner
+            // until the formula has caught up to the GitHub release.
+            // Otherwise users see the prompt, press 'u', and hit a no-op
+            // `brew upgrade` while the formula lags. The brew probes are
+            // sync; offload to keep the runtime free.
+            if let Ok(info) = &mut result {
+                if info.available {
+                    let target = info.latest_version.clone();
+                    let actionable = tokio::task::spawn_blocking(move || {
+                        crate::update::install::install_method_supports_target(&target)
+                    })
+                    .await
+                    .unwrap_or(true);
+                    if !actionable {
+                        info.available = false;
+                    }
+                }
+            }
+            let _ = tx.send(result);
+        });
     }
 
     /// Poll for update check result (non-blocking).
@@ -1056,6 +1098,20 @@ fn persist_dismissed_update_version(version: Option<String>) {
             "failed to persist dismissed_update_version"
         );
     }
+}
+
+/// Decide whether the main loop should spawn a fresh periodic update check.
+/// Pulled out as a pure function so the throttle/in-flight/mode guards are
+/// testable without driving the tokio runtime, the config file, or the
+/// network. `elapsed` is time since the last check started; `interval` is
+/// `settings.check_interval_hours` converted to `Duration`.
+fn should_spawn_periodic_update_check(
+    elapsed: Duration,
+    interval: Duration,
+    rx_in_flight: bool,
+    mode_enabled: bool,
+) -> bool {
+    !rx_in_flight && mode_enabled && elapsed >= interval
 }
 
 /// Polls the update receiver and returns the new state.
@@ -1747,6 +1803,68 @@ mod tests {
         assert!(info.is_none());
         // Receiver should be put back for next poll
         assert!(rx_out.is_some());
+    }
+
+    #[test]
+    fn periodic_recheck_fires_after_interval_elapses() {
+        // The dominant bug (#1471): the original code spawned the update check
+        // only once at startup. After the configured interval has passed in a
+        // long-running TUI, the loop must spawn a fresh check.
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(should_spawn_periodic_update_check(
+            interval + Duration::from_secs(1),
+            interval,
+            false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_holds_within_interval() {
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(!should_spawn_periodic_update_check(
+            interval - Duration::from_secs(1),
+            interval,
+            false,
+            true,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_skips_when_in_flight() {
+        // Don't queue a second check while one is already running; the existing
+        // one will deliver its result on the oneshot channel and the next tick
+        // after that can fire normally.
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(!should_spawn_periodic_update_check(
+            interval + Duration::from_secs(1),
+            interval,
+            true,
+            true,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_skips_when_mode_disabled() {
+        // update_check_mode = "off" should suppress both startup and periodic
+        // checks. Mirror the gate at startup.
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(!should_spawn_periodic_update_check(
+            interval + Duration::from_secs(1),
+            interval,
+            false,
+            false,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_fires_at_interval_boundary() {
+        // `>=`, not `>`. A user with `check_interval_hours = 1` should get the
+        // tick at the 1-hour mark, not 1h + epsilon.
+        let interval = Duration::from_secs(3600);
+        assert!(should_spawn_periodic_update_check(
+            interval, interval, false, true,
+        ));
     }
 
     #[test]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -98,6 +98,13 @@ pub struct App {
     /// the sync `execute_action` can't lend out).
     #[cfg(feature = "serve")]
     pending_cockpit_open: Option<String>,
+    /// Version of the most recent auto-install kicked off in this process.
+    /// The running binary's compile-time `CARGO_PKG_VERSION` stays at the
+    /// old value until restart, so without this guard every periodic
+    /// re-check (#1471) would re-trigger an install for the same release,
+    /// cycling the "auto-updating…" / "update complete" status messages
+    /// and wasting bandwidth.
+    last_auto_installed_version: Option<String>,
 }
 
 /// Check if the app version changed and return the previous version if changelog should be shown.
@@ -214,6 +221,7 @@ impl App {
             mouse_captured: crate::tui::mouse_capture_requested(),
             #[cfg(feature = "serve")]
             pending_cockpit_open: None,
+            last_auto_installed_version: None,
         })
     }
 
@@ -453,6 +461,12 @@ impl App {
         // startup check was disabled) so the first periodic tick is one full
         // interval away rather than firing immediately.
         let mut last_update_check = std::time::Instant::now();
+        // Separate throttle for how often the periodic block re-reads
+        // settings; without this, `last_update_check.elapsed()` would be
+        // permanently above the throttle gap once the first 60s pass (it
+        // only resets on actual spawn), so the config-file read would still
+        // fire on every loop iteration until the full interval elapses.
+        let mut last_update_eval = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
         // Fastest spinner (breathe) changes every 180ms; 120ms ensures smooth animation
@@ -788,7 +802,8 @@ impl App {
             // silently miss releases that ship after the user attached. The
             // throttle gap keeps the per-iteration `get_update_settings()`
             // config-file read off the 20Hz hot path.
-            if last_update_check.elapsed() >= UPDATE_CHECK_THROTTLE_GAP {
+            if last_update_eval.elapsed() >= UPDATE_CHECK_THROTTLE_GAP {
+                last_update_eval = std::time::Instant::now();
                 let settings = get_update_settings();
                 let interval =
                     Duration::from_secs(settings.check_interval_hours.saturating_mul(3600));
@@ -955,6 +970,21 @@ impl App {
             return;
         }
 
+        // Periodic re-checks (#1471) keep finding the same "available"
+        // version until the user restarts (the running binary's
+        // compile-time `CARGO_PKG_VERSION` is stale). Without this guard,
+        // each periodic tick would re-install the same release, cycling
+        // status messages and wasting bandwidth. A genuinely newer release
+        // clears the guard automatically because the version string differs.
+        if self.last_auto_installed_version.as_deref() == Some(version.as_str()) {
+            tracing::info!(
+                target: "update.auto",
+                version,
+                "auto mode skipped: already installed this version this session, restart aoe to use it"
+            );
+            return;
+        }
+
         let method = match detect_install_method() {
             Ok(m) => m,
             Err(e) => {
@@ -984,6 +1014,11 @@ impl App {
         self.update_status = Some(UpdateStatus::transient(format!(
             "auto-updating to v{version} in background…"
         )));
+        // Record before spawning: if the install fails we still skip retries
+        // for this same version, since auto-install failures (disk full,
+        // corrupt download) tend to repeat. The user can press `u` from the
+        // banner, run `aoe update`, or restart aoe to retry.
+        self.last_auto_installed_version = Some(version.clone());
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.update_status_rx = Some(rx);
         let handle = tokio::runtime::Handle::current();

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -443,11 +443,18 @@ impl App {
         crate::tmux::refresh_session_cache();
 
         // Spawn async update check at startup. The periodic re-check below
-        // covers long-running sessions (#1471).
+        // covers long-running sessions (#1471). `last_update_check` stays
+        // `None` when the startup spawn does not fire (mode=off) so that
+        // toggling the mode on later triggers a check immediately, instead
+        // of waiting up to `check_interval_hours` from process launch.
         let settings = get_update_settings();
-        if settings.update_check_mode.is_enabled() {
-            self.spawn_update_check();
-        }
+        let mut last_update_check: Option<std::time::Instant> =
+            if settings.update_check_mode.is_enabled() {
+                self.spawn_update_check();
+                Some(std::time::Instant::now())
+            } else {
+                None
+            };
 
         // SIGHUP/SIGTERM futures so we exit cleanly when the terminal
         // emulator is force-quit, preventing PTY slot leaks (#541).
@@ -473,17 +480,10 @@ impl App {
         let mut last_disk_refresh = std::time::Instant::now();
         let mut last_spinner_redraw = std::time::Instant::now();
         let mut last_heartbeat = std::time::Instant::now();
-        // Tracks when the most recent update check started, so the periodic
-        // re-check in the loop body honors `check_interval_hours` (#1471).
-        // Initialized to the moment startup spawn fired (or "now" when the
-        // startup check was disabled) so the first periodic tick is one full
-        // interval away rather than firing immediately.
-        let mut last_update_check = std::time::Instant::now();
-        // Separate throttle for how often the periodic block re-reads
-        // settings; without this, `last_update_check.elapsed()` would be
-        // permanently above the throttle gap once the first 60s pass (it
-        // only resets on actual spawn), so the config-file read would still
-        // fire on every loop iteration until the full interval elapses.
+        // Throttle for how often the periodic block re-reads settings;
+        // without this, the inner guards would re-fire on every loop
+        // iteration once any time has passed, hitting the config file at
+        // the 20Hz loop rate.
         let mut last_update_eval = std::time::Instant::now();
         const STATUS_REFRESH_INTERVAL: Duration = Duration::from_millis(500);
         const DISK_REFRESH_INTERVAL: Duration = Duration::from_secs(5);
@@ -824,13 +824,13 @@ impl App {
                 last_update_eval = std::time::Instant::now();
                 let settings = get_update_settings();
                 if should_spawn_periodic_update_check(
-                    last_update_check.elapsed(),
+                    last_update_check.map(|t| t.elapsed()),
                     periodic_recheck_interval(settings.check_interval_hours),
                     self.update_rx.is_some(),
                     settings.update_check_mode.is_enabled(),
                 ) {
                     self.spawn_update_check();
-                    last_update_check = std::time::Instant::now();
+                    last_update_check = Some(std::time::Instant::now());
                 }
             }
 
@@ -1173,15 +1173,24 @@ fn periodic_recheck_interval(check_interval_hours: u64) -> Duration {
 /// Decide whether the main loop should spawn a fresh periodic update check.
 /// Pulled out as a pure function so the throttle/in-flight/mode guards are
 /// testable without driving the tokio runtime, the config file, or the
-/// network. `elapsed` is time since the last check started; `interval` is
-/// the value produced by `periodic_recheck_interval`.
+/// network. `elapsed = None` means no check has run yet this process, which
+/// makes the first tick after the user enables update_check_mode mid-session
+/// fire immediately rather than waiting up to `check_interval_hours` from
+/// process launch. `interval` is the value produced by
+/// `periodic_recheck_interval`.
 fn should_spawn_periodic_update_check(
-    elapsed: Duration,
+    elapsed: Option<Duration>,
     interval: Duration,
     rx_in_flight: bool,
     mode_enabled: bool,
 ) -> bool {
-    !rx_in_flight && mode_enabled && elapsed >= interval
+    if rx_in_flight || !mode_enabled {
+        return false;
+    }
+    match elapsed {
+        None => true,
+        Some(e) => e >= interval,
+    }
 }
 
 /// Polls the update receiver and returns the new state.
@@ -1882,7 +1891,7 @@ mod tests {
         // long-running TUI, the loop must spawn a fresh check.
         let interval = Duration::from_secs(24 * 3600);
         assert!(should_spawn_periodic_update_check(
-            interval + Duration::from_secs(1),
+            Some(interval + Duration::from_secs(1)),
             interval,
             false,
             true,
@@ -1893,7 +1902,7 @@ mod tests {
     fn periodic_recheck_holds_within_interval() {
         let interval = Duration::from_secs(24 * 3600);
         assert!(!should_spawn_periodic_update_check(
-            interval - Duration::from_secs(1),
+            Some(interval - Duration::from_secs(1)),
             interval,
             false,
             true,
@@ -1907,7 +1916,7 @@ mod tests {
         // after that can fire normally.
         let interval = Duration::from_secs(24 * 3600);
         assert!(!should_spawn_periodic_update_check(
-            interval + Duration::from_secs(1),
+            Some(interval + Duration::from_secs(1)),
             interval,
             true,
             true,
@@ -1920,10 +1929,31 @@ mod tests {
         // checks. Mirror the gate at startup.
         let interval = Duration::from_secs(24 * 3600);
         assert!(!should_spawn_periodic_update_check(
-            interval + Duration::from_secs(1),
+            Some(interval + Duration::from_secs(1)),
             interval,
             false,
             false,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_fires_immediately_when_never_checked_and_mode_enabled() {
+        // User started with mode=off, toggled to notify/auto mid-session. The
+        // first guard tick after toggle should fire without waiting another
+        // full `check_interval_hours` from process launch.
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(should_spawn_periodic_update_check(
+            None, interval, false, true,
+        ));
+    }
+
+    #[test]
+    fn periodic_recheck_skips_when_never_checked_but_mode_disabled() {
+        // Symmetric: a None elapsed does not override the mode gate. Mode=off
+        // still wins.
+        let interval = Duration::from_secs(24 * 3600);
+        assert!(!should_spawn_periodic_update_check(
+            None, interval, false, false,
         ));
     }
 
@@ -1960,7 +1990,10 @@ mod tests {
         // tick at the 1-hour mark, not 1h + epsilon.
         let interval = Duration::from_secs(3600);
         assert!(should_spawn_periodic_update_check(
-            interval, interval, false, true,
+            Some(interval),
+            interval,
+            false,
+            true,
         ));
     }
 

--- a/src/update/install.rs
+++ b/src/update/install.rs
@@ -465,7 +465,18 @@ pub fn install_method_supports_target(target_version: &str) -> bool {
         return true;
     }
     match brew_available_version() {
-        Some(v) => !is_newer_version(target_version, &v),
+        Some(v) => {
+            let supported = !is_newer_version(target_version, &v);
+            if !supported {
+                tracing::info!(
+                    target: "update.suppress",
+                    brew_version = %v,
+                    target_version = %target_version,
+                    "suppressing update banner: Homebrew formula lags GitHub release"
+                );
+            }
+            supported
+        }
         None => true,
     }
 }


### PR DESCRIPTION
## Description

The startup `tokio::spawn` in `App::run` fires the update check once per process. Long-running TUI sessions (the intended usage pattern for `aoe`) never see another check, so any releases that ship after the user attached stay invisible.

Concrete repro: a user on `aoe 1.6.2` (installed via `brew install aoe`) ran the same TUI for 12 days. `~/.agent-of-empires/update_cache.json` still held `latest: "1.6.2"` from the startup check. v1.7.0, v1.7.1, v1.8.0, and v1.8.1 all shipped in that window. Zero update banners.

This PR adds a periodic re-check in the main loop body, alongside the existing periodic refreshes (status, disk, heartbeat, spinner). It reuses the startup spawn logic via a new `App::spawn_update_check` helper, so the brew-formula-lag suppression and the persisted `dismissed_update_version` snooze both apply identically. The decision is gated by a pure `should_spawn_periodic_update_check` so the throttle / in-flight / mode guards are testable without driving the runtime, the config file, or the network.

A 60s throttle gap keeps the per-iteration `get_update_settings()` config read off the 20Hz hot path.

Also adds a `tracing::info!(target: "update.suppress", brew_version, target_version)` when the Homebrew lag suppression fires, so the next report of this class is greppable in `debug.log` instead of needing reverse engineering.

Fixes #1471

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(No UI change; the banner content and dismiss flow are unchanged. The only behavior delta is that the banner now appears when a new release ships during a long-attached session.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the user-visible behavior is "banner appears after N hours when a new release ships," which would require either fast-forwarding time or a stub release server inside the e2e harness. Instead, the decision function is covered by 5 unit tests in `src/tui/app.rs` that exercise the interval boundary, in-flight guard, and disabled-mode guard. The brew-suppression tracing has no observable behavior to e2e.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 4.7, via Claude Code)

**Any Additional AI Details you'd like to share:** Investigation, root-cause analysis, and fix were drafted by Claude via back-and-forth with @njbrake; the reasoning, the scope decision (just the periodic re-check, not the softer-suppression UX change discussed), and the final acceptance are his. The prose in the issue, this PR body, and the commit message are Claude's.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR makes the TUI re-check for releases periodically during long-running sessions instead of only at startup, so users running the UI for days will see new-release banners without restarting.

## What changed (high-level)
- Periodic update checks added to the TUI main loop (driven by settings.check_interval_hours).
- Startup spawn logic extracted into App::spawn_update_check() and reused for periodic ticks.
- A pure should_spawn_periodic_update_check() predicate added so spawn/skip decision can be unit-tested.
- Added a 60s throttle (UPDATE_CHECK_THROTTLE_GAP) to avoid repeated config reads on the 20Hz UI loop.
- Homebrew suppression now emits a tracing::info!(target: "update.suppress", ...) entry for observability.
- Auto-install/banner handling hardened to avoid re-showing or re-installing the same version during a single process run.
- Unit tests (5) added to validate the spawn-decision behavior; e2e tests were skipped.

## Notable additions & refactors
- New App fields: pending_install_version and last_installed_version_in_session for in-process install deduplication and UI behavior.
- should_spawn_periodic_update_check() centralizes checks for mode enabled, in-flight update task, and elapsed interval (with a 1-hour floor/clamping for very small/zero intervals).
- App::spawn_update_check() preserves Homebrew “formula catch-up” suppression and the persisted dismissed_update_version snooze.
- install_method_supports_target() refactored to log Homebrew suppression events (no change to its boolean behavior).

## Benefits
- Long-running TUI sessions now discover new releases without restarts.
- Maintains existing safeguards (check_interval_hours, Homebrew suppression, dismissed-version snooze).
- Low overhead: default 24h cadence, 60s config-read throttle, background tasks with bounded timeouts.
- Better observability for suppression conditions.
- Prevents duplicate notifications/installs within the same process.

## Tests & review focus
- Unit tests cover timing, mode/in-flight guards, throttle/floor behavior, immediate firing when enabled mid-session, and edge cases.
- Review attention: throttle vs interval semantics, correctness of in-session deduplication (pending_install_version vs last_installed_version_in_session), and that spawn logic preserves Homebrew suppression and snooze behavior.

## Files touched (summary)
- src/tui/app.rs — periodic-check logic, App::spawn_update_check(), should_spawn_periodic_update_check(), new App fields (major changes).
- src/update/install.rs — Homebrew suppression logging and minor refactor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->