### PR TITLE
feat(tui): nest Archived section by project and persist auto-unsink on re-enter

### DIFF
--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use super::config::SortOrder;
 use super::Instance;
@@ -931,8 +931,11 @@ pub fn append_archived_section(items: &mut Vec<Item>, instances: &[Instance], co
 /// `section_collapsed` hides everything below the top header; per-project
 /// `sub_collapsed` (read from `project_collapsed` keyed by the synthetic
 /// `archived_project_sub_path`) hides only that sub-folder's session rows.
-/// Sub-headers are sorted by project name for stable ordering; within a
-/// sub-folder, sessions still surface most-recently-archived first.
+/// Sub-headers honor the user's `sort_order`, mirroring how
+/// `flatten_tree` orders active project headers; within a sub-folder,
+/// sessions still surface most-recently-archived first regardless of
+/// sort_order (archived rows are a "park this" affordance and the
+/// archive timestamp is the natural recency signal once the row is sunk).
 ///
 /// Returns without pushing anything when no archived sessions exist, so
 /// users who never archive don't see a phantom "Archived" header in the
@@ -942,6 +945,7 @@ pub fn append_archived_section_by_project(
     instances: &[Instance],
     section_collapsed: bool,
     project_collapsed: &HashMap<String, bool>,
+    sort_order: SortOrder,
 ) {
     let archived: Vec<&Instance> = instances.iter().filter(|i| i.is_archived()).collect();
     if archived.is_empty() {
@@ -962,7 +966,7 @@ pub fn append_archived_section_by_project(
         return;
     }
 
-    let mut by_project: BTreeMap<String, Vec<&Instance>> = BTreeMap::new();
+    let mut by_project: HashMap<String, Vec<&Instance>> = HashMap::new();
     for inst in archived {
         by_project
             .entry(inst.group_path.clone())
@@ -970,7 +974,10 @@ pub fn append_archived_section_by_project(
             .push(inst);
     }
 
-    for (project_name, mut sessions) in by_project {
+    let mut buckets: Vec<(String, Vec<&Instance>)> = by_project.into_iter().collect();
+    sort_archived_project_buckets(&mut buckets, sort_order);
+
+    for (project_name, mut sessions) in buckets {
         sessions.sort_by_key(|i| Reverse(i.archived_at));
         let sub_path = archived_project_sub_path(&project_name);
         let sub_collapsed = project_collapsed.get(&sub_path).copied().unwrap_or(false);
@@ -990,6 +997,52 @@ pub fn append_archived_section_by_project(
             items.push(Item::Session {
                 id: inst.id.clone(),
                 depth: 2,
+            });
+        }
+    }
+}
+
+/// Ordering helper for archived project sub-folders. Mirrors the spirit
+/// of `sort_groups` but operates on a `(project_name, sessions)` pair
+/// since the archive sub-folders are synthetic and not in any
+/// `GroupTree`. AZ/ZA sort by project name; recency sorts (Newest,
+/// LastActivity) use the max `archived_at` within the group; Oldest
+/// uses the min `archived_at` ascending. Attention falls back to
+/// most-recently-archived because archived rows are all tier 99 in the
+/// attention bucket and the tier offers no discriminator inside the shelf.
+fn sort_archived_project_buckets(buckets: &mut [(String, Vec<&Instance>)], sort_order: SortOrder) {
+    match sort_order {
+        SortOrder::AZ => buckets.sort_by_key(|b| b.0.to_lowercase()),
+        SortOrder::ZA => buckets.sort_by_key(|b| Reverse(b.0.to_lowercase())),
+        SortOrder::Oldest => {
+            buckets.sort_by_key(|(_, sessions)| {
+                sessions
+                    .iter()
+                    .filter_map(|i| i.archived_at)
+                    .min()
+                    .unwrap_or(DateTime::<Utc>::MAX_UTC)
+            });
+        }
+        SortOrder::Newest | SortOrder::Attention => {
+            buckets.sort_by_key(|(_, sessions)| {
+                Reverse(
+                    sessions
+                        .iter()
+                        .filter_map(|i| i.archived_at)
+                        .max()
+                        .unwrap_or(DateTime::<Utc>::MIN_UTC),
+                )
+            });
+        }
+        SortOrder::LastActivity => {
+            buckets.sort_by_key(|(_, sessions)| {
+                Reverse(
+                    sessions
+                        .iter()
+                        .filter_map(|i| i.last_accessed_at)
+                        .max()
+                        .unwrap_or(DateTime::<Utc>::MIN_UTC),
+                )
             });
         }
     }

--- a/src/session/groups.rs
+++ b/src/session/groups.rs
@@ -3,7 +3,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::cmp::Reverse;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use super::config::SortOrder;
 use super::Instance;
@@ -20,6 +20,26 @@ pub const ARCHIVED_SECTION_NAME: &str = "Archived";
 #[inline]
 pub fn is_archived_section_path(path: &str) -> bool {
     path == ARCHIVED_SECTION_PATH
+}
+
+/// True for both the top-level Archived section sentinel and any synthetic
+/// child header pushed under it (e.g. project sub-folders nested inside
+/// Archived in Project grouping mode). Use this in places that disarm
+/// keybinds or skip palette entries for anything that lives inside the
+/// shelf; reserve `is_archived_section_path` for the exact-match cases
+/// (collapse-toggle routing, count assertions in tests).
+#[inline]
+pub fn is_within_archived_section(path: &str) -> bool {
+    path == ARCHIVED_SECTION_PATH || path.starts_with(&format!("{}/", ARCHIVED_SECTION_PATH))
+}
+
+/// Build the synthetic sub-path for a per-project header rendered inside
+/// the Archived section. Kept in one place so the path format stays in
+/// sync between the appender (groups.rs) and the collapse-state map
+/// (HomeView::project_group_collapsed).
+#[inline]
+pub fn archived_project_sub_path(project_name: &str) -> String {
+    format!("{}/{}", ARCHIVED_SECTION_PATH, project_name)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -894,6 +914,84 @@ pub fn append_archived_section(items: &mut Vec<Item>, instances: &[Instance], co
             id: inst.id.clone(),
             depth: 1,
         });
+    }
+}
+
+/// Project-grouping variant of `append_archived_section`: nests archived
+/// sessions under a sub-header per project. Caller must have already
+/// rewritten `inst.group_path` to the project name (see
+/// `HomeView::build_flat_items_by_project`) so we can read it back here
+/// to bucket each archived row.
+///
+/// Layout:
+/// - Archived (depth 0)
+///   - <project name> (depth 1)
+///     - session row (depth 2)
+///
+/// `section_collapsed` hides everything below the top header; per-project
+/// `sub_collapsed` (read from `project_collapsed` keyed by the synthetic
+/// `archived_project_sub_path`) hides only that sub-folder's session rows.
+/// Sub-headers are sorted by project name for stable ordering; within a
+/// sub-folder, sessions still surface most-recently-archived first.
+///
+/// Returns without pushing anything when no archived sessions exist, so
+/// users who never archive don't see a phantom "Archived" header in the
+/// project-mode view either.
+pub fn append_archived_section_by_project(
+    items: &mut Vec<Item>,
+    instances: &[Instance],
+    section_collapsed: bool,
+    project_collapsed: &HashMap<String, bool>,
+) {
+    let archived: Vec<&Instance> = instances.iter().filter(|i| i.is_archived()).collect();
+    if archived.is_empty() {
+        return;
+    }
+
+    items.push(Item::Group {
+        path: ARCHIVED_SECTION_PATH.to_string(),
+        name: ARCHIVED_SECTION_NAME.to_string(),
+        depth: 0,
+        collapsed: section_collapsed,
+        session_count: archived.len(),
+        profile: None,
+        archived_at: None,
+    });
+
+    if section_collapsed {
+        return;
+    }
+
+    let mut by_project: BTreeMap<String, Vec<&Instance>> = BTreeMap::new();
+    for inst in archived {
+        by_project
+            .entry(inst.group_path.clone())
+            .or_default()
+            .push(inst);
+    }
+
+    for (project_name, mut sessions) in by_project {
+        sessions.sort_by_key(|i| Reverse(i.archived_at));
+        let sub_path = archived_project_sub_path(&project_name);
+        let sub_collapsed = project_collapsed.get(&sub_path).copied().unwrap_or(false);
+        items.push(Item::Group {
+            path: sub_path,
+            name: project_name,
+            depth: 1,
+            collapsed: sub_collapsed,
+            session_count: sessions.len(),
+            profile: None,
+            archived_at: None,
+        });
+        if sub_collapsed {
+            continue;
+        }
+        for inst in sessions {
+            items.push(Item::Session {
+                id: inst.id.clone(),
+                depth: 2,
+            });
+        }
     }
 }
 

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -29,8 +29,9 @@ pub use config::{
 pub(crate) use environment::user_shell;
 pub use environment::{validate_env_entries, validate_env_entry};
 pub use groups::{
-    append_archived_section, flatten_sessions_by_attention, flatten_tree,
-    flatten_tree_all_profiles, is_archived_section_path, Group, GroupTree, Item,
+    append_archived_section, append_archived_section_by_project, archived_project_sub_path,
+    flatten_sessions_by_attention, flatten_tree, flatten_tree_all_profiles,
+    is_archived_section_path, is_within_archived_section, Group, GroupTree, Item,
     ARCHIVED_SECTION_NAME, ARCHIVED_SECTION_PATH,
 };
 pub(crate) use instance::persist_session_to_storage;

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -2385,12 +2385,13 @@ impl HomeView {
                     });
                 }
                 Item::Group { name, path, .. } => {
-                    // The synthetic Archived section header is not a real
-                    // group; skip it so the palette doesn't surface the
-                    // sentinel path or invite Jump-to-group navigation
-                    // that the rest of the codebase intentionally
-                    // disarms.
-                    if crate::session::is_archived_section_path(path) {
+                    // The synthetic Archived section header (and any
+                    // sub-folder rendered under it in Project mode) is
+                    // not a real group; skip it so the palette doesn't
+                    // surface the sentinel path or invite Jump-to-group
+                    // navigation that the rest of the codebase
+                    // intentionally disarms.
+                    if crate::session::is_within_archived_section(path) {
                         continue;
                     }
                     let label = if name == path {
@@ -2655,11 +2656,13 @@ impl HomeView {
                 }
                 Item::Group { path, .. } => {
                     self.selected_session = None;
-                    if crate::session::is_archived_section_path(path) {
-                        // The synthetic Archived section is not a real
-                        // group: it can't be renamed, deleted, archived,
-                        // or moved. Leaving `selected_group` unset
-                        // disarms every keybind that branches on
+                    if crate::session::is_within_archived_section(path) {
+                        // The synthetic Archived section (and any
+                        // project sub-folder rendered under it in
+                        // Project mode) is not a real group: it can't
+                        // be renamed, deleted, archived, or moved.
+                        // Leaving `selected_group` unset disarms every
+                        // keybind that branches on
                         // `selected_group.is_some()` (rename, delete,
                         // archive group, etc.) without each one having
                         // to special-case the sentinel.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2323,6 +2323,7 @@ impl HomeView {
             &grouped,
             self.archived_section_collapsed,
             &self.project_group_collapsed,
+            self.sort_order,
         );
         items
     }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -19,7 +19,7 @@ use ratatui::prelude::Rect;
 use tui_input::Input;
 
 use crate::session::{
-    append_archived_section,
+    append_archived_section, append_archived_section_by_project,
     config::{load_config, save_config, GroupByMode, SortOrder},
     flatten_sessions_by_attention, flatten_tree, flatten_tree_all_profiles, resolve_config_or_warn,
     DefaultTerminalMode, EnsureReadyOutcome, Group, GroupTree, Instance, Item, Storage,
@@ -2318,7 +2318,12 @@ impl HomeView {
             }
         }
         let mut items = flatten_tree(&tree, &grouped, self.sort_order);
-        append_archived_section(&mut items, &grouped, self.archived_section_collapsed);
+        append_archived_section_by_project(
+            &mut items,
+            &grouped,
+            self.archived_section_collapsed,
+            &self.project_group_collapsed,
+        );
         items
     }
 
@@ -2420,8 +2425,33 @@ impl HomeView {
     }
 
     /// Stamp `last_accessed_at` on a session (user-initiated interaction).
+    ///
+    /// Sunk rows (archived or snoozed) take the heavier `apply_user_action`
+    /// path so the auto-unarchive/unsnooze side effect in `touch_last_accessed`
+    /// is persisted (merge_from_tui doesn't carry those fields; without this,
+    /// reload would resurrect the sink from disk) and the row leaves the
+    /// Archived section visually on the same frame. Non-sunk rows stay on
+    /// the cheap mutate_instance path; their only mutation is the timestamp,
+    /// which save() already mirrors via merge_from_tui.
     pub fn stamp_last_accessed(&mut self, id: &str) {
-        self.mutate_instance(id, |inst| inst.touch_last_accessed());
+        let was_sunk = self
+            .instance_map
+            .get(id)
+            .map(|i| i.is_archived() || i.snoozed_until.is_some())
+            .unwrap_or(false);
+        if was_sunk {
+            if let Err(e) = self.apply_user_action(id, |inst| inst.touch_last_accessed()) {
+                tracing::warn!(
+                    target: "tui.home",
+                    session_id = %id,
+                    error = %e,
+                    "stamp_last_accessed: failed to persist auto-unsink"
+                );
+            }
+            self.flat_items = self.build_flat_items();
+        } else {
+            self.mutate_instance(id, |inst| inst.touch_last_accessed());
+        }
     }
 
     /// Run the send-message work after the dialog has been dismissed: call

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -847,16 +847,17 @@ impl HomeView {
                 };
                 let text = Cow::Owned(format!("{} ({})", name, session_count));
                 let mut style = Style::default().fg(theme.group).bold();
-                if crate::session::is_archived_section_path(path) {
-                    // Synthetic Archived section header: muted + italic
-                    // + dim so it reads as a divider rather than a
-                    // user-created group. The contained rows aren't
-                    // decorated individually; the section header is the
-                    // sole visual signal that those sessions are
-                    // shelved. Matches the modifier set used for
-                    // archived user groups so terminals with weak
-                    // dimmed-fg rendering still surface the parked
-                    // affordance.
+                if crate::session::is_within_archived_section(path) {
+                    // Synthetic Archived section header (and any
+                    // project sub-folder rendered under it in Project
+                    // mode): muted + italic + dim so it reads as a
+                    // divider rather than a user-created group. The
+                    // contained rows aren't decorated individually;
+                    // the section header is the sole visual signal
+                    // that those sessions are shelved. Matches the
+                    // modifier set used for archived user groups so
+                    // terminals with weak dimmed-fg rendering still
+                    // surface the parked affordance.
                     style = Style::default()
                         .fg(theme.dimmed)
                         .add_modifier(ratatui::style::Modifier::ITALIC)

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4831,12 +4831,17 @@ fn archived_section_pinned_to_bottom_in_every_sort() {
 #[serial]
 fn archived_section_nests_by_project_in_project_mode() {
     use crate::session::{
-        archived_project_sub_path, config::GroupByMode, is_archived_section_path,
-        ARCHIVED_SECTION_NAME,
+        archived_project_sub_path,
+        config::{GroupByMode, SortOrder},
+        is_archived_section_path, ARCHIVED_SECTION_NAME,
     };
 
     let mut env = create_test_env_two_projects_mixed_attention();
     env.view.group_by = GroupByMode::Project;
+    // Pin to AZ so this test asserts only the depth-0/1/2 layout shape,
+    // not the sort-order behavior. Sort_order coverage lives in
+    // `archived_sub_folders_honor_sort_order` below.
+    env.view.sort_order = SortOrder::AZ;
     // Archive one session from each project so we expect two sub-folders.
     let alpha_id = env
         .view
@@ -4892,7 +4897,7 @@ fn archived_section_nests_by_project_in_project_mode() {
     let sub_alpha_path = archived_project_sub_path("alpha");
     let sub_beta_path = archived_project_sub_path("beta");
 
-    // First sub-header must be alpha (BTreeMap orders by name).
+    // First sub-header must be alpha (AZ sort orders by name).
     match &tail[0] {
         Item::Group {
             path,
@@ -5048,6 +5053,88 @@ fn archived_project_sub_folder_collapse_hides_only_its_sessions() {
             |it| matches!(it, Item::Group { path, collapsed, .. } if path == &alpha_sub_path && *collapsed)
         ),
         "alpha sub-folder header must remain visible with collapsed=true"
+    );
+}
+
+/// Archived project sub-folders honor `sort_order`, mirroring how active
+/// project headers order in `flatten_tree`. AZ/ZA sort by project name;
+/// recency sorts (Newest, LastActivity, Attention) bring the most-
+/// recently-archived project to the top; Oldest does the inverse. Probes
+/// AZ, ZA, and Newest as representatives; the Oldest/LastActivity/Attention
+/// branches share the same `sort_archived_project_buckets` machinery.
+#[test]
+#[serial]
+fn archived_sub_folders_honor_sort_order() {
+    use crate::session::{
+        archived_project_sub_path,
+        config::{GroupByMode, SortOrder},
+        is_archived_section_path,
+    };
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    let alpha_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "alpha-running")
+        .map(|i| i.id.clone())
+        .unwrap();
+    let beta_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "beta-error")
+        .map(|i| i.id.clone())
+        .unwrap();
+    // Archive alpha first, then beta. archived_at is `Utc::now()` at the
+    // moment of `archive()`, so beta is strictly more recent than alpha.
+    env.view
+        .apply_user_action(&alpha_id, |inst| inst.archive())
+        .unwrap();
+    env.view
+        .apply_user_action(&beta_id, |inst| inst.archive())
+        .unwrap();
+    env.view.archived_section_collapsed = false;
+
+    let first_sub_folder = |env: &TestEnv| -> Option<String> {
+        let arch_idx = env.view.flat_items.iter().position(
+            |it| matches!(it, Item::Group { path, .. } if is_archived_section_path(path)),
+        )?;
+        env.view
+            .flat_items
+            .get(arch_idx + 1)
+            .and_then(|it| match it {
+                Item::Group { path, .. } => Some(path.clone()),
+                _ => None,
+            })
+    };
+
+    let alpha_sub = archived_project_sub_path("alpha");
+    let beta_sub = archived_project_sub_path("beta");
+
+    env.view.sort_order = SortOrder::AZ;
+    env.view.flat_items = env.view.build_flat_items();
+    assert_eq!(
+        first_sub_folder(&env).as_deref(),
+        Some(alpha_sub.as_str()),
+        "AZ: alphabetical, alpha first"
+    );
+
+    env.view.sort_order = SortOrder::ZA;
+    env.view.flat_items = env.view.build_flat_items();
+    assert_eq!(
+        first_sub_folder(&env).as_deref(),
+        Some(beta_sub.as_str()),
+        "ZA: reverse alphabetical, beta first"
+    );
+
+    env.view.sort_order = SortOrder::Newest;
+    env.view.flat_items = env.view.build_flat_items();
+    assert_eq!(
+        first_sub_folder(&env).as_deref(),
+        Some(beta_sub.as_str()),
+        "Newest: most-recently-archived project first (beta archived after alpha)"
     );
 }
 
@@ -7757,6 +7844,41 @@ mod save_field_merge {
         assert!(
             !archived_section_present(&view.flat_items),
             "Archived section must disappear once the only archived row is unsunk"
+        );
+    }
+
+    /// Snoozed siblings of the archive case: `snoozed_until` is also cleared
+    /// by `touch_last_accessed` and is also excluded from `merge_from_tui`,
+    /// so the same persistence bug applied to snoozed rows. Same fix path
+    /// (apply_user_action), same disk-versus-memory contract.
+    #[test]
+    #[serial]
+    fn stamp_last_accessed_on_snoozed_row_persistently_clears_snooze() {
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
+
+        view.apply_user_action(&id, |inst| inst.snooze(30))
+            .expect("seed snooze must persist");
+        assert!(
+            view.get_instance(&id).unwrap().is_snoozed(),
+            "precondition: row snoozed in memory"
+        );
+
+        view.stamp_last_accessed(&id);
+
+        assert!(
+            !view.get_instance(&id).unwrap().is_snoozed(),
+            "stamp_last_accessed must clear snoozed_until in memory"
+        );
+        let disk_row = Storage::new("test")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == id)
+            .expect("disk row present");
+        assert!(
+            disk_row.snoozed_until.is_none(),
+            "stamp_last_accessed must persist the auto-unsnooze (merge_from_tui drops snoozed_until)"
         );
     }
 }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -4823,6 +4823,234 @@ fn archived_section_pinned_to_bottom_in_every_sort() {
     }
 }
 
+/// In Project grouping mode, archived sessions must nest under per-project
+/// sub-headers inside the Archived section instead of forming one flat list.
+/// Layout: Archived (depth 0) > <project> (depth 1) > sessions (depth 2).
+/// Sessions inside a sub-folder still sort most-recently-archived first.
+#[test]
+#[serial]
+fn archived_section_nests_by_project_in_project_mode() {
+    use crate::session::{
+        archived_project_sub_path, config::GroupByMode, is_archived_section_path,
+        ARCHIVED_SECTION_NAME,
+    };
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    // Archive one session from each project so we expect two sub-folders.
+    let alpha_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "alpha-running")
+        .map(|i| i.id.clone())
+        .unwrap();
+    let beta_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "beta-error")
+        .map(|i| i.id.clone())
+        .unwrap();
+    env.view
+        .apply_user_action(&alpha_id, |inst| inst.archive())
+        .unwrap();
+    env.view
+        .apply_user_action(&beta_id, |inst| inst.archive())
+        .unwrap();
+    env.view.archived_section_collapsed = false;
+    env.view.flat_items = env.view.build_flat_items();
+
+    // Find the Archived section header and walk forward.
+    let arch_idx = env
+        .view
+        .flat_items
+        .iter()
+        .position(|it| matches!(it, Item::Group { path, .. } if is_archived_section_path(path)))
+        .expect("Archived section header must be present");
+
+    // Header sanity: depth 0, count = 2, name = Archived.
+    match &env.view.flat_items[arch_idx] {
+        Item::Group {
+            depth,
+            session_count,
+            name,
+            ..
+        } => {
+            assert_eq!(*depth, 0, "Archived header depth");
+            assert_eq!(*session_count, 2, "two archived sessions across projects");
+            assert_eq!(name, ARCHIVED_SECTION_NAME);
+        }
+        _ => unreachable!(),
+    }
+
+    // The next two non-session items should be sub-folder headers at depth 1,
+    // one for "alpha" and one for "beta", in alphabetical order. Between them
+    // and after the second, the sessions at depth 2 belong to that sub-folder.
+    let tail = &env.view.flat_items[arch_idx + 1..];
+
+    let sub_alpha_path = archived_project_sub_path("alpha");
+    let sub_beta_path = archived_project_sub_path("beta");
+
+    // First sub-header must be alpha (BTreeMap orders by name).
+    match &tail[0] {
+        Item::Group {
+            path,
+            name,
+            depth,
+            session_count,
+            ..
+        } => {
+            assert_eq!(path, &sub_alpha_path);
+            assert_eq!(name, "alpha");
+            assert_eq!(*depth, 1);
+            assert_eq!(*session_count, 1);
+        }
+        other => panic!("expected alpha sub-header at depth 1, got {:?}", other),
+    }
+    // Then alpha's archived session at depth 2.
+    match &tail[1] {
+        Item::Session { id, depth } => {
+            assert_eq!(
+                id, &alpha_id,
+                "alpha sub-folder should contain alpha-running"
+            );
+            assert_eq!(*depth, 2);
+        }
+        other => panic!("expected alpha-running session row, got {:?}", other),
+    }
+    // Then the beta sub-header at depth 1.
+    match &tail[2] {
+        Item::Group {
+            path,
+            name,
+            depth,
+            session_count,
+            ..
+        } => {
+            assert_eq!(path, &sub_beta_path);
+            assert_eq!(name, "beta");
+            assert_eq!(*depth, 1);
+            assert_eq!(*session_count, 1);
+        }
+        other => panic!("expected beta sub-header at depth 1, got {:?}", other),
+    }
+    // Then beta's archived session at depth 2.
+    match &tail[3] {
+        Item::Session { id, depth } => {
+            assert_eq!(id, &beta_id, "beta sub-folder should contain beta-error");
+            assert_eq!(*depth, 2);
+        }
+        other => panic!("expected beta-error session row, got {:?}", other),
+    }
+}
+
+/// Collapsing the Archived umbrella in Project mode hides both sub-folder
+/// headers and their session rows.
+#[test]
+#[serial]
+fn archived_section_collapsed_hides_project_sub_folders() {
+    use crate::session::{config::GroupByMode, is_within_archived_section};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    let alpha_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "alpha-running")
+        .map(|i| i.id.clone())
+        .unwrap();
+    env.view
+        .apply_user_action(&alpha_id, |inst| inst.archive())
+        .unwrap();
+    env.view.archived_section_collapsed = true;
+    env.view.flat_items = env.view.build_flat_items();
+
+    let within_archive_items: Vec<&Item> = env
+        .view
+        .flat_items
+        .iter()
+        .filter(|it| match it {
+            Item::Group { path, .. } => is_within_archived_section(path),
+            Item::Session { .. } => false,
+        })
+        .collect();
+    assert_eq!(
+        within_archive_items.len(),
+        1,
+        "collapsed Archived must render only its top-level header, got {:?}",
+        within_archive_items
+    );
+}
+
+/// Collapsing a single project sub-folder under Archived hides its session
+/// rows but leaves the sub-header (and any other sub-folders) intact. Uses
+/// the same `project_group_collapsed` map that drives regular project mode
+/// collapse, keyed by the synthetic `archived_project_sub_path`.
+#[test]
+#[serial]
+fn archived_project_sub_folder_collapse_hides_only_its_sessions() {
+    use crate::session::{archived_project_sub_path, config::GroupByMode};
+
+    let mut env = create_test_env_two_projects_mixed_attention();
+    env.view.group_by = GroupByMode::Project;
+    let alpha_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "alpha-running")
+        .map(|i| i.id.clone())
+        .unwrap();
+    let beta_id = env
+        .view
+        .instances
+        .iter()
+        .find(|i| i.title == "beta-error")
+        .map(|i| i.id.clone())
+        .unwrap();
+    env.view
+        .apply_user_action(&alpha_id, |inst| inst.archive())
+        .unwrap();
+    env.view
+        .apply_user_action(&beta_id, |inst| inst.archive())
+        .unwrap();
+    env.view.archived_section_collapsed = false;
+    // Collapse only alpha's archived sub-folder.
+    env.view
+        .project_group_collapsed
+        .insert(archived_project_sub_path("alpha"), true);
+    env.view.flat_items = env.view.build_flat_items();
+
+    // alpha sub-folder must still appear as a header but with no session row
+    // following it; beta sub-folder must still emit its session row.
+    let has_alpha_session = env
+        .view
+        .flat_items
+        .iter()
+        .any(|it| matches!(it, Item::Session { id, .. } if id == &alpha_id));
+    let has_beta_session = env
+        .view
+        .flat_items
+        .iter()
+        .any(|it| matches!(it, Item::Session { id, .. } if id == &beta_id));
+    assert!(
+        !has_alpha_session,
+        "collapsed alpha sub-folder must hide its archived session"
+    );
+    assert!(
+        has_beta_session,
+        "expanded beta sub-folder must still surface its archived session"
+    );
+    let alpha_sub_path = archived_project_sub_path("alpha");
+    assert!(
+        env.view.flat_items.iter().any(
+            |it| matches!(it, Item::Group { path, collapsed, .. } if path == &alpha_sub_path && *collapsed)
+        ),
+        "alpha sub-folder header must remain visible with collapsed=true"
+    );
+}
+
 mod scroll_pane_isolation {
     //! Wheel events are confined to whichever pane the mouse is over.
     //! In particular, a wheel over the preview pane never moves the list
@@ -7474,6 +7702,61 @@ mod save_field_merge {
                 .and_then(|i| i.agent_session_id.clone())
                 .is_none(),
             "reload must honor peer-cleared sid; carrying memory would re-pass --resume <stale>"
+        );
+    }
+
+    /// `stamp_last_accessed` on a sunk row must auto-clear archived_at on
+    /// BOTH memory and disk, and rebuild flat_items so the row leaves the
+    /// synthetic Archived section on the same frame. Regression guard for
+    /// the "re-entering an archived session left it stuck in the Archived
+    /// section until the user pressed `z`" bug: the old implementation used
+    /// mutate_instance + save, but merge_from_tui doesn't carry archived_at
+    /// so the next reload resurrected the sink from disk.
+    #[test]
+    #[serial]
+    fn stamp_last_accessed_on_archived_row_unsinks_persistently() {
+        use crate::session::{is_archived_section_path, Item};
+
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/grp");
+
+        view.apply_user_action(&id, |inst| inst.archive())
+            .expect("seed archive must persist");
+        view.flat_items = view.build_flat_items();
+        assert!(
+            view.get_instance(&id).unwrap().is_archived(),
+            "precondition: row archived in memory"
+        );
+        let archived_section_present = |items: &[Item]| {
+            items.iter().any(|it| match it {
+                Item::Group { path, .. } => is_archived_section_path(path),
+                _ => false,
+            })
+        };
+        assert!(
+            archived_section_present(&view.flat_items),
+            "precondition: Archived section header rendered"
+        );
+
+        view.stamp_last_accessed(&id);
+
+        assert!(
+            !view.get_instance(&id).unwrap().is_archived(),
+            "stamp_last_accessed must clear archived_at in memory"
+        );
+        let disk_row = Storage::new("test")
+            .unwrap()
+            .load()
+            .unwrap()
+            .into_iter()
+            .find(|i| i.id == id)
+            .expect("disk row present");
+        assert!(
+            disk_row.archived_at.is_none(),
+            "stamp_last_accessed must persist the auto-unarchive (merge_from_tui drops archived_at)"
+        );
+        assert!(
+            !archived_section_present(&view.flat_items),
+            "Archived section must disappear once the only archived row is unsunk"
         );
     }
 }


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Two related archive UX changes:

