### PR TITLE
feat: relocate sandbox image to ghcr.io/agent-of-empires namespace (4/4)

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -3,7 +3,7 @@
 # Note: Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI,
 # Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code are inherited from the base image
 
-ARG BASE_IMAGE=ghcr.io/njbrake/aoe-sandbox:latest
+ARG BASE_IMAGE=ghcr.io/agent-of-empires/aoe-sandbox:latest
 FROM ${BASE_IMAGE}
 
 USER root

--- a/docs/guides/apple-containers.md
+++ b/docs/guides/apple-containers.md
@@ -49,7 +49,7 @@ To switch your sandbox runtime from Docker (default) to Apple Container, update 
 ```toml
 [sandbox]
 container_runtime = "apple_container"
-default_image = "ghcr.io/njbrake/aoe-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
 ```
 
 ### Profile-Specific Runtime
@@ -112,5 +112,5 @@ container system status
 Apple Container uses its own local image store, separate from Docker Desktop. If you have an image in Docker, you must pull or build it again for Apple Container:
 
 ```bash
-container image pull ghcr.io/njbrake/aoe-sandbox:latest
+container image pull ghcr.io/agent-of-empires/aoe-sandbox:latest
 ```

--- a/docs/guides/configuration.md
+++ b/docs/guides/configuration.md
@@ -206,7 +206,7 @@ init_submodules = true
 ```toml
 [sandbox]
 enabled_by_default = false
-default_image = "ghcr.io/njbrake/aoe-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
 cpu_limit = "4"
 memory_limit = "8g"
 port_mappings = ["3000:3000", "5432:5432"]
@@ -220,7 +220,7 @@ default_terminal_mode = "host"
 | Option | Default | Description |
 |--------|---------|-------------|
 | `enabled_by_default` | `false` | Auto-enable sandbox for new sessions |
-| `default_image` | `ghcr.io/njbrake/aoe-sandbox:latest` | Docker image for containers |
+| `default_image` | `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Docker image for containers |
 | `cpu_limit` | (none) | CPU limit (e.g., `"4"`) |
 | `memory_limit` | (none) | Memory limit (e.g., `"8g"`) |
 | `port_mappings` | `[]` | Host-to-container port mappings (e.g., `["3000:3000"]`) |

--- a/docs/guides/podman.md
+++ b/docs/guides/podman.md
@@ -43,7 +43,7 @@ To switch your sandbox runtime from Docker (the default) to Podman, update `~/.c
 ```toml
 [sandbox]
 container_runtime = "podman"
-default_image = "ghcr.io/njbrake/aoe-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
 ```
 
 ### Profile-Specific Runtime
@@ -83,7 +83,7 @@ Podman is treated as a Docker-compatible runtime by AoE, which means:
 
 A few practical differences to keep in mind:
 
-- **Image store is separate.** Podman maintains its own local image cache. If you previously pulled images with Docker, run `podman pull ghcr.io/njbrake/aoe-sandbox:latest` (or let AoE pull on first use).
+- **Image store is separate.** Podman maintains its own local image cache. If you previously pulled images with Docker, run `podman pull ghcr.io/agent-of-empires/aoe-sandbox:latest` (or let AoE pull on first use).
 - **Rootless networking.** Rootless Podman uses `slirp4netns` or `pasta` for networking by default. Published ports above 1024 work without extra configuration; binding to a privileged port (<1024) requires either rootful Podman or `sysctl net.ipv4.ip_unprivileged_port_start`.
 - **Daemonless.** There is no daemon process to keep running. If you previously used `systemctl start docker`, the Podman equivalent is unnecessary.
 
@@ -101,7 +101,7 @@ If AoE reports the Podman runtime as unavailable, run `podman info` directly. Co
 Podman uses a local image store separate from Docker. Pull the sandbox image once to seed the cache:
 
 ```bash
