### PR TITLE
feat(cockpit): model picker + reasoning effort selector (#1403)

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -525,6 +525,63 @@ The Auto-approve toggle in the wizard does not configure
 `ALLOW_BYPASS`; the env var is a daemon-process input set wherever
 `aoe serve` actually launches.
 
+## Model and reasoning effort
+
+Cockpit sessions render two extra selectors in the composer footer
+beside the mode pill when the ACP adapter advertises them: a model
+dropdown and a reasoning-effort selector. Both come from one wire
+mechanism, ACP `SessionUpdate::ConfigOptionUpdate`, stabilised
+upstream in `claude-agent-acp` v0.37.0. The adapter emits the full
+snapshot of every selector (mode, model, reasoning effort, future
+categories) whenever any one of them changes; the cockpit replaces
+its cached list in full.
+
+### When the pickers appear
+
+The pickers only render if the adapter publishes the matching
+category. `claude-agent-acp` v0.37.0+ advertises a model selector
+for every session, and adds a reasoning-effort selector when the
+current model reports `supportsEffort=true`. Older adapters that
+emit no `config_option_update` show neither picker; this is by
+design so non-Claude backends don't grow empty UI chrome.
+
+### Setting a value
+
+Clicking an option fires `POST /api/sessions/{id}/cockpit/config-option`
+with `{ config_id, value }` which the cockpit supervisor turns into
+ACP `session/set_config_option`. The UI is pessimistic: the chip
+still shows the previous current value while the request is in
+flight, with a subtle dim and a disabled re-click on the just-clicked
+option, until the adapter pushes a confirming `config_option_update`.
+This avoids "snap back" on slow networks (Cloudflare Tunnel can run
+300-800ms round trips).
+
+### The `Default` reasoning effort
+
+The reasoning-effort dropdown includes a `Default` option alongside
+adapter-supported levels like `Low | Medium | High`. `Default` is
+not a fixed effort; the SDK resolves it per current model. Picking
+it explicitly tells the adapter to drop any session-level effort
+pin so the model uses its default reasoning budget. See upstream
+PR agentclientprotocol/claude-agent-acp#701.
+
+### When a switch fails
+
+If the adapter rejects `session/set_config_option` (rate limit,
+missing capability, transient error), an amber non-blocking notice
+appears next to the composer with the configured selector name, the
+rejected value, and the adapter's reason. The notice auto-dismisses
+when a later snapshot reports the originally-requested value as
+current (the user retried and won, or the adapter applied the value
+asynchronously). The session keeps running in whichever value the
+adapter last confirmed.
+
+### Lifecycle clears
+
+The cached selector list clears on `AgentSwitched` (a Claude-to-Codex
+handoff invalidates Claude-specific models) but survives `/clear`:
+adapter capabilities are process-scoped, not conversation-scoped.
+
 ## Approvals
 
 When the agent wants to run a tool that requires approval, the cockpit

--- a/src/cli/cockpit.rs
+++ b/src/cli/cockpit.rs
@@ -823,6 +823,8 @@ fn event_kind(event: &crate::cockpit::Event) -> &'static str {
         Event::CurrentModeChanged { .. } => "current_mode_changed",
         Event::ModeSwitchFailed { .. } => "mode_switch_failed",
         Event::AvailableCommandsUpdated { .. } => "available_commands_updated",
+        Event::ConfigOptionsUpdated { .. } => "config_options_updated",
+        Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::Stopped { .. } => "stopped",

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -40,7 +40,8 @@ use super::approvals::{is_destructive, ApprovalDecision, Nonce};
 use super::fs_handler::{self, FsPolicy, SandboxPathMap};
 use super::permissions::build_approval;
 use super::state::{
-    AvailableCommand, CockpitSessionId, DiffPreview, Event, MemoryRecall, ModeInfo, Plan, PlanStep,
+    AvailableCommand, CockpitSessionId, ConfigOptionCategory, ConfigOptionChoice,
+    ConfigOptionDescriptor, DiffPreview, Event, MemoryRecall, ModeInfo, Plan, PlanStep,
     PlanStepStatus, RateLimitInfo, SessionMode, SessionUsage, StartupErrorDetail, ToolCall,
     UsageCost,
 };
@@ -2744,11 +2745,85 @@ fn map_update_to_events(
             );
             vec![Event::AvailableCommandsUpdated { commands }]
         }
+        SessionUpdate::ConfigOptionUpdate(update) => {
+            let options: Vec<ConfigOptionDescriptor> = update
+                .config_options
+                .into_iter()
+                .filter_map(map_acp_config_option)
+                .collect();
+            debug!(
+                target: "cockpit.acp",
+                count = options.len(),
+                "received ConfigOptionUpdate from agent"
+            );
+            vec![Event::ConfigOptionsUpdated { options }]
+        }
         // Variants we don't have a typed mapping for yet pass through as
         // RawAgentUpdate so the UI can render best-effort and we can
         // narrow these as we go.
         other => vec![raw_event(&other)],
     }
+}
+
+/// Build a cockpit `ConfigOptionDescriptor` from an ACP
+/// `SessionConfigOption`. Returns `None` when the option has a kind
+/// the cockpit does not yet render (today everything except `Select`).
+/// See #1403.
+fn map_acp_config_option(
+    option: agent_client_protocol::schema::SessionConfigOption,
+) -> Option<ConfigOptionDescriptor> {
+    use agent_client_protocol::schema::{
+        SessionConfigKind, SessionConfigOptionCategory, SessionConfigSelectOptions,
+    };
+
+    let category = option.category.map(|c| match c {
+        SessionConfigOptionCategory::Mode => ConfigOptionCategory::Mode,
+        SessionConfigOptionCategory::Model => ConfigOptionCategory::Model,
+        SessionConfigOptionCategory::ThoughtLevel => ConfigOptionCategory::ThoughtLevel,
+        SessionConfigOptionCategory::Other(s) => ConfigOptionCategory::Other(s),
+        _ => ConfigOptionCategory::Other(String::new()),
+    });
+
+    // Only `Select` is rendered today; future kinds (boolean toggles
+    // behind `unstable_boolean_config`) skip until the cockpit grows a
+    // matching widget. The schema enum is `#[non_exhaustive]` so a
+    // catch-all is required.
+    let select = match option.kind {
+        SessionConfigKind::Select(s) => s,
+        _ => return None,
+    };
+
+    let choices: Vec<ConfigOptionChoice> = match select.options {
+        SessionConfigSelectOptions::Ungrouped(opts) => opts
+            .into_iter()
+            .map(|o| ConfigOptionChoice {
+                value: o.value.0.to_string(),
+                name: o.name,
+                description: o.description,
+            })
+            .collect(),
+        SessionConfigSelectOptions::Grouped(groups) => groups
+            .into_iter()
+            .flat_map(|g| {
+                g.options.into_iter().map(|o| ConfigOptionChoice {
+                    value: o.value.0.to_string(),
+                    name: o.name,
+                    description: o.description,
+                })
+            })
+            .collect(),
+        // Catch-all for `#[non_exhaustive]` future variants.
+        _ => Vec::new(),
+    };
+
+    Some(ConfigOptionDescriptor {
+        id: option.id.0.to_string(),
+        name: option.name,
+        description: option.description,
+        category: category.unwrap_or(ConfigOptionCategory::Other(String::new())),
+        current_value: select.current_value.0.to_string(),
+        options: choices,
+    })
 }
 
 fn map_plan_status(status: agent_client_protocol::schema::PlanEntryStatus) -> PlanStepStatus {
@@ -6116,6 +6191,71 @@ mod tests {
                 assert!(!commands[1].accepts_input);
             }
             other => panic!("expected AvailableCommandsUpdated, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_config_option_update_emits_typed_event_with_categories() {
+        use agent_client_protocol::schema::{
+            ConfigOptionUpdate, SessionConfigKind, SessionConfigOption,
+            SessionConfigOptionCategory, SessionConfigSelect, SessionConfigSelectOption,
+            SessionConfigSelectOptions,
+        };
+        let model_option = SessionConfigOption::new(
+            "model",
+            "Model",
+            SessionConfigKind::Select(SessionConfigSelect::new(
+                "claude-opus-4-7",
+                SessionConfigSelectOptions::Ungrouped(vec![
+                    SessionConfigSelectOption::new("claude-opus-4-7", "Claude Opus 4.7"),
+                    SessionConfigSelectOption::new("claude-sonnet-4-6", "Claude Sonnet 4.6"),
+                ]),
+            )),
+        )
+        .category(SessionConfigOptionCategory::Model);
+        let effort_option = SessionConfigOption::new(
+            "effort",
+            "Reasoning Effort",
+            SessionConfigKind::Select(SessionConfigSelect::new(
+                "default",
+                SessionConfigSelectOptions::Ungrouped(vec![
+                    SessionConfigSelectOption::new("default", "Default"),
+                    SessionConfigSelectOption::new("high", "High"),
+                ]),
+            )),
+        )
+        .category(SessionConfigOptionCategory::ThoughtLevel);
+        let mode_option = SessionConfigOption::new(
+            "mode",
+            "Mode",
+            SessionConfigKind::Select(SessionConfigSelect::new(
+                "default",
+                SessionConfigSelectOptions::Ungrouped(vec![
+                    SessionConfigSelectOption::new("default", "Default"),
+                    SessionConfigSelectOption::new("plan", "Plan"),
+                ]),
+            )),
+        )
+        .category(SessionConfigOptionCategory::Mode);
+        let update = ConfigOptionUpdate::new(vec![model_option, effort_option, mode_option]);
+
+        let events = map_update_to_events(
+            SessionUpdate::ConfigOptionUpdate(update),
+            &agent_profiles::CLAUDE,
+        );
+        assert_eq!(events.len(), 1);
+        match &events[0] {
+            Event::ConfigOptionsUpdated { options } => {
+                assert_eq!(options.len(), 3);
+                assert_eq!(options[0].id, "model");
+                assert_eq!(options[0].category, ConfigOptionCategory::Model);
+                assert_eq!(options[0].current_value, "claude-opus-4-7");
+                assert_eq!(options[0].options.len(), 2);
+                assert_eq!(options[1].category, ConfigOptionCategory::ThoughtLevel);
+                assert_eq!(options[1].current_value, "default");
+                assert_eq!(options[2].category, ConfigOptionCategory::Mode);
+            }
+            other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
         }
     }
 

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2790,6 +2790,26 @@ fn map_update_to_events(
     }
 }
 
+/// Map a snapshot of ACP `SessionConfigOption`s (typically pulled
+/// from `NewSessionResponse.config_options` or
+/// `LoadSessionResponse.config_options`) into one
+/// `Event::ConfigOptionsUpdated`. Returns `None` when the snapshot is
+/// absent or empty so callers can skip the emit. See #1403.
+fn config_options_event(
+    options: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
+) -> Option<Event> {
+    let raw = options?;
+    if raw.is_empty() {
+        return None;
+    }
+    let mapped: Vec<ConfigOptionDescriptor> =
+        raw.into_iter().filter_map(map_acp_config_option).collect();
+    if mapped.is_empty() {
+        return None;
+    }
+    Some(Event::ConfigOptionsUpdated { options: mapped })
+}
+
 /// Build a cockpit `ConfigOptionDescriptor` from an ACP
 /// `SessionConfigOption`. Returns `None` when the option has a kind
 /// the cockpit does not yet render (today everything except `Select`).
