### PR TITLE
fix(hermes): implement real pane-based status detection

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -862,9 +862,21 @@ pub fn detect_hermes_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // Input prompt ❯ (default skin) or ⚡ (cyberpunk skin) in the last few
-    // lines means the agent finished its turn. Check before scrollback
-    // activity words to avoid false-positive Running from a previous turn.
+    // While running, Hermes replaces the input prompt with
+    // "❯ Ctrl+C to interrupt…". Check this before the idle-prompt
+    // detection below so we don't misidentify Running as Waiting.
+    if non_empty_lines
+        .iter()
+        .rev()
+        .take(5)
+        .any(|l| l.contains("ctrl+c to interrupt"))
+    {
+        return Status::Running;
+    }
+
+    // Input prompt ❯ (default skin) or ⚡ (cyberpunk skin) on its own means
+    // the agent finished its turn. Placed before scrollback activity words to
+    // avoid false-positive Running from a previous turn.
     for line in non_empty_lines.iter().rev().take(5) {
         let clean = strip_ansi(line).trim().to_string();
         if clean == "❯" || clean.starts_with("❯ ") || clean == "⚡" || clean.starts_with("⚡ ")
@@ -873,7 +885,7 @@ pub fn detect_hermes_status(raw_content: &str) -> Status {
         }
     }
 
-    // Active tool execution lines are prefixed with ┊; check recent lines only
+    // Active streaming lines are prefixed with ┊; check recent lines only
     // to avoid triggering on scrollback from a completed turn.
     if non_empty_lines
         .iter()
