### PR TITLE
feat(web): add opt-in last-activity sort mode to sidebar (#1418)

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -230,6 +230,14 @@ aoe serve --daemon
 - **Connected Devices** view in Settings > Security
 - **Push notifications** on Waiting / Idle / Error transitions, with per-session overrides ([guide](push-notifications.md))
 
+### Sidebar sort
+
+By default the sidebar shows your manually-ordered list. Drag a row with a press-and-hold gesture to move it; the new order persists across browsers and devices via `workspace-ordering.json`.
+
+A sort toggle next to the filter button in the sidebar header switches to **Recent activity** mode, which orders workspaces by the most recent of `last_accessed_at`, `idle_entered_at`, and `created_at` across each workspace's sessions, descending. Drag-to-reorder is disabled while Recent activity is selected, because the order is computed; the press-and-hold gesture does nothing in that mode.
+
+The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The multi-repo group stays pinned at the bottom in both modes.
+
 ## Architecture
 
 The server embeds an axum web server that serves a React frontend and provides:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8,6 +8,7 @@ import { CockpitPrefsProvider } from "./lib/cockpitPrefs";
 import { safeGetItem, safeSetItem } from "./lib/safeStorage";
 import { useWorkspaces } from "./hooks/useWorkspaces";
 import { useRepoGroups } from "./hooks/useRepoGroups";
+import { useSidebarSortMode } from "./hooks/useSidebarSortMode";
 import { useKeyboardShortcuts } from "./hooks/useKeyboardShortcuts";
 import { useResolvedTheme } from "./hooks/useResolvedTheme";
 import { useWebSettings } from "./hooks/useWebSettings";
@@ -222,9 +223,12 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
     sweepOrphanDrafts(new Set(sessions.map((s) => s.id)));
   }, [sessionsLoaded, sessions]);
 
+  const [sidebarSortMode, setSidebarSortMode] = useSidebarSortMode();
+
   const { groups, toggleRepoCollapsed, updateRepoAppearance } = useRepoGroups(
     workspaces,
     workspaceOrdering,
+    sidebarSortMode,
   );
 
   // Drag-end handler for the sidebar. Optimistically applies the new
@@ -880,6 +884,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
             onProjects={handleOpenProjects}
             onDeleteSession={handleDeleteSession}
             readOnly={serverAbout?.read_only}
+            sortMode={sidebarSortMode}
+            onSortModeChange={setSidebarSortMode}
           />
         )}
 

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -10,7 +10,7 @@ import {
   type MutableRefObject,
 } from "react";
 import { createPortal } from "react-dom";
