### PR TITLE
chore(ci): repair codecov config after org move (re-resolve YAML + gate notifications)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@
 # merges will run well below this, so the report-only philosophy lives
 # in the Codecov "informational" flag at the project level until the
 # follow-ups (#1217-#1224) lift the baseline.
+# Touched 2026-05-27 to force a YAML re-resolve after the org transfer to agent-of-empires.
 
 comment:
   after_n_builds: 1

--- a/codecov.yml
+++ b/codecov.yml
@@ -15,7 +15,6 @@
 # Touched 2026-05-27 to force a YAML re-resolve after the org transfer to agent-of-empires.
 
 comment:
-  after_n_builds: 1
   layout: "header, diff, files, components, sunburst, uncovered, footer"
   behavior: default
   # Only post (or update) the PR comment when patch / project coverage
@@ -29,6 +28,17 @@ comment:
 
 codecov:
   disable_default_path_fixes: false
+  # Hold all Codecov notifications (PR comment + status checks) until every
+  # flag has reported. Our CI uploads three separate LCOVs (vitest,
+  # playwright-mocked, playwright-live); without this Codecov evaluates and
+  # posts after the first one lands, then re-evaluates and re-posts on each
+  # subsequent upload, causing patch/project numbers to churn live during CI.
+  # `wait_for_ci: true` additionally holds notifications until GitHub Actions
+  # reports the workflow done, so a hung uploader cannot trigger a premature
+  # evaluation either.
+  notify:
+    after_n_builds: 3
+    wait_for_ci: true
 
 # One flag per test type. Each CI job uploads its own LCOV with its own
 # flag, and Codecov merges them server-side into the combined coverage


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Two `codecov.yml` repairs that surfaced while debugging Codecov on PR #1548 after the repository was transferred into the `agent-of-empires` org.

### 1. Force a YAML re-resolve on the new slug

After the org transfer Codecov stopped applying the committed `codecov.yml` on PR comments. Recent PR comments (e.g. #1548) are bare-bones, missing the configured `layout`, components table, and project-diff block that earlier PRs (e.g. #1521 on the old slug) had.

Root cause: the Codecov repo config page at `https://app.codecov.io/gh/agent-of-empires/agent-of-empires/config/yaml` shows **`Current bot: none`** and an empty resolved YAML, even though `codecov.yml` is committed at the repo root and validates cleanly against `https://codecov.io/validate`. Without the Codecov GitHub App installed on the new org, Codecov has no way to fetch the file from the repo, so the resolved YAML stays empty. Uploads keep working because they are authenticated by `CODECOV_TOKEN`; only config resolution is broken.

Adding a no-op comment line to `codecov.yml` lets the next main-branch upload (triggered by merging this PR) re-resolve the YAML from the new commit and populate the previously empty repo config, **after** the Codecov GitHub App is installed on `agent-of-empires` with access to this repo. The actual GitHub App install step happens on the Codecov / GitHub side and is not in this diff.

### 2. Gate notifications until every flag has uploaded

Codecov was posting and updating the PR comment plus the `codecov/patch` and `codecov/project` status checks after the **first** of three LCOV uploads (`vitest`, `playwright-mocked`, `playwright-live`) landed, then re-evaluating after each subsequent upload. The patch number could flip from pass to fail mid-run while CI was still going. The previous `comment.after_n_builds: 1` made that worse by gating only the comment on the first upload while leaving statuses unbounded.

This PR replaces that with a single global gate:

```yaml
codecov:
  disable_default_path_fixes: false
  notify:
    after_n_builds: 3
    wait_for_ci: true
```

The global `codecov.notify.after_n_builds: 3` covers the comment and every status, so the per-comment override is redundant and removed. `wait_for_ci: true` additionally holds notifications until GitHub Actions reports the workflow done, so a hung uploader cannot trigger a premature evaluation either.

Verified against `https://codecov.io/validate`; YAML parses cleanly.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:**
Investigation and the YAML edits drafted by Claude. njbrake validated the root cause (Codecov bot not installed on the new org; comment churn caused by missing `after_n_builds` gate on statuses) by inspecting the Codecov repo config page and comparing pre/post-move PR comments, then asked for this repair PR.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR touches the repository-root codecov.yml to force Codecov to re-resolve the YAML after the repository moved into the agent-of-empires organization.

### What changed (high level)
- Updated codecov.yml with a no-op top-level comment so the next main-branch upload will prompt Codecov to re-fetch the committed YAML.
- Adjusted Codecov notification gating to use a single global gate so notifications wait for all CI uploads before posting.

### Benefits
- Forces Codecov to re-resolve and populate the repository configuration after the org transfer, restoring the configured PR comment layout, components table, and project-diff blocks once the Codecov GitHub App is installed on the org.
- Prevents premature or partial Codecov comments/status updates by ensuring the comment and status checks wait for all three LCOV uploads (vitest, playwright-mocked, playwright-live), reducing noisy or inconsistent PR feedback.

### Technical details
- Added a top-level comment line in codecov.yml (no functional change to thresholds or component definitions).
- Changed notification behavior by setting:
  - codecov.notify.after_n_builds: 3
  - codecov.notify.wait_for_ci: true
  This moves from per-comment gating to a single global gate so Codecov waits for the specified number of uploads/CI completion before posting.

### Scope and review
- Configuration-only change; no code or exported/public API changes.
- Lines changed: +12/-1 — estimated review effort: Medium

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->