### PR TITLE
fix: reconcile completed Codex hook prompts

### DIFF
--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -409,6 +409,14 @@ fn detect_codex_hook_gap_status(raw_content: &str) -> Option<Status> {
         return Some(Status::Waiting);
     }
 
+    if codex_has_completed_turn_prompt(&non_empty_lines) {
+        return Some(Status::Idle);
+    }
+
+    if codex_has_completed_review_prompt(&non_empty_lines) {
+        return Some(Status::Idle);
+    }
+
     None
 }
 
@@ -471,17 +479,35 @@ fn codex_has_recent_numbered_choice_prompt(non_empty_lines: &[&str]) -> bool {
 }
 
 fn codex_has_non_numbered_cursor_prompt(non_empty_lines: &[&str]) -> bool {
-    non_empty_lines.iter().any(|line| {
-        let trimmed = line.trim();
-        let Some(rest) = trimmed
-            .strip_prefix("❯")
-            .or_else(|| trimmed.strip_prefix("›"))
-        else {
-            return false;
-        };
+    non_empty_lines
+        .iter()
+        .any(|line| codex_is_non_numbered_cursor_prompt(line.trim()))
+}
 
-        !rest.trim_start().is_empty() && !codex_line_has_numbered_choice_cursor(trimmed)
-    })
+fn codex_has_tail_non_numbered_cursor_prompt(non_empty_lines: &[&str]) -> bool {
+    let Some(prompt_index) = non_empty_lines
+        .iter()
+        .rposition(|line| codex_is_non_numbered_cursor_prompt(line.trim()))
+    else {
+        return false;
+    };
+
+    non_empty_lines[prompt_index + 1..]
+        .iter()
+        .all(|line| codex_is_terminal_footer_line(line.trim()))
+}
+
+fn codex_is_non_numbered_cursor_prompt(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("❯").or_else(|| line.strip_prefix("›")) else {
+        return false;
+    };
+
+    !rest.trim_start().is_empty() && !codex_line_has_numbered_choice_cursor(line)
+}
+
+fn codex_is_terminal_footer_line(line: &str) -> bool {
+    line.contains(" · ")
+        && (line.starts_with("gpt-") || line.starts_with("o3") || line.starts_with("o4"))
 }
 
 fn codex_has_interrupted_turn_without_new_activity(non_empty_lines: &[&str]) -> bool {
@@ -500,6 +526,38 @@ fn codex_has_interrupted_turn_without_new_activity(non_empty_lines: &[&str]) -> 
     }
 
     true
