### PR TITLE
fix(tui): keep live-mode entry frame from rendering shifted up

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -1629,21 +1629,27 @@ impl App {
                     .set_instance_status(&id, crate::session::Status::Starting);
                 self.update_status = Some(UpdateStatus::transient("Reviving session...".into()));
                 self.draw(terminal)?;
-                let outcome = self.home.enter_live_send(&id);
-                match outcome {
-                    Ok(Some(sid)) => {
-                        self.update_status = Some(UpdateStatus::transient(format!(
-                            "Resume failed for sid {sid}; live-send sent to a fresh pane (history not loaded)"
-                        )));
-                    }
-                    Ok(None) => {
-                        self.update_status = None;
-                    }
-                    Err(()) => {
-                        // enter_live_send already surfaced the failure via
-                        // info_dialog; just clear the transient toast.
-                        self.update_status = None;
-                    }
+                let outcome = self.home.prepare_live_send(&id);
+                // Settle the toast to its final state BEFORE the sync resize
+                // and redraw, so HomeView's cached `preview_pane_area`
+                // matches the geometry the user will see for the next
+                // several frames. Otherwise the toast row that was on screen
+                // during `prepare_live_send` would make the preview pane one
+                // row shorter than post-toast, the sync resize would target
+                // the smaller pane, and the first capture would render
+                // shifted up.
+                self.update_status = match &outcome {
+                    Ok(Some(sid)) => Some(UpdateStatus::transient(format!(
+                        "Resume failed for sid {sid}; live-send sent to a fresh pane (history not loaded)"
+                    ))),
+                    // On clean ready, drop the toast entirely. On Err the
+                    // info_dialog already carries the failure detail, so the
+                    // transient toast just gets in the way.
+                    Ok(None) | Err(()) => None,
+                };
+                if outcome.is_ok() {
+                    self.draw(terminal)?;
+                    self.home.finalize_live_send_resize();
                 }
             }
             Action::AttachToolSession(id, tool_name) => {

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -599,4 +599,80 @@ mod tests {
             Some(" [80/80] ".to_string())
         );
     }
+
+    // `agent_info_height` drives both the preview layout split in
+    // `render_with_cache` and the live-send sync resize in
+    // `HomeView::finalize_live_send_resize`. A one-row drift here brings
+    // the shifted-preview bug right back, so each branch of the formula
+    // gets a dedicated case.
+    mod agent_info_height {
+        use super::super::agent_info_height;
+        use crate::session::{Instance, SandboxInfo, WorktreeInfo};
+        use chrono::Utc;
+
+        fn worktree(base_branch: Option<&str>) -> WorktreeInfo {
+            WorktreeInfo {
+                branch: "feature/x".into(),
+                main_repo_path: "/repo".into(),
+                managed_by_aoe: true,
+                created_at: Utc::now(),
+                base_branch: base_branch.map(str::to_string),
+            }
+        }
+
+        fn enabled_sandbox() -> SandboxInfo {
+            SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "img".into(),
+                container_name: "ctr".into(),
+                extra_env: None,
+                custom_instruction: None,
+            }
+        }
+
+        #[test]
+        fn plain_session_is_three_rows() {
+            let inst = Instance::new("plain", "/tmp/plain");
+            assert_eq!(agent_info_height(&inst), 3);
+        }
+
+        #[test]
+        fn sandboxed_adds_one_row() {
+            let mut inst = Instance::new("sandboxed", "/tmp/sandboxed");
+            inst.sandbox_info = Some(enabled_sandbox());
+            assert_eq!(agent_info_height(&inst), 4);
+        }
+
+        #[test]
+        fn worktree_without_base_branch_adds_four_rows() {
+            let mut inst = Instance::new("wt", "/tmp/wt");
+            inst.worktree_info = Some(worktree(None));
+            assert_eq!(agent_info_height(&inst), 3 + 4);
+        }
+
+        #[test]
+        fn worktree_with_base_branch_adds_five_rows() {
+            let mut inst = Instance::new("wt-base", "/tmp/wt-base");
+            inst.worktree_info = Some(worktree(Some("main")));
+            assert_eq!(agent_info_height(&inst), 3 + 4 + 1);
+        }
+
+        #[test]
+        fn sandboxed_plus_worktree_with_base_branch_is_max() {
+            let mut inst = Instance::new("both", "/tmp/both");
+            inst.sandbox_info = Some(enabled_sandbox());
+            inst.worktree_info = Some(worktree(Some("main")));
+            assert_eq!(agent_info_height(&inst), 3 + 1 + 4 + 1);
+        }
+
+        #[test]
+        fn disabled_sandbox_does_not_count() {
+            let mut inst = Instance::new("disabled", "/tmp/disabled");
+            let mut sandbox = enabled_sandbox();
+            sandbox.enabled = false;
+            inst.sandbox_info = Some(sandbox);
+            assert_eq!(agent_info_height(&inst), 3);
+        }
+    }
 }

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -31,6 +31,28 @@ impl<'a> CachedPreview<'a> {
     }
 }
 
