### PR TITLE
feat(pi): add hook-backed status reporting

### DIFF
--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -26,6 +26,53 @@ pub(crate) const HOOK_STATUS_BASE: &str = "/tmp/aoe-hooks";
 /// Any hook command containing this string is considered ours.
 const AOE_HOOK_MARKER: &str = "aoe-hooks";
 
+const PI_STATUS_EXTENSION: &str = r#"import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BASE = "/tmp/aoe-hooks";
+
+type AoeStatus = "running" | "idle" | "waiting" | "error";
+
+function writeStatus(status: AoeStatus) {
+  const id = process.env.AOE_INSTANCE_ID;
+  if (!id) return;
+
+  try {
+    const dir = join(BASE, id);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "status"), status);
+  } catch {
+    // AoE status reporting must never break Pi.
+  }
+}
+
+export default function aoeStatus(pi: ExtensionAPI) {
+  pi.on("session_start", () => writeStatus("idle"));
+  pi.on("turn_start", () => writeStatus("running"));
+  pi.on("agent_start", () => writeStatus("running"));
+  pi.on("tool_execution_start", () => writeStatus("running"));
+  pi.on("tool_execution_end", () => writeStatus("running"));
+  pi.on("agent_end", () => writeStatus("idle"));
+  pi.on("turn_end", () => writeStatus("idle"));
+  pi.on("session_shutdown", () => writeStatus("idle"));
+}
+"#;
+
+pub(crate) fn ensure_pi_status_extension(instance_id: &str) -> Result<PathBuf> {
+    let dir = hook_status_dir(instance_id);
+    std::fs::create_dir_all(&dir).with_context(|| {
+        format!(
+            "failed to create Pi status extension directory {}",
+            dir.display()
+        )
+    })?;
+    let path = dir.join("aoe-pi-status.ts");
+    std::fs::write(&path, PI_STATUS_EXTENSION)
+        .with_context(|| format!("failed to write Pi status extension {}", path.display()))?;
+    Ok(path)
+}
+
 /// Resolve the host Codex config path.
 ///
 /// Codex treats `CODEX_HOME` as the directory containing `config.toml`, falling

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -1145,9 +1145,15 @@ pub(crate) fn build_container_config(
             // hook_config path below cannot emit, so they're special-cased here.
             let hermes_hooks = agent.name == "hermes";
             let kiro_hooks = agent.name == "kiro";
-            if hermes_hooks || kiro_hooks || agent.hook_config.is_some() {
+            let pi_hooks = agent.name == "pi";
+            if hermes_hooks || kiro_hooks || pi_hooks || agent.hook_config.is_some() {
                 let hook_dir = crate::hooks::hook_status_dir(instance_id);
-                if let Err(e) = std::fs::create_dir_all(&hook_dir) {
+                let prepare_result = if pi_hooks {
+                    crate::hooks::ensure_pi_status_extension(instance_id).map(|_| ())
+                } else {
+                    std::fs::create_dir_all(&hook_dir).map_err(Into::into)
+                };
+                if let Err(e) = prepare_result {
                     tracing::warn!(target: "session.profile",
                         "Failed to create hook directory {}: {}",
                         hook_dir.display(),
@@ -3448,6 +3454,39 @@ volume_ignores = ["target"]
             "",
         )
         .unwrap()
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_pi_sandbox_mounts_status_extension_dir() {
+        let temp_home = TempDir::new().unwrap();
+        std::env::set_var("HOME", temp_home.path());
+        #[cfg(target_os = "linux")]
+        std::env::set_var("XDG_CONFIG_HOME", temp_home.path().join(".config"));
+
+        let project_dir = TempDir::new().unwrap();
+        git2::Repository::init(project_dir.path()).unwrap();
+        let info = build_minimal_sandbox_info();
+        let instance_id = "test-pi-sandbox-extension";
+        let config = build_container_config(
+            project_dir.path().to_str().unwrap(),
+            &info,
+            ContainerAgentSelection::new("pi", None),
+            false,
+            instance_id,
+            None,
+            "",
+        )
+        .unwrap();
+        let hook_dir = crate::hooks::hook_status_dir(instance_id);
+        let hook_dir_str = hook_dir.to_string_lossy().to_string();
+
+        assert!(hook_dir.join("aoe-pi-status.ts").exists());
+        assert!(config.volumes.iter().any(|volume| {
+            volume.host_path == hook_dir_str
+                && volume.container_path == hook_dir_str
+                && !volume.read_only
+        }));
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -212,6 +212,7 @@ fn status_hook_env_prefix(
     agent: Option<&crate::agents::AgentDef>,
 ) -> String {
     let has_hooks = agent.and_then(|a| a.hook_config.as_ref()).is_some()
+        || agent.is_some_and(|a| a.name == "pi")
         || tool == "settl"
         || tool == "hermes"
         || tool == "kiro";
@@ -1427,6 +1428,7 @@ impl Instance {
                 }
             }
 
+            self.append_pi_status_extension(&mut tool_cmd, agent);
             self.apply_session_flags(&mut tool_cmd, "sandboxed");
             apply_agent_launch_env(&mut tool_cmd, agent);
 
@@ -1557,6 +1559,25 @@ impl Instance {
         crate::hooks::codex_config_path_for_host_environment(&self.profile_host_environment())
     }
 
+    fn append_pi_status_extension(
+        &self,
+        cmd: &mut String,
+        agent: Option<&'static crate::agents::AgentDef>,
+    ) {
+        if !matches!(agent.map(|a| a.name), Some("pi")) || self.has_command_override() {
+            return;
+        }
+
+        match crate::hooks::ensure_pi_status_extension(&self.id) {
+            Ok(path) => {
+                *cmd = format!("{} -e {}", cmd, shell_escape(&path.to_string_lossy()));
+            }
+            Err(e) => {
+                tracing::warn!(target: "session.store", "Failed to prepare Pi status extension: {}", e);
+            }
+        }
+    }
+
     /// Build the tmux command for a sandboxed (Docker) session.
     ///
     /// Runs on_launch hooks inside the container, constructs the tool command
@@ -1612,6 +1633,7 @@ impl Instance {
                         apply_yolo_mode(&mut cmd, yolo, false);
                     }
                 }
+                self.append_pi_status_extension(&mut cmd, agent);
                 self.apply_session_flags(&mut cmd, "host agent");
                 apply_agent_launch_env(&mut cmd, agent);
                 wrap_command_ignore_suspend(&format!("{}{}", env_prefix, cmd))
@@ -4211,6 +4233,37 @@ mod tests {
             status_hook_env_prefix("abc123", "kiro", crate::agents::get_agent("kiro")),
             "AOE_INSTANCE_ID=abc123 "
         );
+        assert_eq!(
+            status_hook_env_prefix("abc123", "pi", crate::agents::get_agent("pi")),
+            "AOE_INSTANCE_ID=abc123 "
+        );
+    }
+
+    #[test]
+    fn test_build_host_command_adds_pi_status_extension_for_builtin_pi() {
+        let mut inst = Instance::new("test-pi-extension", "/tmp/test");
+        inst.id = "test-pi-extension".to_string();
+        inst.tool = "pi".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("pi"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(cmd_str.contains("AOE_INSTANCE_ID=test-pi-extension"));
+        assert!(cmd_str.contains("pi"));
+        assert!(cmd_str.contains(" -e "));
+        assert!(cmd_str.contains("/tmp/aoe-hooks/test-pi-extension/aoe-pi-status.ts"));
+    }
+
+    #[test]
+    fn test_build_host_command_skips_pi_status_extension_for_custom_command() {
+        let mut inst = Instance::new("test-pi-custom", "/tmp/test");
+        inst.id = "test-pi-custom".to_string();
+        inst.tool = "pi".to_string();
+        inst.command = "my-pi-wrapper".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("pi"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(cmd_str.contains("AOE_INSTANCE_ID=test-pi-custom"));
+        assert!(!cmd_str.contains("aoe-pi-status.ts"));
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -974,17 +974,8 @@ pub fn detect_pi_status(raw_content: &str) -> Status {
         return Status::Running;
     }
 
-    // Check for input prompt before activity indicators: words like
-    // "reading" or "writing" linger in scrollback after the agent finishes.
     if matches_input_prompt(&non_empty_lines, 5, &["pi>"]) {
         return Status::Waiting;
-    }
-
-    let activity_indicators = ["thinking", "working", "reading", "writing", "executing"];
-    for indicator in &activity_indicators {
-        if last_lines_lower.contains(indicator) {
-            return Status::Running;
-        }
     }
 
     Status::Idle
@@ -2557,8 +2548,6 @@ run this command? (y/n)
             detect_pi_status("processing request\nesc to interrupt"),
             Status::Running
         );
-        assert_eq!(detect_pi_status("thinking about code"), Status::Running);
-        assert_eq!(detect_pi_status("reading file.ts"), Status::Running);
     }
 
     #[test]
@@ -2577,6 +2566,11 @@ run this command? (y/n)
     fn test_detect_pi_status_idle() {
         assert_eq!(detect_pi_status("file saved"), Status::Idle);
         assert_eq!(detect_pi_status("random output text"), Status::Idle);
+        assert_eq!(
+            detect_pi_status("I was thinking through the code"),
+            Status::Idle
+        );
+        assert_eq!(detect_pi_status("reading file.ts\nDone."), Status::Idle);
     }
 
     #[test]


### PR DESCRIPTION
## Description

Adds AoE-managed Pi status reporting through a generated Pi extension and the existing `/tmp/aoe-hooks/<instance-id>/status` hook-status path.

This change is incoming because AoE's fallback Pi status detection could be fooled by stale terminal text. In particular, a Pi theme displayed `Thinking: off`; the word `Thinking` matched AoE's broad activity-word detection and left the session stuck in a forever-progress/running state even though Pi was no longer working.

- Adds an embedded `aoe-pi-status.ts` extension that listens to Pi lifecycle events and writes `idle` / `running` status for the active AoE instance.
- Prepares the extension under the instance hook directory and appends it to built-in Pi launches with `-e`.
- Mounts the Pi hook directory into sandboxed Pi sessions so the generated extension can write status from inside the container.
- Sets `AOE_INSTANCE_ID` for built-in Pi sessions so status writes land under the correct instance ID.
- Skips extension injection when the user has a custom command override, preserving wrapper/custom launch behavior.
- Simplifies fallback Pi screen-status detection by removing broad activity-word matching, so stale scrollback such as `Thinking: off` no longer keeps a completed session marked running.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: status production changes in Rust, but no dashboard controls, routes, payloads, or rendering states changed.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: existing unit/integration coverage exercises the status parsing, Pi launch command, instance ID propagation, and sandbox mount behavior; no deterministic Pi lifecycle e2e fixture exists yet.

**Validation run**
- [x] `docker run --rm -v "$PWD":/workspace -w /workspace --entrypoint sh rust:1-bookworm -lc 'export PATH=/usr/local/cargo/bin:$PATH; rustup component add rustfmt clippy >/dev/null && CARGO_TARGET_DIR=/tmp/aoe-target cargo fmt -- --check && CARGO_TARGET_DIR=/tmp/aoe-target cargo clippy --all-targets -- -D warnings && CARGO_TARGET_DIR=/tmp/aoe-target cargo test'`
- [x] The isolated `CARGO_TARGET_DIR=/tmp/aoe-target` avoids reusing host-built artifacts from the mounted workspace and resolves the earlier glibc mismatch.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**
GPT 5.5 was used for planning and reviewing. DeepSeek V4 Pro was used for development. Pi / coding-agent tooling was used to inspect the repository, draft the PR, and submit the branch.

**Any Additional AI Details you'd like to share:**
AI assistance was used to plan, develop, review, draft, and submit this changeset. The PR remains human-directed, including the root-cause framing and requested test-scope explanation.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)






