### PR TITLE
feat(tui): allow preview drag-select outside live mode

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -710,12 +710,13 @@ impl App {
                             //
                             // Priority order for `Down(Left)`:
                             //   1. modal dialog click (e.g. delete Yes/No)
-                            //   2. drag-start (divider, or live-mode preview
-                            //      text selection)
+                            //   2. drag-start (divider, or preview text
+                            //      selection)
                             //   3. list row click (existing select/activate)
-                            // A bare click on the preview pane outside live
-                            // mode falls through to the final branch and is
-                            // a no-op aside from clearing any stale highlight.
+                            // A bare press on the preview seeds a 1x1
+                            // PreviewSelect; `handle_drag_end` collapses it
+                            // back to no selection on release if the cursor
+                            // never moved.
                             let click_action = if matches!(
                                 mouse.kind,
                                 MouseEventKind::Down(MouseButton::Left)

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -590,10 +590,10 @@ impl HomeView {
         // Any keystroke drops a finalized preview-pane selection. The
         // highlight pins to cell coords, so as soon as the user starts
         // doing anything else (navigating the list, opening a dialog,
-        // entering live mode, etc.) the cells underneath can change
-        // and the highlight would point at unrelated content.
-        // `handle_live_send_key` repeats this clear inside the
-        // live-send branch so the same dismissal happens there.
+        // typing through live-send, etc.) the cells underneath can
+        // change and the highlight would point at unrelated content.
+        // Doing the clear here covers both the live-send branch below
+        // and the regular home-view path.
         self.clear_preview_selection();
 
         // Live-send capture wins over every other key handler. While
@@ -3232,13 +3232,12 @@ impl HomeView {
             return;
         };
 
-        // Any keystroke in live mode dismisses a finalized preview
-        // selection so the highlight doesn't linger forever once the
-        // user starts typing again. The PageUp/PageDown scroll keys
-        // below also count — scrolling away with a highlight still
-        // visible would point at content that no longer exists at
-        // those cells.
-        self.clear_preview_selection();
+        // `handle_key` already cleared any finalized preview
+        // selection at the top, so the highlight doesn't linger
+        // across the keystroke that switched the user out of
+        // copy-and-look mode. The PageUp/PageDown scroll keys below
+        // would otherwise need their own dismissal; the shared
+        // top-of-handle_key clear covers them too.
 
         // Shift+PageUp / Shift+PageDown scroll the preview pane
         // without forwarding to the agent. Matches the terminal-

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -258,10 +258,10 @@ impl HomeView {
         row >= list_y && row < list_bottom
     }
 
-    /// Begin a drag if `(col, row)` is on the divider, or, while
-    /// live-send is active, inside the preview pane. Returns true when
-    /// a drag actually started, so the caller can mark the event
-    /// handled and skip the row-click path.
+    /// Begin a drag if `(col, row)` is on the divider, or inside the
+    /// preview pane (whenever the pane is on screen, in or out of live
+    /// mode). Returns true when a drag actually started, so the caller
+    /// can mark the event handled and skip the row-click path.
     ///
     /// Divider drags resize the list/preview split (the only kind we
     /// had before live-send shipped). Preview-pane drags start an
@@ -277,7 +277,15 @@ impl HomeView {
             });
             return true;
         }
-        if self.live_send.is_some() && self.hit_preview(col, row) {
+        // Modals that aren't live-send sit over the preview, so a
+        // click inside `preview_area` while one is open is meant for
+        // the modal underneath and should not seed a hidden selection
+        // behind it. `handle_drag_move`'s cancel branch covers a modal
+        // that opens mid-drag; this guards the start.
+        if self.has_non_live_send_overlay() {
+            return false;
+        }
+        if self.hit_preview(col, row) {
             self.preview_selection = Some(PreviewSelection {
                 anchor: (col, row),
                 extent: (col, row),
@@ -579,6 +587,15 @@ impl HomeView {
         key: KeyEvent,
         update_info: Option<&crate::update::UpdateInfo>,
     ) -> Option<Action> {
+        // Any keystroke drops a finalized preview-pane selection. The
+        // highlight pins to cell coords, so as soon as the user starts
+        // doing anything else (navigating the list, opening a dialog,
+        // entering live mode, etc.) the cells underneath can change
+        // and the highlight would point at unrelated content.
+        // `handle_live_send_key` repeats this clear inside the
+        // live-send branch so the same dismissal happens there.
+        self.clear_preview_selection();
+
         // Live-send capture wins over every other key handler. While
         // `live_send` is `Some` the home view is acting as a thin relay
         // to the target pane; dialog hotkeys, search, and list navigation
@@ -3286,10 +3303,11 @@ impl HomeView {
         self.live_send = None;
         self.live_send_worker = None;
         self.live_send_last_resize = None;
-        // A preview selection only ever exists in live mode; leaving
-        // live without dropping it would leave a stale highlight on
-        // the regular preview pane. Clear it here so the home view
-        // returns to its pre-live state cleanly.
+        // Preview selections also work outside live mode now, but a
+        // live-mode highlight pins to the live-resized pane coords,
+        // and exiting reflows the preview back to its normal size.
+        // Drop the selection so the highlight can't survive into a
+        // pane it no longer points at.
         self.clear_preview_selection();
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -74,12 +74,13 @@ pub(super) enum DragKind {
     /// `list_width` at that moment. The new requested width is
     /// `start_width + (current_col - start_col)`, clamped on apply.
     ListDivider { start_col: u16, start_width: u16 },
-    /// Drag-selecting text inside the preview pane while live-send is
-    /// active. The anchor cell is where the user pressed; `preview_selection`
-    /// on `HomeView` carries the live extent and is what the renderer
-    /// reads. We keep the kind here (with no payload beyond a marker) so
-    /// `handle_drag_move` / `handle_drag_end` can dispatch by variant
-    /// without re-checking `live_send`.
+    /// Drag-selecting text inside the preview pane. Available whenever
+    /// the pane is on screen (in or out of live-send mode). The anchor
+    /// cell is where the user pressed; `preview_selection` on
+    /// `HomeView` carries the live extent and is what the renderer
+    /// reads. We keep the kind here (with no payload beyond a marker)
+    /// so `handle_drag_move` / `handle_drag_end` can dispatch by
+    /// variant without re-checking `live_send`.
     PreviewSelect,
 }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -5827,11 +5827,13 @@ mod divider_drag {
 }
 
 mod preview_drag_select {
-    //! Click-and-drag on the preview pane while live-send is active
-    //! starts an in-app text selection. The renderer paints a
-    //! reversed-style highlight; release copies the cells through
-    //! OSC 52. Selections only exist in live mode (terminal-native
-    //! drag-select already handles every other surface).
+    //! Click-and-drag on the preview pane starts an in-app text
+    //! selection whenever the pane is on screen (in or out of live
+    //! mode). The renderer paints a reversed-style highlight; release
+    //! copies the cells through OSC 52. We need our own selection
+    //! handler because the TUI captures mouse events to support wheel
+    //! scroll, which keeps terminal-native drag-select from reaching
+    //! the preview.
 
     use super::*;
     use crate::tui::home::{live_send::LiveSendState, DragKind};
@@ -5853,11 +5855,28 @@ mod preview_drag_select {
 
     #[test]
     #[serial]
-    fn drag_start_outside_live_mode_does_not_start_selection() {
+    fn drag_start_outside_live_mode_installs_selection() {
         let mut env = create_test_env_empty();
         env.view.preview_area = Rect::new(40, 0, 60, 20);
-        // No live_send -> the preview hit is ignored; no selection
-        // installs.
+        // No live_send: a press on the preview pane still seeds a
+        // PreviewSelect so users can copy from a regular session
+        // preview without first entering live mode.
+        assert!(env.view.handle_drag_start(50, 10));
+        assert!(matches!(env.view.drag_state, Some(DragKind::PreviewSelect)));
+        let sel = env.view.preview_selection.expect("selection installed");
+        assert_eq!(sel.anchor, (50, 10));
+        assert_eq!(sel.extent, (50, 10));
+        assert!(!sel.finalized);
+    }
+
+    #[test]
+    #[serial]
+    fn drag_start_blocked_by_non_live_overlay() {
+        // A modal sitting over the preview must swallow the press
+        // instead of seeding a hidden highlight behind the dialog.
+        let mut env = create_test_env_empty();
+        env.view.preview_area = Rect::new(40, 0, 60, 20);
+        env.view.show_help = true;
         assert!(!env.view.handle_drag_start(50, 10));
         assert!(env.view.preview_selection.is_none());
         assert!(env.view.drag_state.is_none());


### PR DESCRIPTION
## Description

Drag-to-select on the preview pane used to be gated on live-send being active. This PR drops that requirement so the same drag, highlight, and OSC 52 copy flow works whenever the preview is on screen, whether or not the user has entered live mode.

The change is small:
- `handle_drag_start` no longer requires `live_send.is_some()` to seed a `PreviewSelect`. A real modal sitting over the preview (`has_non_live_send_overlay()`) still swallows the press so the highlight can't hide behind a dialog.
- `handle_key` clears any finalized highlight at the top, mirroring the existing live-mode dismissal. A stale selection pinned to cell coords would otherwise linger across list navigation as the preview content underneath changes.
- Comments on `DragKind::PreviewSelect`, `handle_drag_start`, `exit_live_send_and_restore_sizing`, and the `Down(Left)` priority list in `app.rs` updated to match the new behavior.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

Unit-test coverage in src/tui/home/tests.rs was updated:
- drag_start_outside_live_mode_does_not_start_selection is replaced by drag_start_outside_live_mode_installs_selection, which asserts the new behavior.
- New drag_start_blocked_by_non_live_overlay test confirms a modal over the preview still swallows the press.
- All 19 tests in the preview_drag_select module pass; full lib suite (2249 tests) passes; cargo clippy --all-targets and cargo fmt --check are clean.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:**
Drafted with Claude in the loop, reviewed and adjusted by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR makes preview-pane drag-to-select available whenever the preview pane is visible, not only during live-send. It also prevents selections from being created under modal overlays and ensures finalized preview highlights are cleared on key navigation.

## What changed

- Drag-selection:
  - handle_drag_start no longer requires live-send; clicking+dragging in the visible preview seeds a PreviewSelect (1x1 on press, expands while dragging).
  - A real modal overlay over the preview (has_non_live_send_overlay()) still swallows the press and blocks selection.
- Selection clearing:
  - handle_key now clears any finalized preview selection on every key event, preventing stale highlights from persisting during navigation or content changes.
  - handle_live_send_key had redundant clearing removed and comments updated to reflect the central clear in handle_key.
- Documentation and comments:
  - DragKind::PreviewSelect docs, handle_drag_start, exit_live_send_and_restore_sizing, and the Down(Left) click-priority comment in app.rs updated to describe the new behavior.
- Tests:
  - Tests updated: replaced the "does not start selection" test with one asserting selection is installed outside live mode; added a test ensuring a non-live overlay blocks selection.
  - All 19 tests in preview_drag_select pass; full suite (2249 tests) passes; clippy and fmt checks clean.

## Benefits

- Improved usability: users can select preview text without entering live-send mode.
- Robustness: modal overlays continue to prevent hidden selections; navigation no longer leaves stale highlights.
- Cleaner code: selection dismissal centralized in handle_key.

## Technical details

- Modified handle_drag_start to begin PreviewSelect when hit_preview(col,row) is true, unless a non-live overlay is present.
- Centralized preview-selection clearing in handle_key; removed duplicate clear from handle_live_send_key.
- Updated comments in exit_live_send_and_restore_sizing and app.rs to reflect selection availability outside live-send.
- No public API/signature changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->