### PR TITLE
fix(session): anchor Claude session poller to its own session id (#1522)

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -243,13 +243,28 @@ pub(crate) fn claude_poll_fn(
     project_path: String,
     known_session_id: Option<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
+    // issue #1522: promote the last successfully captured sid to the anchor
+    // for subsequent polls. Without this, the closure keeps the startup
+    // `known_session_id` forever; once that file goes stale the scan drops
+    // back to global-most-recent and shared-repo fleets can resume
+    // cross-assigning on the next /clear or fork.
+    let last_known = std::sync::Mutex::new(known_session_id);
     move || {
-        capture_claude_session_id(&project_path, known_session_id.as_deref())
+        let current_known = last_known.lock().ok().and_then(|g| g.clone());
+        let captured = capture_claude_session_id(&project_path, current_known.as_deref())
             .map_err(
                 |e| tracing::debug!(target: "session.capture", "Claude disk scan failed: {}", e),
             )
             .ok()
-            .and_then(validated_session_id)
+            .and_then(validated_session_id);
+
+        if let Some(id) = captured.as_ref() {
+            if let Ok(mut guard) = last_known.lock() {
+                *guard = Some(id.clone());
+            }
+        }
+
+        captured
     }
 }
 
@@ -2177,6 +2192,56 @@ mod tests {
             capture_claude_session_id("/tmp/myproject", Some(uuid_known)).unwrap(),
             uuid_fresh
         );
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_claude_poll_fn_promotes_last_known_across_polls() {
+        // issue #1522: once a stale anchor falls back to the disk's most-recent,
+        // the closure must adopt that sid as its new anchor so a later sibling
+        // write (think: another session in the same fleet) cannot steal it
+        // back on the next poll. Without promotion, the closure stays anchored
+        // to its startup sid forever, and shared-repo cross-assignment returns
+        // the moment a session forks (/clear, /new, --fork-session).
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let uuid_startup = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_post_fork = "11111111-2222-3333-4444-555555555555";
+        let uuid_sibling = "99999999-8888-7777-6666-555555555555";
+
+        // Startup anchor's file is stale; the post-fork file is fresh.
+        std::fs::write(project_dir.join(format!("{uuid_startup}.jsonl")), "s\n").unwrap();
+        let stale = std::time::SystemTime::now() - Duration::from_secs(600);
+        std::fs::File::options()
+            .write(true)
+            .open(project_dir.join(format!("{uuid_startup}.jsonl")))
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(stale))
+            .unwrap();
+        std::fs::write(project_dir.join(format!("{uuid_post_fork}.jsonl")), "f\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        let poll = claude_poll_fn("/tmp/myproject".to_string(), Some(uuid_startup.to_string()));
+
+        // First poll: anchor is stale, fall back to most-recent (post-fork).
+        assert_eq!(poll().as_deref(), Some(uuid_post_fork));
+
+        // A sibling session in the same dir writes its transcript with a newer
+        // mtime than the post-fork file.
+        std::fs::write(project_dir.join(format!("{uuid_sibling}.jsonl")), "x\n").unwrap();
+
+        // Second poll: closure must now anchor to the post-fork sid (still
+        // fresh) and refuse to drift onto the sibling's newer file.
+        assert_eq!(poll().as_deref(), Some(uuid_post_fork));
 
         match old_val {
             Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),

--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -79,12 +79,18 @@ fn encode_claude_project_path(project_path: &str) -> String {
 /// falling back to `~/.claude.json` if the dir scan result is stale.
 ///
 /// Used as a fallback when hooks don't fire (e.g. after `/clear` or `/new`).
-pub(crate) fn capture_claude_session_id(project_path: &str) -> Result<String> {
+pub(crate) fn capture_claude_session_id(
+    project_path: &str,
+    known_session_id: Option<&str>,
+) -> Result<String> {
     let claude_home = resolve_agent_home(Some("CLAUDE_CONFIG_DIR"), ".claude")?;
     let canonical = canonicalize_or_raw(project_path);
 
-    // Source 1: most recently modified .jsonl in the project dir
-    if let Some((id, modified)) = scan_claude_project_dir(&claude_home, &canonical)? {
+    // Source 1: this poller's own known session if its .jsonl is still fresh,
+    // otherwise the most recently modified .jsonl in the project dir.
+    if let Some((id, modified)) =
+        scan_claude_project_dir(&claude_home, &canonical, known_session_id)?
+    {
         let age = modified.elapsed().unwrap_or(Duration::from_secs(u64::MAX));
         if age <= Duration::from_secs(5 * 60) {
             return Ok(id);
@@ -108,11 +114,24 @@ pub(crate) fn capture_claude_session_id(project_path: &str) -> Result<String> {
     anyhow::bail!("No active Claude session found for {}", project_path)
 }
 
-/// Scan `~/.claude/projects/{encoded-path}/` for the most recently modified
-/// UUID-named `.jsonl` file.
+/// Scan `~/.claude/projects/{encoded-path}/` for the session this poller should
+/// report.
+///
+/// When several AoE sessions share one `project_path` (a fleet rooted at a
+/// single repo), the bare "most recently modified `.jsonl`" heuristic makes
+/// every session's poller report whichever session most recently wrote — so
+/// they all steal one another's session ids and resume the same conversation
+/// (issue #1522). To prevent that, if the caller's own `known` session still
+/// has a fresh `.jsonl` here, return it: each session sticks to its own
+/// transcript rather than racing for the global most-recent.
+///
+/// Falls back to the most-recent file when `known` is `None`, absent, or stale
+/// (e.g. the session genuinely moved to a new conversation), preserving the
+/// original behaviour for the single-session-per-repo case.
 fn scan_claude_project_dir(
     claude_home: &Path,
     project_path: &Path,
+    known: Option<&str>,
 ) -> Result<Option<(String, std::time::SystemTime)>> {
     let dir_name = encode_claude_project_path(&project_path.to_string_lossy());
     let project_dir = claude_home.join("projects").join(&dir_name);
@@ -122,6 +141,7 @@ fn scan_claude_project_dir(
     }
 
     let mut best: Option<(String, std::time::SystemTime)> = None;
+    let mut known_hit: Option<(String, std::time::SystemTime)> = None;
 
     for entry in resilient_read_dir(&project_dir)? {
         let path = entry.path();
@@ -143,6 +163,22 @@ fn scan_claude_project_dir(
 
         if best.as_ref().is_none_or(|(_, t)| modified > *t) {
             best = Some((stem.to_string(), modified));
+        }
+        if known == Some(stem) {
+            known_hit = Some((stem.to_string(), modified));
+        }
+    }
+
+    // issue #1522: anchor to our own session while its file is fresh, so
+    // sessions sharing a project_path don't cross-assign. The freshness bound
+    // mirrors the caller's staleness gate in `capture_claude_session_id`.
+    if let Some((kid, kmt)) = known_hit {
+        let fresh = kmt
+            .elapsed()
+            .map(|age| age <= Duration::from_secs(5 * 60))
+            .unwrap_or(false);
+        if fresh {
+            return Ok(Some((kid, kmt)));
         }
     }
 
@@ -203,9 +239,12 @@ fn read_claude_json_session_id(project_path: &Path) -> Option<String> {
 /// bypasses `apply_session_id_updates`, replicate the
 /// `retroactive_capture_excludes` filter at the consumer or thread an
 /// `extra_excludes` set into this closure mirroring the other agents.
-pub(crate) fn claude_poll_fn(project_path: String) -> impl Fn() -> Option<String> + Send + 'static {
+pub(crate) fn claude_poll_fn(
+    project_path: String,
+    known_session_id: Option<String>,
+) -> impl Fn() -> Option<String> + Send + 'static {
     move || {
-        capture_claude_session_id(&project_path)
+        capture_claude_session_id(&project_path, known_session_id.as_deref())
             .map_err(
                 |e| tracing::debug!(target: "session.capture", "Claude disk scan failed: {}", e),
             )
@@ -2047,8 +2086,97 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject");
+        let result = capture_claude_session_id("/tmp/myproject", None);
         assert_eq!(result.unwrap(), uuid_new);
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_claude_session_prefers_known_when_shared() {
+        // issue #1522: two sessions share a project_path and both .jsonl files
+        // are fresh. Without an anchor the poller returns the most-recent for
+        // BOTH, cross-assigning ids. With `known`, each sticks to its own file.
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let uuid_a = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_b = "11111111-2222-3333-4444-555555555555";
+        std::fs::write(project_dir.join(format!("{uuid_a}.jsonl")), "a\n").unwrap();
+        // Nudge A 30s into the past so B is unambiguously the most-recent.
+        let a_time = std::time::SystemTime::now() - Duration::from_secs(30);
+        std::fs::File::options()
+            .write(true)
+            .open(project_dir.join(format!("{uuid_a}.jsonl")))
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(a_time))
+            .unwrap();
+        std::fs::write(project_dir.join(format!("{uuid_b}.jsonl")), "b\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        // No anchor -> most recent (B): original behaviour preserved.
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", None).unwrap(),
+            uuid_b
+        );
+        // Anchor to A (fresh) -> stays on A despite B being newer.
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(uuid_a)).unwrap(),
+            uuid_a
+        );
+        // Anchor to B -> B.
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(uuid_b)).unwrap(),
+            uuid_b
+        );
+        // Anchor to an id with no file here -> fall back to most-recent (B).
+        let absent = "99999999-9999-9999-9999-999999999999";
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(absent)).unwrap(),
+            uuid_b
+        );
+
+        match old_val {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_capture_claude_session_known_but_stale_falls_back() {
+        // If our own session's file went stale (>5min), adopt the fresh
+        // most-recent rather than clinging to a dead anchor.
+        let tmp = tempfile::tempdir().unwrap();
+        let project_dir = tmp.path().join("projects").join("-tmp-myproject");
+        std::fs::create_dir_all(&project_dir).unwrap();
+
+        let uuid_known = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_fresh = "11111111-2222-3333-4444-555555555555";
+        std::fs::write(project_dir.join(format!("{uuid_known}.jsonl")), "k\n").unwrap();
+        let stale = std::time::SystemTime::now() - Duration::from_secs(600);
+        std::fs::File::options()
+            .write(true)
+            .open(project_dir.join(format!("{uuid_known}.jsonl")))
+            .unwrap()
+            .set_times(std::fs::FileTimes::new().set_modified(stale))
+            .unwrap();
+        std::fs::write(project_dir.join(format!("{uuid_fresh}.jsonl")), "f\n").unwrap();
+
+        let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
+        std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
+
+        assert_eq!(
+            capture_claude_session_id("/tmp/myproject", Some(uuid_known)).unwrap(),
+            uuid_fresh
+        );
 
         match old_val {
             Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
@@ -2072,7 +2200,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject");
+        let result = capture_claude_session_id("/tmp/myproject", None);
         assert!(result.is_err(), "Agent files should not be picked up");
 
         match old_val {
@@ -2104,7 +2232,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject");
+        let result = capture_claude_session_id("/tmp/myproject", None);
         assert!(result.is_err(), "Stale session file should be rejected");
         assert!(
             result
@@ -2130,7 +2258,7 @@ mod tests {
         let old_val = std::env::var("CLAUDE_CONFIG_DIR").ok();
         std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path());
 
-        let result = capture_claude_session_id("/tmp/myproject");
+        let result = capture_claude_session_id("/tmp/myproject", None);
         assert!(result.is_err(), "Empty dir should return error");
 
         match old_val {

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1786,7 +1786,10 @@ impl Instance {
                         self.container_workdir(),
                     ))
                 } else {
-                    Box::new(claude_poll_fn(self.project_path.clone()))
+                    Box::new(claude_poll_fn(
+                        self.project_path.clone(),
+                        initial_known.clone(),
+                    ))
                 }
             }
             "opencode" => {


### PR DESCRIPTION
## Summary

Fixes #1522.

When several AoE sessions share one `project_path` (a fleet rooted at a single repo), the Claude session-id poller cross-assigns one `agent_session_id` to **all** of them. `capture_claude_session_id` returns the most-recently-modified `.jsonl` in `~/.claude/projects/{encoded-path}/`, keyed only on `project_path` — so every session's poller resolves to whichever session wrote last. Opening the TUI then fires `Session ID changed for <every session>: <same uuid>`, clobbering each session's real `--resume` target. On the next restart every session resumes the *same* conversation.

## Fix

Anchor each poller to its own session. `claude_poll_fn` now receives the instance's known session id (`agent_session_id`, already computed as `initial_known` at the poller-spawn site) and threads it into `capture_claude_session_id` → `scan_claude_project_dir`. The scan now:

- returns the caller's **own** `<known>.jsonl` when that file is still fresh (≤5 min) — so a session sticks to its own transcript instead of racing for the global most-recent;
- falls back to the most-recent file when `known` is `None`, absent, or stale (e.g. the session genuinely moved to a new conversation).

This is deliberately minimal and preserves existing behaviour for the single-session-per-repo case: there, the known id *is* the most-recent file, so the result is unchanged.

### Why anchor rather than exclude?

`claude_poll_fn`'s doc comment notes the `extra_excludes` pattern used by other agents. An excludes-based fix would need a live set of *all other sessions'* ids threaded into each closure (cross-session state + locking). Anchoring needs only this instance's own id, which is already in scope — smaller surface, no new shared state. Happy to switch approaches if you'd prefer the excludes route.

## Tests

Added to `src/session/capture.rs`:

- `test_capture_claude_session_prefers_known_when_shared` — two fresh `.jsonl` files in one project dir; asserts `None` → most-recent (unchanged), `Some(A)` → A even though B is newer, `Some(B)` → B, `Some(absent)` → most-recent.
- `test_capture_claude_session_known_but_stale_falls_back` — a stale known file falls back to the fresh most-recent.

Existing `capture` tests updated for the new signature; `fmt` / `clippy` / `test` run locally via the flake devshell.

## Scope / follow-up

This fixes the **host** path (`capture_claude_session_id`). The sandboxed path (`capture_claude_session_id_in_container`, `ls -t | head -1` inside the container) has the identical root cause; I left it out to keep this change focused and unit-testable, but I'm happy to mirror the anchor there in a follow-up (or this PR if you prefer).

## Caveat

If a session legitimately forks to a new id (`--fork-session`) while its old `.jsonl` is still fresh, detection of the new id lags until the old file passes the 5-min staleness bound. This is acceptable for fixing the cascade and only affects fork-on-resume; documented inline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR fixes a bug where multiple Claude sessions targeting the same repository could all adopt the same session ID (losing distinct resume targets) because the poller always picked the most-recent transcript file. The poller is now anchored to each session's own known session id and will prefer that session's transcript if it's fresh (≤5 minutes); if the anchored file is missing or stale, it falls back to the most-recent file. The sandboxed/container capture path was not changed.

## What Moved / Added / Removed

Added / Updated:
- capture anchoring: capture_claude_session_id now accepts an optional known_session_id and prefers the caller's .jsonl when fresh.
- poller anchoring: claude_poll_fn now accepts known_session_id (wrapped in a Mutex) and promotes the last-accepted session id so a poller stays attached to its session for its lifetime.
- Instance wiring: Instance::maybe_start_poller now passes the session's initial_known into claude_poll_fn.
- Tests: New unit tests in src/session/capture.rs verifying that a session prefers its known transcript when shared and falls back when the known transcript is stale.

Removed / Unchanged:
- No behavioral changes to the sandboxed/container capture path (left for follow-up).
- Existing 5-minute staleness gate and lastSessionId fallback remain.

## Benefits

- Restores correct per-session resume behavior in multi-session-per-repo setups.
- Prevents inadvertent reassignment of session histories across panes/sessions.
- Preserves single-session-per-repo behavior and provides a graceful fallback when anchors are stale.

## Technical Details (brief)

- New signature: capture_claude_session_id(project_path: &str, known_session_id: Option<&str>) -> Result<String>
- New signature: claude_poll_fn(project_path: String, known_session_id: Option<String>) -> impl Fn() -> Option<String> + Send + 'static
- Poller stores its anchor in a Mutex<Option<String>> and updates it after successful captures so the poller remains attached until a fallback is required.
- Staleness threshold: anchored transcript considered fresh if mtime ≤ 5 minutes; otherwise fallback to most-recent transcript.
- Caveat: if a session forks while its old transcript is still fresh, detection of the new id can lag until staleness expires.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->