### PR TITLE
chore(ci): pin dtolnay/rust-toolchain to commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           components: clippy
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: "false"
@@ -62,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           cache-bin: "false"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0

--- a/.github/workflows/e2e-recording.yml
+++ b/.github/workflows/e2e-recording.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install tmux
         run: sudo apt-get update && sudo apt-get install -y tmux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         run: cd web && npm install && npm run build
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Cache compiled binaries too. Same-PR pushes that don't
@@ -178,7 +178,7 @@ jobs:
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           # Cache compiled binaries too. Same-PR pushes that don't


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Replaces the floating `@stable` ref on `dtolnay/rust-toolchain` with a commit SHA across all 9 workflow uses. SHA chosen: `29eef336d9b2848a0b548edc03f92a220660cdb8`, the head of `refs/heads/stable` as of 2026-03-27. The exact SHA was verified two ways before committing:

- `gh api repos/dtolnay/rust-toolchain/git/refs/heads/stable` -> `29eef336d9b2848a0b548edc03f92a220660cdb8`
- `git ls-remote https://github.com/dtolnay/rust-toolchain | grep stable` -> same
- Commit `29eef336` is real on dtolnay/rust-toolchain, authored by David Tolnay, message "toolchain: stable", dated 2026-03-27

## Why

`dtolnay/rust-toolchain@stable` was the only third-party action in this repo's workflows still pinned to a moving ref. Every other action (`actions/checkout`, `docker/*`, `codecov/codecov-action`, etc.) is already SHA-pinned with a trailing `# vX.Y` comment. Closing this gap means a compromised `dtolnay` account cannot inject code into our CI runs, which have access to `GITHUB_TOKEN`.

dtolnay (David Tolnay) is a very high-reputation Rust maintainer, so the probability of compromise is low; but the action is invoked in 9 places across CI / tests / docs / e2e / release workflows, so the blast radius if it ever happened is large. Pin-to-SHA is the standard defense.

## Cost

We lose the implicit "always-latest-stable Rust" behavior. Bumping to a newer toolchain release now requires updating this SHA, which the existing Dependabot `github-actions` ecosystem (see `.github/dependabot.yml`) handles automatically on its weekly cadence. So in practice: one Dependabot PR per minor Rust release, and you can merge it whenever.

## Locations updated

- `.github/workflows/ci.yml` (4 occurrences: lines 18, 28, 49, 65)
- `.github/workflows/tests.yml` (2: lines 21, 181)
- `.github/workflows/docs.yml` (1: line 33)
- `.github/workflows/e2e-recording.yml` (1: line 21)
- `.github/workflows/release.yml` (1: line 90)

Format follows the project convention: `@<sha> # stable` (mirrors how `actions/checkout@de0fac... # v6.0.2` is written elsewhere).

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (CI re-runs against the SHA-pinned action; the action behaves identically to `@stable` at this exact moment in time)
- [x] Documentation was updated where necessary (N/A; no user-facing change)
- [ ] For UI changes: included screenshot or recording (N/A)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A

**TUI / CLI (e2e test)**
- [x] N/A

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code, drafted in conversation with @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)