@@ -884,8 +896,9 @@ pub fn detect_hermes_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // Thinking verbs from built-in and community Hermes skins.
+    // Thinking verbs from the default skin and community Hermes skins.
     let activity_indicators = [
+        "reasoning",
         "pondering",
         "contemplating",
         "forging",
@@ -897,7 +910,6 @@ pub fn detect_hermes_status(raw_content: &str) -> Status {
         "analyzing",
         "computing",
         "evaluating",
-        "ctrl+c to interrupt",
     ];
     for indicator in &activity_indicators {
         if last_lines.contains(indicator) {
@@ -2176,6 +2188,7 @@ run this command? (y/n)
 
     #[test]
     fn test_detect_hermes_status_running_on_thinking_verbs() {
+        assert_eq!(detect_hermes_status("reasoning…"), Status::Running);
         assert_eq!(
             detect_hermes_status("pondering the question"),
             Status::Running
@@ -2185,8 +2198,18 @@ run this command? (y/n)
             Status::Running
         );
         assert_eq!(detect_hermes_status("computing result"), Status::Running);
+    }
+
+    #[test]
+    fn test_detect_hermes_status_running_on_interrupt_hint() {
+        // While running, Hermes shows "❯ Ctrl+C to interrupt…" in the prompt
+        // area. Must detect as Running, not Waiting.
         assert_eq!(
-            detect_hermes_status("processing request\nctrl+c to interrupt"),
+            detect_hermes_status("┊ some response\n❯ Ctrl+C to interrupt…"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_hermes_status("─ (¬‿¬) reasoning…\n❯ Ctrl+C to interrupt…"),
             Status::Running
         );
     }

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -875,13 +875,15 @@ pub fn detect_hermes_status(raw_content: &str) -> Status {
     }
 
     // Input prompt ❯ (default skin) or ⚡ (cyberpunk skin) on its own means
-    // the agent finished its turn. Placed before scrollback activity words to
-    // avoid false-positive Running from a previous turn.
+    // the agent finished its turn and is ready for the next message — Idle,
+    // not Waiting (which in AoE means "needs user approval for a dangerous
+    // command"). Placed before scrollback activity words to avoid false-positive
+    // Running from a previous turn.
     for line in non_empty_lines.iter().rev().take(5) {
         let clean = strip_ansi(line).trim().to_string();
         if clean == "❯" || clean.starts_with("❯ ") || clean == "⚡" || clean.starts_with("⚡ ")
         {
-            return Status::Waiting;
+            return Status::Idle;
         }
     }
 
@@ -2229,10 +2231,12 @@ run this command? (y/n)
     }
 
     #[test]
-    fn test_detect_hermes_status_waiting_on_input_prompt() {
-        assert_eq!(detect_hermes_status("some output\n❯"), Status::Waiting);
-        assert_eq!(detect_hermes_status("some output\n❯ "), Status::Waiting);
-        assert_eq!(detect_hermes_status("some output\n⚡"), Status::Waiting);
+    fn test_detect_hermes_status_idle_on_input_prompt() {
+        // The bare ❯/⚡ prompt means "ready for next message" — Idle in AoE
+        // semantics. Waiting is reserved for dangerous-command approval gates.
+        assert_eq!(detect_hermes_status("some output\n❯"), Status::Idle);
+        assert_eq!(detect_hermes_status("some output\n❯ "), Status::Idle);
+        assert_eq!(detect_hermes_status("some output\n⚡"), Status::Idle);
     }
 
     #[test]
@@ -2240,7 +2244,7 @@ run this command? (y/n)
         // If the input prompt is visible, don't mis-detect Running from old scrollback.
         assert_eq!(
             detect_hermes_status("pondering the question\ntask complete\n❯"),
-            Status::Waiting
+            Status::Idle
         );
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -830,11 +830,89 @@ pub fn detect_droid_status(raw_content: &str) -> Status {
     Status::Idle
 }
 
-/// Hermes status is detected via shell-script hooks (YAML-based) registered
-/// in `~/.hermes/config.yaml`, not tmux pane parsing. This stub exists so
-/// the agent registry has a valid function pointer; it only runs as a
-/// fallback when the hook hasn't written a status file yet.
-pub fn detect_hermes_status(_content: &str) -> Status {
+/// Hermes (NousResearch) status detection via tmux pane parsing.
+/// Used as a fallback when the YAML hook system hasn't written a status file yet.
+/// Detects spinner faces (◜ ◠ ✧), tool execution prefix (┊), thinking verbs,
+/// dangerous-command approval prompt, and input prompt (❯ / ⚡).
+pub fn detect_hermes_status(raw_content: &str) -> Status {
+    let content = raw_content.to_lowercase();
+    let lines: Vec<&str> = content.lines().collect();
+    let non_empty_lines: Vec<&str> = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .copied()
+        .collect();
+
+    let last_lines: String = non_empty_lines
+        .iter()
+        .rev()
+        .take(30)
+        .rev()
+        .copied()
+        .collect::<Vec<&str>>()
+        .join("\n");
+
+    // Hermes spinner faces animate during LLM calls; only present while active
+    // (unicode, unaffected by to_lowercase).
+    const HERMES_SPINNERS: &[&str] = &["◜", "◠", "✧"];
+    if lines
+        .iter()
+        .any(|line| HERMES_SPINNERS.iter().any(|s| line.contains(s)))
+    {
+        return Status::Running;
+    }
+
+    // Input prompt ❯ (default skin) or ⚡ (cyberpunk skin) in the last few
+    // lines means the agent finished its turn. Check before scrollback
+    // activity words to avoid false-positive Running from a previous turn.
+    for line in non_empty_lines.iter().rev().take(5) {
+        let clean = strip_ansi(line).trim().to_string();
+        if clean == "❯" || clean.starts_with("❯ ") || clean == "⚡" || clean.starts_with("⚡ ")
+        {
+            return Status::Waiting;
+        }
+    }
+
+    // Active tool execution lines are prefixed with ┊; check recent lines only
+    // to avoid triggering on scrollback from a completed turn.
+    if non_empty_lines
+        .iter()
+        .rev()
+        .take(10)
+        .any(|l| l.contains("┊"))
+    {
+        return Status::Running;
+    }
+
+    // Thinking verbs from built-in and community Hermes skins.
+    let activity_indicators = [
+        "pondering",
+        "contemplating",
+        "forging",
+        "plotting",
+        "jacking in",
+        "decrypting",
+        "uploading",
+        "processing",
+        "analyzing",
+        "computing",
+        "evaluating",
+        "ctrl+c to interrupt",
+    ];
+    for indicator in &activity_indicators {
+        if last_lines.contains(indicator) {
+            return Status::Running;
+        }
+    }
+
+    // Dangerous-command approval prompt.
+    if contains_approval_prompt(
+        &last_lines,
+        &["choice [o/s/a/d]:", "[o]nce", "dangerous command"],
+    ) {
+        return Status::Waiting;
+    }
+
     Status::Idle
 }
 
@@ -2069,9 +2147,88 @@ run this command? (y/n)
     }
 
     #[test]
-    fn test_detect_hermes_status_is_stub() {
-        // Hermes uses hook-based detection; the stub always returns Idle
+    fn test_detect_hermes_status_running_on_spinner() {
+        assert_eq!(
+            detect_hermes_status("◜ (｡•́︿•̀｡) pondering... (1.2s)"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_hermes_status("◠ (⊙_⊙) contemplating... (2.4s)"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_hermes_status("✧٩(ˊᗜˋ*)و✧ got it! (3.1s)"),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_detect_hermes_status_running_on_tool_execution() {
+        assert_eq!(
+            detect_hermes_status("┊ 💻 terminal 'ls -la' (0.3s)"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_hermes_status("┊ 🔍 web_search (1.2s)"),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_detect_hermes_status_running_on_thinking_verbs() {
+        assert_eq!(
+            detect_hermes_status("pondering the question"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_hermes_status("analyzing the codebase"),
+            Status::Running
+        );
+        assert_eq!(detect_hermes_status("computing result"), Status::Running);
+        assert_eq!(
+            detect_hermes_status("processing request\nctrl+c to interrupt"),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_detect_hermes_status_waiting_on_approval() {
+        assert_eq!(
+            detect_hermes_status(
+                "⚠️  DANGEROUS COMMAND: rm -rf /tmp\n[o]nce  |  [s]ession  |  [a]lways  |  [d]eny\nChoice [o/s/a/D]:"
+            ),
+            Status::Waiting
+        );
+        assert_eq!(
+            detect_hermes_status("dangerous command detected\nproceed?"),
+            Status::Waiting
+        );
+    }
+
+    #[test]
+    fn test_detect_hermes_status_waiting_on_input_prompt() {
+        assert_eq!(detect_hermes_status("some output\n❯"), Status::Waiting);
+        assert_eq!(detect_hermes_status("some output\n❯ "), Status::Waiting);
+        assert_eq!(detect_hermes_status("some output\n⚡"), Status::Waiting);
+    }
+
+    #[test]
+    fn test_detect_hermes_status_prompt_overrides_scrollback() {
+        // If the input prompt is visible, don't mis-detect Running from old scrollback.
+        assert_eq!(
+            detect_hermes_status("pondering the question\ntask complete\n❯"),
+            Status::Waiting
+        );
+    }
+
+    #[test]
+    fn test_detect_hermes_status_idle_on_plain_text() {
         assert_eq!(detect_hermes_status("anything"), Status::Idle);
+        assert_eq!(detect_hermes_status(""), Status::Idle);
+        assert_eq!(
+            detect_hermes_status("task completed successfully"),
+            Status::Idle
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Description

`detect_hermes_status` was a stub that always returned `Status::Idle`, so Hermes sessions never showed Running or Waiting in the TUI regardless of what the agent was doing (fixes #1474).

Replaced the stub with a real pane-content detector covering Hermes v0.14+ output patterns:

| Signal | Status |
|---|---|
| Spinner faces `◜ ◠ ✧` (non-default skins) | Running |
| `❯ Ctrl+C to interrupt…` in the prompt area | Running |
| Active tool-execution lines prefixed with `┊` | Running |
| Thinking verbs (`reasoning`, `pondering`, `analyzing`, …) | Running |
| Dangerous-command approval prompt (`[o/s/a/d]`, `dangerous command`) | Waiting |
| Bare `❯` or `⚡` input prompt (turn finished, ready for next message) | Idle |
| Anything else | Idle |

The `❯`/`⚡` prompt maps to **Idle** rather than Waiting because in AoE semantics `Waiting` means "blocked on user approval for a dangerous command", not "at the input prompt between turns".

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

Manually verified with a live Hermes v0.14.0 session (kimi k2.6 model): the TUI now shows the animated green spinner while processing and the gray static `⠒` icon when idle at the prompt.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the detection logic is fully covered by 8 new unit tests in `src/tmux/status_detection.rs`; an e2e test would require a live Hermes session in CI which isn't available.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (claude-sonnet-4-6)

**Any Additional AI Details you'd like to share:** Used Claude Code to explore the codebase, identify the stub, find the real Hermes output patterns via live testing, and implement + iterate on the fix.

- [ ] I am an AI Agent filling out this form