### PR TITLE
fix(tui): remove clipboard tests that leak xclip/wl-copy daemons

### DIFF
--- a/src/tui/clipboard.rs
+++ b/src/tui/clipboard.rs
@@ -170,21 +170,3 @@ fn write_osc52(bytes: &[u8]) -> std::io::Result<()> {
     write!(stdout, "\x1b]52;c;{}\x07", encoded)?;
     stdout.flush()
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn truncates_oversize_payload() {
-        let huge = "a".repeat(MAX_BYTES + 100);
-        let copied = copy_to_clipboard(&huge);
-        assert_eq!(copied, MAX_BYTES);
-    }
-
-    #[test]
-    fn copies_short_payload_in_full() {
-        let copied = copy_to_clipboard("hello");
-        assert_eq!(copied, 5);
-    }
-}


### PR DESCRIPTION
## Description

The two unit tests at the bottom of `src/tui/clipboard.rs` (`truncates_oversize_payload` and `copies_short_payload_in_full`, added in #1502) call `copy_to_clipboard()`, which spawns `xclip -selection clipboard` / `wl-copy` / `pbcopy` as a real subprocess.

On Linux, `xclip` and `wl-copy` deliberately double-fork into a background daemon to hold the X11 / Wayland selection after their foreground process exits. The 500ms `SUBPROCESS_WAIT` in `run_subprocess` kills the foreground child on timeout, but the daemonized grandchild survives and inherits stdin/stdout/stderr from cargo test. Cargo test then waits on those file descriptors before terminating, hanging the `Tests` job until the GitHub runner force-kills orphan processes at job teardown.

Visible effect in CI:

| Run | Commit | Cargo Test ubuntu | Cargo Test macOS |
|-----|--------|-------------------|------------------|
| Pre-#1502 main | `6f85c780` | ~4 min | ~2 min |
| Post-#1502 main | `9f84b269` | ~79 min | ~51 min |
| Latest main | `fad8db51` | ~54 min | ~52 min |

The job logs end with a sequence of `Terminate orphan process: ... (xclip)` / `(tmux: server)` lines at job-cleanup time, confirming the leak. Every PR rebased onto a post-#1502 main inherits the ~50min wait.

The real `copy_to_clipboard` plumbing is exercised by the integration path (`flow_extract` -> `take_preview_copy_text` -> the app loop drain), which already has unit coverage in `src/tui/home/tests.rs` that does not spawn subprocesses. Recovering the two removed tests properly will require mocking the subprocess (or marking them `#[ignore]` so they only run under an explicit opt-in flag); deleting them unblocks CI today and can be backfilled in a follow-up.

## PR Type

- [x] Bug Fix
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass — manually verified `cargo test --lib tui::clipboard` no longer leaves orphan processes (the two removed tests were the only ones invoking the subprocess path)
- [x] Documentation was updated where necessary — N/A, no public API change

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Skipped a test, because: this PR REMOVES two unit tests that are responsible for hanging CI by leaking subprocess daemons. A proper replacement (mocked subprocess) is left as a follow-up — the integration path that calls `copy_to_clipboard` is already covered by `take_preview_copy_text_drains_once` and `full_render_pipeline_captures_copy_text_after_finalize` in `src/tui/home/tests.rs`.

## AI Usage

Drafted by Claude via back-and-forth with @njbrake. Root cause identified by inspecting the gap between the last printed test (`tui::clipboard::tests::copies_short_payload_in_full ... ok`) and the post-job cleanup timestamp (~51 minutes) in the most recent completed main `Tests` run, plus the orphan-process termination log at job teardown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR removes two unit tests from the clipboard module that were causing CI pipeline hangs. Specifically, the `truncates_oversize_payload` and `copies_short_payload_in_full` tests were removed because they spawned background processes that outlived the tests themselves.

## What was removed

- Two unit tests from `src/tui/clipboard.rs` that validated clipboard copy functionality
- These tests verified that oversized payloads were truncated correctly and that short payloads were copied in full

## Why

The clipboard tests call system utilities (xclip on Linux, wl-copy, and pbcopy on macOS) that spawn child processes. On Linux specifically, these utilities double-fork into background daemons that persist even after the foreground process terminates. The test harness would wait for file descriptors to close, but the orphaned background processes kept them open, causing the entire CI pipeline to hang. This resulted in extreme CI slowdowns:
- Ubuntu: from ~4 minutes to 54-79 minutes
- macOS: from ~2 minutes to 51-52 minutes

## Benefits

- **Unblocks CI**: Cargo test runs complete in normal timeframes instead of timing out
- **Maintains coverage**: The same clipboard functionality is already tested through integration test paths in the app's main flow and in `src/tui/home/tests.rs`, which don't spawn subprocesses
- **Foundation for future improvement**: The removed tests can be recovered later by either mocking the subprocess calls or marking them as ignored tests

## Technical Note

This is a pragmatic solution that removes problematic unit tests in favor of existing integration test coverage that exercises the same code paths without the subprocess side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1518?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->