### PR TITLE
feat(tui): live-send mode — Tab to passthrough keystrokes to a session pane

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -592,6 +592,16 @@ pub struct SessionConfig {
     /// to pick up immediately.
     #[serde(default = "default_session_id_poller_max_threads")]
     pub session_id_poller_max_threads: u32,
+
+    /// Comma-separated list of chord specs that exit live-send mode.
+    /// Each chord is a tmux-style spec like `C-q`, `Ctrl+]`, `M-x`,
+    /// `F12`; the first chord in the list that matches an event ends
+    /// live mode. Multiple chords let users pick whatever works in
+    /// their terminal: `C-q` is friendlier on mobile keyboards and
+    /// in Termius; `C-]` is the telnet convention and preserves
+    /// `C-q` as a passthrough for vim quoted-insert.
+    #[serde(default = "default_live_send_exit_chord")]
+    pub live_send_exit_chord: String,
 }
 
 /// What to render in the per-row tag slot next to the session title.
@@ -634,6 +644,7 @@ impl Default for SessionConfig {
             restart_wake_message: default_restart_wake_message(),
             row_tag: RowTagMode::default(),
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
+            live_send_exit_chord: default_live_send_exit_chord(),
         }
     }
 }
@@ -644,6 +655,13 @@ fn default_snooze_duration_minutes() -> u32 {
 
 fn default_restart_wake_message() -> String {
     "wake up: pick up what you were doing".to_string()
+}
+
+fn default_live_send_exit_chord() -> String {
+    // Both Ctrl+q (mobile-friendly, passes Termius) and Ctrl+] (telnet
+    // convention, preserves C-q as passthrough). Kept in sync with
+    // live_send::DEFAULT_EXIT_CHORD.
+    "C-q,C-]".to_string()
 }
 
 /// Upper bound on snooze duration: 30 days (43,200 minutes). Originally

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -254,6 +254,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub row_tag: Option<super::config::RowTagMode>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub live_send_exit_chord: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -483,6 +486,9 @@ pub fn apply_session_overrides(
     }
     if let Some(row_tag) = source.row_tag {
         target.row_tag = row_tag;
+    }
+    if let Some(ref live_send_exit_chord) = source.live_send_exit_chord {
+        target.live_send_exit_chord = live_send_exit_chord.clone();
     }
 }
 

--- a/src/tmux/mod.rs
+++ b/src/tmux/mod.rs
@@ -228,6 +228,22 @@ fn parse_pane_metadata(output: &str) -> HashMap<String, PaneMetadata> {
     map
 }
 
+/// Test-only: inject a synthetic session name into the cache so
+/// callers of `session_exists_from_cache` see it as present. Used
+/// by live-send tests that install a fake `LiveSendState` without a
+/// real tmux pane; without this the per-keystroke drift check
+/// (which calls `session_exists_from_cache`) trips in CI runs that
+/// have already populated the cache via the e2e suite, causing the
+/// drift detector to flag the fake session as gone.
+#[cfg(test)]
+pub fn test_inject_session_into_cache(name: &str) {
+    if let Ok(mut cache) = SESSION_CACHE.write() {
+        let map = cache.data.get_or_insert_with(HashMap::new);
+        map.insert(name.to_string(), 0);
+        cache.time = Some(Instant::now());
+    }
+}
+
 pub fn session_exists_from_cache(name: &str) -> Option<bool> {
     let cache = SESSION_CACHE.read().ok()?;
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -401,6 +401,69 @@ impl Session {
         Ok(())
     }
 
+    /// Resize the session's window to `cols x rows`. Used on live-send
+    /// entry so the agent renders into the preview pane's actual
+    /// dimensions instead of whatever size it started at: without this
+    /// the captured output wraps oddly or hides UI the user can't see.
+    /// Sends SIGWINCH to the pane process, so well-behaved TUI agents
+    /// (claude-code, codex, vim, ...) repaint automatically.
+    pub fn resize(&self, cols: u16, rows: u16) -> Result<()> {
+        if !self.exists() {
+            bail!("Session does not exist: {}", self.name);
+        }
+        let cols = cols.max(1);
+        let rows = rows.max(1);
+        let target = self.name.clone();
+        let output = Command::new("tmux")
+            .args([
+                "resize-window",
+                "-t",
+                &target,
+                "-x",
+                &cols.to_string(),
+                "-y",
+                &rows.to_string(),
+            ])
+            .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            bail!("tmux resize-window failed: {}", stderr);
+        }
+        Ok(())
+    }
+
+    /// Send literal text to the pane via `tmux send-keys -l --` with no
+    /// trailing Enter. Used by live-send mode so a single typed character
+    /// streams through to the agent immediately rather than being treated
+    /// as a "submit message" payload. `--` ends option parsing so lines
+    /// starting with `-` are passed through verbatim.
+    pub fn send_literal_no_enter(&self, text: &str) -> Result<()> {
+        if !self.exists() {
+            bail!("Session does not exist: {}", self.name);
+        }
+        let target = format!("{}:^.0", self.name);
+        Self::tmux_send(&target, &["-l", "--", text])
+    }
+
+    /// Send a single tmux-named key (e.g. `Escape`, `Up`, `Tab`, `C-c`,
+    /// `Enter`) to the pane without appending Enter afterwards. Used by
+    /// live-send mode to deliver navigation input that the agent must
+    /// receive verbatim, not as literal text plus submit.
+    ///
+    /// `key_name` is passed through to `tmux send-keys` as a key name; tmux
+    /// recognizes the names documented in its KEY BINDINGS section (cursor
+    /// keys, `BSpace`, `BTab`, `DC`, `End`, `Enter`, `Escape`, `F1`..`F12`,
+    /// `Home`, `IC`, `NPage`, `PPage`, `Space`, `Tab`) plus the `C-` / `S-` /
+    /// `M-` modifier prefixes. Anything tmux does not recognize comes back
+    /// as an error.
+    pub fn send_named_key(&self, key_name: &str) -> Result<()> {
+        if !self.exists() {
+            bail!("Session does not exist: {}", self.name);
+        }
+        let target = format!("{}:^.0", self.name);
+        Self::tmux_send(&target, &[key_name])
+    }
+
     /// Deliver `text` to `target` via tmux's load-buffer + paste-buffer.
     /// Buffer names are scoped by pid + a per-call counter so concurrent
     /// senders (and retries) cannot clobber each other. `-p` enables

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1433,6 +1433,33 @@ impl App {
                     }
                 }
             }
+            Action::EnterLiveSend(id) => {
+                // Same revive flow as SendMessage so cold-start (Docker,
+                // agent splash) gives the user "Reviving..." feedback.
+                // After the pane is ready, install the live-send state on
+                // HomeView so the next key event routes through the live
+                // handler instead of the normal action dispatch.
+                self.home
+                    .set_instance_status(&id, crate::session::Status::Starting);
+                self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
+                self.draw(terminal)?;
+                let outcome = self.home.enter_live_send(&id);
+                match outcome {
+                    Ok(Some(sid)) => {
+                        self.update_status = Some(UpdateStatus::transient(format!(
+                            "Resume failed for sid {sid}; live-send sent to a fresh pane (history not loaded)"
+                        )));
+                    }
+                    Ok(None) => {
+                        self.update_status = None;
+                    }
+                    Err(()) => {
+                        // enter_live_send already surfaced the failure via
+                        // info_dialog; just clear the transient toast.
+                        self.update_status = None;
+                    }
+                }
+            }
             Action::AttachToolSession(id, tool_name) => {
                 self.attach_tool_session(&id, &tool_name, terminal)?;
             }
