### PR TITLE
chore: update repo URLs for org migration (1/4)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.85"
 authors = ["Agent of Empires Contributors"]
 description = "Terminal session manager for AI coding agents"
 license = "MIT"
-repository = "https://github.com/njbrake/agent-of-empires"
+repository = "https://github.com/agent-of-empires/agent-of-empires"
 keywords = ["tmux", "tui", "ai", "claude", "terminal"]
 categories = ["command-line-utilities", "development-tools"]
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
   <img src="assets/logo.png" alt="Agent of Empires" width="128">
   <h1 align="center">Agent of Empires (AoE)</h1>
   <p align="center">
-    <a href="https://trendshift.io/repositories/22434" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22434" alt="njbrake%2Fagent-of-empires | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+    <a href="https://trendshift.io/repositories/22434" target="_blank"><img src="https://trendshift.io/api/badge/repositories/22434" alt="agent-of-empires%2Fagent-of-empires | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
   </p>
   <p align="center">
-    <a href="https://github.com/njbrake/agent-of-empires/actions/workflows/ci.yml"><img src="https://github.com/njbrake/agent-of-empires/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+    <a href="https://github.com/agent-of-empires/agent-of-empires/actions/workflows/ci.yml"><img src="https://github.com/agent-of-empires/agent-of-empires/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
     <a href="https://formulae.brew.sh/formula/aoe"><img src="https://img.shields.io/homebrew/v/aoe" alt="Homebrew"></a>
     <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
     <a href="https://clawhub.ai/njbrake/aoe"><img src="https://img.shields.io/badge/ClawHub-aoe-blue" alt="ClawHub"></a>
@@ -73,17 +73,17 @@ The key tmux shortcut to know: **`Ctrl+b d`** detaches from a session and return
 ```bash
 # Quick install (Linux & macOS)
 curl -fsSL \
-  https://raw.githubusercontent.com/njbrake/agent-of-empires/main/scripts/install.sh \
+  https://raw.githubusercontent.com/agent-of-empires/agent-of-empires/main/scripts/install.sh \
   | bash
 
 # Homebrew
 brew install aoe
 
 # Nix
-nix run github:njbrake/agent-of-empires
+nix run github:agent-of-empires/agent-of-empires
 
 # Build from source
-git clone https://github.com/njbrake/agent-of-empires
+git clone https://github.com/agent-of-empires/agent-of-empires
 cd agent-of-empires && cargo build --release
 ```
 
