### PR TITLE
feat(tui): add RowTagMode::Project for fleets with many same-repo sessions

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -666,6 +666,11 @@ pub enum RowTagMode {
     /// Render the worktree branch name (last segment if `/`-namespaced,
     /// truncated to 8 chars).
     Branch,
+    /// Render the project (main-repo) name. Helpful in fleets where many
+    /// sessions point at the same repo and the title is the random civ
+    /// name (`Sumer`, `Aztec`, ...). Last path segment of the worktree's
+    /// main-repo path, truncated to 12 chars.
+    Project,
 }
 
 impl Default for SessionConfig {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -231,6 +231,25 @@ pub(crate) fn compute_row_tag(
                 None
             }
         }
+        RowTagMode::Project => inst.worktree_info.as_ref().and_then(|w| {
+            // Show the project (main-repo) name. Helpful when many
+            // sessions point at the same repo and the title is a random
+            // civ name from `src/cli/add.rs` — `🔵 Sumer  [agent-of-empires]`
+            // tells the user which repo the empire is attached to without
+            // displacing the civ name. Last path segment, truncated to 12
+            // chars so the tag stays narrow. Workspace sessions have no
+            // single `worktree_info` and fall through to `None`.
+            let last = std::path::Path::new(&w.main_repo_path)
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
+            let trimmed: String = last.chars().take(12).collect();
+            if trimmed.is_empty() {
+                Option::<String>::None
+            } else {
+                Some(trimmed)
+            }
+        }),
         RowTagMode::Branch => inst.worktree_info.as_ref().and_then(|w| {
             // Complement the existing branch-on-divergence display
             // (rendered in `theme.branch` color earlier in the row) rather

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -2579,6 +2579,93 @@ fn test_row_tag_branch_renders_when_title_matches_branch() {
     }
 }
 
+/// `RowTagMode::Project` renders the main-repo basename so users with
+/// many sessions on the same repo can see which project each civ name
+/// belongs to without losing the civ name.
+#[test]
+#[serial]
+fn test_row_tag_project_renders_repo_basename() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage = Storage::new("alpha").unwrap();
+    let mut inst = Instance::new("Sumer", "/tmp/wt/sumer");
+    inst.worktree_info = Some(crate::session::WorktreeInfo {
+        branch: "main".to_string(),
+        main_repo_path: "/home/user/agent-of-empires".to_string(),
+        managed_by_aoe: true,
+        created_at: chrono::Utc::now(),
+        base_branch: None,
+    });
+    let instances = vec![inst];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Project;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                text.contains("[agent-of-em"),
+                "Project mode must render the repo basename truncated to 12: {text:?}"
+            );
+            assert!(
+                text.contains("Sumer"),
+                "Project mode must NOT displace the civ-name title: {text:?}"
+            );
+        }
+    }
+}
+
+/// `RowTagMode::Project` renders nothing when the session has no
+/// worktree_info (workspace sessions or pre-worktree sessions).
+#[test]
+#[serial]
+fn test_row_tag_project_skips_without_worktree() {
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+
+    let storage = Storage::new("alpha").unwrap();
+    let instances = vec![Instance::new("Sumer", "/tmp/sumer")];
+    let group_tree = GroupTree::new_with_groups(&instances, &[]);
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = group_tree.get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(None, tools).unwrap();
+    view.group_by = crate::session::config::GroupByMode::Manual;
+    view.row_tag_mode = crate::session::config::RowTagMode::Project;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+
+    for item in &view.flat_items {
+        if let Item::Session { .. } = item {
+            let text = rendered_row_text(&view, item);
+            assert!(
+                !text.contains('['),
+                "Project mode must skip the tag when worktree_info is missing: {text:?}"
+            );
+        }
+    }
+}
+
 /// Legacy `Instance::new` left `source_profile` empty before the per-profile
 /// plumbing landed. The render branch must skip the tag entirely in that
 /// case rather than emit a literal `  []`.

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -387,7 +387,7 @@ const ROTATION_OPTIONS: &[&str] = &["size", "never"];
 /// Display labels for `RowTagMode` in the Settings picker. Order must match
 /// `row_tag_to_index` / `index_to_row_tag` so the index round-trips. `None`
 /// is first because it is the default; existing users see no tag.
-const ROW_TAG_OPTIONS: &[&str] = &["None", "Auto", "Profile", "Sandbox", "Branch"];
+const ROW_TAG_OPTIONS: &[&str] = &["None", "Auto", "Profile", "Sandbox", "Branch", "Project"];
 
 fn row_tag_to_index(mode: crate::session::config::RowTagMode) -> usize {
     use crate::session::config::RowTagMode::*;
@@ -397,6 +397,7 @@ fn row_tag_to_index(mode: crate::session::config::RowTagMode) -> usize {
         Profile => 2,
         Sandbox => 3,
         Branch => 4,
+        Project => 5,
     }
 }
 
