### PR TITLE
test(web): stabilize ensure-session-restart Playwright spec

### DIFF
--- a/web/tests/live/ensure-session-restart.spec.ts
+++ b/web/tests/live/ensure-session-restart.spec.ts
@@ -127,6 +127,15 @@ base.describe("ensure_session restart flow", () => {
         },
       });
 
+      // Delay /ensure so Playwright reliably observes the "pending"
+      // placeholder. Without this the live backend can resolve the
+      // restart before the assertion's first retry, and the placeholder
+      // mounts + unmounts inside a single frame.
+      await page.route("**/api/sessions/*/ensure", async (route) => {
+        await new Promise((r) => setTimeout(r, 2000));
+        await route.continue();
+      });
+
       await page.goto(`${serve.baseUrl}/`);
       const sessionButton = page
         .getByRole("link")


### PR DESCRIPTION
> [!NOTE]
> This PR was made with the assistance of Claude (Opus 4.7).

## Description

The live spec `ensure-session-restart.spec.ts > frontend shows Starting placeholder then connects` is flaky: it asserts the "Starting session..." placeholder is visible after clicking the session link, but the live backend can resolve `POST /api/sessions/{id}/ensure` faster than Playwright's first retry, so the placeholder mounts and unmounts inside a single frame and the `toBeVisible()` assertion times out.

The same race is already called out in `web/tests/live/golden-path.spec.ts:40` (which sidesteps it by not probing the placeholder). Here we want to assert the placeholder, so instead we stall `/ensure` on the browser side with `page.route()` for 2s before `route.continue()` lets the real backend handle the restart. Same pattern as `web/tests/terminal-focus-shortcut.spec.ts:151`.

The `toBeHidden({ timeout: 15_000 })` follow-up still verifies the placeholder clears once ensure resolves, so the test still proves the full pending → ready transition.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

This PR only stabilizes an existing live Playwright spec; no user-facing flow changes, no production code touched, no coverage-matrix entry needed.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (Claude Code)

**Any Additional AI Details you'd like to share:** Diagnosis (initial `ensureState === "pending"` race against fast backend `/ensure` resolution) and the `page.route` + delay fix were authored with Claude assistance; I reviewed the diff and the existing in-repo precedent (`terminal-focus-shortcut.spec.ts`, `golden-path.spec.ts`) before pushing.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR stabilizes a flaky Playwright e2e test in `ensure-session-restart.spec.ts` that was unreliably observing the "Starting session..." placeholder during the session restart flow.

## What Changed

**File Modified:** `web/tests/live/ensure-session-restart.spec.ts`

Added a request interceptor in the "frontend shows Starting placeholder then connects" test that delays `POST /api/sessions/*/ensure` API requests by 2 seconds. The interceptor uses Playwright's `page.route()` to intercept matching requests, wait for 2 seconds via `setTimeout()`, and then allow the request to continue.

**Lines Added:** 9 (no lines removed)

## Why This Matters

The test was previously flaky because the live backend could resolve the ensure request faster than Playwright's retry logic, causing the "Starting session..." placeholder to mount and unmount within a single frame. This made the `toBeVisible()` assertion time out inconsistently.

By introducing a 2-second delay on the backend request, Playwright now reliably observes the placeholder appearing. The test then uses `toBeHidden({ timeout: 15_000 })` to verify the placeholder eventually disappears once the ensure request resolves, preserving the complete pending → ready state transition verification.

## Technical Approach

The fix uses Playwright's route interception pattern (`page.route()`) which mirrors an existing test pattern in `terminal-focus-shortcut.spec.ts`, ensuring consistency with the test suite's conventions. The 2-second delay is sufficient to eliminate the race condition without significantly impacting test execution time.

## Benefits

- **Reliability:** Eliminates flaky test execution by removing timing race conditions
- **Maintainability:** Uses established patterns from the test suite
- **No Production Impact:** This is purely a test infrastructure change with no production code modifications
- **Complete Coverage:** Still validates the full placeholder → connection lifecycle

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->