### PR TITLE
chore: expand CODEOWNERS with cockpit team (2/4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,45 @@
-* @njbrake
+# CODEOWNERS - merge gating for agent-of-empires/agent-of-empires
+#
+# Last-match-wins semantics. Pair with branch protection / ruleset on `main`:
+#   - Require PR before merging
+#   - Require status checks (CI) to pass
+#   - Require signed commits
+#   - Require review from Code Owners
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: njbrake reviews everything not otherwise scoped
+*                                       @njbrake
+
+# Cockpit and web dashboard - cockpit team can self-route, njbrake co-owns
+/web/                                   @agent-of-empires/cockpit @njbrake
+/src/server/cockpit_reconciler.rs       @agent-of-empires/cockpit @njbrake
+/src/server/cockpit_ws.rs               @agent-of-empires/cockpit @njbrake
+/src/server/api/cockpit.rs              @agent-of-empires/cockpit @njbrake
+/src/tui/cockpit_view/                  @agent-of-empires/cockpit @njbrake
+
+# Security-sensitive surface area - njbrake only
+/src/server/auth.rs                     @njbrake
+/src/server/login.rs                    @njbrake
+/src/server/rate_limit.rs               @njbrake
+/src/server/tunnel.rs                   @njbrake
+/src/server/push.rs                     @njbrake
+/src/server/push_send.rs                @njbrake
+
+# Architecture and data-safety critical - njbrake only
+/src/migrations/                        @njbrake
+/src/session/storage.rs                 @njbrake
+/src/tmux/                              @njbrake
+
+# Supply chain, build, release - njbrake only
+/Cargo.toml                             @njbrake
+/Cargo.lock                             @njbrake
+/scripts/                               @njbrake
+/.github/                               @njbrake
+/flake.nix                              @njbrake
+/flake.lock                             @njbrake
+
+# Repo governance - njbrake only
+/AGENTS.md                              @njbrake
+/CLAUDE.md                              @njbrake
+/DESIGN.md                              @njbrake


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake as part of planning the move from \`njbrake/agent-of-empires\` to the new \`agent-of-empires/agent-of-empires\` org. The decisions are his; the prose is Claude's._

## Description

Part 2 of 4 in the org migration sequence. Expands the one-line \`* @njbrake\` CODEOWNERS into a tiered file that:

- Routes \`/web/\` and cockpit-specific source paths to the new \`@agent-of-empires/cockpit\` team alongside @njbrake, so the team can self-route and approve.
- Keeps @njbrake as sole owner on the paths where a bad merge has lasting blast radius: supply chain (\`Cargo.toml\`, \`Cargo.lock\`, \`scripts/\`, \`.github/\`, \`flake.{nix,lock}\`), security surface (\`auth.rs\`, \`login.rs\`, \`tunnel.rs\`, \`push.rs\`, \`rate_limit.rs\`), data-safety (\`migrations/\`, \`session/storage.rs\`, \`tmux/\`), and governance files (\`AGENTS.md\`, \`CLAUDE.md\`, \`DESIGN.md\`).

## Pair with branch protection

For this to actually gate merges, the \`main\` branch protection or ruleset must enable:

- Require PR before merging
- Require status checks (CI) to pass
- Require signed commits
- Require review from Code Owners

Without "Require review from Code Owners," CODEOWNERS only auto-requests reviewers; it does not block merge.

## Merge timing

**Immediately after the repo transfer, once the cockpit team exists in the org.** GitHub flags team handles as invalid until the team is created with the right repo access; merging this PR before the team exists would surface \`Unknown owner\` warnings in the CODEOWNERS UI.

Recommended order:

1. Transfer repo to \`agent-of-empires\` org
2. Create the \`@agent-of-empires/cockpit\` team with \`Maintain\` (or \`Write\`) role on this repo, add seluj78
3. Merge this PR
4. Configure ruleset on \`main\` per above

## Self-approval gotcha worth knowing

GitHub does not let an author approve their own PR. A cockpit-team member's PR to \`/web/\` therefore still needs a second approver (another team member, or @njbrake). If the goal is true self-merge autonomy for the cockpit team, a ruleset bypass list is the right mechanism, not CODEOWNERS alone.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (single-file additive change)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, drafted in conversation with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)