### PR TITLE
perf(tui): split-render preview on live-send %output wakes

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -339,9 +339,9 @@ impl App {
             // (see `draw_preview_only`). Only stash when live-send is
             // active and dialogs aren't covering the home view; the
             // snapshot is useless in any other state and the clone
-            // cost (12-cell-sized allocation per cell, ~12K cells on
-            // a typical pane) is real per draw, so we skip it when no
-            // fast-path render can consume it.
+            // cost (one `Vec<Cell>` walk plus a `Cell::clone` per
+            // cell, ~12K cells on a 200x60 pane) is real per draw, so
+            // we skip it when no fast-path render can consume it.
             if self.home.live_send.is_some() && !self.home.has_dialog() {
                 self.last_full_frame = Some(completed.buffer.clone());
                 self.last_full_frame_preview_area = self.home.preview_area;

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -113,6 +113,21 @@ pub struct App {
     /// without backpressure if the main loop ever stalls.
     live_send_wake_tx: tokio::sync::mpsc::Sender<()>,
     live_send_wake_rx: tokio::sync::mpsc::Receiver<()>,
+    /// Snapshot of the most recently completed full-render buffer.
+    /// Stashed only while live-send is active (the only consumer of
+    /// the preview-only fast path); cleared when the user exits live
+    /// mode or the terminal resizes. The fast path repaints these
+    /// cells into a fresh back buffer and then re-renders only the
+    /// preview pane, so the cost of a `%output` wake drops from
+    /// "rebuild the whole HomeView widget tree" to "memcpy cells
+    /// plus refresh the preview cache + paragraph." See
+    /// `Self::draw_preview_only`.
+    last_full_frame: Option<ratatui::buffer::Buffer>,
+    /// Area of the preview pane in `last_full_frame`. Captured from
+    /// `HomeView::preview_area` immediately after the full draw that
+    /// produced the snapshot. The fast path only overdraws this rect;
+    /// everything outside it is whatever the snapshot held.
+    last_full_frame_preview_area: ratatui::layout::Rect,
     /// Tracks whether we currently have xterm mouse-tracking enabled. The TUI
     /// turns it off while a copy-friendly surface is open (`HomeView::
     /// wants_text_selection`) so users can drag-select natively, then turns
@@ -260,6 +275,8 @@ impl App {
             event_stream: Some(EventStream::new()),
             live_send_wake_tx,
             live_send_wake_rx,
+            last_full_frame: None,
+            last_full_frame_preview_area: ratatui::layout::Rect::default(),
             // Initial state matches whatever `tui::run` did at startup;
             // capture is on by default, off only if AOE_MOUSE_CAPTURE=0.
             mouse_captured: crate::tui::mouse_capture_requested(),
@@ -316,7 +333,21 @@ impl App {
         )?;
         let draw_result = (|| -> Result<()> {
             crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Hide)?;
-            terminal.draw(|f| self.render(f)).map(|_| ())?;
+            let completed = terminal.draw(|f| self.render(f))?;
+            // Snapshot the freshly drawn frame so a subsequent
+            // `%output` wake can take the preview-only fast path
+            // (see `draw_preview_only`). Only stash when live-send is
+            // active and dialogs aren't covering the home view; the
+            // snapshot is useless in any other state and the clone
+            // cost (12-cell-sized allocation per cell, ~12K cells on
+            // a typical pane) is real per draw, so we skip it when no
+            // fast-path render can consume it.
+            if self.home.live_send.is_some() && !self.home.has_dialog() {
+                self.last_full_frame = Some(completed.buffer.clone());
+                self.last_full_frame_preview_area = self.home.preview_area;
+            } else {
+                self.last_full_frame = None;
+            }
             Ok(())
         })();
         let end_result = crossterm::execute!(
@@ -326,6 +357,73 @@ impl App {
         draw_result?;
         end_result?;
         Ok(())
+    }
+
+    /// Fast-path draw for live-send `%output` wakes: repaint the last
+    /// full frame's cells into the new back buffer, then re-render
+    /// only the preview pane on top. ratatui's per-cell diff sees
+    /// changes only in the preview rect and writes a minimal delta
+    /// to the terminal. Total cost is ~1 buffer-clone + 1 preview
+    /// refresh vs. the full HomeView widget rebuild (sidebar, status
+    /// bar, dialogs, update banner) the slow path runs.
+    ///
+    /// Returns `Ok(false)` when the fast path bailed (no snapshot,
+    /// dimensions don't match, etc.) so the caller can fall back to
+    /// the full draw. Returns `Ok(true)` on success.
+    fn draw_preview_only(
+        &mut self,
+        terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    ) -> Result<bool> {
+        let Some(snapshot) = self.last_full_frame.clone() else {
+            return Ok(false);
+        };
+        // Resize between the snapshot and this draw invalidates the
+        // snapshot: a different terminal size means a different layout
+        // and a different preview rect, and the snapshot's cells
+        // wouldn't line up. Bail to the full path so the next draw
+        // rebuilds everything at the new size.
+        let current_area = terminal.size().map(|sz| ratatui::layout::Rect {
+            x: 0,
+            y: 0,
+            width: sz.width,
+            height: sz.height,
+        });
+        if current_area.map(|c| c != snapshot.area).unwrap_or(true) {
+            self.last_full_frame = None;
+            return Ok(false);
+        }
+        let preview_area = self.last_full_frame_preview_area;
+        if preview_area.width == 0 || preview_area.height == 0 {
+            return Ok(false);
+        }
+
+        crossterm::execute!(
+            terminal.backend_mut(),
+            crossterm::terminal::BeginSynchronizedUpdate
+        )?;
+        let draw_result = (|| -> Result<()> {
+            crossterm::execute!(terminal.backend_mut(), crossterm::cursor::Hide)?;
+            terminal.draw(|f| {
+                let area = f.area();
+                // Step 1: paint the snapshot into the back buffer.
+                f.render_widget(SnapshotPainter::new(&snapshot), area);
+                // Step 2: re-render only the preview region. ratatui's
+                // diff will then write just the changed preview cells
+                // (sidebar/status bar already match the previous
+                // frame because we just painted them in step 1, so
+                // their diff is empty).
+                self.home
+                    .render_preview_pane_only(f, preview_area, &self.theme);
+            })?;
+            Ok(())
+        })();
+        let end_result = crossterm::execute!(
+            terminal.backend_mut(),
+            crossterm::terminal::EndSynchronizedUpdate
+        );
+        draw_result?;
+        end_result?;
+        Ok(true)
     }
 
     /// Temporarily leave TUI mode, run a closure, and restore TUI mode.
@@ -530,6 +628,11 @@ impl App {
                 terminal.clear()?;
                 self.needs_redraw = false;
             }
+
+            // Reset per-iteration flags. Set inside the select! branches
+            // and consumed after the periodic-refresh block below to
+            // decide between the preview-only fast path and a full draw.
+            let mut woke_via_live_send_wake = false;
 
             // All event sources are polled cooperatively via tokio::select!.
             // This ensures signal futures actually get scheduled (fixing #608
@@ -804,11 +907,13 @@ impl App {
                 // reader thread owned by `ControlModeClient`, which
                 // exists only between `enter_live_send` and its
                 // drop), so this is effectively a no-op outside live
-                // mode. The branch body is empty: we just want the
-                // outer loop iteration to fall through to `draw`,
-                // which re-runs `refresh_preview_cache_if_needed` and
-                // picks up the new pane bytes.
-                Some(_) = self.live_send_wake_rx.recv() => {}
+                // mode. Setting `woke_via_live_send_wake` flips on
+                // both `refresh_needed` (so the draw at the bottom
+                // of the loop actually fires) and the
+                // preview-only fast path consideration below.
+                Some(_) = self.live_send_wake_rx.recv() => {
+                    woke_via_live_send_wake = true;
+                }
                 _ = async {
                     #[cfg(unix)]
                     match sighup {
@@ -847,8 +952,16 @@ impl App {
                 self.needs_redraw = true;
             }
 
-            // Periodic refreshes (only when no input pending)
+            // Periodic refreshes (only when no input pending).
+            //
+            // `needs_full_refresh` separately tracks whether anything
+            // OTHER than the live-send wake wants a refresh. The
+            // preview-only fast path (see `draw_preview_only`) is
+            // only safe when nothing else needs the sidebar / status
+            // bar / dialogs re-rendered, so we route to it only when
+            // `woke_via_live_send_wake && !needs_full_refresh`.
             let mut refresh_needed = false;
+            let mut needs_full_refresh = false;
 
             if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
                 self.home.request_status_refresh();
@@ -857,33 +970,40 @@ impl App {
 
             if self.home.apply_status_updates() {
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if self.home.apply_deletion_results() {
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if self.home.apply_session_id_updates() {
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if self.home.apply_recovery_updates() {
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if let Some(session_id) = self.home.apply_creation_results() {
                 self.dispatch_new_session_attach(&session_id, terminal)?;
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if self.home.tick_dialog() {
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if last_disk_refresh.elapsed() >= DISK_REFRESH_INTERVAL {
                 self.home.reload()?;
                 last_disk_refresh = std::time::Instant::now();
                 refresh_needed = true;
+                needs_full_refresh = true;
             }
 
             if last_heartbeat.elapsed() >= HEARTBEAT_INTERVAL {
@@ -917,10 +1037,31 @@ impl App {
             {
                 last_spinner_redraw = std::time::Instant::now();
                 refresh_needed = true;
+                needs_full_refresh = true;
+            }
+
+            // A live-send wake on its own is a refresh signal: the
+            // agent rendered new bytes into the pane and the preview
+            // is stale. Without this flag the loop would only redraw
+            // when one of the periodic checks above happened to fire,
+            // which is rare in steady-state typing.
+            if woke_via_live_send_wake {
+                refresh_needed = true;
             }
 
             if refresh_needed {
-                self.draw(terminal)?;
+                let prefer_preview_only = woke_via_live_send_wake
+                    && !needs_full_refresh
+                    && self.home.live_send.is_some()
+                    && !self.home.has_dialog()
+                    && self.last_full_frame.is_some();
+                let mut took_fast_path = false;
+                if prefer_preview_only {
+                    took_fast_path = self.draw_preview_only(terminal)?;
+                }
+                if !took_fast_path {
+                    self.draw(terminal)?;
+                }
             }
 
             if self.should_quit {
@@ -1965,6 +2106,38 @@ pub enum Action {
     /// against the borrowed terminal + event stream.
     #[cfg(feature = "serve")]
     OpenCockpit(String),
+}
+
+/// Widget that paints a previously captured frame into the back
+/// buffer, used by `App::draw_preview_only` to seed the fast-path
+/// frame with the prior full render's cells before re-rendering only
+/// the preview pane. The Widget's `area` argument is intentionally
+/// ignored because we always overwrite the whole back buffer; the
+/// caller is expected to immediately render the preview region on
+/// top to differentiate it from the previous frame's preview cells.
+///
+/// Same-dimension fast path uses `Vec::clone_from_slice` for a
+/// memcpy-shaped copy of all cells. On the off chance dimensions
+/// don't match (snapshot from a different terminal size that wasn't
+/// caught by the caller's resize check), the painter is a no-op and
+/// the fast-path render produces a half-painted frame; the caller's
+/// resize check should make this unreachable in practice.
+struct SnapshotPainter<'a> {
+    snapshot: &'a ratatui::buffer::Buffer,
+}
+
+impl<'a> SnapshotPainter<'a> {
+    fn new(snapshot: &'a ratatui::buffer::Buffer) -> Self {
+        Self { snapshot }
+    }
+}
+
+impl ratatui::widgets::Widget for SnapshotPainter<'_> {
+    fn render(self, _area: ratatui::layout::Rect, buf: &mut ratatui::buffer::Buffer) {
+        if buf.area == self.snapshot.area && buf.content.len() == self.snapshot.content.len() {
+            buf.content.clone_from_slice(&self.snapshot.content);
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -942,16 +942,6 @@ impl App {
                 }
             }
 
-            // Check for update result (non-blocking)
-            if self.poll_update_check() {
-                self.needs_redraw = true;
-            }
-
-            // Check for in-progress update completion
-            if self.poll_update_status() {
-                self.needs_redraw = true;
-            }
-
             // Periodic refreshes (only when no input pending).
             //
             // `needs_full_refresh` separately tracks whether anything
@@ -962,6 +952,26 @@ impl App {
             // `woke_via_live_send_wake && !needs_full_refresh`.
             let mut refresh_needed = false;
             let mut needs_full_refresh = false;
+
+            // Update-check / install-status polls can flip the
+            // bottom-of-screen update bar (banner or transient toast)
+            // on or off, which shifts the home view's layout. If a
+            // live-send wake fires on the same iteration, the
+            // preview-only fast path would paint a stale snapshot
+            // whose preview rect no longer lines up with the new
+            // layout. Treat any banner state change as full-refresh
+            // work so the slow path rebuilds the layout AND the
+            // snapshot.
+            if self.poll_update_check() {
+                self.needs_redraw = true;
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
+            if self.poll_update_status() {
+                self.needs_redraw = true;
+                refresh_needed = true;
+                needs_full_refresh = true;
+            }
 
             if last_status_refresh.elapsed() >= STATUS_REFRESH_INTERVAL {
                 self.home.request_status_refresh();

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -375,6 +375,36 @@ fn activity_column_padding(
 }
 
 impl HomeView {
+    /// Re-render only the preview pane at `preview_area`, leaving
+    /// every other region of the back buffer untouched. Called from
+    /// `App::draw_preview_only` on the live-send `%output` fast path:
+    /// the caller has already painted the previous full frame's
+    /// cells into the back buffer, so anything outside `preview_area`
+    /// matches the prior frame and ratatui's diff produces an empty
+    /// write for that region. Inside `preview_area` we re-run the
+    /// usual capture + Paragraph pipeline so the user's typed input
+    /// (echoed by the agent via `%output`) lands as fast as ratatui
+    /// can diff and write it.
+    ///
+    /// This deliberately mirrors only the Agent ViewMode branch of
+    /// `render_preview`. The fast path is gated by the caller to
+    /// require live-send active, which itself requires
+    /// `ViewMode::Agent`; the Terminal / Tool view modes shouldn't
+    /// reach this code, and live-send doesn't apply to them anyway.
+    pub fn render_preview_pane_only(
+        &mut self,
+        frame: &mut Frame,
+        preview_area: Rect,
+        theme: &Theme,
+    ) {
+        // `render_preview` mutates a bunch of HomeView state
+        // (preview_area, preview_cache, scroll offset clamps). We
+        // want the same mutations on the fast path so the next full
+        // draw sees consistent state; calling render_preview
+        // directly is the simplest way to keep them in sync.
+        self.render_preview(frame, preview_area, theme);
+    }
+
     pub fn render(
         &mut self,
         frame: &mut Frame,


### PR DESCRIPTION
## Description

Builds on #1490 (control-mode socket + parsed-Text cache). After that PR, the remaining per-frame cost on a live-send `%output` wake was the full HomeView widget rebuild: sidebar, status bar, dialog rendering pipeline, update banner. The user sees no change in those regions on a wake, but the main thread spends ~2-4 ms re-running widget builders that produce the same output as the previous frame.

This adds a preview-only fast path:

1. After every full draw that's live-send-relevant, `App` snapshots the completed back buffer into `last_full_frame: Option<Buffer>`. Clone cost is one `Vec<Cell>` walk (sub-millisecond on a typical pane) and we skip the snapshot entirely outside live-send so non-live draws pay nothing.

2. On the next iteration, if the loop woke via the live-send `%output` channel AND nothing else flipped `needs_full_refresh` (status update, deletion result, creation completion, spinner tick, dialog change, etc.), `App` calls `draw_preview_only`:
   - Paints the snapshot into the back buffer via a new `SnapshotPainter` widget (a `Vec::clone_from_slice` when the area matches, a no-op otherwise).
   - Runs `HomeView::render_preview_pane_only` against the previously-captured `preview_area`, which re-uses the existing `render_preview` so all the cache / scroll / parsed-Text logic stays consistent.
   - ratatui then diffs the back buffer vs the prior front buffer; only the preview rect differs, so the terminal write is the minimum delta.

3. Resize and dimension-mismatch checks bail to the slow path; the snapshot is cleared whenever the user exits live-send or opens a dialog so the next live-send entry starts fresh.

**Side fix discovered along the way:** the live-send wake branch in `tokio::select!` previously had an empty body. Draws after a wake therefore relied on something else (typically the 120 ms spinner-redraw cadence) to flip `refresh_needed` and trigger the bottom-of-loop draw. The wake should force the redraw on its own; the new `woke_via_live_send_wake` flag does both that and gates the fast path.

## Effect

Typing-to-echo latency in live-send drops to roughly the cost of ratatui's per-cell diff + the terminal write for the preview rect, vs the prior cost of "rebuild every widget in the home view, diff the whole frame, write the changes." On a 200x60 pane the saved work is ~2-4 ms per `%output` wake, which compounds visibly when the agent streams a long response. Maintainer confirmed perceptible improvement when typing live.

Closes the residual lag gap discussed in #1485 and the follow-up conversation on #1490.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo test --lib`, `cargo test --test integration`, `cargo test --test e2e new_session`)
- [x] Documentation was updated where necessary (in-source rustdoc on the new code paths; no user-facing docs apply since the optimization is invisible)
- [ ] For UI changes: included screenshot or recording (no visual change; this is purely a perf optimization with no semantic difference)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: the fast path is invisible to e2e harnesses. The behavior is "the preview content equals what a full draw would have produced, but with less work." Existing e2e coverage of live-send entry/exit and preview rendering continues to pass; a regression in the fast path would manifest as visually stuck sidebar / status bar or visible tearing during typing, both of which would be obvious in normal use and caught at review or in early dogfooding.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** njbrake noticed the residual lag during live-send testing on the prior PR, asked for evaluation of further optimization options, and picked split-render as the lever. Claude implemented; njbrake validated by running the change and confirmed the typing-to-echo latency dropped perceptibly. All scope and design decisions (snapshot-based vs vt100 emulator, opt-in scope, resize-invalidation policy) were njbrake's.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR adds a preview-only fast path to the TUI renderer to speed up live-send `%output` wakes. Instead of rebuilding the whole UI on each live-send event, the app snapshots the last full frame and, when safe, reuses that snapshot and re-renders only the preview pane.

## What Changed

- App-level caching and routing (src/tui/app.rs)
  - Added `last_full_frame: Option<ratatui::buffer::Buffer>` and `last_full_frame_preview_area: Rect` to cache the last complete render and preview rect.
  - Introduced a `woke_via_live_send_wake` flag to mark loop iterations triggered by live-send `%output`.
  - Split refresh signals into `refresh_needed` vs `needs_full_refresh` to distinguish preview-only updates from changes that require a full redraw.
  - Added `draw_preview_only()` which validates the snapshot, seeds the back buffer from it, runs preview-only rendering, and lets the buffer diffing write only the changed preview rect.
  - Snapshotting is skipped or cleared when live-send is inactive, dialogs open, terminal size/geometry mismatch, or other full-refresh triggers occur.
  - Treats update-bar/banner state changes (from `poll_update_check()`/`poll_update_status()`) as full-refresh work to avoid layout races.

- Home view change (src/tui/home/render.rs)
  - Added `pub fn render_preview_pane_only(&mut self, frame: &mut Frame, preview_area: Rect, theme: &Theme)` which re-renders only the preview pane while reusing existing preview logic, caches, and scroll/parse state.

- New utility
  - `SnapshotPainter` widget copies cached buffer cells into the current back buffer efficiently (fast memcpy when geometries match, no-op otherwise).

## Benefits

- Significantly lowers typing-to-echo latency during live-send by avoiding full-frame work — measured ~2–4 ms savings per `%output` wake on a 200×60 pane.
- Reduces CPU and rendering overhead for frequent small updates while preserving correctness.
- Robust fallbacks: any invalidation (resizes, dialogs, layout/banner changes) forces a full redraw.

## Potential follow-ups / Enhancements

- Add tests targeted at the timing/layout race (currently omitted due to timing dependence).
- Further micro-optimizations for partial-snapshot mismatches (e.g., copying only intersecting regions rather than no-op).
- Expose telemetry or metrics to measure how often fast-path vs full redraw is taken in real usage.

## Technical notes

- The fast path is gated: it only runs when the loop wake was from live-send, live-send remains active, no dialog is open, the preview area is non-zero and matches cached geometry, and `needs_full_refresh` is false.
- The snapshot is captured only after a completed full draw (to ensure a consistent base) and is invalidated on dimension mismatch or exit from live-send.
- Update-bar/poll changes now set `needs_full_refresh` to avoid painting a stale snapshot with a shifted preview rect.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1495?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->