### PR TITLE
fix(dependabot): drop semver-days from non-semver ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,8 +41,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-minor-days: 14
-      semver-major-days: 28
 
   # github-actions
   - package-ecosystem: "github-actions"
@@ -61,8 +59,6 @@ updates:
       include: "scope"
     cooldown:
       default-days: 7
-      semver-minor-days: 14
-      semver-major-days: 28
     groups:
       actions-minor-patch:
         patterns: ["*"]


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Dependabot's validator rejects \`semver-minor-days\` and \`semver-major-days\` under \`cooldown\` for ecosystems that do not emit semver, specifically \`docker\` (image tags) and \`github-actions\` (refs). The keys remain on \`cargo\` and the \`npm\` entries where they are valid.

Surfaces as a failing \`.github/dependabot.yml\` check on every open PR (independent of the PR's own diff). One representative failure: https://github.com/agent-of-empires/agent-of-empires/pull/1503/checks?check_run_id=78052219173 — the parser emits four parse errors against \`#/updates/1/cooldown\` (docker) and \`#/updates/2/cooldown\` (github-actions).

The config got into this state in #1492 ("align ACP cadence and group tailwind bumps") where the cooldown grouping was uniformly applied across all ecosystems. Easy miss; the validator catches it now.

Diff is four line removals, no behavior change for the still-supported \`cargo\` and \`npm\` cooldown entries.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (config-only change; CI re-runs the dependabot.yml validator)
- [ ] Documentation was updated where necessary (N/A)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A

**TUI / CLI (e2e test)**
- [x] N/A

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, drafted in conversation with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)