### PR TITLE
feat(tui): click-to-live + attach-mode setting + settings reorg

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -614,6 +614,16 @@ pub struct SessionConfig {
     /// neither tmux nor live-send applies to them.
     #[serde(default)]
     pub new_session_attach_mode: NewSessionAttachMode,
+
+    /// What `Enter` (and double-click) does on an existing session
+    /// row in the Agent view. `Tmux` (default) attaches to the tmux
+    /// pane, the historical behavior. `LiveSend` enters live-send
+    /// mode instead so the TUI keeps the home list visible and pipes
+    /// keystrokes through to the agent. Terminal/Tool views and
+    /// cockpit-mode sessions ignore this setting; they keep their
+    /// existing activation paths (terminal attach, cockpit open).
+    #[serde(default)]
+    pub default_attach_mode: NewSessionAttachMode,
 }
 
 /// What the TUI does after a new session is created. See
@@ -675,6 +685,7 @@ impl Default for SessionConfig {
             session_id_poller_max_threads: default_session_id_poller_max_threads(),
             live_send_exit_chord: default_live_send_exit_chord(),
             new_session_attach_mode: NewSessionAttachMode::default(),
+            default_attach_mode: NewSessionAttachMode::default(),
         }
     }
 }

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -260,6 +260,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub new_session_attach_mode: Option<super::config::NewSessionAttachMode>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_attach_mode: Option<super::config::NewSessionAttachMode>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -495,6 +498,9 @@ pub fn apply_session_overrides(
     }
     if let Some(new_session_attach_mode) = source.new_session_attach_mode {
         target.new_session_attach_mode = new_session_attach_mode;
+    }
+    if let Some(default_attach_mode) = source.default_attach_mode {
+        target.default_attach_mode = default_attach_mode;
     }
 }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2268,7 +2268,21 @@ impl HomeView {
             }
         }
         match self.view_mode {
-            ViewMode::Agent => Some(Action::AttachSession(id)),
+            ViewMode::Agent => {
+                // `default_attach_mode = LiveSend` swaps the historical
+                // tmux attach for live-send mode on Enter / double-click.
+                // Cockpit was already handled above (the resolver also
+                // returns None for cockpit, so the match is double-safe);
+                // Terminal/Tool views keep their existing paths regardless.
+                if matches!(
+                    self.default_attach_mode(&id),
+                    Some(crate::session::NewSessionAttachMode::LiveSend)
+                ) {
+                    Some(Action::EnterLiveSend(id))
+                } else {
+                    Some(Action::AttachSession(id))
+                }
+            }
             ViewMode::Terminal => {
                 let terminal_mode = if let Some(inst) = self.get_instance(&id) {
                     if inst.is_sandboxed() {
@@ -2466,8 +2480,15 @@ impl HomeView {
     /// outside the inner rect, dialog open, diff view active). Shared by
     /// `handle_click` and `hovered_index` so selection and hover use the
     /// exact same math.
+    ///
+    /// Live-send is intentionally NOT treated as a blocking dialog here.
+    /// `has_dialog()` returns true while live mode is active so other
+    /// surfaces (key shortcuts, preview-click, scroll wheel) stay
+    /// frozen, but clicks on list rows are how the user switches the
+    /// live target session: blocking them would make the feature
+    /// unreachable via mouse.
     pub(super) fn resolve_row_to_index(&self, col: u16, row: u16) -> Option<usize> {
-        if self.diff_view.is_some() || self.has_dialog() {
+        if self.diff_view.is_some() || self.has_blocking_dialog_for_list_click() {
             return None;
         }
         let inner = self.list_inner_area;
@@ -2519,17 +2540,21 @@ impl HomeView {
             .and_then(|(c, r)| self.resolve_row_to_index(c, r))
     }
 
-    /// Route a left-click at (col, row) inside the session list. A single
-    /// click on a session row selects it (same effect as arrow-key
-    /// navigation); a single click on a group row toggles its collapsed
-    /// state; a second click on the same row within
+    /// Route a left-click at (col, row) inside the session list. A
+    /// single click on a session row selects it AND requests live-send
+    /// mode for that row (same `Action::EnterLiveSend` that Tab would
+    /// emit); a single click on a group row toggles its collapsed
+    /// state; a second click on the same session row within
     /// `DOUBLE_CLICK_THRESHOLD` activates the session (the same Action
-    /// the `Enter` keybind would have produced). Returns the activation
-    /// `Action` for the caller to dispatch, or `None` for selection-only /
-    /// no-op clicks. The caller redraws unconditionally so the moved
-    /// cursor / toggled group always paints before the action executes.
-    /// Gated by `has_dialog()` (via `resolve_row_to_index`) so clicks
-    /// don't shift selection out from under an open modal.
+    /// the `Enter` keybind would have produced) so users can still
+    /// drop into a full tmux attach without going through live mode.
+    /// Returns the action for the caller to dispatch, or `None` for
+    /// no-op clicks (group toggle, cockpit/creating rows, same-session
+    /// re-clicks while already live). The caller redraws unconditionally
+    /// so the moved cursor / toggled group always paints before the
+    /// action executes. Gated by `has_dialog()` (via
+    /// `resolve_row_to_index`) so clicks don't shift selection out
+    /// from under an open modal.
     pub fn handle_click(&mut self, col: u16, row: u16) -> Option<Action> {
         self.handle_click_at(std::time::Instant::now(), col, row)
     }
@@ -2582,15 +2607,22 @@ impl HomeView {
         match item {
             Item::Group { path, .. } => {
                 self.toggle_group_collapsed(&path);
+                None
             }
             Item::Session { .. } => {
                 if self.cursor != abs_idx {
                     self.cursor = abs_idx;
                     self.update_selected();
                 }
+                // Single-click on a session row enters live-send for
+                // that row, or switches the live target when already in
+                // live mode. `start_live_send` returns None for rows
+                // that can't host live mode (cockpit, creating/deleting)
+                // and for re-clicks on the already-live session, so the
+                // click is just a selection in those cases.
+                self.start_live_send()
             }
         }
-        None
     }
 
     /// Record the mouse position from a `MouseEventKind::Moved` event so
@@ -2755,9 +2787,15 @@ impl HomeView {
     /// "Reviving..." toast plumbing would never fire.
     ///
     /// Still no-ops on group headers, empty lists, and Creating rows
-    /// (no instance yet, nothing to revive).
+    /// (no instance yet, nothing to revive). Also no-ops when the
+    /// selected session is already the live-send target so click-to-
+    /// enter doesn't re-run ensure_pane_ready / drop the live worker
+    /// when the user clicks the same row twice.
     pub(super) fn start_live_send(&mut self) -> Option<Action> {
         let id = self.selected_session.clone()?;
+        if self.live_send.as_ref().is_some_and(|s| s.session_id == id) {
+            return None;
+        }
         let inst = self.get_instance(&id)?;
         if matches!(inst.status, Status::Creating | Status::Deleting) {
             return None;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2274,11 +2274,21 @@ impl HomeView {
                 // Cockpit was already handled above (the resolver also
                 // returns None for cockpit, so the match is double-safe);
                 // Terminal/Tool views keep their existing paths regardless.
+                //
+                // Route through `start_live_send` so the same-target
+                // guard (already-live on this session) is honored: a
+                // double-click on the live row would otherwise re-run
+                // ensure_pane_ready and respawn the worker for no
+                // reason. `start_live_send` returns `None` for that
+                // and for cockpit/creating rows; in either of those
+                // cases we leave activation alone (cockpit was already
+                // dispatched to OpenCockpit above; same-target re-click
+                // is intentionally a no-op).
                 if matches!(
                     self.default_attach_mode(&id),
                     Some(crate::session::NewSessionAttachMode::LiveSend)
                 ) {
-                    Some(Action::EnterLiveSend(id))
+                    self.start_live_send()
                 } else {
                     Some(Action::AttachSession(id))
                 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -1816,6 +1816,42 @@ impl HomeView {
         serve_open || self.info_dialog.is_some() || self.changelog_dialog.is_some()
     }
 
+    /// Same membership as `has_dialog()` minus live-send: list-row
+    /// clicks must keep working in live mode (that's how the user
+    /// switches the live target by clicking another row), but every
+    /// other modal surface should still freeze the list.
+    pub(super) fn has_blocking_dialog_for_list_click(&self) -> bool {
+        #[cfg(feature = "serve")]
+        let serve_open = self.serve_view.is_some();
+        #[cfg(not(feature = "serve"))]
+        let serve_open = false;
+
+        self.show_help
+            || self.search_active
+            || self.new_dialog.is_some()
+            || self.confirm_dialog.is_some()
+            || self.unified_delete_dialog.is_some()
+            || self.group_delete_options_dialog.is_some()
+            || self.rename_dialog.is_some()
+            || self.restart_dialog.is_some()
+            || self.hook_trust_dialog.is_some()
+            || self.hooks_install_dialog.is_some()
+            || self.welcome_dialog.is_some()
+            || self.no_agents_dialog.is_some()
+            || self.changelog_dialog.is_some()
+            || self.info_dialog.is_some()
+            || self.snooze_duration_dialog.is_some()
+            || self.profile_picker_dialog.is_some()
+            || self.projects_dialog.is_some()
+            || self.command_palette.is_some()
+            || self.tool_picker_dialog.is_some()
+            || self.send_message_dialog.is_some()
+            || self.update_confirm_dialog.is_some()
+            || serve_open
+            || self.settings_view.is_some()
+            || self.diff_view.is_some()
+    }
+
     pub fn has_dialog(&self) -> bool {
         #[cfg(feature = "serve")]
         let serve_open = self.serve_view.is_some();
@@ -2245,6 +2281,17 @@ impl HomeView {
             }
         };
         let tmux_name = tmux_session.name().to_string();
+        // Switching live mode from session A to session B (click on a
+        // different row while already live) overwrites `live_send` and
+        // drops the old worker, but the previous tmux session is still
+        // pinned to manual sizing from live-send's per-keystroke resize
+        // loop. Reset it now so leaving A in the background doesn't
+        // strand it at the preview-pane dimensions.
+        if let Some(prev) = self.live_send.as_ref() {
+            if prev.tmux_name != tmux_name {
+                crate::tmux::Session::from_name(&prev.tmux_name).reset_size_to_latest_client();
+            }
+        }
         // Parse the configured exit-chord list now so the per-keystroke
         // dispatch path doesn't re-parse on every event. Config edits
         // during live mode aren't possible (settings_view participates
@@ -2828,6 +2875,33 @@ impl HomeView {
             crate::session::resolve_config_or_warn(&profile)
                 .session
                 .new_session_attach_mode,
+        )
+    }
+
+    /// Resolve `default_attach_mode` for an existing session row when
+    /// the user activates it (Enter / double-click) in the Agent view.
+    /// Reads the instance's `source_profile` so the picked mode matches
+    /// whatever profile the session was filed under. Returns `None`
+    /// for cockpit-mode sessions because cockpit has its own activation
+    /// path that bypasses both tmux attach and live-send; callers should
+    /// short-circuit to that path before consulting this setting.
+    pub(super) fn default_attach_mode(
+        &self,
+        session_id: &str,
+    ) -> Option<crate::session::NewSessionAttachMode> {
+        let inst = self.get_instance(session_id)?;
+        if inst.is_cockpit_mode() {
+            return None;
+        }
+        let profile = if inst.source_profile.is_empty() {
+            self.config_profile()
+        } else {
+            inst.source_profile.clone()
+        };
+        Some(
+            crate::session::resolve_config_or_warn(&profile)
+                .session
+                .default_attach_mode,
         )
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4774,8 +4774,18 @@ mod click_to_select {
         env.view.update_selected();
 
         // Click the third visible row (inner.y + 2 == 3) -> flat_items[2].
+        // Single-click on a session row both selects it AND requests
+        // live-send mode for that row.
         let action = env.view.handle_click(5, 3);
-        assert!(action.is_none(), "single click should not activate");
+        let expected_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::EnterLiveSend(expected_id)),
+            "single click should select the row and request live mode"
+        );
         assert_eq!(env.view.cursor, 2);
     }
 
@@ -4787,8 +4797,18 @@ mod click_to_select {
         env.view.cursor = 1;
         env.view.update_selected();
 
+        // Re-clicking the already-selected row still requests live mode
+        // (the row is now eligible to be the live target); cursor stays
+        // put.
         let action = env.view.handle_click(5, 2);
-        assert!(action.is_none());
+        let expected_id = match &env.view.flat_items[1] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[1] should be a session"),
+        };
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::EnterLiveSend(expected_id))
+        );
         assert_eq!(env.view.cursor, 1);
     }
 
@@ -4851,7 +4871,11 @@ mod click_to_select {
 
         let t0 = Instant::now();
         let first = env.view.handle_click_at(t0, 5, 3);
-        assert!(first.is_none(), "first click only selects");
+        assert_eq!(
+            first,
+            Some(crate::tui::app::Action::EnterLiveSend(expected_id.clone())),
+            "first click selects and requests live mode"
+        );
         assert_eq!(env.view.cursor, 2);
 
         let t1 = t0 + Duration::from_millis(150);
@@ -4859,7 +4883,7 @@ mod click_to_select {
         assert_eq!(
             second,
             Some(crate::tui::app::Action::AttachSession(expected_id)),
-            "second click within threshold should activate the session"
+            "second click within threshold should attach the session"
         );
     }
 
@@ -4873,13 +4897,28 @@ mod click_to_select {
         env.view.cursor = 0;
         env.view.update_selected();
 
+        let id_row2 = match &env.view.flat_items[1] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[1] should be a session"),
+        };
+        let id_row3 = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
         let t0 = Instant::now();
-        env.view.handle_click_at(t0, 5, 2);
+        let first = env.view.handle_click_at(t0, 5, 2);
+        assert_eq!(
+            first,
+            Some(crate::tui::app::Action::EnterLiveSend(id_row2)),
+            "first click enters live mode for its row"
+        );
         let t1 = t0 + Duration::from_millis(100);
-        let action = env.view.handle_click_at(t1, 5, 3);
-        assert!(
-            action.is_none(),
-            "different-row second click is a fresh single click, not a double-click"
+        let second = env.view.handle_click_at(t1, 5, 3);
+        assert_eq!(
+            second,
+            Some(crate::tui::app::Action::EnterLiveSend(id_row3)),
+            "different-row second click is a fresh single click that switches the live target, not a double-click attach"
         );
         assert_eq!(env.view.cursor, 2);
     }
@@ -4893,14 +4932,21 @@ mod click_to_select {
         setup_inner(&mut env);
         env.view.cursor = 0;
         env.view.update_selected();
+        let id_row3 = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
 
         let t0 = Instant::now();
         env.view.handle_click_at(t0, 5, 3);
         let t1 = t0 + Duration::from_millis(1500);
         let action = env.view.handle_click_at(t1, 5, 3);
-        assert!(
-            action.is_none(),
-            "second click past threshold should not activate"
+        // Past the double-click threshold the second click is a fresh
+        // single click that re-requests live mode for the row; it
+        // never attaches.
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::EnterLiveSend(id_row3))
         );
     }
 
@@ -4922,7 +4968,11 @@ mod click_to_select {
         };
 
         let t0 = Instant::now();
-        env.view.handle_click_at(t0, 5, 3);
+        let first = env.view.handle_click_at(t0, 5, 3);
+        assert_eq!(
+            first,
+            Some(crate::tui::app::Action::EnterLiveSend(clicked_id.clone()))
+        );
         assert_eq!(env.view.cursor, 2);
 
         // Simulate the cursor drifting away between clicks (e.g., a
@@ -4970,6 +5020,155 @@ mod click_to_select {
             action.is_none(),
             "Creating sessions are not attachable; double-click should noop"
         );
+    }
+
+    /// Single click on a session row enters live-send mode for that
+    /// session (the same `Action::EnterLiveSend` that Tab emits) in
+    /// addition to selecting the row.
+    #[test]
+    #[serial]
+    fn single_click_on_session_emits_enter_live_send() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let target_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
+        let action = env.view.handle_click(5, 3);
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::EnterLiveSend(target_id))
+        );
+        assert_eq!(env.view.cursor, 2);
+    }
+
+    /// Already in live mode for session A; clicking a different
+    /// session row emits `EnterLiveSend(B)` so the caller can switch
+    /// the live target.
+    #[test]
+    #[serial]
+    fn click_on_other_session_while_live_switches_target() {
+        use crate::tui::home::live_send::LiveSendState;
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let id_a = match &env.view.flat_items[1] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[1] should be a session"),
+        };
+        let id_b = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
+        // Simulate already being in live mode for session A.
+        env.view.live_send = Some(LiveSendState {
+            session_id: id_a.clone(),
+            title: "session1".to_string(),
+            tmux_name: format!("aoe_test_{}", id_a),
+            exit_chords: Vec::new(),
+        });
+
+        // Click session B's row.
+        let action = env.view.handle_click(5, 3);
+        assert_eq!(
+            action,
+            Some(crate::tui::app::Action::EnterLiveSend(id_b)),
+            "clicking a different session row while live must switch the live target"
+        );
+    }
+
+    /// Clicking the row that is already the live-send target is a
+    /// no-op: re-running `enter_live_send` would drop the worker and
+    /// re-do ensure_pane_ready for no reason.
+    #[test]
+    #[serial]
+    fn click_on_already_live_session_is_noop() {
+        use crate::tui::home::live_send::LiveSendState;
+
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let id_a = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+
+        env.view.live_send = Some(LiveSendState {
+            session_id: id_a.clone(),
+            title: "session2".to_string(),
+            tmux_name: format!("aoe_test_{}", id_a),
+            exit_chords: Vec::new(),
+        });
+
+        let action = env.view.handle_click(5, 3);
+        assert!(
+            action.is_none(),
+            "clicking the already-live session row should not re-enter live mode"
+        );
+        assert_eq!(env.view.cursor, 2, "selection still updates");
+    }
+
+    /// Creating/Deleting sessions can't host live mode, so a single
+    /// click selects the row but emits no action.
+    #[test]
+    #[serial]
+    fn single_click_on_creating_session_returns_no_action() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let target_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        env.view.mutate_instance(&target_id, |inst| {
+            inst.status = crate::session::Status::Creating;
+        });
+
+        let action = env.view.handle_click(5, 3);
+        assert!(
+            action.is_none(),
+            "Creating sessions can't enter live mode; click is a selection only"
+        );
+        assert_eq!(env.view.cursor, 2);
+    }
+
+    /// Cockpit-mode sessions are not tmux-backed, so click cannot
+    /// enter live mode for them; selection still updates.
+    #[cfg(feature = "serve")]
+    #[test]
+    #[serial]
+    fn single_click_on_cockpit_session_returns_no_action() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let target_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        env.view.mutate_instance(&target_id, |inst| {
+            inst.cockpit_mode = true;
+        });
+
+        let action = env.view.handle_click(5, 3);
+        assert!(
+            action.is_none(),
+            "Cockpit sessions can't enter live mode; click is a selection only"
+        );
+        assert_eq!(env.view.cursor, 2);
     }
 
     #[test]
