### PR TITLE
docs(storage): clarify in-process Mutex is fast path, not load-bearing

### DIFF
--- a/src/session/storage.rs
+++ b/src/session/storage.rs
@@ -4,16 +4,38 @@
 //! `Storage` serialises read-modify-write cycles via two layers:
 //!
 //! 1. **In-process per-profile mutex** (one `Arc<Mutex<()>>` per profile name,
-//!    registered process-wide). Cheap, kills intra-process races between
-//!    threads sharing the same `Storage` profile.
+//!    registered process-wide). Performance + observability layer, not a
+//!    correctness primitive on the supported platforms (Linux, macOS): a
+//!    userspace mutex is roughly an order of magnitude cheaper than the
+//!    flock syscall on the uncontended path, and same-thread re-entry
+//!    deadlocks here immediately rather than via a 50ms polling loop on
+//!    the flock. Removing this layer would still produce correct on-disk
+//!    state because `fs2::FileExt` maps to `flock(2)`, whose locks are
+//!    scoped to the open file description (OFD) on **both** Linux and
+//!    macOS/BSD. (A common misconception is that macOS `flock` is
+//!    process-scoped; it is not. Apple's flock(2) man page and
+//!    `xnu/bsd/kern/kern_descrip.c::sys_flock` key the lock on
+//!    `fp->fp_glob`, the open file description, identical in effect to
+//!    Linux's documented OFD scoping.) Every `Storage::update` opens its
+//!    own fd via `OpenOptions::open`, so two `Storage` handles in the
+//!    same process get distinct OFDs and `flock` between them conflicts
+//!    just as it does between processes. If AoE is ever ported to a
+//!    platform whose underlying lock primitive is process-scoped (e.g.
+//!    POSIX `fcntl(F_SETLK)` advisory locks, or certain Windows backends
+//!    that key on the `HANDLE` rather than the open file description),
+//!    this mutex becomes load-bearing and must not be removed without
+//!    re-establishing intra-process exclusion.
 //! 2. **Cross-process advisory `flock(2)`** on a sidecar lock file
 //!    (`<profile_dir>/.storage.lock` for sessions+groups,
-//!    `<app_dir>/.workspace-ordering.lock` for ordering). Polled
-//!    `fs2::FileExt::try_lock_exclusive` with a 50ms backoff so a >1s wait
-//!    can fire a single `tracing::warn`; the kernel releases the lock on
-//!    process exit, including SIGKILL, so a crashed peer cannot wedge other
-//!    aoe processes. Mirrors the pattern already used by `recovery.rs` and
-//!    `logging.rs`.
+//!    `<app_dir>/.workspace-ordering.lock` for ordering). Sole guarantor
+//!    of write serialisation; `atomic_write` separately guarantees that
+//!    lock-free readers observe a consistent JSON document. Every mutator
+//!    holds the flock from before `load` until after `atomic_write`.
+//!    Polled `fs2::FileExt::try_lock_exclusive` with a 50ms backoff so
+//!    that a wait longer than 1s fires a single `tracing::warn`; the
+//!    kernel releases the lock on process exit, including SIGKILL, so a
+//!    crashed peer cannot wedge other aoe processes. Mirrors the pattern
+//!    already used by `recovery.rs` and `logging.rs`.
 //!
 //! All mutation goes through `update` (load -> mutate -> save under both
 //! locks). `save_workspace_ordering` is private and only consumed by


### PR DESCRIPTION
## Description

Followup to the review feedback you left when closing #1434 in favor of #1398:

> Rustdoc in `src/session/storage.rs` clarifying the in-process `Mutex`'s role (fast path, not load-bearing for correctness post-flock).

This PR rewrites the relevant `//!` block in `src/session/storage.rs` to spell that out, plus the technical reason the claim holds and the platform footgun a future port could trip over.

### What changed

The locking-model bullet for the in-process per-profile `Mutex<()>` now says:

- It is a performance + observability layer, not a correctness primitive on the supported platforms (Linux, macOS).
- A userspace mutex is roughly an order of magnitude cheaper than the flock syscall on the uncontended path; same-thread re-entry deadlocks immediately here rather than via a 50ms polling loop on the flock.
- Removing the layer would still produce correct on-disk state because `fs2::FileExt` maps to `flock(2)`, whose locks are scoped to the open file description (OFD): every `Storage::update` opens its own fd via `OpenOptions::open`, so two `Storage` handles in the same process get distinct OFDs and the `flock` between them conflicts just as it does between processes.
- Calls out the platform footgun: if AoE is ever ported to a platform whose underlying lock primitive is process-scoped (e.g. POSIX `fcntl(F_SETLK)` advisory locks), this mutex becomes load-bearing and must not be removed without re-establishing intra-process exclusion.

