### PR TITLE
feat(tui): configurable single-click action on session rows

### DIFF
--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -624,6 +624,31 @@ pub struct SessionConfig {
     /// existing activation paths (terminal attach, cockpit open).
     #[serde(default)]
     pub default_attach_mode: NewSessionAttachMode,
+
+    /// What a single mouse click on a session row does in the Agent
+    /// view. `LiveSend` (default) enters live-send mode for that row,
+    /// the historical behavior. `SelectOnly` just moves the cursor
+    /// to the row so the user can read the preview without ever
+    /// entering live-send. Double-click still activates via
+    /// `default_attach_mode` regardless of this setting.
+    #[serde(default)]
+    pub click_action: ClickAction,
+}
+
+/// What a single mouse click on a session row does in the Agent view.
+/// See `SessionConfig::click_action`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ClickAction {
+    /// Single-click enters live-send mode for the clicked session
+    /// (the historical behavior on `main` before this setting landed).
+    #[default]
+    LiveSend,
+    /// Single-click only moves the cursor to the clicked row, so the
+    /// user can browse session previews without entering live-send.
+    /// Double-click still activates the session via the configured
+    /// `default_attach_mode`.
+    SelectOnly,
 }
 
 /// What the TUI does after a new session is created. See
@@ -686,6 +711,7 @@ impl Default for SessionConfig {
             live_send_exit_chord: default_live_send_exit_chord(),
             new_session_attach_mode: NewSessionAttachMode::default(),
             default_attach_mode: NewSessionAttachMode::default(),
+            click_action: ClickAction::default(),
         }
     }
 }

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -21,7 +21,7 @@ pub use crate::sound::{SoundConfig, SoundConfigOverride};
 pub use crate::status_hooks::{StatusHookConfig, StatusHookConfigOverride};
 pub(crate) use capture::is_valid_session_id;
 pub use config::{
-    get_update_settings, load_config, save_config, validate_snooze_duration, Config,
+    get_update_settings, load_config, save_config, validate_snooze_duration, ClickAction, Config,
     ContainerRuntimeName, DefaultTerminalMode, GroupByMode, NewSessionAttachMode, RowTagMode,
     SandboxConfig, SessionConfig, ThemeConfig, TmuxClipboardMode, TmuxMouseMode, TmuxStatusBarMode,
     UpdatesConfig, WorktreeConfig,

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -263,6 +263,9 @@ pub struct SessionConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_attach_mode: Option<super::config::NewSessionAttachMode>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub click_action: Option<super::config::ClickAction>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -501,6 +504,9 @@ pub fn apply_session_overrides(
     }
     if let Some(default_attach_mode) = source.default_attach_mode {
         target.default_attach_mode = default_attach_mode;
+    }
+    if let Some(click_action) = source.click_action {
+        target.click_action = click_action;
     }
 }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2896,18 +2896,30 @@ impl HomeView {
                 self.toggle_group_collapsed(&path);
                 None
             }
-            Item::Session { .. } => {
+            Item::Session { id, .. } => {
                 if self.cursor != abs_idx {
                     self.cursor = abs_idx;
                     self.update_selected();
                 }
-                // Single-click on a session row enters live-send for
-                // that row, or switches the live target when already in
-                // live mode. `start_live_send` returns None for rows
-                // that can't host live mode (cockpit, creating/deleting)
-                // and for re-clicks on the already-live session, so the
-                // click is just a selection in those cases.
-                self.start_live_send()
+                // Single-click behavior is user-configurable via
+                // `SessionConfig::click_action`. `LiveSend` (default,
+                // historical behavior) enters live-send for the clicked
+                // row, or switches the live target when already in live
+                // mode. `SelectOnly` stops at the cursor update above so
+                // the user can browse preview content without ever
+                // entering live-send; double-click still activates via
+                // `default_attach_mode`. `click_action` returns `None`
+                // for cockpit-mode sessions, where `start_live_send`
+                // already short-circuits, so the historical fall-through
+                // is fine.
+                if matches!(
+                    self.click_action(&id),
+                    Some(crate::session::ClickAction::SelectOnly)
+                ) {
+                    None
+                } else {
+                    self.start_live_send()
+                }
             }
         }
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3117,81 +3117,65 @@ impl HomeView {
             .unwrap_or_else(crate::session::config::resolve_default_profile)
     }
 
