### PR TITLE
refactor(tui): gate Attention workflow visuals + hotkeys to Attention sort

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -509,6 +509,15 @@ pub struct AppStateConfig {
     /// Restored on subsequent opens so users don't re-navigate every time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_browse_dir: Option<PathBuf>,
+
+    /// Collapsed state for the synthetic "Archived" sidebar section.
+    /// Defaults to collapsed when absent. Archived sessions are pulled out
+    /// of the natural sort and grouped under this section at the bottom
+    /// across every sort mode, so they stop interleaving with active rows
+    /// without users in non-Attention modes losing the ability to find a
+    /// shelved session.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archived_section_collapsed: Option<bool>,
 }
 
 /// Session-related configuration defaults

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -8,6 +8,20 @@ use std::collections::HashMap;
 use super::config::SortOrder;
 use super::Instance;
 
+/// Sentinel path used by the synthetic "Archived" sidebar section. Not a
+/// real GroupTree entry; lives only in the flattened `Item` list to give
+/// archived sessions a stable bottom-of-sidebar home across every sort
+/// mode. Code that walks `flat_items` and dispatches on `Item::Group.path`
+/// must skip this path before invoking GroupTree-mutating ops (rename,
+/// delete, archive, etc.) since no matching group exists.
+pub const ARCHIVED_SECTION_PATH: &str = "__aoe_archived_section__";
+pub const ARCHIVED_SECTION_NAME: &str = "Archived";
+
+#[inline]
+pub fn is_archived_section_path(path: &str) -> bool {
+    path == ARCHIVED_SECTION_PATH
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Group {
     pub name: String,
@@ -388,7 +402,7 @@ fn max_created_at_in_group(path: &str, instances: &[Instance]) -> DateTime<Utc> 
     let prefix = format!("{}/", path);
     instances
         .iter()
-        .filter(|i| i.group_path == path || i.group_path.starts_with(&prefix))
+        .filter(|i| (i.group_path == path || i.group_path.starts_with(&prefix)) && !i.is_archived())
         .map(|i| i.created_at)
         .max()
         .unwrap_or(DateTime::<Utc>::MIN_UTC)
@@ -400,7 +414,7 @@ fn min_created_at_in_group(path: &str, instances: &[Instance]) -> DateTime<Utc> 
     let prefix = format!("{}/", path);
     instances
         .iter()
-        .filter(|i| i.group_path == path || i.group_path.starts_with(&prefix))
+        .filter(|i| (i.group_path == path || i.group_path.starts_with(&prefix)) && !i.is_archived())
         .map(|i| i.created_at)
         .min()
         .unwrap_or(DateTime::<Utc>::MAX_UTC)
@@ -413,7 +427,7 @@ fn max_last_accessed_in_group(path: &str, instances: &[Instance]) -> Option<Date
     let prefix = format!("{}/", path);
     instances
         .iter()
-        .filter(|i| i.group_path == path || i.group_path.starts_with(&prefix))
+        .filter(|i| (i.group_path == path || i.group_path.starts_with(&prefix)) && !i.is_archived())
         .filter_map(|i| i.last_accessed_at)
         .max()
 }
@@ -649,10 +663,12 @@ pub fn flatten_tree_all_profiles(
 ) -> Vec<Item> {
     let mut items = Vec::new();
 
-    // Collect all ungrouped sessions across all profiles
+    // Archived sessions are excluded from the natural flow. The caller
+    // appends them under the synthetic "Archived" section via
+    // `append_archived_section`.
     let mut ungrouped: Vec<&Instance> = instances
         .iter()
-        .filter(|i| i.group_path.is_empty())
+        .filter(|i| i.group_path.is_empty() && !i.is_archived())
         .collect();
 
     sort_sessions(&mut ungrouped, sort_order);
@@ -720,7 +736,12 @@ pub fn flatten_tree_all_profiles(
 /// `instances` by profile/storage at the call site; this function honors
 /// whatever slice it receives.
 pub fn flatten_sessions_by_attention(instances: &[Instance]) -> Vec<Item> {
-    let mut refs: Vec<&Instance> = instances.iter().collect();
+    // Archived rows are excluded from the natural attention flow; the
+    // caller appends them under the synthetic "Archived" section via
+    // `append_archived_section`. Snoozed and pane-dead rows still sink to
+    // tier 99 inline because they are transient attention sinks, not
+    // lifecycle terminals.
+    let mut refs: Vec<&Instance> = instances.iter().filter(|i| !i.is_archived()).collect();
     refs.sort_by_key(|i| attention_session_key(i));
     refs.into_iter()
         .map(|inst| Item::Session {
@@ -737,10 +758,12 @@ pub fn flatten_tree(
 ) -> Vec<Item> {
     let mut items = Vec::new();
 
-    // Add ungrouped sessions first (always at top, sorted if needed)
+    // Archived sessions are excluded from the natural flow. The caller
+    // appends them under the synthetic "Archived" section via
+    // `append_archived_section`.
     let mut ungrouped: Vec<&Instance> = instances
         .iter()
-        .filter(|i| i.group_path.is_empty())
+        .filter(|i| i.group_path.is_empty() && !i.is_archived())
         .collect();
 
     sort_sessions(&mut ungrouped, sort_order);
@@ -795,10 +818,12 @@ fn flatten_group(
         return;
     }
 
-    // Add sessions in this group (direct children only), sorted if needed
+    // Archived sessions are pulled out of the natural flow regardless of
+    // their group_path. They reappear under the synthetic "Archived"
+    // section appended by the caller.
     let mut group_sessions: Vec<&Instance> = instances
         .iter()
-        .filter(|i| i.group_path == group.path)
+        .filter(|i| i.group_path == group.path && !i.is_archived())
         .collect();
 
     sort_sessions(&mut group_sessions, sort_order);
@@ -830,8 +855,46 @@ fn count_sessions_in_group(path: &str, instances: &[Instance]) -> usize {
     let prefix = format!("{}/", path);
     instances
         .iter()
-        .filter(|i| i.group_path == path || i.group_path.starts_with(&prefix))
+        .filter(|i| (i.group_path == path || i.group_path.starts_with(&prefix)) && !i.is_archived())
         .count()
+}
+
+/// Append the synthetic "Archived" section to `items`, pinned to the
+/// bottom of the sidebar across every sort mode. The section contains
+/// every session with `is_archived() == true`, ordered by most-recently
+/// archived first (the row a user just shelved is the one they're most
+/// likely to look for). When `collapsed` is true, only the header is
+/// pushed; the header still shows the total count.
+///
+/// No-op when there are no archived sessions, so users who never archive
+/// anything don't see a phantom "Archived (0)" header.
+pub fn append_archived_section(items: &mut Vec<Item>, instances: &[Instance], collapsed: bool) {
+    let mut archived: Vec<&Instance> = instances.iter().filter(|i| i.is_archived()).collect();
+    if archived.is_empty() {
+        return;
+    }
+    archived.sort_by_key(|i| Reverse(i.archived_at));
+
+    items.push(Item::Group {
+        path: ARCHIVED_SECTION_PATH.to_string(),
+        name: ARCHIVED_SECTION_NAME.to_string(),
+        depth: 0,
+        collapsed,
+        session_count: archived.len(),
+        profile: None,
+        archived_at: None,
+    });
+
+    if collapsed {
+        return;
+    }
+
+    for inst in archived {
+        items.push(Item::Session {
+            id: inst.id.clone(),
+            depth: 1,
+        });
+    }
 }
 
 #[cfg(test)]

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,7 +29,9 @@ pub use config::{
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};
 pub use groups::{
-    flatten_sessions_by_attention, flatten_tree, flatten_tree_all_profiles, Group, GroupTree, Item,
+    append_archived_section, flatten_sessions_by_attention, flatten_tree,
+    flatten_tree_all_profiles, is_archived_section_path, Group, GroupTree, Item,
+    ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH,
 };
 pub(crate) use instance::persist_session_to_storage;
 pub use instance::{

--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -60,12 +60,12 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                 ],
             ),
             (
-                "Attention",
+                "Attention (Attention sort only, except Archive)",
                 vec![
                     ("w", "Jump to next waiting/idle"),
-                    ("F", "Toggle favorite"),
-                    ("H", "Snooze (toggle)"),
-                    ("Z", "Archive (toggle)"),
+                    ("F", "Toggle favorite (Attention sort)"),
+                    ("H", "Snooze (toggle, Attention sort)"),
+                    ("Z", "Archive (toggle, any sort)"),
                 ],
             ),
             (
@@ -128,12 +128,12 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
                 ],
             ),
             (
-                "Attention",
+                "Attention (Attention sort only, except Archive)",
                 vec![
                     ("w", "Jump to next waiting/idle"),
-                    ("f", "Toggle favorite"),
-                    ("h", "Snooze (toggle)"),
-                    ("z", "Archive (toggle)"),
+                    ("f", "Toggle favorite (Attention sort)"),
+                    ("h", "Snooze (toggle, Attention sort)"),
+                    ("z", "Archive (toggle, any sort)"),
                 ],
             ),
             (
@@ -453,7 +453,7 @@ mod tests {
             let all = shortcuts(strict);
             let attention = all
                 .iter()
-                .find(|(name, _)| *name == "Attention")
+                .find(|(name, _)| name.starts_with("Attention"))
                 .expect("Attention section should exist");
             let (_, keys) = attention;
             assert!(
@@ -473,7 +473,7 @@ mod tests {
             let all = shortcuts(strict);
             let attention = all
                 .iter()
-                .find(|(name, _)| *name == "Attention")
+                .find(|(name, _)| name.starts_with("Attention"))
                 .expect("Attention section should exist");
             let (_, keys) = attention;
             for needle in ["favorite", "Snooze", "Archive", "waiting"] {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1247,56 +1247,53 @@ impl HomeView {
                 self.view_mode = ViewMode::Agent;
             }
             KeyCode::Char('q') => return Some(Action::Quit),
-            // `w` / `W`: toggle snooze on the cursor's session. Snooze is
-            // "temporary archive": the row sinks to tier 99 for `config.
-            // session.snooze_duration_minutes` (default 30), renders
-            // italic+dim with a `z ` prefix and remaining-time in the age
-            // column, then rejoins the active Attention sort when the
-            // timer elapses (lazy; `is_snoozed()` just compares against
-            // now). Pressing w/W on a snoozed row wakes it immediately.
-            // Mnemonic: Wait. Separate namespace from archive (`z`/`Z`)
-            // and favorite (`f`/`F`). Session-only for v1.
-            KeyCode::Char('w') if !self.strict_hotkeys => {
+            // `w` / `W` (snooze), `h` / `H` (snooze alias), and `f` / `F`
+            // (favorite) are gated to Attention sort. Snooze and favorite
+            // are triage primitives — they only have a visible effect
+            // (and a sort impact) in Attention mode. Outside Attention,
+            // mutating these flags would silently change persisted state
+            // with no on-screen feedback, so we ignore the press
+            // entirely. Other sort modes fall through to the existing
+            // fallback bindings (`h` → collapse, `w` → jump-to-next-
+            // waiting in non-strict mode).
+            KeyCode::Char('w')
+                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_snooze_at_cursor() {
                     tracing::error!("toggle_snooze_at_cursor failed: {}", e);
                 }
             }
-            KeyCode::Char('W') if self.strict_hotkeys => {
+            KeyCode::Char('W')
+                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_snooze_at_cursor() {
                     tracing::error!("toggle_snooze_at_cursor failed: {}", e);
                 }
             }
-            // `h` / `H`: alias for `w` / `W` (snooze). Mnemonic: Hide,
-            // borrowed from email-app conventions where H snoozes the
-            // focused message off the list for a while. Plain `h` was
-            // previously a vim-style left/collapse alias, but ← already
-            // covers that, and users with email-app muscle memory keep
-            // reaching for H expecting snooze. `w`/`W` stays functional
-            // for backward compat; `h`/`H` is the advertised binding.
-            KeyCode::Char('h') if !self.strict_hotkeys => {
+            KeyCode::Char('h')
+                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_snooze_at_cursor() {
                     tracing::error!("toggle_snooze_at_cursor failed: {}", e);
                 }
             }
-            KeyCode::Char('H') if self.strict_hotkeys => {
+            KeyCode::Char('H')
+                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_snooze_at_cursor() {
                     tracing::error!("toggle_snooze_at_cursor failed: {}", e);
                 }
             }
-            // `f` / `F`: toggle favorite on the cursor's session. Within
-            // the Attention sort, favorited rows pin above non-favorited
-            // peers in the same status tier; a favorited Running stays in
-            // the Running bucket but bubbles above plain Running rows.
-            // Render layer (`render.rs`) adds bold + underline and a
-            // leading `* ` glyph. Favorite survives an unsnooze (positive
-            // care-more signal) but archive clears it (mutex in
-            // `Instance::archive()`).
-            KeyCode::Char('f') if !self.strict_hotkeys => {
+            KeyCode::Char('f')
+                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_favorite_at_cursor() {
                     tracing::error!("toggle_favorite_at_cursor failed: {}", e);
                 }
             }
-            KeyCode::Char('F') if self.strict_hotkeys => {
+            KeyCode::Char('F')
+                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
+            {
                 if let Err(e) = self.toggle_favorite_at_cursor() {
                     tracing::error!("toggle_favorite_at_cursor failed: {}", e);
                 }
@@ -2592,8 +2589,20 @@ impl HomeView {
                 }
                 Item::Group { path, .. } => {
                     self.selected_session = None;
-                    self.selected_group = Some(path.clone());
-                    self.selected_group_profile = self.profile_for_cursor(self.cursor);
+                    if crate::session::is_archived_section_path(path) {
+                        // The synthetic Archived section is not a real
+                        // group: it can't be renamed, deleted, archived,
+                        // or moved. Leaving `selected_group` unset
+                        // disarms every keybind that branches on
+                        // `selected_group.is_some()` (rename, delete,
+                        // archive group, etc.) without each one having
+                        // to special-case the sentinel.
+                        self.selected_group = None;
+                        self.selected_group_profile = None;
+                    } else {
+                        self.selected_group = Some(path.clone());
+                        self.selected_group_profile = self.profile_for_cursor(self.cursor);
+                    }
                 }
             }
             if self.selected_session != prev_session {
@@ -2660,6 +2669,14 @@ impl HomeView {
     }
 
     fn toggle_group_collapsed(&mut self, path: &str) {
+        // The synthetic Archived section is not a member of any
+        // GroupTree; its collapsed state lives on HomeView and persists
+        // separately. Route here before either branch tries to mutate a
+        // nonexistent group.
+        if crate::session::is_archived_section_path(path) {
+            self.toggle_archived_section();
+            return;
+        }
         if self.group_by == GroupByMode::Project {
             let collapsed = self
                 .project_group_collapsed

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1249,12 +1249,12 @@ impl HomeView {
             KeyCode::Char('q') => return Some(Action::Quit),
             // `w` / `W` (snooze), `h` / `H` (snooze alias), and `f` / `F`
             // (favorite) are gated to Attention sort. Snooze and favorite
-            // are triage primitives — they only have a visible effect
+            // are triage primitives; they only have a visible effect
             // (and a sort impact) in Attention mode. Outside Attention,
             // mutating these flags would silently change persisted state
             // with no on-screen feedback, so we ignore the press
             // entirely. Other sort modes fall through to the existing
-            // fallback bindings (`h` → collapse, `w` → jump-to-next-
+            // fallback bindings (`h` collapses; `w` is jump-to-next-
             // waiting in non-strict mode).
             KeyCode::Char('w')
                 if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
@@ -2327,6 +2327,14 @@ impl HomeView {
                     });
                 }
                 Item::Group { name, path, .. } => {
+                    // The synthetic Archived section header is not a real
+                    // group; skip it so the palette doesn't surface the
+                    // sentinel path or invite Jump-to-group navigation
+                    // that the rest of the codebase intentionally
+                    // disarms.
+                    if crate::session::is_archived_section_path(path) {
+                        continue;
+                    }
                     let label = if name == path {
                         format!("Jump to group: {}", name)
                     } else {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2168,6 +2168,17 @@ impl HomeView {
             }
         }
         self.flat_items = self.build_flat_items();
+        // Defensive cursor clamp + selection refresh. Today the only
+        // call site routes through `toggle_group_collapsed` after the
+        // cursor lands on the section header, and the header survives
+        // the rebuild at the same end-of-list index, so the cursor stays
+        // valid. Programmatic callers (palette command, future macros)
+        // wouldn't have that invariant, so clamp here rather than rely
+        // on every caller to know about it.
+        if !self.flat_items.is_empty() && self.cursor >= self.flat_items.len() {
+            self.cursor = self.flat_items.len() - 1;
+        }
+        self.update_selected();
     }
 
     pub fn show_welcome(&mut self) {

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -19,6 +19,7 @@ use ratatui::prelude::Rect;
 use tui_input::Input;
 
 use crate::session::{
+    append_archived_section,
     config::{load_config, save_config, GroupByMode, SortOrder},
     flatten_sessions_by_attention, flatten_tree, flatten_tree_all_profiles, resolve_config_or_warn,
     DefaultTerminalMode, EnsureReadyOutcome, Group, GroupTree, Instance, Item, Storage,
@@ -557,6 +558,12 @@ pub struct HomeView {
     /// `app_state.show_preview_info`.
     pub(super) show_preview_info: bool,
 
+    /// Collapsed state of the synthetic "Archived" sidebar section.
+    /// Defaults to `true` (collapsed) so archived rows stay tucked at the
+    /// bottom until the user opts to see them. Persisted to
+    /// `app_state.archived_section_collapsed`.
+    pub(super) archived_section_collapsed: bool,
+
     /// Channel that startup-recovery workers send results back on. `None`
     /// when no recovery was attempted at construction (live tmux, daemon
     /// owns recovery, lock contended, or no candidates). Drained on every
@@ -779,6 +786,10 @@ impl HomeView {
             show_preview_info: user_config
                 .as_ref()
                 .and_then(|c| c.app_state.show_preview_info)
+                .unwrap_or(true),
+            archived_section_collapsed: user_config
+                .as_ref()
+                .and_then(|c| c.app_state.archived_section_collapsed)
                 .unwrap_or(true),
             recovery_rx: None,
             recovery_lock: None,
@@ -2148,6 +2159,17 @@ impl HomeView {
         }
     }
 
+    pub fn toggle_archived_section(&mut self) {
+        self.archived_section_collapsed = !self.archived_section_collapsed;
+        if let Ok(mut config) = load_config().map(|c| c.unwrap_or_default()) {
+            config.app_state.archived_section_collapsed = Some(self.archived_section_collapsed);
+            if let Err(e) = save_config(&config) {
+                tracing::warn!(target: "tui.home", "Failed to save config: {e}");
+            }
+        }
+        self.flat_items = self.build_flat_items();
+    }
+
     pub fn show_welcome(&mut self) {
         tracing::info!(target: "tui.dialog", dialog = "welcome", "opening");
         self.welcome_dialog = Some(WelcomeDialog::new());
@@ -2221,28 +2243,40 @@ impl HomeView {
             } else {
                 self.instances.clone()
             };
-            return flatten_sessions_by_attention(&filtered);
+            let mut items = flatten_sessions_by_attention(&filtered);
+            append_archived_section(&mut items, &filtered, self.archived_section_collapsed);
+            return items;
         }
 
-        if let Some(profile) = &self.active_profile {
+        let (mut items, archive_pool) = if let Some(profile) = &self.active_profile {
             let filtered: Vec<Instance> = self
                 .instances
                 .iter()
                 .filter(|i| i.source_profile == *profile)
                 .cloned()
                 .collect();
-            match self.group_trees.get(profile) {
+            let items = match self.group_trees.get(profile) {
                 Some(tree) => flatten_tree(tree, &filtered, self.sort_order),
                 None => Vec::new(),
-            }
+            };
+            (items, filtered)
         } else if self.storages.len() <= 1 {
-            match self.group_trees.values().next() {
+            let items = match self.group_trees.values().next() {
                 Some(tree) => flatten_tree(tree, &self.instances, self.sort_order),
                 None => Vec::new(),
-            }
+            };
+            (items, self.instances.clone())
         } else {
-            flatten_tree_all_profiles(&self.instances, &self.group_trees, self.sort_order)
-        }
+            let items =
+                flatten_tree_all_profiles(&self.instances, &self.group_trees, self.sort_order);
+            (items, self.instances.clone())
+        };
+
+        // Pin the synthetic Archived section to the bottom regardless of
+        // sort order. Archived rows were filtered out of the natural flow
+        // inside `flatten_tree` / `flatten_tree_all_profiles`.
+        append_archived_section(&mut items, &archive_pool, self.archived_section_collapsed);
+        items
     }
 
     fn build_flat_items_by_project(&self) -> Vec<Item> {
@@ -2272,7 +2306,9 @@ impl HomeView {
                 tree.set_collapsed(path, true);
             }
         }
-        flatten_tree(&tree, &grouped, self.sort_order)
+        let mut items = flatten_tree(&tree, &grouped, self.sort_order);
+        append_archived_section(&mut items, &grouped, self.archived_section_collapsed);
+        items
     }
 
     /// The active profile filter name, or `None` when no filter is applied.

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -164,12 +164,6 @@ impl HomeView {
         if skip {
             return Ok(());
         }
-        // Outside Attention sort, restart on a snoozed row clears the
-        // snooze flag so the persisted state matches what the user sees
-        // after the wake-up (a Running row, no snooze badge).
-        if wake_snooze {
-            self.mutate_instance(&id, |inst| inst.unsnooze());
-        }
 
         // Spam-debounce. Holding `e` or pressing it twice fast otherwise
         // races overlapping restart_with_size calls.
@@ -180,6 +174,15 @@ impl HomeView {
             }
         }
         self.restart_cooldown_at.insert(id.clone(), now);
+
+        // Outside Attention sort, restart on a snoozed row clears the
+        // snooze flag so the persisted state matches what the user sees
+        // after the wake-up (a Running row, no snooze badge). Sequenced
+        // after the debounce so a press dropped by the cooldown doesn't
+        // clear snooze without restarting.
+        if wake_snooze {
+            self.mutate_instance(&id, |inst| inst.unsnooze());
+        }
 
         // Apply tool swap before restart so the new binary starts on the
         // next launch.

--- a/src/tui/home/operations.rs
+++ b/src/tui/home/operations.rs
@@ -101,9 +101,14 @@ impl HomeView {
     /// Guards (apply to bare `e` / `E` / `F5` and dialog-submitted restarts):
     /// - No selection: no-op.
     /// - Transient lifecycle (`Creating` / `Deleting`): drop.
-    /// - Sunk rows (`is_archived`, `is_snoozed`, `pane_dead_observed`):
-    ///   drop. Archive's contract is "do not auto-revive"; the user must
-    ///   unarchive or send first. Dead panes have a dedicated revive path.
+    /// - Sunk rows: archived and pane-dead always drop (archive's contract
+    ///   is "do not auto-revive"; dead panes have a dedicated revive path).
+    ///   Snoozed rows drop only when `sort_order == Attention`; in other
+    ///   sort modes the snooze surface is hidden, so silently swallowing
+    ///   the press would leave the user staring at a row that looks
+    ///   restartable but isn't. Outside Attention we clear the snooze flag
+    ///   and let the restart proceed so behavior matches what the user
+    ///   sees on screen.
     /// - Spam-debounce: if the same session was restarted within the last
     ///   1.5s, the press is dropped. Without this guard rapid `e` presses
     ///   would each spawn a wake-up worker AND tear down the still-booting
@@ -141,19 +146,29 @@ impl HomeView {
 
         // Skip transient + sunk rows. Pull the snapshot details we need on
         // the worker thread in the same borrow so we don't re-look up the
-        // instance under different conditions later.
-        let (skip, title, tool) = match self.get_instance(&id) {
+        // instance under different conditions later. Snoozed rows only
+        // skip when the user is in Attention sort; see method doc.
+        let in_attention = self.sort_order == crate::session::config::SortOrder::Attention;
+        let (skip, wake_snooze, title, tool) = match self.get_instance(&id) {
             Some(inst) => {
+                let snoozed = inst.is_snoozed();
                 let skip = matches!(inst.status, Status::Creating | Status::Deleting)
                     || inst.is_archived()
-                    || inst.is_snoozed()
+                    || (snoozed && in_attention)
                     || inst.pane_dead_observed;
-                (skip, inst.title.clone(), inst.tool.clone())
+                let wake_snooze = snoozed && !in_attention;
+                (skip, wake_snooze, inst.title.clone(), inst.tool.clone())
             }
             None => return Ok(()),
         };
         if skip {
             return Ok(());
+        }
+        // Outside Attention sort, restart on a snoozed row clears the
+        // snooze flag so the persisted state matches what the user sees
+        // after the wake-up (a Running row, no snooze badge).
+        if wake_snooze {
+            self.mutate_instance(&id, |inst| inst.unsnooze());
         }
 
         // Spam-debounce. Holding `e` or pressing it twice fast otherwise

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -820,10 +820,20 @@ impl HomeView {
     ) -> Line<'static> {
         let indent = get_indent(item.depth());
 
+        // Attention-mode-gated visuals. Favorite, snooze (decoration), and
+        // urgent only render when the user is in Attention sort, so the
+        // sidebar stays clean for users who don't run a high-volume
+        // triage workflow. Archive stays universal because it's a
+        // lifecycle action (the pane is killed), and its rows live in
+        // the dedicated bottom-pinned "Archived" section regardless of
+        // sort mode.
+        let in_attention = self.sort_order == SortOrder::Attention;
+
         use std::borrow::Cow;
 
         let (icon, text, style): (&str, Cow<str>, Style) = match item {
             Item::Group {
+                path,
                 name,
                 collapsed,
                 session_count,
@@ -837,9 +847,17 @@ impl HomeView {
                 };
                 let text = Cow::Owned(format!("{} ({})", name, session_count));
                 let mut style = Style::default().fg(theme.group).bold();
-                if archived_at.is_some() {
-                    // Archived groups: italic + dim, still visible at the
-                    // bottom of the Attention sort.
+                if crate::session::is_archived_section_path(path) {
+                    // Synthetic Archived section header: muted + italic
+                    // so it reads as a divider rather than a user-
+                    // created group. The contained rows aren't decorated
+                    // individually; the section header is the sole
+                    // visual signal that those sessions are shelved.
+                    style = Style::default()
+                        .fg(theme.dimmed)
+                        .add_modifier(ratatui::style::Modifier::ITALIC);
+                } else if archived_at.is_some() {
+                    // Archived user groups: italic + dim, still visible.
                     style = style
                         .add_modifier(ratatui::style::Modifier::ITALIC)
                         .add_modifier(ratatui::style::Modifier::DIM);
@@ -894,65 +912,58 @@ impl HomeView {
                                 Status::Creating => theme.accent,
                             };
                             let mut style = Style::default().fg(color);
-                            if inst.is_archived() || inst.is_snoozed() {
-                                // Archived AND snoozed rows render with one
-                                // uniform muted glyph regardless of underlying
-                                // status. Without this override an archived
-                                // session whose sidecar still says `running`
-                                // would keep animating its spinner (just
-                                // dimmed), visually identical to an active
-                                // session and a recurring source of "why is
-                                // this archived row spinning" confusion. The
-                                // semantic state still lives in the persisted
-                                // `inst.status`; we just stop painting it
-                                // here because archive/snooze are by
-                                // definition "not actively asking for
-                                // attention." Delegates to `agent_row_icon`
-                                // so the override is in one place and the
-                                // unit test covers what render shows.
+                            if inst.is_archived() {
+                                // Archived rows render with one uniform
+                                // muted glyph regardless of underlying
+                                // status. The pane is dead, so painting
+                                // the persisted Running/Waiting status
+                                // would be misleading. The Archived
+                                // section header is the sole textual
+                                // cue, so no italic/dim modifier is
+                                // applied here; just a dim color.
+                                icon = agent_row_icon(inst);
+                                style = Style::default().fg(theme.dimmed);
+                            } else if in_attention && inst.is_snoozed() {
+                                // Snooze decoration is Attention-only.
+                                // Outside Attention the row paints its
+                                // real status (the timer keeps running;
+                                // the visual treatment just doesn't
+                                // surface).
                                 icon = agent_row_icon(inst);
                                 style = Style::default()
                                     .fg(theme.dimmed)
                                     .add_modifier(ratatui::style::Modifier::ITALIC)
                                     .add_modifier(ratatui::style::Modifier::DIM);
-                            } else if inst.is_urgent() {
-                                // Agent flagged this row urgent via the
-                                // `attention-urgent` script. Override fg with
-                                // the error color (red) and add BOLD +
-                                // RAPID_BLINK so the row screams across the
-                                // pane. Urgent wins over favorite styling
-                                // since urgent is a cross-tier promoter and
-                                // the visual must match: a row that sorts to
-                                // top must look the part. Archive/snooze
-                                // still wins over urgent because is_urgent()
-                                // returns false for sunk rows.
+                            } else if in_attention && inst.is_urgent() {
+                                // Urgent decoration is Attention-only.
+                                // The flag still persists in non-
+                                // Attention modes, but the cross-tier
+                                // promoter visual only makes sense when
+                                // tier ordering is in effect.
                                 style = Style::default()
                                     .fg(theme.error)
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if inst.is_favorited() {
-                                // Favorited, non-archived: bold + underlined
-                                // + "* " prefix. ASCII-only glyph (previously
-                                // ⭐ but emoji wide-width accounting mis-
-                                // aligned row truncation on iOS Blink /
-                                // Termius, causing stray combining-sequence
-                                // chars to bleed into the title). Archive
-                                // wins over favorite if both are set.
+                            } else if in_attention && inst.is_favorited() {
+                                // Favorite decoration is Attention-only,
+                                // since favorites are within-tier pins.
                                 style = style
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::UNDERLINED);
                             }
-                            // Prefix priority: archive (no prefix) wins over
-                            // snooze (`z `) wins over urgent (`! `) wins over
-                            // favorite (`* `). Matches the sort-tier priority:
-                            // archive > snooze > urgent > favorite.
+                            // Prefix priority: archive (no prefix) wins
+                            // over snooze (`z `) wins over urgent (`! `)
+                            // wins over favorite (`* `). All three
+                            // prefixes are Attention-mode-only so users
+                            // in Newest / AZ / etc. don't see decoration
+                            // for state they didn't opt into managing.
                             let title_text = if inst.is_archived() {
                                 Cow::Owned(inst.title.clone())
-                            } else if inst.is_snoozed() {
+                            } else if in_attention && inst.is_snoozed() {
                                 Cow::Owned(format!("z {}", inst.title))
-                            } else if inst.is_urgent() {
+                            } else if in_attention && inst.is_urgent() {
                                 Cow::Owned(format!("! {}", inst.title))
-                            } else if inst.is_favorited() {
+                            } else if in_attention && inst.is_favorited() {
                                 Cow::Owned(format!("* {}", inst.title))
                             } else {
                                 Cow::Owned(inst.title.clone())
@@ -982,46 +993,36 @@ impl HomeView {
                                 (ICON_IDLE, theme.dimmed)
                             };
                             let mut style = Style::default().fg(color);
-                            if inst.is_archived() || inst.is_snoozed() {
-                                // Mirrors the Agent-view path: archived AND
-                                // snoozed rows render with one uniform muted
-                                // glyph regardless of underlying state. Kills
-                                // the running-spinner-on-archived-row visual
-                                // bug where a stale terminal session would
-                                // animate even after the user parked the row.
+                            if inst.is_archived() {
+                                // Archive lifecycle override mirrors the
+                                // Agent-view path: dim color, stopped
+                                // icon, no italic/dim modifier; the
+                                // Archived section header is the cue.
+                                icon = ICON_STOPPED;
+                                style = Style::default().fg(theme.dimmed);
+                            } else if in_attention && inst.is_snoozed() {
                                 icon = ICON_STOPPED;
                                 style = Style::default()
                                     .fg(theme.dimmed)
                                     .add_modifier(ratatui::style::Modifier::ITALIC)
                                     .add_modifier(ratatui::style::Modifier::DIM);
-                            } else if inst.is_urgent() {
-                                // Mirrors the Agent-view path: agent flagged
-                                // urgent gets red + BOLD + RAPID_BLINK across
-                                // both view modes so the visual is consistent
-                                // when the user toggles agent/terminal view.
+                            } else if in_attention && inst.is_urgent() {
                                 style = Style::default()
                                     .fg(theme.error)
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::RAPID_BLINK);
-                            } else if inst.is_favorited() {
-                                // Favorited, non-archived: bold + underlined
-                                // + "* " prefix. ASCII-only glyph (previously
-                                // ⭐ but emoji wide-width accounting mis-
-                                // aligned row truncation on iOS Blink /
-                                // Termius, causing stray combining-sequence
-                                // chars to bleed into the title). Archive
-                                // wins over favorite if both are set.
+                            } else if in_attention && inst.is_favorited() {
                                 style = style
                                     .add_modifier(ratatui::style::Modifier::BOLD)
                                     .add_modifier(ratatui::style::Modifier::UNDERLINED);
                             }
                             let title_text = if inst.is_archived() {
                                 Cow::Owned(inst.title.clone())
-                            } else if inst.is_snoozed() {
+                            } else if in_attention && inst.is_snoozed() {
                                 Cow::Owned(format!("z {}", inst.title))
-                            } else if inst.is_urgent() {
+                            } else if in_attention && inst.is_urgent() {
                                 Cow::Owned(format!("! {}", inst.title))
-                            } else if inst.is_favorited() {
+                            } else if in_attention && inst.is_favorited() {
                                 Cow::Owned(format!("* {}", inst.title))
                             } else {
                                 Cow::Owned(inst.title.clone())
@@ -1166,12 +1167,21 @@ impl HomeView {
                     if pad_len > 0 {
                         line_spans.push(Span::raw(" ".repeat(pad_len)));
                     }
-                    // Snoozed rows show remaining sleep time ("23m" / "1h").
+                    // In Attention mode, snoozed rows show remaining sleep
+                    // time ("23m" / "1h"). Outside Attention mode, snooze
+                    // is invisible (the timer still ticks; we just don't
+                    // surface it) so the column falls through to the
+                    // normal age path.
                     // Idle rows show time-since-stop (`idle_entered_at`)
                     // since `last_accessed_at` would lie after attach/send.
                     // Fall back to `last_accessed_at` when `idle_entered_at`
                     // is missing.
-                    let age = if let Some(remaining) = inst.snooze_remaining() {
+                    let snooze_remaining = if in_attention {
+                        inst.snooze_remaining()
+                    } else {
+                        None
+                    };
+                    let age = if let Some(remaining) = snooze_remaining {
                         format_snooze_remaining(remaining)
                     } else {
                         let age_ts = if inst.status == Status::Idle {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -849,13 +849,18 @@ impl HomeView {
                 let mut style = Style::default().fg(theme.group).bold();
                 if crate::session::is_archived_section_path(path) {
                     // Synthetic Archived section header: muted + italic
-                    // so it reads as a divider rather than a user-
-                    // created group. The contained rows aren't decorated
-                    // individually; the section header is the sole
-                    // visual signal that those sessions are shelved.
+                    // + dim so it reads as a divider rather than a
+                    // user-created group. The contained rows aren't
+                    // decorated individually; the section header is the
+                    // sole visual signal that those sessions are
+                    // shelved. Matches the modifier set used for
+                    // archived user groups so terminals with weak
+                    // dimmed-fg rendering still surface the parked
+                    // affordance.
                     style = Style::default()
                         .fg(theme.dimmed)
-                        .add_modifier(ratatui::style::Modifier::ITALIC);
+                        .add_modifier(ratatui::style::Modifier::ITALIC)
+                        .add_modifier(ratatui::style::Modifier::DIM);
                 } else if archived_at.is_some() {
                     // Archived user groups: italic + dim, still visible.
                     style = style

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1850,29 +1850,59 @@ fn test_strict_mode_h_collapses_group() {
 
 #[test]
 #[serial]
-fn test_strict_mode_h_still_snoozes_in_non_strict() {
-    // Companion guard for the strict-mode `h` collapse fix: making `h` an
-    // unconditional navigation key would steal the lowercase Snooze binding
-    // in default (non-strict) mode. The earlier `Char('h') if !strict` arm
-    // catches first, so the collapse arm only fires in strict mode.
+fn test_non_strict_h_snoozes_only_in_attention_sort() {
+    // Snooze is Attention-mode-only: in Attention sort `h` toggles snooze on
+    // the cursor's session and the group below the cursor stays expanded;
+    // in every other sort mode the snooze arm declines, control falls
+    // through to the unconditional `Left | Char('h')` collapse handler,
+    // and the group collapses. Before the gating, snooze always caught
+    // first in non-strict mode regardless of sort, which silently mutated
+    // persisted state for users who weren't using Attention sort.
+    use crate::session::config::SortOrder;
+
     let mut env = create_test_env_with_groups();
     env.view.strict_hotkeys = false;
 
+    // Attention sort flattens groups out, so seed a cursor-on-session
+    // scenario and assert that `h` opens the snooze duration dialog
+    // (the actual snooze fires when the user picks a duration).
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+    let session_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|item| matches!(item, Item::Session { .. }))
+        .expect("setup should produce a session in Attention sort");
+    env.view.cursor = session_idx;
+    env.view.update_selected();
+    env.view.handle_key(key(KeyCode::Char('h')), None);
+    assert!(
+        env.view.snooze_duration_dialog.is_some(),
+        "`h` in Attention sort must open the snooze duration dialog"
+    );
+    // Tear the dialog back down before exercising the Newest case so the
+    // next handle_key doesn't get swallowed by dialog input.
+    env.view.snooze_duration_dialog = None;
+    env.view.pending_snooze_session = None;
+
+    // Now flip back to a non-Attention sort and confirm `h` falls
+    // through to the collapse handler instead of snoozing.
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
     let group_idx = env
         .view
         .flat_items
         .iter()
         .position(|item| matches!(item, Item::Group { .. }))
-        .expect("setup should produce a group");
+        .expect("setup should produce a group in Newest sort");
     env.view.cursor = group_idx;
     env.view.update_selected();
-
     env.view.handle_key(key(KeyCode::Char('h')), None);
-
     if let Item::Group { collapsed, .. } = &env.view.flat_items[group_idx] {
         assert!(
-            !collapsed,
-            "non-strict 'h' must remain bound to snooze, not collapse"
+            *collapsed,
+            "non-strict 'h' outside Attention sort must collapse the group, not snooze"
         );
     }
 }
@@ -4582,6 +4612,175 @@ fn manual_grouping_attention_sort_stays_flat() {
         group_count, 0,
         "Manual + Attention should produce a flat list, no group headers"
     );
+}
+
+/// Favorite, snooze, and urgent decorations only render in Attention sort.
+/// In Newest (or any other sort), the row paints with its plain title and
+/// status-driven color even when the flags are set, so users who don't
+/// triage in Attention don't see decoration for state they didn't opt into
+/// managing.
+#[test]
+#[serial]
+fn favorite_decoration_gated_to_attention_sort() {
+    use crate::session::config::SortOrder;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    let title = env.view.instances[0].title.clone();
+    env.view.mutate_instance(&id, |inst| inst.favorite());
+
+    // In Newest: row should NOT have the `* ` prefix or the bold/
+    // underlined favorite styling.
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+    let item = env
+        .view
+        .flat_items
+        .iter()
+        .find(|i| matches!(i, Item::Session { id: sid, .. } if *sid == id))
+        .cloned()
+        .expect("session item present in Newest sort");
+    let text_newest = rendered_row_text(&env.view, &item);
+    assert!(
+        !text_newest.contains("* "),
+        "favorite prefix must be hidden outside Attention sort; got: {:?}",
+        text_newest
+    );
+    assert!(
+        text_newest.contains(&title),
+        "row title must still render; got: {:?}",
+        text_newest
+    );
+
+    // Flip to Attention: the prefix returns.
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+    let item_attention = env
+        .view
+        .flat_items
+        .iter()
+        .find(|i| matches!(i, Item::Session { id: sid, .. } if *sid == id))
+        .cloned()
+        .expect("session item present in Attention sort");
+    let text_attention = rendered_row_text(&env.view, &item_attention);
+    assert!(
+        text_attention.contains("* "),
+        "favorite prefix must surface in Attention sort; got: {:?}",
+        text_attention
+    );
+}
+
+/// Snoozed rows: prefix and remaining-time column only appear in Attention
+/// sort. Outside Attention, the snooze flag persists silently and the row
+/// paints with its underlying status.
+#[test]
+#[serial]
+fn snooze_decoration_gated_to_attention_sort() {
+    use crate::session::config::SortOrder;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.mutate_instance(&id, |inst| inst.snooze(30));
+
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+    let item_newest = env
+        .view
+        .flat_items
+        .iter()
+        .find(|i| matches!(i, Item::Session { id: sid, .. } if *sid == id))
+        .cloned()
+        .expect("session item present in Newest sort");
+    let text_newest = rendered_row_text(&env.view, &item_newest);
+    assert!(
+        !text_newest.contains("z "),
+        "snooze prefix must be hidden outside Attention sort; got: {:?}",
+        text_newest
+    );
+
+    env.view.sort_order = SortOrder::Attention;
+    env.view.flat_items = env.view.build_flat_items();
+    let item_attention = env
+        .view
+        .flat_items
+        .iter()
+        .find(|i| matches!(i, Item::Session { id: sid, .. } if *sid == id))
+        .cloned()
+        .expect("session item present in Attention sort");
+    let text_attention = rendered_row_text(&env.view, &item_attention);
+    assert!(
+        text_attention.contains("z "),
+        "snooze prefix must surface in Attention sort; got: {:?}",
+        text_attention
+    );
+}
+
+/// Archived sessions live under the synthetic "Archived" section pinned to
+/// the bottom of the sidebar in every sort mode, not inline at their
+/// natural position. The section header carries the count; when collapsed
+/// the archived rows themselves are hidden but the header still appears.
+#[test]
+#[serial]
+fn archived_section_pinned_to_bottom_in_every_sort() {
+    use crate::session::{config::SortOrder, is_archived_section_path, ARCHIVED_SECTION_NAME};
+
+    let mut env = create_test_env_with_sessions(3);
+    let id = env.view.instances[0].id.clone();
+    env.view.mutate_instance(&id, |inst| inst.archive());
+    env.view.archived_section_collapsed = true;
+
+    for sort in [SortOrder::Newest, SortOrder::Attention, SortOrder::AZ] {
+        env.view.sort_order = sort;
+        env.view.flat_items = env.view.build_flat_items();
+
+        // Archived row must NOT appear inline among the active sessions.
+        let archived_inline = env
+            .view
+            .flat_items
+            .iter()
+            .take_while(|i| {
+                !matches!(
+                    i,
+                    Item::Group { path, .. } if is_archived_section_path(path)
+                )
+            })
+            .any(|i| matches!(i, Item::Session { id: sid, .. } if *sid == id));
+        assert!(
+            !archived_inline,
+            "[{:?}] archived row must not appear before the Archived section",
+            sort
+        );
+
+        // The synthetic section must sit at the bottom of the list.
+        let last = env
+            .view
+            .flat_items
+            .last()
+            .expect("flat_items should be non-empty");
+        match last {
+            Item::Group {
+                path,
+                name,
+                session_count,
+                collapsed,
+                ..
+            } => {
+                assert!(
+                    is_archived_section_path(path),
+                    "[{:?}] last item must be the Archived section header; got path {:?}",
+                    sort,
+                    path
+                );
+                assert_eq!(name, ARCHIVED_SECTION_NAME, "[{:?}] section name", sort);
+                assert_eq!(*session_count, 1, "[{:?}] one archived row", sort);
+                assert!(*collapsed, "[{:?}] section must default collapsed", sort);
+            }
+            other => panic!(
+                "[{:?}] expected Archived section header, got {:?}",
+                sort, other
+            ),
+        }
+    }
 }
 
 mod scroll_pane_isolation {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4268,16 +4268,56 @@ fn restart_selected_session_skips_archived_row() {
 
 #[test]
 #[serial]
-fn restart_selected_session_skips_snoozed_row() {
+fn restart_selected_session_skips_snoozed_row_in_attention_sort() {
+    use crate::session::config::SortOrder;
+
     let mut env = create_test_env_with_sessions(1);
     let id = env.view.instances[0].id.clone();
     env.view.selected_session = Some(id.clone());
+    env.view.sort_order = SortOrder::Attention;
     env.view.mutate_instance(&id, |inst| inst.snooze(30));
 
     let result = env.view.restart_selected_session(None, None);
     assert!(result.is_ok());
-    assert!(env.view.instances[0].is_snoozed());
-    assert!(env.view.restart_cooldown_at.is_empty());
+    assert!(
+        env.view.instances[0].is_snoozed(),
+        "Attention sort: snooze is the user's explicit `don't revive`; restart must not clear it"
+    );
+    assert!(
+        env.view.restart_cooldown_at.is_empty(),
+        "Attention sort: skipped restart should not set the cooldown"
+    );
+}
+
+/// Outside Attention sort, the snooze badge / dim styling / `z ` prefix
+/// are all invisible, so silently swallowing a restart press on a snoozed
+/// row would leave the user staring at an apparently-restartable row that
+/// doesn't restart. Wake the snooze and let the restart proceed instead.
+#[test]
+#[serial]
+fn restart_selected_session_wakes_snooze_outside_attention_sort() {
+    use crate::session::config::SortOrder;
+
+    let mut env = create_test_env_with_sessions(1);
+    let id = env.view.instances[0].id.clone();
+    env.view.selected_session = Some(id.clone());
+    env.view.sort_order = SortOrder::Newest;
+    env.view.mutate_instance(&id, |inst| inst.snooze(30));
+    assert!(env.view.instances[0].is_snoozed(), "pre-condition");
+
+    let result = env.view.restart_selected_session(None, None);
+    assert!(result.is_ok());
+    assert!(
+        !env.view.instances[0].is_snoozed(),
+        "Newest sort: restart on a snoozed row must clear the snooze so persisted state matches what's on screen"
+    );
+    // Restart cooldown gets set because the press wasn't dropped. Bare
+    // `restart_selected_session` schedules the actual restart on a
+    // worker; we only assert the synchronous bookkeeping here.
+    assert!(
+        env.view.restart_cooldown_at.contains_key(&id),
+        "Newest sort: restart that proceeded must record the cooldown"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Description

Middle-ground response to the design conversation on #1498. Instead of
ripping out the Attention workflow @BTForIT built in #1084 / #1085 /
#1086 / #1087 (the original framing of this PR), the workflow stays in
place; its surface is gated to only activate when the sidebar is sorted
by Attention.

### What changes

- **Favorite (`f` / `F`), snooze (`h` / `H`, `w` / `W`), and urgent
  reads** are gated to `sort_order == SortOrder::Attention`. In every
  other sort mode the bindings decline and the underlying fallbacks fire
  (`h` → collapse, `w` → jump-to-next-waiting, capital keys → strict-
  mode typing guard).
- **Visual decoration is gated too**: the `* ` / `z ` / `! ` prefixes,
  bold+underline (favorite), italic+dim (snooze), and RAPID_BLINK
  (urgent) only paint in Attention sort. In Newest / Recent / Oldest /
  AZ / ZA the row paints with its plain title and status-driven color.
- **Archive stays universal** because it's a lifecycle action (the pane
  is killed, status is stale); archived rows paint `ICON_STOPPED` + dim
  in every sort.
- **Synthetic "Archived" sidebar section** pinned to the bottom across
  every sort mode (sentinel group path `__aoe_archived_section__`,
  collapsed by default, persisted in
  `app_state.archived_section_collapsed`). Archived rows are pulled out
  of the natural flow and grouped here, replacing the
  tier-99-for-archived sink in Attention mode and giving every other
  sort a stable shelved-row destination. Snoozed and pane-dead rows
  still sink to tier 99 inline in Attention sort because they're
  transient sinks, not lifecycle terminals.
- **Help overlay** relabels the section to
  "Attention (Attention sort only, except Archive)" and tags each
  binding with the sort mode where it works.

### Why this shape instead of removal

@BTForIT's writeup on #1498 made the case for keeping the workflow at
high session counts: a 36-session fleet across 7 profiles is the regime
where flat newest-first becomes scroll-and-hunt and the tier model
becomes load-bearing. Ripping the workflow would push the maintenance
into a downstream fork. Gating moves the cost from "implicit on every
render PR" to "explicit Attention-mode test surface," which is a much
better trade.

For users (most of us) who don't run a fleet that size, the default
sidebar is now plain: no favorites, no snooze badges, no urgent blink.
Cycling to Attention sort lights the whole thing up.

### Test coverage

Three new unit tests pin the gates:

- `favorite_decoration_gated_to_attention_sort`: favorite renders `* `
  + bold/underline in Attention, plain in Newest.
- `snooze_decoration_gated_to_attention_sort`: snooze renders `z `
  prefix in Attention, plain in Newest.
- `archived_section_pinned_to_bottom_in_every_sort`: synthetic Archived
  section appears at the bottom of `flat_items` across `Newest`,
  `Attention`, and `AZ`, with the archived row pulled out of the natural
  flow.

Plus `test_non_strict_h_snoozes_only_in_attention_sort` covers the
keybind gate end-to-end (h in Attention opens the snooze dialog; h in
Newest collapses the group via the fallthrough).

Existing tests still pass: 2223 lib + 120 integration.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [x] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (2223 lib + 120 integration green;
  `cargo fmt --check`, `cargo clippy --all-targets`,
  `cargo check --features serve` all clean)
- [x] Documentation was updated where necessary (help overlay section
  retitled; bindings tagged with their sort-mode scope)
- [x] For UI changes: included screenshot or recording

The pre-existing `attention-demo.mp4` in this thread already shows the
"everything is on" state. A "default sort" capture showing the plain
sidebar is straightforward to add if reviewers want one alongside.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow. The
  Attention workflow is TUI-only; no web sidebar code is touched.

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: the gate surface is exercised by 4 new
  unit tests in `src/tui/home/tests.rs` covering the bindings (h-in-
  Attention vs h-outside), the favorite decoration, the snooze
  decoration, and the Archived section placement. An e2e is reasonable
  follow-up once @BTForIT's asciinema lands and we have a clear flow
  to replay, but the unit coverage already pins the behavioral
  contract.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code.

**Any Additional AI Details you'd like to share:** The implementation,
test coverage, and this PR body were drafted by Claude through
back-and-forth with @njbrake after @BTForIT pushed back on the original
removal approach. The middle-ground design (gate instead of remove) and
every scope call are @njbrake's; the labor and the prose came out of
the agent loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->