@@ -5737,6 +5936,117 @@ mod new_session_attach_mode {
         assert!(
             matches!(action, Some(Action::AttachAfterCreate(_))),
             "sync create path must emit AttachAfterCreate (route through attach-mode setting), got {:?}",
+            action
+        );
+    }
+}
+
+/// Tests for the `default_attach_mode` setting that drives whether
+/// pressing Enter (or double-clicking) on an existing session row in
+/// Agent view attaches to tmux or enters live-send mode.
+mod default_attach_mode {
+    use super::*;
+    use crate::session::config::{save_config, Config, NewSessionAttachMode};
+
+    fn add_session(view: &mut HomeView, title: &str) -> String {
+        let mut inst = Instance::new(title, "/tmp/test");
+        inst.source_profile = "test".to_string();
+        let id = inst.id.clone();
+        view.add_instance(inst);
+        id
+    }
+
+    fn write_global_default_attach_mode(mode: NewSessionAttachMode) {
+        let mut config = Config::default();
+        config.session.default_attach_mode = mode;
+        save_config(&config).unwrap();
+    }
+
+    #[test]
+    #[serial]
+    fn defaults_to_tmux_when_no_config_present() {
+        // Default Enter / double-click stays on AttachSession; flipping
+        // it to LiveSend silently changes every existing user's muscle
+        // memory on upgrade.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        let mode = env.view.default_attach_mode(&id);
+        assert_eq!(mode, Some(NewSessionAttachMode::Tmux));
+    }
+
+    #[test]
+    #[serial]
+    fn enter_emits_attach_session_when_default_is_tmux() {
+        // Sanity: with the historical Tmux default, Enter on a session
+        // row produces Action::AttachSession.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.activate_selected_session();
+        assert_eq!(action, Some(Action::AttachSession(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn enter_emits_enter_live_send_when_default_is_live_send() {
+        // User opted into "Enter = live mode": activating an Agent-view
+        // row must dispatch Action::EnterLiveSend instead of AttachSession.
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.activate_selected_session();
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn terminal_view_ignores_default_attach_mode() {
+        // Terminal view has its own activation path (Container/Host
+        // tmux attach). The setting only applies to Agent view, so
+        // Terminal must keep its existing behavior even when
+        // default_attach_mode = LiveSend.
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Terminal;
+        let action = env.view.activate_selected_session();
+        assert!(
+            matches!(&action, Some(Action::AttachTerminal(returned_id, _)) if returned_id == &id),
+            "Terminal view must emit AttachTerminal regardless of default_attach_mode, got {:?}",
+            action
+        );
+    }
+
+    /// Cockpit sessions short-circuit before the setting is consulted
+    /// (the cockpit branch in `activate_selected_session` returns
+    /// `OpenCockpit`/transient-status before we get to the view-mode
+    /// match), so the resolver also returns None for them; the setting
+    /// must not be able to misroute a cockpit row into live mode.
+    #[cfg(feature = "serve")]
+    #[test]
+    #[serial]
+    fn cockpit_session_ignores_default_attach_mode() {
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let id = add_session(&mut env.view, "cockpit-one");
+        env.view.mutate_instance(&id, |inst| {
+            inst.cockpit_mode = true;
+        });
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.activate_selected_session();
+        assert!(
+            matches!(&action, Some(Action::OpenCockpit(returned_id)) if returned_id == &id),
+            "cockpit rows must route to OpenCockpit regardless of default_attach_mode, got {:?}",
             action
         );
     }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -20,6 +20,8 @@ pub enum SettingsCategory {
     Sandbox,
     Tmux,
     Session,
+    Agents,
+    Interaction,
     Sound,
     StatusHooks,
     Hooks,
@@ -37,9 +39,11 @@ impl SettingsCategory {
             Self::Sandbox => "Sandbox",
             Self::Tmux => "Tmux",
             Self::Session => "Session",
+            Self::Agents => "Agents",
+            Self::Interaction => "Interaction",
             Self::Sound => "Sound",
             Self::StatusHooks => "Status Hooks",
-            Self::Hooks => "Hooks",
+            Self::Hooks => "Lifecycle Hooks",
             Self::Web => "Web",
             Self::Cockpit => "Cockpit",
             Self::Logging => "Logging",
@@ -103,6 +107,7 @@ pub enum FieldKey {
     SessionIdPollerMaxThreads,
     LiveSendExitChord,
     NewSessionAttachMode,
+    DefaultAttachMode,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -159,6 +164,12 @@ pub enum FieldKey {
     LoggingMaxSizeMib,
     LoggingKeepCount,
     LoggingShowSpans,
+    /// Pseudo-key for `FieldValue::SectionHeader` rows so apply/clear
+    /// match arms have a defined-but-no-op variant rather than falling
+    /// through to a panic-on-missing-arm wildcard. Carries no payload;
+    /// multiple section markers in one category are disambiguated by
+    /// the label string on the parent `SettingField`.
+    SectionMarker,
 }
 
 /// Map `UpdateCheckMode` to the Select index used by the settings TUI.
@@ -226,6 +237,7 @@ fn value_display_string(value: &FieldValue) -> String {
         }
         FieldValue::List(items) => format!("[{} items]", items.len()),
         FieldValue::OptionalText(v) => v.clone().unwrap_or_else(|| "(empty)".to_string()),
+        FieldValue::SectionHeader => String::new(),
     }
 }
 
@@ -272,6 +284,12 @@ pub enum FieldValue {
     },
     List(Vec<String>),
     OptionalText(Option<String>),
+    /// Non-interactive section divider rendered as a styled heading.
+    /// The `SettingField::label` carries the heading text and
+    /// `description` carries the (optional) subtitle below it. Input
+    /// handlers skip cursor navigation past entries carrying this
+    /// variant; apply / clear pathways no-op for them.
+    SectionHeader,
 }
 
 /// A setting field with metadata
@@ -286,6 +304,15 @@ pub struct SettingField {
     pub has_override: bool,
     /// Human-readable display of the inherited (global/base) value, set when has_override is true
     pub inherited_display: Option<String>,
+}
+
+impl SettingField {
+    /// True when this entry is a non-interactive section divider
+    /// (`FieldValue::SectionHeader`). The renderer paints it as a
+    /// styled heading and the input handler skips navigation past it.
+    pub fn is_section_header(&self) -> bool {
+        matches!(self.value, FieldValue::SectionHeader)
+    }
 }
 
 impl SettingField {
@@ -340,6 +367,8 @@ pub fn build_fields_for_category(
         SettingsCategory::Sandbox => build_sandbox_fields(scope, global, profile),
         SettingsCategory::Tmux => build_tmux_fields(scope, global, profile),
         SettingsCategory::Session => build_session_fields(scope, global, profile),
+        SettingsCategory::Agents => build_agents_fields(scope, global, profile),
+        SettingsCategory::Interaction => build_interaction_fields(scope, global, profile),
         SettingsCategory::Sound => build_sound_fields(scope, global, profile),
         SettingsCategory::StatusHooks => build_status_hook_fields(scope, global, profile),
         SettingsCategory::Hooks => build_hooks_fields(scope, global, profile),
@@ -638,30 +667,12 @@ fn build_cockpit_fields(
             inherited_display: None,
         },
         SettingField {
-            key: FieldKey::CockpitMaxConcurrentWorkers,
-            label: "Max concurrent workers",
-            description: "Hard cap on simultaneously running cockpit agent subprocesses; additional sessions queue.",
-            value: FieldValue::Number(u64::from(max_workers)),
-            category: SettingsCategory::Cockpit,
-            has_override: mw_override,
-            inherited_display: None,
-        },
-        SettingField {
             key: FieldKey::CockpitReplayEvents,
             label: "History cap (events)",
             description: "Per-session retention cap on cockpit events. 0 = unlimited (default); set a non-zero value to bound disk usage on long-running sessions.",
             value: FieldValue::Number(u64::from(replay_events)),
             category: SettingsCategory::Cockpit,
             has_override: re_override,
-            inherited_display: None,
-        },
-        SettingField {
-            key: FieldKey::CockpitReplayBytes,
-            label: "Replay buffer bytes",
-            description: "Maximum bytes of cockpit events kept in the per-session replay buffer.",
-            value: FieldValue::Number(replay_bytes),
-            category: SettingsCategory::Cockpit,
-            has_override: rb_override,
             inherited_display: None,
         },
         SettingField {
@@ -680,6 +691,24 @@ fn build_cockpit_fields(
             value: FieldValue::Bool(show_tool_durations),
             category: SettingsCategory::Cockpit,
             has_override: std_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::SectionMarker,
+            label: "Advanced",
+            description: "Operational tuning — rarely needed after first setup. Adjust only if you've read the description and know what you're changing.",
+            value: FieldValue::SectionHeader,
+            category: SettingsCategory::Cockpit,
+            has_override: false,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitMaxConcurrentWorkers,
+            label: "Max concurrent workers",
+            description: "Hard cap on simultaneously running cockpit agent subprocesses; additional sessions queue.",
+            value: FieldValue::Number(u64::from(max_workers)),
+            category: SettingsCategory::Cockpit,
+            has_override: mw_override,
             inherited_display: None,
         },
         SettingField {
@@ -704,6 +733,15 @@ fn build_cockpit_fields(
             },
             category: SettingsCategory::Cockpit,
             has_override: qdm_override,
+            inherited_display: None,
+        },
+        SettingField {
+            key: FieldKey::CockpitReplayBytes,
+            label: "Replay buffer bytes",
+            description: "Maximum bytes of cockpit events kept in the per-session replay buffer.",
+            value: FieldValue::Number(replay_bytes),
+            category: SettingsCategory::Cockpit,
+            has_override: rb_override,
             inherited_display: None,
         },
         SettingField {
@@ -1500,18 +1538,6 @@ fn build_session_fields(
 ) -> Vec<SettingField> {
     let session = profile.session.as_ref();
 
-    let (default_tool, has_override) = resolve_optional(
-        scope,
-        global.session.default_tool.clone(),
-        session.and_then(|s| s.default_tool.clone()),
-        session.map(|s| s.default_tool.is_some()).unwrap_or(false),
-    );
-
-    let selected = crate::agents::settings_index_from_name(default_tool.as_deref());
-
-    let mut options = vec!["Auto (first available)".to_string()];
-    options.extend(crate::agents::agent_names().iter().map(|n| n.to_string()));
-
     let (yolo_mode_default, yolo_override) = resolve_value(
         scope,
         global.session.yolo_mode_default,
@@ -1538,28 +1564,10 @@ fn build_session_fields(
         session.and_then(|s| s.restart_wake_message.clone()),
     );
 
-    let (live_send_exit_chord, live_send_exit_chord_override) = resolve_value(
-        scope,
-        global.session.live_send_exit_chord.clone(),
-        session.and_then(|s| s.live_send_exit_chord.clone()),
-    );
-
-    let (new_session_attach_mode, new_session_attach_mode_override) = resolve_value(
-        scope,
-        global.session.new_session_attach_mode,
-        session.and_then(|s| s.new_session_attach_mode),
-    );
-
     let (row_tag, row_tag_override) = resolve_value(
         scope,
         global.session.row_tag,
         session.and_then(|s| s.row_tag),
-    );
-
-    let (agent_status_hooks, status_hooks_override) = resolve_value(
-        scope,
-        global.session.agent_status_hooks,
-        session.and_then(|s| s.agent_status_hooks),
     );
 
     let (host_environment, host_env_override) = resolve_value(
@@ -1568,129 +1576,7 @@ fn build_session_fields(
         profile.environment.clone(),
     );
 
-    // Agent extra args: HashMap -> Vec<String> of "key=value" items for List field
-    let (extra_args_map, extra_args_override) = resolve_value(
-        scope,
-        global.session.agent_extra_args.clone(),
-        session.and_then(|s| s.agent_extra_args.clone()),
-    );
-    let extra_args_list: Vec<String> = {
-        let mut items: Vec<_> = extra_args_map
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-
-    // Agent command override: HashMap -> Vec<String> of "key=value" items
-    let (cmd_override_map, cmd_override_override) = resolve_value(
-        scope,
-        global.session.agent_command_override.clone(),
-        session.and_then(|s| s.agent_command_override.clone()),
-    );
-    let cmd_override_list: Vec<String> = {
-        let mut items: Vec<_> = cmd_override_map
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-
-    let global_tool_selected =
-        crate::agents::settings_index_from_name(global.session.default_tool.as_deref());
-
-    let global_extra_args_list: Vec<String> = {
-        let mut items: Vec<_> = global
-            .session
-            .agent_extra_args
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-    let global_cmd_override_list: Vec<String> = {
-        let mut items: Vec<_> = global
-            .session
-            .agent_command_override
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-
-    // Custom agents: HashMap -> Vec<String> of "name=command" items
-    let (custom_agents_map, custom_agents_override) = resolve_value(
-        scope,
-        global.session.custom_agents.clone(),
-        session.and_then(|s| s.custom_agents.clone()),
-    );
-    let custom_agents_list: Vec<String> = {
-        let mut items: Vec<_> = custom_agents_map
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-    let global_custom_agents_list: Vec<String> = {
-        let mut items: Vec<_> = global
-            .session
-            .custom_agents
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-
-    // Agent detect_as: HashMap -> Vec<String> of "name=builtin" items
-    let (detect_as_map, detect_as_override) = resolve_value(
-        scope,
-        global.session.agent_detect_as.clone(),
-        session.and_then(|s| s.agent_detect_as.clone()),
-    );
-    let detect_as_list: Vec<String> = {
-        let mut items: Vec<_> = detect_as_map
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-    let global_detect_as_list: Vec<String> = {
-        let mut items: Vec<_> = global
-            .session
-            .agent_detect_as
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect();
-        items.sort();
-        items
-    };
-
     let mut fields = vec![
-        SettingField {
-            key: FieldKey::DefaultTool,
-            label: "Default Tool",
-            description: "Default coding tool for new sessions",
-            value: FieldValue::Select {
-                selected,
-                options: options.clone(),
-            },
-            category: SettingsCategory::Session,
-            has_override,
-            inherited_display: inherited_if(
-                has_override,
-                FieldValue::Select {
-                    selected: global_tool_selected,
-                    options,
-                },
-            ),
-        },
         SettingField {
             key: FieldKey::YoloModeDefault,
             label: "YOLO Mode Default",
@@ -1741,52 +1627,6 @@ fn build_session_fields(
             ),
         },
         SettingField {
-            key: FieldKey::LiveSendExitChord,
-            label: "Live-Send Exit Chord",
-            description:
-                "Comma-separated chord specs that exit live-send mode. \
-                 Tmux-style: C-q, M-x, F12. Default `C-q` works in \
-                 every terminal we ship to; add entries for additional \
-                 exits if you need to send C-q through to the agent.",
-            value: FieldValue::Text(live_send_exit_chord),
-            category: SettingsCategory::Session,
-            has_override: live_send_exit_chord_override,
-            inherited_display: inherited_if(
-                live_send_exit_chord_override,
-                FieldValue::Text(global.session.live_send_exit_chord.clone()),
-            ),
-        },
-        SettingField {
-            key: FieldKey::NewSessionAttachMode,
-            label: "New Session Attach Mode",
-            description:
-                "What to do after creating a new session: drop into tmux \
-                 (default, historical behavior) or enter live-send mode so \
-                 you never have to be inside tmux. Cockpit sessions ignore \
-                 this setting.",
-            value: FieldValue::Select {
-                selected: new_session_attach_mode_to_index(new_session_attach_mode),
-                options: NEW_SESSION_ATTACH_MODE_OPTIONS
-                    .iter()
-                    .map(|s| s.to_string())
-                    .collect(),
-            },
-            category: SettingsCategory::Session,
-            has_override: new_session_attach_mode_override,
-            inherited_display: inherited_if(
-                new_session_attach_mode_override,
-                FieldValue::Select {
-                    selected: new_session_attach_mode_to_index(
-                        global.session.new_session_attach_mode,
-                    ),
-                    options: NEW_SESSION_ATTACH_MODE_OPTIONS
-                        .iter()
-                        .map(|s| s.to_string())
-                        .collect(),
-                },
-            ),
-        },
-        SettingField {
             key: FieldKey::RowTag,
             label: "Row Tag",
             description:
@@ -1804,68 +1644,6 @@ fn build_session_fields(
                     selected: row_tag_to_index(global.session.row_tag),
                     options: ROW_TAG_OPTIONS.iter().map(|s| s.to_string()).collect(),
                 },
-            ),
-        },
-        SettingField {
-            key: FieldKey::AgentExtraArgs,
-            label: "Agent Extra Args",
-            description:
-                "Per-agent extra arguments appended after the binary (e.g. opencode=--port 8080)",
-            value: FieldValue::List(extra_args_list),
-            category: SettingsCategory::Session,
-            has_override: extra_args_override,
-            inherited_display: inherited_if(
-                extra_args_override,
-                FieldValue::List(global_extra_args_list),
-            ),
-        },
-        SettingField {
-            key: FieldKey::AgentCommandOverride,
-            label: "Agent Command Override",
-            description: "Per-agent command override replacing the binary (e.g. claude=my-wrapper)",
-            value: FieldValue::List(cmd_override_list),
-            category: SettingsCategory::Session,
-            has_override: cmd_override_override,
-            inherited_display: inherited_if(
-                cmd_override_override,
-                FieldValue::List(global_cmd_override_list),
-            ),
-        },
-        SettingField {
-            key: FieldKey::CustomAgents,
-            label: "Custom Agents",
-            description:
-                "User-defined agents: name=command (e.g. lenovo-claude=ssh -t lenovo claude)",
-            value: FieldValue::List(custom_agents_list),
-            category: SettingsCategory::Session,
-            has_override: custom_agents_override,
-            inherited_display: inherited_if(
-                custom_agents_override,
-                FieldValue::List(global_custom_agents_list),
-            ),
-        },
-        SettingField {
-            key: FieldKey::AgentDetectAs,
-            label: "Agent Detect As",
-            description: "Status detection mapping: agent=builtin (e.g. lenovo-claude=claude)",
-            value: FieldValue::List(detect_as_list),
-            category: SettingsCategory::Session,
-            has_override: detect_as_override,
-            inherited_display: inherited_if(
-                detect_as_override,
-                FieldValue::List(global_detect_as_list),
-            ),
-        },
-        SettingField {
-            key: FieldKey::AgentStatusHooks,
-            label: "Agent Status Hooks",
-            description: "Install status-detection hooks into the agent's config file",
-            value: FieldValue::Bool(agent_status_hooks),
-            category: SettingsCategory::Session,
-            has_override: status_hooks_override,
-            inherited_display: inherited_if(
-                status_hooks_override,
-                FieldValue::Bool(global.session.agent_status_hooks),
             ),
         },
         SettingField {
@@ -1898,6 +1676,323 @@ fn build_session_fields(
     }
 
     fields
+}
+
+/// Per-agent / per-tool configuration. Split out of Session because
+/// the bucket was a grab-bag and DefaultTool + the agent_* maps are a
+/// coherent mental model on their own.
+fn build_agents_fields(
+    scope: SettingsScope,
+    global: &Config,
+    profile: &ProfileConfig,
+) -> Vec<SettingField> {
+    let session = profile.session.as_ref();
+
+    let (default_tool, has_override) = resolve_optional(
+        scope,
+        global.session.default_tool.clone(),
+        session.and_then(|s| s.default_tool.clone()),
+        session.map(|s| s.default_tool.is_some()).unwrap_or(false),
+    );
+
+    let selected = crate::agents::settings_index_from_name(default_tool.as_deref());
+
+    let mut options = vec!["Auto (first available)".to_string()];
+    options.extend(crate::agents::agent_names().iter().map(|n| n.to_string()));
+
+    let global_tool_selected =
+        crate::agents::settings_index_from_name(global.session.default_tool.as_deref());
+
+    let (agent_status_hooks, status_hooks_override) = resolve_value(
+        scope,
+        global.session.agent_status_hooks,
+        session.and_then(|s| s.agent_status_hooks),
+    );
+
+    let (extra_args_map, extra_args_override) = resolve_value(
+        scope,
+        global.session.agent_extra_args.clone(),
+        session.and_then(|s| s.agent_extra_args.clone()),
+    );
+    let extra_args_list: Vec<String> = {
+        let mut items: Vec<_> = extra_args_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_extra_args_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .agent_extra_args
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
+    let (cmd_override_map, cmd_override_override) = resolve_value(
+        scope,
+        global.session.agent_command_override.clone(),
+        session.and_then(|s| s.agent_command_override.clone()),
+    );
+    let cmd_override_list: Vec<String> = {
+        let mut items: Vec<_> = cmd_override_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_cmd_override_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .agent_command_override
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
+    let (custom_agents_map, custom_agents_override) = resolve_value(
+        scope,
+        global.session.custom_agents.clone(),
+        session.and_then(|s| s.custom_agents.clone()),
+    );
+    let custom_agents_list: Vec<String> = {
+        let mut items: Vec<_> = custom_agents_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_custom_agents_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .custom_agents
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
+    let (detect_as_map, detect_as_override) = resolve_value(
+        scope,
+        global.session.agent_detect_as.clone(),
+        session.and_then(|s| s.agent_detect_as.clone()),
+    );
+    let detect_as_list: Vec<String> = {
+        let mut items: Vec<_> = detect_as_map
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+    let global_detect_as_list: Vec<String> = {
+        let mut items: Vec<_> = global
+            .session
+            .agent_detect_as
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect();
+        items.sort();
+        items
+    };
+
+    vec![
+        SettingField {
+            key: FieldKey::DefaultTool,
+            label: "Default Tool",
+            description: "Default coding tool for new sessions",
+            value: FieldValue::Select {
+                selected,
+                options: options.clone(),
+            },
+            category: SettingsCategory::Agents,
+            has_override,
+            inherited_display: inherited_if(
+                has_override,
+                FieldValue::Select {
+                    selected: global_tool_selected,
+                    options,
+                },
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentExtraArgs,
+            label: "Agent Extra Args",
+            description:
+                "Per-agent extra arguments appended after the binary (e.g. opencode=--port 8080)",
+            value: FieldValue::List(extra_args_list),
+            category: SettingsCategory::Agents,
+            has_override: extra_args_override,
+            inherited_display: inherited_if(
+                extra_args_override,
+                FieldValue::List(global_extra_args_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentCommandOverride,
+            label: "Agent Command Override",
+            description: "Per-agent command override replacing the binary (e.g. claude=my-wrapper)",
+            value: FieldValue::List(cmd_override_list),
+            category: SettingsCategory::Agents,
+            has_override: cmd_override_override,
+            inherited_display: inherited_if(
+                cmd_override_override,
+                FieldValue::List(global_cmd_override_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::CustomAgents,
+            label: "Custom Agents",
+            description:
+                "User-defined agents: name=command (e.g. lenovo-claude=ssh -t lenovo claude)",
+            value: FieldValue::List(custom_agents_list),
+            category: SettingsCategory::Agents,
+            has_override: custom_agents_override,
+            inherited_display: inherited_if(
+                custom_agents_override,
+                FieldValue::List(global_custom_agents_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentDetectAs,
+            label: "Agent Detect As",
+            description: "Status detection mapping: agent=builtin (e.g. lenovo-claude=claude)",
+            value: FieldValue::List(detect_as_list),
+            category: SettingsCategory::Agents,
+            has_override: detect_as_override,
+            inherited_display: inherited_if(
+                detect_as_override,
+                FieldValue::List(global_detect_as_list),
+            ),
+        },
+        SettingField {
+            key: FieldKey::AgentStatusHooks,
+            label: "Agent Status Hooks",
+            description: "Install status-detection hooks into the agent's config file",
+            value: FieldValue::Bool(agent_status_hooks),
+            category: SettingsCategory::Agents,
+            has_override: status_hooks_override,
+            inherited_display: inherited_if(
+                status_hooks_override,
+                FieldValue::Bool(global.session.agent_status_hooks),
+            ),
+        },
+    ]
+}
+
+/// "How do I get into a session" configuration. The attach-mode trio
+/// (Tab vs Enter vs new-session) is a coherent decision the user
+/// thinks about together; pulling it out of the Session grab-bag puts
+/// the related knobs next to each other.
+fn build_interaction_fields(
+    scope: SettingsScope,
+    global: &Config,
+    profile: &ProfileConfig,
+) -> Vec<SettingField> {
+    let session = profile.session.as_ref();
+
+    let (live_send_exit_chord, live_send_exit_chord_override) = resolve_value(
+        scope,
+        global.session.live_send_exit_chord.clone(),
+        session.and_then(|s| s.live_send_exit_chord.clone()),
+    );
+
+    let (new_session_attach_mode, new_session_attach_mode_override) = resolve_value(
+        scope,
+        global.session.new_session_attach_mode,
+        session.and_then(|s| s.new_session_attach_mode),
+    );
+
+    let (default_attach_mode, default_attach_mode_override) = resolve_value(
+        scope,
+        global.session.default_attach_mode,
+        session.and_then(|s| s.default_attach_mode),
+    );
+
+    vec![
+        SettingField {
+            key: FieldKey::DefaultAttachMode,
+            label: "Default Attach Mode",
+            description: "What Enter (and double-click) does on a session row in \
+                 the Agent view: attach to tmux (default, historical \
+                 behavior) or enter live-send mode so the home list stays \
+                 visible and keystrokes pipe through to the agent. \
+                 Terminal/Tool views and cockpit sessions ignore this \
+                 setting.",
+            value: FieldValue::Select {
+                selected: new_session_attach_mode_to_index(default_attach_mode),
+                options: NEW_SESSION_ATTACH_MODE_OPTIONS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            },
+            category: SettingsCategory::Interaction,
+            has_override: default_attach_mode_override,
+            inherited_display: inherited_if(
+                default_attach_mode_override,
+                FieldValue::Select {
+                    selected: new_session_attach_mode_to_index(global.session.default_attach_mode),
+                    options: NEW_SESSION_ATTACH_MODE_OPTIONS
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                },
+            ),
+        },
+        SettingField {
+            key: FieldKey::NewSessionAttachMode,
+            label: "New Session Attach Mode",
+            description: "What to do after creating a new session: drop into tmux \
+                 (default, historical behavior) or enter live-send mode so \
+                 you never have to be inside tmux. Cockpit sessions ignore \
+                 this setting.",
+            value: FieldValue::Select {
+                selected: new_session_attach_mode_to_index(new_session_attach_mode),
+                options: NEW_SESSION_ATTACH_MODE_OPTIONS
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect(),
+            },
+            category: SettingsCategory::Interaction,
+            has_override: new_session_attach_mode_override,
+            inherited_display: inherited_if(
+                new_session_attach_mode_override,
+                FieldValue::Select {
+                    selected: new_session_attach_mode_to_index(
+                        global.session.new_session_attach_mode,
+                    ),
+                    options: NEW_SESSION_ATTACH_MODE_OPTIONS
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect(),
+                },
+            ),
+        },
+        SettingField {
+            key: FieldKey::LiveSendExitChord,
+            label: "Live-Send Exit Chord",
+            description: "Comma-separated chord specs that exit live-send mode. \
+                 Tmux-style: C-q, M-x, F12. Default `C-q` works in \
+                 every terminal we ship to; add entries for additional \
+                 exits if you need to send C-q through to the agent.",
+            value: FieldValue::Text(live_send_exit_chord),
+            category: SettingsCategory::Interaction,
+            has_override: live_send_exit_chord_override,
+            inherited_display: inherited_if(
+                live_send_exit_chord_override,
+                FieldValue::Text(global.session.live_send_exit_chord.clone()),
+            ),
+        },
+    ]
 }
 
 fn build_sound_fields(
@@ -2379,6 +2474,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         }
         (FieldKey::NewSessionAttachMode, FieldValue::Select { selected, .. }) => {
             config.session.new_session_attach_mode = index_to_new_session_attach_mode(*selected);
+        }
+        (FieldKey::DefaultAttachMode, FieldValue::Select { selected, .. }) => {
+            config.session.default_attach_mode = index_to_new_session_attach_mode(*selected);
         }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
             config.session.row_tag = index_to_row_tag(*selected);
@@ -2862,6 +2960,13 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 |s, val| s.new_session_attach_mode = val,
             );
         }
+        (FieldKey::DefaultAttachMode, FieldValue::Select { selected, .. }) => {
+            set_profile_override(
+                index_to_new_session_attach_mode(*selected),
+                &mut config.session,
+                |s, val| s.default_attach_mode = val,
+            );
+        }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
             set_profile_override(
                 index_to_row_tag(*selected),
@@ -3192,7 +3297,7 @@ mod tests {
         let profile = ProfileConfig::default();
 
         let fields = build_fields_for_category(
-            SettingsCategory::Session,
+            SettingsCategory::Agents,
             SettingsScope::Global,
             &global,
             &profile,
@@ -3433,5 +3538,156 @@ mod tests {
             profile.status_hooks.as_ref().and_then(|s| s.debounce_ms),
             Some(250)
         );
+    }
+
+    /// The Cockpit tab inserts a "Advanced" section header between
+    /// common settings and operational tuning fields. This test pins
+    /// (1) the header is present, (2) the common keys are before it,
+    /// and (3) the tuning keys are after it. The exact ordering
+    /// matters because the renderer puts the visual divider at the
+    /// header's position; if the split drifts, users see headings in
+    /// the wrong place rather than a clean common-then-advanced split.
+    #[test]
+    fn cockpit_fields_have_advanced_section_marker() {
+        let global = Config::default();
+        let profile = ProfileConfig::default();
+        let fields = build_fields_for_category(
+            SettingsCategory::Cockpit,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        );
+        let header_idx = fields
+            .iter()
+            .position(|f| matches!(f.value, FieldValue::SectionHeader))
+            .expect("Cockpit should contain an 'Advanced' section header");
+        let header = &fields[header_idx];
+        assert_eq!(header.label, "Advanced");
+        assert_eq!(header.key, FieldKey::SectionMarker);
+        // Common settings (user-facing) live before the header.
+        let common_keys = [
+            FieldKey::CockpitEnabled,
+            FieldKey::CockpitDefaultForClaude,
+            FieldKey::CockpitDefaultAgent,
+            FieldKey::CockpitReplayEvents,
+            FieldKey::CockpitNodePath,
+            FieldKey::CockpitShowToolDurations,
+        ];
+        for k in common_keys {
+            let pos = fields.iter().position(|f| f.key == k).unwrap();
+            assert!(
+                pos < header_idx,
+                "common cockpit field {:?} must precede the Advanced header (pos={}, header={})",
+                k,
+                pos,
+                header_idx
+            );
+        }
+        // Advanced tuning lives after.
+        let advanced_keys = [
+            FieldKey::CockpitMaxConcurrentWorkers,
+            FieldKey::CockpitMaxConcurrentResumes,
+            FieldKey::CockpitQueueDrainMode,
+            FieldKey::CockpitReplayBytes,
+            FieldKey::CockpitForceEndTurnThresholdSecs,
+            FieldKey::CockpitSilentOrphanGraceSecs,
+            FieldKey::CockpitSilentOrphanFastGraceSecs,
+        ];
+        for k in advanced_keys {
+            let pos = fields.iter().position(|f| f.key == k).unwrap();
+            assert!(
+                pos > header_idx,
+                "advanced cockpit field {:?} must follow the Advanced header (pos={}, header={})",
+                k,
+                pos,
+                header_idx
+            );
+        }
+    }
+
+    /// Splitting Session moved DefaultTool, agent maps, and attach-mode
+    /// settings out into dedicated Agents / Interaction tabs. Pin the
+    /// new homes so a future refactor doesn't silently re-merge them
+    /// without re-evaluating the UX justification.
+    #[test]
+    fn session_split_moved_fields_to_their_new_tabs() {
+        let global = Config::default();
+        let profile = ProfileConfig::default();
+
+        let agents_keys: Vec<FieldKey> = build_fields_for_category(
+            SettingsCategory::Agents,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        )
+        .iter()
+        .map(|f| f.key)
+        .collect();
+        for k in [
+            FieldKey::DefaultTool,
+            FieldKey::AgentExtraArgs,
+            FieldKey::AgentCommandOverride,
+            FieldKey::CustomAgents,
+            FieldKey::AgentDetectAs,
+            FieldKey::AgentStatusHooks,
+        ] {
+            assert!(
+                agents_keys.contains(&k),
+                "expected {:?} in Agents tab, got {:?}",
+                k,
+                agents_keys
+            );
+        }
+
+        let interaction_keys: Vec<FieldKey> = build_fields_for_category(
+            SettingsCategory::Interaction,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        )
+        .iter()
+        .map(|f| f.key)
+        .collect();
+        for k in [
+            FieldKey::DefaultAttachMode,
+            FieldKey::NewSessionAttachMode,
+            FieldKey::LiveSendExitChord,
+        ] {
+            assert!(
+                interaction_keys.contains(&k),
+                "expected {:?} in Interaction tab, got {:?}",
+                k,
+                interaction_keys
+            );
+        }
+
+        let session_keys: Vec<FieldKey> = build_fields_for_category(
+            SettingsCategory::Session,
+            SettingsScope::Global,
+            &global,
+            &profile,
+        )
+        .iter()
+        .map(|f| f.key)
+        .collect();
+        // None of the moved fields should remain in Session.
+        for k in [
+            FieldKey::DefaultTool,
+            FieldKey::AgentExtraArgs,
+            FieldKey::AgentCommandOverride,
+            FieldKey::CustomAgents,
+            FieldKey::AgentDetectAs,
+            FieldKey::AgentStatusHooks,
+            FieldKey::DefaultAttachMode,
+            FieldKey::NewSessionAttachMode,
+            FieldKey::LiveSendExitChord,
+        ] {
+            assert!(
+                !session_keys.contains(&k),
+                "{:?} should have moved out of the Session tab, but it's still there: {:?}",
+                k,
+                session_keys
+            );
+        }
     }
 }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -696,7 +696,7 @@ fn build_cockpit_fields(
         SettingField {
             key: FieldKey::SectionMarker,
             label: "Advanced",
-            description: "Operational tuning — rarely needed after first setup. Adjust only if you've read the description and know what you're changing.",
+            description: "Operational tuning, rarely needed after first setup. Adjust only if you've read the description and know what you're changing.",
             value: FieldValue::SectionHeader,
             category: SettingsCategory::Cockpit,
             has_override: false,

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -194,10 +194,17 @@ impl SettingsView {
             (KeyCode::Up, _) | (KeyCode::Char('k'), _) => {
                 match self.focus {
                     SettingsFocus::Categories => {
-                        if self.selected_category > 0 {
-                            self.selected_category -= 1;
-                            self.rebuild_fields();
-                            self.snap_to_interactive_field_forward();
+                        // Skip non-selectable section dividers so the
+                        // cursor jumps category-to-category.
+                        let mut idx = self.selected_category;
+                        while idx > 0 {
+                            idx -= 1;
+                            if matches!(self.categories[idx], super::CategoryRow::Tab(_)) {
+                                self.selected_category = idx;
+                                self.rebuild_fields();
+                                self.snap_to_interactive_field_forward();
+                                break;
+                            }
                         }
                     }
                     SettingsFocus::Fields => {
@@ -217,10 +224,15 @@ impl SettingsView {
             (KeyCode::Down, _) | (KeyCode::Char('j'), _) => {
                 match self.focus {
                     SettingsFocus::Categories => {
-                        if self.selected_category < self.categories.len().saturating_sub(1) {
-                            self.selected_category += 1;
-                            self.rebuild_fields();
-                            self.snap_to_interactive_field_forward();
+                        let mut idx = self.selected_category + 1;
+                        while idx < self.categories.len() {
+                            if matches!(self.categories[idx], super::CategoryRow::Tab(_)) {
+                                self.selected_category = idx;
+                                self.rebuild_fields();
+                                self.snap_to_interactive_field_forward();
+                                break;
+                            }
+                            idx += 1;
                         }
                     }
                     SettingsFocus::Fields => {
@@ -1368,7 +1380,7 @@ mod tests {
                 "Enter on a hit must close the search overlay"
             );
             assert_eq!(
-                view.categories[view.selected_category],
+                view.current_category(),
                 crate::tui::settings::SettingsCategory::Agents,
                 "must jump to the Agents tab (where Default Tool lives now)"
             );
@@ -1376,6 +1388,45 @@ mod tests {
                 view.fields[view.selected_field].key,
                 FieldKey::DefaultTool,
                 "must position the field cursor on Default Tool"
+            );
+        }
+
+        /// `j`/`k` (and Down/Up) in the categories panel must skip
+        /// non-selectable section dividers so the cursor jumps
+        /// category-to-category. Without this, hitting `j` on the last
+        /// tab of a section would land on the next section header and
+        /// the user would have to press it twice to get to the next
+        /// tab.
+        #[test]
+        #[serial]
+        fn category_nav_skips_section_dividers() {
+            use crate::tui::settings::CategoryRow;
+            let (_t, mut view) = fresh_view();
+            // Constructor lands on the first Tab (Theme, the only tab
+            // in Appearance). One Down should jump over the next
+            // section header ("Sessions") and onto Session.
+            let start = view.selected_category;
+            assert!(
+                matches!(view.categories[start], CategoryRow::Tab(_)),
+                "initial selected_category must be a Tab"
+            );
+            press(&mut view, KeyCode::Down);
+            assert!(
+                matches!(view.categories[view.selected_category], CategoryRow::Tab(_)),
+                "after Down, selected_category must still point at a Tab"
+            );
+            assert_eq!(
+                view.current_category(),
+                crate::tui::settings::SettingsCategory::Session,
+                "Down from Theme should land on Session, skipping the Sessions section header"
+            );
+            // Going back up should return to Theme, skipping the
+            // Appearance section header.
+            press(&mut view, KeyCode::Up);
+            assert_eq!(
+                view.current_category(),
+                crate::tui::settings::SettingsCategory::Theme,
+                "Up from Session should return to Theme, skipping the Sessions/Appearance headers"
             );
         }
 

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -1082,6 +1082,20 @@ impl SettingsView {
             dialog.handle_paste(text);
             return;
         }
+        // The search overlay is a full editing mode (gated on
+        // `search_input.is_some()` in `handle_key`), so bracketed
+        // pastes need a path into it. Without this, terminals that
+        // emit `Paste` events for clipboard input would silently
+        // drop pasted search queries.
+        if let Some(ref mut input) = self.search_input {
+            let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
+            for ch in sanitized.chars() {
+                input.handle(tui_input::InputRequest::InsertChar(ch));
+            }
+            self.search_selected = 0;
+            self.recompute_search_hits();
+            return;
+        }
         if let Some(ref mut input) = self.editing_input {
             let sanitized: String = text.chars().filter(|c| *c != '\n' && *c != '\r').collect();
             for ch in sanitized.chars() {
@@ -1301,7 +1315,8 @@ mod tests {
             press(&mut view, KeyCode::Char('/'));
             assert!(view.search_input.is_some(), "/ must enter search mode");
             // Empty query lists every interactive field across all
-            // visible categories — nonzero hits, so Enter has a target.
+            // visible categories, so the hit list is nonzero and
+            // Enter has a target.
             assert!(
                 !view.search_hits.is_empty(),
                 "empty-query search should list every interactive field"
@@ -1329,8 +1344,8 @@ mod tests {
         }
 
         /// Enter on a hit jumps to that hit's category + field and
-        /// closes the overlay. We pick "default tool" — moved to the
-        /// Agents tab in the Session split — to also verify the jump
+        /// closes the overlay. We pick "default tool" (moved to the
+        /// Agents tab in the Session split) to also verify the jump
         /// crosses categories cleanly.
         #[test]
         #[serial]

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -68,6 +68,15 @@ impl SettingsView {
             return self.handle_list_edit_key(key);
         }
 
+        // Handle settings-wide search overlay. While the overlay is
+        // open every other dispatch (scope cycle, save, navigation in
+        // the main panels) is suppressed: the user is typing into the
+        // search input and picking a hit, not driving the underlying
+        // settings view.
+        if self.search_input.is_some() {
+            return self.handle_search_key(key);
+        }
+
         // Normal mode
         match (key.code, key.modifiers) {
             // Save
@@ -178,19 +187,28 @@ impl SettingsView {
                 SettingsAction::Continue
             }
 
-            // Navigate up/down
+            // Navigate up/down. Inside the field list, navigation skips
+            // past non-interactive section dividers
+            // (`FieldValue::SectionHeader`) so the cursor never lands on
+            // a row the user can't edit.
             (KeyCode::Up, _) | (KeyCode::Char('k'), _) => {
                 match self.focus {
                     SettingsFocus::Categories => {
                         if self.selected_category > 0 {
                             self.selected_category -= 1;
                             self.rebuild_fields();
+                            self.snap_to_interactive_field_forward();
                         }
                     }
                     SettingsFocus::Fields => {
-                        if self.selected_field > 0 {
-                            self.selected_field -= 1;
-                            self.ensure_field_visible(self.fields_viewport_height);
+                        let mut idx = self.selected_field;
+                        while idx > 0 {
+                            idx -= 1;
+                            if !self.fields[idx].is_section_header() {
+                                self.selected_field = idx;
+                                self.ensure_field_visible(self.fields_viewport_height);
+                                break;
+                            }
                         }
                     }
                 }
@@ -202,12 +220,18 @@ impl SettingsView {
                         if self.selected_category < self.categories.len().saturating_sub(1) {
                             self.selected_category += 1;
                             self.rebuild_fields();
+                            self.snap_to_interactive_field_forward();
                         }
                     }
                     SettingsFocus::Fields => {
-                        if self.selected_field < self.fields.len().saturating_sub(1) {
-                            self.selected_field += 1;
-                            self.ensure_field_visible(self.fields_viewport_height);
+                        let mut idx = self.selected_field + 1;
+                        while idx < self.fields.len() {
+                            if !self.fields[idx].is_section_header() {
+                                self.selected_field = idx;
+                                self.ensure_field_visible(self.fields_viewport_height);
+                                break;
+                            }
+                            idx += 1;
                         }
                     }
                 }
@@ -274,6 +298,12 @@ impl SettingsView {
                             // Expand list for editing
                             self.list_edit_state = Some(ListEditState::default());
                         }
+                        FieldValue::SectionHeader => {
+                            // Non-interactive divider. Navigation should
+                            // never land the cursor here in the first
+                            // place; this arm just makes the match
+                            // exhaustive.
+                        }
                     }
                 } else if self.focus == SettingsFocus::Categories {
                     // Move to fields when pressing Enter on a category
@@ -285,6 +315,14 @@ impl SettingsView {
             // Toggle help overlay
             (KeyCode::Char('?'), _) => {
                 self.show_help = true;
+                SettingsAction::Continue
+            }
+
+            // Open the settings-wide search overlay. Any field with a
+            // matching label or description (across every category) is
+            // a hit; Enter jumps to that field.
+            (KeyCode::Char('/'), _) => {
+                self.open_search();
                 SettingsAction::Continue
             }
 
@@ -325,6 +363,40 @@ impl SettingsView {
 
             _ => SettingsAction::Continue,
         }
+    }
+
+    /// Drive the settings-wide search overlay. Esc closes without
+    /// changing selection; Enter jumps to the highlighted hit; up/down
+    /// navigates the hit list; every other key feeds `search_input`
+    /// and re-runs the filter so the list narrows as the user types.
+    fn handle_search_key(&mut self, key: KeyEvent) -> SettingsAction {
+        match key.code {
+            KeyCode::Esc => {
+                self.close_search();
+            }
+            KeyCode::Enter => {
+                self.jump_to_selected_search_hit();
+            }
+            KeyCode::Up => {
+                if self.search_selected > 0 {
+                    self.search_selected -= 1;
+                }
+            }
+            KeyCode::Down => {
+                if self.search_selected + 1 < self.search_hits.len() {
+                    self.search_selected += 1;
+                }
+            }
+            _ => {
+                // Edit the search query and refresh hits.
+                if let Some(ref mut input) = self.search_input {
+                    input.handle_event(&crossterm::event::Event::Key(key));
+                }
+                self.search_selected = 0;
+                self.recompute_search_hits();
+            }
+        }
+        SettingsAction::Continue
     }
 
     fn handle_text_edit_key(&mut self, key: KeyEvent) -> SettingsAction {
@@ -693,6 +765,11 @@ impl SettingsView {
                     s.new_session_attach_mode = None;
                 }
             }
+            FieldKey::DefaultAttachMode => {
+                if let Some(ref mut s) = config.session {
+                    s.default_attach_mode = None;
+                }
+            }
             FieldKey::RowTag => {
                 if let Some(ref mut s) = config.session {
                     s.row_tag = None;
@@ -958,6 +1035,10 @@ impl SettingsView {
             FieldKey::HostEnvironment => {
                 config.environment = None;
             }
+            // Section markers are non-interactive dividers; navigation
+            // and the reset gesture never land here, but the match
+            // arm must exist for exhaustiveness.
+            FieldKey::SectionMarker => {}
         }
 
         // Sync repo_config when in Repo scope
@@ -1177,5 +1258,126 @@ mod tests {
         let err = validate_detect_as_entry("my-agent=nonexistent").unwrap_err();
         assert!(err.contains("not a known built-in agent"));
         assert!(err.contains("Known agents:"));
+    }
+
+    mod search_overlay {
+        use super::*;
+        use crate::session::Storage;
+        use crate::tui::settings::SettingsView;
+        use serial_test::serial;
+        use tempfile::TempDir;
+
+        fn setup_test_home(temp: &TempDir) {
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        fn fresh_view() -> (TempDir, SettingsView) {
+            let temp = TempDir::new().unwrap();
+            setup_test_home(&temp);
+            let _ = Storage::new("test").unwrap();
+            let view = SettingsView::new("test", None).unwrap();
+            (temp, view)
+        }
+
+        fn press(view: &mut SettingsView, code: KeyCode) {
+            let _ = view.handle_key(KeyEvent::new(code, KeyModifiers::NONE));
+        }
+
+        fn type_text(view: &mut SettingsView, text: &str) {
+            for c in text.chars() {
+                press(view, KeyCode::Char(c));
+            }
+        }
+
+        /// `/` opens the search overlay; the overlay is then routed to
+        /// for every subsequent key (gated by `search_input.is_some()`).
+        #[test]
+        #[serial]
+        fn slash_opens_search_overlay() {
+            let (_t, mut view) = fresh_view();
+            assert!(view.search_input.is_none());
+            press(&mut view, KeyCode::Char('/'));
+            assert!(view.search_input.is_some(), "/ must enter search mode");
+            // Empty query lists every interactive field across all
+            // visible categories — nonzero hits, so Enter has a target.
+            assert!(
+                !view.search_hits.is_empty(),
+                "empty-query search should list every interactive field"
+            );
+        }
+
+        /// Typing a query narrows the hit list to matching fields.
+        /// "live" should match the Live-Send Exit Chord row, which now
+        /// lives under the Interaction tab.
+        #[test]
+        #[serial]
+        fn typing_filters_hits_and_finds_moved_field() {
+            let (_t, mut view) = fresh_view();
+            press(&mut view, KeyCode::Char('/'));
+            type_text(&mut view, "live");
+            let labels: Vec<&'static str> =
+                view.search_hits.iter().map(|h| h.field_label).collect();
+            assert!(
+                labels
+                    .iter()
+                    .any(|l| l.to_lowercase().contains("live-send exit chord")),
+                "search 'live' should surface the Live-Send Exit Chord field; got {:?}",
+                labels
+            );
+        }
+
+        /// Enter on a hit jumps to that hit's category + field and
+        /// closes the overlay. We pick "default tool" — moved to the
+        /// Agents tab in the Session split — to also verify the jump
+        /// crosses categories cleanly.
+        #[test]
+        #[serial]
+        fn enter_jumps_to_hit_category_and_field() {
+            let (_t, mut view) = fresh_view();
+            press(&mut view, KeyCode::Char('/'));
+            type_text(&mut view, "default tool");
+            assert!(!view.search_hits.is_empty(), "no hits for 'default tool'");
+            // Position cursor on a hit whose label exactly matches.
+            let target_idx = view
+                .search_hits
+                .iter()
+                .position(|h| h.field_label == "Default Tool")
+                .expect("Default Tool should appear in hits");
+            view.search_selected = target_idx;
+            press(&mut view, KeyCode::Enter);
+
+            assert!(
+                view.search_input.is_none(),
+                "Enter on a hit must close the search overlay"
+            );
+            assert_eq!(
+                view.categories[view.selected_category],
+                crate::tui::settings::SettingsCategory::Agents,
+                "must jump to the Agents tab (where Default Tool lives now)"
+            );
+            assert_eq!(
+                view.fields[view.selected_field].key,
+                FieldKey::DefaultTool,
+                "must position the field cursor on Default Tool"
+            );
+        }
+
+        /// Esc closes the overlay without changing the selected
+        /// category/field; the caller's edit context is preserved.
+        #[test]
+        #[serial]
+        fn esc_closes_search_without_changing_selection() {
+            let (_t, mut view) = fresh_view();
+            let cat_before = view.selected_category;
+            let field_before = view.selected_field;
+            press(&mut view, KeyCode::Char('/'));
+            type_text(&mut view, "tmux");
+            press(&mut view, KeyCode::Esc);
+            assert!(view.search_input.is_none());
+            assert_eq!(view.selected_category, cat_before);
+            assert_eq!(view.selected_field, field_before);
+        }
     }
 }

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -41,6 +41,16 @@ pub struct ListEditState {
     pub adding_new: bool,
 }
 
+/// One result of the settings-wide search overlay: a field that
+/// matched the user's query along with where it lives.
+#[derive(Debug, Clone)]
+pub(super) struct SearchHit {
+    pub category: SettingsCategory,
+    pub field_key: FieldKey,
+    pub field_label: &'static str,
+    pub category_label: &'static str,
+}
+
 /// The settings view state
 pub struct SettingsView {
     /// Current profile name being edited
@@ -111,6 +121,23 @@ pub struct SettingsView {
 
     /// Success message to display
     pub(super) success_message: Option<String>,
+
+    /// Active search input — `Some` while the user is typing in the
+    /// settings-wide `/` search overlay. The settings view freezes
+    /// the categories/fields panels behind the overlay and routes
+    /// keys to the input + hit list until the user picks a hit or
+    /// hits Esc.
+    pub(super) search_input: Option<Input>,
+
+    /// Hits that match the current `search_input` query, recomputed
+    /// each time the query changes. Empty query → all interactive
+    /// fields across every category (lets the user browse the full
+    /// catalog as a flat list, sorted by category then field order).
+    pub(super) search_hits: Vec<SearchHit>,
+
+    /// Cursor inside `search_hits` — bounded by `search_hits.len()`
+    /// so it stays valid as the query narrows.
+    pub(super) search_selected: usize,
 }
 
 impl SettingsView {
@@ -166,6 +193,9 @@ impl SettingsView {
             show_help: false,
             error_message: None,
             success_message: None,
+            search_input: None,
+            search_hits: Vec::new(),
+            search_selected: 0,
         };
 
         view.rebuild_fields();
@@ -176,6 +206,8 @@ impl SettingsView {
         let mut categories = vec![
             SettingsCategory::Theme,
             SettingsCategory::Session,
+            SettingsCategory::Agents,
+            SettingsCategory::Interaction,
             SettingsCategory::Hooks,
         ];
         if scope != SettingsScope::Repo {
@@ -228,6 +260,24 @@ impl SettingsView {
             self.selected_field = 0;
         }
         self.fields_scroll_offset = 0;
+        // If the (clamped) selected_field landed on a non-interactive
+        // section divider, advance to the next real field so the user
+        // never sees the cursor parked on a heading.
+        self.snap_to_interactive_field_forward();
+    }
+
+    /// Advance `selected_field` to the first interactive field
+    /// (`!is_section_header`) at or after the current index. Used
+    /// after a category change so we don't land on a non-editable
+    /// section divider when the new tab happens to begin with one.
+    pub(super) fn snap_to_interactive_field_forward(&mut self) {
+        let mut idx = self.selected_field;
+        while idx < self.fields.len() && self.fields[idx].is_section_header() {
+            idx += 1;
+        }
+        if idx < self.fields.len() {
+            self.selected_field = idx;
+        }
     }
 
     /// Switch to a different profile, reloading its config from disk
@@ -362,5 +412,114 @@ impl SettingsView {
         self.editing_input.is_some()
             || self.list_edit_state.is_some()
             || self.custom_instruction_dialog.is_some()
+            || self.search_input.is_some()
+    }
+
+    /// Open the settings-wide search overlay. Builds the initial hit
+    /// list (empty query → all interactive fields across every
+    /// visible category) and parks the cursor at the top so Enter on
+    /// an empty search picks the first hit instead of doing nothing.
+    pub(super) fn open_search(&mut self) {
+        self.search_input = Some(Input::default());
+        self.search_selected = 0;
+        self.recompute_search_hits();
+    }
+
+    /// Close the search overlay without changing the selected
+    /// category/field. Keeps the caller's edit context (focus, scope,
+    /// scroll) intact.
+    pub(super) fn close_search(&mut self) {
+        self.search_input = None;
+        self.search_hits.clear();
+        self.search_selected = 0;
+    }
+
+    /// Rebuild `search_hits` from the current `search_input` query.
+    /// Iterates every visible category for the current scope, calls
+    /// the same `build_fields_for_category` the main panel uses, and
+    /// keeps fields whose label or description contains every
+    /// whitespace-separated query token (case-insensitive). Empty
+    /// query keeps every interactive field; section-header rows are
+    /// always skipped because the user can't jump to them.
+    pub(super) fn recompute_search_hits(&mut self) {
+        let query = self
+            .search_input
+            .as_ref()
+            .map(|i| i.value().to_string())
+            .unwrap_or_default();
+        let tokens: Vec<String> = query.split_whitespace().map(|t| t.to_lowercase()).collect();
+
+        let (scope_for_fields, global_ref, profile_ref) = match self.scope {
+            SettingsScope::Global => (
+                SettingsScope::Global,
+                &self.global_config,
+                &self.profile_config,
+            ),
+            SettingsScope::Profile => (
+                SettingsScope::Profile,
+                &self.global_config,
+                &self.profile_config,
+            ),
+            SettingsScope::Repo => (
+                SettingsScope::Profile,
+                &self.resolved_base,
+                &self.repo_as_profile,
+            ),
+        };
+
+        let mut hits: Vec<SearchHit> = Vec::new();
+        for &category in &self.categories {
+            let fields = fields::build_fields_for_category(
+                category,
+                scope_for_fields,
+                global_ref,
+                profile_ref,
+            );
+            for field in fields {
+                if field.is_section_header() {
+                    continue;
+                }
+                let label_lower = field.label.to_lowercase();
+                let desc_lower = field.description.to_lowercase();
+                let matches_all = tokens
+                    .iter()
+                    .all(|t| label_lower.contains(t) || desc_lower.contains(t));
+                if !matches_all {
+                    continue;
+                }
+                hits.push(SearchHit {
+                    category,
+                    field_key: field.key,
+                    field_label: field.label,
+                    category_label: category.label(),
+                });
+            }
+        }
+
+        self.search_hits = hits;
+        if self.search_selected >= self.search_hits.len() {
+            self.search_selected = self.search_hits.len().saturating_sub(1);
+        }
+    }
+
+    /// Jump to the currently-selected search hit: switch to its
+    /// category, rebuild fields for the new category, position the
+    /// field cursor on the matching key, and close the overlay.
+    /// No-op when the hit list is empty (Enter on a query with no
+    /// matches stays in search so the user can correct the query).
+    pub(super) fn jump_to_selected_search_hit(&mut self) {
+        let Some(hit) = self.search_hits.get(self.search_selected).cloned() else {
+            return;
+        };
+        if let Some(idx) = self.categories.iter().position(|c| *c == hit.category) {
+            self.selected_category = idx;
+        }
+        self.rebuild_fields();
+        if let Some(idx) = self.fields.iter().position(|f| f.key == hit.field_key) {
+            self.selected_field = idx;
+            self.ensure_field_visible(self.fields_viewport_height);
+        }
+        self.focus = SettingsFocus::Fields;
+        self.close_search();
     }
 }

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -122,7 +122,7 @@ pub struct SettingsView {
     /// Success message to display
     pub(super) success_message: Option<String>,
 
-    /// Active search input — `Some` while the user is typing in the
+    /// Active search input. `Some` while the user is typing in the
     /// settings-wide `/` search overlay. The settings view freezes
     /// the categories/fields panels behind the overlay and routes
     /// keys to the input + hit list until the user picks a hit or
@@ -130,12 +130,13 @@ pub struct SettingsView {
     pub(super) search_input: Option<Input>,
 
     /// Hits that match the current `search_input` query, recomputed
-    /// each time the query changes. Empty query → all interactive
-    /// fields across every category (lets the user browse the full
-    /// catalog as a flat list, sorted by category then field order).
+    /// each time the query changes. Empty query lists every
+    /// interactive field across every category, so the user can
+    /// browse the full catalog as a flat list sorted by category
+    /// then by field order.
     pub(super) search_hits: Vec<SearchHit>,
 
-    /// Cursor inside `search_hits` — bounded by `search_hits.len()`
+    /// Cursor inside `search_hits`, bounded by `search_hits.len()`
     /// so it stays valid as the query narrows.
     pub(super) search_selected: usize,
 }

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -51,6 +51,25 @@ pub(super) struct SearchHit {
     pub category_label: &'static str,
 }
 
+/// One row in the left-hand categories panel. Sections are
+/// non-interactive dividers that group related categories visually
+/// (Sessions, Hooks, Environment, etc.); navigation skips past them
+/// and `selected_category` is always the index of a `Tab` row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum CategoryRow {
+    Section(&'static str),
+    Tab(SettingsCategory),
+}
+
+impl CategoryRow {
+    fn as_tab(self) -> Option<SettingsCategory> {
+        match self {
+            CategoryRow::Tab(c) => Some(c),
+            CategoryRow::Section(_) => None,
+        }
+    }
+}
+
 /// The settings view state
 pub struct SettingsView {
     /// Current profile name being edited
@@ -77,10 +96,13 @@ pub struct SettingsView {
     /// Which panel has focus
     pub(super) focus: SettingsFocus,
 
-    /// Available categories
-    pub(super) categories: Vec<SettingsCategory>,
+    /// Rows in the left-hand categories panel: a mix of non-interactive
+    /// section dividers and selectable category tabs. `selected_category`
+    /// is always the index of a `CategoryRow::Tab` entry.
+    pub(super) categories: Vec<CategoryRow>,
 
-    /// Currently selected category index
+    /// Currently selected category-row index. Points at a `Tab`
+    /// row; navigation helpers maintain this invariant.
     pub(super) selected_category: usize,
 
     /// Fields for the current category
@@ -180,6 +202,8 @@ impl SettingsView {
             scope: SettingsScope::Global,
             focus: SettingsFocus::Categories,
             categories,
+            // 0 is the leading section divider; seek to the first
+            // Tab below so the user lands on a real category.
             selected_category: 0,
             fields: Vec::new(),
             selected_field: 0,
@@ -199,45 +223,101 @@ impl SettingsView {
             search_selected: 0,
         };
 
+        // The constructor parks `selected_category` at 0, which is the
+        // first section divider in the layout. Snap to the first real
+        // Tab before the first render so the cursor lands on Theme.
+        view.selected_category = view.first_tab_index();
         view.rebuild_fields();
         Ok(view)
     }
 
-    fn categories_for_scope(scope: SettingsScope) -> Vec<SettingsCategory> {
-        let mut categories = vec![
-            SettingsCategory::Theme,
-            SettingsCategory::Session,
-            SettingsCategory::Agents,
-            SettingsCategory::Interaction,
-            SettingsCategory::Hooks,
-        ];
+    /// Build the categories-panel layout. Categories are grouped under
+    /// section dividers (Appearance / Sessions / Hooks / Environment /
+    /// Notifications / System) so the list isn't 14 unrelated tabs in
+    /// arbitrary order. Status Hooks is dropped in Repo scope (the only
+    /// scope-conditional category today).
+    fn categories_for_scope(scope: SettingsScope) -> Vec<CategoryRow> {
+        let mut rows: Vec<CategoryRow> = Vec::new();
+        let push_section = |rows: &mut Vec<CategoryRow>, label: &'static str| {
+            rows.push(CategoryRow::Section(label));
+        };
+        let push_tab = |rows: &mut Vec<CategoryRow>, cat: SettingsCategory| {
+            rows.push(CategoryRow::Tab(cat));
+        };
+
+        push_section(&mut rows, "Appearance");
+        push_tab(&mut rows, SettingsCategory::Theme);
+
+        push_section(&mut rows, "Sessions");
+        push_tab(&mut rows, SettingsCategory::Session);
+        push_tab(&mut rows, SettingsCategory::Agents);
+        push_tab(&mut rows, SettingsCategory::Interaction);
+        push_tab(&mut rows, SettingsCategory::Cockpit);
+
+        push_section(&mut rows, "Hooks");
+        push_tab(&mut rows, SettingsCategory::Hooks);
         if scope != SettingsScope::Repo {
-            categories.push(SettingsCategory::StatusHooks);
+            push_tab(&mut rows, SettingsCategory::StatusHooks);
         }
-        categories.extend([
-            SettingsCategory::Sandbox,
-            SettingsCategory::Worktree,
-            SettingsCategory::Updates,
-            SettingsCategory::Tmux,
-            SettingsCategory::Sound,
-            SettingsCategory::Web,
-            SettingsCategory::Cockpit,
-            SettingsCategory::Logging,
-        ]);
-        categories
+
+        push_section(&mut rows, "Environment");
+        push_tab(&mut rows, SettingsCategory::Sandbox);
+        push_tab(&mut rows, SettingsCategory::Worktree);
+        push_tab(&mut rows, SettingsCategory::Tmux);
+
+        push_section(&mut rows, "Notifications");
+        push_tab(&mut rows, SettingsCategory::Sound);
+        push_tab(&mut rows, SettingsCategory::Web);
+
+        push_section(&mut rows, "System");
+        push_tab(&mut rows, SettingsCategory::Updates);
+        push_tab(&mut rows, SettingsCategory::Logging);
+
+        rows
+    }
+
+    /// The category at `selected_category`, by invariant always a
+    /// `Tab` row. Falls back to the first tab in the list if the
+    /// invariant is violated (e.g., an empty layout), so callers can
+    /// dereference without panicking.
+    pub(super) fn current_category(&self) -> SettingsCategory {
+        self.categories
+            .get(self.selected_category)
+            .and_then(|row| row.as_tab())
+            .or_else(|| self.categories.iter().find_map(|r| r.as_tab()))
+            .expect("layout has at least one Tab row")
     }
 
     pub(super) fn rebuild_categories_for_scope(&mut self) {
-        let current = self.categories.get(self.selected_category).copied();
+        let current = self
+            .categories
+            .get(self.selected_category)
+            .and_then(|row| row.as_tab());
         self.categories = Self::categories_for_scope(self.scope);
         self.selected_category = current
-            .and_then(|category| self.categories.iter().position(|c| *c == category))
-            .unwrap_or(0);
+            .and_then(|category| {
+                self.categories
+                    .iter()
+                    .position(|r| *r == CategoryRow::Tab(category))
+            })
+            .unwrap_or_else(|| self.first_tab_index());
+    }
+
+    /// First selectable row in `self.categories`. Section dividers are
+    /// not selectable, so the initial cursor and post-rebuild fallback
+    /// must land on a `Tab`. Layout always starts with a section
+    /// header so the answer is typically `1`, but this is computed
+    /// rather than hard-coded.
+    pub(super) fn first_tab_index(&self) -> usize {
+        self.categories
+            .iter()
+            .position(|r| matches!(r, CategoryRow::Tab(_)))
+            .unwrap_or(0)
     }
 
     /// Rebuild the fields list based on current category and scope
     pub(super) fn rebuild_fields(&mut self) {
-        let category = self.categories[self.selected_category];
+        let category = self.current_category();
         let (scope_for_fields, global_ref, profile_ref) = match self.scope {
             SettingsScope::Global => (
                 SettingsScope::Global,
@@ -469,7 +549,7 @@ impl SettingsView {
         };
 
         let mut hits: Vec<SearchHit> = Vec::new();
-        for &category in &self.categories {
+        for category in self.categories.iter().filter_map(|r| r.as_tab()) {
             let fields = fields::build_fields_for_category(
                 category,
                 scope_for_fields,
@@ -512,7 +592,11 @@ impl SettingsView {
         let Some(hit) = self.search_hits.get(self.search_selected).cloned() else {
             return;
         };
-        if let Some(idx) = self.categories.iter().position(|c| *c == hit.category) {
+        if let Some(idx) = self
+            .categories
+            .iter()
+            .position(|r| *r == CategoryRow::Tab(hit.category))
+        {
             self.selected_category = idx;
         }
         self.rebuild_fields();

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -52,6 +52,14 @@ impl SettingsView {
         if self.show_help {
             self.render_help_overlay(frame, area, theme);
         }
+
+        // Render the search overlay last so it sits above every other
+        // surface (help, dialogs, etc.). The input handler already
+        // gates other key dispatch on `search_input.is_some()`, but
+        // painting last makes that gate visible too.
+        if self.search_input.is_some() {
+            self.render_search_overlay(frame, area, theme);
+        }
     }
 
     fn render_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -328,6 +336,10 @@ impl SettingsView {
 
     pub(super) fn field_height(&self, field: &super::SettingField, index: usize) -> u16 {
         match &field.value {
+            FieldValue::SectionHeader => {
+                // heading line + dimmed subtitle. No value row.
+                1 + 1
+            }
             FieldValue::List(items)
                 if self.list_edit_state.is_some() && index == self.selected_field =>
             {
@@ -347,6 +359,37 @@ impl SettingsView {
         is_selected: bool,
         theme: &Theme,
     ) {
+        // Section headers are non-interactive group dividers (e.g.
+        // "Advanced" inside Cockpit). Render as a styled heading with
+        // a dimmed subtitle. They never appear "selected" because the
+        // input handler skips navigation past them.
+        if matches!(field.value, FieldValue::SectionHeader) {
+            let heading = Line::from(vec![
+                Span::styled("── ", Style::default().fg(theme.border)),
+                Span::styled(
+                    field.label,
+                    Style::default()
+                        .fg(theme.dimmed)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(" ──", Style::default().fg(theme.border)),
+            ]);
+            frame.render_widget(Paragraph::new(heading), area);
+            if !field.description.is_empty() {
+                let subtitle_area = Rect {
+                    x: area.x,
+                    y: area.y + 1,
+                    width: area.width,
+                    height: 1,
+                };
+                frame.render_widget(
+                    Paragraph::new(field.description).style(Style::default().fg(theme.dimmed)),
+                    subtitle_area,
+                );
+            }
+            return;
+        }
+
         let label_style = if is_selected {
             Style::default()
                 .fg(theme.accent)
@@ -424,6 +467,11 @@ impl SettingsView {
             }
             FieldValue::List(items) => {
                 self.render_list_field(frame, value_area, items, index, is_selected, theme);
+            }
+            FieldValue::SectionHeader => {
+                // Already handled by the early return at the top of
+                // render_field; reaching this arm would mean the early
+                // return was bypassed, which is a programmer bug.
             }
         }
     }
@@ -907,6 +955,7 @@ impl SettingsView {
             (
                 "Other",
                 vec![
+                    ("/", "Search settings across all tabs"),
                     ("Ctrl+s", "Save settings"),
                     ("?", "Toggle this help"),
                     ("q", "Close settings"),
@@ -934,5 +983,128 @@ impl SettingsView {
 
         let paragraph = Paragraph::new(lines);
         frame.render_widget(paragraph, inner);
+    }
+
+    /// Render the settings-wide search overlay: a query input at the
+    /// top, the matching hits below, each prefixed with their
+    /// category label. Empty query lists every interactive field
+    /// across every visible category so the user can browse the full
+    /// catalog as a flat list.
+    fn render_search_overlay(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let dialog_width = area.width.saturating_sub(8).clamp(40, 80);
+        let dialog_height = area.height.saturating_sub(4).clamp(10, 24);
+
+        let x = area.x + (area.width.saturating_sub(dialog_width)) / 2;
+        let y = area.y + (area.height.saturating_sub(dialog_height)) / 2;
+        let dialog_area = Rect {
+            x,
+            y,
+            width: dialog_width.min(area.width),
+            height: dialog_height.min(area.height),
+        };
+
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .style(Style::default().bg(theme.background))
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent))
+            .title(" Search settings ")
+            .title_style(
+                Style::default()
+                    .fg(theme.accent)
+                    .add_modifier(Modifier::BOLD),
+            );
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        // Layout: input line, separator, hit list, footer hint.
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([
+                Constraint::Length(1), // input
+                Constraint::Length(1), // separator
+                Constraint::Min(3),    // hits
+                Constraint::Length(1), // footer
+            ])
+            .split(inner);
+
+        // Input row: "/ <query>"
+        if let Some(input) = self.search_input.as_ref() {
+            let prompt_span = Span::styled("/ ", Style::default().fg(theme.accent));
+            let cursor_spans = Self::build_cursor_spans(input.value(), input.cursor(), theme);
+            let mut spans = vec![prompt_span];
+            spans.extend(cursor_spans);
+            frame.render_widget(Paragraph::new(Line::from(spans)), layout[0]);
+        }
+
+        // Separator.
+        frame.render_widget(
+            Paragraph::new("─".repeat(layout[1].width as usize))
+                .style(Style::default().fg(theme.border)),
+            layout[1],
+        );
+
+        // Hits.
+        if self.search_hits.is_empty() {
+            let msg = if self
+                .search_input
+                .as_ref()
+                .map(|i| i.value().is_empty())
+                .unwrap_or(true)
+            {
+                "Type to search settings"
+            } else {
+                "No matching settings"
+            };
+            frame.render_widget(
+                Paragraph::new(msg).style(Style::default().fg(theme.dimmed)),
+                layout[2],
+            );
+        } else {
+            let visible = layout[2].height as usize;
+            let scroll_start = self
+                .search_selected
+                .saturating_sub(visible.saturating_sub(1));
+            let mut lines: Vec<Line> = Vec::new();
+            for (i, hit) in self
+                .search_hits
+                .iter()
+                .enumerate()
+                .skip(scroll_start)
+                .take(visible)
+            {
+                let is_selected = i == self.search_selected;
+                let prefix = if is_selected { "> " } else { "  " };
+                let label_style = if is_selected {
+                    Style::default()
+                        .fg(theme.accent)
+                        .add_modifier(Modifier::BOLD)
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                lines.push(Line::from(vec![
+                    Span::styled(prefix, label_style),
+                    Span::styled(
+                        format!("[{}] ", hit.category_label),
+                        Style::default().fg(theme.dimmed),
+                    ),
+                    Span::styled(hit.field_label, label_style),
+                ]));
+            }
+            frame.render_widget(Paragraph::new(lines), layout[2]);
+        }
+
+        // Footer.
+        let footer = Line::from(vec![
+            Span::styled("Enter ", Style::default().fg(theme.waiting)),
+            Span::styled("jump  ", Style::default().fg(theme.dimmed)),
+            Span::styled("↑/↓ ", Style::default().fg(theme.waiting)),
+            Span::styled("select  ", Style::default().fg(theme.dimmed)),
+            Span::styled("Esc ", Style::default().fg(theme.waiting)),
+            Span::styled("close", Style::default().fg(theme.dimmed)),
+        ]);
+        frame.render_widget(Paragraph::new(footer), layout[3]);
     }
 }

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -13,7 +13,9 @@ use ratatui::{
 use tui_input::Input;
 use unicode_width::UnicodeWidthStr;
 
-use super::{FieldValue, SettingsCategory, SettingsFocus, SettingsScope, SettingsView};
+use super::{
+    CategoryRow, FieldValue, SettingsCategory, SettingsFocus, SettingsScope, SettingsView,
+};
 use crate::tui::components::set_input_cursor_position;
 use crate::tui::styles::Theme;
 
@@ -148,30 +150,42 @@ impl SettingsView {
         let inner = block.inner(area);
         frame.render_widget(block, area);
 
+        // Categories panel: sections render as dimmed, non-selectable
+        // dividers; tabs render with the existing "> "/"  " prefix and
+        // selection highlight. The first tab in each section is
+        // visually indented by the prefix already; sections take the
+        // same horizontal slot so the eye reads the group label as a
+        // heading above the tabs that follow.
         let items: Vec<ListItem> = self
             .categories
             .iter()
             .enumerate()
-            .map(|(i, cat)| {
-                let style = if i == self.selected_category {
-                    if is_focused {
-                        Style::default()
-                            .fg(theme.accent)
-                            .add_modifier(Modifier::BOLD)
+            .map(|(i, row)| match row {
+                CategoryRow::Section(label) => {
+                    let style = Style::default()
+                        .fg(theme.dimmed)
+                        .add_modifier(Modifier::BOLD);
+                    ListItem::new(*label).style(style)
+                }
+                CategoryRow::Tab(cat) => {
+                    let style = if i == self.selected_category {
+                        if is_focused {
+                            Style::default()
+                                .fg(theme.accent)
+                                .add_modifier(Modifier::BOLD)
+                        } else {
+                            Style::default().fg(theme.text)
+                        }
                     } else {
-                        Style::default().fg(theme.text)
-                    }
-                } else {
-                    Style::default().fg(theme.dimmed)
-                };
-
-                let prefix = if i == self.selected_category {
-                    "> "
-                } else {
-                    "  "
-                };
-
-                ListItem::new(format!("{}{}", prefix, cat.label())).style(style)
+                        Style::default().fg(theme.dimmed)
+                    };
+                    let prefix = if i == self.selected_category {
+                        "> "
+                    } else {
+                        "  "
+                    };
+                    ListItem::new(format!("{}{}", prefix, cat.label())).style(style)
+                }
             })
             .collect();
 
@@ -209,7 +223,7 @@ impl SettingsView {
         }
 
         // Show SSH warning for Sound category
-        let current_category = self.categories[self.selected_category];
+        let current_category = self.current_category();
         let warning_offset = if current_category == SettingsCategory::Sound && is_ssh_session() {
             let warning = vec![
                 Line::from(vec![

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -162,9 +162,12 @@ impl SettingsView {
             .enumerate()
             .map(|(i, row)| match row {
                 CategoryRow::Section(label) => {
-                    let style = Style::default()
-                        .fg(theme.dimmed)
-                        .add_modifier(Modifier::BOLD);
+                    // Bumped from `theme.dimmed` to `theme.text` so the
+                    // section dividers read as headings rather than as
+                    // faded background. Bold helps them anchor the
+                    // group visually without competing with the accent
+                    // color used for the active tab.
+                    let style = Style::default().fg(theme.text).add_modifier(Modifier::BOLD);
                     ListItem::new(*label).style(style)
                 }
                 CategoryRow::Tab(cat) => {
@@ -376,15 +379,16 @@ impl SettingsView {
         // Section headers are non-interactive group dividers (e.g.
         // "Advanced" inside Cockpit). Render as a styled heading with
         // a dimmed subtitle. They never appear "selected" because the
-        // input handler skips navigation past them.
+        // input handler skips navigation past them. Label uses
+        // `theme.text` (not dimmed) so it matches the categories-panel
+        // section dividers and reads as a heading rather than fading
+        // into the background.
         if matches!(field.value, FieldValue::SectionHeader) {
             let heading = Line::from(vec![
                 Span::styled("── ", Style::default().fg(theme.border)),
                 Span::styled(
                     field.label,
-                    Style::default()
-                        .fg(theme.dimmed)
-                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(theme.text).add_modifier(Modifier::BOLD),
                 ),
                 Span::styled(" ──", Style::default().fg(theme.border)),
             ]);


### PR DESCRIPTION
## Description

Three UX changes that build on the recent live-send work, plus a
settings TUI reorganization to make those new knobs (and the existing
ones) easier to find.

**1. Click-to-live-mode in the home list.** Single click on a session
row now enters live-send mode for that row, or switches the live target
if you're already in live mode. Double-click still attaches to tmux,
group rows still toggle collapse, and cockpit / creating / deleting
sessions stay selection-only.

**2. `session.default_attach_mode` setting.** New global / per-profile
setting (Tmux / LiveSend, default Tmux) so users who never want to be
in tmux can make Enter and double-click route to live-send directly in
Agent view. Terminal/Tool views and cockpit sessions ignore the setting
and keep their existing activation paths.

**3. Settings TUI reorganization.** The Session tab had grown to 17
fields covering several distinct concepts. This PR:

- Splits Session into **Session** (core behavior: snooze, restart wake,
  row tag, host env, poller threads), **Agents** (per-tool config:
  default tool, agent extra args, command override, custom agents,
  detect-as, agent status hooks), and **Interaction** (the attach-mode
  trio plus live-send exit chord — a coherent "how do I get into a
  session" decision the user thinks about together).
- Adds an `── Advanced ──` subheader inside Cockpit between the user-
  facing settings (enabled, default agent, replay events, etc.) and the
  operational tuning fields (silent-orphan grace, queue drain mode,
  force end turn threshold, replay buffer bytes, max concurrent workers
  / resumes). New `FieldValue::SectionHeader` variant; renderer paints
  it as a styled divider, navigation skips past it.
- Renames **Hooks → Lifecycle Hooks** so it's distinguishable from
  **Status Hooks** at a glance.
- Adds a settings-wide **`/` search overlay** that filters fields
  across every visible category by label and description. Enter on a
  hit jumps to that field's tab and parks the cursor on it; Esc closes
  without changing the underlying selection.

## PR Type

- [x] New Feature
- [x] Refactor

## Checklist

- [x] New and existing tests pass (`cargo test --lib`: 2153 passing,
  `--features serve`: 2730 passing)
- [ ] Documentation was updated where necessary (no user-facing docs
  reference these settings yet; can follow up if needed)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: covered by unit tests in `src/tui/home/tests.rs` and
  `src/tui/settings/{fields,input}.rs`. New tests:
  - `click_to_select::single_click_on_session_emits_enter_live_send`
  - `click_to_select::click_on_other_session_while_live_switches_target`
  - `click_to_select::click_on_already_live_session_is_noop`
  - `click_to_select::single_click_on_creating_session_returns_no_action`
  - `click_to_select::single_click_on_cockpit_session_returns_no_action` (serve only)
  - `default_attach_mode::{defaults_to_tmux_when_no_config_present, enter_emits_attach_session_when_default_is_tmux, enter_emits_enter_live_send_when_default_is_live_send, terminal_view_ignores_default_attach_mode, cockpit_session_ignores_default_attach_mode}`
  - `cockpit_fields_have_advanced_section_marker`
  - `session_split_moved_fields_to_their_new_tabs`
  - `search_overlay::{slash_opens_search_overlay, typing_filters_hits_and_finds_moved_field, enter_jumps_to_hit_category_and_field, esc_closes_search_without_changing_selection}`

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code.

**Any Additional AI Details you'd like to share:**
Iterated on design choices in conversation (e.g., the question of
whether click should always enter live mode vs only switch while in
live mode was answered by the user; same for whether double-click
should keep attaching). The settings reorganization recommendations
were drafted by Claude, reviewed by the user, then approved before
implementation. Tests were written alongside each behavior change.

- [x] I am an AI Agent filling out this form (check box if true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## High-Level Summary

This PR makes three user-facing TUI changes and reorganizes settings to improve workflow and discoverability:

- Single-click to enter/switch LiveSend for a session (double-click or Enter still attaches via tmux). Group rows toggle collapse; cockpit/creating/deleting sessions remain selection-only.
- Adds a configurable default attach mode (Tmux or LiveSend) globally and per-profile so Enter/double-click behavior in Agent view can default to LiveSend.
- Reworks Settings: splits the old Session tab into Session, Agents, and Interaction; adds an “── Advanced ──” divider inside Cockpit; renames Hooks → Lifecycle Hooks; and adds a global "/" search overlay to filter and jump to settings.

Benefits: quicker access to live-send, explicit control over attach behavior, clearer organization of settings, and fast navigation/search across settings.

---

Key Technical Changes (concise)

- Config:
  - Added SessionConfig.default_attach_mode: NewSessionAttachMode (Tmux | LiveSend).
  - Added optional default_attach_mode in SessionConfigOverride and apply logic.

- Home/Activation:
  - HomeView resolves per-session default_attach_mode and routes activation to start_live_send() when configured.
  - Single-click now selects and requests LiveSend; double-click/Enter attach (subject to default_attach_mode).
  - start_live_send() is idempotent (no-op when already targeted).
  - Added has_blocking_dialog_for_list_click() so live mode doesn’t block list click hit-testing.
  - When switching live targets, restores previous tmux pane size to latest client dims.

- Settings UI & Data Model:
  - Session tab split into Session, Agents, Interaction.
  - Added FieldValue::SectionHeader and FieldKey::SectionMarker; navigation skips section headers.
  - Introduced CategoryRow enum (Section | Tab) and snap-to-interactive-field behavior.
  - Added FieldKey::DefaultAttachMode and persisted apply/clear handling for global/profile scopes.
  - Cockpit fields reordered with an “Advanced” section divider; Hooks renamed to Lifecycle Hooks.

- Search Overlay & Interaction:
  - Global "/" overlay with search state (search_input, search_hits, search_selected).
  - Tokenized, label/description search; Enter jumps to match’s category/field and focuses it; Esc closes without changing selection.
  - Paste handling and navigation (Up/Down) integrated with overlay; bracketed paste sanitization supported.

- Rendering & Tests:
  - Renderer draws styled section dividers and full-screen search overlay; help overlay includes "/".
  - Extensive tests added/updated for click semantics, default_attach_mode behavior, settings split and ordering, section headers, and search overlay end-to-end behavior. Tests pass locally per the author.

---

Potential Follow-ups

- Add a persistent UI indicator for the active LiveSend target for better discoverability.
- Consider a brief onboarding hint or help tooltip for single-click LiveSend to reduce surprise.
- Audit focus/navigation edge cases when jumping from search into complex fields and add recovery if needed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->