The `flock(2)` bullet was also tightened: "sole guarantor of correctness" → "sole guarantor of write serialisation", noting that `atomic_write` (tempfile + fsync + rename) separately covers torn-write protection so lock-free readers observe a consistent JSON document.

### Why these specific words

The original wording ("Cheap, kills intra-process races") didn't tell a future contributor whether the layer is mandatory or removable. The two questions that were ambiguous:

1. Could you remove the `Mutex<()>` and rely on the flock alone? (Yes, on Linux/macOS, because of OFD-scoped flock locks.)
2. Why keep it then? (Perf on the uncontended path; faster, louder failure surface for same-thread re-entry bugs.)

Both are now answered explicitly. The platform caveat is there so a future port to a non-OFD lock primitive doesn't silently break correctness.

The other two follow-ups you listed on #1434 (porting `cleanup_partial_create()` semantics, barrier-coordinated cross-process tests) already landed as part of #1398, so this rustdoc tweak is the only outstanding item.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(`cargo fmt`, `cargo clippy --lib --no-deps`, `cargo check --lib`, `cargo doc --no-deps --lib` all clean. Module rustdoc only, no behavior change, no UI surface.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OpenCode (Sisyphus orchestrator + 3 parallel oracle sub-agents for cross-validated review).

**Any Additional AI Details you'd like to share:**

The first draft of the rustdoc rewrite was reviewed by three oracle sub-agents in parallel with non-overlapping prompts (one for clarity vs. AGENTS.md style, one for adversarial concurrency-claim verification against the actual `flock(2)` / OFD semantics in the file, one for "does this match njbrake's stated request"). Cross-validating their outputs surfaced three concrete defects in the v1 prose that the v2 you see here addresses:

1. "Sole guarantor of correctness" overstated, because `atomic_write` is also load-bearing for the torn-write property a lock-free reader relies on.
2. "Orders of magnitude cheaper" overstated; userspace mutex vs. uncontended `flock` syscall on Linux is roughly one order of magnitude, not multiple.
3. The non-load-bearing claim is platform-conditional (depends on flock locks being OFD-scoped, which `flock(2)` is and `fcntl(F_SETLK)` is not), and the v1 prose elided the mechanism, which would have left a future contributor or porter free to break it.

NOTE: I will respond to review comments myself; the PR description text and commit message body were AI-drafted but I read and own the technical claims.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-level summary

- Rewrote the module-level rustdoc in src/session/storage.rs to clarify Storage's two-layer serialization strategy.
- Emphasises that the in-process per-profile Mutex<()> is a performance/observability fast path on supported platforms (Linux, macOS), not the correctness primitive.
- Tightens wording that cross-process flock(2) is the sole guarantor of write serialization and that atomic_write (tempfile + fsync + rename) protects readers from torn writes.
- Adds a platform warning: if AoE is ported to platforms with process-scoped advisory locks (e.g., POSIX fcntl(F_SETLK) or certain Windows backends), the mutex would become load-bearing and must be retained or replaced.
- Documentation-only change; no behavioral changes. Formatting and checks (cargo fmt/clippy/check/doc) pass.
- Diff size: +30 / -8. Estimated review effort: Low.

Technical details
- Explains that fs2::FileExt maps to flock(2), whose locks are scoped to the open file description (OFD) on Linux and macOS, and that Storage::update opens a new fd per operation so OFD-scoped flocks still conflict intra-process.
- Clarifies that every mutator holds the flock from before load until after atomic_write; the cross-process flock is polled with a 50ms backoff and emits a tracing::warn if contention exceeds 1s.
- Notes the RAII/drop semantics for the StorageFlock and the interaction/order between the in-process mutex and the cross-process flock.
- References prior PRs `#1434` and `#1398` for context.

Benefits
- Clearer, less ambiguous documentation reducing future maintenance errors and preventing unsafe removal of the in-process mutex on unsupported platforms.
- Improves observability and rationale for current lock choices, aiding reviewers and maintainers when reasoning about cross-process vs. intra-process exclusion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->