+    /// Resolve the effective `SessionConfig` for an existing session
+    /// row, honoring per-profile overrides. Reads the instance's
+    /// `source_profile` so the picked config matches whatever profile
+    /// the session was filed under (the home view's active profile may
+    /// already have moved on); falls back to `config_profile()` when
+    /// the instance has no recorded profile. Returns `None` for
+    /// cockpit-mode sessions because the attach-mode / click-action
+    /// settings all have cockpit-specific bypass paths upstream;
+    /// callers treat `None` as "skip this setting, the cockpit path
+    /// handles activation."
+    fn resolve_session_config_for(
+        &self,
+        session_id: &str,
+    ) -> Option<crate::session::SessionConfig> {
+        let inst = self.get_instance(session_id)?;
+        if inst.is_cockpit_mode() {
+            return None;
+        }
+        let profile = if inst.source_profile.is_empty() {
+            self.config_profile()
+        } else {
+            inst.source_profile.clone()
+        };
+        Some(crate::session::resolve_config_or_warn(&profile).session)
+    }
+
     /// Resolve `new_session_attach_mode` for a freshly-created session.
-    /// Reads the instance's `source_profile` so the picked mode matches
-    /// whatever profile the session was filed under (the home view's
-    /// active profile may already have moved on). Returns `None` for
-    /// cockpit-mode sessions because neither attach option applies to
-    /// them; callers should fall through to the cockpit-aware path.
+    /// See `resolve_session_config_for` for the profile-resolution and
+    /// cockpit-bypass rules.
     pub fn new_session_attach_mode(
         &self,
         session_id: &str,
     ) -> Option<crate::session::NewSessionAttachMode> {
-        let inst = self.get_instance(session_id)?;
-        if inst.is_cockpit_mode() {
-            return None;
-        }
-        let profile = if inst.source_profile.is_empty() {
-            self.config_profile()
-        } else {
-            inst.source_profile.clone()
-        };
-        Some(
-            crate::session::resolve_config_or_warn(&profile)
-                .session
-                .new_session_attach_mode,
-        )
+        self.resolve_session_config_for(session_id)
+            .map(|s| s.new_session_attach_mode)
     }
 
     /// Resolve `click_action` for an existing session row when the
-    /// user single-clicks it in the Agent view. Reads the instance's
-    /// `source_profile` so the picked mode matches whatever profile
-    /// the session was filed under. Returns `None` for cockpit-mode
-    /// sessions because `start_live_send` already short-circuits on
-    /// them; callers can treat `None` as "fall through to the
-    /// historical live-send path."
+    /// user single-clicks it in the Agent view. See
+    /// `resolve_session_config_for` for resolution rules; `None`
+    /// (cockpit) is treated by the caller as "fall through to the
+    /// historical live-send path," which `start_live_send` itself
+    /// short-circuits for cockpit anyway.
     pub(super) fn click_action(&self, session_id: &str) -> Option<crate::session::ClickAction> {
-        let inst = self.get_instance(session_id)?;
-        if inst.is_cockpit_mode() {
-            return None;
-        }
-        let profile = if inst.source_profile.is_empty() {
-            self.config_profile()
-        } else {
-            inst.source_profile.clone()
-        };
-        Some(
-            crate::session::resolve_config_or_warn(&profile)
-                .session
-                .click_action,
-        )
+        self.resolve_session_config_for(session_id)
+            .map(|s| s.click_action)
     }
 
     /// Resolve `default_attach_mode` for an existing session row when
     /// the user activates it (Enter / double-click) in the Agent view.
