### PR TITLE
fix(web): copy selected terminal text with Ctrl-C

### DIFF
--- a/web/src/components/HelpOverlay.tsx
+++ b/web/src/components/HelpOverlay.tsx
@@ -4,7 +4,7 @@ interface Props {
 
 const TERMINAL_SHORTCUTS = [
   { key: "All keys", desc: "Relayed directly to the agent via PTY" },
-  { key: "Ctrl+C", desc: "Send interrupt to agent" },
+  { key: "Ctrl+C", desc: "Copy selection, otherwise interrupt agent" },
   { key: "Ctrl+D", desc: "Send EOF to agent" },
   { key: "Up/Down", desc: "Scroll terminal history" },
 ];

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -30,7 +30,9 @@ const { captured } = vi.hoisted(() => ({
       | ((s: { cols: number; rows: number }) => void)
       | undefined,
     onData: undefined as ((data: string) => void) | undefined,
+    customKey: undefined as ((e: KeyboardEvent) => boolean) | undefined,
     customWheel: undefined as ((e: WheelEvent) => boolean) | undefined,
+    selection: "",
   },
 }));
 
@@ -70,6 +72,15 @@ vi.mock("@xterm/xterm", () => {
     onData(cb: (data: string) => void): { dispose: () => void } {
       captured.onData = cb;
       return { dispose: () => {} };
+    }
+    attachCustomKeyEventHandler(fn: (e: KeyboardEvent) => boolean): void {
+      captured.customKey = fn;
+    }
+    hasSelection(): boolean {
+      return captured.selection.length > 0;
+    }
+    getSelection(): string {
+      return captured.selection;
     }
     attachCustomWheelEventHandler(fn: (e: WheelEvent) => boolean): void {
       captured.customWheel = fn;
@@ -180,7 +191,9 @@ beforeEach(() => {
   captured.writes = [];
   captured.onResize = undefined;
   captured.onData = undefined;
+  captured.customKey = undefined;
   captured.customWheel = undefined;
+  captured.selection = "";
   originalWebSocket = global.WebSocket;
   global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
   originalResizeObserver = global.ResizeObserver;
@@ -1264,6 +1277,187 @@ describe("useTerminal lifecycle", () => {
       expect(ctrlA).toBeDefined();
       // The ref should also be cleared after consumption.
       expect(result.current.ctrlActiveRef.current).toBe(false);
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("terminal copy events write the selected terminal text to clipboardData", async () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-copy-event", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+
+      captured.selection = "selected terminal text";
+      const clipboardData = {
+        setData: vi.fn(),
+      };
+      const event = new Event("copy", {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "clipboardData", {
+        value: clipboardData,
+      });
+      const xtermEl = div.querySelector(".xterm") as HTMLDivElement;
+      expect(xtermEl.dispatchEvent(event)).toBe(false);
+
+      expect(clipboardData.setData).toHaveBeenCalledWith(
+        "text/plain",
+        "selected terminal text",
+      );
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("terminal copy events fall back to browser selection text", async () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    const originalGetSelection = window.getSelection;
+    Object.defineProperty(window, "getSelection", {
+      configurable: true,
+      value: vi.fn(() => ({ toString: () => "browser selected text" })),
+    });
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-copy-browser-selection", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+
+      captured.selection = "";
+      const clipboardData = {
+        setData: vi.fn(),
+      };
+      const event = new Event("copy", {
+        bubbles: true,
+        cancelable: true,
+      });
+      Object.defineProperty(event, "clipboardData", {
+        value: clipboardData,
+      });
+      const xtermEl = div.querySelector(".xterm") as HTMLDivElement;
+      expect(xtermEl.dispatchEvent(event)).toBe(false);
+
+      expect(clipboardData.setData).toHaveBeenCalledWith(
+        "text/plain",
+        "browser selected text",
+      );
+    } finally {
+      Object.defineProperty(window, "getSelection", {
+        configurable: true,
+        value: originalGetSelection,
+      });
+      div.remove();
+    }
+  });
+
+  it("Ctrl+C copies selected terminal text instead of sending an interrupt", async () => {
+    const originalExecCommand = document.execCommand;
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, "execCommand", {
+      configurable: true,
+      value: execCommand,
+    });
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-copy-selection", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.OPEN;
+        ws.onopen?.(new Event("open"));
+      });
+      await flushAsync();
+
+      captured.selection = "selected terminal text";
+      const before = ws.sent.length;
+      const event = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyC",
+        ctrlKey: true,
+      });
+      const handled = captured.customKey?.(event);
+
+      expect(handled).toBe(false);
+      expect(execCommand).toHaveBeenCalledWith("copy");
+      const ctrlC = ws.sent.slice(before).find((m) => {
+        if (typeof m === "string") return false;
+        return m.length === 1 && m[0] === 0x03;
+      });
+      expect(ctrlC).toBeUndefined();
+    } finally {
+      Object.defineProperty(document, "execCommand", {
+        configurable: true,
+        value: originalExecCommand,
+      });
+      div.remove();
+    }
+  });
+
+  it("Ctrl+C remains available as interrupt when no terminal text is selected", async () => {
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      renderHook(() => {
+        const term = useTerminal("s-copy-empty", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.OPEN;
+        ws.onopen?.(new Event("open"));
+      });
+      await flushAsync();
+
+      const event = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        code: "KeyC",
+        ctrlKey: true,
+      });
+      expect(captured.customKey?.(event)).toBe(true);
+
+      const before = ws.sent.length;
+      act(() => {
+        captured.onData?.("\x03");
+      });
+      const ctrlC = ws.sent.slice(before).find((m) => {
+        if (typeof m === "string") return false;
+        return m.length === 1 && m[0] === 0x03;
+      });
+      expect(ctrlC).toBeDefined();
     } finally {
       div.remove();
     }

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -47,6 +47,44 @@ const twarn = (...args: unknown[]) => {
   console.warn("[terminal.ws]", ...args);
 };
 
+async function copyText(text: string): Promise<boolean> {
+  if (!text) return false;
+  if (window.isSecureContext && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (err) {
+      twarn("clipboard.writeText failed", err);
+      return false;
+    }
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.left = "-9999px";
+  textarea.style.top = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch (err) {
+    twarn("execCommand copy failed", err);
+  } finally {
+    textarea.remove();
+  }
+  return copied;
+}
+
+function setClipboardEventText(event: ClipboardEvent, text: string): boolean {
+  if (!text || !event.clipboardData) return false;
+  event.clipboardData.setData("text/plain", text);
+  event.preventDefault();
+  return true;
+}
+
 // Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s (cap). Seven attempts
 // cover typical tunnel restarts and transient WiFi drops without flooding
 // the server or burning the user's battery on a truly dead backend.
@@ -258,6 +296,41 @@ export function useTerminal(
     term.loadAddon(new WebLinksAddon());
 
     term.open(termEl);
+
+    const getCopySelection = () =>
+      term.getSelection() || window.getSelection()?.toString() || "";
+    const copyTerminalSelection = () => {
+      const selection = getCopySelection();
+      if (!selection) return false;
+      try {
+        if (document.execCommand("copy")) return true;
+      } catch (err) {
+        twarn("execCommand copy failed", err);
+      }
+      void copyText(selection);
+      return true;
+    };
+    const onCopy = (event: ClipboardEvent) => {
+      const selection = getCopySelection();
+      setClipboardEventText(event, selection);
+    };
+    termEl.addEventListener("copy", onCopy);
+
+    term.attachCustomKeyEventHandler((event: KeyboardEvent) => {
+      if (event.type !== "keydown") return true;
+      const isCopy =
+        !event.altKey &&
+        !event.shiftKey &&
+        (event.ctrlKey || event.metaKey) &&
+        event.code === "KeyC";
+      if (!isCopy || !getCopySelection()) return true;
+
+      copyTerminalSelection();
+
+      event.preventDefault();
+      event.stopPropagation();
+      return false;
+    });
 
     // GPU renderer. Loaded after .open() per the addon's contract. Falls
     // back to the DOM renderer silently on machines where the context is
@@ -1227,6 +1300,7 @@ export function useTerminal(
       window.removeEventListener("focus", onWindowFocus);
       window.removeEventListener("online", onOnline);
       window.removeEventListener("pageshow", onPageShow);
+      termEl.removeEventListener("copy", onCopy);
       viewport.removeEventListener("touchstart", onTouchStart, touchOpts);
       viewport.removeEventListener("touchmove", onTouchMove, touchOpts);
       viewport.removeEventListener("touchend", onTouchEnd, touchOpts);
@@ -1293,7 +1367,7 @@ export function useTerminal(
     }
   }, [state.isInScrollback]);
 
-  const manualReconnect = () => {
+  const manualReconnect = useCallback(() => {
     const ws = wsRef.current;
     tdbg("manualReconnect()", {
       readyState: ws?.readyState,
@@ -1327,8 +1401,11 @@ export function useTerminal(
     } else {
       ws.close();
     }
-  };
-  manualReconnectRef.current = manualReconnect;
+  }, []);
+
+  useEffect(() => {
+    manualReconnectRef.current = manualReconnect;
+  }, [manualReconnect]);
 
   const sendData = useCallback((data: string) => {
     if (wsRef.current?.readyState === WebSocket.OPEN) {


### PR DESCRIPTION
## Description
Fixes web terminal copy behavior so `Ctrl+C`/`Cmd+C` copies selected xterm text when a terminal selection exists, while preserving the existing PTY interrupt behavior when nothing is selected.

This addresses the browser-hosted terminal case where the browser default copy action is not reachable while xterm owns the keyboard event. The help overlay now describes the split behavior.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: clipboard writes are browser-permission mediated and the behavior is covered at the xterm hook boundary with Vitest lifecycle tests for selected-copy and no-selection interrupt paths.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate a focused web terminal copy regression fix.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :) 

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `npm run test:unit -- src/hooks/useTerminal.lifecycle.test.ts`
- `npx eslint src/hooks/useTerminal.ts src/hooks/useTerminal.lifecycle.test.ts src/components/HelpOverlay.tsx`
- `npm run build`
- `node tests/validate-coverage-matrix.mjs`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR makes Ctrl+C/Cmd+C in the browser-hosted terminal selection-aware while preserving the existing PTY interrupt behavior:

- Selection-aware Ctrl+C: when the xterm terminal has a selection, Ctrl/Cmd+C (and the DOM "copy" event) copy the selected terminal text to the clipboard; when nothing is selected, Ctrl+C still sends the PTY interrupt (SIGINT / 0x03).
- Clipboard helpers: added copyText() (prefers navigator.clipboard.writeText in secure contexts; falls back to a hidden readonly textarea + document.execCommand("copy")) and setClipboardEventText() (writes ClipboardEvent.clipboardData and prevents default).
- Event wiring: added a terminal element "copy" listener and an xterm attachCustomKeyEventHandler that intercepts Ctrl/Meta+C, performs selection-aware copy, prevents default/propagation, and returns false to bypass xterm's default handling when copying occurs.
- Help text: updated HelpOverlay to describe the dual-mode Ctrl+C behavior.
- Hook cleanup and small refactor: removes the term copy listener on unmount; memoizes manualReconnect with useCallback and keeps its ref synchronized via useEffect.
- Tests: extended useTerminal lifecycle tests with a FakeTerminal supporting attachCustomKeyEventHandler, hasSelection/getSelection and a capturable selection string; added tests for DOM "copy", Ctrl+C with selection (asserts execCommand("copy") and no interrupt sent), and Ctrl+C with no selection (asserts interrupt byte forwarded). A Playwright clipboard spec was skipped due to permission constraints.

Removed: nothing — changes are additive and backward-compatible.

## Benefits

- Restores the expected browser copy shortcut for users selecting text in the terminal while preserving existing PTY interrupt semantics.
- Improves usability with minimal surface-area changes and focused unit test coverage.

## Technical details (brief)

- copyText(text): uses navigator.clipboard.writeText in secure contexts (logs async failures); otherwise uses a hidden readonly textarea + document.execCommand("copy") fallback.
- setClipboardEventText(event, text): sets event.clipboardData.setData("text/plain", text) and calls event.preventDefault().
- termEl.addEventListener("copy", onCopy): fills clipboard from term.getSelection() or window.getSelection().
- term.attachCustomKeyEventHandler: on Ctrl/Meta+C and term.hasSelection(), triggers document.execCommand("copy") (with copyText fallback), stops propagation and returns false so xterm does not treat it as a keypress; otherwise Ctrl+C falls through to existing PTY interrupt handling.
- Tests mock navigator.clipboard and WebSocket interactions and add deterministic selection control to validate both copy and interrupt flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1481?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->