-podman pull ghcr.io/njbrake/aoe-sandbox:latest
+podman pull ghcr.io/agent-of-empires/aoe-sandbox:latest
 ```
 
 ### Permission Denied on Bind Mounts

--- a/docs/guides/repo-config.md
+++ b/docs/guides/repo-config.md
@@ -91,7 +91,7 @@ Override sandbox settings for this repo:
 ```toml
 [sandbox]
 enabled_by_default = true
-default_image = "ghcr.io/njbrake/aoe-dev-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:latest"
 environment = ["NODE_ENV", "DATABASE_URL", "CUSTOM_KEY=value"]
 volume_ignores = ["node_modules", ".next", "target"]
 extra_volumes = ["/data:/data:ro"]
@@ -159,7 +159,7 @@ default_tool = "claude"
 
 [sandbox]
 enabled_by_default = true
-default_image = "ghcr.io/njbrake/aoe-dev-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:latest"
 environment = ["DATABASE_URL", "REDIS_URL", "NODE_ENV=development"]
 volume_ignores = ["node_modules", ".next"]
 

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -50,7 +50,7 @@ aoe remove <session> --keep-container
 ```toml
 [sandbox]
 enabled_by_default = false
-default_image = "ghcr.io/njbrake/aoe-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
 auto_cleanup = true
 cpu_limit = "4"
 memory_limit = "8g"
@@ -64,7 +64,7 @@ environment = ["ANTHROPIC_API_KEY"]
 | Option | Default | Description |
 |--------|---------|-------------|
 | `enabled_by_default` | `false` | Auto-enable sandbox for new sessions |
-| `default_image` | `ghcr.io/njbrake/aoe-sandbox:latest` | Docker image to use |
+| `default_image` | `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Docker image to use |
 | `auto_cleanup` | `true` | Remove containers when sessions are deleted |
 | `cpu_limit` | (none) | CPU limit (e.g., "4") |
 | `memory_limit` | (none) | Memory limit (e.g., "8g") |
@@ -202,8 +202,8 @@ AOE provides two official sandbox images:
 
 | Image | Description |
 |-------|-------------|
-| `ghcr.io/njbrake/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, git, ripgrep, fzf |
-| `ghcr.io/njbrake/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
+| `ghcr.io/agent-of-empires/aoe-sandbox:latest` | Base image with Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, git, ripgrep, fzf |
+| `ghcr.io/agent-of-empires/aoe-dev-sandbox:latest` | Extended image with additional dev tools |
 
 ### Dev Sandbox Tools
 
@@ -218,11 +218,11 @@ To use the dev sandbox:
 
 ```bash
 # Per-session
-aoe add --sandbox-image ghcr.io/njbrake/aoe-dev-sandbox:latest .
+aoe add --sandbox-image ghcr.io/agent-of-empires/aoe-dev-sandbox:latest .
 
 # Or set as default in ~/.agent-of-empires/config.toml
 [sandbox]
-default_image = "ghcr.io/njbrake/aoe-dev-sandbox:latest"
+default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:latest"
 ```
 
 ## Custom Docker Images