@@ -407,6 +408,7 @@ fn index_to_row_tag(idx: usize) -> crate::session::config::RowTagMode {
         2 => Profile,
         3 => Sandbox,
         4 => Branch,
+        5 => Project,
         _ => None,
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to closed #1459 implementing your suggested approach. `RowTagMode::Project` renders the main-repo basename alongside the civ name, e.g.:

\`\`\`
  Sumer  [agent-of-em]
  Aztec  [agent-of-em]
  Inca   [worktree-cl]
\`\`\`

You wrote on #1459:

> Extend the row-tag slot you built in #1244. RowTagMode already has None | Auto | Profile | Sandbox | Branch. Adding Project would render 🔵 Sumer  [agent-of-empires] instead of replacing Sumer. Reuses the dimmed style, the width-aware layout, and the per-profile override surface you already wired up. Much smaller diff than this PR, no breaking signature change on resolve_title, and the civ name stays.

This is that. ~50 LoC + 2 tests + Settings picker entry, opt-in (default \`None\` unchanged), no signature changes.

## What it does

- New \`RowTagMode::Project\` variant on the enum.
- Match arm in \`compute_row_tag\` that returns the last path segment of \`worktree_info.main_repo_path\`, truncated to 12 chars (matches the 8-char Branch cap shape with a touch more room for repo names).
- Workspace sessions (no single \`worktree_info\`) and pre-worktree sessions fall through to \`None\` naturally — no \`[]\` artifacts.
- \`ROW_TAG_OPTIONS\` extended in \`src/tui/settings/fields.rs\` so the Settings picker shows "Project" and the index round-trip stays consistent.

## On the compound-mode idea

You also floated:

> We could make it compound, e.g. RowTagMode::Composite(Vec\<RowTagPart\>) or accept a comma-separated list in settings (\`profile,project\`), and let users pick what shows up.

I think that's the right long-term shape, but it's a bigger refactor with a serialization migration (\`row_tag: "profile"\` → \`row_tag: ["profile", "project"]\` for the same key). I'd rather land the single-variant Project first so we can validate the use case, then revisit composite as a focused refactor if more requests like this come in. Happy to follow up.

## Re: asciinema

You asked for a recording of typical multi-repo session-list use. Working on it — separate followup; I didn't want to gate the code review on it. The pattern I'm trying to capture: ~40 sessions across 3–4 repos, all using civ-name titles, where I currently scroll-and-squint to find which Sumer belongs to which repo. The tag fixes that in-place.

## Test plan

- [x] \`test_row_tag_project_renders_repo_basename\` — instance with worktree pointed at \`/home/user/agent-of-empires\` renders \`[agent-of-em\` while the civ-name title stays.
- [x] \`test_row_tag_project_skips_without_worktree\` — no \`worktree_info\` → no tag.
- [x] All 9 \`row_tag\` tests pass.
- [x] \`cargo fmt && cargo clippy -- -D warnings && cargo test --lib --release\` clean.

Origin slot: #1244 (RowTagMode infrastructure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds a new **Project** variant to the row-tag display mode for TUI sessions. This feature helps users distinguish between sessions working on different repositories by displaying a truncated project name alongside the session's civilization identifier.

## What Changed

**New Feature Added:**
- A new `RowTagMode::Project` option was introduced in the TUI row-tag enum
- When enabled, sessions display the repository's project name (derived from the worktree's main repository path, shortened to 12 characters) next to the existing session name
- Example display: "Sumer  [agent-of-em]" (where "agent-of-em" is the truncated repo name)

**Where It Was Added:**
- Core enum definition added to session configuration
- Rendering logic implemented in the TUI home view to compute and display the project tag
- Settings picker updated to include "Project" as a selectable option
- Comprehensive tests added to verify correct behavior

**Behavior Details:**
- The feature is **opt-in** (defaults to None/disabled)
- Only applies to sessions with a defined worktree; sessions without worktree info are unaffected
- Sessions created before worktree information was tracked remain unchanged

## Benefits

- **Improved Multi-Repository Visibility**: Users managing multiple sessions across different repositories can now easily identify which project each session belongs to without relying solely on the randomized civilization name
- **Non-Breaking Enhancement**: The change is entirely backward-compatible and opt-in, requiring no changes to existing configurations or code
- **Well-Tested**: Two new regression tests verify correct behavior for both sessions with and without worktree information, and all existing tests continue to pass

## Testing & Quality

- Two new UI regression tests cover the core functionality
- All 9 row_tag tests pass
- Code formatting, clippy checks, and release tests all reported clean

---

**Technical Details:**

The implementation extracts the basename from `worktree_info.main_repo_path`, truncates it to 12 characters, and returns `None` if the path segment is missing or empty. The rendering integrates seamlessly with existing `RowTagMode` variants (None, Civ, CivRev) without affecting their behavior. Settings mapping updates ensure the option round-trips correctly through the UI picker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->