### PR TITLE
fix(tests): de-flake cockpit live specs with expect.poll backoff

### DIFF
--- a/web/tests/helpers/cockpit.ts
+++ b/web/tests/helpers/cockpit.ts
@@ -189,6 +189,48 @@ export async function waitForCockpitReady(
 }
 
 /**
+ * Poll `/cockpit/replay?since=0` until the serialized frame list
+ * contains every needle in `needles` (default: `any` matches if at
+ * least one needle is present; pass `mode: "all"` to require all).
+ *
+ * Replaces the `for (let attempt = 0; attempt < 30; attempt++) ... setTimeout(200)`
+ * pattern that was duplicated across the cockpit live specs. Hand-rolled
+ * 30×200ms loops cap at a hard 6s deadline that races supervisor
+ * handshakes under CI load; this helper uses `expect.poll` with
+ * backoff intervals (100, 200, 500, 1000ms) and a 15s default timeout,
+ * which both shortens the happy path and gives long-tail latencies
+ * room to land. On timeout, expect.poll surfaces the last polled value
+ * (the boolean) so failures stay readable.
+ */
+export async function waitForReplayContains(
+  baseUrl: string,
+  sessionId: string,
+  needles: string | string[],
+  options: { timeoutMs?: number; mode?: "any" | "all" } = {},
+): Promise<void> {
+  const list = Array.isArray(needles) ? needles : [needles];
+  const mode = options.mode ?? "any";
+  const timeout = options.timeoutMs ?? 15_000;
+  await expect
+    .poll(
+      async () => {
+        const replay = await fetch(
+          `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+        ).then((r) => r.json());
+        const frames: unknown[] = Array.isArray(replay)
+          ? replay
+          : (replay?.frames ?? []);
+        const json = JSON.stringify(frames);
+        return mode === "all"
+          ? list.every((n) => json.includes(n))
+          : list.some((n) => json.includes(n));
+      },
+      { timeout, intervals: [100, 200, 500, 1000] },
+    )
+    .toBe(true);
+}
+
+/**
  * Enable the cockpit supervisor for a session and wait for it to be
  * ready to accept prompts. Asserts the enable POST succeeded before
  * polling readiness so a 4xx / 5xx surfaces as an explicit failure

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -13,7 +13,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
-import { waitForCockpitReady } from "../helpers/cockpit";
+import { enableCockpitAndWait } from "../helpers/cockpit";
 
 const APPROVAL_SCRIPT = {
   turns: [
@@ -69,14 +69,10 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     const sessions = await listSessions(serve.baseUrl);
     const sessionId = sessions[0]!.id;
 
-    // `cockpit/enable` implicitly spawns the cockpit supervisor.
-    await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`, {
-      method: "POST",
-    });
-    // Wait for the supervisor to finish its ACP handshake before prompting,
-    // by polling replay for any frame. The previous `setTimeout(2_000)` race
-    // proved tight under CI load.
-    await waitForCockpitReady(serve.baseUrl, sessionId);
+    // `cockpit/enable` implicitly spawns the cockpit supervisor;
+    // `enableCockpitAndWait` POSTs it and blocks until the ACP
+    // handshake (initialize + session/new) completes.
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
     await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },

--- a/web/tests/live/cockpit-approval.spec.ts
+++ b/web/tests/live/cockpit-approval.spec.ts
@@ -89,25 +89,29 @@ base("permission_request flows through to the server", async ({}, testInfo) => {
     // build_approval), so the spec must read it back instead of
     // hard-coding a value.
     let nonce: string | undefined;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      const frames: Array<{ event?: ApprovalRequestedEvent }> = Array.isArray(
-        replay,
+    await expect
+      .poll(
+        async () => {
+          const replay = await fetch(
+            `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+          ).then((r) => r.json());
+          const frames: Array<{ event?: ApprovalRequestedEvent }> = Array.isArray(
+            replay,
+          )
+            ? replay
+            : replay.frames ?? [];
+          for (const frame of frames) {
+            const candidate = frame.event?.ApprovalRequested?.approval?.nonce;
+            if (candidate) {
+              nonce = candidate;
+              return true;
+            }
+          }
+          return false;
+        },
+        { timeout: 15_000, intervals: [100, 200, 500, 1000] },
       )
-        ? replay
-        : replay.frames ?? [];
-      for (const frame of frames) {
-        const candidate = frame.event?.ApprovalRequested?.approval?.nonce;
-        if (candidate) {
-          nonce = candidate;
-          break;
-        }
-      }
-      if (nonce) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
+      .toBe(true);
     expect(nonce).toBeDefined();
 
     // Resolve via the explicit endpoint (UI click path is covered by a

--- a/web/tests/live/cockpit-cancel.spec.ts
+++ b/web/tests/live/cockpit-cancel.spec.ts
@@ -20,6 +20,10 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import {
+  enableCockpitAndWait,
+  waitForReplayContains,
+} from "../helpers/cockpit";
 
 const SLOW_TURN_SCRIPT = {
   turns: [
@@ -57,11 +61,7 @@ base.skip("cockpit/cancel publishes Stopped reason:cancelled mid-turn", async ({
     const sessions = await listSessions(serve.baseUrl);
     const sessionId = sessions[0]!.id;
 
-    await fetch(
-      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
-      { method: "POST" },
-    );
-    await new Promise((r) => setTimeout(r, 2_000));
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
 
     await fetch(`${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`, {
       method: "POST",
@@ -75,18 +75,7 @@ base.skip("cockpit/cancel publishes Stopped reason:cancelled mid-turn", async ({
     );
     expect(cancelRes.status).toBe(202);
 
-    let sawCancelled = false;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      if (JSON.stringify(replay).includes("cancelled")) {
-        sawCancelled = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    expect(sawCancelled).toBe(true);
+    await waitForReplayContains(serve.baseUrl, sessionId, "cancelled");
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-context-primer.spec.ts
+++ b/web/tests/live/cockpit-context-primer.spec.ts
@@ -59,21 +59,26 @@ test("cockpit/context-primer renders the seeded turn", async ({}, testInfo) => {
     );
 
     let highestSeq = 0;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      const json = JSON.stringify(replay.frames);
-      if (
-        json.includes(PRIMER_TEXT) &&
-        json.includes("user_forced") &&
-        replay.highest_seq !== null
-      ) {
-        highestSeq = replay.highest_seq;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
+    await expect
+      .poll(
+        async () => {
+          const replay = await fetch(
+            `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+          ).then((r) => r.json());
+          const json = JSON.stringify(replay.frames);
+          if (
+            json.includes(PRIMER_TEXT) &&
+            json.includes("user_forced") &&
+            replay.highest_seq !== null
+          ) {
+            highestSeq = replay.highest_seq;
+            return true;
+          }
+          return false;
+        },
+        { timeout: 15_000, intervals: [100, 200, 500, 1000] },
+      )
+      .toBe(true);
     expect(highestSeq).toBeGreaterThan(0);
 
     const primerRes = await fetch(

--- a/web/tests/live/cockpit-escape-no-cancel.spec.ts
+++ b/web/tests/live/cockpit-escape-no-cancel.spec.ts
@@ -20,6 +20,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { enableCockpitAndWait } from "../helpers/cockpit";
 
 base.skip("Escape inside the cockpit composer does not POST /cockpit/cancel", async ({
   page,
@@ -36,13 +37,7 @@ base.skip("Escape inside the cockpit composer does not POST /cockpit/cancel", as
     const sessions = await listSessions(serve.baseUrl);
     const sessionId: string = sessions[0]!.id;
 
-    const enableRes = await fetch(
-      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
-      { method: "POST" },
-    );
-    expect(enableRes.ok).toBeTruthy();
-    // Allow the supervisor to come up.
-    await new Promise((r) => setTimeout(r, 2_000));
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
 
     // Send a prompt so the agent enters turn-active.
     const promptRes = await fetch(

--- a/web/tests/live/cockpit-force-end-turn.spec.ts
+++ b/web/tests/live/cockpit-force-end-turn.spec.ts
@@ -12,6 +12,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { waitForReplayContains } from "../helpers/cockpit";
 
 test("cockpit/force_end_turn publishes a synthetic Stopped event", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -41,19 +42,7 @@ test("cockpit/force_end_turn publishes a synthetic Stopped event", async ({}, te
     );
     expect(forceRes.status).toBe(202);
 
-    let sawUserForced = false;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      const json = JSON.stringify(replay);
-      if (json.includes("user_forced")) {
-        sawUserForced = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    expect(sawUserForced).toBe(true);
+    await waitForReplayContains(serve.baseUrl, sessionId, "user_forced");
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-lagged-ws.spec.ts
+++ b/web/tests/live/cockpit-lagged-ws.spec.ts
@@ -24,6 +24,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { enableCockpitAndWait } from "../helpers/cockpit";
 
 const FLOOD_UPDATES = Array.from({ length: 300 }, (_, i) => ({
   sessionUpdate: "agent_message_chunk",
@@ -57,11 +58,7 @@ base.skip("lagged WS receiver gets a kind:lagged frame from the server", async (
     const sessions = await listSessions(serve.baseUrl);
     const sessionId = sessions[0]!.id;
 
-    await fetch(
-      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
-      { method: "POST" },
-    );
-    await new Promise((r) => setTimeout(r, 2_000));
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
 
     // Sketch only. The full version would: (1) open a WebSocket to
     // /sessions/:id/cockpit/ws and stop reading its frames so the

--- a/web/tests/live/cockpit-mode-switch.spec.ts
+++ b/web/tests/live/cockpit-mode-switch.spec.ts
@@ -58,10 +58,15 @@ base("session/mode round-trips through the fake ACP agent", async ({}, testInfo)
     expect(modeRes.status).toBeGreaterThanOrEqual(200);
     expect(modeRes.status).toBeLessThan(300);
 
+    // The casing-OR survives a future wire-format flip from PascalCase
+    // to snake_case (or vice versa). The previous version of this
+    // assertion also OR'd in '"plan"' as a sanity check on the target
+    // mode, but that's a generic enough substring to false-positive on
+    // any frame whose payload happens to contain it (tool args, chat
+    // text, etc.), so just match the event name.
     await waitForReplayContains(serve.baseUrl, sessionId, [
       "current_mode_changed",
       "CurrentModeChanged",
-      '"plan"',
     ]);
   } finally {
     await serve.stop();

--- a/web/tests/live/cockpit-mode-switch.spec.ts
+++ b/web/tests/live/cockpit-mode-switch.spec.ts
@@ -10,6 +10,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
+import { waitForReplayContains } from "../helpers/cockpit";
 
 base("session/mode round-trips through the fake ACP agent", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -57,23 +58,11 @@ base("session/mode round-trips through the fake ACP agent", async ({}, testInfo)
     expect(modeRes.status).toBeGreaterThanOrEqual(200);
     expect(modeRes.status).toBeLessThan(300);
 
-    let sawModeChange = false;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      const json = JSON.stringify(replay);
-      if (
-        json.includes("current_mode_changed") ||
-        json.includes("CurrentModeChanged") ||
-        json.includes("\"plan\"")
-      ) {
-        sawModeChange = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    expect(sawModeChange).toBe(true);
+    await waitForReplayContains(serve.baseUrl, sessionId, [
+      "current_mode_changed",
+      "CurrentModeChanged",
+      '"plan"',
+    ]);
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-replay-catchup.spec.ts
+++ b/web/tests/live/cockpit-replay-catchup.spec.ts
@@ -59,16 +59,21 @@ test("cockpit/replay surfaces seeded events and signals lost frames", async ({},
       highest_seq: number | null;
       lowest_seq: number | null;
     } | null = null;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const res = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      );
-      expect(res.ok).toBeTruthy();
-      body = await res.json();
-      const userForcedCount = JSON.stringify(body!.frames).split('"user_forced"').length - 1;
-      if (userForcedCount >= SEED_EVENTS) break;
-      await new Promise((r) => setTimeout(r, 200));
-    }
+    await expect
+      .poll(
+        async () => {
+          const res = await fetch(
+            `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+          );
+          if (!res.ok) return -1;
+          body = await res.json();
+          return (
+            JSON.stringify(body!.frames).split('"user_forced"').length - 1
+          );
+        },
+        { timeout: 15_000, intervals: [100, 200, 500, 1000] },
+      )
+      .toBeGreaterThanOrEqual(SEED_EVENTS);
     expect(body).not.toBeNull();
     expect(body!.frames.length).toBeGreaterThanOrEqual(SEED_EVENTS);
     expect(body!.lowest_seq).not.toBeNull();

--- a/web/tests/live/cockpit-spawn-prompt.spec.ts
+++ b/web/tests/live/cockpit-spawn-prompt.spec.ts
@@ -12,7 +12,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
-import { waitForCockpitReady } from "../helpers/cockpit";
+import { waitForCockpitReady, waitForReplayContains } from "../helpers/cockpit";
 
 base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -55,30 +55,13 @@ base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}
     expect(promptRes.status).toBeGreaterThanOrEqual(200);
     expect(promptRes.status).toBeLessThan(300);
 
-    let sawChunk = false;
-    for (let attempt = 0; attempt < 30; attempt++) {
-      const replay = await fetch(
-        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
-      ).then((r) => r.json());
-      // GET /cockpit/replay returns { frames, lost, highest_seq, lowest_seq }
-      // (src/server/api/cockpit.rs::cockpit_replay). Each frame's serialized
-      // `event` is an externally-tagged enum, so the chunk is keyed
-      // `AgentMessageChunk`. Match either casing to stay robust if the
-      // wire format ever moves to snake_case.
-      const frames: unknown[] = Array.isArray(replay)
-        ? replay
-        : replay.frames ?? [];
-      const json = JSON.stringify(frames);
-      if (
-        json.includes("agent_message_chunk") ||
-        json.includes("AgentMessageChunk")
-      ) {
-        sawChunk = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 200));
-    }
-    expect(sawChunk).toBe(true);
+    // Match either casing in case the wire format moves to snake_case
+    // (frames currently serialize `event` as an externally-tagged enum,
+    // keyed `AgentMessageChunk`; src/server/api/cockpit.rs::cockpit_replay).
+    await waitForReplayContains(serve.baseUrl, sessionId, [
+      "agent_message_chunk",
+      "AgentMessageChunk",
+    ]);
   } finally {
     await serve.stop();
   }

--- a/web/tests/live/cockpit-spawn-prompt.spec.ts
+++ b/web/tests/live/cockpit-spawn-prompt.spec.ts
@@ -12,7 +12,7 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../helpers/aoeServe";
-import { waitForCockpitReady, waitForReplayContains } from "../helpers/cockpit";
+import { enableCockpitAndWait, waitForReplayContains } from "../helpers/cockpit";
 
 base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}, testInfo) => {
   const serve = await spawnAoeServe({
@@ -32,17 +32,10 @@ base("cockpit spawn + prompt round-trip emits an agent_message_chunk", async ({}
     // implicitly spawns the cockpit supervisor via tokio::spawn. A
     // follow-up explicit POST to /cockpit/spawn would 409 with
     // "already running", so we only call enable and let it own the
-    // spawn lifecycle.
-    const enableRes = await fetch(
-      `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
-      { method: "POST" },
-    );
-    expect(enableRes.ok).toBeTruthy();
-    // Wait for the tokio::spawn'd supervisor to finish its ACP handshake
-    // (initialize + session/new) before prompting, by polling replay for
-    // any frame. The previous `setTimeout(2_000)` race proved tight under
-    // CI load.
-    await waitForCockpitReady(serve.baseUrl, sessionId);
+    // spawn lifecycle. `enableCockpitAndWait` POSTs enable, asserts a
+    // 2xx, then waits for the ACP handshake (initialize + session/new)
+    // to finish before returning.
+    await enableCockpitAndWait(serve.baseUrl, sessionId);
 
     const promptRes = await fetch(
       `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/prompt`,


### PR DESCRIPTION
## Description

The cockpit live Playwright specs were slow and flaky because every replay-wait was a hand-rolled `for (let attempt = 0; attempt < 30) ... setTimeout(200)` loop. That's a hard 6s deadline that races the supervisor handshake under CI load: short polls flake on contended runners, longer polls slow down the happy path.

This PR:

1. Adds a small `waitForReplayContains` helper in `web/tests/helpers/cockpit.ts` that uses `expect.poll` with exponential backoff intervals (100, 200, 500, 1000ms) and a 15s default timeout. Shorter on the happy path (first poll lands in ~100ms), more headroom on slow runners.
2. Migrates six active specs to it (force-end-turn, mode-switch, spawn-prompt, plus three skipped specs that will benefit when #1237 unblocks them).
3. Migrates the three specs that extract a value out of replay (approval nonce, context-primer highest_seq, replay-catchup body) to inline `expect.poll` with the same backoff curve.
4. Finishes the `setTimeout(2_000)` to `enableCockpitAndWait` migration for the three quarantined specs (cockpit-cancel, cockpit-escape-no-cancel, cockpit-lagged-ws). The existing helper was already used in spawn-prompt and approval; these three had been left behind.

Net: -127 / +125 lines, no behavior change for green tests, materially less flake under CI load.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR only changes how existing tests poll for state; no test behavior or coverage matrix entries change.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle.

## Verification

Full cockpit live suite locally: 29 passed, 3 skipped (the #1237 quarantine), 7.3s wall time.

```
npx playwright test --config=playwright.live.config.ts 'cockpit-'
```

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

Diagnostic and implementation done with Claude. I reviewed each spec diff before commit; the helper API and intervals choice (100, 200, 500, 1000ms) are based on the existing `waitForCockpitReady` pattern in the same file.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR standardizes and stabilizes cockpit live tests by replacing ad-hoc waits and retry loops with Playwright-backed polling and consistent cockpit setup.

- Added waitForReplayContains helper in web/tests/helpers/cockpit.ts to poll the cockpit replay endpoint with an exponential backoff (100 → 200 → 500 → 1000 ms) and a 15s default timeout. Supports matching any or all provided needle strings.
- Migrated nine live cockpit specs to use the new helper and/or the existing enableCockpitAndWait helper, removing fixed timeouts and hand-rolled retry loops.
- Converted three specs that extract values from replay (approval nonce, context-primer highest_seq, replay-catchup body) to inline expect.poll with the same backoff schedule where appropriate.
- Removed brittle setTimeout(2_000)-style waits and fixed-attempt polling loops.

Net diff: approximately -127 / +125 lines (no intended change to test behavior).

## Benefits

- Reduced CI flakiness through smarter, adaptive polling.
- Faster and more reliable execution under load vs. fixed delays.
- Improved maintainability and consistency by centralizing replay-wait logic.
- Preserves existing test semantics while making timing more robust.

## Files Affected (high level)

- Added: web/tests/helpers/cockpit.ts (waitForReplayContains)
- Updated tests: cockpit-approval, cockpit-cancel, cockpit-context-primer, cockpit-escape-no-cancel, cockpit-force-end-turn, cockpit-lagged-ws, cockpit-mode-switch, cockpit-replay-catchup, cockpit-spawn-prompt

## Technical Notes (brief)

- waitForReplayContains uses Playwright's expect.poll with exponential backoff and normalizes replay payload shapes (array vs. { frames }).
- Polling mode supports "any" (default) or "all" needles; timeout configurable.
- Specific value-extraction cases use inline expect.poll to return parsed values (e.g., approval nonce).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1494?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->