@@ -1833,6 +1860,11 @@ pub enum Action {
     /// can render a "Reviving..." status before the potentially-slow
     /// ensure_pane_ready call.
     SendMessage(String, String),
+    /// Enter live-send mode on a session. Same revive-and-stage pattern
+    /// as `SendMessage`: the deferred action lets the app loop render the
+    /// "Reviving..." toast before `ensure_pane_ready` runs, then the home
+    /// view flips into the live-send capture state for subsequent keys.
+    EnterLiveSend(String),
     /// Attach to a tool session (lazygit, yazi, etc.) for the given agent
     /// session. The tool_name indexes into Config.tools.
     AttachToolSession(String, String),

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -642,7 +642,7 @@ mod tests {
             .expect("builtin commands must include 'live-send'");
         assert_eq!(entry.hotkey, "Tab");
         assert!(
-            matches!(entry.payload, PaletteAction::EnterLiveSend),
+            matches!(&entry.payload, PaletteAction::EnterLiveSend),
             "live-send entry must dispatch PaletteAction::EnterLiveSend"
         );
     }

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -629,6 +629,25 @@ mod tests {
     }
 
     #[test]
+    fn live_send_entry_is_bound_to_tab_with_dedicated_payload() {
+        // Regression guard: the live-send palette entry must keep its
+        // hotkey label and dedicated payload variant. A future rebinding
+        // (e.g., moving Tab elsewhere) or accidentally regressing the
+        // payload to `Key(Tab)` would break strict-mode users who reach
+        // live-send only through the palette.
+        let cmds = builtin_commands(false, false);
+        let entry = cmds
+            .iter()
+            .find(|c| c.id == "live-send")
+            .expect("builtin commands must include 'live-send'");
+        assert_eq!(entry.hotkey, "Tab");
+        assert!(
+            matches!(entry.payload, PaletteAction::EnterLiveSend),
+            "live-send entry must dispatch PaletteAction::EnterLiveSend"
+        );
+    }
+
+    #[test]
     fn keywords_match_searches() {
         // "Move session to group" complaint from issue #889: searching for
         // "move" should surface the rename entry via its keyword.

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -59,6 +59,11 @@ pub enum PaletteAction {
     JumpToCursor(usize),
     /// Open a tool session by name (lazygit, yazi, etc.)
     ToolSession(String),
+    /// Enter live-send mode on the selected session. A dedicated variant
+    /// (rather than synthesizing the keypress) so the palette routes
+    /// correctly in strict mode, where the `m` binding is intentionally
+    /// defanged for the typing-guard.
+    EnterLiveSend,
 }
 
 /// One entry in the palette. `payload` is what gets returned when the user picks it.
@@ -129,6 +134,28 @@ pub fn builtin_commands(serve_enabled: bool, strict_hotkeys: bool) -> Vec<Palett
             keywords: vec!["prompt", "tell", "say"],
             hotkey: hotkey_label("m", "M", strict_hotkeys),
             payload: PaletteAction::Key(key('m')),
+        },
+        PaletteCommand {
+            id: "live-send",
+            title: "Live send: pass keys straight to the agent".to_string(),
+            group: PaletteGroup::Actions,
+            keywords: vec![
+                "live",
+                "passthrough",
+                "attach",
+                "keys",
+                "escape",
+                "arrow",
+                "tab",
+                "interrupt",
+            ],
+            // Tab is the direct binding in both modes (settings / cockpit
+            // / dialogs own their own Tab handlers, the home view's top
+            // level was free). Palette routing uses the dedicated
+            // variant so synthesizing a Tab keypress never accidentally
+            // re-fires this entry from inside a sub-handler.
+            hotkey: "Tab",
+            payload: PaletteAction::EnterLiveSend,
         },
         PaletteCommand {
             id: "stop",

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2729,14 +2729,21 @@ impl HomeView {
     }
 
     /// Attempt to enter live-send mode against the currently-selected
-    /// running session. Resolves via `resolve_paste_target` so group
-    /// rows, empty lists, and non-running selections silently no-op.
-    /// Returns the deferred `Action::EnterLiveSend` so the app loop can
-    /// render the "Reviving..." toast before `ensure_pane_ready` runs;
-    /// the home view's `live_send` state is set later by
-    /// `enter_live_send` once the pane is confirmed ready.
+    /// session. Unlike `resolve_paste_target`, this does NOT require
+    /// the tmux pane to already exist: `enter_live_send` calls
+    /// `ensure_pane_ready` which revives stopped sessions (Docker
+    /// start, splash wait, resume cascade). Without this relaxation
+    /// Tab would silently no-op on dead-but-recoverable rows and the
+    /// "Reviving..." toast plumbing would never fire.
+    ///
+    /// Still no-ops on group headers, empty lists, and Creating rows
+    /// (no instance yet, nothing to revive).
     pub(super) fn start_live_send(&mut self) -> Option<Action> {
-        let (id, _title) = self.resolve_paste_target()?;
+        let id = self.selected_session.clone()?;
+        let inst = self.get_instance(&id)?;
+        if matches!(inst.status, Status::Creating | Status::Deleting) {
+            return None;
+        }
         Some(Action::EnterLiveSend(id))
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2400,15 +2400,26 @@ impl HomeView {
             diff.scroll_up(STEP);
             return true;
         }
-        if self.has_dialog() {
-            return false;
-        }
-        if self.hit_list(col, row) {
-            self.move_cursor(-1);
-            return true;
-        }
-        if !self.hit_preview(col, row) {
-            return false;
+        // Live-send mode lets the user scroll the preview to read
+        // agent history without exiting, but list scroll is suppressed
+        // (changing the selection mid-live-send would silently aim the
+        // next keystroke at a different pane than the one the user is
+        // looking at). All other modals swallow scroll entirely.
+        if self.live_send.is_some() {
+            if !self.hit_preview(col, row) {
+                return false;
+            }
+        } else {
+            if self.has_dialog() {
+                return false;
+            }
+            if self.hit_list(col, row) {
+                self.move_cursor(-1);
+                return true;
+            }
+            if !self.hit_preview(col, row) {
+                return false;
+            }
         }
         if self.selected_session.is_none() {
             return false;
@@ -2606,15 +2617,22 @@ impl HomeView {
             diff.scroll_down(STEP);
             return true;
         }
-        if self.has_dialog() {
-            return false;
-        }
-        if self.hit_list(col, row) {
-            self.move_cursor(1);
-            return true;
-        }
-        if !self.hit_preview(col, row) {
-            return false;
+        // See handle_scroll_up for the live-send / has_dialog reasoning.
+        if self.live_send.is_some() {
+            if !self.hit_preview(col, row) {
+                return false;
+            }
+        } else {
+            if self.has_dialog() {
+                return false;
+            }
+            if self.hit_list(col, row) {
+                self.move_cursor(1);
+                return true;
+            }
+            if !self.hit_preview(col, row) {
+                return false;
+            }
         }
         if self.selected_session.is_none() {
             return false;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2747,15 +2747,39 @@ impl HomeView {
     /// call so fast typing isn't N forks. Ctrl+q clears `live_send`
     /// and drops the worker (which closes its channel, exiting the
     /// thread cleanly on the next iteration).
+    ///
+    /// Before dispatching we re-verify that the target session still
+    /// exists at the same tmux name as it had at entry time. If a peer
+    /// process deleted the session or a rename diverged the name from
+    /// what the worker is targeting, the user would otherwise type
+    /// into the void with only a `tracing::warn!` for company. Auto-
+    /// exit + info dialog instead.
     fn handle_live_send_key(&mut self, key: KeyEvent) {
         let Some(state) = self.live_send.clone() else {
             return;
         };
-        match live_send::translate(key) {
+        let dispatch = live_send::translate(key);
+        // Honor the exit chord before the drift check: exiting is
+        // always safe and the user pressing Ctrl+q to escape a
+        // drifted-and-stuck live mode should not hit a "session
+        // ended" dialog on the way out.
+        if matches!(dispatch, live_send::LiveDispatch::Exit) {
+            self.live_send = None;
+            self.live_send_worker = None;
+            self.live_send_last_resize = None;
+            return;
+        }
+        if let Some(reason) = self.live_send_drift_reason(&state) {
+            self.live_send = None;
+            self.live_send_worker = None;
+            self.live_send_last_resize = None;
+            self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
+            return;
+        }
+        match dispatch {
             live_send::LiveDispatch::Exit => {
-                self.live_send = None;
-                self.live_send_worker = None;
-                self.live_send_last_resize = None;
+                // Handled by the matches! above; this arm only exists
+                // so the match remains exhaustive.
             }
             live_send::LiveDispatch::Ignore => {}
             live_send::LiveDispatch::Send(tmux_key) => {
@@ -2765,6 +2789,23 @@ impl HomeView {
                 self.stamp_last_accessed(&state.session_id);
             }
         }
+    }
+
+    /// Returns `Some(reason)` if the live-send target has drifted out
+    /// from under us between entry and now: instance deleted, instance
+    /// title renamed (which changes the tmux session name), or the
+    /// generated name no longer matches what the worker was spawned
+    /// with. The caller uses the message verbatim in the info dialog,
+    /// so phrase it as a user-facing sentence.
+    fn live_send_drift_reason(&self, state: &live_send::LiveSendState) -> Option<&'static str> {
+        let Some(inst) = self.get_instance(&state.session_id) else {
+            return Some("Session was deleted while live mode was active.");
+        };
+        let current_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        if current_name != state.tmux_name {
+            return Some("Session was renamed while live mode was active.");
+        }
+        None
     }
 
     /// Open the send-message dialog for the currently-selected running session.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -302,7 +302,7 @@ impl HomeView {
         // Live-send capture wins over every other key handler. While
         // `live_send` is `Some` the home view is acting as a thin relay
         // to the target pane; dialog hotkeys, search, and list navigation
-        // all suspend until the user exits with Ctrl+].
+        // all suspend until the user exits with Ctrl+q.
         if self.live_send.is_some() {
             self.handle_live_send_key(key);
             return None;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2744,6 +2744,13 @@ impl HomeView {
         if matches!(inst.status, Status::Creating | Status::Deleting) {
             return None;
         }
+        // Cockpit-mode sessions are not tmux-backed (HomeView's attach
+        // path special-cases them away from tmux). Live-send has no
+        // target in that mode, so silently no-op rather than enqueue
+        // an Action::EnterLiveSend that would fail downstream.
+        if inst.is_cockpit_mode() {
+            return None;
+        }
         Some(Action::EnterLiveSend(id))
     }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2799,11 +2799,22 @@ impl HomeView {
     }
 
     /// Returns `Some(reason)` if the live-send target has drifted out
-    /// from under us between entry and now: instance deleted, instance
-    /// title renamed (which changes the tmux session name), or the
-    /// generated name no longer matches what the worker was spawned
-    /// with. The caller uses the message verbatim in the info dialog,
-    /// so phrase it as a user-facing sentence.
+    /// from under us between entry and now. Three drift modes:
+    /// - Instance row deleted (peer / web cockpit / another aoe killed
+    ///   it).
+    /// - Title renamed (which regenerates the tmux session name; the
+    ///   worker is now targeting a stale name).
+    /// - tmux session itself is gone (`tmux kill-session`, server
+    ///   restart) even though our instance row says otherwise. We use
+    ///   the existing `session_exists_from_cache` lookup so this costs
+    ///   a hashmap probe per keystroke (the status poller refreshes
+    ///   the cache every 500ms anyway). If the cache has no entry
+    ///   (`None`, e.g. before first refresh) we don't claim drift; the
+    ///   instance + name checks above are still the load-bearing
+    ///   safety net.
+    ///
+    /// The caller uses the message verbatim in the info dialog, so
+    /// phrase it as a user-facing sentence.
     fn live_send_drift_reason(&self, state: &live_send::LiveSendState) -> Option<&'static str> {
         let Some(inst) = self.get_instance(&state.session_id) else {
             return Some("Session was deleted while live mode was active.");
@@ -2811,6 +2822,9 @@ impl HomeView {
         let current_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
         if current_name != state.tmux_name {
             return Some("Session was renamed while live mode was active.");
+        }
+        if crate::tmux::session_exists_from_cache(&state.tmux_name) == Some(false) {
+            return Some("tmux pane went away while live mode was active.");
         }
         None
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -302,7 +302,7 @@ impl HomeView {
         // Live-send capture wins over every other key handler. While
         // `live_send` is `Some` the home view is acting as a thin relay
         // to the target pane; dialog hotkeys, search, and list navigation
-        // all suspend until the user exits with Ctrl+].
+        // all suspend until the user exits with Ctrl+q.
         if self.live_send.is_some() {
             self.handle_live_send_key(key);
             return None;
@@ -2776,7 +2776,7 @@ impl HomeView {
     /// the background worker. The worker owns the tmux Session and runs
     /// `send-keys` off the UI thread so a slow fork+exec never blocks
     /// the redraw loop; literal-key runs coalesce into a single tmux
-    /// call so fast typing isn't N forks. Ctrl+] clears `live_send`
+    /// call so fast typing isn't N forks. Ctrl+q clears `live_send`
     /// and drops the worker (which closes its channel, exiting the
     /// thread cleanly on the next iteration).
     ///
@@ -2819,7 +2819,7 @@ impl HomeView {
 
         let dispatch = live_send::translate(key);
         // Honor the exit chord before the drift check: exiting is
-        // always safe and the user pressing Ctrl+] to escape a
+        // always safe and the user pressing Ctrl+q to escape a
         // drifted-and-stuck live mode should not hit a "session
         // ended" dialog on the way out.
         if matches!(dispatch, live_send::LiveDispatch::Exit) {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2817,12 +2817,11 @@ impl HomeView {
             }
         }
 
-        let dispatch = live_send::translate(key);
-        // Honor the exit chord before the drift check: exiting is
-        // always safe and the user pressing Ctrl+q to escape a
-        // drifted-and-stuck live mode should not hit a "session
-        // ended" dialog on the way out.
-        if matches!(dispatch, live_send::LiveDispatch::Exit) {
+        // Exit-chord check runs before the drift check: exiting is
+        // always safe, and the user pressing the chord to escape a
+        // drifted/stuck live mode shouldn't hit a "session ended"
+        // dialog on the way out.
+        if live_send::chord_list_matches(&state.exit_chords, key) {
             self.live_send = None;
             self.live_send_worker = None;
             self.live_send_last_resize = None;
@@ -2835,11 +2834,7 @@ impl HomeView {
             self.info_dialog = Some(InfoDialog::new("Live send ended", reason));
             return;
         }
-        match dispatch {
-            live_send::LiveDispatch::Exit => {
-                // Handled by the matches! above; this arm only exists
-                // so the match remains exhaustive.
-            }
+        match live_send::translate(key) {
             live_send::LiveDispatch::Ignore => {}
             live_send::LiveDispatch::Send(tmux_key) => {
                 if let Some(worker) = &self.live_send_worker {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -5,7 +5,7 @@ use ratatui::prelude::Position;
 use tui_input::backend::crossterm::EventHandler;
 use tui_input::Input;
 
-use super::{DragKind, HomeView, TerminalMode, ViewMode};
+use super::{live_send, DragKind, HomeView, TerminalMode, ViewMode};
 use crate::session::config::{load_config, save_config, GroupByMode, SortOrder};
 use crate::session::{list_profiles, repo_config, resolve_config_or_warn, Item, Status};
 use crate::tui::app::Action;
@@ -299,6 +299,15 @@ impl HomeView {
         key: KeyEvent,
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
+        // Live-send capture wins over every other key handler. While
+        // `live_send` is `Some` the home view is acting as a thin relay
+        // to the target pane; dialog hotkeys, search, and list navigation
+        // all suspend until the user exits with Ctrl+].
+        if self.live_send.is_some() {
+            self.handle_live_send_key(key);
+            return None;
+        }
+
         // Handle unsaved changes confirmation for settings (shown over settings view)
         if self.settings_close_confirm {
             if let Some(dialog) = &mut self.confirm_dialog {
@@ -1856,6 +1865,18 @@ impl HomeView {
             KeyCode::Char('M') if self.strict_hotkeys => {
                 self.open_send_message_dialog();
             }
+            // Tab enters live-send mode on the selected running session.
+            // Free at the home-view top level (settings/cockpit/dialogs
+            // own their own Tab handlers), and the entry-vs-send
+            // distinction is unambiguous: this branch only fires when
+            // `live_send` is None, because the live-send capture at the
+            // top of `handle_key` short-circuits otherwise. While in
+            // live mode Tab is sent verbatim to the agent.
+            KeyCode::Tab => {
+                if let Some(action) = self.start_live_send() {
+                    return Some(action);
+                }
+            }
             KeyCode::Char('o') if key.modifiers.contains(KeyModifiers::CONTROL) => {
                 self.apply_sort_order(self.sort_order.cycle_reverse());
             }
@@ -2128,6 +2149,7 @@ impl HomeView {
                 self.tool_preview_cache = super::PreviewCache::default();
                 None
             }
+            PaletteAction::EnterLiveSend => self.start_live_send(),
         }
     }
 
@@ -2606,12 +2628,26 @@ impl HomeView {
 
     /// Route a bracketed paste event to the active text input dialog.
     ///
-    /// Active text-input dialogs (rename / send_message / new) win first so
-    /// multi-line voice/dictation lands in the dialog the user is actively
-    /// typing into. The settings view is checked last; its paste handler
-    /// strips newlines (settings/input.rs handle_paste sanitizes), which
-    /// would destroy multi-line dictation if we checked it first.
+    /// Live-send mode wins above every dialog: a paste while the user is
+    /// "attached" should stream straight to the agent's pane, not buffer
+    /// in a dialog the user isn't even looking at. Text-input dialogs
+    /// (rename / send_message / new) come next so multi-line dictation
+    /// lands in whichever dialog the user is actively typing into. The
+    /// settings view is checked last; its paste handler strips newlines,
+    /// which would destroy multi-line dictation if we checked it first.
     pub fn handle_paste(&mut self, text: &str) {
+        if let Some(state) = self.live_send.clone() {
+            if let Some(worker) = &self.live_send_worker {
+                // One Literal carries the whole pasted chunk so the worker
+                // dispatches it in a single tmux call. Routing through the
+                // worker (rather than calling tmux inline) keeps the paste
+                // ordered correctly against any in-flight keystrokes
+                // queued from the same event loop tick.
+                worker.send(live_send::TmuxKey::Literal(text.to_string()));
+            }
+            self.stamp_last_accessed(&state.session_id);
+            return;
+        }
         if let Some(ref mut dialog) = self.rename_dialog {
             dialog.handle_paste(text);
             return;
@@ -2690,6 +2726,45 @@ impl HomeView {
             profiles,
             tools,
         ));
+    }
+
+    /// Attempt to enter live-send mode against the currently-selected
+    /// running session. Resolves via `resolve_paste_target` so group
+    /// rows, empty lists, and non-running selections silently no-op.
+    /// Returns the deferred `Action::EnterLiveSend` so the app loop can
+    /// render the "Reviving..." toast before `ensure_pane_ready` runs;
+    /// the home view's `live_send` state is set later by
+    /// `enter_live_send` once the pane is confirmed ready.
+    pub(super) fn start_live_send(&mut self) -> Option<Action> {
+        let (id, _title) = self.resolve_paste_target()?;
+        Some(Action::EnterLiveSend(id))
+    }
+
+    /// Translate one key event in live-send mode and hand the result to
+    /// the background worker. The worker owns the tmux Session and runs
+    /// `send-keys` off the UI thread so a slow fork+exec never blocks
+    /// the redraw loop; literal-key runs coalesce into a single tmux
+    /// call so fast typing isn't N forks. Ctrl+q clears `live_send`
+    /// and drops the worker (which closes its channel, exiting the
+    /// thread cleanly on the next iteration).
+    fn handle_live_send_key(&mut self, key: KeyEvent) {
+        let Some(state) = self.live_send.clone() else {
+            return;
+        };
+        match live_send::translate(key) {
+            live_send::LiveDispatch::Exit => {
+                self.live_send = None;
+                self.live_send_worker = None;
+                self.live_send_last_resize = None;
+            }
+            live_send::LiveDispatch::Ignore => {}
+            live_send::LiveDispatch::Send(tmux_key) => {
+                if let Some(worker) = &self.live_send_worker {
+                    worker.send(tmux_key);
+                }
+                self.stamp_last_accessed(&state.session_id);
+            }
+        }
     }
 
     /// Open the send-message dialog for the currently-selected running session.

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2790,6 +2790,33 @@ impl HomeView {
         let Some(state) = self.live_send.clone() else {
             return;
         };
+
+        // Shift+PageUp / Shift+PageDown scroll the preview pane
+        // without forwarding to the agent. Matches the terminal-
+        // emulator convention (xterm, gnome-terminal, iTerm, etc.)
+        // where shift+page operates on the outer scrollback, not the
+        // inner program. Bare PageUp/PageDown still goes to the agent
+        // so agents that page their own UI keep working.
+        let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+        let alt = key.modifiers.contains(KeyModifiers::ALT);
+        let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+        if shift && !ctrl && !alt {
+            const PAGE_STEP: u16 = 10;
+            match key.code {
+                KeyCode::PageUp => {
+                    self.preview_scroll_offset =
+                        self.preview_scroll_offset.saturating_add(PAGE_STEP);
+                    return;
+                }
+                KeyCode::PageDown => {
+                    self.preview_scroll_offset =
+                        self.preview_scroll_offset.saturating_sub(PAGE_STEP);
+                    return;
+                }
+                _ => {}
+            }
+        }
+
         let dispatch = live_send::translate(key);
         // Honor the exit chord before the drift check: exiting is
         // always safe and the user pressing Ctrl+] to escape a

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -302,7 +302,7 @@ impl HomeView {
         // Live-send capture wins over every other key handler. While
         // `live_send` is `Some` the home view is acting as a thin relay
         // to the target pane; dialog hotkeys, search, and list navigation
-        // all suspend until the user exits with Ctrl+q.
+        // all suspend until the user exits with Ctrl+].
         if self.live_send.is_some() {
             self.handle_live_send_key(key);
             return None;
@@ -2758,7 +2758,7 @@ impl HomeView {
     /// the background worker. The worker owns the tmux Session and runs
     /// `send-keys` off the UI thread so a slow fork+exec never blocks
     /// the redraw loop; literal-key runs coalesce into a single tmux
-    /// call so fast typing isn't N forks. Ctrl+q clears `live_send`
+    /// call so fast typing isn't N forks. Ctrl+] clears `live_send`
     /// and drops the worker (which closes its channel, exiting the
     /// thread cleanly on the next iteration).
     ///
@@ -2774,7 +2774,7 @@ impl HomeView {
         };
         let dispatch = live_send::translate(key);
         // Honor the exit chord before the drift check: exiting is
-        // always safe and the user pressing Ctrl+q to escape a
+        // always safe and the user pressing Ctrl+] to escape a
         // drifted-and-stuck live mode should not hit a "session
         // ended" dialog on the way out.
         if matches!(dispatch, live_send::LiveDispatch::Exit) {

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -5,16 +5,14 @@
 //! module's translator. Each translation produces a `tmux send-keys` call
 //! against the target pane: plain characters go literally, every other
 //! key (arrows, Esc, Tab, modifier combos) goes by tmux key name with
-//! `C-` / `M-` prefixes. The user exits with `Ctrl+]`.
+//! `C-` / `M-` prefixes. The user exits with `Ctrl+q`.
 //!
-//! Exit chord trade-off: `Ctrl+]` is telnet's classic "escape from
-//! captured session" chord. Power users recognize it from telnet /
-//! screen muscle memory, terminal emulators and Mosh pass it through
-//! reliably, and almost no agent binds it (so users don't lose a
-//! commonly-typed chord to the exit mechanism). The cost is that
-//! `C-]` literally can't be sent through live mode; if a user needs
-//! `C-]` in vim/emacs they should use the compose dialog or attach
-//! directly with `a`.
+//! Exit chord trade-off: `Ctrl+q` is memorable ("Q for quit"), is
+//! reachable on mobile keyboards (Termius and similar SSH clients
+//! don't always pass `Ctrl+]` through), and is what we shipped to
+//! users first. The cost is that vim/emacs `C-q` quoted-insert
+//! can't be sent through live mode; anyone needing that flow should
+//! use the compose dialog or attach directly with `a`.
 //!
 //! Trade-offs vs. a compose dialog:
 //! - No echo, no inline editing, no review step. The preview pane is the
@@ -26,7 +24,7 @@
 //!   in a single call.
 //!
 //! Reserved (non-forwarded) chords:
-//! - `Ctrl+]` — exit live mode (see above).
+//! - `Ctrl+q` — exit live mode (see above).
 //! - `Shift+PageUp` / `Shift+PageDown` — scroll the preview pane back
 //!   through agent history without exiting. Matches the terminal-
 //!   emulator convention. Bare `PageUp` / `PageDown` still passes
@@ -151,7 +149,7 @@ impl LiveSendWorker {
     pub(super) fn send(&self, key: TmuxKey) {
         // Channel send only fails if the worker thread panicked. Drop
         // silently rather than spam logs: the user's next exit attempt
-        // (Ctrl+]) will clear the dead worker and we'll spawn a fresh
+        // (Ctrl+q) will clear the dead worker and we'll spawn a fresh
         // one on the next live-send entry.
         let _ = self.tx.send(WorkerMsg::Send(key));
     }
@@ -205,10 +203,9 @@ pub(super) enum TmuxKey {
 /// Map one crossterm `KeyEvent` onto a `LiveDispatch`.
 ///
 /// Conventions:
-/// - `Ctrl+]` is Exit (telnet's classic escape). Alt is rejected so
-///   `Ctrl+Alt+]` still passes through to the agent as `C-M-]` for
-///   any user who wants it; the bare Ctrl+] chord is the one
-///   sacrifice the live-send mode makes.
+/// - `Ctrl+q` (lowercase, bare) is Exit. Holding Shift or Alt
+///   converts the chord to a passthrough (Ctrl+Shift+q, Ctrl+Alt+q)
+///   so the user can still deliver those combinations to the agent.
 /// - Plain printable chars (`KeyCode::Char` with no Ctrl/Alt) go literal
 ///   so the user's case and punctuation are preserved verbatim. The shift
 ///   modifier is implicit in the char itself, so we don't add `S-`.
@@ -225,12 +222,10 @@ pub fn translate(key: KeyEvent) -> LiveDispatch {
     let alt = key.modifiers.contains(KeyModifiers::ALT);
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
-    // Bare Ctrl+] only. Alt held converts the chord to a send-through
-    // (Ctrl+Alt+]) so the user can still deliver C-M-] to the agent.
-    // Shift is ignored here: `]` is symbolic, so terminals don't
-    // consistently set the SHIFT modifier for Ctrl+] and we don't want
-    // the chord to silently stop working depending on the terminal.
-    if ctrl && !alt && matches!(key.code, KeyCode::Char(']')) {
+    // Bare Ctrl+q only. Holding Shift or Alt converts the chord to a
+    // passthrough so the user can still deliver Ctrl+Shift+q (a.k.a.
+    // `C-q` to most agents) or Ctrl+Alt+q to the agent.
+    if ctrl && !shift && !alt && matches!(key.code, KeyCode::Char('q')) {
         return LiveDispatch::Exit;
     }
 
@@ -317,37 +312,35 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_right_bracket_exits() {
+    fn ctrl_q_exits() {
         assert_eq!(
-            translate(k_mod(KeyCode::Char(']'), KeyModifiers::CONTROL)),
+            translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
             LiveDispatch::Exit
         );
     }
 
     #[test]
-    fn ctrl_right_bracket_with_shift_still_exits() {
-        // Some terminals deliver Ctrl+] with SHIFT also set (or strip
-        // it, depending on the keymap). `]` is symbolic so we accept
-        // either; the user's intent is unambiguous.
-        assert_eq!(
-            translate(k_mod(
-                KeyCode::Char(']'),
-                KeyModifiers::CONTROL | KeyModifiers::SHIFT
-            )),
-            LiveDispatch::Exit
-        );
-    }
-
-    #[test]
-    fn ctrl_alt_right_bracket_does_not_exit() {
-        // Adding Alt converts the chord to a passthrough so the user
-        // can still send C-M-] to the agent if they need to.
+    fn ctrl_shift_q_does_not_exit() {
+        // Only bare Ctrl+q exits. Shift held means the user actually
+        // wants to send `C-q` through to the agent (vim quoted-insert,
+        // readline start-output), so this must fall through to a Named
+        // dispatch instead of being eaten as an exit.
         let d = translate(k_mod(
-            KeyCode::Char(']'),
+            KeyCode::Char('Q'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ));
+        assert_ne!(d, LiveDispatch::Exit);
+        assert_named(d, "C-q");
+    }
+
+    #[test]
+    fn ctrl_alt_q_does_not_exit() {
+        let d = translate(k_mod(
+            KeyCode::Char('q'),
             KeyModifiers::CONTROL | KeyModifiers::ALT,
         ));
         assert_ne!(d, LiveDispatch::Exit);
-        assert_named(d, "C-M-]");
+        assert_named(d, "C-M-q");
     }
 
     #[test]
@@ -601,21 +594,20 @@ mod tests {
     }
 
     #[test]
-    fn plain_right_bracket_is_literal_not_exit() {
-        // Without Ctrl, `]` is just a punctuation character the user
-        // wants to send (markdown links, array indexing, etc.).
-        assert_literal(translate(k(KeyCode::Char(']'))), "]");
+    fn plain_q_is_literal_not_exit() {
+        // Without Ctrl, `q` is just a letter the user wants to send.
+        assert_literal(translate(k(KeyCode::Char('q'))), "q");
+        assert_literal(translate(k(KeyCode::Char('Q'))), "Q");
     }
 
     #[test]
-    fn ctrl_q_is_now_a_passthrough() {
-        // The exit chord moved from Ctrl+q to Ctrl+]; that means
-        // Ctrl+q should now pass through to the agent (vim's
-        // quoted-insert / readline's start-output) instead of being
-        // intercepted.
+    fn ctrl_right_bracket_is_now_a_passthrough() {
+        // Ctrl+] used to be the exit chord but it doesn't pass through
+        // some SSH clients (Termius is the reported case). Now it
+        // forwards to the agent like any other modifier chord.
         assert_named(
-            translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
-            "C-q",
+            translate(k_mod(KeyCode::Char(']'), KeyModifiers::CONTROL)),
+            "C-]",
         );
     }
 }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1,0 +1,514 @@
+//! Live-send mode: a "feels-attached" alternative to the compose dialog.
+//!
+//! When a user presses `Tab` on a runnable session, the home view installs
+//! a `LiveSendState` and routes every subsequent key event through this
+//! module's translator. Each translation produces a `tmux send-keys` call
+//! against the target pane: plain characters go literally, every other
+//! key (arrows, Esc, Tab, modifier combos) goes by tmux key name with
+//! `C-` / `M-` prefixes. The user exits with `Ctrl+Q`.
+//!
+//! Exit chord trade-off: `Ctrl+Q` is memorable ("Q for quit") and works
+//! over Mosh/SSH where Alt combos and Ctrl+] often don't. The cost is
+//! that vim/emacs `C-q` quoted-insert can't be sent through live mode;
+//! anyone needing that flow should use the compose dialog or attach
+//! directly with `a`.
+//!
+//! Trade-offs vs. a compose dialog:
+//! - No echo, no inline editing, no review step. The preview pane is the
+//!   only feedback channel; users who need multi-line composition or want
+//!   to proofread voice/dictation should use the compose dialog on `M`.
+//! - One tmux process per keystroke. Acceptable on local machines; visibly
+//!   laggy over Docker / mosh on slow links. Bracketed paste shortcuts the
+//!   per-char cost by routing the whole chunk through `send_literal_no_enter`
+//!   in a single call.
+
+use std::sync::mpsc::{channel, Sender};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Lives on `HomeView::live_send` while the mode is active. Carries just
+/// enough state for the banner to render and for the exit handler to
+/// confirm the right pane was targeted.
+#[derive(Debug, Clone)]
+pub struct LiveSendState {
+    pub session_id: String,
+    pub title: String,
+}
+
+/// One coalesced unit of work the worker hands to tmux. `Literal` runs
+/// fold together; named keys and resizes break the run because their
+/// order vs. surrounding text matters (an Up arrow between "ab" and
+/// "cd" must arrive between, not after; a resize that lands before
+/// keystrokes makes the agent render those keystrokes at the new
+/// geometry).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TmuxAction {
+    Literal(String),
+    Named(String),
+    Resize { cols: u16, rows: u16 },
+}
+
+/// Fold a batch of `WorkerMsg`s into the smallest sequence of
+/// `TmuxAction`s that preserves the original ordering. Consecutive
+/// `Send(Literal)` values merge into one payload (single
+/// `tmux send-keys` call); a `Send(Named)` or `Resize` flushes the
+/// current literal run and goes out on its own. Pure function so tests
+/// can verify ordering without spawning a worker thread.
+pub fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
+    let mut out: Vec<TmuxAction> = Vec::new();
+    let mut run = String::new();
+    let flush = |out: &mut Vec<TmuxAction>, run: &mut String| {
+        if !run.is_empty() {
+            out.push(TmuxAction::Literal(std::mem::take(run)));
+        }
+    };
+    for msg in batch {
+        match msg {
+            WorkerMsg::Send(TmuxKey::Literal(s)) => run.push_str(&s),
+            WorkerMsg::Send(TmuxKey::Named(name)) => {
+                flush(&mut out, &mut run);
+                out.push(TmuxAction::Named(name));
+            }
+            WorkerMsg::Resize { cols, rows } => {
+                flush(&mut out, &mut run);
+                out.push(TmuxAction::Resize { cols, rows });
+            }
+        }
+    }
+    flush(&mut out, &mut run);
+    out
+}
+
+/// One unit of work the worker can be asked to perform. Resizes don't
+/// coalesce with keys because they're sticky pane-level changes; a
+/// burst of keystrokes that brackets a resize must arrive on either
+/// side of the geometry change, not be reordered after it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkerMsg {
+    Send(TmuxKey),
+    Resize { cols: u16, rows: u16 },
+}
+
+/// Background dispatcher: owns a tmux `Session` and drains a channel of
+/// `WorkerMsg`s, calling `coalesce_batch` to compress runs of literal
+/// keys into single `send-keys` invocations. Spawned on
+/// `enter_live_send` and dropped when the user exits live mode;
+/// dropping closes the channel, which makes the worker thread's `recv`
+/// return `Err` and exit on the next iteration. We deliberately do not
+/// `join` because the worker is idempotent and harmless if it survives
+/// a brief moment past the UI thread that owned it (e.g., the user
+/// toggles live mode rapidly).
+pub struct LiveSendWorker {
+    tx: Sender<WorkerMsg>,
+}
+
+impl LiveSendWorker {
+    pub fn spawn(session_name: String) -> Self {
+        let (tx, rx) = channel::<WorkerMsg>();
+        std::thread::spawn(move || {
+            let session = crate::tmux::Session::from_name(&session_name);
+            // Block until the first message, then drain anything else
+            // that piled up during the previous flush. This is enough
+            // to coalesce paste-bursts and held-key autorepeat without
+            // adding any extra sleep that would inflate single-key
+            // latency.
+            while let Ok(first) = rx.recv() {
+                let mut batch = vec![first];
+                while let Ok(msg) = rx.try_recv() {
+                    batch.push(msg);
+                }
+                dispatch_batch(&session, batch);
+            }
+        });
+        Self { tx }
+    }
+
+    /// Enqueue a translated key for dispatch. Returns immediately; the
+    /// fork+exec for `tmux send-keys` happens on the worker thread, so
+    /// the UI never blocks on tmux latency.
+    pub fn send(&self, key: TmuxKey) {
+        // Channel send only fails if the worker thread panicked. Drop
+        // silently rather than spam logs: the user's next exit attempt
+        // (Ctrl+q) will clear the dead worker and we'll spawn a fresh
+        // one on the next live-send entry.
+        let _ = self.tx.send(WorkerMsg::Send(key));
+    }
+
+    /// Enqueue a tmux pane resize. The geometry change is serialized
+    /// with surrounding keystrokes so that keys typed before the
+    /// resize arrive in the old size and keys after arrive in the new
+    /// size (matters when an agent uses cursor-position escapes).
+    pub fn resize(&self, cols: u16, rows: u16) {
+        let _ = self.tx.send(WorkerMsg::Resize { cols, rows });
+    }
+}
+
+/// Walk one drained batch and execute it against `session`. Uses
+/// `coalesce` so literal-key runs collapse into a single `send-keys`
+/// call; named keys and resizes dispatch individually. Tests verify
+/// the ordering via `coalesce` directly without needing a real session.
+fn dispatch_batch(session: &crate::tmux::Session, batch: Vec<WorkerMsg>) {
+    for action in coalesce(batch) {
+        let result = match action {
+            TmuxAction::Literal(s) => session.send_literal_no_enter(&s),
+            TmuxAction::Named(name) => session.send_named_key(&name),
+            TmuxAction::Resize { cols, rows } => session.resize(cols, rows),
+        };
+        if let Err(e) = result {
+            tracing::warn!("live-send worker: tmux op failed: {}", e);
+        }
+    }
+}
+
+/// What the translator says to do with one incoming key event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LiveDispatch {
+    /// User pressed the exit chord; the caller should clear `live_send`.
+    Exit,
+    /// Forward the keystroke to tmux in the requested form.
+    Send(TmuxKey),
+    /// Key has no meaningful tmux mapping (Null, CapsLock, media keys, …).
+    /// Caller should drop it silently rather than echo it elsewhere.
+    Ignore,
+}
+
+/// How the translator wants the keystroke delivered. `Literal` payloads
+/// go through `tmux send-keys -l --`, named keys through `tmux send-keys`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TmuxKey {
+    Literal(String),
+    Named(String),
+}
+
+/// Map one crossterm `KeyEvent` onto a `LiveDispatch`.
+///
+/// Conventions:
+/// - `Ctrl+q` (lowercase only) is Exit. Shift is not accepted: if the
+///   user holds shift the chord becomes `C-q` (often `C-Q` from some
+///   terminals), and that falls through to the named-key path so the
+///   user can still send Ctrl+Shift+q to the agent if they want.
+/// - Plain printable chars (`KeyCode::Char` with no Ctrl/Alt) go literal
+///   so the user's case and punctuation are preserved verbatim. The shift
+///   modifier is implicit in the char itself, so we don't add `S-`.
+/// - Ctrl/Alt + a char folds the char to lowercase and emits a tmux name
+///   like `C-a`, `M-x`, `C-M-x`. Lowercase because tmux's chord names
+///   are case-insensitive for letters and `C-a` is the conventional form.
+/// - All other keys (arrows, function keys, etc.) emit their tmux name
+///   with whatever prefixes apply.
+pub fn translate(key: KeyEvent) -> LiveDispatch {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    // Bare Ctrl+q only. Holding Shift or Alt converts the chord to a
+    // send-through (Ctrl+Shift+q, Ctrl+Alt+q) so the user can still
+    // deliver those combinations to the agent.
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
+    if ctrl && !shift && !alt && matches!(key.code, KeyCode::Char('q')) {
+        return LiveDispatch::Exit;
+    }
+
+    let prefix = match (ctrl, alt) {
+        (true, true) => "C-M-",
+        (true, false) => "C-",
+        (false, true) => "M-",
+        (false, false) => "",
+    };
+    let named = |name: &str| LiveDispatch::Send(TmuxKey::Named(format!("{prefix}{name}")));
+
+    match key.code {
+        KeyCode::Char(c) => {
+            if ctrl || alt {
+                let lower = c.to_ascii_lowercase().to_string();
+                LiveDispatch::Send(TmuxKey::Named(format!("{prefix}{lower}")))
+            } else {
+                LiveDispatch::Send(TmuxKey::Literal(c.to_string()))
+            }
+        }
+        KeyCode::Up => named("Up"),
+        KeyCode::Down => named("Down"),
+        KeyCode::Left => named("Left"),
+        KeyCode::Right => named("Right"),
+        KeyCode::Enter => named("Enter"),
+        KeyCode::Esc => named("Escape"),
+        KeyCode::Tab => named("Tab"),
+        KeyCode::BackTab => named("BTab"),
+        KeyCode::Backspace => named("BSpace"),
+        KeyCode::Delete => named("DC"),
+        KeyCode::Insert => named("IC"),
+        KeyCode::Home => named("Home"),
+        KeyCode::End => named("End"),
+        KeyCode::PageUp => named("PPage"),
+        KeyCode::PageDown => named("NPage"),
+        KeyCode::F(n) => named(&format!("F{n}")),
+        _ => LiveDispatch::Ignore,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn k(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+    fn k_mod(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    fn assert_literal(d: LiveDispatch, expected: &str) {
+        match d {
+            LiveDispatch::Send(TmuxKey::Literal(s)) => assert_eq!(s, expected),
+            other => panic!("expected Literal({expected}), got {other:?}"),
+        }
+    }
+    fn assert_named(d: LiveDispatch, expected: &str) {
+        match d {
+            LiveDispatch::Send(TmuxKey::Named(s)) => assert_eq!(s, expected),
+            other => panic!("expected Named({expected}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ctrl_q_exits() {
+        assert_eq!(
+            translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
+            LiveDispatch::Exit
+        );
+    }
+
+    #[test]
+    fn ctrl_shift_q_does_not_exit() {
+        // Only bare Ctrl+q exits. Shift held means the user actually
+        // wants to send a `C-q` chord through to the agent (e.g.,
+        // vim's quoted-insert), so this must fall through to a Named
+        // dispatch, not be eaten as an exit.
+        let d = translate(k_mod(
+            KeyCode::Char('Q'),
+            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+        ));
+        assert_ne!(d, LiveDispatch::Exit);
+        // Crossterm hands us `Char('Q')` here; the translator folds to
+        // lowercase before emitting the tmux name, so the agent
+        // receives `C-q` which is what they would press for vim.
+        assert_named(d, "C-q");
+    }
+
+    #[test]
+    fn plain_letters_go_literal_preserving_case() {
+        assert_literal(translate(k(KeyCode::Char('a'))), "a");
+        assert_literal(translate(k(KeyCode::Char('Z'))), "Z");
+        assert_literal(translate(k(KeyCode::Char('!'))), "!");
+        assert_literal(translate(k(KeyCode::Char(' '))), " ");
+    }
+
+    #[test]
+    fn ctrl_letter_folds_lowercase_to_named() {
+        assert_named(
+            translate(k_mod(KeyCode::Char('c'), KeyModifiers::CONTROL)),
+            "C-c",
+        );
+        assert_named(
+            translate(k_mod(KeyCode::Char('A'), KeyModifiers::CONTROL)),
+            "C-a",
+        );
+    }
+
+    #[test]
+    fn alt_letter_folds_to_named() {
+        assert_named(
+            translate(k_mod(KeyCode::Char('x'), KeyModifiers::ALT)),
+            "M-x",
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_combo() {
+        assert_named(
+            translate(k_mod(
+                KeyCode::Char('q'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT,
+            )),
+            "C-M-q",
+        );
+    }
+
+    #[test]
+    fn arrow_keys() {
+        assert_named(translate(k(KeyCode::Up)), "Up");
+        assert_named(translate(k(KeyCode::Down)), "Down");
+        assert_named(translate(k(KeyCode::Left)), "Left");
+        assert_named(translate(k(KeyCode::Right)), "Right");
+    }
+
+    #[test]
+    fn ctrl_arrow_chord() {
+        assert_named(translate(k_mod(KeyCode::Up, KeyModifiers::CONTROL)), "C-Up");
+    }
+
+    #[test]
+    fn navigation_named_keys() {
+        assert_named(translate(k(KeyCode::Esc)), "Escape");
+        assert_named(translate(k(KeyCode::Enter)), "Enter");
+        assert_named(translate(k(KeyCode::Tab)), "Tab");
+        assert_named(translate(k(KeyCode::BackTab)), "BTab");
+        assert_named(translate(k(KeyCode::Backspace)), "BSpace");
+        assert_named(translate(k(KeyCode::Delete)), "DC");
+        assert_named(translate(k(KeyCode::Insert)), "IC");
+        assert_named(translate(k(KeyCode::Home)), "Home");
+        assert_named(translate(k(KeyCode::End)), "End");
+        assert_named(translate(k(KeyCode::PageUp)), "PPage");
+        assert_named(translate(k(KeyCode::PageDown)), "NPage");
+    }
+
+    #[test]
+    fn function_keys() {
+        assert_named(translate(k(KeyCode::F(1))), "F1");
+        assert_named(translate(k(KeyCode::F(12))), "F12");
+        assert_named(
+            translate(k_mod(KeyCode::F(5), KeyModifiers::CONTROL)),
+            "C-F5",
+        );
+    }
+
+    fn snd_lit(s: &str) -> WorkerMsg {
+        WorkerMsg::Send(TmuxKey::Literal(s.into()))
+    }
+    fn snd_named(s: &str) -> WorkerMsg {
+        WorkerMsg::Send(TmuxKey::Named(s.into()))
+    }
+
+    #[test]
+    fn coalesce_empty_batch_is_empty() {
+        assert_eq!(coalesce(vec![]), vec![]);
+    }
+
+    #[test]
+    fn coalesce_single_literal_passes_through() {
+        assert_eq!(
+            coalesce(vec![snd_lit("a")]),
+            vec![TmuxAction::Literal("a".into())]
+        );
+    }
+
+    #[test]
+    fn coalesce_single_named_passes_through() {
+        assert_eq!(
+            coalesce(vec![snd_named("Escape")]),
+            vec![TmuxAction::Named("Escape".into())]
+        );
+    }
+
+    #[test]
+    fn coalesce_run_of_literals_merges_into_one_call() {
+        // The whole point of coalescing: typing "hello" should be a
+        // single tmux send-keys call, not five.
+        let out = coalesce(vec![
+            snd_lit("h"),
+            snd_lit("e"),
+            snd_lit("l"),
+            snd_lit("l"),
+            snd_lit("o"),
+        ]);
+        assert_eq!(out, vec![TmuxAction::Literal("hello".into())]);
+    }
+
+    #[test]
+    fn coalesce_named_breaks_the_run() {
+        // An Up arrow in the middle of typing must arrive in order,
+        // not after the surrounding text. Coalescing splits the run at
+        // the named key.
+        let out = coalesce(vec![
+            snd_lit("a"),
+            snd_lit("b"),
+            snd_named("Up"),
+            snd_lit("c"),
+            snd_lit("d"),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Literal("ab".into()),
+                TmuxAction::Named("Up".into()),
+                TmuxAction::Literal("cd".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_back_to_back_named_keys() {
+        // Two named keys in a row (e.g., Up Up) stay as two separate
+        // dispatches; tmux send-keys won't accept them as one literal.
+        let out = coalesce(vec![snd_named("Up"), snd_named("Up")]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Named("Up".into()),
+                TmuxAction::Named("Up".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_trailing_literal_is_flushed() {
+        // Regression guard for the obvious off-by-one: the final
+        // unflushed literal run must escape the loop.
+        let out = coalesce(vec![snd_named("Tab"), snd_lit("x"), snd_lit("y")]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Named("Tab".into()),
+                TmuxAction::Literal("xy".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_resize_breaks_literal_run() {
+        // A pane resize sandwiched between keystrokes must dispatch in
+        // order so the agent renders the trailing keys at the new
+        // geometry (relevant for any agent using cursor-position
+        // escapes or column-aware wrapping).
+        let out = coalesce(vec![
+            snd_lit("a"),
+            snd_lit("b"),
+            WorkerMsg::Resize {
+                cols: 100,
+                rows: 40,
+            },
+            snd_lit("c"),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Literal("ab".into()),
+                TmuxAction::Resize {
+                    cols: 100,
+                    rows: 40
+                },
+                TmuxAction::Literal("c".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn unhandled_keys_are_ignored() {
+        assert_eq!(translate(k(KeyCode::Null)), LiveDispatch::Ignore);
+        assert_eq!(translate(k(KeyCode::CapsLock)), LiveDispatch::Ignore);
+    }
+
+    #[test]
+    fn plain_q_is_literal_not_exit() {
+        // Without Ctrl, `q` is just a letter the user wants to send.
+        assert_literal(translate(k(KeyCode::Char('q'))), "q");
+        assert_literal(translate(k(KeyCode::Char('Q'))), "Q");
+    }
+
+    #[test]
+    fn alt_q_is_named_not_exit() {
+        // Only Ctrl+Q exits. Alt+Q is a normal modifier chord.
+        assert_named(
+            translate(k_mod(KeyCode::Char('q'), KeyModifiers::ALT)),
+            "M-q",
+        );
+    }
+}

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -203,55 +203,79 @@ pub(super) enum TmuxKey {
 /// - Ctrl/Alt + a char folds the char to lowercase and emits a tmux name
 ///   like `C-a`, `M-x`, `C-M-x`. Lowercase because tmux's chord names
 ///   are case-insensitive for letters and `C-a` is the conventional form.
-/// - All other keys (arrows, function keys, etc.) emit their tmux name
-///   with whatever prefixes apply.
+///   Shift is omitted here too (case already encodes it for letters).
+/// - Named keys (arrows, F-keys, etc.) include `S-` when Shift is held
+///   so editors inside the pane see `S-Up` for shift-arrow text
+///   selection. `BackTab` is the lone exception: the keycode already
+///   means Shift+Tab, so we emit `BTab` rather than `S-BTab`.
 pub fn translate(key: KeyEvent) -> LiveDispatch {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
+    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
     // Bare Ctrl+q only. Holding Shift or Alt converts the chord to a
     // send-through (Ctrl+Shift+q, Ctrl+Alt+q) so the user can still
     // deliver those combinations to the agent.
-    let shift = key.modifiers.contains(KeyModifiers::SHIFT);
     if ctrl && !shift && !alt && matches!(key.code, KeyCode::Char('q')) {
         return LiveDispatch::Exit;
     }
 
-    let prefix = match (ctrl, alt) {
-        (true, true) => "C-M-",
-        (true, false) => "C-",
-        (false, true) => "M-",
-        (false, false) => "",
-    };
-    let named = |name: &str| LiveDispatch::Send(TmuxKey::Named(format!("{prefix}{name}")));
-
-    match key.code {
-        KeyCode::Char(c) => {
-            if ctrl || alt {
-                let lower = c.to_ascii_lowercase().to_string();
-                LiveDispatch::Send(TmuxKey::Named(format!("{prefix}{lower}")))
-            } else {
-                LiveDispatch::Send(TmuxKey::Literal(c.to_string()))
-            }
+    // Char path: tmux chord names are case-insensitive for letters and
+    // the case in `Char(c)` already carries Shift, so we drop `S-` here
+    // to avoid double-encoding.
+    if let KeyCode::Char(c) = key.code {
+        if ctrl || alt {
+            let p = mod_prefix(ctrl, alt, false);
+            return LiveDispatch::Send(TmuxKey::Named(format!("{p}{}", c.to_ascii_lowercase())));
         }
-        KeyCode::Up => named("Up"),
-        KeyCode::Down => named("Down"),
-        KeyCode::Left => named("Left"),
-        KeyCode::Right => named("Right"),
-        KeyCode::Enter => named("Enter"),
-        KeyCode::Esc => named("Escape"),
-        KeyCode::Tab => named("Tab"),
-        KeyCode::BackTab => named("BTab"),
-        KeyCode::Backspace => named("BSpace"),
-        KeyCode::Delete => named("DC"),
-        KeyCode::Insert => named("IC"),
-        KeyCode::Home => named("Home"),
-        KeyCode::End => named("End"),
-        KeyCode::PageUp => named("PPage"),
-        KeyCode::PageDown => named("NPage"),
-        KeyCode::F(n) => named(&format!("F{n}")),
-        _ => LiveDispatch::Ignore,
+        return LiveDispatch::Send(TmuxKey::Literal(c.to_string()));
     }
+
+    // Named-key path: Shift IS meaningful (S-Up vs Up for editor text
+    // selection). BackTab is shift+Tab semantically by its own keycode,
+    // so it gets the no-shift prefix.
+    let name = match key.code {
+        KeyCode::Up => "Up",
+        KeyCode::Down => "Down",
+        KeyCode::Left => "Left",
+        KeyCode::Right => "Right",
+        KeyCode::Enter => "Enter",
+        KeyCode::Esc => "Escape",
+        KeyCode::Tab => "Tab",
+        KeyCode::BackTab => {
+            let p = mod_prefix(ctrl, alt, false);
+            return LiveDispatch::Send(TmuxKey::Named(format!("{p}BTab")));
+        }
+        KeyCode::Backspace => "BSpace",
+        KeyCode::Delete => "DC",
+        KeyCode::Insert => "IC",
+        KeyCode::Home => "Home",
+        KeyCode::End => "End",
+        KeyCode::PageUp => "PPage",
+        KeyCode::PageDown => "NPage",
+        KeyCode::F(n) => {
+            let p = mod_prefix(ctrl, alt, shift);
+            return LiveDispatch::Send(TmuxKey::Named(format!("{p}F{n}")));
+        }
+        _ => return LiveDispatch::Ignore,
+    };
+    let p = mod_prefix(ctrl, alt, shift);
+    LiveDispatch::Send(TmuxKey::Named(format!("{p}{name}")))
+}
+
+/// Build a tmux chord prefix (e.g. `"C-S-"`, `"M-"`, `""`).
+fn mod_prefix(ctrl: bool, alt: bool, shift: bool) -> String {
+    let mut p = String::new();
+    if ctrl {
+        p.push_str("C-");
+    }
+    if alt {
+        p.push_str("M-");
+    }
+    if shift {
+        p.push_str("S-");
+    }
+    p
 }
 
 #[cfg(test)]
@@ -353,6 +377,53 @@ mod tests {
     #[test]
     fn ctrl_arrow_chord() {
         assert_named(translate(k_mod(KeyCode::Up, KeyModifiers::CONTROL)), "C-Up");
+    }
+
+    #[test]
+    fn shift_arrow_chord_uses_s_prefix() {
+        // Editors inside the pane rely on `S-Up` / `S-Down` etc. for
+        // text selection. Without the S- prefix Shift+arrow looks the
+        // same as plain arrow and the editor never sees the modifier.
+        assert_named(translate(k_mod(KeyCode::Up, KeyModifiers::SHIFT)), "S-Up");
+        assert_named(
+            translate(k_mod(KeyCode::Home, KeyModifiers::SHIFT)),
+            "S-Home",
+        );
+        assert_named(translate(k_mod(KeyCode::End, KeyModifiers::SHIFT)), "S-End");
+    }
+
+    #[test]
+    fn ctrl_shift_arrow_combines_prefixes() {
+        // Shift+Ctrl+Right is "extend selection by word" in many editors.
+        assert_named(
+            translate(k_mod(
+                KeyCode::Right,
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            )),
+            "C-S-Right",
+        );
+    }
+
+    #[test]
+    fn shift_letter_stays_literal_uppercase() {
+        // The Char path drops Shift from the prefix because the case
+        // already carries it. Pressing Shift+A sends literal "A", not
+        // "S-a" or "S-A".
+        assert_literal(
+            translate(k_mod(KeyCode::Char('A'), KeyModifiers::SHIFT)),
+            "A",
+        );
+    }
+
+    #[test]
+    fn back_tab_stays_btab_even_with_shift_modifier() {
+        // BackTab IS Shift+Tab by keycode. Some terminals also set the
+        // SHIFT modifier on top; we must NOT emit "S-BTab" (tmux would
+        // reject it) just because both signals arrived.
+        assert_named(
+            translate(k_mod(KeyCode::BackTab, KeyModifiers::SHIFT)),
+            "BTab",
+        );
     }
 
     #[test]

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -24,6 +24,15 @@
 //!   laggy over Docker / mosh on slow links. Bracketed paste shortcuts the
 //!   per-char cost by routing the whole chunk through `send_literal_no_enter`
 //!   in a single call.
+//!
+//! Reserved (non-forwarded) chords:
+//! - `Ctrl+]` — exit live mode (see above).
+//! - `Shift+PageUp` / `Shift+PageDown` — scroll the preview pane back
+//!   through agent history without exiting. Matches the terminal-
+//!   emulator convention. Bare `PageUp` / `PageDown` still passes
+//!   through, so agents that page their own UI keep working.
+//! - Mouse wheel over the preview pane — also scrolls the preview,
+//!   handled by `handle_scroll_up` / `handle_scroll_down`.
 
 use std::sync::mpsc::{channel, Sender};
 

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -5,14 +5,16 @@
 //! module's translator. Each translation produces a `tmux send-keys` call
 //! against the target pane: plain characters go literally, every other
 //! key (arrows, Esc, Tab, modifier combos) goes by tmux key name with
-//! `C-` / `M-` prefixes. The user exits with `Ctrl+q`.
+//! `C-` / `M-` prefixes. The user exits with one of the configured
+//! exit chords (default: `Ctrl+q` or `Ctrl+]`).
 //!
-//! Exit chord trade-off: `Ctrl+q` is memorable ("Q for quit"), is
-//! reachable on mobile keyboards (Termius and similar SSH clients
-//! don't always pass `Ctrl+]` through), and is what we shipped to
-//! users first. The cost is that vim/emacs `C-q` quoted-insert
-//! can't be sent through live mode; anyone needing that flow should
-//! use the compose dialog or attach directly with `a`.
+//! Exit chord configuration: the user picks a comma-separated list
+//! of chord specs (`C-q`, `Ctrl+]`, `M-x`, `F12`, …) via settings.
+//! Default includes both `C-q` (mobile/Termius friendly) and `C-]`
+//! (telnet convention). Whichever chord fires first ends live mode.
+//! The cost of binding a chord is that it can't be sent through to
+//! the agent; users who need a particular chord to reach the agent
+//! configure the others.
 //!
 //! Trade-offs vs. a compose dialog:
 //! - No echo, no inline editing, no review step. The preview pane is the
@@ -24,7 +26,7 @@
 //!   in a single call.
 //!
 //! Reserved (non-forwarded) chords:
-//! - `Ctrl+q` — exit live mode (see above).
+//! - The configured exit chord list — exits live mode (see above).
 //! - `Shift+PageUp` / `Shift+PageDown` — scroll the preview pane back
 //!   through agent history without exiting. Matches the terminal-
 //!   emulator convention. Bare `PageUp` / `PageDown` still passes
@@ -35,6 +37,203 @@
 use std::sync::mpsc::{channel, Sender};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+/// Default exit chord set when the user hasn't configured one. Both
+/// `Ctrl+q` (works in mobile / restrictive SSH clients like Termius)
+/// and `Ctrl+]` (telnet convention; preserves `C-q` for vim quoted-
+/// insert when it does pass through) fire exit. Users can override
+/// to whatever single chord they prefer (or any other comma-separated
+/// list) via settings.
+pub(super) const DEFAULT_EXIT_CHORD: &str = "C-q,C-]";
+
+/// Parse a tmux-style chord spec into a `(KeyCode, KeyModifiers)`
+/// pair. Accepts `C-` / `Ctrl-`, `M-` / `Alt-`, `S-` / `Shift-`
+/// prefixes (any order, separated by `-` or `+`) followed by a key
+/// name. Key names: single ASCII chars (`q`, `]`, `1`), or one of the
+/// tmux-named keys (`Escape`, `Tab`, `BTab`, `Up`, `Down`, `Left`,
+/// `Right`, `Enter`, `BSpace` / `Backspace`, `DC` / `Delete`, `IC` /
+/// `Insert`, `Home`, `End`, `PPage` / `PageUp`, `NPage` / `PageDown`,
+/// `Space`, `F1`..`F12`).
+///
+/// Returns `None` on parse failure so the caller can fall back to the
+/// default chord and warn the user. Chord case is normalized: char
+/// keys lowercase under any modifier so `C-q` and `C-Q` parse to the
+/// same canonical form.
+pub(super) fn parse_chord(spec: &str) -> Option<(KeyCode, KeyModifiers)> {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Split on `-` or `+`; both are common in user-facing key specs.
+    let parts: Vec<&str> = trimmed.split(['-', '+']).collect();
+    if parts.is_empty() {
+        return None;
+    }
+    let mut modifiers = KeyModifiers::NONE;
+    for piece in &parts[..parts.len().saturating_sub(1)] {
+        match piece.to_ascii_lowercase().as_str() {
+            "c" | "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+            "m" | "alt" | "meta" => modifiers |= KeyModifiers::ALT,
+            "s" | "shift" => modifiers |= KeyModifiers::SHIFT,
+            _ => return None,
+        }
+    }
+    let key = *parts.last()?;
+    let code = parse_key_name(key, modifiers.contains(KeyModifiers::CONTROL))?;
+    Some((code, modifiers))
+}
+
+fn parse_key_name(name: &str, has_ctrl: bool) -> Option<KeyCode> {
+    if name.is_empty() {
+        return None;
+    }
+    // Function keys: "F1".."F12".
+    if let Some(rest) = name.strip_prefix(['F', 'f']) {
+        if let Ok(n) = rest.parse::<u8>() {
+            if (1..=24).contains(&n) {
+                return Some(KeyCode::F(n));
+            }
+        }
+    }
+    let lower = name.to_ascii_lowercase();
+    let code = match lower.as_str() {
+        "escape" | "esc" => KeyCode::Esc,
+        "tab" => KeyCode::Tab,
+        "btab" | "backtab" => KeyCode::BackTab,
+        "enter" | "return" => KeyCode::Enter,
+        "bspace" | "backspace" => KeyCode::Backspace,
+        "dc" | "delete" | "del" => KeyCode::Delete,
+        "ic" | "insert" | "ins" => KeyCode::Insert,
+        "home" => KeyCode::Home,
+        "end" => KeyCode::End,
+        "ppage" | "pageup" | "pgup" => KeyCode::PageUp,
+        "npage" | "pagedown" | "pgdn" => KeyCode::PageDown,
+        "up" => KeyCode::Up,
+        "down" => KeyCode::Down,
+        "left" => KeyCode::Left,
+        "right" => KeyCode::Right,
+        "space" => KeyCode::Char(' '),
+        _ => {
+            // Single-char key: drop case sensitivity when a modifier
+            // is held (tmux conventionally treats Ctrl+a and Ctrl+A
+            // as the same chord). Without modifiers, preserve case so
+            // a config of "Q" really means uppercase Q.
+            let mut chars = name.chars();
+            let first = chars.next()?;
+            if chars.next().is_some() {
+                return None;
+            }
+            if has_ctrl {
+                return Some(KeyCode::Char(first.to_ascii_lowercase()));
+            }
+            return Some(KeyCode::Char(first));
+        }
+    };
+    Some(code)
+}
+
+/// True when `event` is the configured exit chord. Char codes
+/// normalize under Ctrl (matches the canonical form `parse_chord`
+/// produces). Strict modifier match otherwise: a chord configured as
+/// `C-q` does not fire on `Ctrl+Shift+q` so the user can still
+/// deliver `C-q` to the agent via Shift.
+pub(super) fn chord_matches(spec: (KeyCode, KeyModifiers), event: KeyEvent) -> bool {
+    let mut event_code = event.code;
+    if event.modifiers.contains(KeyModifiers::CONTROL) {
+        if let KeyCode::Char(c) = event_code {
+            event_code = KeyCode::Char(c.to_ascii_lowercase());
+        }
+    }
+    spec.0 == event_code && spec.1 == event.modifiers
+}
+
+/// Parse a comma-separated list of chord specs (e.g. "C-q,C-]")
+/// into the list of `(code, modifiers)` pairs the exit check
+/// compares against. Invalid pieces are dropped with a warning so a
+/// typo in one entry doesn't disable the whole list; an entirely
+/// unparseable string falls back to the default chord set so the
+/// user is never trapped in live mode without a working exit.
+pub(super) fn parse_chord_list(spec: &str) -> Vec<(KeyCode, KeyModifiers)> {
+    let mut out = Vec::new();
+    for piece in spec.split(',') {
+        let trimmed = piece.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match parse_chord(trimmed) {
+            Some(chord) => out.push(chord),
+            None => tracing::warn!(
+                "live-send: ignoring unparseable exit chord '{}' in '{}'",
+                trimmed,
+                spec
+            ),
+        }
+    }
+    if out.is_empty() && spec != DEFAULT_EXIT_CHORD {
+        tracing::warn!(
+            "live-send: exit chord '{}' parsed to nothing; falling back to default '{}'",
+            spec,
+            DEFAULT_EXIT_CHORD
+        );
+        return parse_chord_list(DEFAULT_EXIT_CHORD);
+    }
+    out
+}
+
+/// True when `event` matches any chord in the configured list.
+pub(super) fn chord_list_matches(chords: &[(KeyCode, KeyModifiers)], event: KeyEvent) -> bool {
+    chords.iter().any(|c| chord_matches(*c, event))
+}
+
+/// Render the configured chord list as a banner-friendly string,
+/// e.g. `"Ctrl+Q / Ctrl+]"`. Used for the status-bar live banner so
+/// the user sees every chord they can press to exit.
+pub(super) fn display_chord_list(chords: &[(KeyCode, KeyModifiers)]) -> String {
+    chords
+        .iter()
+        .map(|c| display_chord(*c))
+        .collect::<Vec<_>>()
+        .join(" / ")
+}
+
+/// Render a parsed chord back as a human-readable string for the
+/// banner: e.g. `(KeyCode::Char('q'), CONTROL)` → "Ctrl+Q". Uses
+/// uppercase for letters so the banner reads like the rest of the
+/// chord hints in the TUI (Ctrl+T, Ctrl+K, etc.).
+pub(super) fn display_chord(spec: (KeyCode, KeyModifiers)) -> String {
+    let (code, mods) = spec;
+    let mut out = String::new();
+    if mods.contains(KeyModifiers::CONTROL) {
+        out.push_str("Ctrl+");
+    }
+    if mods.contains(KeyModifiers::ALT) {
+        out.push_str("Alt+");
+    }
+    if mods.contains(KeyModifiers::SHIFT) {
+        out.push_str("Shift+");
+    }
+    match code {
+        KeyCode::Char(c) => out.push(c.to_ascii_uppercase()),
+        KeyCode::Esc => out.push_str("Esc"),
+        KeyCode::Tab => out.push_str("Tab"),
+        KeyCode::BackTab => out.push_str("Shift+Tab"),
+        KeyCode::Enter => out.push_str("Enter"),
+        KeyCode::Backspace => out.push_str("Backspace"),
+        KeyCode::Delete => out.push_str("Delete"),
+        KeyCode::Insert => out.push_str("Insert"),
+        KeyCode::Home => out.push_str("Home"),
+        KeyCode::End => out.push_str("End"),
+        KeyCode::PageUp => out.push_str("PageUp"),
+        KeyCode::PageDown => out.push_str("PageDown"),
+        KeyCode::Up => out.push_str("Up"),
+        KeyCode::Down => out.push_str("Down"),
+        KeyCode::Left => out.push_str("Left"),
+        KeyCode::Right => out.push_str("Right"),
+        KeyCode::F(n) => out.push_str(&format!("F{n}")),
+        _ => out.push('?'),
+    }
+    out
+}
 
 /// Lives on `HomeView::live_send` while the mode is active. Carries
 /// just enough state for the banner to render, for the exit handler
@@ -53,6 +252,10 @@ pub(in crate::tui) struct LiveSendState {
     pub session_id: String,
     pub title: String,
     pub tmux_name: String,
+    /// Chord list parsed from the user's configured exit-chord
+    /// setting at entry time. Captured per-entry so config edits
+    /// don't change behavior mid-session.
+    pub exit_chords: Vec<(KeyCode, KeyModifiers)>,
 }
 
 /// One coalesced unit of work the worker hands to tmux. `Literal` runs
@@ -181,10 +384,12 @@ fn dispatch_batch(session: &crate::tmux::Session, batch: Vec<WorkerMsg>) {
 }
 
 /// What the translator says to do with one incoming key event.
+///
+/// Note: the exit-chord check lives in `handle_live_send_key` (it
+/// consults the user's configured chord list, which translate has no
+/// access to). translate is purely the key-to-tmux mapping.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum LiveDispatch {
-    /// User pressed the exit chord; the caller should clear `live_send`.
-    Exit,
     /// Forward the keystroke to tmux in the requested form.
     Send(TmuxKey),
     /// Key has no meaningful tmux mapping (Null, CapsLock, media keys, …).
@@ -202,10 +407,11 @@ pub(super) enum TmuxKey {
 
 /// Map one crossterm `KeyEvent` onto a `LiveDispatch`.
 ///
+/// Exit-chord detection is NOT done here. `handle_live_send_key`
+/// checks the user's configured chord list before calling translate,
+/// so this function is pure key→tmux mapping.
+///
 /// Conventions:
-/// - `Ctrl+q` (lowercase, bare) is Exit. Holding Shift or Alt
-///   converts the chord to a passthrough (Ctrl+Shift+q, Ctrl+Alt+q)
-///   so the user can still deliver those combinations to the agent.
 /// - Plain printable chars (`KeyCode::Char` with no Ctrl/Alt) go literal
 ///   so the user's case and punctuation are preserved verbatim. The shift
 ///   modifier is implicit in the char itself, so we don't add `S-`.
@@ -221,13 +427,6 @@ pub fn translate(key: KeyEvent) -> LiveDispatch {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
-
-    // Bare Ctrl+q only. Holding Shift or Alt converts the chord to a
-    // passthrough so the user can still deliver Ctrl+Shift+q (a.k.a.
-    // `C-q` to most agents) or Ctrl+Alt+q to the agent.
-    if ctrl && !shift && !alt && matches!(key.code, KeyCode::Char('q')) {
-        return LiveDispatch::Exit;
-    }
 
     // Char path: tmux chord names are case-insensitive for letters and
     // the case in `Char(c)` already carries Shift, so we drop `S-` here
@@ -311,36 +510,160 @@ mod tests {
         }
     }
 
+    // Exit-chord detection moved out of translate() into
+    // handle_live_send_key. Translate now never emits Exit; the
+    // chord-list tests below cover the configurable exit path.
+
     #[test]
-    fn ctrl_q_exits() {
-        assert_eq!(
+    fn translate_never_emits_exit_for_ctrl_q() {
+        // translate is pure key→tmux. Ctrl+q now passes through; the
+        // exit decision belongs to the chord-list matcher.
+        assert_named(
             translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
-            LiveDispatch::Exit
+            "C-q",
         );
     }
 
     #[test]
-    fn ctrl_shift_q_does_not_exit() {
-        // Only bare Ctrl+q exits. Shift held means the user actually
-        // wants to send `C-q` through to the agent (vim quoted-insert,
-        // readline start-output), so this must fall through to a Named
-        // dispatch instead of being eaten as an exit.
-        let d = translate(k_mod(
-            KeyCode::Char('Q'),
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
-        ));
-        assert_ne!(d, LiveDispatch::Exit);
-        assert_named(d, "C-q");
+    fn parse_chord_basics() {
+        assert_eq!(
+            parse_chord("C-q"),
+            Some((KeyCode::Char('q'), KeyModifiers::CONTROL))
+        );
+        // Uppercase letter folds to lowercase under Ctrl (tmux
+        // convention: C-a and C-A are the same chord).
+        assert_eq!(
+            parse_chord("C-Q"),
+            Some((KeyCode::Char('q'), KeyModifiers::CONTROL))
+        );
+        // Punctuation as the key.
+        assert_eq!(
+            parse_chord("C-]"),
+            Some((KeyCode::Char(']'), KeyModifiers::CONTROL))
+        );
+        // Long modifier names.
+        assert_eq!(
+            parse_chord("Ctrl+Alt+x"),
+            Some((
+                KeyCode::Char('x'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT
+            ))
+        );
+        // Named keys.
+        assert_eq!(
+            parse_chord("F12"),
+            Some((KeyCode::F(12), KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_chord("S-Up"),
+            Some((KeyCode::Up, KeyModifiers::SHIFT))
+        );
+        assert_eq!(
+            parse_chord("Escape"),
+            Some((KeyCode::Esc, KeyModifiers::NONE))
+        );
+        assert_eq!(
+            parse_chord("PageUp"),
+            Some((KeyCode::PageUp, KeyModifiers::NONE))
+        );
     }
 
     #[test]
-    fn ctrl_alt_q_does_not_exit() {
-        let d = translate(k_mod(
-            KeyCode::Char('q'),
-            KeyModifiers::CONTROL | KeyModifiers::ALT,
+    fn parse_chord_rejects_garbage() {
+        assert_eq!(parse_chord(""), None);
+        assert_eq!(parse_chord("X-q"), None); // unknown modifier
+        assert_eq!(parse_chord("C-qq"), None); // multi-char key without F-prefix
+        assert_eq!(parse_chord("C-"), None); // missing key
+    }
+
+    #[test]
+    fn chord_matches_handles_ctrl_case_folding() {
+        let spec = parse_chord("C-q").unwrap();
+        // Crossterm may deliver Ctrl+Q as either Char('q') or
+        // Char('Q')+SHIFT depending on terminal; the match should
+        // recognize the lowercase form but NOT the shift form
+        // (shift means the user wants to send Ctrl+Shift+q to the
+        // agent, not exit).
+        assert!(chord_matches(
+            spec,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)
         ));
-        assert_ne!(d, LiveDispatch::Exit);
-        assert_named(d, "C-M-q");
+        assert!(!chord_matches(
+            spec,
+            KeyEvent::new(
+                KeyCode::Char('Q'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )
+        ));
+        assert!(!chord_matches(
+            spec,
+            KeyEvent::new(
+                KeyCode::Char('q'),
+                KeyModifiers::CONTROL | KeyModifiers::ALT
+            )
+        ));
+    }
+
+    #[test]
+    fn parse_chord_list_filters_invalid_pieces() {
+        let chords = parse_chord_list("C-q, garbage, C-]");
+        assert_eq!(
+            chords,
+            vec![
+                (KeyCode::Char('q'), KeyModifiers::CONTROL),
+                (KeyCode::Char(']'), KeyModifiers::CONTROL),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_chord_list_falls_back_to_default_on_all_invalid() {
+        // Misconfigured chord lists shouldn't trap the user in live
+        // mode with no exit; we drop back to the default set.
+        let chords = parse_chord_list("not-a-chord, also-bad");
+        let defaults = parse_chord_list(DEFAULT_EXIT_CHORD);
+        assert_eq!(chords, defaults);
+        assert!(!chords.is_empty());
+    }
+
+    #[test]
+    fn default_chord_set_includes_both_ctrl_q_and_ctrl_right_bracket() {
+        let chords = parse_chord_list(DEFAULT_EXIT_CHORD);
+        assert!(chords.contains(&(KeyCode::Char('q'), KeyModifiers::CONTROL)));
+        assert!(chords.contains(&(KeyCode::Char(']'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn chord_list_matches_any() {
+        let chords = parse_chord_list("C-q, C-]");
+        assert!(chord_list_matches(
+            &chords,
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL)
+        ));
+        assert!(chord_list_matches(
+            &chords,
+            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL)
+        ));
+        assert!(!chord_list_matches(
+            &chords,
+            KeyEvent::new(KeyCode::Char('x'), KeyModifiers::CONTROL)
+        ));
+    }
+
+    #[test]
+    fn display_chord_list_joins_with_slash() {
+        let chords = parse_chord_list("C-q, C-]");
+        assert_eq!(display_chord_list(&chords), "Ctrl+Q / Ctrl+]");
+    }
+
+    #[test]
+    fn display_chord_single() {
+        let chord = parse_chord("C-]").unwrap();
+        assert_eq!(display_chord(chord), "Ctrl+]");
+        let chord = parse_chord("F12").unwrap();
+        assert_eq!(display_chord(chord), "F12");
+        let chord = parse_chord("Ctrl+Alt+Shift+x").unwrap();
+        assert_eq!(display_chord(chord), "Ctrl+Alt+Shift+X");
     }
 
     #[test]
@@ -596,18 +919,9 @@ mod tests {
     #[test]
     fn plain_q_is_literal_not_exit() {
         // Without Ctrl, `q` is just a letter the user wants to send.
+        // translate doesn't decide exit any more, but this still
+        // verifies the passthrough.
         assert_literal(translate(k(KeyCode::Char('q'))), "q");
         assert_literal(translate(k(KeyCode::Char('Q'))), "Q");
-    }
-
-    #[test]
-    fn ctrl_right_bracket_is_now_a_passthrough() {
-        // Ctrl+] used to be the exit chord but it doesn't pass through
-        // some SSH clients (Termius is the reported case). Now it
-        // forwards to the agent like any other modifier chord.
-        assert_named(
-            translate(k_mod(KeyCode::Char(']'), KeyModifiers::CONTROL)),
-            "C-]",
-        );
     }
 }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -26,13 +26,23 @@ use std::sync::mpsc::{channel, Sender};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-/// Lives on `HomeView::live_send` while the mode is active. Carries just
-/// enough state for the banner to render and for the exit handler to
-/// confirm the right pane was targeted.
+/// Lives on `HomeView::live_send` while the mode is active. Carries
+/// just enough state for the banner to render, for the exit handler
+/// to confirm the right pane was targeted, and for the per-keystroke
+/// liveness check to detect that the session has been deleted or
+/// renamed out from under us (the stored `tmux_name` is the entry-time
+/// value; if the instance's current `generate_name(id, title)` diverges
+/// we auto-exit rather than silently sending into the void).
+// Visibility note: `pub(in crate::tui)` rather than `pub(super)` so the
+// scope matches HomeView's field (whose `pub(super)` resolves to
+// `pub(in crate::tui)` from mod.rs). Anything tighter triggers
+// `private_interfaces`; anything looser leaks the type to the rest of
+// the crate.
 #[derive(Debug, Clone)]
-pub struct LiveSendState {
+pub(in crate::tui) struct LiveSendState {
     pub session_id: String,
     pub title: String,
+    pub tmux_name: String,
 }
 
 /// One coalesced unit of work the worker hands to tmux. `Literal` runs
@@ -42,7 +52,7 @@ pub struct LiveSendState {
 /// keystrokes makes the agent render those keystrokes at the new
 /// geometry).
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TmuxAction {
+pub(super) enum TmuxAction {
     Literal(String),
     Named(String),
     Resize { cols: u16, rows: u16 },
@@ -54,7 +64,7 @@ pub enum TmuxAction {
 /// `tmux send-keys` call); a `Send(Named)` or `Resize` flushes the
 /// current literal run and goes out on its own. Pure function so tests
 /// can verify ordering without spawning a worker thread.
-pub fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
+pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
     let mut out: Vec<TmuxAction> = Vec::new();
     let mut run = String::new();
     let flush = |out: &mut Vec<TmuxAction>, run: &mut String| {
@@ -84,7 +94,7 @@ pub fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
 /// burst of keystrokes that brackets a resize must arrive on either
 /// side of the geometry change, not be reordered after it.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum WorkerMsg {
+pub(super) enum WorkerMsg {
     Send(TmuxKey),
     Resize { cols: u16, rows: u16 },
 }
@@ -98,12 +108,12 @@ pub enum WorkerMsg {
 /// `join` because the worker is idempotent and harmless if it survives
 /// a brief moment past the UI thread that owned it (e.g., the user
 /// toggles live mode rapidly).
-pub struct LiveSendWorker {
+pub(in crate::tui) struct LiveSendWorker {
     tx: Sender<WorkerMsg>,
 }
 
 impl LiveSendWorker {
-    pub fn spawn(session_name: String) -> Self {
+    pub(super) fn spawn(session_name: String) -> Self {
         let (tx, rx) = channel::<WorkerMsg>();
         std::thread::spawn(move || {
             let session = crate::tmux::Session::from_name(&session_name);
@@ -126,7 +136,7 @@ impl LiveSendWorker {
     /// Enqueue a translated key for dispatch. Returns immediately; the
     /// fork+exec for `tmux send-keys` happens on the worker thread, so
     /// the UI never blocks on tmux latency.
-    pub fn send(&self, key: TmuxKey) {
+    pub(super) fn send(&self, key: TmuxKey) {
         // Channel send only fails if the worker thread panicked. Drop
         // silently rather than spam logs: the user's next exit attempt
         // (Ctrl+q) will clear the dead worker and we'll spawn a fresh
@@ -138,7 +148,7 @@ impl LiveSendWorker {
     /// with surrounding keystrokes so that keys typed before the
     /// resize arrive in the old size and keys after arrive in the new
     /// size (matters when an agent uses cursor-position escapes).
-    pub fn resize(&self, cols: u16, rows: u16) {
+    pub(super) fn resize(&self, cols: u16, rows: u16) {
         let _ = self.tx.send(WorkerMsg::Resize { cols, rows });
     }
 }
@@ -162,7 +172,7 @@ fn dispatch_batch(session: &crate::tmux::Session, batch: Vec<WorkerMsg>) {
 
 /// What the translator says to do with one incoming key event.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum LiveDispatch {
+pub(super) enum LiveDispatch {
     /// User pressed the exit chord; the caller should clear `live_send`.
     Exit,
     /// Forward the keystroke to tmux in the requested form.
@@ -175,7 +185,7 @@ pub enum LiveDispatch {
 /// How the translator wants the keystroke delivered. `Literal` payloads
 /// go through `tmux send-keys -l --`, named keys through `tmux send-keys`.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TmuxKey {
+pub(super) enum TmuxKey {
     Literal(String),
     Named(String),
 }

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -5,12 +5,15 @@
 //! module's translator. Each translation produces a `tmux send-keys` call
 //! against the target pane: plain characters go literally, every other
 //! key (arrows, Esc, Tab, modifier combos) goes by tmux key name with
-//! `C-` / `M-` prefixes. The user exits with `Ctrl+Q`.
+//! `C-` / `M-` prefixes. The user exits with `Ctrl+]`.
 //!
-//! Exit chord trade-off: `Ctrl+Q` is memorable ("Q for quit") and works
-//! over Mosh/SSH where Alt combos and Ctrl+] often don't. The cost is
-//! that vim/emacs `C-q` quoted-insert can't be sent through live mode;
-//! anyone needing that flow should use the compose dialog or attach
+//! Exit chord trade-off: `Ctrl+]` is telnet's classic "escape from
+//! captured session" chord. Power users recognize it from telnet /
+//! screen muscle memory, terminal emulators and Mosh pass it through
+//! reliably, and almost no agent binds it (so users don't lose a
+//! commonly-typed chord to the exit mechanism). The cost is that
+//! `C-]` literally can't be sent through live mode; if a user needs
+//! `C-]` in vim/emacs they should use the compose dialog or attach
 //! directly with `a`.
 //!
 //! Trade-offs vs. a compose dialog:
@@ -139,7 +142,7 @@ impl LiveSendWorker {
     pub(super) fn send(&self, key: TmuxKey) {
         // Channel send only fails if the worker thread panicked. Drop
         // silently rather than spam logs: the user's next exit attempt
-        // (Ctrl+q) will clear the dead worker and we'll spawn a fresh
+        // (Ctrl+]) will clear the dead worker and we'll spawn a fresh
         // one on the next live-send entry.
         let _ = self.tx.send(WorkerMsg::Send(key));
     }
@@ -193,10 +196,10 @@ pub(super) enum TmuxKey {
 /// Map one crossterm `KeyEvent` onto a `LiveDispatch`.
 ///
 /// Conventions:
-/// - `Ctrl+q` (lowercase only) is Exit. Shift is not accepted: if the
-///   user holds shift the chord becomes `C-q` (often `C-Q` from some
-///   terminals), and that falls through to the named-key path so the
-///   user can still send Ctrl+Shift+q to the agent if they want.
+/// - `Ctrl+]` is Exit (telnet's classic escape). Alt is rejected so
+///   `Ctrl+Alt+]` still passes through to the agent as `C-M-]` for
+///   any user who wants it; the bare Ctrl+] chord is the one
+///   sacrifice the live-send mode makes.
 /// - Plain printable chars (`KeyCode::Char` with no Ctrl/Alt) go literal
 ///   so the user's case and punctuation are preserved verbatim. The shift
 ///   modifier is implicit in the char itself, so we don't add `S-`.
@@ -213,10 +216,12 @@ pub fn translate(key: KeyEvent) -> LiveDispatch {
     let alt = key.modifiers.contains(KeyModifiers::ALT);
     let shift = key.modifiers.contains(KeyModifiers::SHIFT);
 
-    // Bare Ctrl+q only. Holding Shift or Alt converts the chord to a
-    // send-through (Ctrl+Shift+q, Ctrl+Alt+q) so the user can still
-    // deliver those combinations to the agent.
-    if ctrl && !shift && !alt && matches!(key.code, KeyCode::Char('q')) {
+    // Bare Ctrl+] only. Alt held converts the chord to a send-through
+    // (Ctrl+Alt+]) so the user can still deliver C-M-] to the agent.
+    // Shift is ignored here: `]` is symbolic, so terminals don't
+    // consistently set the SHIFT modifier for Ctrl+] and we don't want
+    // the chord to silently stop working depending on the terminal.
+    if ctrl && !alt && matches!(key.code, KeyCode::Char(']')) {
         return LiveDispatch::Exit;
     }
 
@@ -303,28 +308,37 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_q_exits() {
+    fn ctrl_right_bracket_exits() {
         assert_eq!(
-            translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
+            translate(k_mod(KeyCode::Char(']'), KeyModifiers::CONTROL)),
             LiveDispatch::Exit
         );
     }
 
     #[test]
-    fn ctrl_shift_q_does_not_exit() {
-        // Only bare Ctrl+q exits. Shift held means the user actually
-        // wants to send a `C-q` chord through to the agent (e.g.,
-        // vim's quoted-insert), so this must fall through to a Named
-        // dispatch, not be eaten as an exit.
+    fn ctrl_right_bracket_with_shift_still_exits() {
+        // Some terminals deliver Ctrl+] with SHIFT also set (or strip
+        // it, depending on the keymap). `]` is symbolic so we accept
+        // either; the user's intent is unambiguous.
+        assert_eq!(
+            translate(k_mod(
+                KeyCode::Char(']'),
+                KeyModifiers::CONTROL | KeyModifiers::SHIFT
+            )),
+            LiveDispatch::Exit
+        );
+    }
+
+    #[test]
+    fn ctrl_alt_right_bracket_does_not_exit() {
+        // Adding Alt converts the chord to a passthrough so the user
+        // can still send C-M-] to the agent if they need to.
         let d = translate(k_mod(
-            KeyCode::Char('Q'),
-            KeyModifiers::CONTROL | KeyModifiers::SHIFT,
+            KeyCode::Char(']'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
         ));
         assert_ne!(d, LiveDispatch::Exit);
-        // Crossterm hands us `Char('Q')` here; the translator folds to
-        // lowercase before emitting the tmux name, so the agent
-        // receives `C-q` which is what they would press for vim.
-        assert_named(d, "C-q");
+        assert_named(d, "C-M-]");
     }
 
     #[test]
@@ -578,18 +592,21 @@ mod tests {
     }
 
     #[test]
-    fn plain_q_is_literal_not_exit() {
-        // Without Ctrl, `q` is just a letter the user wants to send.
-        assert_literal(translate(k(KeyCode::Char('q'))), "q");
-        assert_literal(translate(k(KeyCode::Char('Q'))), "Q");
+    fn plain_right_bracket_is_literal_not_exit() {
+        // Without Ctrl, `]` is just a punctuation character the user
+        // wants to send (markdown links, array indexing, etc.).
+        assert_literal(translate(k(KeyCode::Char(']'))), "]");
     }
 
     #[test]
-    fn alt_q_is_named_not_exit() {
-        // Only Ctrl+Q exits. Alt+Q is a normal modifier chord.
+    fn ctrl_q_is_now_a_passthrough() {
+        // The exit chord moved from Ctrl+q to Ctrl+]; that means
+        // Ctrl+q should now pass through to the agent (vim's
+        // quoted-insert / readline's start-output) instead of being
+        // intercepted.
         assert_named(
-            translate(k_mod(KeyCode::Char('q'), KeyModifiers::ALT)),
-            "M-q",
+            translate(k_mod(KeyCode::Char('q'), KeyModifiers::CONTROL)),
+            "C-q",
         );
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2208,7 +2208,17 @@ impl HomeView {
         };
         let inst = match self.get_instance(session_id) {
             Some(inst) => inst.clone(),
-            None => return Err(()),
+            None => {
+                // Defensive: ensure_pane_ready succeeded but the
+                // instance is gone (deleted by a peer process between
+                // those two calls). Without a dialog the user would
+                // press Tab and see nothing happen, with no clue why.
+                self.info_dialog = Some(InfoDialog::new(
+                    "Live send failed",
+                    "Session disappeared before live mode could start.",
+                ));
+                return Err(());
+            }
         };
         // Resolve the tmux session name up front so the worker thread
         // can reconstruct a Session without re-touching HomeView. If we

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -8,7 +8,9 @@ mod render;
 #[cfg(test)]
 mod tests;
 
-pub use live_send::LiveSendState;
+// LiveSendState is intentionally NOT re-exported: it's an internal
+// detail of the home module. Tests that need to install it directly
+// go through the `super::live_send::LiveSendState` path.
 
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -238,7 +240,7 @@ pub struct HomeView {
     /// until the user presses the exit chord (Ctrl+q). Set by `Tab` (in
     /// both modes) and by the palette entry; cleared by the exit chord
     /// inside the live handler.
-    pub(super) live_send: Option<LiveSendState>,
+    pub(super) live_send: Option<live_send::LiveSendState>,
     /// Background dispatcher created alongside `live_send`. Owns the
     /// tmux Session and a worker thread that drains a channel of
     /// translated keystrokes, coalescing runs of literals into single
@@ -2234,13 +2236,13 @@ impl HomeView {
                 return Err(());
             }
         };
-        self.live_send = Some(LiveSendState {
+        let tmux_name = tmux_session.name().to_string();
+        self.live_send = Some(live_send::LiveSendState {
             session_id: inst.id.clone(),
             title: inst.title.clone(),
+            tmux_name: tmux_name.clone(),
         });
-        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(
-            tmux_session.name().to_string(),
-        ));
+        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name));
         // Force the preview-refresh path to issue a resize on the
         // first draw inside live mode (it dedups against
         // live_send_last_resize), so the agent's render matches the

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -237,7 +237,7 @@ pub struct HomeView {
     pub(super) pending_send_session: Option<String>,
     /// Live-send mode: when `Some`, every key event in the home view is
     /// translated to a tmux send-keys call against this session's pane
-    /// until the user presses the exit chord (Ctrl+]). Set by `Tab` (in
+    /// until the user presses the exit chord (Ctrl+q). Set by `Tab` (in
     /// both modes) and by the palette entry; cleared by the exit chord
     /// inside the live handler.
     pub(super) live_send: Option<live_send::LiveSendState>,

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1,11 +1,14 @@
 //! Home view - main session list and navigation
 
 mod input;
+mod live_send;
 mod operations;
 mod render;
 
 #[cfg(test)]
 mod tests;
+
+pub use live_send::LiveSendState;
 
 use std::collections::{HashMap, HashSet};
 use std::time::Instant;
@@ -230,6 +233,23 @@ pub struct HomeView {
     pub(super) send_message_dialog: Option<super::dialogs::SendMessageDialog>,
     /// Session to receive the message from the send dialog
     pub(super) pending_send_session: Option<String>,
+    /// Live-send mode: when `Some`, every key event in the home view is
+    /// translated to a tmux send-keys call against this session's pane
+    /// until the user presses the exit chord (Ctrl+q). Set by `Tab` (in
+    /// both modes) and by the palette entry; cleared by the exit chord
+    /// inside the live handler.
+    pub(super) live_send: Option<LiveSendState>,
+    /// Background dispatcher created alongside `live_send`. Owns the
+    /// tmux Session and a worker thread that drains a channel of
+    /// translated keystrokes, coalescing runs of literals into single
+    /// `tmux send-keys` calls so the UI thread never blocks on fork
+    /// latency. Dropping (set to None when live mode exits) closes the
+    /// channel and the worker thread exits cleanly on its own.
+    pub(super) live_send_worker: Option<live_send::LiveSendWorker>,
+    /// Last (cols, rows) we asked the worker to resize the pane to in
+    /// the current live-send session. Used to dedup the resize messages
+    /// fired from the preview refresh path; cleared on live-send exit.
+    pub(super) live_send_last_resize: Option<(u16, u16)>,
     /// Pasted text captured at the home view that we couldn't immediately
     /// route (no session selected, cursor on a group header, etc.). Drained
     /// into the next compose dialog the user opens, so voice/dictation never
@@ -513,6 +533,9 @@ impl HomeView {
             update_confirm_dialog: None,
             send_message_dialog: None,
             pending_send_session: None,
+            live_send: None,
+            live_send_worker: None,
+            live_send_last_resize: None,
             pending_paste: None,
             pending_attach_after_warning: None,
             pending_stop_session: None,
@@ -1789,7 +1812,8 @@ impl HomeView {
         #[cfg(not(feature = "serve"))]
         let serve_open = false;
 
-        self.show_help
+        self.live_send.is_some()
+            || self.show_help
             || self.search_active
             || self.new_dialog.is_some()
             || self.confirm_dialog.is_some()
@@ -1835,7 +1859,12 @@ impl HomeView {
         if !self.has_dialog() {
             return true;
         }
-        self.rename_dialog.is_some()
+        // Live-send mode is also paste-aware: handle_paste forwards the
+        // chunk straight to the pane via send_literal_no_enter, which is
+        // strictly faster and safer than letting the chars fan out as
+        // individual KeyEvents and stream per-char tmux calls.
+        self.live_send.is_some()
+            || self.rename_dialog.is_some()
             || self.send_message_dialog.is_some()
             || self.new_dialog.is_some()
             || self.settings_view.is_some()
@@ -2145,6 +2174,71 @@ impl HomeView {
             self.selected_session = None;
         }
         stale_sid
+    }
+
+    /// Stage live-send mode against `session_id`. Mirrors
+    /// `execute_send_message`'s revive cascade so a cold-start (Docker
+    /// pull, agent splash) is handled before the user starts typing,
+    /// then installs `live_send` state so subsequent keystrokes are
+    /// captured by `handle_live_send_key`.
+    ///
+    /// Returns `Ok(Some(stale_sid))` when the resume-fallback cascade
+    /// fired during respawn, `Ok(None)` on a clean ready, and `Err(())`
+    /// if the pane could not be readied (`info_dialog` is set with the
+    /// underlying error so the caller only has to clear its toast).
+    pub fn enter_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
+        let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
+            inst.ensure_pane_ready().map_err(Into::into)
+        });
+        let stale_sid = match outcome {
+            Ok(Some(EnsureReadyOutcome::Respawned {
+                stale_sid: Some(sid),
+            }))
+            | Ok(Some(EnsureReadyOutcome::Started {
+                stale_sid: Some(sid),
+            })) => Some(sid),
+            Ok(_) => None,
+            Err(err) => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Live send failed",
+                    &format!("Cannot prepare session: {}", err),
+                ));
+                return Err(());
+            }
+        };
+        let inst = match self.get_instance(session_id) {
+            Some(inst) => inst.clone(),
+            None => return Err(()),
+        };
+        // Resolve the tmux session name up front so the worker thread
+        // can reconstruct a Session without re-touching HomeView. If we
+        // can't even build the Session here, surface the error before
+        // installing live state.
+        let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
+            Ok(s) => s,
+            Err(e) => {
+                self.info_dialog = Some(InfoDialog::new(
+                    "Live send failed",
+                    &format!("Cannot resolve tmux session: {}", e),
+                ));
+                return Err(());
+            }
+        };
+        self.live_send = Some(LiveSendState {
+            session_id: inst.id.clone(),
+            title: inst.title.clone(),
+        });
+        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(
+            tmux_session.name().to_string(),
+        ));
+        // Force the preview-refresh path to issue a resize on the
+        // first draw inside live mode (it dedups against
+        // live_send_last_resize), so the agent's render matches the
+        // preview pane's actual dimensions instead of whatever the
+        // session was last sized to.
+        self.live_send_last_resize = None;
+        self.stamp_last_accessed(session_id);
+        Ok(stale_sid)
     }
 
     pub fn save(&mut self) -> anyhow::Result<()> {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2237,10 +2237,20 @@ impl HomeView {
             }
         };
         let tmux_name = tmux_session.name().to_string();
+        // Parse the configured exit-chord list now so the per-keystroke
+        // dispatch path doesn't re-parse on every event. Config edits
+        // during live mode aren't possible (settings_view participates
+        // in has_dialog and lives in its own takeover), so a snapshot
+        // at entry time is sufficient.
+        let exit_chord_spec = resolve_config_or_warn(&self.config_profile())
+            .session
+            .live_send_exit_chord;
+        let exit_chords = live_send::parse_chord_list(&exit_chord_spec);
         self.live_send = Some(live_send::LiveSendState {
             session_id: inst.id.clone(),
             title: inst.title.clone(),
             tmux_name: tmux_name.clone(),
+            exit_chords,
         });
         self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name));
         // Force the preview-refresh path to issue a resize on the

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -237,7 +237,7 @@ pub struct HomeView {
     pub(super) pending_send_session: Option<String>,
     /// Live-send mode: when `Some`, every key event in the home view is
     /// translated to a tmux send-keys call against this session's pane
-    /// until the user presses the exit chord (Ctrl+q). Set by `Tab` (in
+    /// until the user presses the exit chord (Ctrl+]). Set by `Tab` (in
     /// both modes) and by the palette entry; cleared by the exit chord
     /// inside the live handler.
     pub(super) live_send: Option<live_send::LiveSendState>,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -426,7 +426,7 @@ impl HomeView {
 
         // Layout: optional live-send header at top + main area + status bar
         // + optional update bar at bottom. The live-send header makes the
-        // exit chord (Ctrl+Q) unmissable from the top of the screen;
+        // exit chord (Ctrl+]) unmissable from the top of the screen;
         // mirroring it in the status bar covers the bottom-of-screen gaze.
         // The update bar surfaces both persistent update-available banners
         // (update_info) and transient toasts (update_status); we need a row
@@ -1755,7 +1755,7 @@ impl HomeView {
     /// gaze direction.
     ///
     /// On narrow terminals the title is truncated with an ellipsis so
-    /// the `Ctrl+Q` hint stays visible. The fixed parts (chip prefix +
+    /// the `Ctrl+]` hint stays visible. The fixed parts (chip prefix +
     /// exit chord + suffix) are reserved first; whatever's left goes to
     /// the title.
     fn render_live_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -1769,7 +1769,7 @@ impl HomeView {
         };
 
         let chip = " \u{25CF} LIVE SEND \u{2192} ";
-        let chord = "Ctrl+Q";
+        let chord = "Ctrl+]";
         let suffix = " to exit live mode ";
         let separator = "  "; // between title and chord
 
@@ -1826,7 +1826,7 @@ impl HomeView {
                 state.title.as_str()
             };
             let chip = " \u{25CF} LIVE \u{2192} ";
-            let chord = "Ctrl+Q";
+            let chord = "Ctrl+]";
             let suffix = " to exit ";
             // Spaces between chip→title and title→chord. Title gets the
             // budget after the fixed pieces; reserved last so the exit

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -8,8 +8,8 @@ use std::time::{Duration, Instant};
 use rattles::presets::prelude as spinners;
 
 use super::{
-    get_indent, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING, ICON_ERROR,
-    ICON_EXPANDED, ICON_IDLE, ICON_STOPPED, ICON_UNKNOWN,
+    get_indent, live_send, HomeView, TerminalMode, ViewMode, ICON_COLLAPSED, ICON_DELETING,
+    ICON_ERROR, ICON_EXPANDED, ICON_IDLE, ICON_STOPPED, ICON_UNKNOWN,
 };
 use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
@@ -424,51 +424,34 @@ impl HomeView {
             return;
         }
 
-        // Layout: optional live-send header at top + main area + status bar
-        // + optional update bar at bottom. The live-send header makes the
-        // exit chord (Ctrl+q) unmissable from the top of the screen;
-        // mirroring it in the status bar covers the bottom-of-screen gaze.
+        // Layout: main area + status bar + optional update bar at bottom.
         // The update bar surfaces both persistent update-available banners
         // (update_info) and transient toasts (update_status); we need a row
         // for it whenever either is present, otherwise toasts fired without
         // a pending update would never reach the screen.
         let has_update_bar = update_info.is_some() || update_status.is_some();
-        let has_live_header = self.live_send.is_some();
-        let mut constraints: Vec<Constraint> = Vec::with_capacity(4);
-        if has_live_header {
-            constraints.push(Constraint::Length(1));
-        }
-        constraints.push(Constraint::Min(0));
-        constraints.push(Constraint::Length(1));
-        if has_update_bar {
-            constraints.push(Constraint::Length(1));
-        }
+        let constraints = if has_update_bar {
+            vec![
+                Constraint::Min(0),
+                Constraint::Length(1),
+                Constraint::Length(1),
+            ]
+        } else {
+            vec![Constraint::Min(0), Constraint::Length(1)]
+        };
         let main_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(constraints)
             .split(area);
-        // Slice indices shift when the live header is present. Resolve
-        // them once so the rest of this function reads naturally.
-        let header_idx = if has_live_header { Some(0) } else { None };
-        let body_idx = if has_live_header { 1 } else { 0 };
-        let status_idx = body_idx + 1;
-        let update_idx = if has_update_bar {
-            Some(status_idx + 1)
-        } else {
-            None
-        };
-        if let Some(idx) = header_idx {
-            self.render_live_header(frame, main_chunks[idx], theme);
-        }
 
         // Below STACKED_BREAKPOINT (80 cols), put the list above the preview
         // instead of side-by-side. At 80 cols a side-by-side preview is only
         // ~45 cols (with default list_width 35), too cramped for output;
         // stacking gives the preview the full width.
-        let available_width = main_chunks[body_idx].width;
+        let available_width = main_chunks[0].width;
         self.main_area_width = available_width;
         if available_width < responsive::STACKED_BREAKPOINT {
-            let main_height = main_chunks[body_idx].height;
+            let main_height = main_chunks[0].height;
             let list_height = responsive::stacked_list_height(main_height);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -476,7 +459,7 @@ impl HomeView {
                     Constraint::Length(list_height),
                     Constraint::Min(responsive::STACKED_PREVIEW_MIN),
                 ])
-                .split(main_chunks[body_idx]);
+                .split(main_chunks[0]);
 
             // Stacked layout has no vertical divider; only the side-by-side
             // path exposes the resize-by-drag affordance.
@@ -497,7 +480,7 @@ impl HomeView {
                     Constraint::Length(effective_list_width),
                     Constraint::Min(responsive::PREVIEW_MIN_WIDTH),
                 ])
-                .split(main_chunks[body_idx]);
+                .split(main_chunks[0]);
 
             // Layout chunks are contiguous, so chunks[1].x is the first
             // column of the preview block, i.e. the visible left border
@@ -508,10 +491,10 @@ impl HomeView {
             self.render_list(frame, chunks[0], theme);
             self.render_preview(frame, chunks[1], theme);
         }
-        self.render_status_bar(frame, main_chunks[status_idx], theme);
+        self.render_status_bar(frame, main_chunks[1], theme);
 
-        if let Some(idx) = update_idx {
-            self.render_update_bar(frame, main_chunks[idx], theme, update_info, update_status);
+        if has_update_bar {
+            self.render_update_bar(frame, main_chunks[2], theme, update_info, update_status);
         }
 
         // Render dialogs on top
@@ -1748,93 +1731,14 @@ impl HomeView {
         }
     }
 
-    /// Top-of-screen live-send banner. Painted as a reversed-color chip
-    /// that fills the row width so it reads as a mode indicator rather
-    /// than floating chrome. The status bar gets a more compact mirror
-    /// of the same content so the exit chord is visible from either
-    /// gaze direction.
-    ///
-    /// On narrow terminals the title is truncated with an ellipsis so
-    /// the `Ctrl+Q` hint stays visible. The fixed parts (chip prefix +
-    /// exit chord + suffix) are reserved first; whatever's left goes to
-    /// the title.
-    fn render_live_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let Some(state) = &self.live_send else {
-            return;
-        };
-        let raw_title = if state.title.is_empty() {
-            "session"
-        } else {
-            state.title.as_str()
-        };
-
-        let chip = " \u{25CF} LIVE SEND \u{2192} ";
-        let chord = "Ctrl+Q";
-        let suffix = " to exit live mode ";
-        let separator = "  "; // between title and the trailing block
-
-        // Surface the same scroll indicator the preview pane shows
-        // (top-right of the preview block), but here at the very top
-        // of the screen so the user always knows how far back into
-        // history they're looking. None while live-following.
-        let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(3);
-        let scroll = format_scroll_indicator(
-            self.preview_cache.captured_lines,
-            visible_height,
-            self.preview_scroll_offset,
-        )
-        .unwrap_or_default();
-
-        let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
-            + unicode_width::UnicodeWidthStr::width(separator)
-            + unicode_width::UnicodeWidthStr::width(scroll.as_str())
-            + unicode_width::UnicodeWidthStr::width(chord)
-            + unicode_width::UnicodeWidthStr::width(suffix);
-        let title_budget = (area.width as usize).saturating_sub(fixed_width);
-        let title = truncate_to_width(raw_title, title_budget);
-
-        let chip_style = Style::default()
-            .fg(theme.background)
-            .bg(theme.running)
-            .bold();
-        let body_style = Style::default().fg(theme.background).bg(theme.running);
-        let chord_style = Style::default()
-            .fg(theme.background)
-            .bg(theme.running)
-            .bold();
-
-        let mut spans: Vec<Span<'static>> = vec![
-            Span::styled(chip, chip_style),
-            Span::styled(title, body_style),
-            Span::styled(separator, body_style),
-        ];
-        if !scroll.is_empty() {
-            spans.push(Span::styled(scroll, body_style));
-        }
-        spans.push(Span::styled(chord, chord_style));
-        spans.push(Span::styled(suffix, body_style));
-        // Pad the remainder of the row with the same bg color so the
-        // banner reads as a continuous strip rather than a floating chip.
-        let used: usize = spans
-            .iter()
-            .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()))
-            .sum();
-        let pad = (area.width as usize).saturating_sub(used);
-        if pad > 0 {
-            spans.push(Span::styled(
-                " ".repeat(pad),
-                Style::default().bg(theme.running),
-            ));
-        }
-        frame.render_widget(Paragraph::new(Line::from(spans)), area);
-    }
-
     fn render_status_bar(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         // Live-send banner takes over the status bar so the user has an
-        // always-visible reminder that keystrokes are being relayed to the
-        // pane (and how to get out). Distinct color + bold so it can't be
-        // confused with the regular footer. The render_live_header
-        // counterpart paints the top of the screen with the same intent.
+        // always-visible reminder that keystrokes are being relayed to
+        // the pane (and how to get out). Distinct color + bold so it
+        // can't be confused with the regular footer. The scroll
+        // indicator (only present when the user has scrolled back from
+        // the live edge) sits between the title and the exit chord
+        // hint so it gets noticed when there's something to notice.
         if let Some(state) = &self.live_send {
             let raw_title = if state.title.is_empty() {
                 "session"
@@ -1842,19 +1746,42 @@ impl HomeView {
                 state.title.as_str()
             };
             let chip = " \u{25CF} LIVE \u{2192} ";
-            let chord = "Ctrl+Q";
+            // The chord display is built from the user's configured
+            // exit-chord list so the hint always shows what actually
+            // exits live mode for this user. Empty list (impossible
+            // under normal config — parse_chord_list falls back to
+            // the default set) renders as "?" so the user notices
+            // something's wrong rather than thinking the mode is
+            // unescapable.
+            let chord = if state.exit_chords.is_empty() {
+                "?".to_string()
+            } else {
+                live_send::display_chord_list(&state.exit_chords)
+            };
             let suffix = " to exit ";
+            // Match the preview pane's visible_height calculation
+            // (`area.height - 2` for borders, then `- 1` for the
+            // compact branch in render_output_cached) so the indicator
+            // count stays consistent as the user scrolls.
+            let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(3);
+            let scroll = format_scroll_indicator(
+                self.preview_cache.captured_lines,
+                visible_height,
+                self.preview_scroll_offset,
+            )
+            .unwrap_or_default();
             // Spaces between chip→title and title→chord. Title gets the
             // budget after the fixed pieces; reserved last so the exit
             // chord never falls off on narrow terminals.
             let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
                 + 1 // single space after the chip
                 + 2 // double space before the chord
-                + unicode_width::UnicodeWidthStr::width(chord)
-                + unicode_width::UnicodeWidthStr::width(suffix);
+                + unicode_width::UnicodeWidthStr::width(chord.as_str())
+                + unicode_width::UnicodeWidthStr::width(suffix)
+                + unicode_width::UnicodeWidthStr::width(scroll.as_str());
             let title_budget = (area.width as usize).saturating_sub(fixed_width);
             let title = truncate_to_width(raw_title, title_budget);
-            let line = Line::from(vec![
+            let mut spans: Vec<Span<'static>> = vec![
                 Span::styled(
                     chip,
                     Style::default()
@@ -1864,11 +1791,20 @@ impl HomeView {
                 ),
                 Span::raw(" "),
                 Span::styled(title, Style::default().fg(theme.text).bold()),
-                Span::raw("  "),
-                Span::styled(chord, Style::default().fg(theme.accent).bold()),
-                Span::styled(suffix, Style::default().fg(theme.dimmed)),
-            ]);
-            frame.render_widget(Paragraph::new(line), area);
+            ];
+            if !scroll.is_empty() {
+                spans.push(Span::styled(
+                    scroll,
+                    Style::default().fg(theme.dimmed).italic(),
+                ));
+            }
+            spans.push(Span::raw("  "));
+            spans.push(Span::styled(
+                chord,
+                Style::default().fg(theme.accent).bold(),
+            ));
+            spans.push(Span::styled(suffix, Style::default().fg(theme.dimmed)));
+            frame.render_widget(Paragraph::new(Line::from(spans)), area);
             return;
         }
 

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -426,7 +426,7 @@ impl HomeView {
 
         // Layout: optional live-send header at top + main area + status bar
         // + optional update bar at bottom. The live-send header makes the
-        // exit chord (Ctrl+]) unmissable from the top of the screen;
+        // exit chord (Ctrl+q) unmissable from the top of the screen;
         // mirroring it in the status bar covers the bottom-of-screen gaze.
         // The update bar surfaces both persistent update-available banners
         // (update_info) and transient toasts (update_status); we need a row
@@ -1755,7 +1755,7 @@ impl HomeView {
     /// gaze direction.
     ///
     /// On narrow terminals the title is truncated with an ellipsis so
-    /// the `Ctrl+]` hint stays visible. The fixed parts (chip prefix +
+    /// the `Ctrl+Q` hint stays visible. The fixed parts (chip prefix +
     /// exit chord + suffix) are reserved first; whatever's left goes to
     /// the title.
     fn render_live_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -1769,12 +1769,25 @@ impl HomeView {
         };
 
         let chip = " \u{25CF} LIVE SEND \u{2192} ";
-        let chord = "Ctrl+]";
+        let chord = "Ctrl+Q";
         let suffix = " to exit live mode ";
-        let separator = "  "; // between title and chord
+        let separator = "  "; // between title and the trailing block
+
+        // Surface the same scroll indicator the preview pane shows
+        // (top-right of the preview block), but here at the very top
+        // of the screen so the user always knows how far back into
+        // history they're looking. None while live-following.
+        let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(3);
+        let scroll = format_scroll_indicator(
+            self.preview_cache.captured_lines,
+            visible_height,
+            self.preview_scroll_offset,
+        )
+        .unwrap_or_default();
 
         let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
             + unicode_width::UnicodeWidthStr::width(separator)
+            + unicode_width::UnicodeWidthStr::width(scroll.as_str())
             + unicode_width::UnicodeWidthStr::width(chord)
             + unicode_width::UnicodeWidthStr::width(suffix);
         let title_budget = (area.width as usize).saturating_sub(fixed_width);
@@ -1794,9 +1807,12 @@ impl HomeView {
             Span::styled(chip, chip_style),
             Span::styled(title, body_style),
             Span::styled(separator, body_style),
-            Span::styled(chord, chord_style),
-            Span::styled(suffix, body_style),
         ];
+        if !scroll.is_empty() {
+            spans.push(Span::styled(scroll, body_style));
+        }
+        spans.push(Span::styled(chord, chord_style));
+        spans.push(Span::styled(suffix, body_style));
         // Pad the remainder of the row with the same bg color so the
         // banner reads as a continuous strip rather than a floating chip.
         let used: usize = spans
@@ -1826,7 +1842,7 @@ impl HomeView {
                 state.title.as_str()
             };
             let chip = " \u{25CF} LIVE \u{2192} ";
-            let chord = "Ctrl+]";
+            let chord = "Ctrl+Q";
             let suffix = " to exit ";
             // Spaces between chip→title and title→chord. Title gets the
             // budget after the fixed pieces; reserved last so the exit

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -61,9 +61,6 @@ fn compose_list_title(
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
-/// Number of pane lines to capture for the preview, accounting for the user's
-/// scrollback offset. A small buffer is added so moderate scrolls don't force a
-/// fresh capture on every wheel tick.
 /// Trim `text` to fit within `max_width` display cells, appending '…'
 /// if anything was dropped. Used by the live-send banners so a long
 /// session title never pushes the exit-chord hint off-screen on a
@@ -93,6 +90,9 @@ fn truncate_to_width(text: &str, max_width: usize) -> String {
     out
 }
 
+/// Number of pane lines to capture for the preview, accounting for the user's
+/// scrollback offset. A small buffer is added so moderate scrolls don't force a
+/// fresh capture on every wheel tick.
 fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
     height
         .saturating_add(scroll_offset)

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -64,6 +64,35 @@ const CAPTURE_BUFFER: u16 = 20;
 /// Number of pane lines to capture for the preview, accounting for the user's
 /// scrollback offset. A small buffer is added so moderate scrolls don't force a
 /// fresh capture on every wheel tick.
+/// Trim `text` to fit within `max_width` display cells, appending '…'
+/// if anything was dropped. Used by the live-send banners so a long
+/// session title never pushes the exit-chord hint off-screen on a
+/// narrow terminal. Returns "" when max_width is 0 (the title gets
+/// sacrificed entirely so the fixed chord text wins).
+fn truncate_to_width(text: &str, max_width: usize) -> String {
+    use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+    if max_width == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(text) <= max_width {
+        return text.to_string();
+    }
+    // Reserve one cell for the ellipsis.
+    let budget = max_width.saturating_sub(1);
+    let mut out = String::new();
+    let mut w = 0;
+    for c in text.chars() {
+        let cw = UnicodeWidthChar::width(c).unwrap_or(0);
+        if w + cw > budget {
+            break;
+        }
+        out.push(c);
+        w += cw;
+    }
+    out.push('\u{2026}');
+    out
+}
+
 fn capture_lines_for(height: u16, scroll_offset: u16) -> usize {
     height
         .saturating_add(scroll_offset)
@@ -1724,29 +1753,49 @@ impl HomeView {
     /// than floating chrome. The status bar gets a more compact mirror
     /// of the same content so the exit chord is visible from either
     /// gaze direction.
+    ///
+    /// On narrow terminals the title is truncated with an ellipsis so
+    /// the `Ctrl+Q` hint stays visible. The fixed parts (chip prefix +
+    /// exit chord + suffix) are reserved first; whatever's left goes to
+    /// the title.
     fn render_live_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let Some(state) = &self.live_send else {
             return;
         };
-        let title = if state.title.is_empty() {
-            "session".to_string()
+        let raw_title = if state.title.is_empty() {
+            "session"
         } else {
-            state.title.clone()
+            state.title.as_str()
         };
+
+        let chip = " \u{25CF} LIVE SEND \u{2192} ";
+        let chord = "Ctrl+Q";
+        let suffix = " to exit live mode ";
+        let separator = "  "; // between title and chord
+
+        let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
+            + unicode_width::UnicodeWidthStr::width(separator)
+            + unicode_width::UnicodeWidthStr::width(chord)
+            + unicode_width::UnicodeWidthStr::width(suffix);
+        let title_budget = (area.width as usize).saturating_sub(fixed_width);
+        let title = truncate_to_width(raw_title, title_budget);
+
         let chip_style = Style::default()
             .fg(theme.background)
             .bg(theme.running)
             .bold();
-        let title_style = Style::default().fg(theme.background).bg(theme.running);
-        let exit_style = Style::default()
+        let body_style = Style::default().fg(theme.background).bg(theme.running);
+        let chord_style = Style::default()
             .fg(theme.background)
             .bg(theme.running)
             .bold();
+
         let mut spans: Vec<Span<'static>> = vec![
-            Span::styled(" \u{25CF} LIVE SEND \u{2192} ", chip_style),
-            Span::styled(format!("{}  ", title), title_style),
-            Span::styled("Ctrl+Q", exit_style),
-            Span::styled(" to exit live mode ", title_style),
+            Span::styled(chip, chip_style),
+            Span::styled(title, body_style),
+            Span::styled(separator, body_style),
+            Span::styled(chord, chord_style),
+            Span::styled(suffix, body_style),
         ];
         // Pad the remainder of the row with the same bg color so the
         // banner reads as a continuous strip rather than a floating chip.
@@ -1771,14 +1820,27 @@ impl HomeView {
         // confused with the regular footer. The render_live_header
         // counterpart paints the top of the screen with the same intent.
         if let Some(state) = &self.live_send {
-            let title = if state.title.is_empty() {
-                "session".to_string()
+            let raw_title = if state.title.is_empty() {
+                "session"
             } else {
-                state.title.clone()
+                state.title.as_str()
             };
+            let chip = " \u{25CF} LIVE \u{2192} ";
+            let chord = "Ctrl+Q";
+            let suffix = " to exit ";
+            // Spaces between chip→title and title→chord. Title gets the
+            // budget after the fixed pieces; reserved last so the exit
+            // chord never falls off on narrow terminals.
+            let fixed_width = unicode_width::UnicodeWidthStr::width(chip)
+                + 1 // single space after the chip
+                + 2 // double space before the chord
+                + unicode_width::UnicodeWidthStr::width(chord)
+                + unicode_width::UnicodeWidthStr::width(suffix);
+            let title_budget = (area.width as usize).saturating_sub(fixed_width);
+            let title = truncate_to_width(raw_title, title_budget);
             let line = Line::from(vec![
                 Span::styled(
-                    " \u{25CF} LIVE \u{2192} ",
+                    chip,
                     Style::default()
                         .fg(theme.background)
                         .bg(theme.running)
@@ -1787,8 +1849,8 @@ impl HomeView {
                 Span::raw(" "),
                 Span::styled(title, Style::default().fg(theme.text).bold()),
                 Span::raw("  "),
-                Span::styled("Ctrl+Q", Style::default().fg(theme.accent).bold()),
-                Span::styled(" to exit ", Style::default().fg(theme.dimmed)),
+                Span::styled(chord, Style::default().fg(theme.accent).bold()),
+                Span::styled(suffix, Style::default().fg(theme.dimmed)),
             ]);
             frame.render_widget(Paragraph::new(line), area);
             return;
@@ -1999,6 +2061,33 @@ impl HomeView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn truncate_to_width_passthrough_when_fits() {
+        assert_eq!(truncate_to_width("hello", 10), "hello");
+        assert_eq!(truncate_to_width("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_to_width_appends_ellipsis_when_overflow() {
+        // 5-char budget, 7-char input → 4 chars + ellipsis.
+        assert_eq!(truncate_to_width("abcdefg", 5), "abcd\u{2026}");
+    }
+
+    #[test]
+    fn truncate_to_width_zero_returns_empty() {
+        // Zero budget: title is sacrificed entirely so the fixed exit-
+        // chord text has space to render on very narrow terminals.
+        assert_eq!(truncate_to_width("anything", 0), "");
+    }
+
+    #[test]
+    fn truncate_to_width_respects_wide_chars() {
+        // East Asian wide char is 2 cells. Budget 3 should fit one wide
+        // char + ellipsis (2 + 1 = 3) — but we reserve 1 for ellipsis
+        // so budget for content is 2, fitting exactly one wide char.
+        assert_eq!(truncate_to_width("你好世界", 3), "你\u{2026}");
+    }
 
     #[test]
     fn compose_list_title_omits_profile_and_suffix_at_defaults() {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -395,34 +395,51 @@ impl HomeView {
             return;
         }
 
-        // Layout: main area + status bar + optional update bar at bottom.
+        // Layout: optional live-send header at top + main area + status bar
+        // + optional update bar at bottom. The live-send header makes the
+        // exit chord (Ctrl+Q) unmissable from the top of the screen;
+        // mirroring it in the status bar covers the bottom-of-screen gaze.
         // The update bar surfaces both persistent update-available banners
         // (update_info) and transient toasts (update_status); we need a row
         // for it whenever either is present, otherwise toasts fired without
         // a pending update would never reach the screen.
         let has_update_bar = update_info.is_some() || update_status.is_some();
-        let constraints = if has_update_bar {
-            vec![
-                Constraint::Min(0),
-                Constraint::Length(1),
-                Constraint::Length(1),
-            ]
-        } else {
-            vec![Constraint::Min(0), Constraint::Length(1)]
-        };
+        let has_live_header = self.live_send.is_some();
+        let mut constraints: Vec<Constraint> = Vec::with_capacity(4);
+        if has_live_header {
+            constraints.push(Constraint::Length(1));
+        }
+        constraints.push(Constraint::Min(0));
+        constraints.push(Constraint::Length(1));
+        if has_update_bar {
+            constraints.push(Constraint::Length(1));
+        }
         let main_chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints(constraints)
             .split(area);
+        // Slice indices shift when the live header is present. Resolve
+        // them once so the rest of this function reads naturally.
+        let header_idx = if has_live_header { Some(0) } else { None };
+        let body_idx = if has_live_header { 1 } else { 0 };
+        let status_idx = body_idx + 1;
+        let update_idx = if has_update_bar {
+            Some(status_idx + 1)
+        } else {
+            None
+        };
+        if let Some(idx) = header_idx {
+            self.render_live_header(frame, main_chunks[idx], theme);
+        }
 
         // Below STACKED_BREAKPOINT (80 cols), put the list above the preview
         // instead of side-by-side. At 80 cols a side-by-side preview is only
         // ~45 cols (with default list_width 35), too cramped for output;
         // stacking gives the preview the full width.
-        let available_width = main_chunks[0].width;
+        let available_width = main_chunks[body_idx].width;
         self.main_area_width = available_width;
         if available_width < responsive::STACKED_BREAKPOINT {
-            let main_height = main_chunks[0].height;
+            let main_height = main_chunks[body_idx].height;
             let list_height = responsive::stacked_list_height(main_height);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
@@ -430,7 +447,7 @@ impl HomeView {
                     Constraint::Length(list_height),
                     Constraint::Min(responsive::STACKED_PREVIEW_MIN),
                 ])
-                .split(main_chunks[0]);
+                .split(main_chunks[body_idx]);
 
             // Stacked layout has no vertical divider; only the side-by-side
             // path exposes the resize-by-drag affordance.
@@ -451,7 +468,7 @@ impl HomeView {
                     Constraint::Length(effective_list_width),
                     Constraint::Min(responsive::PREVIEW_MIN_WIDTH),
                 ])
-                .split(main_chunks[0]);
+                .split(main_chunks[body_idx]);
 
             // Layout chunks are contiguous, so chunks[1].x is the first
             // column of the preview block, i.e. the visible left border
@@ -462,10 +479,10 @@ impl HomeView {
             self.render_list(frame, chunks[0], theme);
             self.render_preview(frame, chunks[1], theme);
         }
-        self.render_status_bar(frame, main_chunks[1], theme);
+        self.render_status_bar(frame, main_chunks[status_idx], theme);
 
-        if has_update_bar {
-            self.render_update_bar(frame, main_chunks[2], theme, update_info, update_status);
+        if let Some(idx) = update_idx {
+            self.render_update_bar(frame, main_chunks[idx], theme, update_info, update_status);
         }
 
         // Render dialogs on top
@@ -1137,7 +1154,37 @@ impl HomeView {
 
     /// Refresh preview cache if needed (session changed, dimensions changed, or timer expired)
     fn refresh_preview_cache_if_needed(&mut self, width: u16, height: u16) {
-        const PREVIEW_REFRESH_MS: u128 = 250; // Refresh preview 4x/second max
+        // 250ms (4 Hz) is the steady-state cadence, enough to surface
+        // status changes without forking tmux on every loop tick. While
+        // the user is in live-send mode they're watching the preview
+        // for feedback on each keystroke, so drop to 50ms (20 Hz,
+        // matching the app loop's refresh_interval) so typed input
+        // shows up the next time the loop ticks rather than a beat
+        // later.
+        const PREVIEW_REFRESH_MS_IDLE: u128 = 250;
+        const PREVIEW_REFRESH_MS_LIVE: u128 = 50;
+        let in_live = self.live_send.is_some();
+        let refresh_ms = if in_live {
+            PREVIEW_REFRESH_MS_LIVE
+        } else {
+            PREVIEW_REFRESH_MS_IDLE
+        };
+
+        // While in live-send mode, keep the tmux pane geometry in sync
+        // with the preview's actual cell dimensions so the agent
+        // renders directly into the visible area (no wrap, no cropped
+        // UI). Deduped against live_send_last_resize so we only fire
+        // when the user first enters live mode or the preview pane is
+        // resized (terminal resize, divider drag, layout flip).
+        if in_live && width > 0 && height > 0 {
+            let next = (width, height);
+            if self.live_send_last_resize != Some(next) {
+                if let Some(worker) = &self.live_send_worker {
+                    worker.resize(width, height);
+                }
+                self.live_send_last_resize = Some(next);
+            }
+        }
 
         let scroll_offset = self.preview_scroll_offset;
         let session_changed = match &self.selected_session {
@@ -1145,8 +1192,7 @@ impl HomeView {
             None => false,
         };
         let dims_changed = self.preview_cache.dimensions != (width, height);
-        let timer_expired =
-            self.preview_cache.last_refresh.elapsed().as_millis() > PREVIEW_REFRESH_MS;
+        let timer_expired = self.preview_cache.last_refresh.elapsed().as_millis() > refresh_ms;
         // Only re-capture for scroll when the cached window can no longer
         // cover the requested offset. Wheel ticks inside the BUFFER headroom
         // re-render from the existing content without forking tmux.
@@ -1673,7 +1719,81 @@ impl HomeView {
         }
     }
 
+    /// Top-of-screen live-send banner. Painted as a reversed-color chip
+    /// that fills the row width so it reads as a mode indicator rather
+    /// than floating chrome. The status bar gets a more compact mirror
+    /// of the same content so the exit chord is visible from either
+    /// gaze direction.
+    fn render_live_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let Some(state) = &self.live_send else {
+            return;
+        };
+        let title = if state.title.is_empty() {
+            "session".to_string()
+        } else {
+            state.title.clone()
+        };
+        let chip_style = Style::default()
+            .fg(theme.background)
+            .bg(theme.running)
+            .bold();
+        let title_style = Style::default().fg(theme.background).bg(theme.running);
+        let exit_style = Style::default()
+            .fg(theme.background)
+            .bg(theme.running)
+            .bold();
+        let mut spans: Vec<Span<'static>> = vec![
+            Span::styled(" \u{25CF} LIVE SEND \u{2192} ", chip_style),
+            Span::styled(format!("{}  ", title), title_style),
+            Span::styled("Ctrl+Q", exit_style),
+            Span::styled(" to exit live mode ", title_style),
+        ];
+        // Pad the remainder of the row with the same bg color so the
+        // banner reads as a continuous strip rather than a floating chip.
+        let used: usize = spans
+            .iter()
+            .map(|s| unicode_width::UnicodeWidthStr::width(s.content.as_ref()))
+            .sum();
+        let pad = (area.width as usize).saturating_sub(used);
+        if pad > 0 {
+            spans.push(Span::styled(
+                " ".repeat(pad),
+                Style::default().bg(theme.running),
+            ));
+        }
+        frame.render_widget(Paragraph::new(Line::from(spans)), area);
+    }
+
     fn render_status_bar(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Live-send banner takes over the status bar so the user has an
+        // always-visible reminder that keystrokes are being relayed to the
+        // pane (and how to get out). Distinct color + bold so it can't be
+        // confused with the regular footer. The render_live_header
+        // counterpart paints the top of the screen with the same intent.
+        if let Some(state) = &self.live_send {
+            let title = if state.title.is_empty() {
+                "session".to_string()
+            } else {
+                state.title.clone()
+            };
+            let line = Line::from(vec![
+                Span::styled(
+                    " \u{25CF} LIVE \u{2192} ",
+                    Style::default()
+                        .fg(theme.background)
+                        .bg(theme.running)
+                        .bold(),
+                ),
+                Span::raw(" "),
+                Span::styled(title, Style::default().fg(theme.text).bold()),
+                Span::raw("  "),
+                Span::styled("Ctrl+Q", Style::default().fg(theme.accent).bold()),
+                Span::styled(" to exit ", Style::default().fg(theme.dimmed)),
+            ]);
+            frame.render_widget(Paragraph::new(line), area);
+            return;
+        }
+
         let key_style = Style::default().fg(theme.accent).bold();
         let desc_style = Style::default().fg(theme.dimmed);
         let sep_style = Style::default().fg(theme.border);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5230,25 +5230,54 @@ mod live_send_mode {
     //! Live-send wiring at the home view level. Translation correctness
     //! is covered by unit tests in src/tui/home/live_send.rs. Here we
     //! verify the integration points: keys are captured while live mode
-    //! is active, Ctrl+] clears the state, and the predicate plumbing
-    //! treats live mode like a modal capture so the rest of the TUI
-    //! suspends underneath it.
+    //! is active, Ctrl+q clears the state, the per-keystroke liveness
+    //! check auto-exits on drift, and the predicate plumbing treats
+    //! live mode like a modal capture so the rest of the TUI suspends
+    //! underneath it.
 
+    use super::super::live_send::LiveSendState;
     use super::*;
-    use crate::tui::home::LiveSendState;
 
-    fn install_live(env: &mut TestEnv) {
+    /// Seed live-send state pointing at the first instance in the test
+    /// env, with a matching tmux_name so the drift check passes. Tests
+    /// that want to trigger drift either install pointing at a missing
+    /// id or mutate the instance's title after installing.
+    fn install_live_for_first_session(env: &mut TestEnv) -> String {
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has no sessions; use install_live_orphan instead");
+        let inst = env.view.get_instance(&id).unwrap().clone();
+        let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
         env.view.live_send = Some(LiveSendState {
-            session_id: "fake-id".to_string(),
-            title: "fake-title".to_string(),
+            session_id: inst.id.clone(),
+            title: inst.title,
+            tmux_name,
+        });
+        id
+    }
+
+    /// Install live-send state pointing at a session id the env does
+    /// NOT contain — used to verify the drift check fires (auto-exit
+    /// + info dialog) when the underlying instance has vanished.
+    fn install_live_orphan(env: &mut TestEnv) {
+        env.view.live_send = Some(LiveSendState {
+            session_id: "missing-id".to_string(),
+            title: "missing-title".to_string(),
+            tmux_name: "missing-tmux".to_string(),
         });
     }
 
     #[test]
     #[serial]
     fn ctrl_q_exits_live_mode() {
-        let mut env = create_test_env_empty();
-        install_live(&mut env);
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
         assert!(env.view.live_send.is_some());
 
         env.view.handle_key(
@@ -5261,19 +5290,69 @@ mod live_send_mode {
 
     #[test]
     #[serial]
+    fn ctrl_q_exits_even_when_session_has_drifted() {
+        // Ctrl+q is the safety chord: it must always exit cleanly,
+        // even if the underlying session went away (so the user can
+        // recover from a stuck live mode without an extra dialog).
+        let mut env = create_test_env_empty();
+        install_live_orphan(&mut env);
+        env.view.handle_key(
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            None,
+        );
+        assert!(env.view.live_send.is_none());
+        assert!(env.view.info_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
     fn arbitrary_key_in_live_mode_does_not_emit_action() {
         // Live-send swallows the key (forwards it to tmux). The tmux
-        // call will quietly fail because the fake session does not
-        // exist, but the home view must NOT bubble an Action::* out
-        // (otherwise the action would race with the live state).
-        let mut env = create_test_env_empty();
-        install_live(&mut env);
+        // call will quietly fail because the test env doesn't have a
+        // real tmux pane, but the home view must NOT bubble an
+        // Action::* out (otherwise the action would race with the
+        // live state).
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
         let action = env
             .view
             .handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), None);
         assert!(action.is_none());
-        // Still in live mode; only Ctrl+] exits.
+        // Still in live mode; only Ctrl+q exits.
         assert!(env.view.live_send.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn drift_check_auto_exits_when_instance_missing() {
+        // If the session is deleted while live mode is active, the
+        // very next keystroke should auto-exit and surface an info
+        // dialog explaining why (so the user isn't typing into the
+        // void with no feedback).
+        let mut env = create_test_env_empty();
+        install_live_orphan(&mut env);
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
+        assert!(env.view.live_send.is_none());
+        assert!(env.view.info_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn drift_check_auto_exits_when_session_renamed() {
+        // Title changes the generated tmux name. After a rename the
+        // worker is targeting a stale name, so the next keystroke
+        // should auto-exit. Simulate the rename by mutating the
+        // instance title after installing live state.
+        let mut env = create_test_env_with_sessions(1);
+        let id = install_live_for_first_session(&mut env);
+        env.view.mutate_instance(&id, |inst| {
+            inst.title = "renamed-after-entry".to_string();
+        });
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
+        assert!(env.view.live_send.is_none());
+        assert!(env.view.info_dialog.is_some());
     }
 
     #[test]
@@ -5284,7 +5363,7 @@ mod live_send_mode {
         // mode for free via this single addition.
         let mut env = create_test_env_empty();
         assert!(!env.view.has_dialog());
-        install_live(&mut env);
+        install_live_orphan(&mut env);
         assert!(env.view.has_dialog());
     }
 
@@ -5296,7 +5375,7 @@ mod live_send_mode {
         // markers are missing (mosh, some SSH wrappers). Live mode wants
         // batching so a paste streams as one tmux call.
         let mut env = create_test_env_empty();
-        install_live(&mut env);
+        install_live_orphan(&mut env);
         assert!(env.view.wants_paste_burst());
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5226,6 +5226,96 @@ mod preview_click {
     }
 }
 
+mod live_send_mode {
+    //! Live-send wiring at the home view level. Translation correctness
+    //! is covered by unit tests in src/tui/home/live_send.rs. Here we
+    //! verify the integration points: keys are captured while live mode
+    //! is active, Ctrl+] clears the state, and the predicate plumbing
+    //! treats live mode like a modal capture so the rest of the TUI
+    //! suspends underneath it.
+
+    use super::*;
+    use crate::tui::home::LiveSendState;
+
+    fn install_live(env: &mut TestEnv) {
+        env.view.live_send = Some(LiveSendState {
+            session_id: "fake-id".to_string(),
+            title: "fake-title".to_string(),
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn ctrl_q_exits_live_mode() {
+        let mut env = create_test_env_empty();
+        install_live(&mut env);
+        assert!(env.view.live_send.is_some());
+
+        env.view.handle_key(
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            None,
+        );
+
+        assert!(env.view.live_send.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn arbitrary_key_in_live_mode_does_not_emit_action() {
+        // Live-send swallows the key (forwards it to tmux). The tmux
+        // call will quietly fail because the fake session does not
+        // exist, but the home view must NOT bubble an Action::* out
+        // (otherwise the action would race with the live state).
+        let mut env = create_test_env_empty();
+        install_live(&mut env);
+        let action = env
+            .view
+            .handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), None);
+        assert!(action.is_none());
+        // Still in live mode; only Ctrl+] exits.
+        assert!(env.view.live_send.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn live_mode_makes_has_dialog_true() {
+        // Every dialog-gating predicate that already inspects has_dialog()
+        // (mouse swallow, list nav suspend, palette skip) inherits live
+        // mode for free via this single addition.
+        let mut env = create_test_env_empty();
+        assert!(!env.view.has_dialog());
+        install_live(&mut env);
+        assert!(env.view.has_dialog());
+    }
+
+    #[test]
+    #[serial]
+    fn live_mode_enables_paste_burst() {
+        // wants_paste_burst is what tells the runtime to batch a stream
+        // of Char events into a single Paste event when bracketed-paste
+        // markers are missing (mosh, some SSH wrappers). Live mode wants
+        // batching so a paste streams as one tmux call.
+        let mut env = create_test_env_empty();
+        install_live(&mut env);
+        assert!(env.view.wants_paste_burst());
+    }
+
+    #[test]
+    #[serial]
+    fn tab_does_not_start_live_send_without_runnable_selection() {
+        // resolve_paste_target rejects empty list, group rows, and
+        // non-running sessions, so plain Tab must silently no-op rather
+        // than crashing or trapping the user in a live mode targeting
+        // nothing.
+        let mut env = create_test_env_empty();
+        let action = env
+            .view
+            .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
+        assert!(action.is_none());
+        assert!(env.view.live_send.is_none());
+    }
+}
+
 mod save_field_merge {
     use super::*;
     use chrono::Utc;

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5381,17 +5381,37 @@ mod live_send_mode {
 
     #[test]
     #[serial]
-    fn tab_does_not_start_live_send_without_runnable_selection() {
-        // resolve_paste_target rejects empty list, group rows, and
-        // non-running sessions, so plain Tab must silently no-op rather
-        // than crashing or trapping the user in a live mode targeting
-        // nothing.
+    fn tab_does_not_start_live_send_without_selection() {
+        // No session selected (empty list, cursor on a group, etc.) →
+        // Tab must silently no-op rather than emitting a deferred
+        // action targeting nothing.
         let mut env = create_test_env_empty();
         let action = env
             .view
             .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
         assert!(action.is_none());
         assert!(env.view.live_send.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn tab_emits_enter_live_send_for_stopped_session() {
+        // start_live_send is intentionally permissive: it accepts any
+        // non-Creating instance and defers ensure_pane_ready to
+        // enter_live_send. Without this, Tab would silently no-op on
+        // stopped/dead-but-recoverable rows because the tmux session
+        // doesn't exist yet.
+        let mut env = create_test_env_with_sessions(1);
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env
+            .view
+            .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
+        assert!(
+            matches!(action, Some(Action::EnterLiveSend(_))),
+            "Tab on a stopped session should emit Action::EnterLiveSend, got {:?}",
+            action
+        );
     }
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5230,7 +5230,7 @@ mod live_send_mode {
     //! Live-send wiring at the home view level. Translation correctness
     //! is covered by unit tests in src/tui/home/live_send.rs. Here we
     //! verify the integration points: keys are captured while live mode
-    //! is active, Ctrl+q clears the state, the per-keystroke liveness
+    //! is active, Ctrl+] clears the state, the per-keystroke liveness
     //! check auto-exits on drift, and the predicate plumbing treats
     //! live mode like a modal capture so the rest of the TUI suspends
     //! underneath it.
@@ -5275,13 +5275,13 @@ mod live_send_mode {
 
     #[test]
     #[serial]
-    fn ctrl_q_exits_live_mode() {
+    fn ctrl_right_bracket_exits_live_mode() {
         let mut env = create_test_env_with_sessions(1);
         install_live_for_first_session(&mut env);
         assert!(env.view.live_send.is_some());
 
         env.view.handle_key(
-            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL),
             None,
         );
 
@@ -5290,14 +5290,14 @@ mod live_send_mode {
 
     #[test]
     #[serial]
-    fn ctrl_q_exits_even_when_session_has_drifted() {
-        // Ctrl+q is the safety chord: it must always exit cleanly,
+    fn ctrl_right_bracket_exits_even_when_session_has_drifted() {
+        // Ctrl+] is the safety chord: it must always exit cleanly,
         // even if the underlying session went away (so the user can
         // recover from a stuck live mode without an extra dialog).
         let mut env = create_test_env_empty();
         install_live_orphan(&mut env);
         env.view.handle_key(
-            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL),
             None,
         );
         assert!(env.view.live_send.is_none());
@@ -5318,7 +5318,7 @@ mod live_send_mode {
             .view
             .handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), None);
         assert!(action.is_none());
-        // Still in live mode; only Ctrl+q exits.
+        // Still in live mode; only Ctrl+] exits.
         assert!(env.view.live_send.is_some());
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4709,6 +4709,9 @@ mod scroll_pane_isolation {
             session_id: "fake".to_string(),
             title: "fake".to_string(),
             tmux_name: "fake".to_string(),
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
         });
 
         let up_handled = env.view.handle_scroll_up(50, 10);
@@ -4736,6 +4739,9 @@ mod scroll_pane_isolation {
             session_id: "fake".to_string(),
             title: "fake".to_string(),
             tmux_name: "fake".to_string(),
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
         });
 
         let handled = env.view.handle_scroll_down(5, 10);
@@ -5314,6 +5320,9 @@ mod live_send_mode {
             session_id: inst.id.clone(),
             title: inst.title,
             tmux_name,
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
         });
         id
     }
@@ -5326,6 +5335,9 @@ mod live_send_mode {
             session_id: "missing-id".to_string(),
             title: "missing-title".to_string(),
             tmux_name: "missing-tmux".to_string(),
+            exit_chords: crate::tui::home::live_send::parse_chord_list(
+                crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
+            ),
         });
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4686,6 +4686,62 @@ mod scroll_pane_isolation {
         assert!(handled);
         assert_eq!(env.view.cursor, 0, "wheel over list should retreat cursor");
     }
+
+    /// Live-send mode is meant to feel like an attach — users still need
+    /// to scroll the preview to read agent history without exiting. The
+    /// has_dialog() gate would otherwise swallow these events because
+    /// live_send.is_some() participates in that predicate.
+    #[test]
+    #[serial]
+    fn wheel_over_preview_in_live_mode_scrolls_preview() {
+        use crate::tui::home::live_send::LiveSendState;
+        let mut env = create_test_env_with_sessions(3);
+        setup_panes(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        env.view.preview_cache.dimensions = (80, 24);
+        env.view.preview_cache.captured_lines = 200;
+        env.view.preview_scroll_offset = 10;
+        // Install live state directly so we don't have to stand up a
+        // tmux session; the scroll handler only cares about
+        // live_send.is_some().
+        env.view.live_send = Some(LiveSendState {
+            session_id: "fake".to_string(),
+            title: "fake".to_string(),
+            tmux_name: "fake".to_string(),
+        });
+
+        let up_handled = env.view.handle_scroll_up(50, 10);
+        assert!(up_handled, "preview scroll should work while in live mode");
+        assert!(
+            env.view.preview_scroll_offset > 10,
+            "preview should scroll back into history"
+        );
+        // And we should still be in live mode (scroll doesn't exit).
+        assert!(env.view.live_send.is_some());
+    }
+
+    /// List-pane wheel scroll stays suppressed in live mode: changing
+    /// the selection mid-session would silently aim the next keystroke
+    /// at a different pane than the preview is showing.
+    #[test]
+    #[serial]
+    fn wheel_over_list_in_live_mode_does_not_change_selection() {
+        use crate::tui::home::live_send::LiveSendState;
+        let mut env = create_test_env_with_sessions(3);
+        setup_panes(&mut env);
+        env.view.cursor = 1;
+        env.view.update_selected();
+        env.view.live_send = Some(LiveSendState {
+            session_id: "fake".to_string(),
+            title: "fake".to_string(),
+            tmux_name: "fake".to_string(),
+        });
+
+        let handled = env.view.handle_scroll_down(5, 10);
+        assert!(!handled, "list scroll must be a no-op in live mode");
+        assert_eq!(env.view.cursor, 1, "selection must not change in live mode");
+    }
 }
 
 mod click_to_select {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5404,6 +5404,21 @@ mod live_send_mode {
         let mut env = create_test_env_with_sessions(1);
         env.view.cursor = 0;
         env.view.update_selected();
+        // Pin the status explicitly so this regression guard doesn't
+        // rely on the implicit Instance::new default surviving future
+        // refactors. A real stopped session is what we're modeling.
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+        env.view.mutate_instance(&id, |inst| {
+            inst.status = crate::session::Status::Stopped;
+        });
         let action = env
             .view
             .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
@@ -5412,6 +5427,41 @@ mod live_send_mode {
             "Tab on a stopped session should emit Action::EnterLiveSend, got {:?}",
             action
         );
+    }
+
+    /// Cockpit-mode is a `serve` feature; the `cockpit_mode` field on
+    /// Instance only exists when that feature is compiled in. Without
+    /// it, `is_cockpit_mode()` is hard-coded to false and the gate is
+    /// a no-op, so there's nothing meaningful to verify in the default
+    /// build.
+    #[cfg(feature = "serve")]
+    #[test]
+    #[serial]
+    fn tab_does_not_start_live_send_for_cockpit_session() {
+        // Cockpit sessions are not tmux-backed, so live-send has no
+        // valid target. Tab must silently no-op rather than enqueue
+        // an Action::EnterLiveSend that would fail downstream.
+        let mut env = create_test_env_with_sessions(1);
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let id = env
+            .view
+            .flat_items
+            .iter()
+            .find_map(|item| match item {
+                crate::session::Item::Session { id, .. } => Some(id.clone()),
+                _ => None,
+            })
+            .expect("test env has one session");
+        env.view.mutate_instance(&id, |inst| {
+            inst.status = crate::session::Status::Stopped;
+            inst.cockpit_mode = true;
+        });
+        let action = env
+            .view
+            .handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE), None);
+        assert!(action.is_none(), "expected no action, got {:?}", action);
+        assert!(env.view.live_send.is_none());
     }
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5395,6 +5395,65 @@ mod live_send_mode {
 
     #[test]
     #[serial]
+    fn shift_page_up_scrolls_preview_instead_of_sending_to_agent() {
+        // Terminal-emulator convention: Shift+PageUp scrolls the outer
+        // scrollback, not the inner program. Live mode honors that so
+        // users can read agent history without exiting.
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
+        env.view.preview_scroll_offset = 0;
+
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::SHIFT), None);
+
+        assert!(
+            env.view.preview_scroll_offset > 0,
+            "Shift+PageUp should scroll the preview back into history"
+        );
+        // Still in live mode — the intercept doesn't exit.
+        assert!(env.view.live_send.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn shift_page_down_scrolls_preview_forward() {
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
+        env.view.preview_scroll_offset = 50;
+
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::PageDown, KeyModifiers::SHIFT), None);
+
+        assert!(
+            env.view.preview_scroll_offset < 50,
+            "Shift+PageDown should reduce the offset (scroll toward live)"
+        );
+        assert!(env.view.live_send.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn bare_page_up_still_passes_through_to_agent() {
+        // Regression guard: only the Shift-modified Page chord is
+        // intercepted. Bare PageUp must keep flowing to the agent so
+        // agents that page their own UI (claude-code transcript, etc.)
+        // keep responding.
+        let mut env = create_test_env_with_sessions(1);
+        install_live_for_first_session(&mut env);
+        env.view.preview_scroll_offset = 25;
+
+        env.view
+            .handle_key(KeyEvent::new(KeyCode::PageUp, KeyModifiers::NONE), None);
+
+        assert_eq!(
+            env.view.preview_scroll_offset, 25,
+            "bare PageUp must NOT change preview scroll offset"
+        );
+        assert!(env.view.live_send.is_some());
+    }
+
+    #[test]
+    #[serial]
     fn drift_check_auto_exits_when_session_renamed() {
         // Title changes the generated tmux name. After a rename the
         // worker is targeting a stale name, so the next keystroke

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5316,6 +5316,14 @@ mod live_send_mode {
             .expect("test env has no sessions; use install_live_orphan instead");
         let inst = env.view.get_instance(&id).unwrap().clone();
         let tmux_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        // CI runs the e2e suite in the same `cargo test` invocation,
+        // which populates the global tmux session cache. The drift
+        // check then sees our fake test session name as "not in tmux"
+        // (Some(false)) and clears live_send mid-test. Pre-inject the
+        // name so the cache reports Some(true) for it; orphan tests
+        // (install_live_orphan) deliberately skip this and let the
+        // instance-missing branch fire instead.
+        crate::tmux::test_inject_session_into_cache(&tmux_name);
         env.view.live_send = Some(LiveSendState {
             session_id: inst.id.clone(),
             title: inst.title,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5286,7 +5286,7 @@ mod live_send_mode {
     //! Live-send wiring at the home view level. Translation correctness
     //! is covered by unit tests in src/tui/home/live_send.rs. Here we
     //! verify the integration points: keys are captured while live mode
-    //! is active, Ctrl+] clears the state, the per-keystroke liveness
+    //! is active, Ctrl+q clears the state, the per-keystroke liveness
     //! check auto-exits on drift, and the predicate plumbing treats
     //! live mode like a modal capture so the rest of the TUI suspends
     //! underneath it.
@@ -5331,13 +5331,13 @@ mod live_send_mode {
 
     #[test]
     #[serial]
-    fn ctrl_right_bracket_exits_live_mode() {
+    fn ctrl_q_exits_live_mode() {
         let mut env = create_test_env_with_sessions(1);
         install_live_for_first_session(&mut env);
         assert!(env.view.live_send.is_some());
 
         env.view.handle_key(
-            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
             None,
         );
 
@@ -5346,14 +5346,14 @@ mod live_send_mode {
 
     #[test]
     #[serial]
-    fn ctrl_right_bracket_exits_even_when_session_has_drifted() {
-        // Ctrl+] is the safety chord: it must always exit cleanly,
+    fn ctrl_q_exits_even_when_session_has_drifted() {
+        // Ctrl+q is the safety chord: it must always exit cleanly,
         // even if the underlying session went away (so the user can
         // recover from a stuck live mode without an extra dialog).
         let mut env = create_test_env_empty();
         install_live_orphan(&mut env);
         env.view.handle_key(
-            KeyEvent::new(KeyCode::Char(']'), KeyModifiers::CONTROL),
+            KeyEvent::new(KeyCode::Char('q'), KeyModifiers::CONTROL),
             None,
         );
         assert!(env.view.live_send.is_none());
@@ -5367,14 +5367,15 @@ mod live_send_mode {
         // call will quietly fail because the test env doesn't have a
         // real tmux pane, but the home view must NOT bubble an
         // Action::* out (otherwise the action would race with the
-        // live state).
+        // live state). Use bare `x` so the test doesn't collide with
+        // the Ctrl+q exit chord.
         let mut env = create_test_env_with_sessions(1);
         install_live_for_first_session(&mut env);
         let action = env
             .view
-            .handle_key(KeyEvent::new(KeyCode::Char('q'), KeyModifiers::NONE), None);
+            .handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE), None);
         assert!(action.is_none());
-        // Still in live mode; only Ctrl+] exits.
+        // Still in live mode; only Ctrl+q exits.
         assert!(env.view.live_send.is_some());
     }
 

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -101,6 +101,7 @@ pub enum FieldKey {
     AgentDetectAs,
     HostEnvironment,
     SessionIdPollerMaxThreads,
+    LiveSendExitChord,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -1515,6 +1516,12 @@ fn build_session_fields(
         session.and_then(|s| s.restart_wake_message.clone()),
     );
 
+    let (live_send_exit_chord, live_send_exit_chord_override) = resolve_value(
+        scope,
+        global.session.live_send_exit_chord.clone(),
+        session.and_then(|s| s.live_send_exit_chord.clone()),
+    );
+
     let (row_tag, row_tag_override) = resolve_value(
         scope,
         global.session.row_tag,
@@ -1703,6 +1710,21 @@ fn build_session_fields(
             inherited_display: inherited_if(
                 restart_wake_message_override,
                 FieldValue::Text(global.session.restart_wake_message.clone()),
+            ),
+        },
+        SettingField {
+            key: FieldKey::LiveSendExitChord,
+            label: "Live-Send Exit Chord",
+            description:
+                "Comma-separated chord specs that exit live-send mode. \
+                 Tmux-style: C-q, Ctrl+], M-x, F12. Default `C-q,C-]` covers \
+                 mobile keyboards and telnet-style terminals.",
+            value: FieldValue::Text(live_send_exit_chord),
+            category: SettingsCategory::Session,
+            has_override: live_send_exit_chord_override,
+            inherited_display: inherited_if(
+                live_send_exit_chord_override,
+                FieldValue::Text(global.session.live_send_exit_chord.clone()),
             ),
         },
         SettingField {
@@ -2293,6 +2315,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             config.session.restart_wake_message = v.clone();
         }
+        (FieldKey::LiveSendExitChord, FieldValue::Text(v)) => {
+            config.session.live_send_exit_chord = v.clone();
+        }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
             config.session.row_tag = index_to_row_tag(*selected);
         }
@@ -2761,6 +2786,11 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
         (FieldKey::RestartWakeMessage, FieldValue::Text(v)) => {
             set_profile_override(v.clone(), &mut config.session, |s, val| {
                 s.restart_wake_message = val
+            });
+        }
+        (FieldKey::LiveSendExitChord, FieldValue::Text(v)) => {
+            set_profile_override(v.clone(), &mut config.session, |s, val| {
+                s.live_send_exit_chord = val
             });
         }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -683,6 +683,11 @@ impl SettingsView {
                     s.restart_wake_message = None;
                 }
             }
+            FieldKey::LiveSendExitChord => {
+                if let Some(ref mut s) = config.session {
+                    s.live_send_exit_chord = None;
+                }
+            }
             FieldKey::RowTag => {
                 if let Some(ref mut s) = config.session {
                     s.row_tag = None;


### PR DESCRIPTION
## Description

Closes #1475.

A "feels-attached" alternative to the compose dialog. **Press `Tab`** on the home view and every key relays straight to the selected session's tmux pane, no popup. **`Ctrl+q`** (bare lowercase) exits.

The compose dialog on `m` / `M` is unchanged. Tab is purely additive.

**Why a worker thread + coalescing.** A naïve implementation forks `tmux send-keys` per keystroke, which feels laggy over Docker / Mosh. This branch spawns a worker thread on entry that owns the tmux `Session` and drains a mpsc channel of `WorkerMsg`s. A pure `coalesce()` folds consecutive `Literal` keys into a single `send-keys -l --` call so typing "hello" is one fork instead of five. `Named` keys and `Resize`s break the run because their order vs. surrounding text matters. The UI thread does `worker.send()` and returns immediately, so the redraw loop never blocks on fork latency.

**Why auto-resize.** On entry the worker resizes the tmux pane to the preview pane's actual cell dimensions, so the agent renders into the visible area instead of whatever size it was created at. Divider drags and terminal resizes re-fire the resize automatically (deduped via `live_send_last_resize`).

**Why faster refresh.** Preview cadence drops from 250ms (4 Hz) to 50ms (20 Hz, matching the app loop's `refresh_interval`) while live mode is active, so typed input appears the next tick instead of a beat later.

**Visibility of the exit chord.** Banner painted at both the top of the screen (full-width reversed-color strip: `● LIVE SEND → <title>   Ctrl+Q to exit live mode`) and in the status bar, so the exit is unmissable from either gaze direction.

**Strict-mode users** reach live mode via the command palette (`Tab` works there too, but the palette entry is the discoverable affordance for users who muscle-memory'd `m`).

**Trade-offs (documented in `live_send.rs`):**
- No inline echo. Feedback comes from the preview pane, not character-by-character at the cursor. Users who need composition / voice review should keep using compose on `M`.
- `Ctrl+q` exit means vim/emacs's `C-q` quoted-insert isn't reachable from live mode (use compose or `a` attach instead).
- One tmux process per dispatch action (after coalescing). For most flows this is invisible; on very slow links it may still be perceptible.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (\`cargo fmt --check\`, \`cargo clippy --features serve -D warnings\`, \`cargo test --lib\` 2094 passed, \`cargo test --tests\` 120 passed)
- [ ] Documentation was updated where necessary. The module-level docstring on \`src/tui/home/live_send.rs\` documents the design and trade-offs in detail; no user-facing docs file added.
- [ ] For UI changes: included screenshot or recording. See "Test plan" below; happy to add a recording on request.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under \`tests/e2e/\`
- [x] Skipped a test, because: live-send's value is in the live tmux roundtrip (real \`send-keys\` + real agent + real \`capture-pane\`), which the current e2e harness can stage with \`spawn_tui\` but cannot easily assert against (no fake agent that paints into a pane in response to keystrokes). The PR ships 18 translation / coalescing / state tests + 5 home-view wiring tests against the pure logic; a full e2e is a worthwhile follow-up.

## Test plan

- [ ] On a running session, press \`Tab\`. Banner appears top + bottom, agent receives keystrokes verbatim
- [ ] Type a sentence at speed. Coalesces into single tmux call (verify via \`AGENT_OF_EMPIRES_DEBUG=1\` log)
- [ ] Press arrows / Esc / Ctrl+C. Each forwards correctly
- [ ] Press \`Ctrl+q\`. Exits live mode, banner gone
- [ ] Press \`Ctrl+Shift+q\`. Does NOT exit, sends \`C-q\` to agent (vim quoted-insert)
- [ ] Drag the list/preview divider while in live mode. Pane resizes to match
- [ ] Open command palette in strict mode → "Live send" entry → enters live mode
- [ ] Compose dialog on \`m\` / \`M\` still works unchanged

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Pair-programmed end to end; architecture decisions (worker-thread design, exit-chord choice, banner placement, coalescing semantics) were the human's calls after Claude proposed and challenged alternatives.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

Adds a new "live-send" mode to the TUI that forwards keystrokes directly to a selected tmux session pane. Enter from the home view (Tab or command palette); while active, keystrokes (printable, navigation, and control keys) are sent straight to the session, Ctrl+Q exits, and compose-on-m / M remains unchanged. The UI shows a full-width reversed header and a compact status-bar banner during live-send, and preview refresh frequency increases for responsiveness.

What changed, at a glance:
- New live-send mode reachable via Tab and the command palette.
- Background LiveSendWorker thread owning a tmux Session and consuming an mpsc channel to dispatch actions.
- Session API additions to resize panes and send literal text or named keys without appending Enter.
- HomeView integration: state fields (live_send, live_send_worker, live_send_last_resize), entry/exit logic, priority paste handling, and drift detection that auto-exits with info dialogs when the target session is invalid/stale.
- Keystroke coalescing: consecutive literal characters are batched into single tmux send-keys -l calls; named keys and resize events break batches to preserve ordering.
- UI: top live-send banner, mirrored status message in the status bar, ellipsis-aware title truncation, and reduced preview refresh interval while live-send is active (250ms → 50ms).
- Tests: extensive unit tests for translation/coalescing/state and several home-view wiring tests; e2e tests omitted.

## Technical details (concise)

- New module: src/tui/home/live_send.rs
  - Implements LiveSendState, LiveSendWorker (spawn + mpsc), TmuxKey/TmuxAction, LiveDispatch and translation of KeyEvent -> LiveDispatch.
  - coalesce(batch) merges consecutive literal WorkerMsg into single Literal actions; dispatch runs send_literal_no_enter, send_named_key, and resize on the Session.
  - Comprehensive unit tests for translate and coalesce behavior.
- Session helpers: src/tmux/session.rs
  - Added pub fn resize(cols, rows), send_literal_no_enter(text), send_named_key(key_name) with validation and error logging.
- Home view & input: src/tui/home/{mod.rs,input.rs,render.rs}
  - enter_live_send(session_id) stages live-send, revives session if needed, spawns worker, and forces initial resize.
  - Live-send short-circuits normal routing: keys and paste bursts are forwarded to the worker; drift/end conditions clear state and surface dialogs.
  - render_live_header, updated status bar rendering, and live_send_last_resize-driven worker resizes on layout changes.
- App/commands: Action::EnterLiveSend and PaletteAction::EnterLiveSend wired into dispatch and command palette.

## Benefits

- Enables interactive control of remote applications (navigation, editors, cancels) from the TUI without using compose popups.
- Improves perceived responsiveness via keystroke coalescing and higher preview refresh cadence.
- Integrates with existing revive/ensure flows for resilient session selection and clear UI affordances while live.

## Trade-offs and potential enhancements

- No inline echo in the main UI; feedback relies on the preview pane.
- Capturing bare Ctrl+Q disables quoted-insert (Ctrl+Q cannot be forwarded).
- Each dispatched (post-coalescing) action invokes a tmux process — may be noticeable on very slow links; a persistent control channel or reducing process churn could help.
- No end-to-end integration tests included; adding e2e coverage would increase confidence across real network/session scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->