### PR TITLE
fix(tui): route 'm' and live mode to the paired terminal pane in Terminal view

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -3205,7 +3205,7 @@ impl HomeView {
         // throw voice text on the floor; losing dictation is worse than
         // silently catching it.
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = dialog_label_for_target(&title, target);
+            let label = live_send::format_target_label(&title, target);
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);
@@ -3464,7 +3464,7 @@ impl HomeView {
         let Some((id, title, target)) = self.resolve_send_target() else {
             return;
         };
-        let label = dialog_label_for_target(&title, target);
+        let label = live_send::format_target_label(&title, target);
         self.pending_send_session = Some(id);
         self.pending_send_target = target;
         let mut dialog = SendMessageDialog::new(&label);
@@ -3546,7 +3546,7 @@ impl HomeView {
         }
 
         if let Some((id, title, target)) = self.resolve_send_target() {
-            let label = dialog_label_for_target(&title, target);
+            let label = live_send::format_target_label(&title, target);
             self.pending_send_session = Some(id);
             self.pending_send_target = target;
             let mut dialog = SendMessageDialog::new(&label);
@@ -3781,39 +3781,29 @@ impl HomeView {
     }
 }
 
-/// Render the dialog title suffix for a given live-send target so the
-/// user can tell at a glance which pane the compose dialog will send
-/// to. Agent uses the bare title (historical look); terminal variants
-/// append a short suffix.
-fn dialog_label_for_target(title: &str, target: live_send::LiveSendTarget) -> String {
-    match target {
-        live_send::LiveSendTarget::Agent => title.to_string(),
-        live_send::LiveSendTarget::Terminal => format!("{title} (terminal)"),
-        live_send::LiveSendTarget::ContainerTerminal => format!("{title} (container)"),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::session::config::{SessionConfig, ToolSessionConfig};
 
     #[test]
-    fn dialog_label_for_target_distinguishes_terminal_panes() {
+    fn format_target_label_distinguishes_terminal_panes() {
         // Users firing 'm' from Terminal view should see the dialog
-        // title call out the target pane so they don't accidentally
-        // send agent prompts into a shell (or vice versa).
-        use live_send::LiveSendTarget;
+        // title (and the live-mode banner) call out the target pane so
+        // they don't accidentally send agent prompts into a shell (or
+        // vice versa). Both the compose dialog and the status-bar
+        // banner route through the same helper so the label can't drift.
+        use live_send::{format_target_label, LiveSendTarget};
         assert_eq!(
-            dialog_label_for_target("my-session", LiveSendTarget::Agent),
+            format_target_label("my-session", LiveSendTarget::Agent),
             "my-session",
         );
         assert_eq!(
-            dialog_label_for_target("my-session", LiveSendTarget::Terminal),
+            format_target_label("my-session", LiveSendTarget::Terminal),
             "my-session (terminal)",
         );
         assert_eq!(
-            dialog_label_for_target("my-session", LiveSendTarget::ContainerTerminal),
+            format_target_label("my-session", LiveSendTarget::ContainerTerminal),
             "my-session (container)",
         );
     }

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1197,6 +1197,7 @@ impl HomeView {
                 DialogResult::Cancel => {
                     self.send_message_dialog = None;
                     self.pending_send_session = None;
+                    self.pending_send_target = live_send::LiveSendTarget::Agent;
                 }
                 DialogResult::Submit(message) => {
                     self.send_message_dialog = None;
@@ -2191,7 +2192,14 @@ impl HomeView {
             KeyCode::Char('M') if self.strict_hotkeys => {
                 self.open_send_message_dialog();
             }
-            // Tab enters live-send mode on the selected running session.
+            // Tab is the activation key's complement: it does whichever
+            // of (live-send, tmux attach) `Enter` doesn't. When
+            // `default_attach_mode = LiveSend`, Enter activates live
+            // mode, so Tab swaps to a full tmux attach (the escape
+            // hatch). When `default_attach_mode = Tmux` (the default),
+            // Enter still attaches and Tab keeps its historical
+            // live-send role.
+            //
             // Free at the home-view top level (settings/cockpit/dialogs
             // own their own Tab handlers), and the entry-vs-send
             // distinction is unambiguous: this branch only fires when
@@ -2199,7 +2207,21 @@ impl HomeView {
             // top of `handle_key` short-circuits otherwise. While in
             // live mode Tab is sent verbatim to the agent.
             KeyCode::Tab => {
-                if let Some(action) = self.start_live_send() {
+                let swap_to_attach = self
+                    .selected_session
+                    .as_deref()
+                    .map(|id| {
+                        matches!(
+                            self.default_attach_mode(id),
+                            Some(crate::session::NewSessionAttachMode::LiveSend)
+                        )
+                    })
+                    .unwrap_or(false);
+                if swap_to_attach {
+                    if let Some(action) = self.tab_attach_action() {
+                        return Some(action);
+                    }
+                } else if let Some(action) = self.start_live_send() {
                     return Some(action);
                 }
             }
@@ -2626,7 +2648,9 @@ impl HomeView {
                 // tmux attach for live-send mode on Enter / double-click.
                 // Cockpit was already handled above (the resolver also
                 // returns None for cockpit, so the match is double-safe);
-                // Terminal/Tool views keep their existing paths regardless.
+                // Terminal view honors the same setting (live-send onto
+                // the paired terminal pane); Tool view keeps its
+                // existing AttachToolSession path.
                 //
                 // Route through `start_live_send` so the same-target
                 // guard (already-live on this session) is honored: a
@@ -2646,6 +2670,60 @@ impl HomeView {
                     Some(Action::AttachSession(id))
                 }
             }
+            ViewMode::Terminal => {
+                // Mirror Agent view: when `default_attach_mode = LiveSend`,
+                // Enter on the terminal row enters live-send mode against
+                // the paired terminal pane (host or container, whichever
+                // is currently shown). Otherwise fall back to the
+                // historical tmux attach.
+                if matches!(
+                    self.default_attach_mode(&id),
+                    Some(crate::session::NewSessionAttachMode::LiveSend)
+                ) {
+                    return self.start_live_send();
+                }
+                let terminal_mode = if let Some(inst) = self.get_instance(&id) {
+                    if inst.is_sandboxed() {
+                        self.get_terminal_mode(&id)
+                    } else {
+                        TerminalMode::Host
+                    }
+                } else {
+                    TerminalMode::Host
+                };
+                Some(Action::AttachTerminal(id, terminal_mode))
+            }
+            ViewMode::Tool(ref tool_name) => Some(Action::AttachToolSession(id, tool_name.clone())),
+        }
+    }
+
+    /// Resolve the "Tab swap" action that fires when
+    /// `default_attach_mode = LiveSend`: Enter takes the live-send
+    /// slot, so Tab takes the tmux-attach slot. Mirrors the cockpit
+    /// and in-flight guards from `activate_selected_session`; returns
+    /// the same per-view-mode attach actions Enter produces under the
+    /// historical default.
+    pub(super) fn tab_attach_action(&mut self) -> Option<Action> {
+        let id = self.selected_session.clone()?;
+        if let Some(inst) = self.get_instance(&id) {
+            if matches!(inst.status, Status::Deleting | Status::Creating) {
+                return None;
+            }
+            if inst.is_cockpit_mode() {
+                #[cfg(feature = "serve")]
+                {
+                    return Some(Action::OpenCockpit(id));
+                }
+                #[cfg(not(feature = "serve"))]
+                {
+                    return Some(Action::SetTransientStatus(
+                        "Cockpit session: rebuild with --features serve to attach".to_string(),
+                    ));
+                }
+            }
+        }
+        match self.view_mode {
+            ViewMode::Agent => Some(Action::AttachSession(id)),
             ViewMode::Terminal => {
                 let terminal_mode = if let Some(inst) = self.get_instance(&id) {
                     if inst.is_sandboxed() {
@@ -3126,9 +3204,11 @@ impl HomeView {
         // next dialog open (typically the next `m` press) drains it. Never
         // throw voice text on the floor; losing dictation is worse than
         // silently catching it.
-        if let Some((id, title)) = self.resolve_paste_target() {
+        if let Some((id, title, target)) = self.resolve_send_target() {
+            let label = dialog_label_for_target(&title, target);
             self.pending_send_session = Some(id);
-            let mut dialog = SendMessageDialog::new(&title);
+            self.pending_send_target = target;
+            let mut dialog = SendMessageDialog::new(&label);
             dialog.handle_paste(text);
             self.send_message_dialog = Some(dialog);
             return;
@@ -3185,7 +3265,7 @@ impl HomeView {
     }
 
     /// Attempt to enter live-send mode against the currently-selected
-    /// session. Unlike `resolve_paste_target`, this does NOT require
+    /// session. Unlike `resolve_send_target`, this does NOT require
     /// the tmux pane to already exist: `prepare_live_send` calls
     /// `ensure_pane_ready` which revives stopped sessions (Docker
     /// start, splash wait, resume cascade). Without this relaxation
@@ -3213,6 +3293,24 @@ impl HomeView {
         if inst.is_cockpit_mode() {
             return None;
         }
+        // Pick the live-send target based on which pane the user is
+        // currently previewing. Agent view → agent pane (historical
+        // default). Terminal view → the paired host or container
+        // terminal pane, so 'm'/Tab compose against the same shell
+        // the user sees. Tool view stays out of live-send (no clean
+        // target for lazygit/yazi etc.; let the caller fall back to
+        // AttachToolSession).
+        self.pending_live_send_target = match &self.view_mode {
+            ViewMode::Agent => live_send::LiveSendTarget::Agent,
+            ViewMode::Terminal => {
+                if inst.is_sandboxed() && self.get_terminal_mode(&id) == TerminalMode::Container {
+                    live_send::LiveSendTarget::ContainerTerminal
+                } else {
+                    live_send::LiveSendTarget::Terminal
+                }
+            }
+            ViewMode::Tool(_) => return None,
+        };
         Some(Action::EnterLiveSend(id))
     }
 
@@ -3334,7 +3432,17 @@ impl HomeView {
         let Some(inst) = self.get_instance(&state.session_id) else {
             return Some("Session was deleted while live mode was active.");
         };
-        let current_name = crate::tmux::Session::generate_name(&inst.id, &inst.title);
+        let current_name = match state.target {
+            live_send::LiveSendTarget::Agent => {
+                crate::tmux::Session::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::Terminal => {
+                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::ContainerTerminal => {
+                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
+            }
+        };
         if current_name != state.tmux_name {
             return Some("Session was renamed while live mode was active.");
         }
@@ -3348,12 +3456,18 @@ impl HomeView {
     /// If pending_paste has accumulated text from earlier untargeted pastes,
     /// drain it into the dialog so voice/dictation captured before a session
     /// was picked still gets used. No-op if no running session is targetable.
+    ///
+    /// Honors `view_mode`: in Terminal view, the dialog targets the paired
+    /// terminal pane (host or container) rather than the agent, so 'm'
+    /// composes a command for the same shell the user is previewing.
     fn open_send_message_dialog(&mut self) {
-        let Some((id, title)) = self.resolve_paste_target() else {
+        let Some((id, title, target)) = self.resolve_send_target() else {
             return;
         };
+        let label = dialog_label_for_target(&title, target);
         self.pending_send_session = Some(id);
-        let mut dialog = SendMessageDialog::new(&title);
+        self.pending_send_target = target;
+        let mut dialog = SendMessageDialog::new(&label);
         if let Some(buf) = self.pending_paste.take() {
             if !buf.is_empty() {
                 dialog.handle_paste(&buf);
@@ -3362,44 +3476,54 @@ impl HomeView {
         self.send_message_dialog = Some(dialog);
     }
 
-    /// Resolve a target session id + title for an untargeted paste/type-burst.
-    /// Only returns Some when an explicit, runnable session is selected.
-    ///
-    /// Cases that return None (caller stashes to `pending_paste`):
-    /// - Cursor on a group header (`selected_session` is None).
-    /// - No selection at all (empty list, no sessions).
-    /// - Selected session is non-running (Stopped, Error, Creating, or tmux
-    ///   pane gone).
-    ///
-    /// Why no first-running fallback: silently dispatching paste/dictation
-    /// to "whichever session sorts first" misroutes voice messages across
-    /// groups. A user with cursor on the "backend" group expanding it to
-    /// browse, dictating, and having the paste land in a "frontend" session
-    /// is exactly the misrouting the archived-selection fix is preventing.
-    /// Stashing to `pending_paste` is strictly better: the status-bar
-    /// indicator surfaces the captured count, and the next `m` against a
-    /// runnable selection drains it into the compose dialog.
-    ///
-    /// Defensive fall-through: when `selected_session` references an id
-    /// that no longer maps to an instance (deleted underneath us between
-    /// select and paste, shouldn't happen in steady state), we also stash
-    /// rather than reroute.
-    fn resolve_paste_target(&self) -> Option<(String, String)> {
-        let pick = |inst: &crate::session::Instance| -> Option<(String, String)> {
-            if inst.status == Status::Creating {
-                return None;
+    /// Compose target for the current view: agent in Agent view, the
+    /// paired host/container terminal in Terminal view. Tool view has
+    /// no clean compose target (the tool owns the pane), so it falls
+    /// through to Agent for the historical paste/letter-capture path.
+    pub(super) fn current_send_target(&self) -> live_send::LiveSendTarget {
+        match &self.view_mode {
+            ViewMode::Agent => live_send::LiveSendTarget::Agent,
+            ViewMode::Terminal => {
+                if let Some(id) = self.selected_session.as_deref() {
+                    if let Some(inst) = self.get_instance(id) {
+                        if inst.is_sandboxed()
+                            && self.get_terminal_mode(id) == TerminalMode::Container
+                        {
+                            return live_send::LiveSendTarget::ContainerTerminal;
+                        }
+                    }
+                }
+                live_send::LiveSendTarget::Terminal
             }
-            let tmux_session = crate::tmux::Session::new(&inst.id, &inst.title).ok();
-            if tmux_session.as_ref().is_some_and(|s| s.exists()) {
-                Some((inst.id.clone(), inst.title.clone()))
-            } else {
-                None
-            }
-        };
+            ViewMode::Tool(_) => live_send::LiveSendTarget::Agent,
+        }
+    }
 
+    /// Resolve `(id, title, target)` for an untargeted paste, 'm', or
+    /// strict-mode letter capture. Agent targets keep the historical
+    /// gate (the agent tmux pane must already exist) so the compose
+    /// dialog can't open against a stopped session; terminal targets
+    /// relax that gate because `execute_send_message` will spawn the
+    /// paired terminal on demand the same way `attach_terminal` does.
+    fn resolve_send_target(&self) -> Option<(String, String, live_send::LiveSendTarget)> {
         let id = self.selected_session.as_ref()?;
         let inst = self.get_instance(id)?;
-        pick(inst)
+        if matches!(inst.status, Status::Creating | Status::Deleting) {
+            return None;
+        }
+        let target = self.current_send_target();
+        let ready = match target {
+            live_send::LiveSendTarget::Agent => crate::tmux::Session::new(&inst.id, &inst.title)
+                .map(|s| s.exists())
+                .unwrap_or(false),
+            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => {
+                true
+            }
+        };
+        if !ready {
+            return None;
+        }
+        Some((inst.id.clone(), inst.title.clone(), target))
     }
 
     /// Strict-mode typing guard: a bare lowercase letter was pressed outside
@@ -3421,9 +3545,11 @@ impl HomeView {
             return;
         }
 
-        if let Some((id, title)) = self.resolve_paste_target() {
+        if let Some((id, title, target)) = self.resolve_send_target() {
+            let label = dialog_label_for_target(&title, target);
             self.pending_send_session = Some(id);
-            let mut dialog = SendMessageDialog::new(&title);
+            self.pending_send_target = target;
+            let mut dialog = SendMessageDialog::new(&label);
             dialog.handle_paste(&s);
             self.send_message_dialog = Some(dialog);
             return;
@@ -3655,10 +3781,42 @@ impl HomeView {
     }
 }
 
+/// Render the dialog title suffix for a given live-send target so the
+/// user can tell at a glance which pane the compose dialog will send
+/// to. Agent uses the bare title (historical look); terminal variants
+/// append a short suffix.
+fn dialog_label_for_target(title: &str, target: live_send::LiveSendTarget) -> String {
+    match target {
+        live_send::LiveSendTarget::Agent => title.to_string(),
+        live_send::LiveSendTarget::Terminal => format!("{title} (terminal)"),
+        live_send::LiveSendTarget::ContainerTerminal => format!("{title} (container)"),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::session::config::{SessionConfig, ToolSessionConfig};
+
+    #[test]
+    fn dialog_label_for_target_distinguishes_terminal_panes() {
+        // Users firing 'm' from Terminal view should see the dialog
+        // title call out the target pane so they don't accidentally
+        // send agent prompts into a shell (or vice versa).
+        use live_send::LiveSendTarget;
+        assert_eq!(
+            dialog_label_for_target("my-session", LiveSendTarget::Agent),
+            "my-session",
+        );
+        assert_eq!(
+            dialog_label_for_target("my-session", LiveSendTarget::Terminal),
+            "my-session (terminal)",
+        );
+        assert_eq!(
+            dialog_label_for_target("my-session", LiveSendTarget::ContainerTerminal),
+            "my-session (container)",
+        );
+    }
 
     #[test]
     fn hook_install_agent_uses_detect_as_for_custom_codex_wrapper() {

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -267,10 +267,30 @@ pub(in crate::tui) struct LiveSendState {
     pub session_id: String,
     pub title: String,
     pub tmux_name: String,
+    /// Which paired pane the live-send is targeting. Captured at entry
+    /// time so the drift check, exit-sizing reset, and view-mode flips
+    /// during live-send don't change where keystrokes are dispatched.
+    pub target: LiveSendTarget,
     /// Chord list parsed from the user's configured exit-chord
     /// setting at entry time. Captured per-entry so config edits
     /// don't change behavior mid-session.
     pub exit_chords: Vec<(KeyCode, KeyModifiers)>,
+}
+
+/// Which paired tmux pane a live-send dispatch targets. The agent
+/// pane is the historical default; terminal panes (host and
+/// container) reuse the same live-send dispatch machinery but route
+/// to the paired terminal's tmux session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(in crate::tui) enum LiveSendTarget {
+    /// The agent's tmux pane (default, pre-existing behavior).
+    #[default]
+    Agent,
+    /// The paired host-shell terminal pane.
+    Terminal,
+    /// The paired container-shell terminal pane (sandboxed sessions
+    /// in container terminal mode).
+    ContainerTerminal,
 }
 
 /// One coalesced unit of work the worker hands to tmux. `Literal` runs

--- a/src/tui/home/live_send.rs
+++ b/src/tui/home/live_send.rs
@@ -293,6 +293,19 @@ pub(in crate::tui) enum LiveSendTarget {
     ContainerTerminal,
 }
 
+/// Format a display label for a `(title, target)` pair so the compose
+/// dialog header and the live-mode status banner stay in lockstep.
+/// Agent keeps the bare title (historical look); terminal variants
+/// get a short parenthetical so the user sees which pane the
+/// keystrokes will land on without having to read the preview chrome.
+pub(in crate::tui) fn format_target_label(title: &str, target: LiveSendTarget) -> String {
+    match target {
+        LiveSendTarget::Agent => title.to_string(),
+        LiveSendTarget::Terminal => format!("{title} (terminal)"),
+        LiveSendTarget::ContainerTerminal => format!("{title} (container)"),
+    }
+}
+
 /// One coalesced unit of work the worker hands to tmux. `Literal` runs
 /// fold together; named keys, hex-byte runs, and resizes break the run
 /// because their order vs. surrounding text matters (an Up arrow between

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -381,6 +381,18 @@ pub struct HomeView {
     pub(super) send_message_dialog: Option<super::dialogs::SendMessageDialog>,
     /// Session to receive the message from the send dialog
     pub(super) pending_send_session: Option<String>,
+    /// Which pane the pending send-message dialog will target. Set
+    /// alongside `pending_send_session` and read when the dialog
+    /// submits, so 'm' in Terminal view routes to the terminal pane
+    /// instead of the agent. Defaults to Agent for the historical
+    /// path (paste/dictation capture, palette compose).
+    pub(super) pending_send_target: live_send::LiveSendTarget,
+    /// Which pane the next `Action::EnterLiveSend` should target.
+    /// Set by `start_live_send` before returning the action, read by
+    /// `prepare_live_send` to pick the right tmux pane (agent vs
+    /// host terminal vs container terminal). Defaults to Agent for
+    /// the historical path.
+    pub(super) pending_live_send_target: live_send::LiveSendTarget,
     /// Live-send mode: when `Some`, every key event in the home view is
     /// translated to a tmux send-keys call against this session's pane
     /// until the user presses the exit chord (Ctrl+q). Set by `Tab` (in
@@ -731,6 +743,8 @@ impl HomeView {
             update_confirm_dialog: None,
             send_message_dialog: None,
             pending_send_session: None,
+            pending_send_target: live_send::LiveSendTarget::Agent,
+            pending_live_send_target: live_send::LiveSendTarget::Agent,
             live_send: None,
             live_send_worker: None,
             live_send_last_resize: None,
@@ -2465,37 +2479,85 @@ impl HomeView {
     /// during the implicit respawn so the caller can toast the user about
     /// the lost history; `None` otherwise.
     pub fn execute_send_message(&mut self, session_id: &str, message: &str) -> Option<String> {
-        let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
-            inst.ensure_pane_ready().map_err(Into::into)
-        });
-        let stale_sid = match outcome {
-            Ok(Some(EnsureReadyOutcome::Respawned {
-                stale_sid: Some(sid),
-            }))
-            | Ok(Some(EnsureReadyOutcome::Started {
-                stale_sid: Some(sid),
-            })) => Some(sid),
-            Ok(_) => None,
-            Err(err) => {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Send Failed",
-                    &format!("Cannot prepare session: {}", err),
-                ));
-                return None;
+        let target = std::mem::replace(
+            &mut self.pending_send_target,
+            live_send::LiveSendTarget::Agent,
+        );
+        let size = crate::terminal::get_size();
+        // Same pane-readiness cascades as live-send: agent runs the
+        // full `ensure_pane_ready` (Docker, splash, resume); terminals
+        // just need their tmux session to exist with a live pane.
+        let stale_sid = match target {
+            live_send::LiveSendTarget::Agent => {
+                let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
+                    inst.ensure_pane_ready().map_err(Into::into)
+                });
+                match outcome {
+                    Ok(Some(EnsureReadyOutcome::Respawned {
+                        stale_sid: Some(sid),
+                    }))
+                    | Ok(Some(EnsureReadyOutcome::Started {
+                        stale_sid: Some(sid),
+                    })) => Some(sid),
+                    Ok(_) => None,
+                    Err(err) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Send Failed",
+                            &format!("Cannot prepare session: {}", err),
+                        ));
+                        return None;
+                    }
+                }
+            }
+            live_send::LiveSendTarget::Terminal => {
+                if let Err(e) = self.ensure_terminal_pane_ready(session_id, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Send Failed",
+                        &format!("Cannot prepare terminal: {}", e),
+                    ));
+                    return None;
+                }
+                None
+            }
+            live_send::LiveSendTarget::ContainerTerminal => {
+                if let Err(e) = self.ensure_container_terminal_pane_ready(session_id, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Send Failed",
+                        &format!("Cannot prepare container terminal: {}", e),
+                    ));
+                    return None;
+                }
+                None
             }
         };
         let inst = self.get_instance(session_id)?;
-        let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
-            Ok(s) => s,
-            Err(e) => {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Send Failed",
-                    &format!("Failed to resolve session: {}", e),
-                ));
-                return None;
+        let tmux_session = match target {
+            live_send::LiveSendTarget::Agent => {
+                match crate::tmux::Session::new(&inst.id, &inst.title) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Send Failed",
+                            &format!("Failed to resolve session: {}", e),
+                        ));
+                        return None;
+                    }
+                }
             }
+            live_send::LiveSendTarget::Terminal => crate::tmux::Session::from_name(
+                &crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title),
+            ),
+            live_send::LiveSendTarget::ContainerTerminal => crate::tmux::Session::from_name(
+                &crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title),
+            ),
         };
-        let delay = crate::agents::send_keys_enter_delay(&inst.tool);
+        // Agent gets a tool-specific Enter delay so paste-burst-aware
+        // agents (e.g. Codex) don't swallow the final Enter. Shells in
+        // the paired terminal panes don't need the delay.
+        let delay = match target {
+            live_send::LiveSendTarget::Agent => crate::agents::send_keys_enter_delay(&inst.tool),
+            live_send::LiveSendTarget::Terminal | live_send::LiveSendTarget::ContainerTerminal => 0,
+        };
         if let Err(e) = tmux_session.send_keys_with_delay(message, delay) {
             self.info_dialog = Some(InfoDialog::new(
                 "Send Failed",
@@ -2536,23 +2598,55 @@ impl HomeView {
     /// if the pane could not be readied (`info_dialog` is set with the
     /// underlying error so the caller only has to clear its toast).
     pub fn prepare_live_send(&mut self, session_id: &str) -> Result<Option<String>, ()> {
-        let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
-            inst.ensure_pane_ready().map_err(Into::into)
-        });
-        let stale_sid = match outcome {
-            Ok(Some(EnsureReadyOutcome::Respawned {
-                stale_sid: Some(sid),
-            }))
-            | Ok(Some(EnsureReadyOutcome::Started {
-                stale_sid: Some(sid),
-            })) => Some(sid),
-            Ok(_) => None,
-            Err(err) => {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Live send failed",
-                    &format!("Cannot prepare session: {}", err),
-                ));
-                return Err(());
+        let target = self.pending_live_send_target;
+        self.pending_live_send_target = live_send::LiveSendTarget::Agent;
+        let size = crate::terminal::get_size();
+        // Agent targets revive the agent pane via the full
+        // ensure_pane_ready cascade (Docker, splash, resume). Terminal
+        // targets are simpler: the paired terminal is a plain shell,
+        // so we just ensure the tmux session exists and re-spawn it if
+        // the pane has died (matches `attach_terminal`).
+        let stale_sid = match target {
+            live_send::LiveSendTarget::Agent => {
+                let outcome = self.try_mutate_instance_writeback_on_err(session_id, |inst| {
+                    inst.ensure_pane_ready().map_err(Into::into)
+                });
+                match outcome {
+                    Ok(Some(EnsureReadyOutcome::Respawned {
+                        stale_sid: Some(sid),
+                    }))
+                    | Ok(Some(EnsureReadyOutcome::Started {
+                        stale_sid: Some(sid),
+                    })) => Some(sid),
+                    Ok(_) => None,
+                    Err(err) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Live send failed",
+                            &format!("Cannot prepare session: {}", err),
+                        ));
+                        return Err(());
+                    }
+                }
+            }
+            live_send::LiveSendTarget::Terminal => {
+                if let Err(e) = self.ensure_terminal_pane_ready(session_id, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Live send failed",
+                        &format!("Cannot prepare terminal: {}", e),
+                    ));
+                    return Err(());
+                }
+                None
+            }
+            live_send::LiveSendTarget::ContainerTerminal => {
+                if let Err(e) = self.ensure_container_terminal_pane_ready(session_id, size) {
+                    self.info_dialog = Some(InfoDialog::new(
+                        "Live send failed",
+                        &format!("Cannot prepare container terminal: {}", e),
+                    ));
+                    return Err(());
+                }
+                None
             }
         };
         let inst = match self.get_instance(session_id) {
@@ -2570,20 +2664,27 @@ impl HomeView {
             }
         };
         // Resolve the tmux session name up front so the worker thread
-        // can reconstruct a Session without re-touching HomeView. If we
-        // can't even build the Session here, surface the error before
-        // installing live state.
-        let tmux_session = match crate::tmux::Session::new(&inst.id, &inst.title) {
-            Ok(s) => s,
-            Err(e) => {
-                self.info_dialog = Some(InfoDialog::new(
-                    "Live send failed",
-                    &format!("Cannot resolve tmux session: {}", e),
-                ));
-                return Err(());
+        // can reconstruct a Session without re-touching HomeView.
+        let tmux_name = match target {
+            live_send::LiveSendTarget::Agent => {
+                match crate::tmux::Session::new(&inst.id, &inst.title) {
+                    Ok(s) => s.name().to_string(),
+                    Err(e) => {
+                        self.info_dialog = Some(InfoDialog::new(
+                            "Live send failed",
+                            &format!("Cannot resolve tmux session: {}", e),
+                        ));
+                        return Err(());
+                    }
+                }
+            }
+            live_send::LiveSendTarget::Terminal => {
+                crate::tmux::TerminalSession::generate_name(&inst.id, &inst.title)
+            }
+            live_send::LiveSendTarget::ContainerTerminal => {
+                crate::tmux::ContainerTerminalSession::generate_name(&inst.id, &inst.title)
             }
         };
-        let tmux_name = tmux_session.name().to_string();
         // Switching live mode from session A to session B (click on a
         // different row while already live): we need to drop the old
         // worker BEFORE resetting the old session's window-size,
@@ -2619,6 +2720,7 @@ impl HomeView {
             session_id: inst.id.clone(),
             title: inst.title.clone(),
             tmux_name: tmux_name.clone(),
+            target,
             exit_chords,
         });
         // Spawn the background worker that dispatches translated
@@ -3160,6 +3262,55 @@ impl HomeView {
     ) -> anyhow::Result<()> {
         self.try_mutate_instance(id, |inst| inst.start_terminal_with_size(size))?;
         self.save()?;
+        Ok(())
+    }
+
+    /// Make sure the paired host-terminal tmux pane is alive and
+    /// ready to receive keystrokes. Mirrors `attach_terminal`: if the
+    /// session doesn't exist (or its pane has died), kill the
+    /// tombstone and spawn a fresh one with the requested size. Used
+    /// by `prepare_live_send` when the live target is the terminal.
+    fn ensure_terminal_pane_ready(
+        &mut self,
+        session_id: &str,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<()> {
+        let inst = self
+            .get_instance(session_id)
+            .ok_or_else(|| anyhow::anyhow!("session not found: {}", session_id))?
+            .clone();
+        let term = inst.terminal_tmux_session()?;
+        if !term.exists() || term.is_pane_dead() {
+            if term.exists() {
+                let _ = term.kill();
+            }
+            self.start_terminal_for_instance_with_size(session_id, size)?;
+        }
+        Ok(())
+    }
+
+    /// Container-shell counterpart of `ensure_terminal_pane_ready`,
+    /// used when the live-send target is the container terminal
+    /// (sandboxed sessions in container terminal mode).
+    fn ensure_container_terminal_pane_ready(
+        &mut self,
+        session_id: &str,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<()> {
+        let inst = self
+            .get_instance(session_id)
+            .ok_or_else(|| anyhow::anyhow!("session not found: {}", session_id))?
+            .clone();
+        if !inst.is_sandboxed() {
+            anyhow::bail!("Cannot prepare container terminal for non-sandboxed session");
+        }
+        let term = inst.container_terminal_tmux_session()?;
+        if !term.exists() || term.is_pane_dead() {
+            if term.exists() {
+                let _ = term.kill();
+            }
+            self.start_container_terminal_for_instance_with_size(session_id, size)?;
+        }
         Ok(())
     }
 

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -388,10 +388,11 @@ pub struct HomeView {
     /// path (paste/dictation capture, palette compose).
     pub(super) pending_send_target: live_send::LiveSendTarget,
     /// Which pane the next `Action::EnterLiveSend` should target.
-    /// Set by `start_live_send` before returning the action, read by
-    /// `prepare_live_send` to pick the right tmux pane (agent vs
-    /// host terminal vs container terminal). Defaults to Agent for
-    /// the historical path.
+    /// Set by `start_live_send` whenever it returns an action; read
+    /// (and reset to Agent) by `prepare_live_send` so each action
+    /// carries its own target without a stale value leaking into a
+    /// later live-send call. Defaults to Agent for the historical
+    /// path (Tab in Agent view).
     pub(super) pending_live_send_target: live_send::LiveSendTarget,
     /// Live-send mode: when `Some`, every key event in the home view is
     /// translated to a tmux send-keys call against this session's pane

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1993,10 +1993,20 @@ impl HomeView {
         // the live edge) sits between the title and the exit chord
         // hint so it gets noticed when there's something to notice.
         if let Some(state) = &self.live_send {
-            let raw_title = if state.title.is_empty() {
+            let base_title = if state.title.is_empty() {
                 "session"
             } else {
                 state.title.as_str()
+            };
+            // Surface which pane keystrokes are landing on (Agent stays
+            // bare so the historical look survives unchanged for users
+            // who never enter Terminal/container live mode).
+            let raw_title: String = match state.target {
+                live_send::LiveSendTarget::Agent => base_title.to_string(),
+                live_send::LiveSendTarget::Terminal => format!("{base_title} (terminal)"),
+                live_send::LiveSendTarget::ContainerTerminal => {
+                    format!("{base_title} (container)")
+                }
             };
             let chip = " \u{25CF} LIVE \u{2192} ";
             // The chord display is built from the user's configured
@@ -2035,7 +2045,7 @@ impl HomeView {
                 + unicode_width::UnicodeWidthStr::width(suffix)
                 + unicode_width::UnicodeWidthStr::width(scroll.as_str());
             let title_budget = (area.width as usize).saturating_sub(fixed_width);
-            let title = truncate_to_width(raw_title, title_budget);
+            let title = truncate_to_width(&raw_title, title_budget);
             let mut spans: Vec<Span<'static>> = vec![
                 Span::styled(
                     chip,

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -1998,16 +1998,10 @@ impl HomeView {
             } else {
                 state.title.as_str()
             };
-            // Surface which pane keystrokes are landing on (Agent stays
-            // bare so the historical look survives unchanged for users
-            // who never enter Terminal/container live mode).
-            let raw_title: String = match state.target {
-                live_send::LiveSendTarget::Agent => base_title.to_string(),
-                live_send::LiveSendTarget::Terminal => format!("{base_title} (terminal)"),
-                live_send::LiveSendTarget::ContainerTerminal => {
-                    format!("{base_title} (container)")
-                }
-            };
+            // Surface which pane keystrokes are landing on; the shared
+            // formatter keeps this label in lockstep with the compose
+            // dialog's title.
+            let raw_title = live_send::format_target_label(base_title, state.target);
             let chip = " \u{25CF} LIVE \u{2192} ";
             // The chord display is built from the user's configured
             // exit-chord list so the hint always shows what actually

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -3956,7 +3956,7 @@ fn set_instance_status_runs_status_hook_on_transition() {
 /// Earlier behavior fell through to the first-running fallback whenever
 /// `selected_session` was None — silently misrouting voice/dictation
 /// across groups. With cursor on a group, `selected_session` is None and
-/// `resolve_paste_target` must return None unconditionally.
+/// `resolve_send_target` must return None unconditionally.
 #[test]
 #[serial]
 fn paste_on_group_header_stashes_instead_of_misrouting() {
@@ -5289,6 +5289,7 @@ mod scroll_pane_isolation {
             session_id: "fake".to_string(),
             title: "fake".to_string(),
             tmux_name: "fake".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
@@ -5319,6 +5320,7 @@ mod scroll_pane_isolation {
             session_id: "fake".to_string(),
             title: "fake".to_string(),
             tmux_name: "fake".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
@@ -5752,6 +5754,7 @@ mod click_to_select {
             session_id: id_a.clone(),
             title: "session1".to_string(),
             tmux_name: format!("aoe_test_{}", id_a),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
         });
 
@@ -5786,6 +5789,7 @@ mod click_to_select {
             session_id: id_a.clone(),
             title: "session2".to_string(),
             tmux_name: format!("aoe_test_{}", id_a),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
         });
 
@@ -6164,6 +6168,7 @@ mod preview_drag_select {
             session_id: "test-session".to_string(),
             title: "test".to_string(),
             tmux_name: "aoe_test_drag_select".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
         });
     }
@@ -6526,6 +6531,7 @@ mod preview_drag_select {
             session_id: "fake-id".to_string(),
             title: "fake".to_string(),
             tmux_name: "aoe_test_full_pipeline".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: Vec::new(),
         });
 
@@ -6648,6 +6654,7 @@ mod live_send_mode {
             session_id: inst.id.clone(),
             title: inst.title,
             tmux_name,
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
@@ -6663,6 +6670,7 @@ mod live_send_mode {
             session_id: "missing-id".to_string(),
             title: "missing-title".to_string(),
             tmux_name: "missing-tmux".to_string(),
+            target: crate::tui::home::live_send::LiveSendTarget::Agent,
             exit_chords: crate::tui::home::live_send::parse_chord_list(
                 crate::tui::home::live_send::DEFAULT_EXIT_CHORD,
             ),
@@ -7356,11 +7364,15 @@ mod default_attach_mode {
 
     #[test]
     #[serial]
-    fn terminal_view_ignores_default_attach_mode() {
-        // Terminal view has its own activation path (Container/Host
-        // tmux attach). The setting only applies to Agent view, so
-        // Terminal must keep its existing behavior even when
-        // default_attach_mode = LiveSend.
+    fn terminal_view_honors_default_attach_mode_live_send() {
+        // The `default_attach_mode = LiveSend` setting applies to
+        // Terminal view too: pressing Enter on a terminal-view row
+        // dispatches `Action::EnterLiveSend` against the paired
+        // terminal pane (the live-send target resolution happens in
+        // `start_live_send` based on view_mode). Without this, the
+        // user's "Enter = live mode" preference would silently flip
+        // back to a full tmux attach whenever they were previewing a
+        // terminal.
         let mut env = create_test_env_empty();
         write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
         let id = add_session(&mut env.view, "session-one");
@@ -7369,10 +7381,127 @@ mod default_attach_mode {
         env.view.update_selected();
         env.view.view_mode = crate::tui::home::ViewMode::Terminal;
         let action = env.view.activate_selected_session();
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn terminal_view_falls_back_to_attach_when_default_is_tmux() {
+        // Inverse of the LiveSend case: with the historical Tmux
+        // default, Enter on a terminal-view row keeps the historical
+        // `Action::AttachTerminal` so users who haven't opted into
+        // live mode see no change.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Terminal;
+        let action = env.view.activate_selected_session();
         assert!(
             matches!(&action, Some(Action::AttachTerminal(returned_id, _)) if returned_id == &id),
-            "Terminal view must emit AttachTerminal regardless of default_attach_mode, got {:?}",
+            "default Tmux mode must keep Terminal view on AttachTerminal, got {:?}",
             action
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn tab_swaps_to_attach_session_when_default_is_live_send() {
+        // When `default_attach_mode = LiveSend`, Enter takes over the
+        // live-send slot, so Tab swaps to a full tmux attach (the
+        // escape hatch). Without this, the user would have no
+        // single-key path to the underlying tmux session.
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.handle_key(key(KeyCode::Tab), None);
+        assert_eq!(action, Some(Action::AttachSession(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn tab_still_enters_live_send_when_default_is_tmux() {
+        // With the historical Tmux default, Enter still attaches and
+        // Tab keeps its historical live-send role.
+        let mut env = create_test_env_empty();
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        let action = env.view.handle_key(key(KeyCode::Tab), None);
+        assert_eq!(action, Some(Action::EnterLiveSend(id)));
+    }
+
+    #[test]
+    #[serial]
+    fn tab_in_terminal_view_swaps_to_attach_terminal_when_default_is_live_send() {
+        // Terminal-view counterpart of the swap: with Enter pinned to
+        // live-send, Tab in Terminal view attaches the paired terminal
+        // pane rather than the agent pane.
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Terminal;
+        let action = env.view.handle_key(key(KeyCode::Tab), None);
+        assert!(
+            matches!(&action, Some(Action::AttachTerminal(returned_id, _)) if returned_id == &id),
+            "Tab in Terminal view with LiveSend default must AttachTerminal, got {:?}",
+            action
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn m_in_terminal_view_targets_terminal_pane() {
+        // The 'm' bug from #1554: pressing 'm' from Terminal view used
+        // to open a compose dialog that targeted the agent pane,
+        // sending commands meant for the shell into the agent's input
+        // box. The fix: `pending_send_target` reflects view_mode at
+        // dialog open time so `execute_send_message` routes to the
+        // paired terminal pane.
+        let mut env = create_test_env_empty();
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Terminal;
+        let _ = env.view.handle_key(key(KeyCode::Char('m')), None);
+        assert!(
+            env.view.send_message_dialog.is_some(),
+            "Terminal view 'm' must open the compose dialog even when \
+             the paired tmux pane hasn't spawned yet"
+        );
+        assert_eq!(
+            env.view.pending_send_target,
+            crate::tui::home::live_send::LiveSendTarget::Terminal,
+            "compose dialog opened from Terminal view must target the terminal pane"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn start_live_send_in_terminal_view_targets_terminal_pane() {
+        // Direct check on the live-send target resolution: in Terminal
+        // view, `start_live_send` stages the host terminal as the
+        // pending target so `prepare_live_send` will dispatch
+        // keystrokes to the paired terminal tmux pane.
+        let mut env = create_test_env_empty();
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        env.view.view_mode = crate::tui::home::ViewMode::Terminal;
+        let _ = env.view.start_live_send();
+        assert_eq!(
+            env.view.pending_live_send_target,
+            crate::tui::home::live_send::LiveSendTarget::Terminal
         );
     }
 


### PR DESCRIPTION
## Description

In Terminal view, pressing `m` opened a compose dialog targeted at the agent pane, so commands typed for the shell silently went to the agent's input. Tab/Enter also only entered live mode on the agent pane, leaving the terminal preview without any live-send affordance.

This PR generalizes the live-send dispatch path with a `LiveSendTarget` enum (`Agent` / `Terminal` / `ContainerTerminal`) and a `target` field on `LiveSendState`. The `m` compose dialog, Tab activation, and Enter activation all pick the target from `view_mode` at dispatch time, so each routes to the pane the user is previewing. The compose dialog title gains a `(terminal)` or `(container)` suffix when it isn't aimed at the agent.

Bonus per the issue: `default_attach_mode = LiveSend` now applies in Terminal view too, and Tab swaps to a full tmux attach when Enter is bound to live mode so the user always has both affordances on one keystroke.

Fixes #1554

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new behaviors are exercised by unit tests under `src/tui/home/tests.rs::default_attach_mode` (terminal-view Enter under both defaults, Tab swap under both defaults, Tab swap in Terminal view, `start_live_send` target selection, `m` in Terminal view setting `pending_send_target`). An e2e for live-send onto a real terminal pane is best added as a follow-up alongside the existing `live_send_*` e2e specs once we have a tmux fixture for the paired terminal session.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:** Implementation drafted by Claude through back-and-forth with @njbrake. The reasoning and decisions are his; the code structure and prose are Claude's. Hand-verified that the change preserves the historical Tmux/Agent defaults for users who haven't opted into LiveSend.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
Fixes Terminal view routing so compose (`m`), live mode entry, and Tab/Enter actions go to the pane the user is previewing (agent, host terminal, or container terminal). Terminal view now supports the same configurable live-send vs full-attach behavior as agent sessions, and the UI indicates which pane will receive input.

## What changed (high level)
- Compose/send routing: `m` opens the compose dialog targeted at the currently previewed pane; dialog title adds “(terminal)” or “(container)” when appropriate.
- Live-send target model: added LiveSendTarget (Agent / Terminal / ContainerTerminal) and stored the chosen target in LiveSendState so live-send dispatch is pinned to the intended pane.
- Key behavior: `Enter` in Terminal view honors `default_attach_mode` (can start live-send against terminals). When `default_attach_mode = LiveSend`, `Tab` is repurposed to perform a full tmux attach so both live-send and full-attach remain accessible via the same keystroke pair.
- Pane readiness & session resolution: send and live-send flows perform target-specific readiness checks and resolve tmux session names differently for agent vs terminal vs container-terminal.
- UI: status banner and compose dialog labels are formatted to show the selected target.
- Tests: unit tests updated/expanded (including Terminal view `default_attach_mode` behavior); e2e live-send test deferred until a tmux fixture exists.

## Benefits
- Consistency: identical live-send/attach semantics across Agent and Terminal views.
- Clarity: UI clearly indicates which pane will receive composed input or live-send.
- Usability: users get predictable behavior based on `default_attach_mode` while still having quick access to full-attach via `Tab`.
- Flexibility: explicit support for host and container-backed terminal panes.

## Technical details (concise / optional)
- New enum live_send::LiveSendTarget { Agent, Terminal, ContainerTerminal } and LiveSendState.target; helper format_target_label(title, target).
- HomeView adds pending_send_target and pending_live_send_target; input handling resolves (id, title, target) at dispatch via resolve_send_target().
- execute_send_message and prepare_live_send refactored to consume pending targets, run target-specific readiness logic, and derive tmux session targets per chosen target.
- When staging live-send, state includes the selected target so drift checks and session-name lookups use the right pane.
- Small render change: status bar uses formatted title with target suffix.
- Tests updated to initialize LiveSendState target, assert label differences for Agent/Terminal/ContainerTerminal, and cover Tab/Enter behavior in Terminal view.

Fixes issue `#1554`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->