@@ -234,7 +234,7 @@ The default sandbox image includes all supported agents, git, and basic developm
 Create a `Dockerfile` in your project (or a shared location):
 
 ```dockerfile
-FROM ghcr.io/njbrake/aoe-sandbox:latest
+FROM ghcr.io/agent-of-empires/aoe-sandbox:latest
 
 # Example: Add Python for a data science project
 RUN apt-get update && apt-get install -y \

--- a/src/containers/runtime_base.rs
+++ b/src/containers/runtime_base.rs
@@ -144,7 +144,7 @@ impl RuntimeBase {
     }
 
     pub fn default_sandbox_image(&self) -> &'static str {
-        "ghcr.io/njbrake/aoe-sandbox:latest"
+        "ghcr.io/agent-of-empires/aoe-sandbox:latest"
     }
 
     pub fn effective_default_image(&self) -> String {

--- a/src/migrations/mod.rs
+++ b/src/migrations/mod.rs
@@ -18,13 +18,14 @@ mod v007_serve_log_to_legacy;
 mod v008_lock_in_default_profile;
 mod v009_update_check_mode;
 mod v010_drop_legacy_live_send_exit_chord;
+mod v011_relocate_sandbox_image;
 
 use anyhow::Result;
 use std::fs;
 use std::path::PathBuf;
 use tracing::{debug, info};
 
-const CURRENT_VERSION: u32 = 10;
+const CURRENT_VERSION: u32 = 11;
 const VERSION_FILE: &str = ".schema_version";
 
 struct Migration {
@@ -83,6 +84,11 @@ const MIGRATIONS: &[Migration] = &[
         version: 10,
         name: "drop_legacy_live_send_exit_chord",
         run: v010_drop_legacy_live_send_exit_chord::run,
+    },
+    Migration {
+        version: 11,
+        name: "relocate_sandbox_image",
+        run: v011_relocate_sandbox_image::run,
     },
 ];
 

--- a/src/migrations/v011_relocate_sandbox_image.rs
+++ b/src/migrations/v011_relocate_sandbox_image.rs
@@ -1,0 +1,214 @@
+//! Migration v011: Relocate sandbox image from ghcr.io/njbrake to ghcr.io/agent-of-empires
+//!
+//! When the repo moved from `njbrake/agent-of-empires` to `agent-of-empires/agent-of-empires`
+//! the published container images moved with it: `ghcr.io/njbrake/aoe-sandbox` and
+//! `ghcr.io/njbrake/aoe-dev-sandbox` are republished as `ghcr.io/agent-of-empires/aoe-sandbox`
+//! and `ghcr.io/agent-of-empires/aoe-dev-sandbox`. GHCR keeps the old paths alive as redirects
+//! for now, but they should not be the canonical reference in stored config.
+//!
+//! This migration rewrites `[sandbox] default_image` in the global config and every profile
+//! config to point at the new namespace. Idempotent: re-running on already-migrated configs
+//! is a no-op.
+
+use anyhow::Result;
+use std::fs;
+use std::path::PathBuf;
+use tracing::{debug, info};
+
+const OLD_NAMESPACE: &str = "ghcr.io/njbrake/";
+const NEW_NAMESPACE: &str = "ghcr.io/agent-of-empires/";
+
+pub fn run() -> Result<()> {
+    let app_dir = crate::session::get_app_dir()?;
+
+    let global_config = app_dir.join("config.toml");
+    migrate_config_file(&global_config)?;
+
+    let profiles_dir = app_dir.join("profiles");
+    if profiles_dir.exists() {
+        for entry in fs::read_dir(&profiles_dir)? {
+            let entry = entry?;
+            if entry.path().is_dir() {
+                let profile_config = entry.path().join("config.toml");
+                migrate_config_file(&profile_config)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn migrate_config_file(path: &PathBuf) -> Result<()> {
+    if !path.exists() {
+        debug!("Config file {} does not exist, skipping", path.display());
+        return Ok(());
+    }
+
+    let content = fs::read_to_string(path)?;
+    let mut doc: toml::Table = match content.parse() {
+        Ok(table) => table,
+        Err(e) => {
+            debug!("Failed to parse {}: {}, skipping", path.display(), e);
+            return Ok(());
+        }
+    };
+
+    let Some(sandbox) = doc.get_mut("sandbox").and_then(|s| s.as_table_mut()) else {
+        return Ok(());
+    };
+
+    let Some(value) = sandbox.get("default_image").and_then(|v| v.as_str()) else {
+        return Ok(());
+    };
+
+    if !value.starts_with(OLD_NAMESPACE) {
+        return Ok(());
+    }
+
+    let new_value = format!("{}{}", NEW_NAMESPACE, &value[OLD_NAMESPACE.len()..]);
+    info!(
+        "Relocating sandbox default_image: {} -> {} in {}",
+        value,
+        new_value,
+        path.display()
+    );
+
+    sandbox.insert("default_image".to_string(), toml::Value::String(new_value));
+
+    let new_content = toml::to_string_pretty(&doc)?;
+    fs::write(path, new_content)?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rewrites_aoe_sandbox() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"[sandbox]
+default_image = "ghcr.io/njbrake/aoe-sandbox:latest"
+"#,
+        )
+        .unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(
+            result["sandbox"]["default_image"].as_str(),
+            Some("ghcr.io/agent-of-empires/aoe-sandbox:latest")
+        );
+    }
+
+    #[test]
+    fn test_rewrites_aoe_dev_sandbox() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"[sandbox]
+default_image = "ghcr.io/njbrake/aoe-dev-sandbox:0.10"
+"#,
+        )
+        .unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(
+            result["sandbox"]["default_image"].as_str(),
+            Some("ghcr.io/agent-of-empires/aoe-dev-sandbox:0.10")
+        );
+    }
+
+    #[test]
+    fn test_idempotent_on_already_migrated() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        let original = r#"[sandbox]
+default_image = "ghcr.io/agent-of-empires/aoe-sandbox:latest"
+"#;
+        fs::write(&config_path, original).unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(
+            result["sandbox"]["default_image"].as_str(),
+            Some("ghcr.io/agent-of-empires/aoe-sandbox:latest")
+        );
+    }
+
+    #[test]
+    fn test_leaves_unrelated_images_alone() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"[sandbox]
+default_image = "docker.io/library/ubuntu:22.04"
+"#,
+        )
+        .unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(
+            result["sandbox"]["default_image"].as_str(),
+            Some("docker.io/library/ubuntu:22.04")
+        );
+    }
+
+    #[test]
+    fn test_no_sandbox_section() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"[session]
+default_tool = "claude"
+"#,
+        )
+        .unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(result["session"]["default_tool"].as_str(), Some("claude"));
+    }
+
+    #[test]
+    fn test_no_default_image_set() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("config.toml");
+        fs::write(
+            &config_path,
+            r#"[sandbox]
+enabled_by_default = true
+"#,
+        )
+        .unwrap();
+
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+
+        let result: toml::Table = fs::read_to_string(&config_path).unwrap().parse().unwrap();
+        assert_eq!(
+            result["sandbox"]["enabled_by_default"].as_bool(),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn test_nonexistent_file() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let config_path = dir.path().join("nonexistent.toml");
+        migrate_config_file(&config_path.to_path_buf()).unwrap();
+    }
+}

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1182,7 +1182,7 @@ impl Default for SandboxConfig {
 }
 
 fn default_sandbox_image() -> String {
-    "ghcr.io/njbrake/aoe-sandbox:latest".to_string()
+    "ghcr.io/agent-of-empires/aoe-sandbox:latest".to_string()
 }
 
 fn default_sandbox_environment() -> Vec<String> {

--- a/src/session/repo_config.rs
+++ b/src/session/repo_config.rs
@@ -986,7 +986,7 @@ pub const INIT_TEMPLATE: &str = r#"# Agent of Empires - Repository Configuration
 
 # [sandbox]
 # enabled_by_default = true
-# default_image = "ghcr.io/njbrake/aoe-dev-sandbox:0.10"
+# default_image = "ghcr.io/agent-of-empires/aoe-dev-sandbox:0.10"
 # List fields below replace (not append to) global settings when set:
 # environment = ["NODE_ENV", "DATABASE_URL"]
 # volume_ignores = ["node_modules", ".next"]

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -268,7 +268,7 @@ export function SettingsView({
               label="Default container image"
               value={(sandbox.default_image as string) ?? ""}
               onChange={(v) => saveField("sandbox", sandbox, "default_image", v)}
-              placeholder="ghcr.io/njbrake/aoe-sandbox:latest"
+              placeholder="ghcr.io/agent-of-empires/aoe-sandbox:latest"
               mono
             />
             <SelectField

--- a/web/src/components/session-wizard/steps/AgentStep.tsx
+++ b/web/src/components/session-wizard/steps/AgentStep.tsx
@@ -328,7 +328,7 @@ export function AgentStep({ data, onChange, agents, profiles, dockerAvailable, o
                   type="text"
                   value={data.sandboxImage}
                   onChange={(e) => onChange("sandboxImage", e.target.value)}
-                  placeholder="ghcr.io/njbrake/aoe-sandbox:latest"
+                  placeholder="ghcr.io/agent-of-empires/aoe-sandbox:latest"
                   className="w-full bg-surface-900 border border-surface-700 rounded-lg px-3 py-2.5 text-sm font-mono text-text-primary placeholder:text-text-dim focus:border-brand-600 focus:outline-none"
                 />
               </div>


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake as part of planning the move from \`njbrake/agent-of-empires\` to the new \`agent-of-empires/agent-of-empires\` org. The decisions are his; the prose is Claude's._

## Description

Part 4 of 4 in the org migration sequence. Updates every \`ghcr.io/njbrake/aoe-sandbox\` and \`ghcr.io/njbrake/aoe-dev-sandbox\` reference to the new \`ghcr.io/agent-of-empires/\` namespace, and adds migration \`v011_relocate_sandbox_image\` that rewrites \`[sandbox] default_image\` in stored config.

GHCR packages do not auto-follow a GitHub repo transfer, so the images have to be republished under the new namespace before this PR can land.

### Scope

Code and docs (sed-replaced):

- \`docker/Dockerfile.dev\` -> \`BASE_IMAGE\` default
- \`src/containers/runtime_base.rs\` -> \`DEFAULT_SANDBOX_IMAGE\`
- \`src/session/config.rs\` -> default value for \`default_image\`
- \`src/session/repo_config.rs\` -> commented example in init template
- \`web/src/components/SettingsView.tsx\` and \`web/src/components/session-wizard/steps/AgentStep.tsx\` -> placeholder text
- \`docs/guides/{sandbox,configuration,repo-config,podman,apple-containers}.md\` -> every example

New migration:

- \`src/migrations/v011_relocate_sandbox_image.rs\` -> rewrites \`[sandbox] default_image\` from old namespace to new in the global config and every profile config. Idempotent on already-migrated configs. Leaves unrelated images (e.g. \`docker.io/library/ubuntu\`) alone.
- \`src/migrations/mod.rs\` -> bumps \`CURRENT_VERSION\` 10 -> 11 and registers the migration.

### What is NOT changed (deliberate)

- \`src/migrations/v002_seed_sandbox_from_volumes.rs\` -> historical migration; keeps the old image name in its local-image-candidates fallback list. v002 ran once per user; rewriting it now would be revisionist. New users running v002 for the first time fall through to the alpine/busybox/ubuntu fallbacks if the new image is not yet cached locally, and v011 (which runs right after) re-seeds the right value.
- \`src/migrations/v003_yolo_mode_config.rs\` -> historical migration; test fixture documents what the world looked like when v003 was written. Test still passes because v003 does not care about the image value.

### Merge timing

**Just before the next release, AFTER the new images are published to \`ghcr.io/agent-of-empires/\`.** If this merges while the new images do not exist, fresh installs hit 404 on sandbox pull. Recommended order:

1. Republish \`aoe-sandbox:latest\`, \`aoe-sandbox:<version>\`, and \`aoe-dev-sandbox:*\` to \`ghcr.io/agent-of-empires/\` (the release CI \`docker/build-push-action\` workflows need their \`tags:\` updated)
2. Merge this PR
3. Cut the release; users on next launch run v011 and have their stored \`default_image\` rewritten

GHCR keeps the old paths alive as redirects for some time, so already-installed users with cached old image names continue working until they re-pull.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (v011 ships with seven unit tests covering rewrite, idempotency, unrelated images, no-sandbox-section, no-default-image, missing-file)
- [x] Documentation was updated where necessary (every sandbox/configuration/podman/apple-containers/repo-config example reflects the new namespace)
- [ ] For UI changes: included screenshot or recording (N/A; only placeholder text strings changed in two web inputs)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: only placeholder text strings change in \`SettingsView.tsx\` and \`AgentStep.tsx\`; no behavior change

**TUI / CLI (e2e test)**
- [x] N/A: container runtime defaults, no TUI rendering or CLI surface change

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, drafted in conversation with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)