-import { Pencil } from "lucide-react";
+import { Clock, ListOrdered, Pencil } from "lucide-react";
 import {
   DndContext,
   MouseSensor,
@@ -49,6 +49,7 @@ import { useIdleDecayWindowMs } from "../lib/idleDecay";
 import { renameSession, setSessionNotifications } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
+import type { SidebarSortMode } from "../lib/sidebarSort";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 
@@ -83,6 +84,8 @@ interface Props {
   onProjects: () => void;
   onDeleteSession?: (workspaceId: string) => void;
   readOnly?: boolean;
+  sortMode: SidebarSortMode;
+  onSortModeChange: (mode: SidebarSortMode) => void;
 }
 
 function bestSession(
@@ -295,15 +298,18 @@ function SortableSessionRow(props: {
   onClick: () => void;
   onDelete?: (workspaceId: string) => void;
   readOnly?: boolean;
+  dragDisabled?: boolean;
 }) {
   const dragSuppressRef = useDragSuppressRef();
-  // `disabled: readOnly` no-ops the sensor listeners, so a read-only
-  // viewer can't drag the row (and can't fire the PUT, which the
-  // server would reject anyway). Skipping the sortable wiring entirely
-  // would also drop the click suppressor; that's harmless in read-only
-  // since nothing else triggers a drag.
+  // `disabled` no-ops the sensor listeners. `readOnly` covers viewers
+  // who can't write, `dragDisabled` covers modes where the visible order
+  // is computed (e.g. last-activity sort), so a drag would have no
+  // meaning. Skipping the sortable wiring entirely would also drop the
+  // click suppressor; that's harmless in either case since nothing else
+  // triggers a drag.
+  const dragOff = !!props.readOnly || !!props.dragDisabled;
   const { listeners, setNodeRef, transform, transition, isDragging } =
-    useSortable({ id: props.workspace.id, disabled: props.readOnly });
+    useSortable({ id: props.workspace.id, disabled: dragOff });
   useEffect(() => {
     if (isDragging) {
       // Keep extending the window while dragging so a slow drag still
@@ -334,9 +340,9 @@ function SortableSessionRow(props: {
     <div
       ref={setNodeRef}
       style={style}
-      {...(props.readOnly ? {} : listeners)}
+      {...(dragOff ? {} : listeners)}
       aria-roledescription={
-        props.readOnly ? undefined : "Press and hold to reorder"
+        dragOff ? undefined : "Press and hold to reorder"
       }
       // While dragging, the row gets an amber ring (matches the active
       // session accent) and a soft shadow so it reads as elevated above
@@ -1017,7 +1023,10 @@ export function WorkspaceSidebar({
   onProjects,
   onDeleteSession,
   readOnly,
+  sortMode,
+  onSortModeChange,
 }: Props) {
+  const dragDisabled = !!readOnly || sortMode === "lastActivity";
   const dragSuppressRef = useRef<number>(0);
   useSuppressClickAfterDrag(dragSuppressRef);
   const offline = useServerDown();
@@ -1159,6 +1168,40 @@ export function WorkspaceSidebar({
           <span className="text-sm text-text-muted flex-1">
             Projects
           </span>
+          <Tooltip
+            text={
+              sortMode === "lastActivity"
+                ? "Sort: last activity, drag disabled"
+                : "Sort: manual, drag enabled"
+            }
+          >
+            <button
+              onClick={() =>
+                onSortModeChange(
+                  sortMode === "manual" ? "lastActivity" : "manual",
+                )
+              }
+              aria-pressed={sortMode === "lastActivity"}
+              aria-label={
+                sortMode === "lastActivity"
+                  ? "Sort by last activity, currently pressed"
+                  : "Sort by manual order"
+              }
+              data-testid="sidebar-sort-toggle"
+              data-sort-mode={sortMode}
+              className={`w-8 h-8 flex items-center justify-center cursor-pointer rounded-md transition-colors ${
+                sortMode === "lastActivity"
+                  ? "text-brand-500"
+                  : "text-text-dim hover:text-text-secondary"
+              }`}
+            >
+              {sortMode === "lastActivity" ? (
+                <Clock className="h-3.5 w-3.5" />
+              ) : (
+                <ListOrdered className="h-3.5 w-3.5" />
+              )}
+            </button>
+          </Tooltip>
           <Tooltip text="Filter">
             <button
               onClick={toggleFilter}
@@ -1236,7 +1279,7 @@ export function WorkspaceSidebar({
           <DndContext
             sensors={sensors}
             collisionDetection={closestCenter}
-            onDragEnd={readOnly ? undefined : handleDragEnd}
+            onDragEnd={dragDisabled ? undefined : handleDragEnd}
           >
             {filteredGroups.map((group) => {
               const showExpanded = q ? true : !group.collapsed;
@@ -1273,6 +1316,7 @@ export function WorkspaceSidebar({
                           }}
                           onDelete={onDeleteSession}
                           readOnly={readOnly}
+                          dragDisabled={sortMode === "lastActivity"}
                         />
                       ))}
                     </SortableContext>

--- a/web/src/hooks/useRepoGroups.test.ts
+++ b/web/src/hooks/useRepoGroups.test.ts
@@ -1,0 +1,307 @@
+// @vitest-environment jsdom
+//
+// Hook tests for useRepoGroups (#1418). The hook owns three orthogonal
+// concerns:
+//   1. Grouping workspaces by repo (and pulling multi-repo workspaces
+//      into a synthetic group).
+//   2. Sorting workspaces inside each group, plus sorting groups across
+//      the sidebar. Branches on sortMode.
+//   3. Collapsed + appearance state plumbed through localStorage.
+//
+// The sort comparator's edge cases (null timestamps, tie-breakers) are
+// covered by sidebarSort.test.ts. These tests assert the integration:
+// manual mode preserves the #1171 rank-driven order, lastActivity mode
+// flips it, the multi-repo group stays pinned in both modes, and the
+// stateful API (toggleRepoCollapsed, updateRepoAppearance) round-trips
+// through localStorage.
+
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useRepoGroups, MULTI_REPO_GROUP_ID } from "./useRepoGroups";
+import type {
+  SessionResponse,
+  Workspace,
+  WorkspaceRepoSummary,
+} from "../lib/types";
+
+function session(over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "t",
+    project_path: "/repo-a",
+    group_path: "/repo-a",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    ...over,
+  };
+}
+
+function workspace(
+  id: string,
+  projectPath: string,
+  sessions: SessionResponse[],
+  over: Partial<Workspace> = {},
+): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath,
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+    ...over,
+  };
+}
+
+const multiRepos: WorkspaceRepoSummary[] = [
+  { name: "repo-a", source_path: "/repo-a", branch: "main" },
+  { name: "repo-b", source_path: "/repo-b", branch: "main" },
+];
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useRepoGroups grouping", () => {
+  it("groups single-repo workspaces by projectPath and pins multi-repo to the bottom", () => {
+    const wA1 = workspace("a1", "/repo-a", [
+      session({ id: "s-a1", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const wA2 = workspace("a2", "/repo-a", [
+      session({ id: "s-a2", created_at: "2025-02-01T00:00:00Z" }),
+    ]);
+    const wB1 = workspace("b1", "/repo-b", [
+      session({ id: "s-b1", created_at: "2025-03-01T00:00:00Z" }),
+    ]);
+    const wMulti = workspace("multi", "/repo-a", [
+      session({
+        id: "s-multi",
+        created_at: "2025-04-01T00:00:00Z",
+        workspace_repos: multiRepos,
+      }),
+    ]);
+
+    const { result } = renderHook(() =>
+      useRepoGroups([wA1, wA2, wB1, wMulti], ["a1", "a2", "b1", "multi"]),
+    );
+
+    const groups = result.current.groups;
+    expect(groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      "/repo-b",
+      MULTI_REPO_GROUP_ID,
+    ]);
+    expect(groups[0].workspaces.map((w) => w.id)).toEqual(["a1", "a2"]);
+    expect(groups[1].workspaces.map((w) => w.id)).toEqual(["b1"]);
+    expect(groups[2].workspaces.map((w) => w.id)).toEqual(["multi"]);
+  });
+
+  it("derives group displayName from the last path segment", () => {
+    const w = workspace("a1", "/home/user/code/repo-x", [session()]);
+    const { result } = renderHook(() => useRepoGroups([w], ["a1"]));
+    expect(result.current.groups[0].displayName).toBe("repo-x");
+  });
+
+  it("marks a group active when any workspace is active", () => {
+    const wIdle = workspace(
+      "a1",
+      "/repo-a",
+      [session({ id: "s1" })],
+      { status: "idle" },
+    );
+    const wActive = workspace(
+      "a2",
+      "/repo-a",
+      [session({ id: "s2" })],
+      { status: "active" },
+    );
+    const { result } = renderHook(() =>
+      useRepoGroups([wIdle, wActive], ["a1", "a2"]),
+    );
+    expect(result.current.groups[0].status).toBe("active");
+  });
+});
+
+describe("useRepoGroups sortMode = manual (#1171 behaviour)", () => {
+  it("orders workspaces inside a group by their position in workspaceOrdering", () => {
+    const wNew = workspace("new", "/repo-a", [
+      session({ id: "s-new", created_at: "2025-09-01T00:00:00Z" }),
+    ]);
+    const wOld = workspace("old", "/repo-a", [
+      session({ id: "s-old", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    // Server pins old first even though new is newer.
+    const { result } = renderHook(() =>
+      useRepoGroups([wNew, wOld], ["old", "new"], "manual"),
+    );
+    expect(result.current.groups[0].workspaces.map((w) => w.id)).toEqual([
+      "old",
+      "new",
+    ]);
+  });
+
+  it("orders groups by the minimum rank of their workspaces", () => {
+    const wA = workspace("a1", "/repo-a", [session({ id: "s-a" })]);
+    const wB = workspace("b1", "/repo-b", [session({ id: "s-b" })]);
+    // b1 has the lower rank, so /repo-b group renders first.
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB], ["b1", "a1"], "manual"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-b",
+      "/repo-a",
+    ]);
+  });
+});
+
+describe("useRepoGroups sortMode = lastActivity (#1418)", () => {
+  it("orders workspaces inside a group by recency descending, ignoring workspaceOrdering", () => {
+    const wOld = workspace("old", "/repo-a", [
+      session({ id: "s-old", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const wNew = workspace("new", "/repo-a", [
+      session({
+        id: "s-new",
+        created_at: "2025-03-01T00:00:00Z",
+        last_accessed_at: "2025-09-01T00:00:00Z",
+      }),
+    ]);
+    // Server ordering pins old first; lastActivity overrides.
+    const { result } = renderHook(() =>
+      useRepoGroups([wOld, wNew], ["old", "new"], "lastActivity"),
+    );
+    expect(result.current.groups[0].workspaces.map((w) => w.id)).toEqual([
+      "new",
+      "old",
+    ]);
+  });
+
+  it("orders groups by the most-recent activity timestamp across each group's workspaces", () => {
+    const wA = workspace("a1", "/repo-a", [
+      session({ id: "s-a", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const wB = workspace("b1", "/repo-b", [
+      session({
+        id: "s-b",
+        created_at: "2025-01-01T00:00:00Z",
+        last_accessed_at: "2025-09-01T00:00:00Z",
+      }),
+    ]);
+    const { result } = renderHook(() =>
+      useRepoGroups([wA, wB], ["a1", "b1"], "lastActivity"),
+    );
+    // /repo-b's max activity is newer, so it floats above /repo-a.
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-b",
+      "/repo-a",
+    ]);
+  });
+
+  it("falls back to repoPath alphabetical when two groups have identical activity", () => {
+    const ts = "2025-05-01T00:00:00Z";
+    const wA = workspace("a1", "/repo-a", [
+      session({ id: "s-a", created_at: ts }),
+    ]);
+    const wB = workspace("b1", "/repo-b", [
+      session({ id: "s-b", created_at: ts }),
+    ]);
+    const { result } = renderHook(() =>
+      useRepoGroups([wB, wA], ["b1", "a1"], "lastActivity"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      "/repo-b",
+    ]);
+  });
+
+  it("keeps the multi-repo group pinned at the bottom even when its activity is the freshest", () => {
+    const wSingle = workspace("single", "/repo-a", [
+      session({ id: "s-single", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const wMulti = workspace("multi", "/repo-a", [
+      session({
+        id: "s-multi",
+        created_at: "2025-01-01T00:00:00Z",
+        last_accessed_at: "2025-12-31T00:00:00Z",
+        workspace_repos: multiRepos,
+      }),
+    ]);
+    const { result } = renderHook(() =>
+      useRepoGroups([wMulti, wSingle], ["multi", "single"], "lastActivity"),
+    );
+    expect(result.current.groups.map((g) => g.id)).toEqual([
+      "/repo-a",
+      MULTI_REPO_GROUP_ID,
+    ]);
+  });
+});
+
+describe("useRepoGroups stateful API", () => {
+  it("toggleRepoCollapsed flips collapsed and round-trips to localStorage", () => {
+    const w = workspace("a1", "/repo-a", [session()]);
+    const { result, rerender } = renderHook(() =>
+      useRepoGroups([w], ["a1"]),
+    );
+    expect(result.current.groups[0].collapsed).toBe(false);
+
+    act(() => {
+      result.current.toggleRepoCollapsed("/repo-a");
+    });
+    rerender();
+    expect(result.current.groups[0].collapsed).toBe(true);
+    expect(window.localStorage.getItem("aoe-repo-collapsed-/repo-a")).toBe(
+      "1",
+    );
+
+    act(() => {
+      result.current.toggleRepoCollapsed("/repo-a");
+    });
+    rerender();
+    expect(result.current.groups[0].collapsed).toBe(false);
+    expect(
+      window.localStorage.getItem("aoe-repo-collapsed-/repo-a"),
+    ).toBeNull();
+  });
+
+  it("updateRepoAppearance applies an alias and surfaces it in displayName", () => {
+    const w = workspace("a1", "/repo-a", [session()]);
+    const { result, rerender } = renderHook(() =>
+      useRepoGroups([w], ["a1"]),
+    );
+    expect(result.current.groups[0].displayName).toBe("repo-a");
+
+    act(() => {
+      result.current.updateRepoAppearance("/repo-a", { alias: "pretty-name" });
+    });
+    rerender();
+
+    expect(result.current.groups[0].displayName).toBe("pretty-name");
+    expect(result.current.groups[0].alias).toBe("pretty-name");
+  });
+});

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -7,6 +7,11 @@ import {
   persistRepoAppearances,
   type RepoAppearanceUpdate,
 } from "../lib/repoAppearance";
+import {
+  compareWorkspacesByLastActivityDesc,
+  repoGroupLastActivityMs,
+  type SidebarSortMode,
+} from "../lib/sidebarSort";
 
 const COLLAPSED_KEY_PREFIX = "aoe-repo-collapsed-";
 export const MULTI_REPO_GROUP_ID = "__multi_repo__";
@@ -22,11 +27,18 @@ function isMultiRepoWorkspace(ws: Workspace): boolean {
 // Workspaces and their groups both sort by their position in
 // `workspaceOrdering` (the persisted user order, prepended by App.tsx
 // whenever a new workspace appears). For groups, "position" is the best
-// (lowest) rank held by any of the group's workspaces — newest workspace
+// (lowest) rank held by any of the group's workspaces, newest workspace
 // in the group pulls the group up. See #1169.
+//
+// When `sortMode === "lastActivity"` (opt-in, per-browser, #1418), the
+// manual rank is bypassed in favour of a recency comparator that keys on
+// max(last_accessed_at, idle_entered_at, created_at) across each
+// workspace's sessions. The multi-repo group stays pinned to the bottom
+// in both modes so its position is predictable across toggles.
 export function useRepoGroups(
   workspaces: Workspace[],
   workspaceOrdering: readonly string[] = [],
+  sortMode: SidebarSortMode = "manual",
 ): {
   groups: RepoGroup[];
   toggleRepoCollapsed: (repoId: string) => void;
@@ -40,6 +52,10 @@ export function useRepoGroups(
     const rankOf = (id: string) => rank.get(id) ?? Infinity;
     const sortByRank = (list: Workspace[]) =>
       [...list].sort((a, b) => rankOf(a.id) - rankOf(b.id));
+    const sortByActivity = (list: Workspace[]) =>
+      [...list].sort(compareWorkspacesByLastActivityDesc);
+    const sortWorkspaces =
+      sortMode === "lastActivity" ? sortByActivity : sortByRank;
 
     const byRepo = new Map<string, Workspace[]>();
     const multiRepo: Workspace[] = [];
@@ -57,7 +73,7 @@ export function useRepoGroups(
     const repoGroups: RepoGroup[] = [];
 
     for (const [repoPath, repoWorkspaces] of byRepo) {
-      const sorted = sortByRank(repoWorkspaces);
+      const sorted = sortWorkspaces(repoWorkspaces);
       const hasActive = sorted.some((ws) => ws.status === "active");
       const collapsed = collapsedMap[repoPath] ?? loadCollapsed(repoPath);
       const remoteOwner = sorted[0]?.sessions[0]?.remote_owner ?? null;
@@ -79,7 +95,7 @@ export function useRepoGroups(
     }
 
     if (multiRepo.length > 0) {
-      const sorted = sortByRank(multiRepo);
+      const sorted = sortWorkspaces(multiRepo);
       const hasActive = sorted.some((ws) => ws.status === "active");
       const collapsed =
         collapsedMap[MULTI_REPO_GROUP_ID] ?? loadCollapsed(MULTI_REPO_GROUP_ID);
@@ -102,6 +118,12 @@ export function useRepoGroups(
     repoGroups.sort((a, b) => {
       if (a.id === MULTI_REPO_GROUP_ID) return 1;
       if (b.id === MULTI_REPO_GROUP_ID) return -1;
+      if (sortMode === "lastActivity") {
+        const ak = repoGroupLastActivityMs(a.workspaces);
+        const bk = repoGroupLastActivityMs(b.workspaces);
+        if (ak !== bk) return bk - ak;
+        return a.repoPath.localeCompare(b.repoPath);
+      }
       const am = Math.min(...a.workspaces.map((w) => rankOf(w.id)));
       const bm = Math.min(...b.workspaces.map((w) => rankOf(w.id)));
       if (am !== bm) return am - bm;
@@ -109,7 +131,7 @@ export function useRepoGroups(
     });
 
     return repoGroups;
-  }, [workspaces, workspaceOrdering, collapsedMap, appearanceMap]);
+  }, [workspaces, workspaceOrdering, sortMode, collapsedMap, appearanceMap]);
 
   const toggleRepoCollapsed = useCallback((repoId: string) => {
     setCollapsedMap((prev) => {

--- a/web/src/hooks/useSidebarSortMode.test.ts
+++ b/web/src/hooks/useSidebarSortMode.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment jsdom
+//
+// Contract test for the useSidebarSortMode hook (#1418). The hook is a
+// thin React wrapper around sidebarSort's load/save helpers; the
+// helpers' edge cases are covered by sidebarSort.test.ts. These tests
+// pin the public hook contract: defaults to "manual" when localStorage
+// is empty, restores a stored "lastActivity", and the setter persists.
+
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useSidebarSortMode } from "./useSidebarSortMode";
+import { SIDEBAR_SORT_MODE_KEY } from "../lib/sidebarSort";
+
+beforeEach(() => {
+  window.localStorage.clear();
+});
+
+describe("useSidebarSortMode", () => {
+  it("defaults to 'manual' when localStorage is empty", () => {
+    const { result } = renderHook(() => useSidebarSortMode());
+    expect(result.current[0]).toBe("manual");
+  });
+
+  it("hydrates from a stored 'lastActivity' value", () => {
+    window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "lastActivity");
+    const { result } = renderHook(() => useSidebarSortMode());
+    expect(result.current[0]).toBe("lastActivity");
+  });
+
+  it("falls back to 'manual' for an unrecognised stored value", () => {
+    window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "garbage");
+    const { result } = renderHook(() => useSidebarSortMode());
+    expect(result.current[0]).toBe("manual");
+  });
+
+  it("setter updates state and persists to localStorage", () => {
+    const { result } = renderHook(() => useSidebarSortMode());
+    expect(result.current[0]).toBe("manual");
+
+    act(() => {
+      result.current[1]("lastActivity");
+    });
+
+    expect(result.current[0]).toBe("lastActivity");
+    expect(window.localStorage.getItem(SIDEBAR_SORT_MODE_KEY)).toBe(
+      "lastActivity",
+    );
+  });
+
+  it("setter is stable across renders (useCallback)", () => {
+    const { result, rerender } = renderHook(() => useSidebarSortMode());
+    const setter1 = result.current[1];
+    rerender();
+    const setter2 = result.current[1];
+    expect(setter1).toBe(setter2);
+  });
+
+  it("toggle back to 'manual' persists", () => {
+    window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "lastActivity");
+    const { result } = renderHook(() => useSidebarSortMode());
+    expect(result.current[0]).toBe("lastActivity");
+
+    act(() => {
+      result.current[1]("manual");
+    });
+
+    expect(result.current[0]).toBe("manual");
+    expect(window.localStorage.getItem(SIDEBAR_SORT_MODE_KEY)).toBe("manual");
+  });
+});

--- a/web/src/hooks/useSidebarSortMode.ts
+++ b/web/src/hooks/useSidebarSortMode.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from "react";
+import {
+  loadSidebarSortMode,
+  saveSidebarSortMode,
+  type SidebarSortMode,
+} from "../lib/sidebarSort";
+
+export function useSidebarSortMode(): readonly [
+  SidebarSortMode,
+  (mode: SidebarSortMode) => void,
+] {
+  const [mode, setMode] = useState<SidebarSortMode>(loadSidebarSortMode);
+
+  const update = useCallback((next: SidebarSortMode) => {
+    setMode(next);
+    saveSidebarSortMode(next);
+  }, []);
+
+  return [mode, update] as const;
+}

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+import type { SessionResponse, Workspace } from "../types";
+import {
+  SIDEBAR_SORT_MODE_KEY,
+  compareWorkspacesByLastActivityDesc,
+  loadSidebarSortMode,
+  repoGroupLastActivityMs,
+  saveSidebarSortMode,
+  workspaceLastActivityMs,
+} from "../sidebarSort";
+
+function session(over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "t",
+    project_path: "/p",
+    group_path: "/p",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    ...over,
+  };
+}
+
+function workspace(id: string, sessions: SessionResponse[]): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+  };
+}
+
+describe("workspaceLastActivityMs", () => {
+  it("returns max across last_accessed_at, idle_entered_at, created_at", () => {
+    const ws = workspace("w", [
+      session({
+        created_at: "2025-01-01T00:00:00Z",
+        idle_entered_at: "2025-03-01T00:00:00Z",
+        last_accessed_at: "2025-02-01T00:00:00Z",
+      }),
+    ]);
+    expect(workspaceLastActivityMs(ws)).toBe(
+      Date.parse("2025-03-01T00:00:00Z"),
+    );
+  });
+
+  it("ignores null timestamps; created_at fallback works", () => {
+    const ws = workspace("w", [
+      session({
+        created_at: "2025-05-01T00:00:00Z",
+        idle_entered_at: null,
+        last_accessed_at: null,
+      }),
+    ]);
+    expect(workspaceLastActivityMs(ws)).toBe(
+      Date.parse("2025-05-01T00:00:00Z"),
+    );
+  });
+
+  it("ignores unparseable strings (no NaN poison)", () => {
+    const ws = workspace("w", [
+      session({
+        created_at: "2025-04-01T00:00:00Z",
+        idle_entered_at: "not-a-date",
+        last_accessed_at: "also-bad",
+      }),
+    ]);
+    expect(workspaceLastActivityMs(ws)).toBe(
+      Date.parse("2025-04-01T00:00:00Z"),
+    );
+  });
+
+  it("returns max across every session in a multi-session workspace", () => {
+    const ws = workspace("w", [
+      session({ id: "s1", created_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2", created_at: "2025-06-01T00:00:00Z" }),
+      session({ id: "s3", created_at: "2025-03-01T00:00:00Z" }),
+    ]);
+    expect(workspaceLastActivityMs(ws)).toBe(
+      Date.parse("2025-06-01T00:00:00Z"),
+    );
+  });
+
+  it("returns NEGATIVE_INFINITY when no usable timestamp exists", () => {
+    const ws = workspace("w", [
+      session({
+        created_at: "bad",
+        idle_entered_at: null,
+        last_accessed_at: null,
+      }),
+    ]);
+    expect(workspaceLastActivityMs(ws)).toBe(Number.NEGATIVE_INFINITY);
+  });
+});
+
+describe("compareWorkspacesByLastActivityDesc", () => {
+  it("orders newer activity first", () => {
+    const older = workspace("older", [
+      session({ id: "s1", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const newer = workspace("newer", [
+      session({ id: "s2", created_at: "2025-09-01T00:00:00Z" }),
+    ]);
+    const list = [older, newer].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["newer", "older"]);
+  });
+
+  it("breaks ties by workspace id ascending (deterministic)", () => {
+    const ts = "2025-01-01T00:00:00Z";
+    const wsB = workspace("b", [session({ id: "sb", created_at: ts })]);
+    const wsA = workspace("a", [session({ id: "sa", created_at: ts })]);
+    const wsC = workspace("c", [session({ id: "sc", created_at: ts })]);
+    const list = [wsB, wsA, wsC].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("repoGroupLastActivityMs", () => {
+  it("returns the max across workspaces in the group", () => {
+    const a = workspace("a", [
+      session({ id: "sa", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const b = workspace("b", [
+      session({ id: "sb", created_at: "2025-07-01T00:00:00Z" }),
+    ]);
+    expect(repoGroupLastActivityMs([a, b])).toBe(
+      Date.parse("2025-07-01T00:00:00Z"),
+    );
+  });
+
+  it("returns NEGATIVE_INFINITY on an empty group", () => {
+    expect(repoGroupLastActivityMs([])).toBe(Number.NEGATIVE_INFINITY);
+  });
+});
+
+describe("loadSidebarSortMode / saveSidebarSortMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("defaults to 'manual' when localStorage is empty", () => {
+    expect(loadSidebarSortMode()).toBe("manual");
+  });
+
+  it("returns 'manual' for an unrecognised stored value", () => {
+    window.localStorage.setItem(SIDEBAR_SORT_MODE_KEY, "nonsense");
+    expect(loadSidebarSortMode()).toBe("manual");
+  });
+
+  it("round-trips 'lastActivity'", () => {
+    saveSidebarSortMode("lastActivity");
+    expect(window.localStorage.getItem(SIDEBAR_SORT_MODE_KEY)).toBe(
+      "lastActivity",
+    );
+    expect(loadSidebarSortMode()).toBe("lastActivity");
+  });
+
+  it("round-trips 'manual'", () => {
+    saveSidebarSortMode("lastActivity");
+    saveSidebarSortMode("manual");
+    expect(loadSidebarSortMode()).toBe("manual");
+  });
+});

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -142,6 +142,23 @@ describe("compareWorkspacesByLastActivityDesc", () => {
     const list = [wsB, wsA, wsC].sort(compareWorkspacesByLastActivityDesc);
     expect(list.map((w) => w.id)).toEqual(["a", "b", "c"]);
   });
+
+  it("breaks ties by id when both sides have no usable timestamp", () => {
+    // Both workspaces return NEGATIVE_INFINITY from
+    // workspaceLastActivityMs. Subtracting two -Infinity values yields
+    // NaN, which Array.sort treats like equality and skips the
+    // tie-break, so this case would silently flake without the
+    // explicit `<` / `>` comparison in the comparator.
+    const bad = {
+      created_at: "bad",
+      idle_entered_at: null,
+      last_accessed_at: null,
+    };
+    const wsB = workspace("b", [session({ id: "sb", ...bad })]);
+    const wsA = workspace("a", [session({ id: "sa", ...bad })]);
+    const list = [wsB, wsA].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["a", "b"]);
+  });
 });
 
 describe("repoGroupLastActivityMs", () => {

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -1,0 +1,66 @@
+import type { Workspace } from "./types";
+import { safeGetItem, safeSetItem } from "./safeStorage";
+
+export type SidebarSortMode = "manual" | "lastActivity";
+
+export const SIDEBAR_SORT_MODE_KEY = "aoe-sidebar-sort-mode";
+
+const VALID_MODES: readonly SidebarSortMode[] = ["manual", "lastActivity"];
+
+export function loadSidebarSortMode(): SidebarSortMode {
+  const raw = safeGetItem(SIDEBAR_SORT_MODE_KEY);
+  if (raw && (VALID_MODES as readonly string[]).includes(raw)) {
+    return raw as SidebarSortMode;
+  }
+  return "manual";
+}
+
+export function saveSidebarSortMode(mode: SidebarSortMode): void {
+  safeSetItem(SIDEBAR_SORT_MODE_KEY, mode);
+}
+
+function epochOr(ts: string | null | undefined): number {
+  if (!ts) return Number.NEGATIVE_INFINITY;
+  const n = Date.parse(ts);
+  return Number.isFinite(n) ? n : Number.NEGATIVE_INFINITY;
+}
+
+/** Most-recent activity timestamp across a workspace's sessions, in epoch ms.
+ *  Considers `last_accessed_at`, `idle_entered_at`, and `created_at`; nulls
+ *  and unparseable strings are skipped. Returns `Number.NEGATIVE_INFINITY`
+ *  when no usable timestamp exists. */
+export function workspaceLastActivityMs(ws: Workspace): number {
+  let best = Number.NEGATIVE_INFINITY;
+  for (const s of ws.sessions) {
+    const m = Math.max(
+      epochOr(s.last_accessed_at),
+      epochOr(s.idle_entered_at),
+      epochOr(s.created_at),
+    );
+    if (m > best) best = m;
+  }
+  return best;
+}
+
+/** Group-level activity key: max across the group's workspaces. */
+export function repoGroupLastActivityMs(
+  workspaces: readonly Workspace[],
+): number {
+  let best = Number.NEGATIVE_INFINITY;
+  for (const ws of workspaces) {
+    const m = workspaceLastActivityMs(ws);
+    if (m > best) best = m;
+  }
+  return best;
+}
+
+/** Stable, deterministic comparator. Activity descending, tie-break by id
+ *  ascending so equal timestamps never flake the render order. */
+export function compareWorkspacesByLastActivityDesc(
+  a: Workspace,
+  b: Workspace,
+): number {
+  const diff = workspaceLastActivityMs(b) - workspaceLastActivityMs(a);
+  if (diff !== 0) return diff;
+  return a.id.localeCompare(b.id);
+}

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -55,12 +55,19 @@ export function repoGroupLastActivityMs(
 }
 
 /** Stable, deterministic comparator. Activity descending, tie-break by id
- *  ascending so equal timestamps never flake the render order. */
+ *  ascending so equal timestamps never flake the render order. The two
+ *  activity keys are compared with `<` / `>` rather than subtraction
+ *  because workspaces with no usable timestamp return
+ *  `Number.NEGATIVE_INFINITY`; `-Infinity - -Infinity` is `NaN`, which
+ *  `Array.prototype.sort` treats like `0` (equal) and would silently skip
+ *  the id tie-break, leaving ordering at the mercy of input order. */
 export function compareWorkspacesByLastActivityDesc(
   a: Workspace,
   b: Workspace,
 ): number {
-  const diff = workspaceLastActivityMs(b) - workspaceLastActivityMs(a);
-  if (diff !== 0) return diff;
+  const aMs = workspaceLastActivityMs(a);
+  const bMs = workspaceLastActivityMs(b);
+  if (aMs < bMs) return 1;
+  if (aMs > bMs) return -1;
   return a.id.localeCompare(b.id);
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -346,6 +346,27 @@
       ]
     },
     {
+      "id": "sidebar.sort-pure",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/lib/__tests__/sidebarSort.test.ts"],
+      "components": []
+    },
+    {
+      "id": "sidebar.sort-toggle-ui",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": ["tests/sidebar-sort-mode.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
+      "id": "sidebar.sort-live",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": ["tests/live/sidebar-sort-mode.spec.ts"],
+      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+    },
+    {
       "id": "session.lifecycle",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -353,6 +353,20 @@
       "components": []
     },
     {
+      "id": "sidebar.sort-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/hooks/useSidebarSortMode.test.ts"],
+      "components": []
+    },
+    {
+      "id": "sidebar.repo-groups-hook",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": ["src/hooks/useRepoGroups.test.ts"],
+      "components": []
+    },
+    {
       "id": "sidebar.sort-toggle-ui",
       "kind": "mocked-playwright",
       "risk": "high",

--- a/web/tests/live/sidebar-sort-mode.spec.ts
+++ b/web/tests/live/sidebar-sort-mode.spec.ts
@@ -1,0 +1,188 @@
+// Live coverage for the sidebar sort-mode toggle (#1418).
+//
+// Drives a real `aoe serve` subprocess against three seeded sessions
+// whose `created_at` timestamps differ by ~1.2s each. Asserts that
+// flipping the toggle to "lastActivity" reorders the sidebar rows by
+// newest-created first, and that the localStorage-backed preference
+// survives a page reload.
+//
+// Pure comparator semantics across `last_accessed_at`, `idle_entered_at`,
+// and `created_at` (including null fallback) are covered by the Vitest
+// suite at web/src/lib/__tests__/sidebarSort.test.ts. The mocked
+// Playwright suite at web/tests/sidebar-sort-mode.spec.ts covers drag
+// disablement and the multi-repo pin. This spec proves the wiring boots
+// against the real server end-to-end.
+//
+// Pairs with web/tests/live/workspace-ordering.spec.ts for manual-mode
+// regressions.
+//
+// The seeded `created_at` deltas use 1.2s sleeps. RFC3339 timestamps
+// the server emits have sub-second precision, so a tighter gap would
+// still work, but the wider window keeps this resilient to any process
+// scheduling jitter between sequential `aoe add` invocations.
+
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  resolveAoeBinary,
+} from "../helpers/aoeServe";
+
+interface SeededSession {
+  dir: string;
+  title: string;
+}
+
+function seedSequentialSessions(sessions: SeededSession[]) {
+  return async ({
+    home,
+    env,
+  }: {
+    home: string;
+    shimBin: string;
+    env: NodeJS.ProcessEnv;
+  }) => {
+    const binary = resolveAoeBinary();
+    for (let i = 0; i < sessions.length; i++) {
+      const { dir, title } = sessions[i]!;
+      const projectDir = join(home, dir);
+      mkdirSync(projectDir, { recursive: true });
+      spawnSync("git", ["init", "-q"], { cwd: projectDir });
+      spawnSync(
+        "git",
+        ["commit", "--allow-empty", "-q", "-m", "init"],
+        {
+          cwd: projectDir,
+          env: {
+            ...env,
+            GIT_AUTHOR_NAME: "t",
+            GIT_AUTHOR_EMAIL: "t@t",
+            GIT_COMMITTER_NAME: "t",
+            GIT_COMMITTER_EMAIL: "t@t",
+          },
+        },
+      );
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+      if (i < sessions.length - 1) {
+        await new Promise((r) => setTimeout(r, 1200));
+      }
+    }
+  };
+}
+
+async function readWorkspaceTitles(page: import("@playwright/test").Page) {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>(
+        "[data-testid='sidebar-session-row']",
+      ),
+    );
+    return rows
+      .map((a) => a.querySelector("[title]")?.getAttribute("title") ?? "")
+      .filter(Boolean);
+  });
+}
+
+const TOGGLE = "[data-testid='sidebar-sort-toggle']";
+
+base.describe("sidebar sort-mode live (#1418)", () => {
+  base(
+    "toggle reorders by newest-created and persists across reload",
+    async ({ page }, testInfo) => {
+      const serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: seedSequentialSessions([
+          { dir: "repo-oldest", title: "oldest-session" },
+          { dir: "repo-middle", title: "middle-session" },
+          { dir: "repo-newest", title: "newest-session" },
+        ]),
+      });
+
+      try {
+        const seeded = await listSessions(serve.baseUrl);
+        expect(seeded).toHaveLength(3);
+
+        await page.goto(`${serve.baseUrl}/`);
+
+        // 4-worker cold start can lag past Playwright's 5s default;
+        // bump the first paint waits, matching sidebar-groups.spec.ts.
+        const rows = page.locator("[data-testid='sidebar-session-row']");
+        await expect(rows).toHaveCount(3, { timeout: 10_000 });
+        await expect(page.locator(TOGGLE)).toHaveAttribute(
+          "data-sort-mode",
+          "manual",
+        );
+
+        // Capture the manual-mode order. With three brand-new sessions
+        // and no prior drag, the workspace_ordering file is prepended
+        // newest-first as workspaces are observed (see #1171 server
+        // merge), so the live default already happens to match the
+        // last-activity outcome. We assert against the toggle's effect,
+        // not against a specific manual ordering, by capturing it.
+        const manualOrder = await readWorkspaceTitles(page);
+        expect(manualOrder.sort()).toEqual([
+          "middle-session",
+          "newest-session",
+          "oldest-session",
+        ]);
+
+        await page.locator(TOGGLE).click();
+        await expect(page.locator(TOGGLE)).toHaveAttribute(
+          "data-sort-mode",
+          "lastActivity",
+        );
+
+        await expect
+          .poll(() => readWorkspaceTitles(page), { timeout: 5000 })
+          .toEqual([
+            "newest-session",
+            "middle-session",
+            "oldest-session",
+          ]);
+
+        // Reload: localStorage carries the toggle state across reloads
+        // even against the live server.
+        await page.reload();
+        await expect(rows).toHaveCount(3, { timeout: 10_000 });
+        await expect(page.locator(TOGGLE)).toHaveAttribute(
+          "data-sort-mode",
+          "lastActivity",
+        );
+        await expect
+          .poll(() => readWorkspaceTitles(page), { timeout: 5000 })
+          .toEqual([
+            "newest-session",
+            "middle-session",
+            "oldest-session",
+          ]);
+
+        // Toggle back: returns to whatever the server has as manual
+        // order. We don't assert a specific order here because the
+        // server's workspace-ordering merge produces an order that's
+        // valid but depends on observation timing; the contract we
+        // care about is "toggle back exits last-activity mode."
+        await page.locator(TOGGLE).click();
+        await expect(page.locator(TOGGLE)).toHaveAttribute(
+          "data-sort-mode",
+          "manual",
+        );
+      } finally {
+        await serve.stop();
+      }
+    },
+  );
+});

--- a/web/tests/sidebar-drag-reorder.spec.ts
+++ b/web/tests/sidebar-drag-reorder.spec.ts
@@ -118,6 +118,14 @@ test.describe("Sidebar drag-to-reorder (#1169)", () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await page.goto("/");
 
+    // Drag tests rely on the sidebar starting in manual sort mode (the
+    // default). If a future change flips the default to last-activity,
+    // the drag affordance disappears and these tests break in confusing
+    // ways. Assert the toggle's state up front so the failure mode is
+    // obvious. See #1418.
+    await expect(
+      page.locator("[data-testid='sidebar-sort-toggle']"),
+    ).toHaveAttribute("data-sort-mode", "manual");
     await expect
       .poll(() => readWorkspaceOrder(page), { timeout: 8000 })
       .toEqual(["old-ws", "new-ws"]);

--- a/web/tests/sidebar-sort-mode.spec.ts
+++ b/web/tests/sidebar-sort-mode.spec.ts
@@ -1,0 +1,347 @@
+// Mocked-Playwright coverage for the sidebar sort-mode toggle (#1418).
+//
+// Drives the WorkspaceSidebar header toggle through its two states
+// (manual, lastActivity) against fully-stubbed /api responses, so the
+// only thing under test is the React + dnd-kit wiring:
+//   1. Default is manual; rows honor server-supplied workspace_ordering.
+//   2. Toggling to lastActivity reorders client-side by the issue's
+//      sort key (max of last_accessed_at, idle_entered_at, created_at).
+//   3. localStorage persists across reloads; the toggle starts pressed.
+//   4. Press-and-hold in lastActivity mode does not lift or PUT.
+//   5. Multi-repo group stays pinned at the bottom in lastActivity mode.
+//
+// Live persistence semantics (real aoe serve, real last_accessed_at
+// bump) live in the matching tests/live/sidebar-sort-mode.spec.ts.
+
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+  branch: string | null;
+  created_at: string;
+  last_accessed_at?: string | null;
+  idle_entered_at?: string | null;
+  workspace_repos?: { name: string; source_path: string; branch: string }[];
+}
+
+function sessionResponse(s: MockSession) {
+  return {
+    id: s.id,
+    title: s.title,
+    project_path: s.project_path,
+    group_path: s.project_path,
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: s.created_at,
+    last_accessed_at: s.last_accessed_at ?? null,
+    idle_entered_at: s.idle_entered_at ?? null,
+    last_error: null,
+    branch: s.branch,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: s.workspace_repos ?? [],
+  };
+}
+
+async function mockApis(
+  page: Page,
+  getSessions: () => MockSession[],
+  getOrdering: () => string[],
+  onPut?: (order: string[]) => void,
+) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: getSessions().map(sessionResponse),
+        workspace_ordering: getOrdering(),
+      },
+    });
+  });
+  await page.route("**/api/workspace-ordering", (r) => {
+    const body = JSON.parse(r.request().postData() || "{}") as {
+      order?: string[];
+    };
+    if (body.order) onPut?.(body.order);
+    return r.fulfill({ json: { order: body.order ?? [] } });
+  });
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+async function readWorkspaceTitles(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLAnchorElement>(
+        "[data-testid='sidebar-session-row']",
+      ),
+    );
+    return rows
+      .map((a) => a.querySelector("[title]")?.getAttribute("title") ?? "")
+      .filter(Boolean);
+  });
+}
+
+const TOGGLE = "[data-testid='sidebar-sort-toggle']";
+
+test.describe("Sidebar sort-mode toggle (#1418)", () => {
+  test("default is manual; rows follow server workspace_ordering", async ({
+    page,
+  }) => {
+    const sessions: MockSession[] = [
+      {
+        id: "s-old",
+        title: "old-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/old",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        id: "s-new",
+        title: "new-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/new",
+        created_at: "2025-04-01T00:00:00Z",
+        last_accessed_at: "2025-04-15T00:00:00Z",
+      },
+    ];
+    // Server pins old-ws above new-ws. Manual mode honors this even
+    // though new-ws has a fresher last_accessed_at.
+    await mockApis(
+      page,
+      () => sessions,
+      () => ["/tmp/repo::feature/old", "/tmp/repo::feature/new"],
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "manual",
+    );
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
+      .toEqual(["old-ws", "new-ws"]);
+  });
+
+  test("clicking toggle reorders by last-activity desc and persists", async ({
+    page,
+    context,
+  }) => {
+    const sessions: MockSession[] = [
+      {
+        id: "s-old",
+        title: "old-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/old",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        id: "s-new",
+        title: "new-ws",
+        project_path: "/tmp/repo",
+        branch: "feature/new",
+        created_at: "2025-04-01T00:00:00Z",
+        last_accessed_at: "2025-04-15T00:00:00Z",
+      },
+    ];
+    await mockApis(
+      page,
+      () => sessions,
+      () => ["/tmp/repo::feature/old", "/tmp/repo::feature/new"],
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
+      .toEqual(["old-ws", "new-ws"]);
+
+    await page.locator(TOGGLE).click();
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "lastActivity",
+    );
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
+      .toEqual(["new-ws", "old-ws"]);
+
+    const stored = await page.evaluate(() =>
+      window.localStorage.getItem("aoe-sidebar-sort-mode"),
+    );
+    expect(stored).toBe("lastActivity");
+
+    // Reload: mode and order persist on first paint without another
+    // toggle click. Use the same browser context so localStorage carries.
+    await page.reload();
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "lastActivity",
+    );
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 8000 })
+      .toEqual(["new-ws", "old-ws"]);
+
+    // Toggling back restores manual order.
+    await page.locator(TOGGLE).click();
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "manual",
+    );
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
+      .toEqual(["old-ws", "new-ws"]);
+    // suppress unused-binding lint without changing the signature
+    void context;
+  });
+
+  test("drag affordances are absent in last-activity mode", async ({ page }) => {
+    const sessions: MockSession[] = [
+      {
+        id: "s1",
+        title: "alpha",
+        project_path: "/tmp/repo",
+        branch: "feature/a",
+        created_at: "2025-01-01T00:00:00Z",
+      },
+      {
+        id: "s2",
+        title: "beta",
+        project_path: "/tmp/repo",
+        branch: "feature/b",
+        created_at: "2025-02-01T00:00:00Z",
+      },
+    ];
+    const puts: string[][] = [];
+    await mockApis(
+      page,
+      () => sessions,
+      () => ["/tmp/repo::feature/a", "/tmp/repo::feature/b"],
+      (order) => puts.push(order),
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    // Sanity: drag wrappers are present in manual mode.
+    await expect(
+      page.locator("[aria-roledescription='Press and hold to reorder']"),
+    ).toHaveCount(2, { timeout: 8000 });
+
+    await page.locator(TOGGLE).click();
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "lastActivity",
+    );
+
+    // Drag wrappers gone in last-activity mode.
+    await expect(
+      page.locator("[aria-roledescription='Press and hold to reorder']"),
+    ).toHaveCount(0);
+
+    // No PUT to workspace-ordering fires from a press-and-hold attempt.
+    const rows = page.locator("[data-testid='sidebar-session-row']");
+    const sourceBox = await rows.nth(1).boundingBox();
+    if (!sourceBox) throw new Error("row missing");
+    await page.mouse.move(
+      sourceBox.x + sourceBox.width - 4,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.waitForTimeout(300);
+    await page.mouse.move(sourceBox.x + 4, sourceBox.y + 4, { steps: 6 });
+    await page.mouse.up();
+
+    // Toggle back to manual: drag affordances return.
+    await page.locator(TOGGLE).click();
+    await expect(
+      page.locator("[aria-roledescription='Press and hold to reorder']"),
+    ).toHaveCount(2);
+
+    expect(puts.length).toBe(0);
+  });
+
+  test("multi-repo group stays pinned at the bottom in last-activity mode", async ({
+    page,
+  }) => {
+    const sessions: MockSession[] = [
+      {
+        id: "s-multi",
+        title: "multi-recent",
+        project_path: "/tmp/repo",
+        branch: "feature/multi",
+        // Highest last_accessed_at across the dataset; absent the pin
+        // this would float to the top of the sidebar.
+        created_at: "2025-01-01T00:00:00Z",
+        last_accessed_at: "2025-12-01T00:00:00Z",
+        workspace_repos: [
+          { name: "repo-a", source_path: "/tmp/repo", branch: "feature/multi" },
+          { name: "repo-b", source_path: "/tmp/other", branch: "feature/multi" },
+        ],
+      },
+      {
+        id: "s-single",
+        title: "single-old",
+        project_path: "/tmp/repo",
+        branch: "feature/single",
+        created_at: "2025-02-01T00:00:00Z",
+        last_accessed_at: "2025-03-01T00:00:00Z",
+      },
+    ];
+    await mockApis(
+      page,
+      () => sessions,
+      () => [
+        "/tmp/repo::feature/multi",
+        "/tmp/repo::feature/single",
+      ],
+    );
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+
+    // Wait for the sidebar to render both rows before flipping the mode.
+    await expect(
+      page.locator("[data-testid='sidebar-session-row']"),
+    ).toHaveCount(2, { timeout: 8000 });
+
+    await page.locator(TOGGLE).click();
+    await expect(page.locator(TOGGLE)).toHaveAttribute(
+      "data-sort-mode",
+      "lastActivity",
+    );
+
+    // Multi-repo group's row stays last even though its workspace has
+    // the freshest activity. Single-repo row renders first.
+    await expect
+      .poll(() => readWorkspaceTitles(page), { timeout: 4000 })
+      .toEqual(["single-old", "multi-recent"]);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds an opt-in **Recent activity** sort mode to the web sidebar. Default stays manual (the #1171 behavior, drag-to-reorder, server-side `workspace-ordering.json`, untouched). A new icon toggle in the sidebar header flips to a recency comparator that keys on the maximum of `last_accessed_at`, `idle_entered_at`, and `created_at` across each workspace's sessions, descending. While Recent activity is selected the drag handles are disabled, because the order is computed.

This closes the loop on the original #993 ask, which #1171 had to override to stop sessions from jumping around when their status flipped. Long-running users with many sessions now have a one-click switch between "my manual layout" and "what I touched most recently."

Design notes worth surfacing in review:

- **Per-browser, not per-profile, not server-synced.** The toggle's state lives in `localStorage["aoe-sidebar-sort-mode"]`. The sidebar is cross-profile (it aggregates every profile's sessions into one merged view), so `WebConfig` is the wrong abstraction. Cross-device sync is explicitly out of scope per the issue.
- **Drag-disable.** A new `dragDisabled` prop is threaded through `WorkspaceSidebar.tsx` separately from `readOnly` so a future change to one does not affect the other. Both null `useSortable`'s listeners, suppress the `aria-roledescription="Press and hold to reorder"` label, and skip the `DndContext.onDragEnd` handler, so a press-and-hold in Recent activity mode never lifts the row and never fires a PUT.
- **Tie-break.** Same-activity rows are sorted by `workspace.id.localeCompare`. Deterministic, prevents flake.
- **Multi-repo group pin** stays at the bottom in both modes, deliberate. Avoids changing two variables in the same PR. If users push back, a follow-up can revisit.
- **Active-first tier** is dropped. Pure recency. Status remains visually encoded by glyph and color.
- The comparator lives in `web/src/lib/sidebarSort.ts` as a pure module so the timestamp edge cases (null, unparseable, multi-session) are unit-testable without React or DOM.

Closes #1418

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## How to test

User-runnable verification steps:

- [x] Open the web dashboard. The sidebar header now shows a sort-mode toggle next to the filter button. Hover it: tooltip reads "Sort: manual, drag enabled". `aria-pressed="false"`.
- [x] Press-and-hold any session row. It lifts (amber ring + soft shadow), drag-to-reorder still works, PUT to `/api/workspace-ordering` fires.
- [x] Click the sort-mode toggle. Icon changes to a clock, tooltip reads "Sort: last activity, drag disabled", `aria-pressed="true"`. Rows reorder client-side without a page refresh, newest-active workspace first.
- [x] Press-and-hold a session row in Recent activity mode. No lift, no shadow, no drag, no PUT.
- [x] Reload the page. The toggle stays pressed in Recent activity and the order is the same on first paint.
- [x] Click the toggle a second time. Sidebar returns to your stored manual order. Drag works again.
- [x] Open Chrome DevTools → Application → Local Storage. Confirm `aoe-sidebar-sort-mode` is `"lastActivity"` or `"manual"` as expected.
- [x] Open the dashboard in a different browser (or incognito). Recent activity does NOT carry over (per-device).
- [x] (Optional, multi-repo only) Create a multi-repo workspace. Toggle to Recent activity. The "Multi-repo" group remains pinned at the bottom regardless of mode.

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

New specs: `web/tests/sidebar-sort-mode.spec.ts` (mocked, 4 scenarios: default-manual, toggle-reorder-persist, drag-disabled, multi-repo-pin) and `web/tests/live/sidebar-sort-mode.spec.ts` (live, real `aoe serve`, deterministic `created_at` ordering). Existing `web/tests/sidebar-drag-reorder.spec.ts` gains a `data-sort-mode="manual"` sanity assertion. Pure comparator covered by Vitest at `web/src/lib/__tests__/sidebarSort.test.ts` (14 cases). Coverage matrix updated with `sidebar.sort-pure`, `sidebar.sort-toggle-ui`, and `sidebar.sort-live`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, design, and implementation drafted by Claude under my direction. The design was hardened against a three-model debate (`gemini`, `openai`, `anthropic`) that converged on the localStorage + pure-module + lifted-hook architecture in this PR; the multi-repo pin, tie-break chain, and live-test seeding strategy are all explicit verdicts from that debate.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR adds an opt-in "Recent activity" sidebar sort mode while keeping the current manual drag-to-reorder behavior as the default.

- New: client-side recency sorting keyed on the most recent of each workspace’s timestamps (last_accessed_at, idle_entered_at, created_at), newest-first.
- New: per-browser toggle UI in the sidebar header to switch between "manual" and "Recent activity"; toggle state persisted to localStorage["aoe-sidebar-sort-mode"].
- New: pure sorting utilities in web/src/lib/sidebarSort.ts and a hook web/src/hooks/useSidebarSortMode.ts to load/save and expose the mode.
- Updated: App and repo-grouping logic (web/src/App.tsx, web/src/hooks/useRepoGroups.ts) to accept and apply the selected sort mode.
- Updated: WorkspaceSidebar and SortableSessionRow (web/src/components/WorkspaceSidebar.tsx) to show the header toggle and disable drag handles/PUTs to /api/workspace-ordering while in Recent activity mode.
- Tests & docs: unit tests for the comparator, mocked and live Playwright specs covering toggle behavior, persistence, non-drag behavior, multi-repo pinning; docs/guides/web-dashboard.md updated. AI-assisted drafting/refactoring noted.

Benefits
- Lets users opt into automatic, meaningful recent-activity ordering without removing manual reordering.
- Preserves existing server-backed ordering and drag UX by default.
- Deterministic tie-break using workspace.id to avoid flakiness.
- Local-only persistence (per-browser) keeps behavior predictable across devices.
- Clear UX cue: drag affordances removed in Recent activity mode to indicate read-only ordering.

Technical details (short)
- New type SidebarSortMode = "manual" | "lastActivity" and storage key SIDEBAR_SORT_MODE_KEY = "aoe-sidebar-sort-mode".
- workspaceLastActivityMs computes epoch-ms max across sessions' last_accessed_at, idle_entered_at, created_at (invalid/missing → Number.NEGATIVE_INFINITY).
- compareWorkspacesByLastActivityDesc sorts by that key descending, falling back to workspace.id.localeCompare for ties; comparator avoids subtraction to prevent NaN edge cases.
- When in lastActivity mode, drag handlers are disabled and no PUTs to /api/workspace-ordering are emitted.

Potential follow-ups
- Consider making sort preference syncable across profiles/devices (if desired).
- Re-evaluate multi-repo pinning behavior in last-activity mode in a future UX discussion.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/njbrake/agent-of-empires/pull/1425?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
