### PR TITLE
test(web): stabilize mobile sidebar open in Playwright specs

### DIFF
--- a/web/tests/helpers/sidebar.ts
+++ b/web/tests/helpers/sidebar.ts
@@ -15,5 +15,54 @@ export async function clickSidebarSession(page: Page, title: string) {
   // exactly this race.
   const sessionLink = page.getByRole("link").filter({ hasText: title }).first();
   await sessionLink.waitFor({ state: "visible", timeout: 20_000 });
+  // On mobile the sidebar slides in from the left; while it is closed or
+  // mid-transition, the row's bounding box has a negative x. Playwright's
+  // `visible` check passes (non-zero box, not display:none) but `.click()`
+  // then loops on "element is outside of the viewport" for the full 30s
+  // test timeout. Wait until the box settles inside the viewport.
+  await page.waitForFunction(
+    (linkTitle) => {
+      const links = Array.from(document.querySelectorAll("a"));
+      const link = links.find((a) => a.textContent?.includes(linkTitle));
+      if (!link) return false;
+      const r = link.getBoundingClientRect();
+      return r.x >= 0 && r.y >= 0 && r.width > 0 && r.height > 0;
+    },
+    title,
+    { timeout: 10_000 },
+  );
   await sessionLink.click();
+}
+
+// Mobile specs (`devices['iPhone 13']`) open the workspace sidebar before
+// clicking a session row. The old recipe `if (await toggle.isVisible())`
+// is a single non-retrying snapshot that races with React hydration on
+// loaded CI workers, so the toggle click is skipped and the sidebar stays
+// closed; the subsequent row click then times out on actionability.
+//
+// This helper is deterministic: it waits for the toggle to mount, probes
+// the sidebar's current x via the session-row testid, and only clicks the
+// toggle when the sidebar is fully closed (x < -row width / 2). It then
+// blocks until the slide-in transition settles the box at x >= 0.
+export async function openMobileSidebar(page: Page) {
+  const toggle = page.getByRole("button", { name: "Toggle sidebar" });
+  await toggle.waitFor({ state: "visible", timeout: 10_000 });
+  const probe = page.getByTestId("sidebar-session-row").first();
+  await probe.waitFor({ state: "attached", timeout: 10_000 });
+  const initial = await probe.boundingBox();
+  if (!initial || initial.x < 0) {
+    await toggle.click();
+  }
+  await page.waitForFunction(
+    () => {
+      const row = document.querySelector(
+        '[data-testid="sidebar-session-row"]',
+      );
+      if (!row) return false;
+      const r = (row as HTMLElement).getBoundingClientRect();
+      return r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
 }

--- a/web/tests/keyboard-resize-stickiness.spec.ts
+++ b/web/tests/keyboard-resize-stickiness.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
-import { clickSidebarSession } from "./helpers/sidebar";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
 import { mockTerminalApis, type MockHandle } from "./helpers/terminal-mocks";
 
 // Regression for the SIGWINCH-on-every-soft-keyboard-cycle bug.
@@ -87,12 +87,7 @@ async function setKeyboard(page: Page, opts: { open: boolean; px?: number; pwa?:
 }
 
 async function openSession(page: Page, handle: MockHandle) {
-  // Sidebar is collapsed on mobile; open it before clicking the session row.
-  const sidebarToggle = page.getByRole("button", { name: "Toggle sidebar" });
-  if (await sidebarToggle.isVisible()) {
-    await sidebarToggle.click();
-    await page.waitForTimeout(200);
-  }
+  await openMobileSidebar(page);
   await clickSidebarSession(page, "pinch-test");
   await page
     .locator('[data-term="agent"] .xterm')

--- a/web/tests/mobile-keyboard.spec.ts
+++ b/web/tests/mobile-keyboard.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
-import { clickSidebarSession } from "./helpers/sidebar";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
 import { mockTerminalApis, seedSettings } from "./helpers/terminal-mocks";
 
 // Use iPhone 13 profile: pointer:coarse, hasTouch, correct viewport, WebKit UA.
@@ -71,12 +71,7 @@ async function simulateKeyboardClose(page: Page) {
 }
 
 async function openSession(page: Page) {
-  // On mobile the sidebar is collapsed; open it first.
-  const sidebarToggle = page.getByRole("button", { name: "Toggle sidebar" });
-  if (await sidebarToggle.isVisible()) {
-    await sidebarToggle.click();
-    await page.waitForTimeout(300);
-  }
+  await openMobileSidebar(page);
   await clickSidebarSession(page, "pinch-test");
   await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/web/tests/pinch-zoom.spec.ts
+++ b/web/tests/pinch-zoom.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
-import { clickSidebarSession } from "./helpers/sidebar";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -13,12 +13,7 @@ test.use({ ...devices["iPhone 13"] });
 
 test.describe("Terminal pinch zoom (mobile)", () => {
   async function openSession(page: Page) {
-    // On mobile the sidebar is collapsed; open it first.
-    const sidebarToggle = page.getByRole("button", { name: "Toggle sidebar" });
-    if (await sidebarToggle.isVisible()) {
-      await sidebarToggle.click();
-      await page.waitForTimeout(300);
-    }
+    await openMobileSidebar(page);
     await clickSidebarSession(page, "pinch-test");
     await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
   }

--- a/web/tests/scrollback-exit.spec.ts
+++ b/web/tests/scrollback-exit.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "./helpers/mockedTest";
 import { devices, type Page } from "@playwright/test";
-import { clickSidebarSession } from "./helpers/sidebar";
+import { clickSidebarSession, openMobileSidebar } from "./helpers/sidebar";
 import {
   mockTerminalApis,
   installTerminalSpies,
@@ -36,11 +36,7 @@ function countSeq(handle: MockHandle, seq: string): number {
 }
 
 async function openSession(page: Page) {
-  const sidebarToggle = page.getByRole("button", { name: "Toggle sidebar" });
-  if (await sidebarToggle.isVisible()) {
-    await sidebarToggle.click();
-    await page.waitForTimeout(300);
-  }
+  await openMobileSidebar(page);
   await clickSidebarSession(page, "pinch-test");
   await page.locator(".xterm").waitFor({ state: "visible", timeout: 10_000 });
 }


### PR DESCRIPTION
> [!NOTE]
> This PR was authored by an AI agent (Claude Opus 4.7) under human supervision.

## Description

The pinch-zoom and scrollback-exit specs flaked in CI with "element is outside of the viewport" loops on the session-row click ([failed run](https://github.com/agent-of-empires/agent-of-empires/actions/runs/26510924716/job/78074976189?pr=1526)).

Root cause: the per-spec mobile `openSession` helpers used `if (await toggle.isVisible())`, a non-retrying snapshot that races React hydration on loaded CI workers. When it returns `false`, the toggle click is skipped, the sidebar stays translated `-100%`, and the subsequent row click retries actionability for the full 30s timeout. The 300ms `waitForTimeout` after the toggle was also marginal under v8 coverage instrumentation on the 4-vCPU runner.

Fix: replace the racy block with a deterministic `openMobileSidebar(page)` helper that waits for the toggle to mount, probes the row's bounding box, clicks the toggle only if the sidebar is closed, and polls until the slide-in transition settles inside the viewport. Adds the same in-viewport poll to `clickSidebarSession` so any future caller that forgets to open the sidebar fails fast instead of timing out at 30s.

Applied to all four mobile specs: `pinch-zoom`, `scrollback-exit`, `mobile-keyboard`, `keyboard-resize-stickiness`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [x] For UI changes: included screenshot or recording

(no UI changes; test-only)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

(test-only PR; stabilizes existing specs)

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## Verification

- `npx playwright test --config=playwright.config.ts --workers=6` → 194 passed, 3 skipped (full mocked suite)
- `npx playwright test pinch-zoom.spec.ts scrollback-exit.spec.ts mobile-keyboard.spec.ts keyboard-resize-stickiness.spec.ts --repeat-each=2 --workers=6` → 46/46 passed (stress under CI-like worker count)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Diagnosis and patch authored by the agent; verified locally with the full mocked suite plus a 2x repeat of the four mobile specs at 6 workers.

- [x] I am an AI Agent filling out this form (check box if true)