### PR TITLE
test(web): session wizard user stories PW specs

### DIFF
--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1506,6 +1506,185 @@
         "web/src/components/cockpit/Composer.tsx",
         "web/src/components/cockpit/ToolCards.tsx"
       ]
+    },
+    {
+      "id": "story.wizard-open-close",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-open-close.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-tabs-visible",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-tabs-visible.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-clone-url-input",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-clone-url-input.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-browse-disk",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-browse-disk.spec.ts"
+      ],
+      "components": [
+        "web/src/components/DirectoryBrowser.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-recent-project",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-recent-project.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ProjectStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-close-via-escape",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-close-via-escape.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-prefill-from-group",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-session-title-edit",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-session-title-edit.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/SessionStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-worktree-toggle",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/SessionStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-group-field",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-group-field.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/SessionStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-extra-repos",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-extra-repos.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ExtraReposPicker.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-launch-cmd-enter",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-launch-cmd-enter.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx",
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-creating-banner",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-creating-banner.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-last-tool-persists",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-launch-button",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-launch-button.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
+    },
+    {
+      "id": "story.wizard-branch-from-title",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/wizard-branch-from-title.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/sessionNames.ts",
+        "web/src/components/session-wizard/steps/ReviewStep.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -328,11 +328,17 @@ async function waitForServer(
 function writeFakeClaudeShim(binDir: string): void {
   // Dashboard tracer specs only need the tmux pane to stay open with a
   // long-running process. Cockpit specs swap this for the ACP agent shim
-  // via `writeFakeAcpShim`.
+  // via `writeFakeAcpShim`. Install shims for the built-in agents the
+  // wizard UI surfaces (claude / codex / gemini); the agent picker
+  // filters by `which <binary>` (src/tmux/mod.rs::is_agent_available),
+  // so without these the picker only offers claude and persistence
+  // specs that pick a non-default tool would hang on a missing button.
   const script = "#!/bin/bash\nexec tail -f /dev/null\n";
-  const path = join(binDir, "claude");
-  writeFileSync(path, script);
-  chmodSync(path, 0o755);
+  for (const name of ["claude", "codex", "gemini"]) {
+    const path = join(binDir, name);
+    writeFileSync(path, script);
+    chmodSync(path, 0o755);
+  }
 }
 
 function writeFakeAcpShim(

--- a/web/tests/live/cockpit-stories/wizard-branch-from-title.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-branch-from-title.spec.ts
@@ -1,0 +1,50 @@
+// User story: setting the session title with the branch field blank
+// auto-derives the branch on the Review step.
+//
+// `getReviewSummary` falls back: branch = worktreeBranch || title ||
+// "Auto-generated". The Review EditableRow renders summary.branch as
+// its display value when the user hasn't typed a branch.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard derives the branch from the title on the Review step", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-branch-autogen-seed" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    // skipToReview opens the wizard on Review.
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Edit the Title row inline; with the Branch field blank, the
+    // Review summary mirrors the title into the Branch / worktree row.
+    await page.getByRole("button", { name: /^Title/i }).click();
+    const titleInput = page.locator('input[placeholder="Auto-generated"]').first();
+    await titleInput.fill("autogen-branch-here");
+    await titleInput.blur();
+
+    // Title + branch rows both show "autogen-branch-here".
+    await expect(
+      page.getByText("autogen-branch-here").first(),
+    ).toBeVisible({ timeout: 10_000 });
+    const occurrences = await page
+      .getByText("autogen-branch-here")
+      .count();
+    expect(occurrences).toBeGreaterThanOrEqual(2);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-browse-disk.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-browse-disk.spec.ts
@@ -1,0 +1,26 @@
+// User story: open the wizard's Browse tab and see the directory
+// browser load.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("wizard Browse tab renders the directory browser", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    await page.getByRole("button", { name: "Browse" }).click();
+
+    await expect(
+      page.getByRole("navigation", { name: "Directory path" }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByPlaceholder("Type to filter...")).toBeVisible();
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-clone-url-input.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-clone-url-input.spec.ts
@@ -1,0 +1,30 @@
+// User story: enter a URL on the Clone URL tab; the input accepts it
+// and is ready to submit.
+//
+// Full clone is an HTTP round-trip outside test scope; this story
+// covers the input plumbing only. The Clone button only enables when
+// the URL is non-empty.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("wizard Clone URL tab accepts a repo URL", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    await page.getByRole("button", { name: "Clone URL", exact: true }).click();
+
+    const input = page.getByPlaceholder("https://github.com/user/repo.git");
+    await expect(input).toBeVisible({ timeout: 5_000 });
+    await input.fill("https://github.com/example/repo.git");
+    await expect(input).toHaveValue("https://github.com/example/repo.git");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-clone-url-input.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-clone-url-input.spec.ts
@@ -21,9 +21,12 @@ base("wizard Clone URL tab accepts a repo URL", async ({ page }, testInfo) => {
     await page.getByRole("button", { name: "Clone URL", exact: true }).click();
 
     const input = page.getByPlaceholder("https://github.com/user/repo.git");
+    const cloneButton = page.getByRole("button", { name: /^Clone repository$/i });
     await expect(input).toBeVisible({ timeout: 5_000 });
+    await expect(cloneButton).toBeDisabled({ timeout: 5_000 });
     await input.fill("https://github.com/example/repo.git");
     await expect(input).toHaveValue("https://github.com/example/repo.git");
+    await expect(cloneButton).toBeEnabled({ timeout: 5_000 });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-close-via-escape.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-close-via-escape.spec.ts
@@ -1,0 +1,31 @@
+// User story: pressing Escape closes the open new-session wizard.
+//
+// App.tsx wires the global Escape handler to close several overlays;
+// the wizard is among them. This story opens the wizard via the
+// sidebar New trigger and dismisses with Escape.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("Escape closes the open new-session wizard", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    const wizardHeading = page.getByRole("heading", {
+      name: "New session",
+      exact: true,
+    });
+    await expect(wizardHeading).toBeVisible({ timeout: 10_000 });
+
+    await page.keyboard.press("Escape");
+    await expect(wizardHeading).toBeHidden({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-creating-banner.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-creating-banner.spec.ts
@@ -1,0 +1,53 @@
+// User story: while a new session is being created, the wizard shows
+// a "Creating session..." banner on the Launch button.
+//
+// SessionWizard dispatches SUBMIT_START before the POST /api/sessions
+// resolves, flipping isSubmitting=true. ReviewStep then swaps the
+// button copy to "Creating session..." with a spinner. We delay the
+// POST via page.route() so the banner is observable.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("Creating session banner appears while POST is in flight", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-banner-seed" }),
+  });
+
+  try {
+    // Delay the create-session POST so the banner is observable.
+    await page.route("**/api/sessions", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.continue();
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 1500));
+      await route.continue();
+    });
+
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    // skipToReview lands the wizard on the Review step with prefilled
+    // values; click Launch directly.
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    const launchButton = page.getByRole("button", { name: /Launch session/i });
+    await launchButton.click();
+
+    await expect(page.getByText("Creating session...")).toBeVisible({
+      timeout: 5_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-extra-repos.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-extra-repos.spec.ts
@@ -1,0 +1,54 @@
+// User story: add an extra repo path to a wizard session via the
+// ExtraReposPicker free-text input.
+//
+// After selecting a primary project, the ExtraReposPicker mounts under
+// the selection. Free-text path + Add (or Enter) appends to
+// data.extraRepoPaths; a chip renders with a Remove button.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard ExtraReposPicker accepts a free-text path", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-extra-repos" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    // Use the global New session trigger so ProjectStep is the first
+    // step (group-level prefill would skip past it).
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "Project folder", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Pick a recent project so `data.path` is set; scope the search to
+    // the wizard overlay so the sidebar group-header (which also has a
+    // child button containing "project") doesn't shadow the row.
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    const recentRow = wizard
+      .locator("button")
+      .filter({ hasText: "project" })
+      .first();
+    await recentRow.click();
+
+    const extra = page.getByPlaceholder("/path/to/another/repo");
+    await expect(extra).toBeVisible({ timeout: 10_000 });
+    await extra.fill("/extra/repo-path");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+
+    await expect(
+      page.getByRole("button", { name: "Remove repo-path" }),
+    ).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-group-field.spec.ts
@@ -1,0 +1,49 @@
+// User story: enter a Group value in the wizard's session step.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard session step records Group", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-group" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    // Use the global New session button so the wizard opens on
+    // ProjectStep and walks through Session step; the group-level
+    // button skips to Review where the Group field is not rendered.
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await wizard
+      .locator("button")
+      .filter({ hasText: "project" })
+      .first()
+      .click();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const groupField = page.getByPlaceholder(
+      "Optional, for organizing related sessions",
+    );
+    await expect(groupField).toBeVisible({ timeout: 10_000 });
+    await groupField.fill("my-group");
+    await expect(groupField).toHaveValue("my-group");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -36,7 +36,7 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
     ).toBeVisible({ timeout: 10_000 });
     await page.getByRole("button", { name: /^Agent / }).first().click();
     await expect(
-      page.getByRole("heading", { name: /Choose an agent/i }),
+      page.getByRole("heading", { name: /Which AI agent\?/i }),
     ).toBeVisible({ timeout: 10_000 });
     await page.getByRole("button", { name: /^codex/i }).first().click();
     await page.getByRole("button", { name: /Next/i }).click();

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -26,7 +26,20 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
     await groupHeader.getByRole("button", { name: /New session in /i }).click();
 
     // Group click opens the wizard on Review with `data.tool = claude`
-    // (preselected from prefill / loadLastUsedTool fallback).
+    // (preselected from prefill / loadLastUsedTool fallback). Jump
+    // back to the Agent step and pick a non-default tool so the
+    // persistence test actually proves persistence: if save/restore
+    // is broken, the wizard would fall back to "claude" on reload
+    // and a claude → claude round-trip would pass falsely.
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: /^Agent / }).first().click();
+    await expect(
+      page.getByRole("heading", { name: /Choose an agent/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: /^codex/i }).first().click();
+    await page.getByRole("button", { name: /Next/i }).click();
     await expect(
       page.getByRole("heading", { name: /Review & Launch/i }),
     ).toBeVisible({ timeout: 10_000 });
@@ -38,16 +51,16 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
 
     await page.reload();
 
-    // saveLastUsedTool persists `claude` on submit success. The key is
-    // `aoe-cockpit-last-tool` (LAST_USED_TOOL_KEY in SessionWizard.tsx).
-    // localStorage on its own is an implementation detail; the user
-    // story is that reopening the wizard preselects the tool in the
-    // rendered DOM. Reopen the wizard and assert against the Review
-    // step's Agent row.
+    // saveLastUsedTool persists the chosen tool on submit success.
+    // The key is `aoe-cockpit-last-tool` (LAST_USED_TOOL_KEY in
+    // SessionWizard.tsx). localStorage alone is an implementation
+    // detail; the user story is that reopening the wizard preselects
+    // the tool in the rendered DOM. Reopen the wizard and assert
+    // against the Review step's Agent row.
     const stored = await page.evaluate(() =>
       localStorage.getItem("aoe-cockpit-last-tool"),
     );
-    expect(stored).toBe("claude");
+    expect(stored).toBe("codex");
 
     const reopenedHeader = page
       .locator('[data-testid="sidebar-group-header"]')
@@ -59,8 +72,8 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
     await expect(
       page.getByRole("heading", { name: /Review & Launch/i }),
     ).toBeVisible({ timeout: 10_000 });
-    const agentRow = page.locator("button", { hasText: "Agent" }).first();
-    await expect(agentRow).toContainText("claude", { timeout: 5_000 });
+    const agentRow = page.getByRole("button", { name: /^Agent / });
+    await expect(agentRow).toContainText("codex", { timeout: 5_000 });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -81,9 +81,12 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
     await expect(
       page.getByRole("heading", { name: /Project folder/i }),
     ).toBeVisible({ timeout: 10_000 });
+    // Recent tile text concatenates path + timeAgo + session count, so
+    // the regex must not anchor to end of string. Look for the path
+    // segment followed by the session-count suffix.
     const recentProjectTile = page
       .locator("button")
-      .filter({ hasText: /\/project$/ })
+      .filter({ hasText: /\/project.*session/ })
       .first();
     await expect(recentProjectTile).toBeVisible({ timeout: 5_000 });
     await recentProjectTile.click();

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -1,0 +1,50 @@
+// User story: the wizard remembers the last-picked agent across
+// reloads.
+//
+// SessionWizard persists `data.tool` to localStorage key
+// "aoe-wizard-last-tool" on every submit. Reopen the wizard later and
+// the agent picker pre-selects that tool, so users iterating on a
+// project don't have to repeat the choice.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard remembers the last-picked agent after reload", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-last-tool-seed" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    // Group click opens the wizard on Review with `data.tool = claude`
+    // (preselected from prefill / loadLastUsedTool fallback).
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: /Launch session/i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeHidden({ timeout: 20_000 });
+
+    await page.reload();
+
+    // saveLastUsedTool persists `claude` on submit success. The key is
+    // `aoe-cockpit-last-tool` (LAST_USED_TOOL_KEY in SessionWizard.tsx).
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("aoe-cockpit-last-tool"),
+    );
+    expect(stored).toBe("claude");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -40,10 +40,27 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
 
     // saveLastUsedTool persists `claude` on submit success. The key is
     // `aoe-cockpit-last-tool` (LAST_USED_TOOL_KEY in SessionWizard.tsx).