+/// Row count of the Agent-view info header (profile/tool, path, status,
+/// optional sandbox line, optional worktree block) for `instance`.
+///
+/// Exposed at the module level so callers outside `Preview::render_with_cache`
+/// can compute the same split — in particular, the live-send sync resize
+/// in `HomeView::finalize_live_send_resize` needs to size the tmux pane
+/// to the OUTPUT portion (inner minus this header), not the full inner.
+/// If the agent renders into the full inner while the output portion is
+/// shorter by `agent_info_height` rows, the top of the agent's output
+/// gets clipped on every frame and the user sees content shifted up.
+pub fn agent_info_height(instance: &Instance) -> u16 {
+    let base: u16 = 3; // profile+tool / path / status
+    let sandbox_lines: u16 = if instance.is_sandboxed() { 1 } else { 0 };
+    if let Some(wt) = instance.worktree_info.as_ref() {
+        // blank + header + branch + main (+ optional base)
+        let base_branch_line: u16 = if wt.base_branch.is_some() { 1 } else { 0 };
+        base + sandbox_lines + 4 + base_branch_line
+    } else {
+        base + sandbox_lines
+    }
+}
+
 pub struct Preview;
 
 impl Preview {
@@ -198,15 +220,7 @@ impl Preview {
             return;
         }
 
-        // 3 base lines (profile+tool / path / status) + optional sandbox + optional worktree block
-        let base = 3;
-        let sandbox_lines = if instance.is_sandboxed() { 1 } else { 0 };
-        let info_height = if let Some(wt) = instance.worktree_info.as_ref() {
-            let base_branch_line = if wt.base_branch.is_some() { 1 } else { 0 };
-            base + sandbox_lines + 4 + base_branch_line // blank + header + branch + main (+ optional base)
-        } else {
-            base + sandbox_lines
-        };
+        let info_height = agent_info_height(instance);
 
         let chunks = Layout::default()
             .direction(Direction::Vertical)

--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -35,7 +35,7 @@ impl<'a> CachedPreview<'a> {
 /// optional sandbox line, optional worktree block) for `instance`.
 ///
 /// Exposed at the module level so callers outside `Preview::render_with_cache`
-/// can compute the same split — in particular, the live-send sync resize
+/// can compute the same split. In particular, the live-send sync resize
 /// in `HomeView::finalize_live_send_resize` needs to size the tmux pane
 /// to the OUTPUT portion (inner minus this header), not the full inner.
 /// If the agent renders into the full inner while the output portion is

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3083,7 +3083,7 @@ impl HomeView {
 
     /// Attempt to enter live-send mode against the currently-selected
     /// session. Unlike `resolve_paste_target`, this does NOT require
-    /// the tmux pane to already exist: `enter_live_send` calls
+    /// the tmux pane to already exist: `prepare_live_send` calls
     /// `ensure_pane_ready` which revives stopped sessions (Docker
     /// start, splash wait, resume cascade). Without this relaxation
     /// Tab would silently no-op on dead-but-recoverable rows and the

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -329,7 +329,7 @@ pub(super) enum WorkerMsg {
 
 /// Background dispatcher: drains a channel of `WorkerMsg`s and runs
 /// each via a one-shot `tmux send-keys` / `resize-window` subprocess
-/// after coalescing with `coalesce`. Spawned on `enter_live_send` and
+/// after coalescing with `coalesce`. Spawned by `prepare_live_send` and
 /// dropped when the user exits live mode; dropping closes the channel,
 /// which makes the worker thread's `recv` return `Err` and exit on the
 /// next iteration. We deliberately do not `join` because the worker is

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -446,8 +446,8 @@ pub struct HomeView {
     pub(super) preview_scroll_offset: u16,
     pub(super) preview_area: Rect,
     /// Sub-rect of `preview_area` where the agent's captured pane content
-    /// is actually painted — i.e. `preview_area` minus the info header
-    /// when the user has it expanded (Agent view, non-compact). When the
+    /// is actually painted: `preview_area` minus the info header when
+    /// the user has it expanded (Agent view, non-compact). When the
     /// info header is hidden or the layout is compact, this matches
     /// `preview_area` exactly.
     ///

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -445,6 +445,19 @@ pub struct HomeView {
     /// Reset to 0 whenever the selected session changes.
     pub(super) preview_scroll_offset: u16,
     pub(super) preview_area: Rect,
+    /// Sub-rect of `preview_area` where the agent's captured pane content
+    /// is actually painted — i.e. `preview_area` minus the info header
+    /// when the user has it expanded (Agent view, non-compact). When the
+    /// info header is hidden or the layout is compact, this matches
+    /// `preview_area` exactly.
+    ///
+    /// `refresh_preview_cache_if_needed` and the live-send sync resize
+    /// both read this so the tmux pane is sized to the visible output
+    /// portion, not the full inner. Sizing to the full inner caused the
+    /// agent to render `info_height` extra rows that the user couldn't
+    /// see; tail-anchored display clipped those rows off the top, so
+    /// every frame in info-expanded mode looked shifted up.
+    pub(super) preview_pane_area: Rect,
     /// Outer rect of the preview pane (block + borders + content), captured
     /// during `render_preview`. The live-send preview-only fast path uses
     /// this to call back into `render_preview` with the correct OUTER area,
@@ -736,6 +749,7 @@ impl HomeView {
             tool_preview_cache: PreviewCache::default(),
             preview_scroll_offset: 0,
             preview_area: Rect::default(),
+            preview_pane_area: Rect::default(),
             preview_outer_area: Rect::default(),
             diff_area: Rect::default(),
             list_area: Rect::default(),
@@ -2427,11 +2441,22 @@ impl HomeView {
     /// then installs `live_send` state so subsequent keystrokes are
     /// captured by `handle_live_send_key`.
     ///
+    /// Geometry-sensitive work is intentionally split out into
+    /// `finalize_live_send_resize`: the caller is expected to settle
+    /// any toast/banner state (which can shift `preview_pane_area` by a
+    /// row) and redraw between `prepare_live_send` and
+    /// `finalize_live_send_resize`, so the sync resize targets the
+    /// geometry the user will actually see for the next several frames.
+    /// Without that split, the "Reviving session..." toast shown during
+    /// this slow phase made `preview_pane_area` one row shorter than
+    /// the post-toast frame, and the agent's first capture rendered
+    /// shifted up.
+    ///
     /// Returns `Ok(Some(stale_sid))` when the resume-fallback cascade
     /// fired during respawn, `Ok(None)` on a clean ready, and `Err(())`
     /// if the pane could not be readied (`info_dialog` is set with the
     /// underlying error so the caller only has to clear its toast).
-    pub fn enter_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
+    pub fn prepare_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
         let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
             inst.ensure_pane_ready().map_err(Into::into)
         });
@@ -2522,66 +2547,78 @@ impl HomeView {
         // pre-#1485 path; control-mode was tried as an optimization
         // but turned out to be unreliable on real-world tmux setups
         // and was removed in favor of this simpler model).
-        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name.clone()));
-        // Synchronously resize the pane to match what the next refresh
-        // will ask for, so the first frame already shows the agent
-        // re-laid-out at the new size. Without this the first frame
-        // captures the OLD pane and frame 2 (after the async worker
-        // resize completes) jumps to the new size: the visible
-        // "shift" the user perceives on entering live mode.
-        //
-        // Use `self.preview_area` (the cached INNER rect) directly.
-        // The preview pane uses `Borders::ALL` + `Padding::horizontal(1)`,
-        // so `inner.width = outer.width - 4` and `inner.height =
-        // outer.height - 2`. Earlier versions of this code subtracted
-        // 2 from both dimensions of `preview_outer_area`, which was off
-        // by 2 columns and caused the very thing it was meant to
-        // prevent: the next refresh saw a different inner.width,
-        // detected the dedup miss, and queued ANOTHER async resize.
+        self.live_send_worker = Some(live_send::LiveSendWorker::spawn(tmux_name));
+        // Clear the resize dedup so `finalize_live_send_resize` always
+        // issues its sync resize, even if the cached geometry from a
+        // prior session happens to match the current preview_pane_area.
         self.live_send_last_resize = None;
-        let inner = self.preview_area;
-        if inner.width > 0 && inner.height > 0 {
-            let resize_status = std::process::Command::new("tmux")
-                .args([
-                    "resize-window",
-                    "-t",
-                    &tmux_name,
-                    "-x",
-                    &inner.width.to_string(),
-                    "-y",
-                    &inner.height.to_string(),
-                ])
-                .stderr(std::process::Stdio::null())
-                .status();
-            // Only register the dedup if the resize subprocess
-            // actually succeeded. If tmux failed (session died
-            // between our state install and now, tmux binary
-            // missing, etc.), leaving `live_send_last_resize` as
-            // None lets the next `refresh_preview_cache_if_needed`
-            // try the resize again through the worker.
-            if matches!(&resize_status, Ok(s) if s.success()) {
-                self.live_send_last_resize = Some((inner.width, inner.height));
-            }
-            // Give the agent ~50ms to handle SIGWINCH and re-lay out
-            // before we capture the first frame. Some agents (claude-
-            // code in particular) do a full clear-screen + redraw on
-            // resize; capturing during that produces a partial frame.
-            // 50ms is the smallest delay that empirically lets the
-            // most-common agents settle.
-            //
-            // Wrap the sleep in `block_in_place` so the tokio
-            // multi-threaded runtime can reschedule any other tasks
-            // off this worker for the duration. Without it, the 50ms
-            // would block every other tokio task (status pollers,
-            // update checks, etc.) from running on this thread. The
-            // call is a no-op on a current-thread runtime; aoe
-            // always uses multi-threaded (`#[tokio::main]`).
-            tokio::task::block_in_place(|| {
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            });
-        }
         self.stamp_last_accessed(session_id);
         Ok(stale_sid)
+    }
+
+    /// Synchronously resize the live-send pane to match `self.preview_pane_area`,
+    /// then block for ~50 ms so the agent has time to handle SIGWINCH and
+    /// re-lay out before the next preview capture.
+    ///
+    /// Must be called after `prepare_live_send` returns `Ok(_)` and after
+    /// the caller has redrawn the frame in the post-toast geometry the
+    /// user will see for the next several frames. See `prepare_live_send`
+    /// for why the two are split.
+    ///
+    /// `preview_pane_area` is the cached OUTPUT sub-rect: the full inner
+    /// (after border + padding) minus the Agent-view info header when the
+    /// user has it expanded. Sizing to the full inner instead would leave
+    /// the top `info_height` rows of the agent's output outside the
+    /// visible window; tail-clip semantics in the preview's `Paragraph`
+    /// render then drop those rows on every frame, which the user
+    /// perceives as content shifted up.
+    pub fn finalize_live_send_resize(&mut self) {
+        let Some(state) = self.live_send.as_ref() else {
+            return;
+        };
+        let tmux_name = state.tmux_name.clone();
+        let pane = self.preview_pane_area;
+        if pane.width == 0 || pane.height == 0 {
+            return;
+        }
+        let resize_status = std::process::Command::new("tmux")
+            .args([
+                "resize-window",
+                "-t",
+                &tmux_name,
+                "-x",
+                &pane.width.to_string(),
+                "-y",
+                &pane.height.to_string(),
+            ])
+            .stderr(std::process::Stdio::null())
+            .status();
+        // Only register the dedup if the resize subprocess actually
+        // succeeded. If tmux failed (session died between our state
+        // install and now, tmux binary missing, etc.), leaving
+        // `live_send_last_resize` as None lets the next
+        // `refresh_preview_cache_if_needed` try the resize again
+        // through the worker.
+        if matches!(&resize_status, Ok(s) if s.success()) {
+            self.live_send_last_resize = Some((pane.width, pane.height));
+        }
+        // Give the agent ~50ms to handle SIGWINCH and re-lay out
+        // before we capture the first frame. Some agents (claude-
+        // code in particular) do a full clear-screen + redraw on
+        // resize; capturing during that produces a partial frame.
+        // 50ms is the smallest delay that empirically lets the
+        // most-common agents settle.
+        //
+        // Wrap the sleep in `block_in_place` so the tokio
+        // multi-threaded runtime can reschedule any other tasks
+        // off this worker for the duration. Without it, the 50ms
+        // would block every other tokio task (status pollers,
+        // update checks, etc.) from running on this thread. The
+        // call is a no-op on a current-thread runtime; aoe
+        // always uses multi-threaded (`#[tokio::main]`).
+        tokio::task::block_in_place(|| {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        });
     }
 
     pub fn save(&mut self) -> anyhow::Result<()> {

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1996,11 +1996,13 @@ impl HomeView {
                 live_send::display_chord_list(&state.exit_chords)
             };
             let suffix = " to exit ";
-            // Match the preview pane's visible_height calculation
-            // (`area.height - 2` for borders, then `- 1` for the
-            // compact branch in render_output_cached) so the indicator
-            // count stays consistent as the user scrolls.
-            let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(3);
+            // `preview_cache.dimensions` is the output pane area passed to
+            // `refresh_preview_cache_if_needed`, and `render_output_cached`
+            // uses `area.height - 1` as its visible height (one row of
+            // headroom for the inner " Output " banner / compact-branch
+            // padding). Match that here so the live `[offset/max]`
+            // indicator agrees with the actual scroll math.
+            let visible_height = (self.preview_cache.dimensions.1 as usize).saturating_sub(1);
             let scroll = format_scroll_indicator(
                 self.preview_cache.captured_lines,
                 visible_height,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::session::config::{GroupByMode, SortOrder};
 use crate::session::{Item, Status};
-use crate::tui::components::preview::CachedPreview;
+use crate::tui::components::preview::{self, CachedPreview};
 use crate::tui::components::{
     format_scroll_indicator, set_prefixed_input_cursor_position, HelpOverlay, Preview,
 };
@@ -428,6 +428,7 @@ impl HomeView {
         // Diff view takes over the whole screen
         if self.diff_view.is_some() {
             self.preview_area = Rect::default();
+            self.preview_pane_area = Rect::default();
             self.preview_outer_area = Rect::default();
             self.diff_area = self.active_diff_area(area);
         }
@@ -1597,6 +1598,14 @@ impl HomeView {
         // the inner there draws a nested block.
         self.preview_outer_area = area;
         self.diff_area = Rect::default();
+        // The agent-pane sub-rect of `inner`: full inner when the info
+        // header is hidden or the layout is compact, otherwise inner
+        // shifted down past the info section. `Preview::render_with_cache`
+        // splits the same way internally, so this mirrors what the user
+        // actually sees and is what we size the tmux pane to in live mode.
+        // Default to `inner`; the Agent branch below refines it if it can
+        // resolve the selected instance.
+        self.preview_pane_area = inner;
         frame.render_widget(block, area);
 
         match self.view_mode {
@@ -1611,13 +1620,38 @@ impl HomeView {
                 if is_creating {
                     self.render_creating_preview(frame, inner, theme);
                 } else {
+                    // Mirror the info-vs-output split in
+                    // `Preview::render_with_cache` so the cache + tmux pane
+                    // match the visible output area. Sizing to the full
+                    // `inner` while the user has the info header expanded
+                    // leaves the top `info_height` rows of the agent's
+                    // pane outside the displayed window, where they get
+                    // tail-clipped on every frame.
+                    let pane_area = if compact || !self.show_preview_info {
+                        inner
+                    } else {
+                        self.selected_session
+                            .as_ref()
+                            .and_then(|id| self.get_instance(id))
+                            .map(|inst| {
+                                let info_h = preview::agent_info_height(inst).min(inner.height);
+                                Rect {
+                                    x: inner.x,
+                                    y: inner.y + info_h,
+                                    width: inner.width,
+                                    height: inner.height - info_h,
+                                }
+                            })
+                            .unwrap_or(inner)
+                    };
+                    self.preview_pane_area = pane_area;
                     // Refresh the raw `content` cache, then ensure the
                     // parsed `Text<'static>` cache reflects it. Doing
                     // the parse here (under `&mut self.preview_cache`)
                     // means subsequent shared borrows on
                     // `parsed_text` and on `self.get_instance` can
                     // coexist in the actual render call.
-                    self.refresh_preview_cache_if_needed(inner.width, inner.height);
+                    self.refresh_preview_cache_if_needed(pane_area.width, pane_area.height);
                     self.preview_cache.ensure_parsed();
 
                     if let Some(id) = &self.selected_session {

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5211,7 +5211,7 @@ mod click_to_select {
     }
 
     /// Clicking the row that is already the live-send target is a
-    /// no-op: re-running `enter_live_send` would drop the worker and
+    /// no-op: re-running `prepare_live_send` would drop the worker and
     /// re-do ensure_pane_ready for no reason.
     #[test]
     #[serial]
@@ -6281,7 +6281,7 @@ mod live_send_mode {
     fn tab_emits_enter_live_send_for_stopped_session() {
         // start_live_send is intentionally permissive: it accepts any
         // non-Creating instance and defers ensure_pane_ready to
-        // enter_live_send. Without this, Tab would silently no-op on
+        // prepare_live_send. Without this, Tab would silently no-op on
         // stopped/dead-but-recoverable rows because the tmux session
         // doesn't exist yet.
         let mut env = create_test_env_with_sessions(1);


### PR DESCRIPTION
## Description

When entering live mode (Tab on a session row), the first frame would sometimes render with the agent's output anchored too high in the preview pane. Exiting and re-entering live mode "fixed" it. Two compounding causes, fixed together.

**1. Toast-row geometry mismatch.** `Action::EnterLiveSend` sets a `"Reviving session..."` transient toast and calls `draw()` before invoking `enter_live_send`. That toast adds a bottom status row, shrinking the preview by one row. The sync `tmux resize-window` inside `enter_live_send` then read `self.preview_area` from the toast frame and targeted geometry that didn't match what the user would see one frame later, after the toast cleared. Intermittency tracks whether the persistent update-available banner was already keeping `has_update_bar = true` (which masks the effect).

Split `enter_live_send` into `prepare_live_send` (slow path: `ensure_pane_ready`, install state, spawn worker) and `finalize_live_send_resize` (sync tmux resize + 50ms SIGWINCH-settle sleep). The handler now settles the toast to its final state (either `"Resume failed..."` or `None`) and redraws between the two halves, so the resize geometry matches the post-toast frame the user actually sees for the next several frames.

**2. Info-panel sizing.** `refresh_preview_cache_if_needed` and the sync resize both sized the tmux pane to the full preview inner. `Preview::render_with_cache` splits that inner into an info header + output sub-rect when the user has the info panel expanded (Agent view, non-compact). The agent rendered `info_height` more rows than were visible; tail-anchored `Paragraph::scroll` then dropped those rows off the top of every frame, making content look shifted up even after entry settled.

Add a `preview_pane_area` field that mirrors the info-vs-output split, factor `agent_info_height` into a module-level helper in `preview.rs`, and route both the worker resize and the sync resize through the new sub-rect.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (`cargo test --lib`: 2214 passed)
- [x] Documentation was updated where necessary (in-code docstrings on `prepare_live_send`, `finalize_live_send_resize`, `preview_pane_area`, `agent_info_height`)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the visible symptom requires asserting that the agent's bottom row lands on the preview's last row across two successive frames immediately after `EnterLiveSend`. The existing `TuiTestHarness` captures screen text but doesn't expose per-frame geometry or cell-row anchoring, and the shift on a real agent depends on `info_height` + `agent_info_height` returning the same values the renderer uses. Happy to add the harness plumbing in a follow-up if reviewers want it.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:** Pair-debugged the root cause (toast-row mismatch + info-panel sizing) and refactored `enter_live_send` into `prepare`/`finalize` halves. Verified locally with `cargo fmt --check`, `cargo clippy --tests`, and `cargo test --lib`.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes an intermittent TUI bug where the first frame after entering live mode could render the agent output shifted upward. Two root causes were addressed: a toast/resize timing mismatch during live-entry, and incorrect preview sizing when the info panel is expanded.

## What changed (high level)
- Split live-send startup into two steps:
  - prepare_live_send: install state and spawn the live-send worker (no synchronous resize).
  - finalize_live_send_resize: perform synchronous tmux resize and settle layout before capturing frames.
- Redrew the UI between those steps so the synchronous resize targets the post-toast layout the user actually sees.
- Added HomeView.preview_pane_area to track the visible output sub-rectangle (excluding the info header) separately from the full preview area.
- Centralized the info-header sizing formula into a new agent_info_height(instance) helper and replaced duplicated logic.
- Updated preview rendering/cache refresh and live-send resize flows to use the output sub-rect (preview_pane_area) so captures match what the user sees.
- Fixed live-mode footer scroll indicator math (adjust visible height calculation) and added unit tests covering agent_info_height branches.
- Updated docstrings/comments/tests; one e2e TUI test was skipped due to harness limitations.

## Benefits
- Eliminates the visual frame-shift by ensuring resize occurs against the actual visible layout.
- Prevents off-screen rendering/clipping when the info panel is expanded.
- Improves reliability by waiting ~50ms for SIGWINCH/layout to settle before capture.
- Reduces duplicated sizing logic and makes live-send startup responsibilities clearer.
- Adds tests to prevent regressions in info-header sizing and footer indicator math.

## Technical notes (concise)
- API/struct changes:
  - enter_live_send renamed/split into prepare_live_send(&mut, session_id) -> Result<Option<String>, ()> and finalize_live_send_resize(&mut).
  - Added pub(super) preview_pane_area: Rect to HomeView.
  - Added pub fn agent_info_height(instance: &Instance) -> u16 in preview module.
- Resize behavior: finalize_live_send_resize synchronously calls tmux resize-window, updates live_send_last_resize only on success, then blocks ~50ms (tokio::task::block_in_place) to let SIGWINCH/layout settle.
- Tests: cargo test --lib passes (2214); an e2e TUI test was intentionally skipped. AI-assisted coding (Claude) is noted in commits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->