### PR TITLE
fix(web): allow SPA bootstrap session routes

### DIFF
--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -234,15 +234,22 @@ fn normalize_path(path: &str) -> &str {
 
 /// Whether a request path is exempt from the passphrase session +
 /// device-binding check. These are the login bootstrap surfaces and
-/// static assets that pre-load the SPA shell. Shared by the
+/// static assets that pre-load the SPA shell. Browser document
+/// navigations to the SPA (for example `/session/<id>`) cannot attach
+/// the device-binding header; the API and websocket routes stay
+/// non-exempt so the device-bound session still protects data and
+/// terminal attachment. Shared by the
 /// token-with-passphrase branch of `auth_middleware` and by
 /// `run_passphrase_wall` so a new bootstrap path only needs to be
 /// added once.
 fn is_login_session_exempt(path: &str) -> bool {
-    path == "/login"
+    path == "/"
+        || path == "/login"
+        || path.starts_with("/session/")
         || path == "/api/login"
         || path == "/api/login/status"
         || path == "/api/logout"
+        || path == "/theme-bootstrap.js"
         || path.starts_with("/assets/")
         || path == "/manifest.json"
         || path == "/sw.js"
@@ -1167,14 +1174,16 @@ mod tests {
         // Login-exempt: must not refresh.
         assert!(!should_refresh_session_cookie("/api/logout"));
         assert!(!should_refresh_session_cookie("/api/login"));
+        assert!(!should_refresh_session_cookie("/"));
         assert!(!should_refresh_session_cookie("/login"));
+        assert!(!should_refresh_session_cookie("/session/abc"));
         assert!(!should_refresh_session_cookie("/api/login/status"));
+        assert!(!should_refresh_session_cookie("/theme-bootstrap.js"));
         assert!(!should_refresh_session_cookie("/assets/index.js"));
         assert!(!should_refresh_session_cookie("/manifest.json"));
         assert!(!should_refresh_session_cookie("/sw.js"));
 
         // Non-exempt: must refresh (sliding window).
-        assert!(should_refresh_session_cookie("/"));
         assert!(should_refresh_session_cookie("/api/sessions"));
         assert!(should_refresh_session_cookie(
             "/api/sessions/abc/cockpit/ws"
@@ -1190,12 +1199,16 @@ mod tests {
         // Bootstrap + status endpoints: the user might hit these
         // before a session exists (or after it expired) and the
         // middleware must let them through so the SPA can recover.
+        assert!(is_login_session_exempt("/"));
         assert!(is_login_session_exempt("/login"));
+        assert!(is_login_session_exempt("/session/abc"));
+        assert!(is_login_session_exempt("/session/2626c6af68754732"));
         assert!(is_login_session_exempt("/api/login"));
         assert!(is_login_session_exempt("/api/login/status"));
         assert!(is_login_session_exempt("/api/logout"));
 
         // Static assets: pre-load the SPA shell before any auth.
+        assert!(is_login_session_exempt("/theme-bootstrap.js"));
         assert!(is_login_session_exempt("/assets/index.css"));
         assert!(is_login_session_exempt("/assets/index-abc123.js"));
         assert!(is_login_session_exempt("/manifest.json"));
@@ -1203,11 +1216,12 @@ mod tests {
         assert!(is_login_session_exempt("/icon-192.png"));
         assert!(is_login_session_exempt("/fonts/inter.woff2"));
 
-        // Everything else stays gated.
-        assert!(!is_login_session_exempt("/"));
+        // Everything else stays gated, including real data/API and
+        // websocket attach routes that can send a device binding.
         assert!(!is_login_session_exempt("/api/sessions"));
         assert!(!is_login_session_exempt("/api/login/elevate"));
         assert!(!is_login_session_exempt("/api/settings"));
+        assert!(!is_login_session_exempt("/sessions/abc/ws"));
         assert!(!is_login_session_exempt("/api/sessions/abc/ws"));
         // /api/login/foo is not the same as /api/login exactly.
         assert!(!is_login_session_exempt("/api/login/foo"));


### PR DESCRIPTION
## Description
Fixes a web attach/bootstrap failure where direct browser navigation to a session route such as `/session/<id>` could be redirected back to `/login` even after passphrase login.

Browser document navigations and static bootstrap scripts cannot attach the `X-Aoe-Device-Binding` header. The auth middleware now treats SPA bootstrap routes (`/`, `/session/<id>`, and `/theme-bootstrap.js`) like the existing static shell bootstrap paths, while keeping API and websocket attach routes device-bound.

Observed locally on the Mayans session: before the fix, logs showed `had_session_cookie=true had_device_binding=false` for `/session/2626c6af68754732` and no terminal websocket attach. After the fix, the same document route returned 200 and the Mayans terminal websocket attached.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because: <!-- explain (e.g. pure styling tweak, copy change) -->

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: <!-- explain -->

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to investigate the auth/bootstrap failure from local server logs, implement the focused middleware fix, and run validation.

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `cargo fmt -- --check`
- `cargo test --features serve login_session_exempt_paths -- --nocapture`
- `cargo test --features serve session_cookie_refresh_skips_login_exempt_paths -- --nocapture`
- `cargo test --features serve post_token_auth_action_matrix -- --nocapture`
- `cargo clippy --features serve -- -D warnings`
- `git diff --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`
- Local deployment smoke test: `/session/2626c6af68754732?token=<redacted>` returned HTTP 200 with the SPA root, and debug logs showed Mayans `terminal.ws` attach/resize.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

The authentication middleware was updated to allow direct browser navigation to Single Page Application (SPA) session routes without requiring device binding headers. Specifically, three types of routes are now treated as authentication-exempt bootstrap paths:

1. **Root and login pages** - `/` and `/login`
2. **Session routes** - Any path starting with `/session/` (e.g., `/session/2626c6af68754732`)
3. **Theme bootstrap script** - `/theme-bootstrap.js`

These routes now bypass the device-binding requirement while existing API and WebSocket routes maintain their strict device-binding security checks.

## Why This Matters

Browser document navigations cannot attach the `X-Aoe-Device-Binding` header, causing users to be redirected back to `/login` even after successfully authenticating. The fix allows the SPA to load and function properly on direct browser navigation while preserving security for API and WebSocket endpoints that can attach binding headers.

## Testing Impact

Unit tests were updated to verify:
- Session cookie refresh is skipped on the newly exempt routes (preventing cookie conflicts during login/logout)
- All newly exempt paths are properly recognized as login-exempt
- Non-exempt routes continue to require device binding

## Technical Summary

The `is_login_session_exempt()` function was modified to add pattern matching for:
- Exact path match on `/` and `/login`
- Prefix match on `/session/` (routes with dynamic session IDs)
- Exact path match on `/theme-bootstrap.js`

The `should_refresh_session_cookie()` function correctly delegates to `is_login_session_exempt()` to prevent cookie refresh on these bootstrap paths, avoiding conflicts with handlers that manage their own session cookie lifecycle during login/logout operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1489?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->