### PR TITLE
fix(session): force color for codex launches

### DIFF
--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2689,17 +2689,21 @@ fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
 
 /// Prepend agent-specific environment overrides to a launch command.
 ///
-/// Antigravity inherits the parent tmux env, which can carry `NO_COLOR=1` and
-/// silently disable its terminal palette even though the web renderer handles
-/// ANSI fine. Unsetting `NO_COLOR` and forcing `FORCE_COLOR=1` /
+/// Some terminal agents inherit the parent tmux env, which can carry
+/// `NO_COLOR=1` and silently disable their terminal palettes even though the
+/// web renderer handles ANSI fine. Unsetting `NO_COLOR` and forcing
+/// `TERM=xterm-256color`, `FORCE_COLOR=1`, and
 /// `COLORTERM=truecolor` at launch keeps color on without leaking the override
 /// to other agents.
 fn apply_agent_launch_env(cmd: &mut String, agent: Option<&'static crate::agents::AgentDef>) {
-    if !matches!(agent.map(|a| a.name), Some("antigravity")) {
+    if !matches!(agent.map(|a| a.name), Some("antigravity" | "codex")) {
         return;
     }
 
-    *cmd = format!("env -u NO_COLOR FORCE_COLOR=1 COLORTERM=truecolor {}", cmd);
+    *cmd = format!(
+        "env -u NO_COLOR TERM=xterm-256color FORCE_COLOR=1 COLORTERM=truecolor {}",
+        cmd
+    );
 }
 
 /// Wrap a command to disable Ctrl-Z (SIGTSTP) suspension.
@@ -4291,6 +4295,7 @@ mod tests {
         let cmd_str = cmd.unwrap();
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("TERM=xterm-256color"));
         assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("agy"));
@@ -4305,19 +4310,35 @@ mod tests {
         let cmd_str = cmd.unwrap();
 
         assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("TERM=xterm-256color"));
         assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("agy --some-flag"));
     }
 
     #[test]
-    fn test_build_host_command_color_env_is_antigravity_only() {
+    fn test_build_host_command_codex_forces_color() {
         let mut inst = Instance::new("test", "/tmp/test");
         inst.tool = "codex".to_string();
         let cmd = inst.build_host_command(crate::agents::get_agent("codex"), &None);
         let cmd_str = cmd.unwrap();
 
+        assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("TERM=xterm-256color"));
+        assert!(cmd_str.contains("FORCE_COLOR=1"));
+        assert!(cmd_str.contains("COLORTERM=truecolor"));
+        assert!(cmd_str.contains("codex"));
+    }
+
+    #[test]
+    fn test_build_host_command_color_env_is_limited_to_color_sensitive_agents() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "cursor".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("cursor"), &None);
+        let cmd_str = cmd.unwrap();
+
         assert!(!cmd_str.contains("env -u NO_COLOR"));
+        assert!(!cmd_str.contains("TERM=xterm-256color"));
         assert!(!cmd_str.contains("FORCE_COLOR=1"));
         assert!(!cmd_str.contains("COLORTERM=truecolor"));
     }


### PR DESCRIPTION
## Description
Fixes Codex web terminal sessions launching without color when the parent AoE/tmux environment carries `NO_COLOR=1` or weak terminal capability values.

AoE already forced color for Antigravity launches. This extends that launch environment override to Codex and pins `TERM=xterm-256color`, `FORCE_COLOR=1`, and `COLORTERM=truecolor` for the affected agents while keeping the override off for Cursor and other agents.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

No docs or screenshots are needed for this Rust launch-command fix.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the changed behavior is pure launch-command construction and is covered by in-module Rust unit tests. Full TUI e2e would need real Codex/Antigravity binaries and environment-sensitive color output.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate a focused Rust launch-environment fix.

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `cargo test session::instance::tests::test_build_host_command -- --nocapture`
- `cargo fmt -- --check`
- `git diff --check`
- `cargo build --profile dev-release --features serve`
- `cargo clippy -- -D warnings`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The fix extends color environment settings from **Antigravity** to **Codex** agents. When these agents launch, they now receive explicit color configuration to ensure colorized terminal output displays properly, even when the parent tmux session has color disabled or limited terminal capabilities.

The change modifies the `apply_agent_launch_env` function to apply the same color override to both agents. Additional environment variable `TERM=xterm-256color` was also added alongside the existing `FORCE_COLOR=1` and `COLORTERM=truecolor` settings. The override only applies to these two color-sensitive agents and is intentionally excluded from agents like Cursor that already handle colors correctly.

Unit tests were updated to validate that:
- Both `antigravity` and `codex` receive the forced color environment settings
- Other agents like `cursor` correctly do NOT receive these overrides

## Benefits

This fix ensures Codex's web terminal (which supports ANSI colors via xterm.js) displays colors correctly even when launched from an environment with `NO_COLOR=1` or weak terminal capability signals. Users will see properly colorized output in Codex without needing to manually configure their shell environment.

## Technical Details

**Changed function:** `apply_agent_launch_env` in `src/session/instance.rs`
- Now checks for both `"antigravity"` and `"codex"` agents (previously antigravity only)
- Prepends environment override: `env -u NO_COLOR TERM=xterm-256color FORCE_COLOR=1 COLORTERM=truecolor` to launch commands
- This unsets the parent NO_COLOR variable and forces a 256-color terminal with true color support

**Test updates:** 
- Assertions for antigravity now include the new `TERM=xterm-256color` check
- Codex launch commands are now tested to receive the same color environment overrides
- Verification that cursor and other agents do not receive the forced color settings

**Code metrics:** +27/-6 lines changed

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1478?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->