@@ -3420,7 +3440,7 @@ async fn run_connection_task<W, R>(
                             suppress_for_block.store(true, Ordering::Relaxed);
                             let req = LoadSessionRequest::new(stored.clone(), cwd.clone());
                             match connection.send_request(req).block_task().await {
-                                Ok(_resp) => {
+                                Ok(resp) => {
                                     info!(
                                         target: "cockpit.acp",
                                         session = %session_label,
@@ -3439,6 +3459,15 @@ async fn run_connection_task<W, R>(
                                             acp_session_id: stored.clone(),
                                         })
                                         .await;
+                                    // Per ACP schema 0.12, LoadSessionResponse
+                                    // carries config_options. Surface them so
+                                    // the cockpit picker hydrates on resume
+                                    // without waiting for a notification. See
+                                    // #1403.
+                                    if let Some(event) = config_options_event(resp.config_options)
+                                    {
+                                        let _ = event_tx_for_block.send(event).await;
+                                    }
                                     acp_session_id = Some(SessionId::from(stored));
                                 }
                                 Err(e) => {
@@ -3500,6 +3529,17 @@ async fn run_connection_task<W, R>(
                                     modes: infos,
                                 })
                                 .await;
+                        }
+
+                        // Per ACP schema 0.12, NewSessionResponse carries
+                        // config_options (claude-agent-acp v0.37.0 emits the
+                        // initial model + effort + mode set here, not as a
+                        // subsequent notification). Surface them so the
+                        // cockpit pickers render immediately. See #1403.
+                        if let Some(event) =
+                            config_options_event(new_session.config_options.clone())
+                        {
+                            let _ = event_tx_for_block.send(event).await;
                         }
 
                         // Tell the server-side listener so it can persist the

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -22,8 +22,9 @@ use agent_client_protocol::schema::{
     KillTerminalResponse, LoadSessionRequest, NewSessionRequest, PermissionOptionKind,
     PromptRequest, ProtocolVersion, ReadTextFileRequest, ReadTextFileResponse,
     ReleaseTerminalRequest, ReleaseTerminalResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome, SessionId,
-    SessionNotification, SessionUpdate, SetSessionModeRequest, StopReason, TerminalId,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionConfigId, SessionConfigValueId, SessionId, SessionNotification, SessionUpdate,
+    SetSessionConfigOptionRequest, SetSessionModeRequest, StopReason, TerminalId,
     TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
     WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
@@ -228,6 +229,14 @@ enum ClientCmd {
     Prompt(String),
     Cancel,
     SetMode(String),
+    /// Send `session/set_config_option` for the given (`config_id`,
+    /// `value`) pair. The connection task fires the request detached so
+    /// the cmd_rx loop keeps polling for Cancel during the round-trip.
+    /// See #1403.
+    SetConfigOption {
+        config_id: String,
+        value: String,
+    },
     Shutdown,
 }
 
@@ -1402,6 +1411,22 @@ impl AcpClient {
         let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
         cmd_tx
             .send(ClientCmd::SetMode(mode_id.to_string()))
+            .await
+            .map_err(|_| AcpError::AgentExited)
+    }
+
+    /// Set a per-session selector (model, reasoning effort, etc.) via
+    /// ACP `session/set_config_option`. The cockpit treats every
+    /// adapter-advertised category through this one path; specific
+    /// helpers per category would just duplicate the wiring. See
+    /// #1403.
+    pub async fn set_config_option(&self, config_id: &str, value: &str) -> Result<(), AcpError> {
+        let cmd_tx = self.cmd_tx.as_ref().ok_or(AcpError::NotRunning)?;
+        cmd_tx
+            .send(ClientCmd::SetConfigOption {
+                config_id: config_id.to_string(),
+                value: value.to_string(),
+            })
             .await
             .map_err(|_| AcpError::AgentExited)
     }
@@ -3855,6 +3880,42 @@ async fn run_connection_task<W, R>(
                                                 );
                                             }
                                         }
+                                        Some(ClientCmd::SetConfigOption { config_id, value }) => {
+                                            info!(
+                                                target: "cockpit.acp",
+                                                "sending session/set_config_option {config_id}={value} during in-flight prompt"
+                                            );
+                                            let sent = connection.send_request(
+                                                SetSessionConfigOptionRequest::new(
+                                                    acp_session_id.clone(),
+                                                    SessionConfigId::new(config_id.clone()),
+                                                    SessionConfigValueId::new(value.clone()),
+                                                ),
+                                            );
+                                            let tx = event_tx_for_block.clone();
+                                            tokio::spawn(async move {
+                                                if let Err(e) = sent.block_task().await {
+                                                    let reason = format!("{e}");
+                                                    warn!(
+                                                        target: "cockpit.acp",
+                                                        "session/set_config_option failed mid-turn: {reason}"
+                                                    );
+                                                    let _ = tx
+                                                        .send(Event::ConfigOptionSwitchFailed {
+                                                            config_id,
+                                                            value,
+                                                            reason,
+                                                        })
+                                                        .await;
+                                                }
+                                                // On success the adapter
+                                                // emits a ConfigOptionUpdate
+                                                // notification which the
+                                                // ingest path turns into
+                                                // ConfigOptionsUpdated. No
+                                                // synthetic event needed.
+                                            });
+                                        }
                                         Some(ClientCmd::SetMode(mode_id)) => {
                                             info!(
                                                 target: "cockpit.acp",
@@ -4042,6 +4103,34 @@ async fn run_connection_task<W, R>(
                                         .send(Event::ModeSwitchFailed { mode_id, reason })
                                         .await;
                                 }
+                            }
+                        });
+                    }
+                    Some(ClientCmd::SetConfigOption { config_id, value }) => {
+                        info!(
+                            target: "cockpit.acp",
+                            "sending session/set_config_option {config_id}={value}"
+                        );
+                        let sent = connection.send_request(SetSessionConfigOptionRequest::new(
+                            acp_session_id.clone(),
+                            SessionConfigId::new(config_id.clone()),
+                            SessionConfigValueId::new(value.clone()),
+                        ));
+                        let tx = event_tx_for_block.clone();
+                        tokio::spawn(async move {
+                            if let Err(e) = sent.block_task().await {
+                                let reason = format!("{e}");
+                                warn!(
+                                    target: "cockpit.acp",
+                                    "session/set_config_option failed: {reason}"
+                                );
+                                let _ = tx
+                                    .send(Event::ConfigOptionSwitchFailed {
+                                        config_id,
+                                        value,
+                                        reason,
+                                    })
+                                    .await;
                             }
                         });
                     }

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -2793,20 +2793,17 @@ fn map_update_to_events(
 /// Map a snapshot of ACP `SessionConfigOption`s (typically pulled
 /// from `NewSessionResponse.config_options` or
 /// `LoadSessionResponse.config_options`) into one
-/// `Event::ConfigOptionsUpdated`. Returns `None` when the snapshot is
-/// absent or empty so callers can skip the emit. See #1403.
+/// `Event::ConfigOptionsUpdated`. Returns `None` only when the
+/// snapshot itself is absent (the adapter did not include the field).
+/// A present-but-empty snapshot is still a real full replacement and
+/// must be propagated, otherwise stale cached selectors never clear
+/// when an adapter intentionally drops them. See #1403.
 fn config_options_event(
     options: Option<Vec<agent_client_protocol::schema::SessionConfigOption>>,
 ) -> Option<Event> {
     let raw = options?;
-    if raw.is_empty() {
-        return None;
-    }
     let mapped: Vec<ConfigOptionDescriptor> =
         raw.into_iter().filter_map(map_acp_config_option).collect();
-    if mapped.is_empty() {
-        return None;
-    }
     Some(Event::ConfigOptionsUpdated { options: mapped })
 }
 
@@ -6414,6 +6411,25 @@ mod tests {
             }
             other => panic!("expected ConfigOptionsUpdated, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn config_options_event_propagates_empty_snapshot() {
+        // A present-but-empty snapshot from the adapter is a real
+        // full replacement and must clear stale cached selectors, so
+        // `config_options_event(Some(vec![]))` returns
+        // `Some(ConfigOptionsUpdated { options: [] })` (not `None`).
+        let event =
+            config_options_event(Some(Vec::new())).expect("Some(vec![]) should produce an event");
+        match event {
+            Event::ConfigOptionsUpdated { options } => {
+                assert!(options.is_empty());
+            }
+            other => panic!("expected empty ConfigOptionsUpdated, got {other:?}"),
+        }
+        // Absent snapshot (the adapter omitted the field) still
+        // returns None so callers skip the emit.
+        assert!(config_options_event(None).is_none());
     }
 
     #[test]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -3934,26 +3934,38 @@ async fn run_connection_task<W, R>(
                                             );
                                             let tx = event_tx_for_block.clone();
                                             tokio::spawn(async move {
-                                                if let Err(e) = sent.block_task().await {
-                                                    let reason = format!("{e}");
-                                                    warn!(
-                                                        target: "cockpit.acp",
-                                                        "session/set_config_option failed mid-turn: {reason}"
-                                                    );
-                                                    let _ = tx
-                                                        .send(Event::ConfigOptionSwitchFailed {
-                                                            config_id,
-                                                            value,
-                                                            reason,
-                                                        })
-                                                        .await;
+                                                match sent.block_task().await {
+                                                    Ok(resp) => {
+                                                        // claude-agent-acp's setSessionConfigOption
+                                                        // returns the full updated config_options
+                                                        // list in the response but does NOT emit a
+                                                        // follow-up `config_option_update`
+                                                        // notification (see acp-agent.js:1003-1057).
+                                                        // Synthesize ConfigOptionsUpdated from the
+                                                        // response so the frontend reducer clears
+                                                        // pending state and shows the new current
+                                                        // value. See #1403.
+                                                        if let Some(event) =
+                                                            config_options_event(Some(resp.config_options))
+                                                        {
+                                                            let _ = tx.send(event).await;
+                                                        }
+                                                    }
+                                                    Err(e) => {
+                                                        let reason = format!("{e}");
+                                                        warn!(
+                                                            target: "cockpit.acp",
+                                                            "session/set_config_option failed mid-turn: {reason}"
+                                                        );
+                                                        let _ = tx
+                                                            .send(Event::ConfigOptionSwitchFailed {
+                                                                config_id,
+                                                                value,
+                                                                reason,
+                                                            })
+                                                            .await;
+                                                    }
                                                 }
-                                                // On success the adapter
-                                                // emits a ConfigOptionUpdate
-                                                // notification which the
-                                                // ingest path turns into
-                                                // ConfigOptionsUpdated. No
-                                                // synthetic event needed.
                                             });
                                         }
                                         Some(ClientCmd::SetMode(mode_id)) => {
@@ -4158,19 +4170,35 @@ async fn run_connection_task<W, R>(
                         ));
                         let tx = event_tx_for_block.clone();
                         tokio::spawn(async move {
-                            if let Err(e) = sent.block_task().await {
-                                let reason = format!("{e}");
-                                warn!(
-                                    target: "cockpit.acp",
-                                    "session/set_config_option failed: {reason}"
-                                );
-                                let _ = tx
-                                    .send(Event::ConfigOptionSwitchFailed {
-                                        config_id,
-                                        value,
-                                        reason,
-                                    })
-                                    .await;
+                            match sent.block_task().await {
+                                Ok(resp) => {
+                                    // claude-agent-acp's setSessionConfigOption returns the
+                                    // full updated config_options list in the response but
+                                    // does NOT emit a follow-up `config_option_update`
+                                    // notification (see acp-agent.js:1003-1057). Synthesize
+                                    // ConfigOptionsUpdated from the response so the frontend
+                                    // reducer clears pending state and shows the new
+                                    // current value. See #1403.
+                                    if let Some(event) =
+                                        config_options_event(Some(resp.config_options))
+                                    {
+                                        let _ = tx.send(event).await;
+                                    }
+                                }
+                                Err(e) => {
+                                    let reason = format!("{e}");
+                                    warn!(
+                                        target: "cockpit.acp",
+                                        "session/set_config_option failed: {reason}"
+                                    );
+                                    let _ = tx
+                                        .send(Event::ConfigOptionSwitchFailed {
+                                            config_id,
+                                            value,
+                                            reason,
+                                        })
+                                        .await;
+                                }
                             }
                         });
                     }

--- a/src/cockpit/event_store.rs
+++ b/src/cockpit/event_store.rs
@@ -832,6 +832,8 @@ fn event_kind(event: &Event) -> &'static str {
         Event::CurrentModeChanged { .. } => "current_mode_changed",
         Event::ModeSwitchFailed { .. } => "mode_switch_failed",
         Event::AvailableCommandsUpdated { .. } => "available_commands_updated",
+        Event::ConfigOptionsUpdated { .. } => "config_options_updated",
+        Event::ConfigOptionSwitchFailed { .. } => "config_option_switch_failed",
         Event::RawAgentUpdate { .. } => "raw_agent_update",
         Event::AgentMessageChunk { .. } => "agent_message_chunk",
         Event::Stopped { .. } => "stopped",

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -186,6 +186,62 @@ pub struct AvailableCommand {
     pub accepts_input: bool,
 }
 
+/// Semantic category for an ACP `SessionConfigOption`. Mirrors the
+/// upstream schema's `SessionConfigOptionCategory` so the cockpit UI
+/// can pick the right widget per category (model dropdown, effort
+/// segmented control, etc.) without hardcoding option ids. Unknown
+/// categories fall through to `Other(String)` so the broadcast frame
+/// stays forward-compatible with new adapter categories.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfigOptionCategory {
+    Mode,
+    Model,
+    ThoughtLevel,
+    #[serde(untagged)]
+    Other(String),
+}
+
+/// One choice in a `Select`-kind `SessionConfigOption`. `value` is the
+/// token the agent expects back via `session/set_config_option`;
+/// `name` is the user-facing label.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigOptionChoice {
+    pub value: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// Cockpit's view of a single ACP `SessionConfigOption`. Built from
+/// `SessionUpdate::ConfigOptionUpdate` notifications; the adapter
+/// resends the full snapshot whenever any selector changes, so the
+/// cockpit treats each `ConfigOptionsUpdated` event as a full
+/// replacement of the previous list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigOptionDescriptor {
+    pub id: String,
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub category: ConfigOptionCategory,
+    pub current_value: String,
+    pub options: Vec<ConfigOptionChoice>,
+}
+
+/// Carried by `Event::ConfigOptionSwitchFailed` and stored on
+/// `CockpitState.config_option_switch_failed` so the UI can render a
+/// non-blocking notice when the adapter rejects a
+/// `session/set_config_option` call. Auto-clears when a later
+/// `ConfigOptionsUpdated` snapshot reports the originally-requested
+/// value as current, or on `AgentSwitched`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConfigOptionSwitchFailure {
+    pub config_id: String,
+    pub value: String,
+    pub reason: String,
+}
+
 /// Structured detail about why aoe refused to enter the session after
 /// the ACP `initialize` handshake completed. Distinct from the runtime
 /// `Stopped` taxonomy: a startup error means the session never reached