@@ -198,7 +198,7 @@ unchanged.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=njbrake/agent-of-empires&type=date&legend=top-left)](https://www.star-history.com/#njbrake/agent-of-empires&type=date&legend=top-left)
+[![Star History Chart](https://api.star-history.com/svg?repos=agent-of-empires/agent-of-empires&type=date&legend=top-left)](https://www.star-history.com/#agent-of-empires/agent-of-empires&type=date&legend=top-left)
 
 ## Acknowledgments
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -16,7 +16,7 @@ The format follows [Conventional Commits](https://www.conventionalcommits.org/).
 """
 body = """
 {% if version %}\
-## [{{ version | trim_start_matches(pat="v") }}](https://github.com/njbrake/agent-of-empires/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version | trim_start_matches(pat="v") }}](https://github.com/agent-of-empires/agent-of-empires/releases/tag/{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
 ## [Unreleased]
 {% endif %}
@@ -26,8 +26,8 @@ body = """
 
 {% for commit in commits %}\
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | upper_first }}\
-{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/njbrake/agent-of-empires/pull/{{ commit.remote.pr_number }}){% endif %}\
-{% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){% endif %} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/njbrake/agent-of-empires/commit/{{ commit.id }}))
+{% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/agent-of-empires/agent-of-empires/pull/{{ commit.remote.pr_number }}){% endif %}\
+{% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){% endif %} ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/agent-of-empires/agent-of-empires/commit/{{ commit.id }}))
 {% endfor %}
 {% endfor %}
 {%- if github.contributors | filter(attribute="is_first_time", value=true) | length > 0 %}
@@ -35,19 +35,19 @@ body = """
 ### New Contributors
 
 {% for contributor in github.contributors | filter(attribute="is_first_time", value=true) -%}
-- [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution in [#{{ contributor.pr_number }}](https://github.com/njbrake/agent-of-empires/pull/{{ contributor.pr_number }})
+- [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution in [#{{ contributor.pr_number }}](https://github.com/agent-of-empires/agent-of-empires/pull/{{ contributor.pr_number }})
 {% endfor %}
 {%- endif %}
 {% if previous and previous.version and version -%}
 
-**Full Changelog**: https://github.com/njbrake/agent-of-empires/compare/{{ previous.version }}...{{ version }}
+**Full Changelog**: https://github.com/agent-of-empires/agent-of-empires/compare/{{ previous.version }}...{{ version }}
 {% endif %}
 """
 trim = true
 footer = ""
 
 [remote.github]
-owner = "njbrake"
+owner = "agent-of-empires"
 repo = "agent-of-empires"
 
 [git]

--- a/contrib/openclaw-skill/SKILL.md
+++ b/contrib/openclaw-skill/SKILL.md
@@ -7,7 +7,7 @@ metadata:
       bins:
         - aoe
         - tmux
-    homepage: https://github.com/njbrake/agent-of-empires
+    homepage: https://github.com/agent-of-empires/agent-of-empires
 ---
 
 # Agent of Empires (aoe) Skill

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -476,7 +476,7 @@ gone until the next `session/load` failure. See #1004.
 The bundled `aoe-agent` doesn't yet support context restoration; its
 transcript still replays from disk, but the model starts fresh on each
 spawn. Tracked in
-[#1005](https://github.com/njbrake/agent-of-empires/issues/1005).
+[#1005](https://github.com/agent-of-empires/agent-of-empires/issues/1005).
 
 ## Permission modes and YOLO
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -4,7 +4,7 @@ The web dashboard lets you monitor and interact with agent sessions from any bro
 
 ## Availability
 
-The web dashboard is included in all release binaries: [GitHub Releases](https://github.com/njbrake/agent-of-empires/releases), the [quick install script](../installation.md#quick-install-recommended), and Homebrew (`brew install aoe`). No extra build steps needed, just run `aoe serve`.
+The web dashboard is included in all release binaries: [GitHub Releases](https://github.com/agent-of-empires/agent-of-empires/releases), the [quick install script](../installation.md#quick-install-recommended), and Homebrew (`brew install aoe`). No extra build steps needed, just run `aoe serve`.
 
 ## Building from source
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ Run the install script:
 
 ```bash
 curl -fsSL \
-  https://raw.githubusercontent.com/njbrake/agent-of-empires/main/scripts/install.sh \
+  https://raw.githubusercontent.com/agent-of-empires/agent-of-empires/main/scripts/install.sh \
   | bash
 ```
 
@@ -27,7 +27,7 @@ brew install aoe
 ### Build from Source
 
 ```bash
-git clone https://github.com/njbrake/agent-of-empires
+git clone https://github.com/agent-of-empires/agent-of-empires
 cd agent-of-empires
 cargo build --release
 ```

--- a/docs/sounds.md
+++ b/docs/sounds.md
@@ -61,7 +61,7 @@ This downloads and installs 10 CC0 (public domain) fantasy/RPG sounds from the G
 - macOS: `~/.agent-of-empires/sounds/`
 
 **Note:** Requires an internet connection for the initial download. Sounds are downloaded from:
-`https://github.com/njbrake/agent-of-empires/tree/main/bundled_sounds`
+`https://github.com/agent-of-empires/agent-of-empires/tree/main/bundled_sounds`
 
 ### Useful Commands
 

--- a/flake.nix
+++ b/flake.nix
@@ -58,7 +58,7 @@
 
                 Supports Claude Code, OpenCode, Mistral Vibe, Codex CLI, and Gemini CLI.
               '';
-              homepage = "https://github.com/njbrake/agent-of-empires";
+              homepage = "https://github.com/agent-of-empires/agent-of-empires";
               license = licenses.mit;
               platforms = platforms.unix;
               mainProgram = "aoe";

--- a/src/cli/sounds.rs
+++ b/src/cli/sounds.rs
@@ -66,7 +66,9 @@ async fn install_bundled() -> Result<()> {
             eprintln!("  • Check your internet connection");
             eprintln!("  • Try again later if GitHub is unavailable");
             eprintln!("  • You can manually download sounds from:");
-            eprintln!("    https://github.com/njbrake/agent-of-empires/tree/main/bundled_sounds");
+            eprintln!(
+                "    https://github.com/agent-of-empires/agent-of-empires/tree/main/bundled_sounds"
+            );
             Err(e)
         }
     }

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -286,7 +286,7 @@ pub async fn run(args: UninstallArgs) -> Result<()> {
 
     println!();
     println!("Thank you for using Agent of Empires!");
-    println!("Feedback: https://github.com/njbrake/agent-of-empires/issues");
+    println!("Feedback: https://github.com/agent-of-empires/agent-of-empires/issues");
 
     Ok(())
 }

--- a/src/git/remote.rs
+++ b/src/git/remote.rs
@@ -149,24 +149,26 @@ mod tests {
     #[test]
     fn test_parse_owner_ssh_shorthand() {
         assert_eq!(
-            parse_owner_from_remote_url("git@github.com:njbrake/agent-of-empires.git"),
-            Some("njbrake".to_string()),
+            parse_owner_from_remote_url("git@github.com:agent-of-empires/agent-of-empires.git"),
+            Some("agent-of-empires".to_string()),
         );
     }
 
     #[test]
     fn test_parse_owner_https() {
         assert_eq!(
-            parse_owner_from_remote_url("https://github.com/njbrake/agent-of-empires.git"),
-            Some("njbrake".to_string()),
+            parse_owner_from_remote_url("https://github.com/agent-of-empires/agent-of-empires.git"),
+            Some("agent-of-empires".to_string()),
         );
     }
 
     #[test]
     fn test_parse_owner_ssh_url() {
         assert_eq!(
-            parse_owner_from_remote_url("ssh://git@github.com/njbrake/agent-of-empires.git"),
-            Some("njbrake".to_string()),
+            parse_owner_from_remote_url(
+                "ssh://git@github.com/agent-of-empires/agent-of-empires.git"
+            ),
+            Some("agent-of-empires".to_string()),
         );
     }
 
@@ -181,8 +183,8 @@ mod tests {
     #[test]
     fn test_parse_owner_no_dotgit_suffix() {
         assert_eq!(
-            parse_owner_from_remote_url("https://github.com/njbrake/agent-of-empires"),
-            Some("njbrake".to_string()),
+            parse_owner_from_remote_url("https://github.com/agent-of-empires/agent-of-empires"),
+            Some("agent-of-empires".to_string()),
         );
     }
 

--- a/src/server/push.rs
+++ b/src/server/push.rs
@@ -345,7 +345,7 @@ pub struct PushState {
 /// URL but does not require deliverability; major push services do not
 /// validate this for reachability in practice. We use the project's
 /// public URL so providers that do care have somewhere real to reach.
-pub const VAPID_SUBJECT: &str = "https://github.com/njbrake/agent-of-empires";
+pub const VAPID_SUBJECT: &str = "https://github.com/agent-of-empires/agent-of-empires";
 
 impl PushState {
     pub fn init(app_dir: &Path) -> anyhow::Result<Self> {

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -971,7 +971,7 @@ pub fn execute_hooks_in_container_streamed(
 /// Template content for `aoe init`.
 pub const INIT_TEMPLATE: &str = r#"# Agent of Empires - Repository Configuration
 # This file configures aoe behavior for this repository.
-# See: https://github.com/njbrake/agent-of-empires
+# See: https://github.com/agent-of-empires/agent-of-empires
 
 # [hooks]
 # Commands run once when a session is first created

--- a/src/tui/cockpit_view/mod.rs
+++ b/src/tui/cockpit_view/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! Directory name is `cockpit_view` (not `cockpit`) to avoid colliding
 //! with `src/cockpit/` per the recipe in
-//! https://github.com/njbrake/agent-of-empires/issues/1018#issuecomment-4444040929.
+//! https://github.com/agent-of-empires/agent-of-empires/issues/1018#issuecomment-4444040929.
 
 pub mod input;
 pub mod reducer;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1705,10 +1705,10 @@ impl HomeView {
                         ) {
                             let msg = match &method {
                                 InstallMethod::Nix => {
-                                    "Nix install: run `nix run github:njbrake/agent-of-empires` to update".to_string()
+                                    "Nix install: run `nix run github:agent-of-empires/agent-of-empires` to update".to_string()
                                 }
                                 InstallMethod::Cargo => {
-                                    "Cargo install: run `cargo install --git https://github.com/njbrake/agent-of-empires aoe`".to_string()
+                                    "Cargo install: run `cargo install --git https://github.com/agent-of-empires/agent-of-empires aoe`".to_string()
                                 }
                                 InstallMethod::Unknown { .. } => {
                                     "Unknown install method: run `aoe update` in a terminal for instructions".to_string()

--- a/tests/e2e/cli.rs
+++ b/tests/e2e/cli.rs
@@ -770,7 +770,7 @@ fn test_cli_session_capture_plain() {
 }
 
 /// Renaming a session via CLI should rename the tmux session, not kill it.
-/// Regression test for https://github.com/njbrake/agent-of-empires/issues/431
+/// Regression test for https://github.com/agent-of-empires/agent-of-empires/issues/431
 #[test]
 #[serial]
 fn test_cli_rename_preserves_tmux_session() {

--- a/web/src/components/AboutModal.tsx
+++ b/web/src/components/AboutModal.tsx
@@ -19,8 +19,8 @@ const LINKS: LinkRow[] = [
   },
   {
     label: "GitHub",
-    href: "https://github.com/njbrake/agent-of-empires",
-    display: "github.com/njbrake/agent-of-empires",
+    href: "https://github.com/agent-of-empires/agent-of-empires",
+    display: "github.com/agent-of-empires/agent-of-empires",
   },
   {
     label: "Twitter",
@@ -50,7 +50,7 @@ function buildFeedbackUrl(version: string | null): string {
     body,
     labels: "web,feedback",
   });
-  return `https://github.com/njbrake/agent-of-empires/issues/new?${params.toString()}`;
+  return `https://github.com/agent-of-empires/agent-of-empires/issues/new?${params.toString()}`;
 }
 
 export function AboutModal({ onClose }: Props) {

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -339,7 +339,7 @@
     {
       "id": "sidebar.favorite-indicator",
       "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
+      "issue": "https://github.com/agent-of-empires/agent-of-empires/issues/986",
       "risk": "low",
       "components": [
         "web/src/components/WorkspaceSidebar.tsx"
@@ -731,7 +731,7 @@
     {
       "id": "modals",
       "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
+      "issue": "https://github.com/agent-of-empires/agent-of-empires/issues/986",
       "risk": "low",
       "components": [
         "web/src/components/AboutModal.tsx",
@@ -742,7 +742,7 @@
     {
       "id": "projects-view",
       "kind": "deferred",
-      "issue": "https://github.com/njbrake/agent-of-empires/issues/986",
+      "issue": "https://github.com/agent-of-empires/agent-of-empires/issues/986",
       "risk": "low",
       "components": [
         "web/src/components/ProjectsView.tsx"

--- a/website/public/main.js
+++ b/website/public/main.js
@@ -63,7 +63,7 @@ function toggleMobileSidebar(btn) {
 }
 
 // Fetch GitHub star count
-fetch('https://api.github.com/repos/njbrake/agent-of-empires')
+fetch('https://api.github.com/repos/agent-of-empires/agent-of-empires')
   .then(res => res.json())
   .then(data => {
     const count = data.stargazers_count;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -261,7 +261,7 @@ const URL_MAP = {
 };
 
 const GITHUB_BASE =
-  "https://github.com/njbrake/agent-of-empires/blob/main/";
+  "https://github.com/agent-of-empires/agent-of-empires/blob/main/";
 
 function rewriteLinks(content, sourceDir) {
   // Rewrite markdown links to .md files: [text](target.md) or [text](target.md#anchor)

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -21,7 +21,7 @@
           <li><a href="/docs/" class="text-gray-400 hover:text-white transition-colors">Documentation</a></li>
           <li><a href="/docs/installation/" class="text-gray-400 hover:text-white transition-colors">Installation</a></li>
           <li><a href="/docs/quick-start/" class="text-gray-400 hover:text-white transition-colors">Quick Start</a></li>
-          <li><a href="https://github.com/njbrake/agent-of-empires/releases" class="text-gray-400 hover:text-white transition-colors">Releases</a></li>
+          <li><a href="https://github.com/agent-of-empires/agent-of-empires/releases" class="text-gray-400 hover:text-white transition-colors">Releases</a></li>
         </ul>
       </div>
 
@@ -38,10 +38,10 @@
       <div>
         <h4 class="text-gray-100 font-semibold text-sm uppercase tracking-wider mb-4">Community</h4>
         <ul class="space-y-2 text-sm">
-          <li><a href="https://github.com/njbrake/agent-of-empires" class="text-gray-400 hover:text-white transition-colors">GitHub</a></li>
-          <li><a href="https://github.com/njbrake/agent-of-empires/issues" class="text-gray-400 hover:text-white transition-colors">Issues</a></li>
+          <li><a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-400 hover:text-white transition-colors">GitHub</a></li>
+          <li><a href="https://github.com/agent-of-empires/agent-of-empires/issues" class="text-gray-400 hover:text-white transition-colors">Issues</a></li>
           <li><a href="https://github.com/users/njbrake/projects/1" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
-          <li><a href="https://github.com/njbrake/agent-of-empires/blob/main/LICENSE" class="text-gray-400 hover:text-white transition-colors">MIT License</a></li>
+          <li><a href="https://github.com/agent-of-empires/agent-of-empires/blob/main/LICENSE" class="text-gray-400 hover:text-white transition-colors">MIT License</a></li>
         </ul>
       </div>
     </div>
@@ -56,7 +56,7 @@
         <a href="https://www.linkedin.com/in/njbrake/" class="text-gray-500 hover:text-white transition-colors" aria-label="Connect on LinkedIn">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
         </a>
-        <a href="https://github.com/njbrake/agent-of-empires" class="text-gray-500 hover:text-white transition-colors" aria-label="GitHub repository">
+        <a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-500 hover:text-white transition-colors" aria-label="GitHub repository">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         </a>
       </div>

--- a/website/src/components/InstallBlock.astro
+++ b/website/src/components/InstallBlock.astro
@@ -43,9 +43,9 @@
     </div>
     <div class="px-5 py-4 font-mono text-sm md:text-base flex items-center justify-between gap-4">
       <code class="text-gray-100 overflow-x-auto">
-        <span class="text-gray-500 select-none">$ </span><span class="text-brand-400">curl</span> -fsSL https://raw.githubusercontent.com/njbrake/agent-of-empires/main/scripts/install.sh <span class="text-gray-500">|</span> <span class="text-brand-400">bash</span>
+        <span class="text-gray-500 select-none">$ </span><span class="text-brand-400">curl</span> -fsSL https://raw.githubusercontent.com/agent-of-empires/agent-of-empires/main/scripts/install.sh <span class="text-gray-500">|</span> <span class="text-brand-400">bash</span>
       </code>
-      <button onclick="copyCommand('curl -fsSL https://raw.githubusercontent.com/njbrake/agent-of-empires/main/scripts/install.sh | bash', this)" class="install-copy-btn text-gray-500 hover:text-brand-400 transition-colors p-2 rounded-lg hover:bg-surface-700/50 flex-shrink-0" title="Copy to clipboard">
+      <button onclick="copyCommand('curl -fsSL https://raw.githubusercontent.com/agent-of-empires/agent-of-empires/main/scripts/install.sh | bash', this)" class="install-copy-btn text-gray-500 hover:text-brand-400 transition-colors p-2 rounded-lg hover:bg-surface-700/50 flex-shrink-0" title="Copy to clipboard">
         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"/>
         </svg>

--- a/website/src/components/Nav.astro
+++ b/website/src/components/Nav.astro
@@ -14,7 +14,7 @@
       <a href="/docs/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Docs</a>
       <a href="/guides/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Guides</a>
       <a href="/merch/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium py-3 px-2">Merch</a>
-      <a href="https://github.com/njbrake/agent-of-empires" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium py-3 px-2">
+      <a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium py-3 px-2">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
       </a>
@@ -56,7 +56,7 @@
       <a href="/docs/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Docs</a>
       <a href="/guides/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Guides</a>
       <a href="/merch/" class="text-gray-200 hover:text-white transition-colors text-sm font-medium">Merch</a>
-      <a href="https://github.com/njbrake/agent-of-empires" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium">
+      <a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-200 hover:text-white transition-colors flex items-center gap-2 text-sm font-medium">
         <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
         GitHub
       </a>

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -40,8 +40,8 @@ const structuredData = {
     "name": "Nate Brake",
     "url": "https://twitter.com/natebrake"
   },
-  "license": "https://github.com/njbrake/agent-of-empires/blob/main/LICENSE",
-  "codeRepository": "https://github.com/njbrake/agent-of-empires",
+  "license": "https://github.com/agent-of-empires/agent-of-empires/blob/main/LICENSE",
+  "codeRepository": "https://github.com/agent-of-empires/agent-of-empires",
   "keywords": ["AI coding agent", "terminal session manager", "tmux", "Claude Code", "Codex", "OpenCode", "Mistral Vibe", "Gemini CLI", "git worktrees", "Docker sandbox"]
 };
 ---

--- a/website/src/pages/guides/index.astro
+++ b/website/src/pages/guides/index.astro
@@ -65,7 +65,7 @@ const guides = [
     </div>
 
     <p class="text-gray-400 leading-relaxed">
-      Have a guide you'd like to see? <a href="https://github.com/njbrake/agent-of-empires/issues" target="_blank" rel="noopener" class="text-brand-500 hover:text-brand-400 transition-colors">Open a GitHub issue</a> and let us know.
+      Have a guide you'd like to see? <a href="https://github.com/agent-of-empires/agent-of-empires/issues" target="_blank" rel="noopener" class="text-brand-500 hover:text-brand-400 transition-colors">Open a GitHub issue</a> and let us know.
     </p>
   </main>
   <Footer />

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -94,7 +94,7 @@ const compactFeatures = [
         <a href="/docs/quick-start/" class="btn-primary text-base px-8 py-3.5 inline-flex items-center justify-center">
           Get Started
         </a>
-        <a href="https://github.com/njbrake/agent-of-empires" target="_blank" rel="noopener" class="btn-secondary text-base px-8 py-3.5 group inline-flex items-center justify-center gap-2" title="Star on GitHub">
+        <a href="https://github.com/agent-of-empires/agent-of-empires" target="_blank" rel="noopener" class="btn-secondary text-base px-8 py-3.5 group inline-flex items-center justify-center gap-2" title="Star on GitHub">
           <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
           <svg class="w-4 h-4 text-brand-400 group-hover:scale-110 transition-transform" fill="currentColor" viewBox="0 0 24 24"><path d="M12 .587l3.668 7.568 8.332 1.151-6.064 5.828 1.48 8.279-7.416-3.967-7.417 3.967 1.481-8.279-6.064-5.828 8.332-1.151z"/></svg>
           <span id="star-count">...</span> Stars


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake as part of planning the move from \`njbrake/agent-of-empires\` to the new \`agent-of-empires/agent-of-empires\` org. The decisions are his; the prose is Claude's._

## Description

Part 1 of 4 in the org migration sequence. Updates every reference to \`github.com/njbrake/agent-of-empires\` to \`github.com/agent-of-empires/agent-of-empires\` in docs, website, branding, and user-facing strings.

**Scope is intentionally limited to references with no runtime fetch behavior.** Things that pull from GitHub at runtime (update checker, install scripts, sound downloader) are split into PR3; GHCR/Docker image references are split into PR4. That split lets this PR merge immediately after the repo transfer with no release-coordination cost, while the runtime URLs get sequenced with the next release.

**Merge timing:** immediately after the repo transfer to the new org. Old URLs redirect indefinitely so there is no urgency, but the canonical paths should be right ASAP.

## What's NOT included (intentional)

- \`scripts/install.sh\`, \`scripts/update-formula.sh\`, \`scripts/release_metrics.sh\` -> PR3
- \`src/update/{mod,install}.rs\`, \`src/sound/bundled.rs\` -> PR3
- \`tests/integration/update_command.rs\`, \`web/tests/update-banner.spec.ts\` -> PR3 (these test the URLs PR3 changes)
- All \`ghcr.io/njbrake/aoe-sandbox\` references plus a new relocate-sandbox-image migration -> PR4
- \`CHANGELOG.md\` (historical audit log; GitHub permanently redirects old links so rewriting it would be revisionist for no gain)
- ClawHub badge in README (external service, separate concern)
- The user-project board link in README (project boards do not auto-transfer with the repo; decision deferred)

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (\`src/git/remote.rs\` test fixtures updated alongside)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A, string-only)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow; the only web-app touch is a string in \`AboutModal.tsx\` and a JSON metadata file

**TUI / CLI (e2e test)**
- [x] N/A: TUI install-prompt strings update only; no rendering or lifecycle change

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, drafted in conversation with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)