-    /// Reads the instance's `source_profile` so the picked mode matches
-    /// whatever profile the session was filed under. Returns `None`
-    /// for cockpit-mode sessions because cockpit has its own activation
-    /// path that bypasses both tmux attach and live-send; callers should
-    /// short-circuit to that path before consulting this setting.
+    /// See `resolve_session_config_for` for resolution rules; callers
+    /// short-circuit to the cockpit-specific activation path before
+    /// consulting this setting.
     pub(super) fn default_attach_mode(
         &self,
         session_id: &str,
     ) -> Option<crate::session::NewSessionAttachMode> {
-        let inst = self.get_instance(session_id)?;
-        if inst.is_cockpit_mode() {
-            return None;
-        }
-        let profile = if inst.source_profile.is_empty() {
-            self.config_profile()
-        } else {
-            inst.source_profile.clone()
-        };
-        Some(
-            crate::session::resolve_config_or_warn(&profile)
-                .session
-                .default_attach_mode,
-        )
+        self.resolve_session_config_for(session_id)
+            .map(|s| s.default_attach_mode)
     }
 
     /// Pin selection to `session_id` and place the cursor on its row.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3143,6 +3143,30 @@ impl HomeView {
         )
     }
 
+    /// Resolve `click_action` for an existing session row when the
+    /// user single-clicks it in the Agent view. Reads the instance's
+    /// `source_profile` so the picked mode matches whatever profile
+    /// the session was filed under. Returns `None` for cockpit-mode
+    /// sessions because `start_live_send` already short-circuits on
+    /// them; callers can treat `None` as "fall through to the
+    /// historical live-send path."
+    pub(super) fn click_action(&self, session_id: &str) -> Option<crate::session::ClickAction> {
+        let inst = self.get_instance(session_id)?;
+        if inst.is_cockpit_mode() {
+            return None;
+        }
+        let profile = if inst.source_profile.is_empty() {
+            self.config_profile()
+        } else {
+            inst.source_profile.clone()
+        };
+        Some(
+            crate::session::resolve_config_or_warn(&profile)
+                .session
+                .click_action,
+        )
+    }
+
     /// Resolve `default_attach_mode` for an existing session row when
     /// the user activates it (Enter / double-click) in the Agent view.
     /// Reads the instance's `source_profile` so the picked mode matches

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4817,6 +4817,35 @@ mod click_to_select {
 
     #[test]
     #[serial]
+    fn select_only_click_moves_cursor_without_entering_live_mode() {
+        // With `click_action = SelectOnly`, a single click must move the
+        // cursor (so the preview pane updates) but NOT emit
+        // EnterLiveSend. Double-click + Enter still activate the row,
+        // but that path is gated by `default_attach_mode`, not this
+        // setting, so it's exercised elsewhere.
+        use crate::session::config::{save_config, ClickAction, Config};
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let mut config = Config::default();
+        config.session.click_action = ClickAction::SelectOnly;
+        save_config(&config).unwrap();
+
+        let action = env.view.handle_click(5, 3);
+        assert_eq!(
+            action, None,
+            "SelectOnly must not emit EnterLiveSend on single click"
+        );
+        assert_eq!(
+            env.view.cursor, 2,
+            "SelectOnly must still move the cursor to the clicked row"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn click_on_already_selected_row_does_not_move_cursor() {
         let mut env = create_test_env_with_sessions(3);
         setup_inner(&mut env);

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4846,6 +4846,76 @@ mod click_to_select {
 
     #[test]
     #[serial]
+    fn select_only_click_honors_per_profile_override() {
+        // Global stays LiveSend (default) but the test profile pins
+        // SelectOnly via SessionConfigOverride. The resolver must
+        // pick the profile override, not the global default, so a
+        // single click returns None and the cursor still moves.
+        use crate::session::config::ClickAction;
+        use crate::session::profile_config::{
+            save_profile_config, ProfileConfig, SessionConfigOverride,
+        };
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let profile_config = ProfileConfig {
+            session: Some(SessionConfigOverride {
+                click_action: Some(ClickAction::SelectOnly),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        save_profile_config("test", &profile_config).unwrap();
+
+        let action = env.view.handle_click(5, 3);
+        assert_eq!(
+            action, None,
+            "per-profile SelectOnly must override the LiveSend global default"
+        );
+        assert_eq!(env.view.cursor, 2);
+    }
+
+    #[test]
+    #[serial]
+    fn double_click_still_attaches_under_select_only() {
+        // Defensive: `SelectOnly` only changes single-click; double-click
+        // must still activate the row via `default_attach_mode` (Tmux by
+        // default, so we expect AttachSession). Locks down the
+        // separation between the two settings so a future refactor
+        // can't accidentally route double-click through `click_action`.
+        use crate::session::config::{save_config, ClickAction, Config};
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        let mut config = Config::default();
+        config.session.click_action = ClickAction::SelectOnly;
+        save_config(&config).unwrap();
+
+        let t0 = std::time::Instant::now();
+        let first = env.view.handle_click_at(t0, 5, 3);
+        assert_eq!(
+            first, None,
+            "first click under SelectOnly must not emit an action"
+        );
+        let t1 = t0 + std::time::Duration::from_millis(100);
+        let second = env.view.handle_click_at(t1, 5, 3);
+        let expected_id = match &env.view.flat_items[2] {
+            crate::session::Item::Session { id, .. } => id.clone(),
+            _ => panic!("flat_items[2] should be a session"),
+        };
+        assert_eq!(
+            second,
+            Some(crate::tui::app::Action::AttachSession(expected_id)),
+            "double-click must still activate via default_attach_mode (Tmux)"
+        );
+    }
+
+    #[test]
+    #[serial]
     fn click_on_already_selected_row_does_not_move_cursor() {
         let mut env = create_test_env_with_sessions(3);
         setup_inner(&mut env);

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -108,6 +108,7 @@ pub enum FieldKey {
     LiveSendExitChord,
     NewSessionAttachMode,
     DefaultAttachMode,
+    ClickAction,
     // Sound
     SoundEnabled,
     SoundMode,
@@ -429,6 +430,28 @@ fn index_to_new_session_attach_mode(idx: usize) -> crate::session::NewSessionAtt
     match idx {
         1 => LiveSend,
         _ => Tmux,
+    }
+}
+
+/// Display labels for `ClickAction`. Order must match
+/// `click_action_to_index` / `index_to_click_action`. `LiveSend` is
+/// first so it is the default selection (matches the historical
+/// single-click-enters-live behavior).
+const CLICK_ACTION_OPTIONS: &[&str] = &["Live mode", "Select only"];
+
+fn click_action_to_index(mode: crate::session::ClickAction) -> usize {
+    use crate::session::ClickAction::*;
+    match mode {
+        LiveSend => 0,
+        SelectOnly => 1,
+    }
+}
+
+fn index_to_click_action(idx: usize) -> crate::session::ClickAction {
+    use crate::session::ClickAction::*;
+    match idx {
+        1 => SelectOnly,
+        _ => LiveSend,
     }
 }
 
@@ -1918,6 +1941,12 @@ fn build_interaction_fields(
         session.and_then(|s| s.default_attach_mode),
     );
 
+    let (click_action, click_action_override) = resolve_value(
+        scope,
+        global.session.click_action,
+        session.and_then(|s| s.click_action),
+    );
+
     vec![
         SettingField {
             key: FieldKey::DefaultAttachMode,
@@ -1974,6 +2003,29 @@ fn build_interaction_fields(
                         .iter()
                         .map(|s| s.to_string())
                         .collect(),
+                },
+            ),
+        },
+        SettingField {
+            key: FieldKey::ClickAction,
+            label: "Mouse Click Action",
+            description: "What a single mouse click on a session row does in the \
+                 Agent view. `Live mode` (default) enters live-send for the \
+                 clicked row, the historical behavior. `Select only` just \
+                 moves the cursor so you can read the preview without ever \
+                 entering live-send. Double-click still activates via Default \
+                 Attach Mode regardless of this setting.",
+            value: FieldValue::Select {
+                selected: click_action_to_index(click_action),
+                options: CLICK_ACTION_OPTIONS.iter().map(|s| s.to_string()).collect(),
+            },
+            category: SettingsCategory::Interaction,
+            has_override: click_action_override,
+            inherited_display: inherited_if(
+                click_action_override,
+                FieldValue::Select {
+                    selected: click_action_to_index(global.session.click_action),
+                    options: CLICK_ACTION_OPTIONS.iter().map(|s| s.to_string()).collect(),
                 },
             ),
         },
@@ -2478,6 +2530,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
         (FieldKey::DefaultAttachMode, FieldValue::Select { selected, .. }) => {
             config.session.default_attach_mode = index_to_new_session_attach_mode(*selected);
         }
+        (FieldKey::ClickAction, FieldValue::Select { selected, .. }) => {
+            config.session.click_action = index_to_click_action(*selected);
+        }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
             config.session.row_tag = index_to_row_tag(*selected);
         }
@@ -2965,6 +3020,13 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 index_to_new_session_attach_mode(*selected),
                 &mut config.session,
                 |s, val| s.default_attach_mode = val,
+            );
+        }
+        (FieldKey::ClickAction, FieldValue::Select { selected, .. }) => {
+            set_profile_override(
+                index_to_click_action(*selected),
+                &mut config.session,
+                |s, val| s.click_action = val,
             );
         }
         (FieldKey::RowTag, FieldValue::Select { selected, .. }) => {
@@ -3651,6 +3713,7 @@ mod tests {
         for k in [
             FieldKey::DefaultAttachMode,
             FieldKey::NewSessionAttachMode,
+            FieldKey::ClickAction,
             FieldKey::LiveSendExitChord,
         ] {
             assert!(
@@ -3680,6 +3743,7 @@ mod tests {
             FieldKey::AgentStatusHooks,
             FieldKey::DefaultAttachMode,
             FieldKey::NewSessionAttachMode,
+            FieldKey::ClickAction,
             FieldKey::LiveSendExitChord,
         ] {
             assert!(

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -782,6 +782,11 @@ impl SettingsView {
                     s.default_attach_mode = None;
                 }
             }
+            FieldKey::ClickAction => {
+                if let Some(ref mut s) = config.session {
+                    s.click_action = None;
+                }
+            }
             FieldKey::RowTag => {
                 if let Some(ref mut s) = config.session {
                     s.row_tag = None;


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Adds a new **Mouse Click Action** setting (Interaction tab) that lets users pick what a single mouse click on a session row does:

- **Live mode** (default, current behavior): single-click enters live-send for the clicked row, matching how `main` behaves today.
- **Select only**: single-click only moves the cursor, so the user can browse session previews without ever entering live-send. Double-click still activates the row via the existing **Default Attach Mode** setting (tmux attach or live-send), so the activation path is unchanged.

Wired through the standard global + per-profile path:

- `ClickAction` enum on `SessionConfig` (default `LiveSend` so no UX change on upgrade) and a matching `Option<ClickAction>` on `SessionConfigOverride` + merge.
- `FieldKey::ClickAction` in the Interaction settings tab, with apply-to-global, apply-to-profile, and clear-profile-override arms.
- New `HomeView::click_action()` resolver mirroring `default_attach_mode()`, consulted in `handle_click_at` so `SelectOnly` returns early after the cursor update without emitting `Action::EnterLiveSend`.

Cockpit-mode sessions ignore the setting (the resolver returns `None`), matching how `default_attach_mode` already handles them.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo fmt`, `cargo clippy --features serve --all-targets`, `cargo test --lib --features serve`: 2801 passed)
- [x] Documentation was updated where necessary (the settings TUI surfaces the description text inline; no separate docs change needed)
- [x] For UI changes: included screenshot or recording (N/A: TUI-only, the new control is a standard Select field in the existing Interaction tab)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the click handler has dense unit coverage in `src/tui/home/tests.rs::click_to_select`. I added `select_only_click_moves_cursor_without_entering_live_mode` there, which writes a `ClickAction::SelectOnly` config and asserts the cursor still moves while `handle_click` returns `None`. The behavior is pure dispatch on a config value with no tmux/render side effects, so the unit-level coverage is the right granularity.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (claude-opus-4-7, 1M context)

**Any Additional AI Details you'd like to share:**
Claude wrote the implementation and the unit test under interactive direction. Decisions (the two-option Live mode vs Select only design, global + per-profile scope to match the existing attach-mode pattern, default of LiveSend to preserve current UX on upgrade) were mine. Claude verified `cargo fmt`, `cargo clippy --features serve --all-targets`, and `cargo test --lib --features serve` all clean before this PR was opened.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR adds a configurable "Mouse Click Action" setting that controls what a single mouse click on a session row does. Default behavior remains "Live mode" (single-click enters live-send). The new "Select only" mode makes a single click only move the cursor/selection and preview; double-click still activates the session via the existing attach behavior.

What changed (high-level)

- New user-facing setting: "Mouse Click Action" on the Interaction settings tab with two options: Live mode (default) and Select only.
- SessionConfig extended with a new ClickAction enum (LiveSend, SelectOnly) and default set to LiveSend.
- SessionConfigOverride now supports an optional click_action for per-profile overrides; merge logic applies overrides when present.
- Home view:
  - Added resolve_session_config_for helper to centralize session-config resolution and cockpit-mode short-circuiting.
  - Added HomeView::click_action(session_id) to compute the effective click action.
  - HomeView::handle_click_at consults the click action and, for SelectOnly, only updates the cursor/selection without emitting EnterLiveSend.
  - Cockpit-mode sessions ignore this setting (resolver returns None), matching existing default attach-mode behavior.
- Settings UI:
  - New FieldKey::ClickAction and UI wiring (options, index mapping, apply-to-global/profile, clear-profile-override).
  - Settings apply/clear code updated to persist global and per-profile values.
- Tests:
  - New and updated tests verifying select-only single-click behavior, per-profile override precedence, and that double-click still triggers attach.

Technical details (concise)

- Added public enum ClickAction { LiveSend, SelectOnly } and SessionConfig.click_action with ClickAction::default() = LiveSend.
- SessionConfigOverride.click_action: Option<ClickAction> uses existing "None means inherit" semantics; apply_session_overrides merges it into effective config.
- resolve_session_config_for centralizes instance lookup, cockpit bypass, profile fallback and warnings; new resolvers (new_session_attach_mode, default_attach_mode, click_action) wrap it.
- handle_click_at: after moving cursor/selection, if click_action == SelectOnly, return early to avoid emitting Action::EnterLiveSend.
- Cockpit-mode sessions: resolver returns None so behavior remains unchanged.
- Tests: select_only_click_moves_cursor_without_entering_live_mode plus regression tests for per-profile override and double-click behavior.

Benefits

- Preserves current default for backward compatibility while giving users control to avoid accidental live-send activation.
- Improves usability when browsing session previews (single-click no longer forces mode change).
- Supports profile-level customization for team or workflow differences.
- Reuses existing configuration and override patterns; code refactor centralizes resolution logic and reduces duplication.

Potential areas for further improvement

- Document the new setting in user-facing docs/CHANGELOG (the TUI surfaces an inline description; consider a docs entry).
- Consider exposing click-action mapping in keyboard/shortcut documentation or accessibility notes.
- Evaluate whether other views or modes should respect the same click-action semantics beyond HomeView.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->