+    // localStorage on its own is an implementation detail; the user
+    // story is that reopening the wizard preselects the tool in the
+    // rendered DOM. Reopen the wizard and assert against the Review
+    // step's Agent row.
     const stored = await page.evaluate(() =>
       localStorage.getItem("aoe-cockpit-last-tool"),
     );
     expect(stored).toBe("claude");
+
+    const reopenedHeader = page
+      .locator('[data-testid="sidebar-group-header"]')
+      .first();
+    await expect(reopenedHeader).toBeVisible({ timeout: 10_000 });
+    await reopenedHeader
+      .getByRole("button", { name: /New session in /i })
+      .click();
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    const agentRow = page.locator("button", { hasText: "Agent" }).first();
+    await expect(agentRow).toContainText("claude", { timeout: 5_000 });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -62,18 +62,47 @@ base("wizard remembers the last-picked agent after reload", async ({ page }, tes
     );
     expect(stored).toBe("codex");
 
-    const reopenedHeader = page
-      .locator('[data-testid="sidebar-group-header"]')
-      .first();
-    await expect(reopenedHeader).toBeVisible({ timeout: 10_000 });
-    await reopenedHeader
-      .getByRole("button", { name: /New session in /i })
+    // Reopen via the GLOBAL "New session" button (aria-label="New
+    // session"), not the per-group "New session in <name>" button.
+    // The group button routes through handleCreateSession which
+    // overrides prefill.tool from the latest matching session
+    // (App.tsx:451), bypassing loadLastUsedTool entirely. The global
+    // button passes wizardPrefill=undefined, so buildInitialData()
+    // picks up the persisted tool from localStorage and the wizard
+    // mounts with data.tool="codex". Open it, jump to the Agent step
+    // via the step indicator dot is non-clickable, so navigate
+    // through Project (pick the seeded path) → Session → Agent and
+    // assert the codex tile is selected. That proves the read side
+    // of loadLastUsedTool.
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
       .click();
     await expect(
-      page.getByRole("heading", { name: /Review & Launch/i }),
+      page.getByRole("heading", { name: /Project folder/i }),
     ).toBeVisible({ timeout: 10_000 });
-    const agentRow = page.getByRole("button", { name: /^Agent / });
-    await expect(agentRow).toContainText("codex", { timeout: 5_000 });
+    const recentProjectTile = page
+      .locator("button")
+      .filter({ hasText: /\/project$/ })
+      .first();
+    await expect(recentProjectTile).toBeVisible({ timeout: 5_000 });
+    await recentProjectTile.click();
+    await page.getByRole("button", { name: /^Next$/ }).click();
+    await expect(
+      page.getByRole("heading", { name: /Name your session/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await page.getByRole("button", { name: /^Next$/ }).click();
+    await expect(
+      page.getByRole("heading", { name: /Which AI agent\?/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    // The codex tile carries `border-brand-600` only when data.tool
+    // matches. Assert that styling instead of clicking Next twice more
+    // to reach Review — keeps the spec tight while still verifying the
+    // read side of persistence.
+    const codexTile = page.getByRole("button", { name: /^codex/i });
+    await expect(codexTile).toHaveClass(/border-brand-600/, {
+      timeout: 5_000,
+    });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-last-tool-persists.spec.ts
@@ -2,7 +2,7 @@
 // reloads.
 //
 // SessionWizard persists `data.tool` to localStorage key
-// "aoe-wizard-last-tool" on every submit. Reopen the wizard later and
+// "aoe-cockpit-last-tool" on every submit. Reopen the wizard later and
 // the agent picker pre-selects that tool, so users iterating on a
 // project don't have to repeat the choice.
 

--- a/web/tests/live/cockpit-stories/wizard-launch-button.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-launch-button.spec.ts
@@ -1,0 +1,54 @@
+// User story: launch a session by clicking the Launch button on the
+// wizard's Review step (mouse path).
+//
+// Mirrors wizard-launch-cmd-enter but exercises the click path that
+// many users prefer over the keyboard chord.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("Launch button on Review step creates the session", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-launch-button-seed" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Edit the title inline so the new row is easy to find in the sidebar.
+    await page.getByRole("button", { name: /^Title/i }).click();
+    const titleInput = page.locator('input[placeholder="Auto-generated"]').first();
+    await titleInput.fill("story-launched-button");
+    await titleInput.blur();
+
+    const before = await listSessions(serve.baseUrl);
+    await page.getByRole("button", { name: /Launch session/i }).click();
+
+    await expect
+      .poll(async () => (await listSessions(serve.baseUrl)).length, {
+        timeout: 20_000,
+      })
+      .toBeGreaterThan(before.length);
+
+    await expect(
+      page
+        .locator('[data-testid="sidebar-session-row"]')
+        .filter({ hasText: "story-launched-button" }),
+    ).toHaveCount(1, { timeout: 15_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-launch-cmd-enter.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-launch-cmd-enter.spec.ts
@@ -1,0 +1,60 @@
+// User story: launch a session via the wizard, pressing Cmd/Ctrl+Enter
+// on the Review step.
+//
+// Group-level New session sets skipToReview, so the wizard opens
+// directly on the Review step with prefilled values. Inline-edit the
+// title via Review's EditableRow, then press the chord; /api/sessions
+// returns 201 and a new sidebar row appears.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+const MOD = process.platform === "darwin" ? "Meta" : "Control";
+
+base("Cmd/Ctrl+Enter on the Review step creates the session", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-launch-seed" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    // skipToReview opens the wizard on Review & Launch.
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Inline-edit the title via Review's EditableRow so the new row is
+    // easy to pick out of the sidebar afterwards.
+    await page.getByRole("button", { name: /^Title/i }).click();
+    const titleInput = page.locator('input[placeholder="Auto-generated"]').first();
+    await titleInput.fill("story-launched");
+    await titleInput.blur();
+
+    const before = await listSessions(serve.baseUrl);
+    await page.keyboard.press(`${MOD}+Enter`);
+
+    await expect
+      .poll(
+        async () => (await listSessions(serve.baseUrl)).length,
+        { timeout: 20_000 },
+      )
+      .toBeGreaterThan(before.length);
+
+    const rows = page.locator('[data-testid="sidebar-session-row"]');
+    await expect(rows.filter({ hasText: "story-launched" })).toHaveCount(1, {
+      timeout: 15_000,
+    });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-open-close.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-open-close.spec.ts
@@ -1,0 +1,37 @@
+// User story: open the new-session wizard from the sidebar New button
+// and close it via the Close button.
+//
+// Sidebar has aria-label="New session" trigger that opens the wizard.
+// Wizard renders an X (aria-label="Close") in its header that
+// dismisses the modal.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("sidebar New session opens wizard and X closes it", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+
+    // The empty-state sidebar exposes a single "New session" trigger
+    // before any groups exist; once groups exist, every group header
+    // also has its own. Click the topbar/sidebar primary one.
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+
+    await expect(
+      page.getByRole("heading", { name: "New session", exact: true }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(
+      page.getByRole("heading", { name: "New session", exact: true }),
+    ).toBeHidden({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
@@ -37,13 +37,13 @@ base("group-level New session prefills the wizard", async ({ page }, testInfo) =
       page.getByRole("heading", { name: /Review & Launch/i }),
     ).toBeVisible({ timeout: 10_000 });
 
-    // The "Project" row should render the seeded repo path
-    // (`${home}/project`, per seedSessionViaAoeAdd). Asserting on
-    // skipToReview alone is not enough; the user story is that the
-    // clicked group's repo flows through wizardPrefill into the
-    // Review step's rendered DOM.
-    const projectRow = page.locator("button", { hasText: "Project" }).first();
-    await expect(projectRow).toContainText("/project", { timeout: 5_000 });
+    // The Review step's "Project" row renders the seeded repo path
+    // (`${home}/project`, per seedSessionViaAoeAdd). Match the row's
+    // accessible name ("Project <value>") via getByRole so we do not
+    // collide with the StepIndicator's expanded step button (whose
+    // accname is just "project", lowercase, no leading slash).
+    const projectRow = page.getByRole("button", { name: /^Project \// });
+    await expect(projectRow).toContainText("/project", { timeout: 10_000 });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
@@ -1,0 +1,42 @@
+// User story: click the group-level New session button; the wizard
+// opens with the project path pre-filled to that group's repo.
+//
+// WorkspaceSidebar group headers render a per-group "New session in
+// <group>" button. Clicking it calls App.tsx's handleCreateSession
+// with the repoPath, which sets `wizardPrefill: { path: repoPath }`
+// before showing the wizard. The wizard skips the Project step when
+// path is preselected and lands on the Agent step.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("group-level New session prefills the wizard", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-prefill-from-group" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await expect(groupHeader).toBeVisible({ timeout: 10_000 });
+
+    const newInGroup = groupHeader.getByRole("button", {
+      name: /New session in /i,
+    });
+    await newInGroup.click();
+
+    // skipToReview lands the wizard directly on the Review & Launch
+    // step with the prefill values populated.
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-prefill-from-group.spec.ts
@@ -36,6 +36,14 @@ base("group-level New session prefills the wizard", async ({ page }, testInfo) =
     await expect(
       page.getByRole("heading", { name: /Review & Launch/i }),
     ).toBeVisible({ timeout: 10_000 });
+
+    // The "Project" row should render the seeded repo path
+    // (`${home}/project`, per seedSessionViaAoeAdd). Asserting on
+    // skipToReview alone is not enough; the user story is that the
+    // clicked group's repo flows through wizardPrefill into the
+    // Review step's rendered DOM.
+    const projectRow = page.locator("button", { hasText: "Project" }).first();
+    await expect(projectRow).toContainText("/project", { timeout: 5_000 });
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-stories/wizard-recent-project.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-recent-project.spec.ts
@@ -1,0 +1,57 @@
+// User story: pick a project from the Recent tab in the wizard.
+//
+// Seed a session so the project shows up under Recent. Open the
+// wizard, the Recent tab is the default (because hasRecents is true);
+// click the row and the wizard records `data.path` and advances.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard Recent tab selects a known project", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-recent" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "Project folder", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Recent tab appears only when hasRecents is true (seeded session
+    // registered the project under aoe project).
+    const recentTab = page.getByRole("button", { name: "Recent" });
+    await expect(recentTab).toBeVisible({ timeout: 5_000 });
+
+    // Recent rows render as <button>s containing the project's display
+    // name. Scope to the wizard overlay so the sidebar's matching
+    // group-header button (rendered behind the overlay) doesn't
+    // intercept the click.
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    const recentRow = wizard
+      .locator("button")
+      .filter({ hasText: "project" })
+      .first();
+    await expect(recentRow).toBeVisible({ timeout: 5_000 });
+    await recentRow.click();
+
+    await page.getByRole("button", { name: "Next" }).click();
+
+    // Step order: project → session → agent. After a chosen project,
+    // Next lands on the Session step.
+    await expect(
+      page.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-session-title-edit.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-session-title-edit.spec.ts
@@ -1,0 +1,43 @@
+// User story: edit the session title via the wizard's Review step
+// inline edit affordance.
+//
+// Group click opens the wizard with skipToReview; the Title row in
+// Review is an EditableRow that flips to an inline input on click.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard records the title from Review's inline editor", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-title" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    const groupHeader = page.locator('[data-testid="sidebar-group-header"]').first();
+    await groupHeader.getByRole("button", { name: /New session in /i }).click();
+
+    await expect(
+      page.getByRole("heading", { name: /Review & Launch/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await page.getByRole("button", { name: /^Title/i }).click();
+    const titleInput = page.locator('input[placeholder="Auto-generated"]').first();
+    await expect(titleInput).toBeVisible({ timeout: 5_000 });
+    await titleInput.fill("my-session-title");
+    await expect(titleInput).toHaveValue("my-session-title");
+    await titleInput.blur();
+
+    await expect(
+      page.getByText("my-session-title").first(),
+    ).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-tabs-visible.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-tabs-visible.spec.ts
@@ -1,0 +1,34 @@
+// User story: open the new-session wizard and verify the ProjectStep
+// surfaces the Browse + Clone URL tabs (Recent shows only when there
+// are recent projects).
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+
+base("wizard ProjectStep exposes Browse and Clone URL tabs", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    await page.getByRole("button", { name: "New session", exact: true }).first().click();
+    await expect(
+      page.getByRole("heading", { name: "Project folder", exact: true }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.getByRole("button", { name: "Browse" })).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Clone URL", exact: true }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: "Clone URL", exact: true }).click();
+    await expect(
+      page.getByPlaceholder("https://github.com/user/repo.git"),
+    ).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
@@ -1,0 +1,61 @@
+// User story: toggle the "Create a worktree" switch on the wizard's
+// session step.
+//
+// useWorktree defaults to true; toggling it off hides the worktree
+// branch input. Toggling back on re-mounts the input.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+
+base("wizard worktree toggle hides and shows the branch input", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionViaAoeAdd({ title: "story-wizard-worktree" }),
+  });
+
+  try {
+    await page.goto(serve.baseUrl);
+    // Use the global New session button (no prefill) so the wizard
+    // opens on ProjectStep; group-level prefill skips to Review where
+    // the worktree toggle is not rendered.
+    await page
+      .getByRole("button", { name: "New session", exact: true })
+      .first()
+      .click();
+    const wizard = page.locator(
+      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
+    );
+    await wizard
+      .locator("button")
+      .filter({ hasText: "project" })
+      .first()
+      .click();
+    await page.getByRole("button", { name: "Next" }).click();
+
+    await expect(
+      page.getByRole("heading", { name: "Name your session", exact: true }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const branchLabel = page.getByText("Branch / worktree name");
+    await expect(branchLabel).toBeVisible({ timeout: 10_000 });
+
+    // Click the Toggle switch directly (clicking the wrapping label
+    // double-toggles, since both the label and the switch fire onChange).
+    const worktreeRow = page
+      .locator("label")
+      .filter({ hasText: "Create a worktree" });
+    const worktreeSwitch = worktreeRow.locator('button[role="switch"]');
+    await worktreeSwitch.click();
+    await expect(branchLabel).toBeHidden({ timeout: 5_000 });
+
+    await worktreeSwitch.click();
+    await expect(branchLabel).toBeVisible({ timeout: 5_000 });
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
+++ b/web/tests/live/cockpit-stories/wizard-worktree-toggle.spec.ts
@@ -9,6 +9,7 @@ import {
   spawnAoeServe,
   seedSessionViaAoeAdd,
 } from "../../helpers/aoeServe";
+import { wizardScope } from "../../helpers/cockpit";
 
 base("wizard worktree toggle hides and shows the branch input", async ({ page }, testInfo) => {
   const serve = await spawnAoeServe({
@@ -27,15 +28,13 @@ base("wizard worktree toggle hides and shows the branch input", async ({ page },
       .getByRole("button", { name: "New session", exact: true })
       .first()
       .click();
-    const wizard = page.locator(
-      'div.fixed.inset-0.z-50:has(h1:has-text("New session"))',
-    );
+    const wizard = wizardScope(page);
     await wizard
       .locator("button")
       .filter({ hasText: "project" })
       .first()
       .click();
-    await page.getByRole("button", { name: "Next" }).click();
+    await wizard.getByRole("button", { name: "Next" }).click();
 
     await expect(
       page.getByRole("heading", { name: "Name your session", exact: true }),


### PR DESCRIPTION
> ⚠️ **Reopens #1444** which was auto-closed by the `pr-template-check` close-stale job (the `missing-template` label persisted from initial creation even after the body was fixed). The branch is unchanged; only the PR shell is new. All prior CodeRabbit review threads on #1444 are resolved.

## Description

Sixteen Playwright live specs for the new-session wizard flows:

- Open / close, tab navigation
- Repo source: clone URL, browse disk, recent project, extra repos
- Worktree toggle, group field, session title edit
- Branch from title, command line (cmd + Enter), launch button
- Creating banner, last-tool-persists, prefill-from-group
- Close via Escape

Part of #1383.

## PR Type

- [x] New Feature

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording
- [x] I understand the code I am submitting

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under \`web/tests/\` and updated \`web/tests/coverage-matrix.json\`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

**Any Additional AI Details you'd like to share:** Claude wrote the spec scaffolding from a flow checklist I provided. Decisions about which flows to cover are mine.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Added 16 Playwright end-to-end specs exercising the "New session" wizard flows in the web UI and registered them in web/tests/coverage-matrix.json (story.wizard-* entries). One test file also fixed a stale file-header comment to match the actual localStorage key.

## What Was Added

- Sixteen new Playwright test files under web/tests/live/cockpit-stories/ that cover:
  - Wizard lifecycle: open/close via header X and Escape
  - Tab visibility and navigation: Browse, Clone URL, Recent
  - Repository selection flows: Clone URL input validation, directory browser (Browse), Recent project selection, Extra repos free-text entry
  - Session configuration behaviors: Group field input and retention, worktree toggle hiding/showing branch input, inline session-title editing, deriving branch name from the edited title
  - Launch flows: Launch button click, platform Cmd/Ctrl+Enter submit, and "Creating session…" banner while POST /api/sessions is pending
  - Persistence and prefill: last-selected agent/tool persisted to localStorage and group-level "New session in …" prefill (skips to Review step)
- Updated web/tests/coverage-matrix.json to add story.wizard-* entries mapping each spec to risk and covered components (net +179 lines).
- Tests consistently start a local AOE dev server (seeded where appropriate) and ensure teardown in finally blocks.

## Benefits

- Substantially increases automated coverage for the session-wizard UX, reducing regression risk across navigation, inputs, keyboard shortcuts, async session creation, and persistence behaviors.
- Provides executable, behavior-driven documentation for expected wizard interactions, aiding debugging and future changes.

## Technical details (brief)

- Playwright live specs use spawnAoeServe with seed data when needed and assert via role/name queries, placeholders, enabled/disabled states, inline editor interactions, keyboard events, DOM banners, and polling the sessions API.
- One test intercepts and delays POST /api/sessions to validate the creating banner; another asserts localStorage key "aoe-cockpit-last-tool".
- No production code or exported/public APIs were changed; modifications are limited to tests and coverage metadata.

## Suggestions / Potential Enhancements

- Add short CI notes (authMode, seeding, parallelization hints) and a one-line README for running these live specs to improve reliability in CI and local runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1483?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->