### PR TITLE
chore(dependabot): align ACP cadence and group tailwind bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -89,6 +89,11 @@ updates:
       semver-minor-days: 14
       semver-major-days: 28
     groups:
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+        update-types: ["minor", "patch"]
       web-minor-patch:
         patterns: ["*"]
         exclude-patterns:
@@ -146,7 +151,8 @@ updates:
   - package-ecosystem: "npm"
     directory: "/cockpit-worker/test-shim"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+      day: "monday"
       time: "06:00"
       timezone: "Etc/UTC"
     open-pull-requests-limit: 3
@@ -161,6 +167,10 @@ updates:
       default-days: 7
       semver-minor-days: 14
       semver-major-days: 28
+    groups:
+      acp:
+        patterns: ["@agentclientprotocol/*"]
+        update-types: ["minor", "patch"]
 
   # npm: website
   - package-ecosystem: "npm"
@@ -181,6 +191,11 @@ updates:
       semver-minor-days: 14
       semver-major-days: 28
     groups:
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+        update-types: ["minor", "patch"]
       website-minor-patch:
         patterns: ["*"]
         exclude-patterns:


### PR DESCRIPTION
## Description

Followup to your APPROVED review on #1457, which listed two soft, non-blocking suggestions:

> 1. `cockpit-worker/test-shim` and `cockpit-worker/aoe-agent` share `@agentclientprotocol/sdk`; running the shim monthly while the agent runs weekly can drift the two by up to 3 weeks. ACP minor bumps are unlikely to break protocol compat, so this is just symmetry.
> 2. `tailwindcss` + `@tailwindcss/*` could be bundled into a dedicated group so they bump together as one PR instead of two or three separate PRs against `web/` and `website/` on the same Monday.

This PR addresses both.

### Change 1: ACP cadence symmetry

`cockpit-worker/test-shim` moves from `interval: "monthly"` to `interval: "weekly"` with `day: "monday"` at 06:00 UTC, matching `cockpit-worker/aoe-agent`. Adds an `acp` group on the test-shim entry (patterns `@agentclientprotocol/*`, `update-types: ["minor", "patch"]`) mirroring the one already present on the agent side, so the two land in lockstep instead of drifting up to 3 weeks apart.

The group is technically a single-package group on test-shim today (only `@agentclientprotocol/sdk` is installed), but that mirrors the agent-side shape, future-proofs against more `@agentclientprotocol/*` packages landing in test-shim, and produces a slightly clearer PR title (`bump the acp group` instead of a bare package name).

### Change 2: Dedicated `tailwind` group in `web/` and `website/`

Each of `web/` and `website/` gets a new `tailwind` group bundling `tailwindcss` + `@tailwindcss/*` for minor+patch. Declared **before** the existing catchall `*-minor-patch` group, so first-match-wins routes Tailwind into `tailwind`.

Kept intact and unchanged:
- The catchall's `exclude-patterns` for `tailwindcss` / `@tailwindcss/*` (defense-in-depth: the dependabot-core specificity-scoring quirk tracked in [dependabot/dependabot-core#14576](https://github.com/dependabot/dependabot-core/issues/14576) means the catchall could in principle outrank `tailwind` on criteria count; the existing exclude-patterns guarantee Tailwind still falls into the dedicated group regardless).
- The existing `ignore: version-update:semver-major` rules for both names, in both ecosystems.

Cross-ecosystem grouping is not supported by Dependabot (each `updates[]` entry is independent), so the result is one Tailwind PR per ecosystem on the same Monday rather than the previous two-or-three split per ecosystem.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording — N/A

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via OpenCode (Sisyphus orchestrator + 3 parallel oracle sub-agents for cross-validated review).

**Any Additional AI Details you'd like to share:**

The change was cross-validated by three oracle sub-agents in parallel against three independent angles:

1. Dependabot v2 schema correctness (group ordering, name-reuse-across-entries, `update-types` interaction with `ignore` major rules, `day` field validity on weekly).
2. Match against your stated followup intent (per-ecosystem grouping is the correct interpretation of "as one PR instead of two or three"; ACP group symmetry naturally extends "weekly cadence").
3. Unintended side effects (Monday burst PR volume, single-package group cosmetics, day-of-week shift, group ordering vs. dependabot-core#14576).

The schema audit surfaced one non-obvious load-bearing detail: the catchall's pre-existing `exclude-patterns` for tailwindcss/@tailwindcss/\* is no longer redundant once the dedicated `tailwind` group exists — it's the safety net against dependabot-core#14576 (specificity scoring can outrank declaration order). That's why this PR doesn't remove those lines despite them looking redundant.

NOTE: I will respond to review comments myself; the PR description text and commit message body were AI-drafted but I read and own the technical claims.

- [ ] I am an AI Agent filling out this form (check box if true)