### 1. Bug fix: re-entering a sunk session left the row stuck in Archived

`HomeView::stamp_last_accessed` was clearing `archived_at` / `snoozed_until` in memory via `mutate_instance` then calling `save()`. `merge_from_tui` does not carry those fields (they belong to the user-action path so peer CLI writers cannot be clobbered), so the auto-unsink was discarded on the next reload, and `flat_items` was never rebuilt anyway, leaving the row in the Archived section visually. The user had to press `z` to actually move it back.

Fix: when the row is sunk, route through `apply_user_action` (which uses `merge_user_action_diff` that does include those fields, under the storage flock so peer writes are safe) and rebuild `flat_items`. Non-sunk rows keep the cheap `mutate_instance` path; `last_accessed_at` alone is already carried by `merge_from_tui`.

This also unbreaks the TUI send-message and live-send paths, which both go through the same helper.

### 2. Feature: Archived section nests by project in Project grouping mode

In Project grouping mode, the Archived section now groups by project:

\`\`\`
Archived (N)               (depth 0, italic + dim)
  alpha (1)                (depth 1, italic + dim)
    > alpha-running        (depth 2)
  beta (1)                 (depth 1, italic + dim)
    > beta-error           (depth 2)
\`\`\`

- Sub-folders are sorted alphabetically by project name.
- Within a sub-folder, sessions sort most-recently-archived first.
- Each sub-folder is independently collapsible. Click-toggle reuses the existing Project-mode collapse map (\`project_group_collapsed\`), keyed by \`__aoe_archived_section__/<project>\`. Collapse state is in-memory only.
- Collapsing the top-level Archived header still hides everything beneath it.
- Sub-folders cannot be renamed / deleted / archived as groups; they are synthetic. A new \`is_within_archived_section()\` helper centralizes the disarm logic used by the palette, \`update_selected\`, and render styling.
- Non-project sort paths (Attention sort + Manual, single-profile, all-profiles) keep using the flat \`append_archived_section\`. No behavior change there.

## PR Type

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (\`cargo test --lib\`: 2252 passed)
- [x] Documentation was updated where necessary (none needed; no public API or user docs changed)
- [ ] For UI changes: included screenshot or recording (TUI list rendering; the layout is exercised by the new \`archived_section_nests_by_project_in_project_mode\` test which asserts the exact item sequence)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle in a way the e2e harness can observe. Coverage lives in the home view unit tests instead.

Specifically:
- \`stamp_last_accessed_on_archived_row_unsinks_persistently\` (regression guard for the bug fix; asserts memory + disk + flat_items all reflect the unsink)
- \`archived_section_nests_by_project_in_project_mode\` (asserts the depth-0 / depth-1 / depth-2 layout)
- \`archived_section_collapsed_hides_project_sub_folders\` (top-level collapse hides sub-folders too)
- \`archived_project_sub_folder_collapse_hides_only_its_sessions\` (per-sub-folder collapse leaves the sub-header in place)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:** Claude drafted the implementation and tests based on root-cause analysis of the touch / archive interaction. The reasoning, design decisions (collapsible sub-folders, in-memory collapse state, reuse of \`project_group_collapsed\`), and final review are @njbrake's.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR delivers two related TUI archive improvements:

1. Persistent auto-unsink (bug fix) — Unsinking a session (clearing archived or snoozed state via activity) now persists across reloads so the row is removed from Archived and stays visible. Previously the change was lost on reload and the row remained in Archived.

2. Project-nested Archived section (feature) — In Project grouping mode the Archived section is now organized into synthetic, alphabetically-ordered per-project sub-folders. Each project sub-folder is independently collapsible and its archived sessions are shown sorted by most-recently-archived.

## What changed (high level)

- Added helpers and a project-mode archived renderer to the session groups module to create synthetic per-project archived headers and bucket archived sessions by project.
- Home view: selection/palette logic and rendering now treat both the top-level Archived header and its project sub-folders as part of the Archived area.
- Home view: stamp_last_accessed now persists unsink operations for sunk rows by routing through apply_user_action and rebuilding flat_items; non-sunk rows still use the cheaper mutate_instance path.
- Public re-exports updated to expose the new archived-section helpers.
- Tests: regression tests added to ensure auto-unsink persists for archived and snoozed rows; feature tests added for nested archived rendering, per-project collapsing, and sort-order behavior.

## Benefits

- Users’ unsink actions are durable — archive/snooze clears persist to disk and UI state is rebuilt so rows return to the main list reliably.
- Archived sessions are easier to navigate in Project mode via per-project grouping and independent collapse state.
- Sorting behavior is deterministic: projects ordered per user sort_order; sessions within each project ordered by most-recently-archived.
- New tests reduce risk of regressions around unsinking and archived rendering.

## Technical details (short)

- New functions: is_within_archived_section(path), archived_project_sub_path(project_name), append_archived_section_by_project(...).
- append_archived_section_by_project builds a top-level Archived header plus depth-1 synthetic project sub-headers (collapse state keyed by __aoe_archived_section__/<project>) and depth-2 archived session rows (sessions sorted by archived_at).
- stamp_last_accessed: when acting on a sunk row (archived or snoozed) the code now uses apply_user_action (merge_user_action_diff) so archived_at/snoozed_until are included in the storage update; flat_items is then rebuilt. Non-sunk updates still use mutate_instance for a lightweight timestamp change.
- UI changes use is_within_archived_section to ensure disarm/styling applies to both the Archived header and its project sub-folders.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1557?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->