@@ -260,6 +316,19 @@ pub struct CockpitState {
     /// only carry a free-form message; see `Event::AgentStartupError`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub startup_error: Option<StartupErrorDetail>,
+    /// Full snapshot of the per-session selectors the adapter
+    /// advertises (model, reasoning effort, mode, future categories).
+    /// Mirrors the most recent ACP `ConfigOptionUpdate` notification.
+    /// Empty when the adapter does not advertise any config options
+    /// (older adapters, non-Claude backends). See #1403.
+    #[serde(default)]
+    pub config_options: Vec<ConfigOptionDescriptor>,
+    /// Non-blocking notice for the most recent `session/set_config_option`
+    /// rejection. Cleared automatically by the next snapshot whose
+    /// matching `config_id` carries the originally-requested value, or
+    /// on `AgentSwitched`. Mirrors `ModeSwitchFailed` (#1233).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_option_switch_failed: Option<ConfigOptionSwitchFailure>,
 
     pub last_seq: u64,
     pub updated_at: DateTime<Utc>,
@@ -287,6 +356,8 @@ impl CockpitState {
             available_commands: Vec::new(),
             last_agent_switch: None,
             startup_error: None,
+            config_options: Vec::new(),
+            config_option_switch_failed: None,
             last_seq: 0,
             updated_at: Utc::now(),
         }
@@ -431,6 +502,27 @@ pub enum Event {
     /// changes; e.g. after plugin enable/disable).
     AvailableCommandsUpdated {
         commands: Vec<AvailableCommand>,
+    },
+    /// Full snapshot of the per-session selectors the adapter
+    /// advertises. Comes from ACP `SessionUpdate::ConfigOptionUpdate`
+    /// (stabilised in claude-agent-acp v0.37.0). The adapter resends
+    /// the full set whenever any selector changes; the reducer
+    /// replaces (not merges) the prior `config_options`. Also
+    /// auto-clears `config_option_switch_failed` when the snapshot's
+    /// matching config_id current_value equals the previously-failed
+    /// value. See #1403.
+    ConfigOptionsUpdated {
+        options: Vec<ConfigOptionDescriptor>,
+    },
+    /// `session/set_config_option` round-trip rejected by the adapter.
+    /// UI renders a non-blocking notice and the session keeps whatever
+    /// value the adapter last reported. Mirrors `ModeSwitchFailed`
+    /// (#1233). Auto-dismisses on the next confirming
+    /// `ConfigOptionsUpdated` snapshot or on `AgentSwitched`.
+    ConfigOptionSwitchFailed {
+        config_id: String,
+        value: String,
+        reason: String,
     },
     /// Passthrough for an ACP `session/update` payload that we have not yet
     /// finished mapping to a typed variant. Useful while the cockpit's
@@ -630,6 +722,35 @@ impl CockpitState {
             Event::AvailableCommandsUpdated { commands } => {
                 self.available_commands = commands;
             }
+            Event::ConfigOptionsUpdated { options } => {
+                // Auto-dismiss a stale switch-failed notice when this
+                // snapshot reports the originally-requested value as
+                // current (the user retried and won, or the adapter
+                // applied the value asynchronously). Without this the
+                // notice would linger until the user dismissed it.
+                if let Some(failure) = self.config_option_switch_failed.as_ref() {
+                    let confirmed = options
+                        .iter()
+                        .find(|opt| opt.id == failure.config_id)
+                        .map(|opt| opt.current_value == failure.value)
+                        .unwrap_or(false);
+                    if confirmed {
+                        self.config_option_switch_failed = None;
+                    }
+                }
+                self.config_options = options;
+            }
+            Event::ConfigOptionSwitchFailed {
+                config_id,
+                value,
+                reason,
+            } => {
+                self.config_option_switch_failed = Some(ConfigOptionSwitchFailure {
+                    config_id,
+                    value,
+                    reason,
+                });
+            }
             // The next four variants don't directly mutate persistent
             // CockpitState fields (yet); they bump seq/updated_at so
             // clients see them in the replay buffer and know the session
@@ -704,6 +825,11 @@ impl CockpitState {
                 self.available_commands = Vec::new();
                 self.current_plan = None;
                 self.mode = SessionMode::Default;
+                // Per-adapter selectors (model, effort, etc.) belong
+                // to the previous backend's capability surface; the
+                // new backend will publish its own snapshot.
+                self.config_options = Vec::new();
+                self.config_option_switch_failed = None;
                 self.last_agent_switch = Some(AgentSwitchInfo {
                     from,
                     to,
@@ -841,6 +967,175 @@ mod tests {
         assert_eq!(s.available_commands.len(), 2);
         assert_eq!(s.available_commands[0].name, "review");
         assert!(s.available_commands[0].accepts_input);
+    }
+
+    fn sample_config_options() -> Vec<ConfigOptionDescriptor> {
+        vec![
+            ConfigOptionDescriptor {
+                id: "model".into(),
+                name: "Model".into(),
+                description: None,
+                category: ConfigOptionCategory::Model,
+                current_value: "claude-opus-4-7".into(),
+                options: vec![
+                    ConfigOptionChoice {
+                        value: "claude-opus-4-7".into(),
+                        name: "Claude Opus 4.7".into(),
+                        description: None,
+                    },
+                    ConfigOptionChoice {
+                        value: "claude-sonnet-4-6".into(),
+                        name: "Claude Sonnet 4.6".into(),
+                        description: None,
+                    },
+                ],
+            },
+            ConfigOptionDescriptor {
+                id: "effort".into(),
+                name: "Reasoning Effort".into(),
+                description: None,
+                category: ConfigOptionCategory::ThoughtLevel,
+                current_value: "default".into(),
+                options: vec![
+                    ConfigOptionChoice {
+                        value: "default".into(),
+                        name: "Default".into(),
+                        description: None,
+                    },
+                    ConfigOptionChoice {
+                        value: "high".into(),
+                        name: "High".into(),
+                        description: None,
+                    },
+                ],
+            },
+        ]
+    }
+
+    #[test]
+    fn config_options_updated_replaces_previous_list() {
+        let mut s = fresh_state();
+        assert!(s.config_options.is_empty());
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        assert_eq!(s.config_options.len(), 2);
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: vec![ConfigOptionDescriptor {
+                id: "model".into(),
+                name: "Model".into(),
+                description: None,
+                category: ConfigOptionCategory::Model,
+                current_value: "claude-sonnet-4-6".into(),
+                options: Vec::new(),
+            }],
+        })
+        .unwrap();
+        assert_eq!(s.config_options.len(), 1);
+        assert_eq!(s.config_options[0].current_value, "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn config_option_switch_failed_records_notice_without_mutating_options() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        let before = s.config_options.clone();
+        s.apply_event(Event::ConfigOptionSwitchFailed {
+            config_id: "model".into(),
+            value: "claude-sonnet-4-6".into(),
+            reason: "rate limited".into(),
+        })
+        .unwrap();
+        let notice = s
+            .config_option_switch_failed
+            .as_ref()
+            .expect("notice populated");
+        assert_eq!(notice.config_id, "model");
+        assert_eq!(notice.value, "claude-sonnet-4-6");
+        assert_eq!(notice.reason, "rate limited");
+        assert_eq!(s.config_options, before);
+    }
+
+    #[test]
+    fn config_options_updated_clears_matching_failure_notice() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        s.apply_event(Event::ConfigOptionSwitchFailed {
+            config_id: "model".into(),
+            value: "claude-sonnet-4-6".into(),
+            reason: "transient".into(),
+        })
+        .unwrap();
+        let mut next = sample_config_options();
+        next[0].current_value = "claude-sonnet-4-6".into();
+        s.apply_event(Event::ConfigOptionsUpdated { options: next })
+            .unwrap();
+        assert!(s.config_option_switch_failed.is_none());
+    }
+
+    #[test]
+    fn config_options_updated_preserves_non_matching_failure_notice() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        s.apply_event(Event::ConfigOptionSwitchFailed {
+            config_id: "model".into(),
+            value: "claude-sonnet-4-6".into(),
+            reason: "transient".into(),
+        })
+        .unwrap();
+        // Snapshot still shows opus as current; the failure notice for
+        // a sonnet switch attempt must survive.
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        assert!(s.config_option_switch_failed.is_some());
+    }
+
+    #[test]
+    fn agent_switched_clears_config_options_and_failure_notice() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        s.apply_event(Event::ConfigOptionSwitchFailed {
+            config_id: "effort".into(),
+            value: "high".into(),
+            reason: "unsupported".into(),
+        })
+        .unwrap();
+        s.apply_event(Event::AgentSwitched {
+            from: "claude".into(),
+            to: "codex".into(),
+            reason: "rate_limit".into(),
+        })
+        .unwrap();
+        assert!(s.config_options.is_empty());
+        assert!(s.config_option_switch_failed.is_none());
+    }
+
+    #[test]
+    fn session_cleared_preserves_config_options() {
+        let mut s = fresh_state();
+        s.apply_event(Event::ConfigOptionsUpdated {
+            options: sample_config_options(),
+        })
+        .unwrap();
+        s.apply_event(Event::SessionCleared).unwrap();
+        // Adapter capabilities outlive /clear; the model has forgotten
+        // the conversation but still advertises the same selectors.
+        assert_eq!(s.config_options.len(), 2);
     }
 
     #[test]

--- a/src/cockpit/state.rs
+++ b/src/cockpit/state.rs
@@ -1013,6 +1013,31 @@ mod tests {
     }
 
     #[test]
+    fn config_option_category_unknown_value_round_trips_as_other() {
+        // Variant-level `#[serde(untagged)]` on `Other(String)` is the
+        // canonical pattern (matches upstream `SessionConfigOptionCategory`
+        // in agent-client-protocol-schema 0.12). Known snake_case values
+        // map to their unit variants; unknown ones fall through into
+        // `Other(String)`. Lock both behaviors so a future refactor
+        // doesn't silently break forward-compat with new adapter
+        // categories.
+        let model: ConfigOptionCategory = serde_json::from_str("\"model\"").unwrap();
+        assert_eq!(model, ConfigOptionCategory::Model);
+        let thought: ConfigOptionCategory = serde_json::from_str("\"thought_level\"").unwrap();
+        assert_eq!(thought, ConfigOptionCategory::ThoughtLevel);
+        let unknown: ConfigOptionCategory = serde_json::from_str("\"future_category\"").unwrap();
+        assert_eq!(
+            unknown,
+            ConfigOptionCategory::Other("future_category".to_string())
+        );
+        // Serializing the Other variant preserves the underlying
+        // string so the broadcast frame stays stable for clients
+        // that don't yet recognize the new category.
+        let back = serde_json::to_string(&ConfigOptionCategory::Other("x".into())).unwrap();
+        assert_eq!(back, "\"x\"");
+    }
+
+    #[test]
     fn config_options_updated_replaces_previous_list() {
         let mut s = fresh_state();
         assert!(s.config_options.is_empty());

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -1414,6 +1414,21 @@ impl<S: BroadcastSink> Supervisor<S> {
         Ok(())
     }
 
+    /// Set a per-session selector via ACP session/set_config_option.
+    /// Delegates to the per-session AcpClient. See #1403.
+    pub async fn set_config_option(
+        &self,
+        session_id: &str,
+        config_id: &str,
+        value: &str,
+    ) -> Result<(), SupervisorError> {
+        self.wait_for_worker(session_id, std::time::Duration::from_secs(10))
+            .await;
+        let client = self.client_for_session(session_id).await?;
+        client.set_config_option(config_id, value).await?;
+        Ok(())
+    }
+
     /// Resolve a pending approval.
     pub async fn resolve_permission(
         &self,

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -912,6 +912,46 @@ pub async fn cockpit_set_mode(
     }
 }
 
+#[derive(Debug, Deserialize)]
+pub struct SetConfigOptionRequest {
+    pub config_id: String,
+    pub value: String,
+}
+
+/// Set a per-session selector (model, reasoning effort, etc.) via ACP
+/// `session/set_config_option`. The cockpit treats every category
+/// through this one endpoint; rejection surfaces as a non-blocking
+/// `Event::ConfigOptionSwitchFailed` notice on the broadcast bus. See
+/// #1403.
+pub async fn cockpit_set_config_option(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    req: Result<Json<SetConfigOptionRequest>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if let Some(resp) = read_only_block(&state) {
+        return resp;
+    }
+    let Json(req) = match req {
+        Ok(j) => j,
+        Err(rej) => return rej.into_response(),
+    };
+    match state
+        .cockpit_supervisor
+        .set_config_option(&id, &req.config_id, &req.value)
+        .await
+    {
+        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Err(SupervisorError::UnknownSession(_)) => {
+            (StatusCode::NOT_FOUND, "session has no running cockpit").into_response()
+        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("set_config_option failed: {e}"),
+        )
+            .into_response(),
+    }
+}
+
 pub async fn resolve_approval(
     State(state): State<Arc<AppState>>,
     Path((id, nonce_str)): Path<(String, String)>,

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -23,8 +23,9 @@ mod system;
 #[cfg(feature = "serve")]
 pub use cockpit::{
     cockpit_cancel, cockpit_context_primer, cockpit_disable, cockpit_enable, cockpit_files,
-    cockpit_force_end_turn, cockpit_prompt, cockpit_replay, cockpit_set_mode, list_cockpit_agents,
-    resolve_approval, set_cockpit_master, shutdown_cockpit, spawn_cockpit, switch_cockpit_agent,
+    cockpit_force_end_turn, cockpit_prompt, cockpit_replay, cockpit_set_config_option,
+    cockpit_set_mode, list_cockpit_agents, resolve_approval, set_cockpit_master, shutdown_cockpit,
+    spawn_cockpit, switch_cockpit_agent,
 };
 
 #[cfg(feature = "serve")]
@@ -224,6 +225,7 @@ mod tests {
                     "cockpit_enable",
                     "cockpit_disable",
                     "cockpit_set_mode",
+                    "cockpit_set_config_option",
                     "resolve_approval",
                     "set_cockpit_master",
                 ],
@@ -350,6 +352,7 @@ mod tests {
                     "cockpit_enable",
                     "cockpit_disable",
                     "cockpit_set_mode",
+                    "cockpit_set_config_option",
                     "resolve_approval",
                     "set_cockpit_master",
                 ],

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1214,6 +1214,10 @@ fn build_router(state: Arc<AppState>) -> Router {
             post(api::cockpit_set_mode),
         )
         .route(
+            "/api/sessions/{id}/cockpit/config-option",
+            post(api::cockpit_set_config_option),
+        )
+        .route(
             "/api/sessions/{id}/cockpit/enable",
             post(api::cockpit_enable),
         )

--- a/src/tui/cockpit_view/reducer.rs
+++ b/src/tui/cockpit_view/reducer.rs
@@ -387,7 +387,9 @@ impl CockpitTranscript {
             | Event::WakeupScheduled { .. }
             | Event::PromptRejected { .. }
             | Event::AgentSwitched { .. }
-            | Event::ModeSwitchFailed { .. } => {
+            | Event::ModeSwitchFailed { .. }
+            | Event::ConfigOptionsUpdated { .. }
+            | Event::ConfigOptionSwitchFailed { .. } => {
                 // Surface as info notes for now; richer renderers are
                 // followup work tracked in the plan's "out of scope".
             }

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -83,6 +83,8 @@ export interface CockpitContext {
   clearQueue: () => void;
   dismissRejectedPrompt: (id: string) => void;
   dismissModeSwitchFailed: () => void;
+  setConfigOption: (configId: string, value: string) => Promise<void>;
+  dismissConfigOptionSwitchFailed: () => void;
 }
 
 /**
@@ -157,6 +159,8 @@ export function CockpitRuntime({
         clearQueue: cockpit.clearQueue,
         dismissRejectedPrompt: cockpit.dismissRejectedPrompt,
         dismissModeSwitchFailed: cockpit.dismissModeSwitchFailed,
+        setConfigOption: cockpit.setConfigOption,
+        dismissConfigOptionSwitchFailed: cockpit.dismissConfigOptionSwitchFailed,
       })}
     </AssistantRuntimeProvider>
   );

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -38,6 +38,7 @@ import {
   type CockpitContext,
 } from "./CockpitRuntime";
 import { Composer } from "./Composer";
+import { ConfigOptionSwitchFailedNotice } from "./SessionConfigControls";
 import { ContextPrimerBanner } from "./ContextPrimerBanner";
 import { RateLimitRecoveryModal } from "./RateLimitRecoveryModal";
 import { Markdown } from "./Markdown";
@@ -142,6 +143,8 @@ function CockpitChrome({
   clearQueue,
   dismissRejectedPrompt,
   dismissModeSwitchFailed,
+  setConfigOption,
+  dismissConfigOptionSwitchFailed,
 }: CockpitContext & {
   sessionId: string;
   cockpitWorkerState: "absent" | "resuming" | "running";
@@ -380,6 +383,12 @@ function CockpitChrome({
             onDismiss={dismissModeSwitchFailed}
           />
 
+          <ConfigOptionSwitchFailedNotice
+            failure={state.configOptionSwitchFailed}
+            configOptions={state.configOptions}
+            onDismiss={dismissConfigOptionSwitchFailed}
+          />
+
           <ContextPrimerBanner
             sessionId={sessionId}
             available={state.contextPrimerAvailable}
@@ -397,6 +406,9 @@ function CockpitChrome({
             availableModes={state.availableModes}
             currentModeId={state.currentModeId}
             legacyMode={state.mode}
+            configOptions={state.configOptions}
+            pendingConfigOption={state.pendingConfigOption}
+            setConfigOption={setConfigOption}
             sessionUsage={state.sessionUsage}
             availableCommands={state.availableCommands}
             connected={status === "open" && !state.workerStopped && !state.workerRestarting}

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 
 import { useFilesIndex, fuzzyFilter } from "./useFilesIndex";
+import { SessionConfigControls } from "./SessionConfigControls";
 import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
@@ -136,6 +137,18 @@ interface Props {
   /** Legacy enum-based mode used as fallback when the agent does not
    *  advertise modes via NewSessionResponse. */
   legacyMode: CockpitState["mode"];
+  /** Per-session selectors advertised by the adapter (model,
+   *  reasoning effort, future categories). Empty when the adapter
+   *  does not emit `ConfigOptionUpdate`. See #1403. */
+  configOptions: CockpitState["configOptions"];
+  /** In-flight config-option click; drives the pending affordance
+   *  on the just-clicked option. */
+  pendingConfigOption: CockpitState["pendingConfigOption"];
+  /** Send `session/set_config_option` for the given pair. */
+  setConfigOption: (
+    configId: string,
+    value: string,
+  ) => void | Promise<void>;
   /** Latest agent-reported context-window usage. Null until the agent
    *  has emitted at least one ACP `UsageUpdate`. */
   sessionUsage: CockpitState["sessionUsage"];
@@ -178,6 +191,9 @@ export function Composer({
   availableModes,
   currentModeId,
   legacyMode,
+  configOptions,
+  pendingConfigOption,
+  setConfigOption,
   sessionUsage,
   availableCommands,
   connected,
@@ -564,6 +580,11 @@ export function Composer({
                   availableModes={availableModes}
                   currentModeId={currentModeId}
                   legacyMode={legacyMode}
+                />
+                <SessionConfigControls
+                  configOptions={configOptions}
+                  pendingConfigOption={pendingConfigOption}
+                  onSetConfigOption={setConfigOption}
                 />
               </div>
 

--- a/web/src/components/cockpit/SessionConfigControls.test.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.test.tsx
@@ -126,6 +126,24 @@ describe("SessionConfigControls", () => {
     expect(screen.getByTestId("config-option-effort")).toBeTruthy();
   });
 
+  it("model trigger exposes aria-expanded + aria-controls toggling open state", () => {
+    render(
+      <SessionConfigControls
+        configOptions={[modelOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    const chip = screen.getByTestId("config-option-model");
+    expect(chip.getAttribute("aria-haspopup")).toBe("menu");
+    expect(chip.getAttribute("aria-expanded")).toBe("false");
+    expect(chip.getAttribute("aria-controls")).toBeNull();
+    fireEvent.click(chip);
+    expect(chip.getAttribute("aria-expanded")).toBe("true");
+    expect(chip.getAttribute("aria-controls")).toBe("config-option-menu-model");
+    expect(document.getElementById("config-option-menu-model")).not.toBeNull();
+  });
+
   it("clicking a model option invokes onSetConfigOption with config_id and value", () => {
     const fn = vi.fn();
     render(

--- a/web/src/components/cockpit/SessionConfigControls.test.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.test.tsx
@@ -1,0 +1,254 @@
+// @vitest-environment jsdom
+//
+// Rendering + interaction tests for the cockpit model + reasoning
+// effort pickers (#1403). Covers:
+//   - render shape per category (filter on category, label
+//     truncation, pending affordance),
+//   - effort widget adaptive switch (segmented vs dropdown),
+//   - click invokes the callback with (config_id, value) and not the
+//     option's display name,
+//   - hidden chrome when the adapter advertises neither category,
+//   - non-blocking switch-failed notice renders + dismisses.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  ConfigOptionSwitchFailedNotice,
+  SessionConfigControls,
+} from "./SessionConfigControls";
+import type { ConfigOptionDescriptor } from "../../lib/cockpitTypes";
+
+afterEach(() => {
+  cleanup();
+});
+
+function modelOption(): ConfigOptionDescriptor {
+  return {
+    id: "model",
+    name: "Model",
+    category: "model",
+    current_value: "claude-opus-4-7",
+    options: [
+      { value: "claude-opus-4-7", name: "Claude Opus 4.7" },
+      { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    ],
+  };
+}
+
+function effortOption(): ConfigOptionDescriptor {
+  return {
+    id: "effort",
+    name: "Reasoning Effort",
+    category: "thought_level",
+    current_value: "default",
+    options: [
+      { value: "default", name: "Default" },
+      { value: "low", name: "Low" },
+      { value: "medium", name: "Medium" },
+      { value: "high", name: "High" },
+    ],
+  };
+}
+
+describe("SessionConfigControls", () => {
+  it("renders nothing when adapter advertises neither category", () => {
+    const { container } = render(
+      <SessionConfigControls
+        configOptions={[]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders only the model dropdown when no effort option exists", () => {
+    render(
+      <SessionConfigControls
+        configOptions={[modelOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("config-option-model")).toBeTruthy();
+    expect(screen.queryByTestId("config-option-effort")).toBeNull();
+  });
+
+  it("renders only the effort segmented control when no model option exists", () => {
+    render(
+      <SessionConfigControls
+        configOptions={[effortOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("config-option-effort")).toBeTruthy();
+    expect(screen.queryByTestId("config-option-model")).toBeNull();
+  });
+
+  it("renders the effort options as a segmented radiogroup for short lists", () => {
+    render(
+      <SessionConfigControls
+        configOptions={[effortOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    const group = screen.getByRole("radiogroup", { name: "Reasoning Effort" });
+    expect(group).toBeTruthy();
+    expect(screen.getByText("Default")).toBeTruthy();
+    expect(screen.getByText("High")).toBeTruthy();
+  });
+
+  it("falls back from segmented to dropdown when the effort list is too long", () => {
+    const sixOptions: ConfigOptionDescriptor = {
+      ...effortOption(),
+      options: [
+        { value: "default", name: "Default" },
+        { value: "low", name: "Low" },
+        { value: "medium", name: "Medium" },
+        { value: "high", name: "High" },
+        { value: "very_high", name: "Very High" },
+        { value: "extreme", name: "Extreme reasoning" },
+      ],
+    };
+    render(
+      <SessionConfigControls
+        configOptions={[sixOptions]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    // > 5 options trips the threshold; dropdown is rendered (no
+    // radiogroup) and a single chip is shown for the current value.
+    expect(screen.queryByRole("radiogroup")).toBeNull();
+    expect(screen.getByTestId("config-option-effort")).toBeTruthy();
+  });
+
+  it("clicking a model option invokes onSetConfigOption with config_id and value", () => {
+    const fn = vi.fn();
+    render(
+      <SessionConfigControls
+        configOptions={[modelOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={fn}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("config-option-model"));
+    fireEvent.click(
+      screen.getByTestId("config-option-model-value-claude-sonnet-4-6"),
+    );
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith("model", "claude-sonnet-4-6");
+  });
+
+  it("clicking an effort segment invokes onSetConfigOption with the value (not the label)", () => {
+    const fn = vi.fn();
+    render(
+      <SessionConfigControls
+        configOptions={[effortOption()]}
+        pendingConfigOption={null}
+        onSetConfigOption={fn}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("config-option-effort-value-high"));
+    expect(fn).toHaveBeenCalledWith("effort", "high");
+  });
+
+  it("disables only the pending option in the dropdown", () => {
+    render(
+      <SessionConfigControls
+        configOptions={[modelOption()]}
+        pendingConfigOption={{
+          configId: "model",
+          value: "claude-sonnet-4-6",
+        }}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByTestId("config-option-model"));
+    const pending = screen.getByTestId(
+      "config-option-model-value-claude-sonnet-4-6",
+    ) as HTMLButtonElement;
+    const other = screen.getByTestId(
+      "config-option-model-value-claude-opus-4-7",
+    ) as HTMLButtonElement;
+    expect(pending.disabled).toBe(true);
+    expect(other.disabled).toBe(false);
+  });
+
+  it("truncates long model labels in the chip", () => {
+    const longModel: ConfigOptionDescriptor = {
+      ...modelOption(),
+      current_value: "long",
+      options: [
+        {
+          value: "long",
+          name: "A Very Long Model Name That Does Not Fit Inline",
+        },
+      ],
+    };
+    render(
+      <SessionConfigControls
+        configOptions={[longModel]}
+        pendingConfigOption={null}
+        onSetConfigOption={vi.fn()}
+      />,
+    );
+    const chip = screen.getByTestId("config-option-model");
+    // truncate() preserves the trailing ellipsis on overflow; assert
+    // we see it on the chip (not the menu items).
+    expect(chip.textContent ?? "").toContain("…");
+  });
+});
+
+describe("ConfigOptionSwitchFailedNotice", () => {
+  it("renders nothing when there is no failure", () => {
+    const { container } = render(
+      <ConfigOptionSwitchFailedNotice
+        failure={null}
+        configOptions={[]}
+        onDismiss={vi.fn()}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the configured label and the rejection reason", () => {
+    render(
+      <ConfigOptionSwitchFailedNotice
+        failure={{
+          configId: "model",
+          value: "claude-sonnet-4-6",
+          reason: "rate limited",
+          at: new Date().toISOString(),
+        }}
+        configOptions={[modelOption()]}
+        onDismiss={vi.fn()}
+      />,
+    );
+    const notice = screen.getByTestId("config-option-switch-failed-notice");
+    expect(notice.textContent ?? "").toContain("Model");
+    expect(notice.textContent ?? "").toContain("Claude Sonnet 4.6");
+    expect(notice.textContent ?? "").toContain("rate limited");
+  });
+
+  it("invokes onDismiss when the dismiss button is clicked", () => {
+    const fn = vi.fn();
+    render(
+      <ConfigOptionSwitchFailedNotice
+        failure={{
+          configId: "model",
+          value: "claude-sonnet-4-6",
+          reason: "rate limited",
+          at: new Date().toISOString(),
+        }}
+        configOptions={[modelOption()]}
+        onDismiss={fn}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss notice" }));
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/cockpit/SessionConfigControls.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.tsx
@@ -1,0 +1,305 @@
+// Cockpit per-session config picker (#1403).
+//
+// Renders the model dropdown + reasoning-effort selector by filtering
+// the unified `configOptions` snapshot the daemon publishes from
+// ACP `SessionUpdate::ConfigOptionUpdate`. Mode is handled by the
+// existing ModePicker because the legacy mode pipeline still drives
+// `availableModes`/`currentModeId`; a follow-up migrates it onto this
+// same path.
+//
+// Behavior:
+// - Pessimistic UI. Current value stays put until the adapter pushes a
+//   confirming `ConfigOptionsUpdated`. The clicked option is dimmed
+//   and disabled while `pendingConfigOption?.configId === id`.
+// - Effort is adaptive: segmented control when the option count and
+//   total label width comfortably fit, dropdown fallback otherwise.
+//   The threshold is intentionally simple (count + label-length); a
+//   container query is YAGNI until adapters actually emit long lists.
+// - Hidden entirely when neither category appears.
+// - `ConfigOptionSwitchFailedNotice` lives in this file because it
+//   shares the dismiss callback's home.
+
+import { ChevronUp } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import type {
+  ConfigOptionDescriptor,
+  CockpitState,
+} from "../../lib/cockpitTypes";
+
+interface Props {
+  configOptions: CockpitState["configOptions"];
+  pendingConfigOption: CockpitState["pendingConfigOption"];
+  onSetConfigOption: (configId: string, value: string) => void | Promise<void>;
+}
+
+const MODEL_LABEL_MAX = 24;
+const EFFORT_SEGMENTED_MAX_COUNT = 5;
+const EFFORT_SEGMENTED_MAX_TOTAL_LABEL_LEN = 40;
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + "…";
+}
+
+function findByCategory(
+  options: ConfigOptionDescriptor[],
+  category: "model" | "thought_level",
+): ConfigOptionDescriptor | undefined {
+  return options.find((o) => o.category === category);
+}
+
+export function SessionConfigControls({
+  configOptions,
+  pendingConfigOption,
+  onSetConfigOption,
+}: Props) {
+  const model = findByCategory(configOptions, "model");
+  const effort = findByCategory(configOptions, "thought_level");
+
+  // Hidden entirely when neither selector exists; avoids empty chrome
+  // on adapters that don't advertise either category.
+  if (!model && !effort) return null;
+
+  return (
+    <div
+      data-testid="session-config-controls"
+      className="inline-flex items-center gap-1.5"
+    >
+      {model && (
+        <ModelDropdown
+          option={model}
+          pending={
+            pendingConfigOption?.configId === model.id
+              ? pendingConfigOption.value
+              : null
+          }
+          onSelect={(value) => onSetConfigOption(model.id, value)}
+        />
+      )}
+      {effort && (
+        <EffortControl
+          option={effort}
+          pending={
+            pendingConfigOption?.configId === effort.id
+              ? pendingConfigOption.value
+              : null
+          }
+          onSelect={(value) => onSetConfigOption(effort.id, value)}
+        />
+      )}
+    </div>
+  );
+}
+
+interface SubProps {
+  option: ConfigOptionDescriptor;
+  /** The value currently in flight for this option (rendered with a
+   *  pending affordance), or null when nothing is pending. */
+  pending: string | null;
+  onSelect: (value: string) => void | Promise<void>;
+}
+
+function ModelDropdown({ option, pending, onSelect }: SubProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const current =
+    option.options.find((o) => o.value === option.current_value) ??
+    option.options[0];
+  const label = current?.name ?? option.current_value;
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (!ref.current?.contains(e.target as Node)) setOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onClick);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onClick);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        title={`${option.name}: ${label}`}
+        aria-label={`${option.name}: ${label}`}
+        data-testid={`config-option-${option.id}`}
+        className={[
+          "inline-flex items-center gap-1 rounded-md border border-surface-700 bg-surface-800/60 px-2 py-1 text-[11px] font-medium",
+          "text-text-secondary",
+          "transition-colors hover:border-brand-600/60 hover:text-text-primary",
+        ].join(" ")}
+      >
+        <span>{truncate(label, MODEL_LABEL_MAX)}</span>
+        <ChevronUp className="h-3 w-3 opacity-70" />
+      </button>
+      {open && (
+        <div
+          className="absolute bottom-full left-0 z-30 mb-1 w-64 overflow-hidden rounded-md border border-surface-700 bg-surface-850 shadow-xl"
+          role="menu"
+        >
+          <div className="border-b border-surface-800 px-3 py-1.5 text-[10px] uppercase tracking-wider text-text-dim">
+            {option.name}
+          </div>
+          {option.options.map((opt) => {
+            const isCurrent = opt.value === option.current_value;
+            const isPending = pending === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                role="menuitem"
+                disabled={isPending}
+                onClick={() => {
+                  if (isPending || isCurrent) {
+                    setOpen(false);
+                    return;
+                  }
+                  setOpen(false);
+                  void onSelect(opt.value);
+                }}
+                data-testid={`config-option-${option.id}-value-${opt.value}`}
+                className={[
+                  "flex w-full items-start gap-2 px-3 py-1.5 text-left text-[12px]",
+                  isCurrent
+                    ? "bg-surface-800 text-text-primary"
+                    : "text-text-secondary hover:bg-surface-800 hover:text-text-primary",
+                  isPending ? "cursor-not-allowed opacity-50" : "",
+                ].join(" ")}
+              >
+                <span className="flex-1">
+                  <span className="block font-medium">{opt.name}</span>
+                  {opt.description && (
+                    <span className="block text-[11px] text-text-dim">
+                      {opt.description}
+                    </span>
+                  )}
+                </span>
+                {isCurrent && !isPending && (
+                  <span className="text-[10px] uppercase text-brand-500">
+                    Active
+                  </span>
+                )}
+                {isPending && (
+                  <span className="text-[10px] uppercase text-text-dim">
+                    …
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EffortControl(props: SubProps) {
+  const { option } = props;
+  const totalLabelLen = option.options.reduce(
+    (acc, o) => acc + o.name.length,
+    0,
+  );
+  const useSegmented =
+    option.options.length > 0 &&
+    option.options.length <= EFFORT_SEGMENTED_MAX_COUNT &&
+    totalLabelLen <= EFFORT_SEGMENTED_MAX_TOTAL_LABEL_LEN;
+  return useSegmented ? (
+    <EffortSegmented {...props} />
+  ) : (
+    <ModelDropdown {...props} />
+  );
+}
+
+function EffortSegmented({ option, pending, onSelect }: SubProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label={option.name}
+      data-testid={`config-option-${option.id}`}
+      className="inline-flex items-center gap-0.5 rounded-md border border-surface-700 bg-surface-800/60 p-0.5"
+    >
+      {option.options.map((opt) => {
+        const isCurrent = opt.value === option.current_value;
+        const isPending = pending === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={isCurrent}
+            disabled={isPending}
+            onClick={() => {
+              if (isPending || isCurrent) return;
+              void onSelect(opt.value);
+            }}
+            title={opt.description ?? `${option.name}: ${opt.name}`}
+            data-testid={`config-option-${option.id}-value-${opt.value}`}
+            className={[
+              "rounded px-2 py-0.5 text-[11px] font-medium transition-colors",
+              isCurrent
+                ? "bg-surface-700 text-text-primary"
+                : "text-text-secondary hover:text-text-primary",
+              isPending ? "cursor-not-allowed opacity-50" : "",
+            ].join(" ")}
+          >
+            {opt.name}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface NoticeProps {
+  failure: CockpitState["configOptionSwitchFailed"];
+  configOptions: CockpitState["configOptions"];
+  onDismiss: () => void;
+}
+
+/** Non-blocking notice rendered near the picker when the adapter
+ *  rejects a `session/set_config_option`. Auto-dismisses via the
+ *  reducer when a later snapshot confirms the requested value; the
+ *  manual dismiss button is the user-visible escape hatch. */
+export function ConfigOptionSwitchFailedNotice({
+  failure,
+  configOptions,
+  onDismiss,
+}: NoticeProps) {
+  if (!failure) return null;
+  const config = configOptions.find((c) => c.id === failure.configId);
+  const optionLabel =
+    config?.options.find((o) => o.value === failure.value)?.name ??
+    failure.value;
+  const configLabel = config?.name ?? failure.configId;
+  return (
+    <div
+      data-testid="config-option-switch-failed-notice"
+      role="status"
+      className="flex items-start gap-3 rounded-md border border-amber-700/60 bg-amber-900/30 px-3 py-2 text-[12px] text-amber-100"
+    >
+      <div className="flex-1">
+        <div className="font-medium">
+          {configLabel} could not switch to {optionLabel}
+        </div>
+        <div className="text-[11px] text-amber-200/80">{failure.reason}</div>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        aria-label="Dismiss notice"
+        className="rounded px-1.5 py-0.5 text-amber-100 hover:bg-amber-700/30"
+      >
+        Dismiss
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/cockpit/SessionConfigControls.tsx
+++ b/web/src/components/cockpit/SessionConfigControls.tsx
@@ -103,6 +103,7 @@ interface SubProps {
 function ModelDropdown({ option, pending, onSelect }: SubProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
+  const menuId = `config-option-menu-${option.id}`;
   const current =
     option.options.find((o) => o.value === option.current_value) ??
     option.options[0];
@@ -129,6 +130,9 @@ function ModelDropdown({ option, pending, onSelect }: SubProps) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
         title={`${option.name}: ${label}`}
         aria-label={`${option.name}: ${label}`}
         data-testid={`config-option-${option.id}`}
@@ -143,6 +147,7 @@ function ModelDropdown({ option, pending, onSelect }: SubProps) {
       </button>
       {open && (
         <div
+          id={menuId}
           className="absolute bottom-full left-0 z-30 mb-1 w-64 overflow-hidden rounded-md border border-surface-700 bg-surface-850 shadow-xl"
           role="menu"
         >

--- a/web/src/hooks/useCockpit.configOption.test.ts
+++ b/web/src/hooks/useCockpit.configOption.test.ts
@@ -273,16 +273,43 @@ describe("useCockpit / setConfigOption", () => {
     expect(result.current.state.lastError).toMatch(/Network error setting effort/);
   });
 
-  it("dismissConfigOptionSwitchFailed clears the notice", async () => {
+  it("dismissConfigOptionSwitchFailed clears a populated notice", async () => {
     const { result } = renderHook(() => useCockpit("sess-cfg-5"), { wrapper });
     await flushAsync();
-    // Seed a notice via the reducer dispatch path.
+
+    // Seed the notice through the WS broadcast path: drive a
+    // ConfigOptionSwitchFailed frame into the hook's reducer so the
+    // dismiss callback has something real to clear. The hook's
+    // onmessage handler expects the raw CockpitFrame shape (session_id
+    // + seq + event); no kind/frame wrapper.
+    const ws = sockets[0]!;
     await act(async () => {
-      // Inject a synthetic frame so applyEvent records the failure
-      // notice and the next call can dismiss it.
+      ws.readyState = FakeWebSocket.OPEN;
+      ws.onopen?.(new Event("open"));
+      ws.onmessage?.(
+        new MessageEvent("message", {
+          data: JSON.stringify({
+            session_id: "sess-cfg-5",
+            seq: 1,
+            event: {
+              ConfigOptionSwitchFailed: {
+                config_id: "model",
+                value: "claude-sonnet-4-6",
+                reason: "rate limited",
+              },
+            },
+          }),
+        }),
+      );
+    });
+    expect(result.current.state.configOptionSwitchFailed).not.toBeNull();
+    expect(result.current.state.configOptionSwitchFailed?.reason).toBe(
+      "rate limited",
+    );
+
+    await act(async () => {
       result.current.dismissConfigOptionSwitchFailed();
     });
-    // Notice was already null; dismiss leaves it null without crashing.
     expect(result.current.state.configOptionSwitchFailed).toBeNull();
   });
 

--- a/web/src/hooks/useCockpit.configOption.test.ts
+++ b/web/src/hooks/useCockpit.configOption.test.ts
@@ -69,6 +69,53 @@ describe("cockpitHookReducer / config option actions", () => {
     });
     expect(state.pendingConfigOption?.value).toBe("claude-sonnet-4-6");
   });
+
+  it("clear_pending_config_option_if_match clears when the request matches the current pending", () => {
+    const seeded = cockpitHookReducer(emptyCockpitState(), {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+    const next = cockpitHookReducer(seeded, {
+      kind: "clear_pending_config_option_if_match",
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+    expect(next.pendingConfigOption).toBeNull();
+  });
+
+  it("clear_pending_config_option_if_match leaves a newer pending intact when a stale request fails", () => {
+    // Request A for model=opus dispatched, then request B for
+    // model=sonnet replaced pending. A's failure must NOT wipe B.
+    let state = cockpitHookReducer(emptyCockpitState(), {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-opus-4-7",
+    });
+    state = cockpitHookReducer(state, {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+    const next = cockpitHookReducer(state, {
+      kind: "clear_pending_config_option_if_match",
+      configId: "model",
+      value: "claude-opus-4-7",
+    });
+    expect(next.pendingConfigOption).toEqual({
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+  });
+
+  it("clear_pending_config_option_if_match is a no-op when pending is already cleared", () => {
+    const next = cockpitHookReducer(emptyCockpitState(), {
+      kind: "clear_pending_config_option_if_match",
+      configId: "model",
+      value: "claude-opus-4-7",
+    });
+    expect(next.pendingConfigOption).toBeNull();
+  });
 });
 
 // ---- Hook async tests ---------------------------------------------------

--- a/web/src/hooks/useCockpit.configOption.test.ts
+++ b/web/src/hooks/useCockpit.configOption.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+//
+// Hook-reducer tests for the cockpit config-option (model picker +
+// reasoning effort) feature (#1403). Covers the new internal actions
+// that drive pending state and the dismissable failure notice. The
+// POST shape and the end-to-end pessimistic-update flow are exercised
+// by the mocked Playwright spec under web/tests/.
+
+import { describe, expect, it } from "vitest";
+
+import { emptyCockpitState } from "../lib/cockpitTypes";
+import { cockpitHookReducer } from "./useCockpit";
+
+describe("cockpitHookReducer / config option actions", () => {
+  it("set_pending_config_option records the requested click", () => {
+    const next = cockpitHookReducer(emptyCockpitState(), {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+    expect(next.pendingConfigOption).toEqual({
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+  });
+
+  it("clear_pending_config_option drops the in-flight record", () => {
+    const seeded = cockpitHookReducer(emptyCockpitState(), {
+      kind: "set_pending_config_option",
+      configId: "effort",
+      value: "high",
+    });
+    const next = cockpitHookReducer(seeded, {
+      kind: "clear_pending_config_option",
+    });
+    expect(next.pendingConfigOption).toBeNull();
+  });
+
+  it("dismiss_config_option_switch_failed clears the notice", () => {
+    const seeded = {
+      ...emptyCockpitState(),
+      configOptionSwitchFailed: {
+        configId: "model",
+        value: "claude-sonnet-4-6",
+        reason: "rate limited",
+        at: new Date().toISOString(),
+      },
+    };
+    const next = cockpitHookReducer(seeded, {
+      kind: "dismiss_config_option_switch_failed",
+    });
+    expect(next.configOptionSwitchFailed).toBeNull();
+  });
+
+  it("set_pending overrides any previous pending click on the same option", () => {
+    let state = cockpitHookReducer(emptyCockpitState(), {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-opus-4-7",
+    });
+    state = cockpitHookReducer(state, {
+      kind: "set_pending_config_option",
+      configId: "model",
+      value: "claude-sonnet-4-6",
+    });
+    expect(state.pendingConfigOption?.value).toBe("claude-sonnet-4-6");
+  });
+});

--- a/web/src/hooks/useCockpit.configOption.test.ts
+++ b/web/src/hooks/useCockpit.configOption.test.ts
@@ -1,15 +1,19 @@
 // @vitest-environment jsdom
 //
-// Hook-reducer tests for the cockpit config-option (model picker +
-// reasoning effort) feature (#1403). Covers the new internal actions
-// that drive pending state and the dismissable failure notice. The
-// POST shape and the end-to-end pessimistic-update flow are exercised
-// by the mocked Playwright spec under web/tests/.
+// Hook tests for the cockpit config-option (model picker + reasoning
+// effort) feature (#1403). Covers the new internal reducer actions
+// that drive pending state and the dismissable failure notice, plus
+// the async setConfigOption hook callback wired up to a stubbed
+// fetch. End-to-end UI flows are exercised by the mocked Playwright
+// specs under web/tests/.
 
-import { describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { emptyCockpitState } from "../lib/cockpitTypes";
-import { cockpitHookReducer } from "./useCockpit";
+import { AgentProfileProvider } from "../lib/agentProfileContext";
+import { cockpitHookReducer, useCockpit } from "./useCockpit";
 
 describe("cockpitHookReducer / config option actions", () => {
   it("set_pending_config_option records the requested click", () => {
@@ -64,5 +68,225 @@ describe("cockpitHookReducer / config option actions", () => {
       value: "claude-sonnet-4-6",
     });
     expect(state.pendingConfigOption?.value).toBe("claude-sonnet-4-6");
+  });
+});
+
+// ---- Hook async tests ---------------------------------------------------
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: ((ev: Event) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  close: () => void;
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+}
+
+const sockets: FakeSocket[] = [];
+let originalWebSocket: typeof WebSocket;
+
+class FakeWebSocket implements FakeSocket {
+  url: string;
+  readyState: number = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this);
+  }
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) {
+      this.onclose({
+        code: 1000,
+        reason: "test close",
+        wasClean: true,
+      } as CloseEvent);
+    }
+  }
+  send(): void {
+    /* no-op */
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+const wrapper = ({ children }: { children: ReactNode }): ReactNode =>
+  createElement(AgentProfileProvider, { toolKey: "claude" }, children);
+
+describe("useCockpit / setConfigOption", () => {
+  let postBodies: Array<{ url: string; body: unknown }>;
+  let postShouldFail: number | "throw" | null;
+
+  beforeEach(() => {
+    sockets.length = 0;
+    postBodies = [];
+    postShouldFail = null;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/cockpit/replay")) {
+          return new Response(
+            JSON.stringify({ frames: [], lost: false, highest_seq: 0 }),
+            { status: 200 },
+          );
+        }
+        if (url.includes("/cockpit/config-option")) {
+          if (postShouldFail === "throw") {
+            throw new TypeError("network down");
+          }
+          postBodies.push({
+            url,
+            body: typeof init?.body === "string"
+              ? JSON.parse(init.body)
+              : init?.body,
+          });
+          if (typeof postShouldFail === "number") {
+            return new Response("simulated failure", {
+              status: postShouldFail,
+            });
+          }
+          return new Response("{}", { status: 202 });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+    vi.unstubAllGlobals();
+  });
+
+  it("setConfigOption posts to the cockpit config-option endpoint with the right body shape", async () => {
+    const { result } = renderHook(() => useCockpit("sess-cfg-1"), { wrapper });
+    await flushAsync();
+    await act(async () => {
+      await result.current.setConfigOption("model", "claude-sonnet-4-6");
+    });
+    expect(postBodies).toHaveLength(1);
+    expect(postBodies[0]!.url).toContain(
+      "/api/sessions/sess-cfg-1/cockpit/config-option",
+    );
+    expect(postBodies[0]!.body).toEqual({
+      config_id: "model",
+      value: "claude-sonnet-4-6",
+    });
+  });
+
+  it("setConfigOption posts the effort body shape", async () => {
+    const { result } = renderHook(() => useCockpit("sess-cfg-2"), { wrapper });
+    await flushAsync();
+    await act(async () => {
+      await result.current.setConfigOption("effort", "high");
+    });
+    expect(postBodies).toHaveLength(1);
+    expect(postBodies[0]!.body).toEqual({
+      config_id: "effort",
+      value: "high",
+    });
+  });
+
+  it("setConfigOption clears pending and records lastError on non-OK response", async () => {
+    postShouldFail = 500;
+    const { result } = renderHook(() => useCockpit("sess-cfg-3"), { wrapper });
+    await flushAsync();
+    await act(async () => {
+      await result.current.setConfigOption("model", "claude-sonnet-4-6");
+    });
+    expect(result.current.state.pendingConfigOption).toBeNull();
+    expect(result.current.state.lastError).toMatch(/Could not set model/);
+  });
+
+  it("setConfigOption clears pending and records lastError on network failure (throw)", async () => {
+    postShouldFail = "throw";
+    const { result } = renderHook(() => useCockpit("sess-cfg-4"), { wrapper });
+    await flushAsync();
+    await act(async () => {
+      await result.current.setConfigOption("effort", "low");
+    });
+    expect(result.current.state.pendingConfigOption).toBeNull();
+    expect(result.current.state.lastError).toMatch(/Network error setting effort/);
+  });
+
+  it("dismissConfigOptionSwitchFailed clears the notice", async () => {
+    const { result } = renderHook(() => useCockpit("sess-cfg-5"), { wrapper });
+    await flushAsync();
+    // Seed a notice via the reducer dispatch path.
+    await act(async () => {
+      // Inject a synthetic frame so applyEvent records the failure
+      // notice and the next call can dismiss it.
+      result.current.dismissConfigOptionSwitchFailed();
+    });
+    // Notice was already null; dismiss leaves it null without crashing.
+    expect(result.current.state.configOptionSwitchFailed).toBeNull();
+  });
+
+  it("setConfigOption is a no-op when sessionId is empty", async () => {
+    const { result } = renderHook(() => useCockpit(""), { wrapper });
+    await flushAsync();
+    await act(async () => {
+      await result.current.setConfigOption("model", "claude-opus-4-7");
+    });
+    expect(postBodies).toHaveLength(0);
+    // No pending state set either, because the early return fires
+    // before the dispatch.
+    expect(result.current.state.pendingConfigOption).toBeNull();
+  });
+});
+
+// ---- normaliseTurnCounters backfill -------------------------------------
+
+describe("normaliseTurnCounters / config-option backfill", () => {
+  it("backfills empty configOptions when the persisted entry pre-dates #1403", async () => {
+    const { normaliseTurnCounters } = await import("../lib/cockpitTypes");
+    const stale = {
+      ...emptyCockpitState(),
+    } as Record<string, unknown>;
+    delete stale.configOptions;
+    delete stale.configOptionSwitchFailed;
+    delete stale.pendingConfigOption;
+    const next = normaliseTurnCounters(
+      stale as unknown as Parameters<typeof normaliseTurnCounters>[0],
+    );
+    expect(next.configOptions).toEqual([]);
+    expect(next.configOptionSwitchFailed).toBeNull();
+    expect(next.pendingConfigOption).toBeNull();
+  });
+
+  it("preserves a populated configOptions list across hydration", async () => {
+    const { normaliseTurnCounters } = await import("../lib/cockpitTypes");
+    const seeded = {
+      ...emptyCockpitState(),
+      configOptions: [
+        {
+          id: "model",
+          name: "Model",
+          category: "model" as const,
+          current_value: "claude-opus-4-7",
+          options: [{ value: "claude-opus-4-7", name: "Claude Opus 4.7" }],
+        },
+      ],
+    };
+    const next = normaliseTurnCounters(seeded);
+    expect(next.configOptions).toHaveLength(1);
+    expect(next.configOptions[0]!.current_value).toBe("claude-opus-4-7");
   });
 });

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -46,6 +46,16 @@ export type Action =
   | { kind: "dismiss_mode_switch_failed" }
   | { kind: "set_pending_config_option"; configId: string; value: string }
   | { kind: "clear_pending_config_option" }
+  | {
+      /** Clear pendingConfigOption only when it still matches the
+       *  (configId, value) pair of the failed request. Prevents a
+       *  stale request A from wiping a newer request B's pending
+       *  state after the user clicked a second option mid-flight.
+       *  See #1403 (review feedback). */
+      kind: "clear_pending_config_option_if_match";
+      configId: string;
+      value: string;
+    }
   | { kind: "dismiss_config_option_switch_failed" };
 
 // LRU-capped module cache keyed by cockpit session id. Mirrors the
@@ -427,6 +437,15 @@ function reducer(state: CockpitState, action: Action): CockpitState {
   }
   if (action.kind === "clear_pending_config_option") {
     return { ...state, pendingConfigOption: null };
+  }
+  if (action.kind === "clear_pending_config_option_if_match") {
+    if (
+      state.pendingConfigOption?.configId === action.configId &&
+      state.pendingConfigOption?.value === action.value
+    ) {
+      return { ...state, pendingConfigOption: null };
+    }
+    return state;
   }
   if (action.kind === "dismiss_config_option_switch_failed") {
     return { ...state, configOptionSwitchFailed: null };
@@ -1165,7 +1184,14 @@ export function useCockpit(
         );
         if (!res.ok) {
           const detail = await safeText(res);
-          dispatch({ kind: "clear_pending_config_option" });
+          // Guard against the user clicking a second option before this
+          // request's response landed: clear pending only when it
+          // still matches our (configId, value) pair. See #1403.
+          dispatch({
+            kind: "clear_pending_config_option_if_match",
+            configId,
+            value,
+          });
           dispatch({
             kind: "error",
             message:
@@ -1173,7 +1199,11 @@ export function useCockpit(
           });
         }
       } catch (e) {
-        dispatch({ kind: "clear_pending_config_option" });
+        dispatch({
+          kind: "clear_pending_config_option_if_match",
+          configId,
+          value,
+        });
         dispatch({
           kind: "error",
           message: `Network error setting ${configId}: ${describeError(e)}`,

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -43,7 +43,10 @@ export type Action =
   | { kind: "clear_queue" }
   | { kind: "dismiss_primer" }
   | { kind: "dismiss_rejected_prompt"; id: string }
-  | { kind: "dismiss_mode_switch_failed" };
+  | { kind: "dismiss_mode_switch_failed" }
+  | { kind: "set_pending_config_option"; configId: string; value: string }
+  | { kind: "clear_pending_config_option" }
+  | { kind: "dismiss_config_option_switch_failed" };
 
 // LRU-capped module cache keyed by cockpit session id. Mirrors the
 // per-session CockpitState into `localStorage` under
@@ -415,6 +418,18 @@ function reducer(state: CockpitState, action: Action): CockpitState {
   }
   if (action.kind === "dismiss_mode_switch_failed") {
     return { ...state, modeSwitchFailed: null };
+  }
+  if (action.kind === "set_pending_config_option") {
+    return {
+      ...state,
+      pendingConfigOption: { configId: action.configId, value: action.value },
+    };
+  }
+  if (action.kind === "clear_pending_config_option") {
+    return { ...state, pendingConfigOption: null };
+  }
+  if (action.kind === "dismiss_config_option_switch_failed") {
+    return { ...state, configOptionSwitchFailed: null };
   }
   return emptyCockpitState();
 }
@@ -1126,6 +1141,52 @@ export function useCockpit(
     dispatch({ kind: "dismiss_mode_switch_failed" });
   }, []);
 
+  // Send `session/set_config_option` to the daemon (model / reasoning
+  // effort / future selector). Pessimistic: the current value stays put
+  // until the adapter pushes a confirming `ConfigOptionsUpdated`. The
+  // pending dispatch records the in-flight click so the UI can dim the
+  // just-clicked option without lying about active state. On HTTP
+  // failure the pending state clears and lastError surfaces a banner;
+  // adapter-side rejection comes back as a `ConfigOptionSwitchFailed`
+  // frame which clears pending in the reducer and renders a
+  // non-blocking notice. See #1403.
+  const setConfigOption = useCallback(
+    async (configId: string, value: string) => {
+      if (!sessionId) return;
+      dispatch({ kind: "set_pending_config_option", configId, value });
+      try {
+        const res = await fetch(
+          `/api/sessions/${encodeURIComponent(sessionId)}/cockpit/config-option`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ config_id: configId, value }),
+          },
+        );
+        if (!res.ok) {
+          const detail = await safeText(res);
+          dispatch({ kind: "clear_pending_config_option" });
+          dispatch({
+            kind: "error",
+            message:
+              `Could not set ${configId} (${res.status}). ${detail}`.trim(),
+          });
+        }
+      } catch (e) {
+        dispatch({ kind: "clear_pending_config_option" });
+        dispatch({
+          kind: "error",
+          message: `Network error setting ${configId}: ${describeError(e)}`,
+        });
+      }
+    },
+    [sessionId],
+  );
+
+  const dismissConfigOptionSwitchFailed = useCallback(() => {
+    dispatch({ kind: "dismiss_config_option_switch_failed" });
+  }, []);
+
   // Cancels the in-flight agent turn (ACP session/cancel). Must only
   // fire on an explicit user gesture against a dedicated cancel/stop
   // affordance; never bind this to the Escape key. Claude Code CLI
@@ -1261,6 +1322,8 @@ export function useCockpit(
     clearQueue,
     dismissRejectedPrompt,
     dismissModeSwitchFailed,
+    setConfigOption,
+    dismissConfigOptionSwitchFailed,
   };
 }
 

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1914,3 +1914,185 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
     expect(state.incompatibleAgent).toBeNull();
   });
 });
+
+describe("applyEvent / ConfigOptions (#1403)", () => {
+  function sampleOptions() {
+    return [
+      {
+        id: "model",
+        name: "Model",
+        category: "model" as const,
+        current_value: "claude-opus-4-7",
+        options: [
+          { value: "claude-opus-4-7", name: "Claude Opus 4.7" },
+          { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+        ],
+      },
+      {
+        id: "effort",
+        name: "Reasoning Effort",
+        category: "thought_level" as const,
+        current_value: "default",
+        options: [
+          { value: "default", name: "Default" },
+          { value: "high", name: "High" },
+        ],
+      },
+    ];
+  }
+
+  it("applies ConfigOptionsUpdated as a full snapshot replacement", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    expect(state.configOptions).toHaveLength(2);
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ConfigOptionsUpdated: {
+          options: [
+            {
+              id: "model",
+              name: "Model",
+              category: "model",
+              current_value: "claude-sonnet-4-6",
+              options: [],
+            },
+          ],
+        },
+      },
+    });
+    expect(state.configOptions).toHaveLength(1);
+    expect(state.configOptions[0].current_value).toBe("claude-sonnet-4-6");
+  });
+
+  it("populates configOptionSwitchFailed without mutating configOptions", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    const before = state.configOptions;
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ConfigOptionSwitchFailed: {
+          config_id: "model",
+          value: "claude-sonnet-4-6",
+          reason: "rate limited",
+        },
+      },
+    });
+    expect(state.configOptions).toBe(before);
+    expect(state.configOptionSwitchFailed).toEqual({
+      configId: "model",
+      value: "claude-sonnet-4-6",
+      reason: "rate limited",
+      at: expect.any(String),
+    });
+  });
+
+  it("clears pending and auto-dismisses matching failure on confirming snapshot", () => {
+    let state: CockpitState = {
+      ...emptyCockpitState(),
+      pendingConfigOption: { configId: "model", value: "claude-sonnet-4-6" },
+    };
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 1,
+      event: {
+        ConfigOptionSwitchFailed: {
+          config_id: "model",
+          value: "claude-sonnet-4-6",
+          reason: "transient",
+        },
+      },
+    });
+    expect(state.pendingConfigOption).toBeNull();
+    expect(state.configOptionSwitchFailed).not.toBeNull();
+
+    const confirming = sampleOptions();
+    confirming[0].current_value = "claude-sonnet-4-6";
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: { ConfigOptionsUpdated: { options: confirming } },
+    });
+    expect(state.configOptionSwitchFailed).toBeNull();
+    expect(state.pendingConfigOption).toBeNull();
+  });
+
+  it("preserves a non-matching failure notice across snapshots", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ConfigOptionSwitchFailed: {
+          config_id: "model",
+          value: "claude-sonnet-4-6",
+          reason: "transient",
+        },
+      },
+    });
+    // Snapshot still shows opus as current; the failure for the sonnet
+    // switch attempt must survive.
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    expect(state.configOptionSwitchFailed).not.toBeNull();
+  });
+
+  it("AgentSwitched clears configOptions and the failure notice", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: {
+        ConfigOptionSwitchFailed: {
+          config_id: "effort",
+          value: "high",
+          reason: "unsupported",
+        },
+      },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 3,
+      event: {
+        AgentSwitched: { from: "claude", to: "codex", reason: "rate_limit" },
+      },
+    });
+    expect(state.configOptions).toEqual([]);
+    expect(state.configOptionSwitchFailed).toBeNull();
+    expect(state.pendingConfigOption).toBeNull();
+  });
+
+  it("SessionCleared preserves configOptions (adapter capabilities outlive /clear)", () => {
+    let state = applyEvent(emptyCockpitState(), {
+      session_id: "s-1",
+      seq: 1,
+      event: { ConfigOptionsUpdated: { options: sampleOptions() } },
+    });
+    state = applyEvent(state, {
+      session_id: "s-1",
+      seq: 2,
+      event: "SessionCleared",
+    });
+    expect(state.configOptions).toHaveLength(2);
+  });
+});

--- a/web/src/lib/cockpitTypes.ts
+++ b/web/src/lib/cockpitTypes.ts
@@ -102,6 +102,50 @@ export interface AvailableCommand {
   accepts_input: boolean;
 }
 
+/** Semantic category for a session configuration option, mirroring
+ *  ACP's `SessionConfigOptionCategory`. The cockpit UI uses this to
+ *  pick the right widget per category (model dropdown, effort
+ *  segmented control). Unknown categories preserve their string
+ *  payload so the broadcast frame stays forward-compatible. See
+ *  #1403. */
+export type ConfigOptionCategory =
+  | "mode"
+  | "model"
+  | "thought_level"
+  | { Other: string };
+
+/** One choice in a `Select`-kind ConfigOptionDescriptor. */
+export interface ConfigOptionChoice {
+  value: string;
+  name: string;
+  description?: string | null;
+}
+
+/** Cockpit's view of a single ACP `SessionConfigOption`. Each
+ *  `ConfigOptionsUpdated` event replaces the prior list in full;
+ *  the adapter resends the full snapshot whenever any selector
+ *  changes. */
+export interface ConfigOptionDescriptor {
+  id: string;
+  name: string;
+  description?: string | null;
+  category: ConfigOptionCategory;
+  current_value: string;
+  options: ConfigOptionChoice[];
+}
+
+/** Carried by `ConfigOptionSwitchFailed`. Lives on
+ *  `CockpitState.configOptionSwitchFailed` so the UI can render a
+ *  non-blocking notice when the adapter rejects a `set_config_option`
+ *  call. Auto-clears when the next `ConfigOptionsUpdated` snapshot
+ *  confirms the originally-requested value. */
+export interface ConfigOptionSwitchFailure {
+  configId: string;
+  value: string;
+  reason: string;
+  at: string;
+}
+
 export interface Approval {
   nonce: string;
   tool_call: ToolCall;
@@ -221,6 +265,14 @@ export type CockpitEvent =
   | { CurrentModeChanged: { current_mode_id: string } }
   | { ModeSwitchFailed: { mode_id: string; reason: string } }
   | { AvailableCommandsUpdated: { commands: AvailableCommand[] } }
+  | { ConfigOptionsUpdated: { options: ConfigOptionDescriptor[] } }
+  | {
+      ConfigOptionSwitchFailed: {
+        config_id: string;
+        value: string;
+        reason: string;
+      };
+    }
   | { RawAgentUpdate: { payload: unknown } }
   | { AgentMessageChunk: { text: string } }
   | { Stopped: { reason: string } }
@@ -411,6 +463,26 @@ export interface CockpitState {
     reason: string;
     at: string;
   } | null;
+  /** Full snapshot of the per-session selectors (model, reasoning
+   *  effort, mode, future categories) the adapter advertises through
+   *  ACP `SessionUpdate::ConfigOptionUpdate`. Empty when the adapter
+   *  emits no config options. Replaced wholesale on each
+   *  `ConfigOptionsUpdated` frame; cleared on `AgentSwitched`. See
+   *  #1403. */
+  configOptions: ConfigOptionDescriptor[];
+  /** Non-blocking notice for the most recent
+   *  `session/set_config_option` rejection. Auto-clears when the
+   *  next snapshot confirms the originally-requested value, or on
+   *  `AgentSwitched`. */
+  configOptionSwitchFailed: ConfigOptionSwitchFailure | null;
+  /** Set when the user clicks a model/effort option and the POST is
+   *  in flight; cleared by the next `ConfigOptionsUpdated` snapshot
+   *  (which reconciles authoritative state) or by
+   *  `ConfigOptionSwitchFailed`. Drives the pending affordance
+   *  (opacity dim + disabled re-click) on the just-clicked option;
+   *  the picker keeps showing the previously-current value until the
+   *  adapter confirms, so the UI never lies about active state. */
+  pendingConfigOption: { configId: string; value: string } | null;
   /** Set when the daemon emitted `Stopped { reason: "prompt_orphaned" }`,
    *  meaning the silent-orphan watchdog detected that the adapter
    *  finished streaming the turn but never sent the JSON-RPC
@@ -522,6 +594,9 @@ export function emptyCockpitState(): CockpitState {
     agentOrphaned: false,
     modeSwitchFailed: null,
     lastAgentSwitch: null,
+    configOptions: [],
+    configOptionSwitchFailed: null,
+    pendingConfigOption: null,
   };
 }
 
@@ -799,6 +874,40 @@ export function applyEvent(
   }
   if ("AvailableCommandsUpdated" in event) {
     next.availableCommands = event.AvailableCommandsUpdated.commands;
+    return next;
+  }
+  if ("ConfigOptionsUpdated" in event) {
+    const options = event.ConfigOptionsUpdated.options;
+    next.configOptions = options;
+    // The snapshot is authoritative, so any in-flight pending click
+    // resolves here regardless of whether the adapter applied the
+    // exact requested value. A rejected change comes through
+    // `ConfigOptionSwitchFailed` and clears pending on that path
+    // instead.
+    next.pendingConfigOption = null;
+    // Auto-dismiss a stale switch-failed notice when this snapshot
+    // confirms the originally-requested value: user retried and won,
+    // or the adapter applied asynchronously after the rejection.
+    if (next.configOptionSwitchFailed) {
+      const failure = next.configOptionSwitchFailed;
+      const confirmed = options.some(
+        (opt) =>
+          opt.id === failure.configId && opt.current_value === failure.value,
+      );
+      if (confirmed) {
+        next.configOptionSwitchFailed = null;
+      }
+    }
+    return next;
+  }
+  if ("ConfigOptionSwitchFailed" in event) {
+    next.configOptionSwitchFailed = {
+      configId: event.ConfigOptionSwitchFailed.config_id,
+      value: event.ConfigOptionSwitchFailed.value,
+      reason: event.ConfigOptionSwitchFailed.reason,
+      at: new Date().toISOString(),
+    };
+    next.pendingConfigOption = null;
     return next;
   }
   if ("AgentMessageChunk" in event) {
@@ -1141,6 +1250,11 @@ export function applyEvent(
     next.workerStopped = false;
     next.workerRestarting = false;
     next.agentUnresponsive = false;
+    // Per-adapter selectors belong to the previous backend; the new
+    // backend will publish its own snapshot. See #1403.
+    next.configOptions = [];
+    next.configOptionSwitchFailed = null;
+    next.pendingConfigOption = null;
     next.activity = [
       ...next.activity,
       {
@@ -1226,6 +1340,9 @@ export function normaliseTurnCounters(
     agentUnresponsive?: boolean;
     agentOrphaned?: boolean;
     usageBaseline?: { cost: number } | null;
+    configOptions?: ConfigOptionDescriptor[];
+    configOptionSwitchFailed?: ConfigOptionSwitchFailure | null;
+    pendingConfigOption?: { configId: string; value: string } | null;
   },
 ): CockpitState {
   const pendingUserPromptSeq =
@@ -1263,12 +1380,25 @@ export function normaliseTurnCounters(
   // start subtracting normally.
   const usageBaseline =
     state.usageBaseline === undefined ? null : state.usageBaseline;
+  // Pre-#1403 persisted entries lack the config-option trio.
+  const configOptions = Array.isArray(state.configOptions)
+    ? state.configOptions
+    : [];
+  const configOptionSwitchFailed =
+    state.configOptionSwitchFailed === undefined
+      ? null
+      : state.configOptionSwitchFailed;
+  const pendingConfigOption =
+    state.pendingConfigOption === undefined ? null : state.pendingConfigOption;
   return {
     ...state,
     rejectedPrompts,
     agentUnresponsive,
     agentOrphaned,
     usageBaseline,
+    configOptions,
+    configOptionSwitchFailed,
+    pendingConfigOption,
     pendingUserPromptSeq,
     lastStoppedSeq,
     turnActive: isTurnActive({ pendingUserPromptSeq, lastStoppedSeq }),

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -545,6 +545,24 @@
       "components": []
     },
     {
+      "id": "cockpit.config-pickers",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-config-pickers.spec.ts",
+        "src/components/cockpit/SessionConfigControls.test.tsx",
+        "src/hooks/useCockpit.configOption.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/SessionConfigControls.tsx",
+        "web/src/components/cockpit/Composer.tsx",
+        "web/src/components/cockpit/CockpitView.tsx",
+        "web/src/components/cockpit/CockpitRuntime.tsx",
+        "web/src/hooks/useCockpit.ts",
+        "web/src/lib/cockpitTypes.ts"
+      ]
+    },
+    {
       "id": "cockpit.mode-switch",
       "kind": "live-playwright",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -550,6 +550,7 @@
       "risk": "medium",
       "specs": [
         "tests/live/cockpit-config-pickers.spec.ts",
+        "tests/live/cockpit-config-pickers-ui.spec.ts",
         "src/components/cockpit/SessionConfigControls.test.tsx",
         "src/hooks/useCockpit.configOption.test.ts"
       ],

--- a/web/tests/helpers/aoeServe.ts
+++ b/web/tests/helpers/aoeServe.ts
@@ -77,6 +77,11 @@ export interface SpawnOptions {
   cockpit?: boolean;
   /** Optional path to a FAKE_ACP_SCRIPT for cockpit tests. */
   fakeAcpScript?: string;
+  /** Extra environment variables exported in the fake-ACP shim. Lets
+   *  cockpit tests toggle behavior on the fake agent (e.g. force a
+   *  rejection of session/set_config_option) without writing a full
+   *  scripted turn file. */
+  extraEnv?: Record<string, string>;
   /**
    * Runs after the isolated $HOME tree is set up and the fake shim is on
    * PATH, but BEFORE `aoe serve` spawns. Use to call `aoe add` so the
@@ -345,6 +350,7 @@ function writeFakeAcpShim(
   binDir: string,
   fakeAcpScript: string | undefined,
   fakeAcpDebugLog: string,
+  extraEnv: Record<string, string> | undefined,
 ): void {
   // The cockpit supervisor resolves the agent through `AgentRegistry`
   // (src/cockpit/agent_registry.rs): the `claude` tool key maps to
@@ -368,6 +374,9 @@ function writeFakeAcpShim(
     scriptLines.push("unset FAKE_ACP_SCRIPT");
   }
   scriptLines.push(`export FAKE_ACP_DEBUG_LOG=${JSON.stringify(fakeAcpDebugLog)}`);
+  for (const [key, value] of Object.entries(extraEnv ?? {})) {
+    scriptLines.push(`export ${key}=${JSON.stringify(value)}`);
+  }
   const script = `#!/bin/bash\n${scriptLines.join("\n")}\nexec node ${JSON.stringify(fakeAgentJs)} "$@"\n`;
   for (const name of ["claude", "claude-agent-acp", "aoe-agent"]) {
     const path = join(binDir, name);
@@ -467,7 +476,7 @@ export async function spawnAoeServe(opts: SpawnOptions): Promise<ServeHandle> {
   }
   const fakeAcpDebugLog = join(home, "fake-acp.log");
   if (opts.cockpit) {
-    writeFakeAcpShim(shimBin, opts.fakeAcpScript, fakeAcpDebugLog);
+    writeFakeAcpShim(shimBin, opts.fakeAcpScript, fakeAcpDebugLog, opts.extraEnv);
   } else {
     writeFakeClaudeShim(shimBin);
   }

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -332,7 +332,43 @@ async function handleRequest(msg) {
     case "session/new":
     case "session/load": {
       const sessionId = params?.sessionId ?? makeSessionId();
-      sendResult(id, { sessionId });
+      // Mirror claude-agent-acp v0.37.0: the initial set of
+      // per-session selectors (model + effort + mode) ships in the
+      // session/new and session/load *response*, not as a subsequent
+      // notification. The cockpit's acp_client reads the response
+      // field and emits Event::ConfigOptionsUpdated. See #1403.
+      const includeConfigOptions =
+        process.env.FAKE_ACP_EMIT_CONFIG_OPTIONS !== "0";
+      const result = { sessionId };
+      if (includeConfigOptions) {
+        result.configOptions = [
+          {
+            id: "model",
+            name: "Model",
+            category: "model",
+            type: "select",
+            currentValue: "claude-opus-4-7",
+            options: [
+              { value: "claude-opus-4-7", name: "Claude Opus 4.7" },
+              { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+            ],
+          },
+          {
+            id: "effort",
+            name: "Reasoning Effort",
+            category: "thought_level",
+            type: "select",
+            currentValue: "default",
+            options: [
+              { value: "default", name: "Default" },
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+            ],
+          },
+        ];
+      }
+      sendResult(id, result);
       return;
     }
 
@@ -349,6 +385,51 @@ async function handleRequest(msg) {
         // a server-side Event::CurrentModeChanged for the reducer.
         await emitSessionUpdates(sessionId, [
           { sessionUpdate: "current_mode_update", currentModeId: modeId },
+        ]);
+      }
+      return;
+    }
+
+    case "session/set_config_option": {
+      // Mirrors claude-agent-acp's setSessionConfigOption: accept the
+      // new value, emit a follow-up config_option_update with the
+      // updated currentValue for that option. Tests opt into a
+      // rejected response by setting FAKE_ACP_REJECT_CONFIG_OPTION.
+      // See #1403.
+      const sessionId = params?.sessionId;
+      const configId = params?.configId;
+      const value = params?.value;
+      if (process.env.FAKE_ACP_REJECT_CONFIG_OPTION) {
+        sendError(id, -32000, process.env.FAKE_ACP_REJECT_CONFIG_OPTION);
+        return;
+      }
+      sendResult(id, {});
+      if (sessionId && configId && value) {
+        await emitSessionUpdates(sessionId, [
+          {
+            sessionUpdate: "config_option_update",
+            configOptions: [
+              {
+                id: configId,
+                name: configId === "model" ? "Model" : "Reasoning Effort",
+                category: configId === "model" ? "model" : "thought_level",
+                type: "select",
+                currentValue: value,
+                options:
+                  configId === "model"
+                    ? [
+                        { value: "claude-opus-4-7", name: "Claude Opus 4.7" },
+                        { value: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+                      ]
+                    : [
+                        { value: "default", name: "Default" },
+                        { value: "low", name: "Low" },
+                        { value: "medium", name: "Medium" },
+                        { value: "high", name: "High" },
+                      ],
+              },
+            ],
+          },
         ]);
       }
       return;

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -392,23 +392,22 @@ async function handleRequest(msg) {
 
     case "session/set_config_option": {
       // Mirrors claude-agent-acp's setSessionConfigOption: accept the
-      // new value, emit a follow-up config_option_update with the
-      // updated currentValue for that option. Tests opt into a
-      // rejected response by setting FAKE_ACP_REJECT_CONFIG_OPTION.
-      // See #1403.
-      const sessionId = params?.sessionId;
+      // new value, return the updated configOptions list in the
+      // response payload. Real claude-agent-acp's setSessionConfigOption
+      // does NOT emit a follow-up config_option_update notification
+      // (acp-agent.js:1003-1057); the response carries the new state
+      // and aoe synthesizes Event::ConfigOptionsUpdated from it. Tests
+      // opt into a rejected response by setting
+      // FAKE_ACP_REJECT_CONFIG_OPTION. See #1403.
       const configId = params?.configId;
       const value = params?.value;
       if (process.env.FAKE_ACP_REJECT_CONFIG_OPTION) {
         sendError(id, -32000, process.env.FAKE_ACP_REJECT_CONFIG_OPTION);
         return;
       }
-      sendResult(id, {});
-      if (sessionId && configId && value) {
-        await emitSessionUpdates(sessionId, [
-          {
-            sessionUpdate: "config_option_update",
-            configOptions: [
+      const configOptions =
+        configId && value
+          ? [
               {
                 id: configId,
                 name: configId === "model" ? "Model" : "Reasoning Effort",
@@ -428,10 +427,9 @@ async function handleRequest(msg) {
                         { value: "high", name: "High" },
                       ],
               },
-            ],
-          },
-        ]);
-      }
+            ]
+          : [];
+      sendResult(id, { configOptions });
       return;
     }
 

--- a/web/tests/live/cockpit-config-pickers-ui.spec.ts
+++ b/web/tests/live/cockpit-config-pickers-ui.spec.ts
@@ -1,0 +1,187 @@
+// Browser-driven user stories for the cockpit model + reasoning
+// effort pickers (#1403). The sibling cockpit-config-pickers spec
+// pins the HTTP / replay wire shape; this one drives the actual
+// React surface: click the chip, pick a value, watch the chip
+// reflect the adapter's confirming snapshot.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+import { waitForCockpitReady } from "../helpers/cockpit";
+
+async function enableAndWait(baseUrl: string, sessionId: string) {
+  const enableRes = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+    { method: "POST" },
+  );
+  expect(enableRes.ok).toBeTruthy();
+  await waitForCockpitReady(baseUrl, sessionId);
+}
+
+base(
+  "user sees model and effort pickers after the adapter advertises config options",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "ui-pickers-render" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+
+      const modelChip = page.getByTestId("config-option-model");
+      await expect(modelChip).toBeVisible({ timeout: 15_000 });
+      await expect(modelChip).toContainText("Claude Opus 4.7");
+
+      const effortControl = page.getByTestId("config-option-effort");
+      await expect(effortControl).toBeVisible();
+      await expect(effortControl).toContainText("Default");
+      await expect(effortControl).toContainText("High");
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "user switches the model and the chip reflects the adapter confirmation",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "ui-pickers-switch-model" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndWait(serve.baseUrl, sessionId);
+
+      const postRequests: Array<{ url: string; body: string | null }> = [];
+      page.on("request", (req) => {
+        if (
+          req.method() === "POST" &&
+          req.url().includes(`/cockpit/config-option`)
+        ) {
+          postRequests.push({ url: req.url(), body: req.postData() });
+        }
+      });
+
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+
+      const modelChip = page.getByTestId("config-option-model");
+      await expect(modelChip).toBeVisible({ timeout: 15_000 });
+      await expect(modelChip).toContainText("Claude Opus 4.7");
+
+      await modelChip.click();
+      await page
+        .getByTestId("config-option-model-value-claude-sonnet-4-6")
+        .click();
+
+      // POST shape: { config_id: "model", value: "claude-sonnet-4-6" }.
+      await expect.poll(() => postRequests.length).toBeGreaterThan(0);
+      const body = postRequests[0]!.body;
+      expect(body).not.toBeNull();
+      const parsed = JSON.parse(body!);
+      expect(parsed).toEqual({
+        config_id: "model",
+        value: "claude-sonnet-4-6",
+      });
+
+      // Adapter's confirming snapshot lands via WS; chip updates.
+      await expect(modelChip).toContainText("Claude Sonnet 4.6", {
+        timeout: 10_000,
+      });
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "user picks reasoning effort and the segment becomes active",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "ui-pickers-switch-effort" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+
+      const effortControl = page.getByTestId("config-option-effort");
+      await expect(effortControl).toBeVisible({ timeout: 15_000 });
+
+      const highSegment = page.getByTestId("config-option-effort-value-high");
+      await highSegment.click();
+
+      // After the adapter confirms, the High radio reports
+      // aria-checked=true and Default no longer does.
+      await expect(highSegment).toHaveAttribute("aria-checked", "true", {
+        timeout: 10_000,
+      });
+      await expect(
+        page.getByTestId("config-option-effort-value-default"),
+      ).toHaveAttribute("aria-checked", "false");
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "rejected switch renders a dismissable non-blocking notice",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "ui-pickers-reject" }),
+      extraEnv: { FAKE_ACP_REJECT_CONFIG_OPTION: "rate limited (test)" },
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${sessionId}`);
+
+      const modelChip = page.getByTestId("config-option-model");
+      await expect(modelChip).toBeVisible({ timeout: 15_000 });
+      await modelChip.click();
+      await page
+        .getByTestId("config-option-model-value-claude-sonnet-4-6")
+        .click();
+
+      const notice = page.getByTestId("config-option-switch-failed-notice");
+      await expect(notice).toBeVisible({ timeout: 10_000 });
+      await expect(notice).toContainText("rate limited (test)");
+
+      // Chip stays on the previously-current value: pessimistic UI.
+      await expect(modelChip).toContainText("Claude Opus 4.7");
+
+      // Manual dismiss removes the notice.
+      await notice.getByRole("button", { name: "Dismiss notice" }).click();
+      await expect(notice).toHaveCount(0);
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-config-pickers.spec.ts
+++ b/web/tests/live/cockpit-config-pickers.spec.ts
@@ -1,0 +1,222 @@
+// Cockpit model picker + reasoning effort selector (#1403).
+//
+// POST /api/sessions/:id/cockpit/config-option forwards to the fake
+// ACP agent's `session/set_config_option` handler, which emits a
+// follow-up `config_option_update` notification. The cockpit reducer
+// records both the initial snapshot (emitted on session/new) and the
+// post-set update via the replay endpoint. Mirrors
+// cockpit-mode-switch.spec.ts.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+async function enableAndSpawn(baseUrl: string, sessionId: string) {
+  const enableRes = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/enable`,
+    { method: "POST" },
+  );
+  expect(enableRes.ok).toBeTruthy();
+  const spawnRes = await fetch(
+    `${baseUrl}/api/sessions/${sessionId}/cockpit/spawn`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agent: "claude" }),
+    },
+  );
+  expect([200, 202, 409]).toContain(spawnRes.status);
+}
+
+async function waitForReplay(
+  baseUrl: string,
+  sessionId: string,
+  predicate: (replayJson: string) => boolean,
+  maxAttempts = 30,
+): Promise<boolean> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const replay = await fetch(
+      `${baseUrl}/api/sessions/${sessionId}/cockpit/replay?since=0`,
+    ).then((r) => r.json());
+    const json = JSON.stringify(replay);
+    if (predicate(json)) return true;
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+base(
+  "initial config_option_update from the adapter lands in cockpit replay",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "config-pickers-initial" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const saw = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionsUpdated") &&
+          json.includes("claude-opus-4-7") &&
+          json.includes("thought_level"),
+      );
+      expect(saw).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "session/set_config_option round-trips and the adapter confirms with a new snapshot",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "config-pickers-set" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      // Wait for the initial snapshot so we know the supervisor saw
+      // session/new complete before issuing set_config_option.
+      const sawInitial = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) => json.includes("ConfigOptionsUpdated"),
+      );
+      expect(sawInitial).toBe(true);
+
+      const setRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/config-option`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            config_id: "model",
+            value: "claude-sonnet-4-6",
+          }),
+        },
+      );
+      expect(setRes.status).toBeGreaterThanOrEqual(200);
+      expect(setRes.status).toBeLessThan(300);
+
+      // Confirming snapshot from the adapter carries the requested
+      // value as the new current_value. The replay endpoint should
+      // contain at least one ConfigOptionsUpdated event whose payload
+      // includes `claude-sonnet-4-6`.
+      const sawConfirm = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionsUpdated") &&
+          json.includes("claude-sonnet-4-6"),
+      );
+      expect(sawConfirm).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "user switches reasoning effort to a valid level",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "config-pickers-effort" }),
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const setRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/config-option`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ config_id: "effort", value: "high" }),
+        },
+      );
+      expect(setRes.status).toBeGreaterThanOrEqual(200);
+      expect(setRes.status).toBeLessThan(300);
+
+      const sawConfirm = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionsUpdated") &&
+          /"effort"[^}]*"current_value"\s*:\s*"high"/.test(json),
+      );
+      expect(sawConfirm).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "rejected set_config_option surfaces as ConfigOptionSwitchFailed",
+  async ({}, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "config-pickers-reject" }),
+      extraEnv: { FAKE_ACP_REJECT_CONFIG_OPTION: "rate limited (test)" },
+    });
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const sessionId: string = sessions[0]!.id;
+      await enableAndSpawn(serve.baseUrl, sessionId);
+
+      const setRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/config-option`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            config_id: "model",
+            value: "claude-sonnet-4-6",
+          }),
+        },
+      );
+      // The HTTP path itself succeeds (the request is sent); the
+      // rejection arrives as an async ConfigOptionSwitchFailed event
+      // on the broadcast bus.
+      expect(setRes.status).toBeGreaterThanOrEqual(200);
+      expect(setRes.status).toBeLessThan(300);
+
+      const sawFailure = await waitForReplay(
+        serve.baseUrl,
+        sessionId,
+        (json) =>
+          json.includes("ConfigOptionSwitchFailed") &&
+          json.includes("rate limited"),
+      );
+      expect(sawFailure).toBe(true);
+    } finally {
+      await serve.stop();
+    }
+  },
+);

--- a/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
+++ b/web/tests/live/cockpit-stories/profile-settings-isolation.spec.ts
@@ -42,7 +42,19 @@ base("per-profile settings stay isolated across profile switches", async ({ page
     await expect(
       profileSelect.locator("option", { hasText: "isolation-b" }),
     ).toHaveCount(1, { timeout: 5_000 });
+    // Race-proofing: after switching profiles, SettingsView fires a
+    // useEffect that GETs /api/profiles/<name>/settings. The assertion
+    // below toHaveValue-polls the rendered select, but on slower CI
+    // runners (#1383 flake) the poll can race the re-fetch and read
+    // the previously-loaded profile's value within its 10s window.
+    // Await the network round trip explicitly before each assertion.
+    const waitForBSettings = page.waitForResponse(
+      (r) =>
+        r.url().includes("/api/settings?profile=isolation-b") &&
+        r.request().method() === "GET",
+    );
     await profileSelect.selectOption("isolation-b");
+    await waitForBSettings;
     await openSettingsTab(page, "Tmux");
 
     // Profile B starts fresh; tmux status_bar should be the unset
@@ -51,7 +63,13 @@ base("per-profile settings stay isolated across profile switches", async ({ page
     await expect(statusBarB).toHaveValue("auto", { timeout: 10_000 });
 
     // Switch back to profile A; the value set above must still hold.
+    const waitForASettings = page.waitForResponse(
+      (r) =>
+        r.url().includes(`/api/settings?profile=${profileA}`) &&
+        r.request().method() === "GET",
+    );
     await profileSelect.selectOption(profileA);
+    await waitForASettings;
     await openSettingsTab(page, "Tmux");
     const statusBarA = settingsSelectByLabel(page, "Status bar");
     await expect(statusBarA).toHaveValue("disabled", { timeout: 10_000 });

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -86,9 +86,11 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await fireWheel(page, { deltaY: 120, times: 3 });
 
     // WebSocket message delivery from page to Playwright handler is async;
-    // poll briefly so the assertion doesn't race the message capture.
+    // poll so the assertion doesn't race the message capture. 5s gives
+    // enough headroom for CI runners under load (2s was tight enough
+    // to flake on heavy parallel runs).
     await expect
-      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 2_000 })
+      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 5_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
   });
@@ -106,7 +108,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await fireWheel(page, { deltaY: -120, times: 3 });
 
     await expect
-      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 2_000 })
+      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 5_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
   });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Adds a model picker and a reasoning-effort selector to the cockpit composer footer beside the existing mode pill. Both surfaces are driven by the unified `SessionUpdate::ConfigOptionUpdate` notification that `claude-agent-acp` v0.37.0 stabilised upstream (PRs #637, #701, #702, #704), so the cockpit gets new selectors without a per-category pipeline and stays forward-compatible with future categories the adapter may add.

The wire path is intentionally one mechanism end-to-end:
- **Inbound**: `SessionUpdate::ConfigOptionUpdate { config_options }` becomes `Event::ConfigOptionsUpdated { options }` (full snapshot, replace not merge). Auto-dismisses any stale switch-failed notice when the snapshot confirms the originally-requested value.
- **Outbound**: `POST /api/sessions/{id}/cockpit/config-option { config_id, value }` lands as ACP `session/set_config_option`. On rejection the broadcast bus emits `ConfigOptionSwitchFailed` so the UI can render a non-blocking amber notice mirroring the existing `ModeSwitchFailed` pattern (#1233).

The UI is pessimistic with a pending affordance: the chip still shows the previously-current value while the request is in flight (subtle opacity dip + disabled re-click on the just-clicked option), and only updates once the adapter pushes a confirming snapshot. This avoids "snap back" on slow networks (Cloudflare Tunnel can run 300-800ms round trips) and keeps multi-tab state consistent because the broadcast frame is the only sync channel.

The effort widget is adaptive: segmented control when the option list is short and labels fit (the common `Default | Low | Medium | High` shape), dropdown fallback otherwise. Model always renders as a dropdown. `Default` effort is sent as the literal value `"default"`; the adapter resolves the actual budget for the current model.

`AgentSwitched` clears the cached selector list (Claude-to-Codex handoff invalidates Claude-specific models); `/clear` deliberately preserves it because adapter capabilities outlive a conversation reset, matching the contract established for `availableCommands` in #1128.

The plan and the design decisions came out of a three-model `/debate` (gpt-5.5, claude-opus-4-7, gemini-3.1-pro-preview, two rounds) covering wire shape, UI placement, effort widget, optimistic vs pessimistic, and failure UI.

Closes #1403

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Added `web/tests/live/cockpit-config-pickers.spec.ts` with four user-observable scenarios (initial snapshot lands, model switch round-trips with adapter confirmation, effort switch round-trips, adapter rejection surfaces as ConfigOptionSwitchFailed). The fake ACP agent (`web/tests/helpers/fakeAcpAgent.mjs`) grew handlers for `session/set_config_option` and emits an initial `config_option_update` on `session/new`. Coverage matrix entry registered as `cockpit.config-pickers`.

Also added matching Vitest coverage:
- `src/lib/cockpitTypes.test.ts` — six new tests for reducer arms (full replacement, failure population, auto-dismiss on confirming snapshot, preserve on non-confirming snapshot, AgentSwitched clears, SessionCleared preserves).
- `src/hooks/useCockpit.configOption.test.ts` — four tests for the three new internal actions (set/clear pending, dismiss notice).
- `src/components/cockpit/SessionConfigControls.test.tsx` — twelve tests for component rendering, the adaptive segmented/dropdown switch, pending affordance, and the failure notice.
- Rust unit tests in `src/cockpit/state.rs` (six) and `src/cockpit/acp_client.rs` (one) for the same reducer + ingest semantics.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The TUI cockpit reducer only stores the new event variants as no-op seq-bumps; no new rendering surface in the TUI. CLI surface is unchanged.

## How to test

User-runnable behavioral checks once the branch is up and CI is green:

- [x] Start a Claude cockpit session: `aoe serve` and create or attach a cockpit session, agent `claude`.
- [ ] Verify the composer footer renders a model dropdown (showing the current model name truncated to fit) and an effort segmented control (`Default | Low | Medium | High`) beside the existing mode pill.
- [ ] Click the model dropdown, pick a different model. The dropdown stays on the previous current value briefly (with a dim on the just-clicked option) and updates once the adapter confirms. The session continues running.
- [ ] Click the `Default` effort segment, then send a prompt. The agent responds without an explicit effort pin; the segment stays on `Default`.
- [ ] Click `High` effort, send a prompt. The agent responds; the segment stays on `High`.
- [ ] Refresh the page. The pickers re-hydrate from the replay buffer with the current values (no empty placeholder flicker).
- [ ] With an adapter that does not advertise `Model` / `ThoughtLevel` categories (e.g. an older claude-agent-acp), confirm neither picker renders. The mode pill stays visible on its own.
- [ ] Hand the session off via `/cockpit switch-agent` (or `aoe cockpit switch-agent ...`). After the handoff, confirm the model dropdown disappears or reflects the new backend's selectors; no stale Claude models persist.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill). Plan stage used `/debate` across gpt-5.5, claude-opus-4-7, and gemini-3.1-pro-preview (two rounds) to settle the wire shape and UX decisions.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (Composer-footer placement, pessimistic-with-pending, adaptive segmented effort, explicit ConfigOptionSwitchFailed), and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR adds per-session model and reasoning-effort pickers to the Cockpit composer footer, backed by adapter-provided snapshots and a server API. It introduces end-to-end support (backend, client, state, UI, tests, docs) so users can select model and effort from the chat UI while keeping adapter snapshots authoritative.

What changed (high-level)
- UI:
  - Adds composer footer controls: model dropdown; reasoning-effort selector (segmented control when labels fit, dropdown fallback).
  - Non-blocking amber notice for adapter rejections (dismissable, auto-clears when a confirming snapshot arrives).
  - Pessimistic-with-pending UX: UI retains last confirmed value while a change is pending (dim + disable clicked option) and updates only after adapter confirmation.
- Backend & adapter integration:
  - New REST endpoint: POST /api/sessions/{id}/cockpit/config-option → maps to ACP session/set_config_option.
  - AcpClient.set_config_option and supervisor.set_config_option added; connection task synthesizes ConfigOptionsUpdated snapshots or emits ConfigOptionSwitchFailed on error.
  - Fake ACP test shim extended to emit and reject config-option changes for tests.
- State & events:
  - Cockpit state stores full snapshots (configOptions), pending in-flight selection, and a last-switch failure notice.
  - New events: ConfigOptionsUpdated (full-snapshot replace) and ConfigOptionSwitchFailed.
  - Snapshot semantics: incoming updates replace (not merge) choice lists; confirming snapshots auto-dismiss matching failures.
  - AgentSwitched clears cached selector lists; SessionCleared preserves them.
- Tests, docs & tooling:
  - Playwright UI and live E2E specs, Vitest unit/component tests, Rust unit tests added.
  - Documentation: "Model and reasoning effort" section in cockpit.md.
  - coverage-matrix entry cockpit.config-pickers added.

What was added
- Frontend: SessionConfigControls, ModelDropdown, EffortControl, ConfigOptionSwitchFailedNotice; Composer and CockpitView wiring; CockpitRuntime/CockpitContext API: setConfigOption and dismissConfigOptionSwitchFailed.
- Hooks/types/state: pendingConfigOption, ConfigOptionDescriptor/Choice/Category/SwitchFailure, reducer behavior and normalisation/backfill for older persisted state.
- Backend: AcpClient::set_config_option, Supervisor::set_config_option, server handler cockpit_set_config_option, route wiring and read-only guard.
- Tests: Playwright suites for UI & replay behavior, Vitest suites for reducer/hook/components, Rust tests for ACP mapping and handshake snapshot emission.
- Test harness: fake ACP agent and serve harness env support for config-option test scenarios.

What moved or was removed
- No removals; existing ModeSwitchFailed UX pattern reused and extended for config option failures. New wiring added across backend, state, frontend, and tests.

Benefits
- Lets users change model and reasoning-effort per-session directly from the UI.
- Prevents jarring snap-backs and improves multi-tab consistency via pessimistic pending UX.
- Surfaces adapter rejection reasons non-blockingly while deferring final state to adapter snapshots.
- Comprehensive tests and docs lower regression risk and clarify lifecycle semantics.

Concise technical notes
- Snapshot flow: SessionUpdate::ConfigOptionUpdate → Event::ConfigOptionsUpdated replaces the full options list (replace, not merge).
- Outbound flow: POST /api/sessions/{id}/cockpit/config-option → Supervisor → AcpClient::set_config_option → ACP session/set_config_option; adapter rejections produce ConfigOptionSwitchFailed for UI notice.
- UI pending protection: pendingConfigOption tracks in-flight (configId, value); UI dims/disables the clicked option until a confirming snapshot arrives; failures clear pending only when matching or on explicit dismiss.
- "Default" effort is sent literally as "default" and resolved by the adapter.

Estimated review effort: Medium–High (widespread changes across backend client, state, frontend UI, and tests).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1548?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->