### PR TITLE
fix(tui): clear hover highlight on keyboard nav

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1926,6 +1926,7 @@ impl HomeView {
             }
             KeyCode::Home => {
                 self.cursor = 0;
+                self.mouse_pos = None;
                 self.update_selected();
             }
             KeyCode::Char('g')
@@ -1938,6 +1939,7 @@ impl HomeView {
             }
             KeyCode::End | KeyCode::Char('G') if !self.flat_items.is_empty() => {
                 self.cursor = self.flat_items.len() - 1;
+                self.mouse_pos = None;
                 self.update_selected();
             }
             KeyCode::Enter => {
@@ -2239,6 +2241,14 @@ impl HomeView {
         };
 
         self.cursor = new_cursor;
+        // Keyboard nav overrides any prior hover. Without this, when mosh
+        // (or any prediction layer) eats the `Moved` event that fires as
+        // the cursor leaves the list, the hover background stays painted
+        // on the row the mouse was last on while the keyboard-selected
+        // row also paints — two highlighted rows at once. handle_hover
+        // only clears `mouse_pos` when it RECEIVES an off-list Moved, so
+        // any keyboard transition has to clear it directly.
+        self.mouse_pos = None;
         self.update_selected();
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5240,6 +5240,27 @@ mod click_to_select {
 
     #[test]
     #[serial]
+    fn move_cursor_clears_hover() {
+        // Repro for the keyboard-after-hover stuck-highlight bug: when
+        // mosh (or any prediction layer) eats the off-list `Moved` event,
+        // `mouse_pos` stays stuck on the row the mouse last touched while
+        // the keyboard moves to a new row, painting two rows at once.
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+
+        env.view.handle_hover(5, 2);
+        assert_eq!(env.view.hovered_index(), Some(1));
+
+        env.view.move_cursor(1);
+        assert_eq!(
+            env.view.hovered_index(),
+            None,
+            "keyboard nav must clear hover so only the selected row paints"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn hover_below_last_item_resolves_to_none() {
         let mut env = create_test_env_with_sessions(3);
         setup_inner(&mut env);


### PR DESCRIPTION
## Summary

Repro: hover the mouse over a session row, then press arrow-down. Both the old row (hover bg) and the new row (selection bg) paint at the same time.

## Root cause

\`handle_hover\` only clears \`mouse_pos\` when it RECEIVES a \`Moved\` event whose coordinates fall outside \`list_inner_area\`. Two real-world cases stop that event from arriving:

1. **Keyboard nav after a hover** — the mouse hasn't moved, so no \`Moved\` event fires. \`mouse_pos\` stays on the last-hovered cell while \`cursor\` moves elsewhere via keyboard.
2. **Mosh / SSH prediction layers** — the off-list \`Moved\` is frequently dropped or coalesced. Even after the pointer physically leaves the terminal window, no event reaches the app.

\`hovered_index()\` resolves \`mouse_pos\` → row index every frame, so the stale position keeps painting until the user happens to wiggle the mouse over the list again.

## Fix

Clear \`mouse_pos\` at every keyboard transition that moves the selection: \`move_cursor\`, \`Home\`, \`End\`/\`G\`. \`handle_hover\` stays unchanged for mouse-driven transitions, so pixel-level hover twitches are still no-ops.

Origin commit: \`cf81bd4\` (#1392, hover support).

## Test plan

- [x] New regression test \`click_to_select::move_cursor_clears_hover\` — hover row 1, \`move_cursor(1)\`, assert \`hovered_index() == None\`.
- [x] Existing \`click_to_select::hover_*\` tests still pass (6/6).
- [x] \`cargo fmt && cargo clippy -- -D warnings && cargo test --lib --release\` clean.
- [ ] Manual: hover a row in a multi-row list, press ↓, only the new row paints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes a visual bug in the terminal UI where keyboard navigation after mouse hovering would display both the old hovered row and the new selected row with their respective highlighting simultaneously, creating a confusing visual state.

## What Changed

**Problem:** When you hovered your mouse over a row and then pressed the down arrow key, the UI would paint both rows as highlighted (one with hover background, one with selection background) instead of just showing the newly selected row.

**Solution:** Modified keyboard navigation handlers to clear the mouse hover state when moving the selection via arrow keys, Home key, or End key, ensuring that keyboard-driven cursor movement removes any stale hover highlighting.

**Files modified:**
- `src/tui/home/input.rs` – Added mouse position clearing logic to `move_cursor`, `Home`, and `End` key handlers
- `src/tui/home/tests.rs` – Added a new regression test `move_cursor_clears_hover` to ensure this issue doesn't reoccur

## Benefits

- **Improved UX:** Keyboard navigation now produces clean, unambiguous visual feedback—only one row is highlighted at a time
- **Better robustness:** The fix handles edge cases where mouse movement events may be dropped or coalesced (e.g., in SSH/mosh sessions)
- **Regression prevention:** New test ensures this specific scenario stays fixed

## Technical Details

The root cause was that `hovered_index()` resolves the `mouse_pos` state every frame. When keyboard navigation occurred after hovering, the mouse hadn't physically moved, so the Moved event that would normally clear `mouse_pos` never arrived. This left a stale `mouse_pos` value that continued to highlight the old row.

The fix explicitly clears `mouse_pos` on every keyboard-driven selection transition (move_cursor, Home, End), ensuring hover highlighting is reliably removed regardless of whether the mouse actually moved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->