+}
+
+fn codex_has_completed_turn_prompt(non_empty_lines: &[&str]) -> bool {
+    let Some(divider_index) = non_empty_lines
+        .iter()
+        .rposition(|line| codex_is_completed_work_divider(line.trim()))
+    else {
+        return false;
+    };
+
+    let lines_after_divider = &non_empty_lines[divider_index + 1..];
+    !codex_has_running_signal(lines_after_divider)
+        && !codex_has_plan_radio_prompt(lines_after_divider)
+        && !codex_has_recent_numbered_choice_prompt(lines_after_divider)
+        && !codex_has_approval_prompt(lines_after_divider)
+        && codex_has_tail_non_numbered_cursor_prompt(lines_after_divider)
+}
+
+fn codex_has_completed_review_prompt(non_empty_lines: &[&str]) -> bool {
+    let Some(marker_index) = non_empty_lines
+        .iter()
+        .rposition(|line| line.trim().contains("<< code review finished >>"))
+    else {
+        return false;
+    };
+
+    let lines_after_marker = &non_empty_lines[marker_index + 1..];
+    !codex_has_running_signal(lines_after_marker)
+        && !codex_has_plan_radio_prompt(lines_after_marker)
+        && !codex_has_recent_numbered_choice_prompt(lines_after_marker)
+        && !codex_has_approval_prompt(lines_after_marker)
+        && codex_has_tail_non_numbered_cursor_prompt(lines_after_marker)
 }
 
 fn codex_interruption_marker_end_index(non_empty_lines: &[&str]) -> Option<usize> {
@@ -1954,6 +2012,118 @@ report the issue.
         assert_eq!(
             reconcile_codex_hook_status(Status::Running, pane),
             Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_codex_hook_status_idle_after_completed_review() {
+        let pane = r#"
+>> Code review started: staged changes <<
+
+• Ran git diff --stat
+  └ 1 file changed, 3 insertions(+)
+
+• Explored
+  └ Read src/main.rs
+
+<< Code review finished >>
+
+──────────────────────────────────────────────────────────────
+
+• No discrete correctness issues were found in the provided command changes.
+
+─ Worked for 7m 40s ──────────────────────────────────────────
+
+› Implement {feature}
+
+  gpt-5.5 xhigh fast · ~/project
+"#;
+
+        assert_eq!(
+            reconcile_codex_hook_status(Status::Running, pane),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_codex_hook_status_idle_after_completed_review_without_worked_divider() {
+        let pane = r#"
+╭────────────────────────────────────────────────────╮
+│ >_ OpenAI Codex (v0.133.0)                         │
+│                                                    │
+│ model:     gpt-5.5 xhigh   fast   /model to change │
+│ directory: ~/project                               │
+╰────────────────────────────────────────────────────╯
+
+  Tip: Use /rename to rename your threads for easier thread resuming.
+
+>> Code review started: src/main.rs <<
+
+<< Code review finished >>
+
+• No discrete correctness issues were found in the provided command changes.
+
+› Improve documentation in @filename
+
+  gpt-5.5 xhigh fast · ~/project
+"#;
+
+        assert_eq!(
+            reconcile_codex_hook_status(Status::Running, pane),
+            Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_reconcile_codex_hook_status_keeps_running_after_completed_turn_with_new_activity() {
+        let pane = r#"
+<< Code review finished >>
+
+─ Worked for 7m 40s ──────────────────────────────────────────
+
+› Implement the fix
+
+• Working (4s • esc to interrupt)
+"#;
+
+        assert_eq!(
+            reconcile_codex_hook_status(Status::Running, pane),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_codex_hook_status_keeps_running_after_completed_turn_with_plain_new_output() {
+        let pane = r#"
+─ Worked for 7m 40s ──────────────────────────────────────────
+
+› Implement the fix
+
+I’ll inspect the status detection path first and then adjust the idle override.
+"#;
+
+        assert_eq!(
+            reconcile_codex_hook_status(Status::Running, pane),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_reconcile_codex_hook_status_keeps_running_after_completed_review_with_plain_new_output()
+    {
+        let pane = r#"
+>> Code review started: staged changes <<
+
+<< Code review finished >>
+
+› Implement the review comment
+
+I’ll inspect the status detection path first and then adjust the idle override.
+"#;
+
+        assert_eq!(
+            reconcile_codex_hook_status(Status::Running, pane),
+            Status::Running
         );
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -505,6 +505,12 @@ fn codex_is_non_numbered_cursor_prompt(line: &str) -> bool {
     !rest.trim_start().is_empty() && !codex_line_has_numbered_choice_cursor(line)
 }
 
+// The footer Codex prints under its input prompt looks like
+// `gpt-5.5 xhigh fast · ~/project`. The model-prefix list is intentionally
+// narrow so unrelated lines (e.g. assistant prose containing ` · `) don't
+// accidentally satisfy the tail check. If Codex ships a new model family
+// prefix this list needs to grow; the safe failure mode is that the hook
+// keeps reporting Running until it catches up on its own.
 fn codex_is_terminal_footer_line(line: &str) -> bool {
     line.contains(" · ")
         && (line.starts_with("gpt-") || line.starts_with("o3") || line.starts_with("o4"))
@@ -529,26 +535,22 @@ fn codex_has_interrupted_turn_without_new_activity(non_empty_lines: &[&str]) -> 
 }
 
 fn codex_has_completed_turn_prompt(non_empty_lines: &[&str]) -> bool {
-    let Some(divider_index) = non_empty_lines
-        .iter()
-        .rposition(|line| codex_is_completed_work_divider(line.trim()))
-    else {
-        return false;
-    };
-
-    let lines_after_divider = &non_empty_lines[divider_index + 1..];
-    !codex_has_running_signal(lines_after_divider)
-        && !codex_has_plan_radio_prompt(lines_after_divider)
-        && !codex_has_recent_numbered_choice_prompt(lines_after_divider)
-        && !codex_has_approval_prompt(lines_after_divider)
-        && codex_has_tail_non_numbered_cursor_prompt(lines_after_divider)
+    codex_has_idle_prompt_after_marker(non_empty_lines, |line| {
+        codex_is_completed_work_divider(line.trim())
+    })
 }
 
 fn codex_has_completed_review_prompt(non_empty_lines: &[&str]) -> bool {
-    let Some(marker_index) = non_empty_lines
-        .iter()
-        .rposition(|line| line.trim().contains("<< code review finished >>"))
-    else {
+    codex_has_idle_prompt_after_marker(non_empty_lines, |line| {
+        line.trim().contains("<< code review finished >>")
+    })
+}
+
+fn codex_has_idle_prompt_after_marker(
+    non_empty_lines: &[&str],
+    is_marker: impl Fn(&str) -> bool,
+) -> bool {
+    let Some(marker_index) = non_empty_lines.iter().rposition(|line| is_marker(line)) else {
         return false;
     };
 
@@ -2034,7 +2036,7 @@ report the issue.
 
 ─ Worked for 7m 40s ──────────────────────────────────────────
 
-› Implement {feature}
+› Implement the fix
 
   gpt-5.5 xhigh fast · ~/project
 "#;


### PR DESCRIPTION
## Description
Fixes Codex hook status reconciliation for panes where the Codex hook still reports `Running` after Codex has already returned to a completed-turn or completed-review prompt.

The reconciliation path now recognizes explicit completed-turn and completed-review prompt tails, but only when the prompt is the current terminal state. If a later turn has started and plain assistant output appears after an old `Worked for ...` divider or `<< code review finished >>` marker, the hook remains authoritative and the session stays `Running`.

Regression tests cover completed review prompts with and without `Worked for ...` dividers, visible new activity after a completed turn, and plain prose after stale completed-turn or review markers.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist
<!-- If you delete this checklist, your PR will be immediately closed -->

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

<!--
For user-facing changes we prefer to land the test alongside the code rather
than file a follow-up issue. Think of each new behavior or bug fix as a "user
story" that deserves a regression test. Pick one option per surface; if you
think a test isn't warranted, say why so reviewers can sanity-check.
-->

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain -->

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: status reconciliation is covered by focused unit tests around the Codex pane parsing and hook reconciliation logic.

## AI Usage

<!-- Check one -->
- [ ] No AI was used
- [x] AI was used

<!-- If AI was used, please share details -->
**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used Codex to implement the status reconciliation fix, add regression tests, run validation, and prepare this PR.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Fixed status detection so panes where the Codex hook still reports "Running" are reconciled to Idle when the UI shows an explicit completed-turn or completed-review prompt tail. This removes spurious Running states after a turn or review has finished.
- Added and refactored prompt-detection helpers so completed-prompt patterns (worked-for divider and "<< code review finished >>" marker) are recognized only when they form the current terminal state; if newer activity appears after those markers the hook remains authoritative and the session stays Running.
- Added regression tests covering completed review prompts (with and without the "Worked for ..." divider), visible new activity after a completed turn, and plain prose after stale completion markers.
- No public APIs changed; small net code additions and focused refactors to reduce duplication.

Technical details:
- Consolidated completed-prompt detection by extracting codex_has_idle_prompt_after_marker and sharing logic between completed-turn and completed-review detectors; only the marker predicate differs.
- Introduced tail-only non-numbered cursor prompt detection and a narrow "terminal footer" matcher (model/status metadata prefixes and a required " · " token) to safely accept certain footer lines while preventing stale markers from overriding live hook state.
- Documentation comments and test fixtures updated; a placeholder test string replaced with a concrete fixture.

Benefits:
- Reduces false-positive Running statuses and improves UX by reflecting actual completion when the terminal UI indicates it.
- Safer reconciliation: stale completion markers no longer mask real new output.
- Regression tests help prevent future regressions in reconciliation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1488?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->