### PR TITLE
fix(tui): wrap multiline live-send pastes in bracketed paste markers

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -28,21 +28,50 @@ use crate::tui::settings::{SettingsAction, SettingsView};
 /// fast for trackpads or too slow on remote sessions.
 const DOUBLE_CLICK_THRESHOLD: std::time::Duration = std::time::Duration::from_millis(400);
 
+/// xterm bracketed-paste start sequence: `ESC [ 2 0 0 ~`. An agent that
+/// has enabled bracketed paste mode (`\e[?2004h`) treats everything
+/// between this marker and the matching end marker as one paste rather
+/// than as keystrokes, so interior newlines accumulate in the input
+/// buffer instead of firing `submit` per line.
+const BRACKETED_PASTE_START: &[u8] = &[0x1b, b'[', b'2', b'0', b'0', b'~'];
+
+/// xterm bracketed-paste end sequence: `ESC [ 2 0 1 ~`. Pairs with
+/// [`BRACKETED_PASTE_START`].
+const BRACKETED_PASTE_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
+
 /// Decompose pasted text into a series of `TmuxKey`s safe for the
-/// live-send worker to dispatch. Control bytes can't ride inside a
-/// `send-keys -l` payload (tmux's command parser splits on newlines
-/// and we have no safe encoding for raw control bytes), so we split
-/// the paste around them: printable runs go through as `Literal`,
-/// known control characters translate to their named equivalents
-/// (`\n` and `\r` → `Enter`, `\t` → `Tab`), and anything else below
-/// 0x20 is dropped rather than mapped to a surprising named key. A
-/// `\r\n` pair coalesces to a single `Enter` so Windows-line-ending
-/// pastes don't fire two newlines in a row.
+/// live-send worker to dispatch.
+///
+/// Single-line pastes (no `\n` / `\r`) skip the bracketed-paste
+/// wrapping and travel as a single `Literal`: a bare shell or any
+/// agent that hasn't enabled `\e[?2004h` keeps working unchanged,
+/// because we never emit the escape markers it would render as
+/// literal text. Tabs in single-line pastes still go through as
+/// `Named("Tab")` to mirror the historical path.
+///
+/// Multi-line pastes get wrapped in xterm bracketed-paste markers
+/// (`\e[200~` / `\e[201~`) so the receiving agent sees the entire
+/// payload as one paste rather than as N independent Enter keypresses.
+/// Without the wrapping, agents that submit on Enter (Claude Code,
+/// Codex, OpenCode, ...) post one user message per pasted line, which
+/// is the bug behind #1546. Inside the markers, interior newlines and
+/// tabs ride as raw bytes (CR=0x0d, TAB=0x09) via `send-keys -H`, and
+/// printable runs ride as `Literal` via `send-keys -l`. `\r\n` pairs
+/// coalesce to a single CR so Windows-line-ending pastes don't double
+/// up. Other control bytes (BEL, ESC, ...) are dropped rather than
+/// risking that an embedded escape corrupts the agent's input.
 pub(super) fn split_paste_for_live_send(text: &str) -> Vec<live_send::TmuxKey> {
+    let has_newline = text.contains('\n') || text.contains('\r');
+    if !has_newline {
+        return split_inline_paste(text);
+    }
+    split_bracketed_paste(text)
+}
+
+fn split_inline_paste(text: &str) -> Vec<live_send::TmuxKey> {
     let mut out = Vec::new();
     let mut buf = String::new();
-    let mut chars = text.chars().peekable();
-    while let Some(ch) = chars.next() {
+    for ch in text.chars() {
         let is_control = (ch as u32) < 0x20 || ch == '\x7f';
         if !is_control {
             buf.push(ch);
@@ -51,24 +80,57 @@ pub(super) fn split_paste_for_live_send(text: &str) -> Vec<live_send::TmuxKey> {
         if !buf.is_empty() {
             out.push(live_send::TmuxKey::Literal(std::mem::take(&mut buf)));
         }
-        match ch {
-            '\n' => out.push(live_send::TmuxKey::Named("Enter".to_string())),
-            '\r' => {
-                if chars.peek() == Some(&'\n') {
-                    chars.next();
-                }
-                out.push(live_send::TmuxKey::Named("Enter".to_string()));
-            }
-            '\t' => out.push(live_send::TmuxKey::Named("Tab".to_string())),
-            _ => {
-                // BEL, ESC, etc.: dropping is friendlier than mapping
-                // to a named key that could cancel the agent's input.
-            }
+        if ch == '\t' {
+            out.push(live_send::TmuxKey::Named("Tab".to_string()));
         }
+        // BEL, ESC, etc.: dropping is friendlier than mapping
+        // to a named key that could cancel the agent's input.
     }
     if !buf.is_empty() {
         out.push(live_send::TmuxKey::Literal(buf));
     }
+    out
+}
+
+fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
+    let mut out = Vec::new();
+    out.push(live_send::TmuxKey::HexBytes(BRACKETED_PASTE_START.to_vec()));
+
+    let mut buf = String::new();
+    let flush = |out: &mut Vec<live_send::TmuxKey>, buf: &mut String| {
+        if !buf.is_empty() {
+            out.push(live_send::TmuxKey::Literal(std::mem::take(buf)));
+        }
+    };
+    let mut chars = text.chars().peekable();
+    while let Some(ch) = chars.next() {
+        match ch {
+            '\n' => {
+                flush(&mut out, &mut buf);
+                out.push(live_send::TmuxKey::HexBytes(vec![0x0d]));
+            }
+            '\r' => {
+                if chars.peek() == Some(&'\n') {
+                    chars.next();
+                }
+                flush(&mut out, &mut buf);
+                out.push(live_send::TmuxKey::HexBytes(vec![0x0d]));
+            }
+            '\t' => {
+                flush(&mut out, &mut buf);
+                out.push(live_send::TmuxKey::HexBytes(vec![0x09]));
+            }
+            c if (c as u32) < 0x20 || c == '\x7f' => {
+                // Embedded ESC / BEL / etc. has no safe encoding
+                // inside the paste payload; drop rather than risk a
+                // bogus terminal escape closing the paste early.
+            }
+            c => buf.push(c),
+        }
+    }
+    flush(&mut out, &mut buf);
+
+    out.push(live_send::TmuxKey::HexBytes(BRACKETED_PASTE_END.to_vec()));
     out
 }
 

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -54,12 +54,13 @@ const BRACKETED_PASTE_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
 /// payload as one paste rather than as N independent Enter keypresses.
 /// Without the wrapping, agents that submit on Enter (Claude Code,
 /// Codex, OpenCode, ...) post one user message per pasted line, which
-/// is the bug behind #1546. Inside the markers, interior newlines and
-/// tabs ride as raw bytes (CR=0x0d, TAB=0x09) via `send-keys -H`, and
-/// printable runs ride as `Literal` via `send-keys -l`. `\r\n` pairs
-/// coalesce to a single CR so Windows-line-ending pastes don't double
-/// up. Other control bytes (BEL, ESC, ...) are dropped rather than
-/// risking that an embedded escape corrupts the agent's input.
+/// is the bug behind #1546. The whole payload (markers, printable
+/// runs, interior CRs, and tabs) goes through as a single `HexBytes`,
+/// so the worker fires one `tmux send-keys -H` subprocess per paste
+/// instead of one per chunk. `\r\n` pairs coalesce to a single CR so
+/// Windows-line-ending pastes don't double up; other control bytes
+/// (BEL, ESC, ...) are dropped rather than risk that an embedded
+/// escape closes the bracketed-paste sequence on the agent's side.
 pub(super) fn split_paste_for_live_send(text: &str) -> Vec<live_send::TmuxKey> {
     let has_newline = text.contains('\n') || text.contains('\r');
     if !has_newline {
@@ -93,45 +94,40 @@ fn split_inline_paste(text: &str) -> Vec<live_send::TmuxKey> {
 }
 
 fn split_bracketed_paste(text: &str) -> Vec<live_send::TmuxKey> {
-    let mut out = Vec::new();
-    out.push(live_send::TmuxKey::HexBytes(BRACKETED_PASTE_START.to_vec()));
+    // Build one contiguous byte payload: start marker, then the paste
+    // content with printables as their UTF-8 bytes / interior newlines
+    // as CR (0x0d) / tabs as 0x09, then the end marker. Sending it as
+    // one `HexBytes` means the worker fires exactly one `tmux send-keys
+    // -H` subprocess per paste rather than one per chunk.
+    let mut bytes = Vec::with_capacity(text.len() + BRACKETED_PASTE_START.len() * 2);
+    bytes.extend_from_slice(BRACKETED_PASTE_START);
 
-    let mut buf = String::new();
-    let flush = |out: &mut Vec<live_send::TmuxKey>, buf: &mut String| {
-        if !buf.is_empty() {
-            out.push(live_send::TmuxKey::Literal(std::mem::take(buf)));
-        }
-    };
     let mut chars = text.chars().peekable();
+    let mut utf8_buf = [0u8; 4];
     while let Some(ch) = chars.next() {
         match ch {
-            '\n' => {
-                flush(&mut out, &mut buf);
-                out.push(live_send::TmuxKey::HexBytes(vec![0x0d]));
-            }
+            '\n' => bytes.push(0x0d),
             '\r' => {
                 if chars.peek() == Some(&'\n') {
                     chars.next();
                 }
-                flush(&mut out, &mut buf);
-                out.push(live_send::TmuxKey::HexBytes(vec![0x0d]));
+                bytes.push(0x0d);
             }
-            '\t' => {
-                flush(&mut out, &mut buf);
-                out.push(live_send::TmuxKey::HexBytes(vec![0x09]));
-            }
+            '\t' => bytes.push(0x09),
             c if (c as u32) < 0x20 || c == '\x7f' => {
                 // Embedded ESC / BEL / etc. has no safe encoding
                 // inside the paste payload; drop rather than risk a
                 // bogus terminal escape closing the paste early.
             }
-            c => buf.push(c),
+            c => {
+                let s = c.encode_utf8(&mut utf8_buf);
+                bytes.extend_from_slice(s.as_bytes());
+            }
         }
     }
-    flush(&mut out, &mut buf);
 
-    out.push(live_send::TmuxKey::HexBytes(BRACKETED_PASTE_END.to_vec()));
-    out
+    bytes.extend_from_slice(BRACKETED_PASTE_END);
+    vec![live_send::TmuxKey::HexBytes(bytes)]
 }
 
 fn resolve_hook_install_agent(

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -1007,10 +1007,12 @@ mod tests {
     }
 
     #[test]
-    fn coalesce_bracketed_paste_shape() {
-        // End-to-end shape of a two-line bracketed paste: start marker,
-        // first literal, CR, second literal, end marker. Verifies the
-        // ordering the live-send paste path relies on.
+    fn coalesce_preserves_order_when_hex_bytes_and_literals_interleave() {
+        // A future caller could send `HexBytes` and `Literal` payloads
+        // back to back (e.g. a typed-then-pasted burst the worker
+        // drained in one tick). Coalesce must keep wire ordering
+        // intact: each `Literal` flushes the run, and only adjacent
+        // `HexBytes` pairs merge.
         let start = vec![0x1b, b'[', b'2', b'0', b'0', b'~'];
         let end = vec![0x1b, b'[', b'2', b'0', b'1', b'~'];
         let out = coalesce(vec![

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -274,24 +274,27 @@ pub(in crate::tui) struct LiveSendState {
 }
 
 /// One coalesced unit of work the worker hands to tmux. `Literal` runs
-/// fold together; named keys and resizes break the run because their
-/// order vs. surrounding text matters (an Up arrow between "ab" and
-/// "cd" must arrive between, not after; a resize that lands before
-/// keystrokes makes the agent render those keystrokes at the new
-/// geometry).
+/// fold together; named keys, hex-byte runs, and resizes break the run
+/// because their order vs. surrounding text matters (an Up arrow between
+/// "ab" and "cd" must arrive between, not after; a resize that lands
+/// before keystrokes makes the agent render those keystrokes at the new
+/// geometry). Consecutive `HexBytes` payloads do merge with each other
+/// so a multi-blank-line paste collapses into one `send-keys -H` call.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TmuxAction {
     Literal(String),
     Named(String),
+    HexBytes(Vec<u8>),
     Resize { cols: u16, rows: u16 },
 }
 
 /// Fold a batch of `WorkerMsg`s into the smallest sequence of
 /// `TmuxAction`s that preserves the original ordering. Consecutive
-/// `Send(Literal)` values merge into one payload (single
-/// `tmux send-keys` call); a `Send(Named)` or `Resize` flushes the
-/// current literal run and goes out on its own. Pure function so tests
-/// can verify ordering without spawning a worker thread.
+/// `Send(Literal)` values merge into one `send-keys -l` payload, and
+/// consecutive `Send(HexBytes)` values merge into one `send-keys -H`
+/// argument list; a `Send(Named)`, `Send(HexBytes)`, or `Resize`
+/// flushes the current literal run. Pure function so tests can verify
+/// ordering without spawning a worker thread.
 pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
     let mut out: Vec<TmuxAction> = Vec::new();
     let mut run = String::new();
@@ -306,6 +309,13 @@ pub(super) fn coalesce(batch: Vec<WorkerMsg>) -> Vec<TmuxAction> {
             WorkerMsg::Send(TmuxKey::Named(name)) => {
                 flush(&mut out, &mut run);
                 out.push(TmuxAction::Named(name));
+            }
+            WorkerMsg::Send(TmuxKey::HexBytes(bytes)) => {
+                flush(&mut out, &mut run);
+                match out.last_mut() {
+                    Some(TmuxAction::HexBytes(prev)) => prev.extend_from_slice(&bytes),
+                    _ => out.push(TmuxAction::HexBytes(bytes)),
+                }
             }
             WorkerMsg::Resize { cols, rows } => {
                 flush(&mut out, &mut run);
@@ -428,6 +438,16 @@ fn dispatch_via_fork(tmux_name: &str, action: &TmuxAction) -> anyhow::Result<()>
         TmuxAction::Named(name) => {
             cmd.args(["send-keys", "-t", &target, name.as_str()]);
         }
+        TmuxAction::HexBytes(bytes) => {
+            // `-H` sends each subsequent arg as the hex byte value of an
+            // ASCII character. We use this for control bytes (CR, TAB,
+            // ESC) and the bracketed-paste markers, none of which can
+            // ride a `-l` payload safely.
+            cmd.args(["send-keys", "-t", &target, "-H"]);
+            for b in bytes {
+                cmd.arg(format!("{:02x}", b));
+            }
+        }
         TmuxAction::Resize { cols, rows } => {
             cmd.args([
                 "resize-window",
@@ -464,11 +484,15 @@ pub(super) enum LiveDispatch {
 }
 
 /// How the translator wants the keystroke delivered. `Literal` payloads
-/// go through `tmux send-keys -l --`, named keys through `tmux send-keys`.
+/// go through `tmux send-keys -l --`, named keys through `tmux send-keys`,
+/// and `HexBytes` through `tmux send-keys -H <byte> <byte> ...` for raw
+/// bytes that can't ride a literal payload (control bytes like ESC, CR,
+/// TAB, and the bracketed-paste markers).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) enum TmuxKey {
     Literal(String),
     Named(String),
+    HexBytes(Vec<u8>),
 }
 
 /// Map one crossterm `KeyEvent` onto a `LiveDispatch`.
@@ -867,6 +891,9 @@ mod tests {
     fn snd_named(s: &str) -> WorkerMsg {
         WorkerMsg::Send(TmuxKey::Named(s.into()))
     }
+    fn snd_hex(bytes: &[u8]) -> WorkerMsg {
+        WorkerMsg::Send(TmuxKey::HexBytes(bytes.to_vec()))
+    }
 
     #[test]
     fn coalesce_empty_batch_is_empty() {
@@ -949,6 +976,58 @@ mod tests {
             vec![
                 TmuxAction::Named("Tab".into()),
                 TmuxAction::Literal("xy".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_hex_bytes_breaks_literal_run() {
+        // A HexBytes payload (bracketed-paste marker, raw CR, etc.)
+        // must dispatch in order, not after surrounding literals.
+        let out = coalesce(vec![snd_lit("a"), snd_hex(&[0x0d]), snd_lit("b")]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::Literal("a".into()),
+                TmuxAction::HexBytes(vec![0x0d]),
+                TmuxAction::Literal("b".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn coalesce_back_to_back_hex_bytes_merge() {
+        // Consecutive HexBytes payloads (e.g. a paste with a blank line
+        // produces two raw-CR sends in a row) collapse into one
+        // `send-keys -H` invocation. Named keys can't merge because
+        // each is a separate key argument; raw bytes have no such
+        // constraint.
+        let out = coalesce(vec![snd_hex(&[0x0d]), snd_hex(&[0x0d])]);
+        assert_eq!(out, vec![TmuxAction::HexBytes(vec![0x0d, 0x0d])]);
+    }
+
+    #[test]
+    fn coalesce_bracketed_paste_shape() {
+        // End-to-end shape of a two-line bracketed paste: start marker,
+        // first literal, CR, second literal, end marker. Verifies the
+        // ordering the live-send paste path relies on.
+        let start = vec![0x1b, b'[', b'2', b'0', b'0', b'~'];
+        let end = vec![0x1b, b'[', b'2', b'0', b'1', b'~'];
+        let out = coalesce(vec![
+            snd_hex(&start),
+            snd_lit("a"),
+            snd_hex(&[0x0d]),
+            snd_lit("b"),
+            snd_hex(&end),
+        ]);
+        assert_eq!(
+            out,
+            vec![
+                TmuxAction::HexBytes(start),
+                TmuxAction::Literal("a".into()),
+                TmuxAction::HexBytes(vec![0x0d]),
+                TmuxAction::Literal("b".into()),
+                TmuxAction::HexBytes(end),
             ]
         );
     }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6651,8 +6651,9 @@ mod live_send_mode {
         //! Single-line pastes stay on the simple `Literal` + `Named("Tab")`
         //! path so raw shells and bracketed-paste-unaware agents keep
         //! working. Multi-line pastes get wrapped in xterm bracketed-
-        //! paste markers (#1546) so receiving agents see one paste
-        //! instead of one `Enter` per line.
+        //! paste markers (#1546) and dispatched as a single `HexBytes`
+        //! payload so the receiving agent sees one paste instead of one
+        //! `Enter` per line.
 
         use crate::tui::home::input::split_paste_for_live_send;
         use crate::tui::home::live_send::TmuxKey;
@@ -6663,19 +6664,23 @@ mod live_send_mode {
         fn named(name: &str) -> TmuxKey {
             TmuxKey::Named(name.to_string())
         }
-        fn hex(bytes: &[u8]) -> TmuxKey {
-            TmuxKey::HexBytes(bytes.to_vec())
-        }
 
         /// xterm bracketed-paste start: `ESC [ 2 0 0 ~`.
         const BP_START: &[u8] = &[0x1b, b'[', b'2', b'0', b'0', b'~'];
         /// xterm bracketed-paste end: `ESC [ 2 0 1 ~`.
         const BP_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
-        /// CR (0x0d) is the xterm convention for line break inside a paste.
-        const CR: &[u8] = &[0x0d];
-        /// TAB (0x09) rides as raw bytes inside a bracketed paste so the
-        /// agent sees a literal tab character in its input buffer.
-        const TAB: &[u8] = &[0x09];
+
+        /// Build the expected `HexBytes` payload for a multi-line
+        /// paste: start marker, then the per-line `body` bytes, then
+        /// end marker. Keeps each test focused on the *shape* of the
+        /// paste content rather than on hand-rolled byte arithmetic.
+        fn wrap(body: &[u8]) -> Vec<TmuxKey> {
+            let mut out = Vec::with_capacity(BP_START.len() + body.len() + BP_END.len());
+            out.extend_from_slice(BP_START);
+            out.extend_from_slice(body);
+            out.extend_from_slice(BP_END);
+            vec![TmuxKey::HexBytes(out)]
+        }
 
         #[test]
         fn printable_paste_stays_one_literal() {
@@ -6693,13 +6698,7 @@ mod live_send_mode {
             // posts each line as its own user message (#1546).
             assert_eq!(
                 split_paste_for_live_send("first\nsecond"),
-                vec![
-                    hex(BP_START),
-                    lit("first"),
-                    hex(CR),
-                    lit("second"),
-                    hex(BP_END),
-                ],
+                wrap(b"first\x0dsecond"),
             );
         }
 
@@ -6711,34 +6710,25 @@ mod live_send_mode {
             // review before sending.
             assert_eq!(
                 split_paste_for_live_send("only line\n"),
-                vec![hex(BP_START), lit("only line"), hex(CR), hex(BP_END)],
+                wrap(b"only line\x0d"),
             );
         }
 
         #[test]
         fn leading_newline_stays_inside_bracketed_paste() {
-            assert_eq!(
-                split_paste_for_live_send("\nbody"),
-                vec![hex(BP_START), hex(CR), lit("body"), hex(BP_END)],
-            );
+            assert_eq!(split_paste_for_live_send("\nbody"), wrap(b"\x0dbody"));
         }
 
         #[test]
         fn crlf_coalesces_to_single_cr() {
             // Windows-style line endings collapse to one CR inside the
             // bracketed paste so the agent doesn't see a double newline.
-            assert_eq!(
-                split_paste_for_live_send("a\r\nb"),
-                vec![hex(BP_START), lit("a"), hex(CR), lit("b"), hex(BP_END)],
-            );
+            assert_eq!(split_paste_for_live_send("a\r\nb"), wrap(b"a\x0db"));
         }
 
         #[test]
         fn bare_cr_becomes_cr_inside_bracketed_paste() {
-            assert_eq!(
-                split_paste_for_live_send("a\rb"),
-                vec![hex(BP_START), lit("a"), hex(CR), lit("b"), hex(BP_END)],
-            );
+            assert_eq!(split_paste_for_live_send("a\rb"), wrap(b"a\x0db"));
         }
 
         #[test]
@@ -6755,18 +6745,7 @@ mod live_send_mode {
             // Inside a bracketed paste, tab is a literal character of
             // the paste content, not a key event, so we send it as a
             // raw 0x09 byte alongside the rest of the payload.
-            assert_eq!(
-                split_paste_for_live_send("a\tb\nc"),
-                vec![
-                    hex(BP_START),
-                    lit("a"),
-                    hex(TAB),
-                    lit("b"),
-                    hex(CR),
-                    lit("c"),
-                    hex(BP_END),
-                ],
-            );
+            assert_eq!(split_paste_for_live_send("a\tb\nc"), wrap(b"a\x09b\x0dc"),);
         }
 
         #[test]
@@ -6784,11 +6763,9 @@ mod live_send_mode {
             // Same drop policy applies inside the bracketed paste: an
             // embedded ESC could prematurely close the paste sequence
             // on the agent's side, so we strip it rather than forward.
-            // Adjacent printables stay in one literal run because a
-            // dropped control byte never flushes the running buffer.
             assert_eq!(
                 split_paste_for_live_send("a\x07b\x1bc\nd"),
-                vec![hex(BP_START), lit("abc"), hex(CR), lit("d"), hex(BP_END)],
+                wrap(b"abc\x0dd"),
             );
         }
 
@@ -6800,15 +6777,33 @@ mod live_send_mode {
             // agent sees one paste instead of three Enter keypresses.
             assert_eq!(
                 split_paste_for_live_send("alpha beta\nsecond line\nthird"),
-                vec![
-                    hex(BP_START),
-                    lit("alpha beta"),
-                    hex(CR),
-                    lit("second line"),
-                    hex(CR),
-                    lit("third"),
-                    hex(BP_END),
-                ],
+                wrap(b"alpha beta\x0dsecond line\x0dthird"),
+            );
+        }
+
+        #[test]
+        fn multiline_paste_dispatches_as_one_hex_payload() {
+            // Single-fork dispatch: the entire paste (markers, content,
+            // CRs) is one `HexBytes` so the worker fires exactly one
+            // `tmux send-keys -H` subprocess. Verifies the length-of-1
+            // invariant the worker relies on for paste latency.
+            let out = split_paste_for_live_send("a\nb\nc\nd");
+            assert_eq!(out.len(), 1, "multiline paste must be one TmuxKey");
+            match &out[0] {
+                TmuxKey::HexBytes(_) => {}
+                other => panic!("expected HexBytes, got {other:?}"),
+            }
+        }
+
+        #[test]
+        fn multiline_paste_with_utf8_preserves_bytes() {
+            // Non-ASCII chars (emoji, accented letters) ride as their
+            // UTF-8 byte sequences so the agent receives the same text
+            // the user copied. Regression guard for any future "ASCII
+            // only" filter.
+            assert_eq!(
+                split_paste_for_live_send("café\n🚀"),
+                wrap("café\x0d🚀".as_bytes()),
             );
         }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -6648,9 +6648,11 @@ mod live_send_mode {
     mod paste_splitting {
         //! `split_paste_for_live_send` decomposes a pasted string into
         //! tmux operations the live-send worker can actually deliver.
-        //! `send-keys -l` rejects control bytes, so newlines, tabs, and
-        //! CR/CRLF must come through as Named keys. Everything else
-        //! travels as Literal runs.
+        //! Single-line pastes stay on the simple `Literal` + `Named("Tab")`
+        //! path so raw shells and bracketed-paste-unaware agents keep
+        //! working. Multi-line pastes get wrapped in xterm bracketed-
+        //! paste markers (#1546) so receiving agents see one paste
+        //! instead of one `Enter` per line.
 
         use crate::tui::home::input::split_paste_for_live_send;
         use crate::tui::home::live_send::TmuxKey;
@@ -6661,6 +6663,19 @@ mod live_send_mode {
         fn named(name: &str) -> TmuxKey {
             TmuxKey::Named(name.to_string())
         }
+        fn hex(bytes: &[u8]) -> TmuxKey {
+            TmuxKey::HexBytes(bytes.to_vec())
+        }
+
+        /// xterm bracketed-paste start: `ESC [ 2 0 0 ~`.
+        const BP_START: &[u8] = &[0x1b, b'[', b'2', b'0', b'0', b'~'];
+        /// xterm bracketed-paste end: `ESC [ 2 0 1 ~`.
+        const BP_END: &[u8] = &[0x1b, b'[', b'2', b'0', b'1', b'~'];
+        /// CR (0x0d) is the xterm convention for line break inside a paste.
+        const CR: &[u8] = &[0x0d];
+        /// TAB (0x09) rides as raw bytes inside a bracketed paste so the
+        /// agent sees a literal tab character in its input buffer.
+        const TAB: &[u8] = &[0x09];
 
         #[test]
         fn printable_paste_stays_one_literal() {
@@ -6671,47 +6686,64 @@ mod live_send_mode {
         }
 
         #[test]
-        fn newline_splits_into_literal_enter_literal() {
+        fn newline_wraps_in_bracketed_paste() {
+            // Two-line paste must wrap in `\e[200~` / `\e[201~` markers,
+            // with the interior newline riding as a raw CR. Without the
+            // wrapping the agent treats the `\n` as Enter -> submit and
+            // posts each line as its own user message (#1546).
             assert_eq!(
                 split_paste_for_live_send("first\nsecond"),
-                vec![lit("first"), named("Enter"), lit("second")],
+                vec![
+                    hex(BP_START),
+                    lit("first"),
+                    hex(CR),
+                    lit("second"),
+                    hex(BP_END),
+                ],
             );
         }
 
         #[test]
-        fn trailing_newline_emits_enter_with_no_literal_after() {
+        fn trailing_newline_stays_inside_bracketed_paste() {
+            // A single line plus a trailing newline still wraps: the
+            // user gets a paste with a trailing CR in the agent's input
+            // buffer rather than a paste-then-submit. Lets the user
+            // review before sending.
             assert_eq!(
                 split_paste_for_live_send("only line\n"),
-                vec![lit("only line"), named("Enter")],
+                vec![hex(BP_START), lit("only line"), hex(CR), hex(BP_END)],
             );
         }
 
         #[test]
-        fn leading_newline_emits_enter_first() {
+        fn leading_newline_stays_inside_bracketed_paste() {
             assert_eq!(
                 split_paste_for_live_send("\nbody"),
-                vec![named("Enter"), lit("body")],
+                vec![hex(BP_START), hex(CR), lit("body"), hex(BP_END)],
             );
         }
 
         #[test]
-        fn crlf_coalesces_to_single_enter() {
+        fn crlf_coalesces_to_single_cr() {
+            // Windows-style line endings collapse to one CR inside the
+            // bracketed paste so the agent doesn't see a double newline.
             assert_eq!(
                 split_paste_for_live_send("a\r\nb"),
-                vec![lit("a"), named("Enter"), lit("b")],
+                vec![hex(BP_START), lit("a"), hex(CR), lit("b"), hex(BP_END)],
             );
         }
 
         #[test]
-        fn bare_cr_emits_enter() {
+        fn bare_cr_becomes_cr_inside_bracketed_paste() {
             assert_eq!(
                 split_paste_for_live_send("a\rb"),
-                vec![lit("a"), named("Enter"), lit("b")],
+                vec![hex(BP_START), lit("a"), hex(CR), lit("b"), hex(BP_END)],
             );
         }
 
         #[test]
-        fn tab_emits_named_tab() {
+        fn tab_in_single_line_paste_emits_named_tab() {
+            // Single-line tab pastes stay on the historical path.
             assert_eq!(
                 split_paste_for_live_send("a\tb"),
                 vec![lit("a"), named("Tab"), lit("b")],
@@ -6719,7 +6751,26 @@ mod live_send_mode {
         }
 
         #[test]
-        fn other_control_bytes_are_dropped() {
+        fn tab_in_multiline_paste_rides_as_raw_byte() {
+            // Inside a bracketed paste, tab is a literal character of
+            // the paste content, not a key event, so we send it as a
+            // raw 0x09 byte alongside the rest of the payload.
+            assert_eq!(
+                split_paste_for_live_send("a\tb\nc"),
+                vec![
+                    hex(BP_START),
+                    lit("a"),
+                    hex(TAB),
+                    lit("b"),
+                    hex(CR),
+                    lit("c"),
+                    hex(BP_END),
+                ],
+            );
+        }
+
+        #[test]
+        fn other_control_bytes_are_dropped_in_single_line_path() {
             // BEL (0x07) and ESC (0x1b) have no safe paste mapping;
             // they're dropped to avoid surprising agent input cancels.
             assert_eq!(
@@ -6729,20 +6780,44 @@ mod live_send_mode {
         }
 
         #[test]
+        fn other_control_bytes_are_dropped_inside_bracketed_paste() {
+            // Same drop policy applies inside the bracketed paste: an
+            // embedded ESC could prematurely close the paste sequence
+            // on the agent's side, so we strip it rather than forward.
+            // Adjacent printables stay in one literal run because a
+            // dropped control byte never flushes the running buffer.
+            assert_eq!(
+                split_paste_for_live_send("a\x07b\x1bc\nd"),
+                vec![hex(BP_START), lit("abc"), hex(CR), lit("d"), hex(BP_END)],
+            );
+        }
+
+        #[test]
         fn multiline_drag_select_paste_round_trip() {
             // Exact shape that comes back from drag-select copy: lines
-            // joined with `\n` and no trailing newline. The agent
-            // should see literal text + Enter + literal text.
+            // joined with `\n` and no trailing newline. After the fix
+            // for #1546 this wraps in bracketed-paste markers so the
+            // agent sees one paste instead of three Enter keypresses.
             assert_eq!(
                 split_paste_for_live_send("alpha beta\nsecond line\nthird"),
                 vec![
+                    hex(BP_START),
                     lit("alpha beta"),
-                    named("Enter"),
+                    hex(CR),
                     lit("second line"),
-                    named("Enter"),
+                    hex(CR),
                     lit("third"),
+                    hex(BP_END),
                 ],
             );
+        }
+
+        #[test]
+        fn empty_paste_is_empty() {
+            // An empty paste should drop the entire bracketed-paste
+            // wrapper too: pushing `\e[200~\e[201~` with no payload
+            // would still flash through some agents' paste handlers.
+            assert!(split_paste_for_live_send("").is_empty());
         }
     }
 }


### PR DESCRIPTION
## Description

Live mode used to translate every `\n` / `\r` in a paste to a tmux `Named("Enter")` keystroke. Agents (Claude Code, Codex, OpenCode, ...) treat Enter as "submit", so pasting a three-line block in live mode posted three separate user messages instead of accumulating the paste in the input buffer. The issue reporter quoted the symptom precisely on OpenCode: "pasted text becomes the user message right away, missing trailing newline doesn't keep it in an editable input state, internal newline between paragraph and heading may be getting collapsed in the message body."

This PR wraps multiline pastes in xterm bracketed-paste markers (`\e[200~` ... `\e[201~`) with interior newlines riding as raw CR via `tmux send-keys -H`. Agents with bracketed-paste mode enabled (every modern TUI agent we ship hooks for) recognize the wrapper and keep the whole payload editable in the input field. Single-line pastes stay on the original literal path so a raw shell or a bracketed-paste-unaware agent keeps working unchanged.

To carry the escape bytes through tmux, `TmuxKey` and `TmuxAction` gain a `HexBytes(Vec<u8>)` variant that the worker dispatches via `tmux send-keys -H`. Consecutive `HexBytes` payloads coalesce into one invocation (a paste with a blank line collapses two raw-CR sends into one).

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Covered by unit tests:

- `paste_splitting::*` (12 tests) verifies the new bracketed-paste shape (start marker, literal/CR interleave, end marker), CRLF coalescing, trailing/leading newlines, tab handling in both single-line and multiline paths, and that an empty paste stays empty.
- `live_send::tests::coalesce_hex_bytes_*` / `coalesce_bracketed_paste_shape` covers the new `HexBytes` `TmuxAction` (run-break vs back-to-back merge) and the end-to-end shape the dispatcher receives for a two-line bracketed paste.

There is no live-send e2e harness for paste behavior today (would need a fake agent that echoes bracketed-paste bytes back to a scrollback the test can grep). Existing unit coverage exercises the full translation pipeline minus the tmux subprocess; the dispatcher's `-H` arg construction is straightforward.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (claude-opus-4-7).

**Any Additional AI Details you'd like to share:** Claude drafted the implementation and the PR body via back-and-forth with @njbrake. Reasoning and decisions are mine; the prose is Claude's.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1546