### PR TITLE
fix(tui): show correct Enter/Tab labels in help overlay

### DIFF
--- a/src/tui/components/help.rs
+++ b/src/tui/components/help.rs
@@ -30,7 +30,15 @@ const SMALL_VIEWPORT_WIDTH: u16 = 40;
 /// Same idea for height: drop top/bottom margin below this.
 const SMALL_VIEWPORT_HEIGHT: u16 = 16;
 
-fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+fn shortcuts(
+    strict: bool,
+    live_on_enter: bool,
+) -> Vec<(&'static str, Vec<(&'static str, &'static str)>)> {
+    let (enter_desc, tab_desc) = if live_on_enter {
+        ("Live mode (send keys to agent)", "Attach to tmux session")
+    } else {
+        ("Attach to tmux session", "Live mode (send keys to agent)")
+    };
     if strict {
         vec![
             (
@@ -47,7 +55,8 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
             (
                 "Actions (strict mode)",
                 vec![
-                    ("Enter", "Attach to session"),
+                    ("Enter", enter_desc),
+                    ("Tab", tab_desc),
                     ("Ctrl+T", "Attach to terminal"),
                     (";", "Open tool session"),
                     ("N", "New session"),
@@ -115,7 +124,8 @@ fn shortcuts(strict: bool) -> Vec<(&'static str, Vec<(&'static str, &'static str
             (
                 "Actions",
                 vec![
-                    ("Enter", "Attach to session"),
+                    ("Enter", enter_desc),
+                    ("Tab", tab_desc),
                     ("T", "Attach to terminal"),
                     (";", "Open tool session"),
                     ("n", "New session"),
@@ -176,8 +186,8 @@ struct HelpSection {
     rows: Vec<(String, String)>,
 }
 
-fn build_sections(strict: bool, sort_order: SortOrder) -> Vec<HelpSection> {
-    let raw = shortcuts(strict);
+fn build_sections(strict: bool, sort_order: SortOrder, live_on_enter: bool) -> Vec<HelpSection> {
+    let raw = shortcuts(strict, live_on_enter);
     let sort_label = format!("(current sort: {})", sort_order.label());
     raw.into_iter()
         .map(|(title, keys)| {
@@ -339,6 +349,7 @@ impl HelpOverlay {
         theme: &Theme,
         sort_order: SortOrder,
         strict_hotkeys: bool,
+        live_on_enter: bool,
         scroll: &mut u16,
     ) {
         if area.width == 0 || area.height == 0 {
@@ -347,7 +358,7 @@ impl HelpOverlay {
         let dialog_area = compute_dialog_area(area);
         frame.render_widget(Clear, dialog_area);
 
-        let sections = build_sections(strict_hotkeys, sort_order);
+        let sections = build_sections(strict_hotkeys, sort_order, live_on_enter);
 
         let version = format!(" Agent of Empires v{} ", env!("CARGO_PKG_VERSION"));
         let block = Block::default()
@@ -433,7 +444,7 @@ mod tests {
     #[test]
     fn help_contains_resize_shortcut() {
         for strict in [false, true] {
-            let all = shortcuts(strict);
+            let all = shortcuts(strict, false);
             let views_section = all.iter().find(|(name, _)| *name == "Views");
             assert!(views_section.is_some(), "Views section should exist");
             let (_, keys) = views_section.unwrap();
@@ -450,7 +461,7 @@ mod tests {
         // non-strict) but did not advertise it in the help overlay. Lock the
         // listing in so a future binding rename keeps the docs honest.
         for (strict, expected_key) in [(false, "h"), (true, "H")] {
-            let all = shortcuts(strict);
+            let all = shortcuts(strict, false);
             let attention = all
                 .iter()
                 .find(|(name, _)| name.starts_with("Attention"))
@@ -470,7 +481,7 @@ mod tests {
         // so users see them together instead of scattered across Navigation
         // and Actions.
         for strict in [false, true] {
-            let all = shortcuts(strict);
+            let all = shortcuts(strict, false);
             let attention = all
                 .iter()
                 .find(|(name, _)| name.starts_with("Attention"))
@@ -502,7 +513,7 @@ mod tests {
         // Asserts both keymaps surface the Ctrl+K command palette entry in
         // their "Other" section so users can discover the palette from `?`.
         for strict in [false, true] {
-            let all = shortcuts(strict);
+            let all = shortcuts(strict, false);
             let other = all
                 .iter()
                 .find(|(name, _)| *name == "Other")
@@ -513,6 +524,55 @@ mod tests {
                     .any(|(k, desc)| *k == "Ctrl+K" && desc.contains("Command palette")),
                 "Other section should contain Ctrl+K Command palette (strict={strict})"
             );
+        }
+    }
+
+    #[test]
+    fn enter_and_tab_swap_descriptions_with_default_attach_mode() {
+        // Enter and Tab are complements: whichever Enter doesn't do,
+        // Tab does. The help overlay has to reflect the user's current
+        // `default_attach_mode` so the two rows aren't lying.
+        for strict in [false, true] {
+            for live_on_enter in [false, true] {
+                let all = shortcuts(strict, live_on_enter);
+                let actions_name = if strict {
+                    "Actions (strict mode)"
+                } else {
+                    "Actions"
+                };
+                let (_, keys) = all
+                    .iter()
+                    .find(|(n, _)| *n == actions_name)
+                    .expect("Actions section should exist");
+                let enter = keys
+                    .iter()
+                    .find(|(k, _)| *k == "Enter")
+                    .expect("Enter entry");
+                let tab = keys.iter().find(|(k, _)| *k == "Tab").expect("Tab entry");
+                if live_on_enter {
+                    assert!(
+                        enter.1.contains("Live mode"),
+                        "live_on_enter=true → Enter should say Live mode, got {:?}",
+                        enter.1
+                    );
+                    assert!(
+                        tab.1.contains("tmux"),
+                        "live_on_enter=true → Tab should say tmux, got {:?}",
+                        tab.1
+                    );
+                } else {
+                    assert!(
+                        enter.1.contains("tmux"),
+                        "live_on_enter=false → Enter should say tmux, got {:?}",
+                        enter.1
+                    );
+                    assert!(
+                        tab.1.contains("Live mode"),
+                        "live_on_enter=false → Tab should say Live mode, got {:?}",
+                        tab.1
+                    );
+                }
+            }
         }
     }
 
@@ -572,7 +632,7 @@ mod tests {
         // Sanity check: the chosen 4 → 3 split keeps max column height
         // below the naive [1, 3, 0] alternative that would happen if we
         // pushed all extras to one column.
-        let sections = build_sections(false, SortOrder::Newest);
+        let sections = build_sections(false, SortOrder::Newest, false);
         let heights: Vec<usize> = sections.iter().map(section_height).collect();
         let cols = distribute_sections(sections.len(), 3);
         let max_h = cols
@@ -600,7 +660,7 @@ mod tests {
         terminal
             .draw(|frame| {
                 let area = frame.area();
-                HelpOverlay::render(frame, area, &theme, SortOrder::Newest, false, scroll);
+                HelpOverlay::render(frame, area, &theme, SortOrder::Newest, false, false, scroll);
             })
             .unwrap();
         terminal.backend().buffer().clone()

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -343,6 +343,11 @@ pub struct HomeView {
     /// the render layer reads this rather than re-resolving the config on
     /// every paint.
     pub(super) row_tag_mode: crate::session::config::RowTagMode,
+    /// Active profile's `default_attach_mode`, cached at construction and
+    /// refreshed by `refresh_from_config` / `switch_profile`. The help
+    /// overlay falls back to this when no session row is selected so the
+    /// render path never touches disk for the Enter/Tab labels.
+    pub(super) profile_default_attach_mode: crate::session::NewSessionAttachMode,
     /// Collapsed state for project-mode groups (persists across rebuilds)
     pub(super) project_group_collapsed: HashMap<String, bool>,
 
@@ -714,6 +719,7 @@ impl HomeView {
             sort_order,
             group_by,
             row_tag_mode: resolved.session.row_tag,
+            profile_default_attach_mode: resolved.session.default_attach_mode,
             project_group_collapsed: HashMap::new(),
             show_help: false,
             help_scroll: 0,
@@ -3482,23 +3488,19 @@ impl HomeView {
             .map(|s| s.default_attach_mode)
     }
 
-    /// True when Enter on the current row would enter live-send mode
-    /// (and Tab would swap to a tmux attach). Prefers the selected
-    /// session's resolved config so per-profile overrides are honored;
-    /// otherwise falls back to the active profile's config so an empty
-    /// list still describes what would happen on the next create. Drives
-    /// the Enter/Tab labels in the help overlay.
-    pub(super) fn help_live_on_enter(&self) -> bool {
-        if let Some(id) = self.selected_session.as_deref() {
-            if let Some(mode) = self.default_attach_mode(id) {
-                return matches!(mode, crate::session::NewSessionAttachMode::LiveSend);
-            }
-        }
-        let cfg = crate::session::resolve_config_or_warn(&self.config_profile());
-        matches!(
-            cfg.session.default_attach_mode,
+    /// True when Enter on the *currently selected session row* would
+    /// enter live-send mode (and Tab would swap to a tmux attach).
+    /// Returns `None` when the cursor is not on a session row (group or
+    /// nothing selected) so the help overlay can fall back to a stable
+    /// default rather than mislabel keys that don't apply. Honors per-
+    /// profile overrides via `default_attach_mode(id)`.
+    pub(super) fn help_live_on_enter(&self) -> Option<bool> {
+        let id = self.selected_session.as_deref()?;
+        let mode = self.default_attach_mode(id)?;
+        Some(matches!(
+            mode,
             crate::session::NewSessionAttachMode::LiveSend
-        )
+        ))
     }
 
     /// Pin selection to `session_id` and place the cursor on its row.
@@ -3568,6 +3570,7 @@ impl HomeView {
         self.refresh_status_hook_config_cache();
         self.strict_hotkeys = config.session.strict_hotkeys;
         self.row_tag_mode = config.session.row_tag;
+        self.profile_default_attach_mode = config.session.default_attach_mode;
         self.idle_decay_window =
             crate::tui::styles::idle_decay_window(config.theme.idle_decay_minutes);
         self.tool_configs = config.tools;

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -3482,6 +3482,25 @@ impl HomeView {
             .map(|s| s.default_attach_mode)
     }
 
+    /// True when Enter on the current row would enter live-send mode
+    /// (and Tab would swap to a tmux attach). Prefers the selected
+    /// session's resolved config so per-profile overrides are honored;
+    /// otherwise falls back to the active profile's config so an empty
+    /// list still describes what would happen on the next create. Drives
+    /// the Enter/Tab labels in the help overlay.
+    pub(super) fn help_live_on_enter(&self) -> bool {
+        if let Some(id) = self.selected_session.as_deref() {
+            if let Some(mode) = self.default_attach_mode(id) {
+                return matches!(mode, crate::session::NewSessionAttachMode::LiveSend);
+            }
+        }
+        let cfg = crate::session::resolve_config_or_warn(&self.config_profile());
+        matches!(
+            cfg.session.default_attach_mode,
+            crate::session::NewSessionAttachMode::LiveSend
+        )
+    }
+
     /// Pin selection to `session_id` and place the cursor on its row.
     /// If the containing group is collapsed (manual grouping or
     /// project grouping), it's force-expanded and `flat_items` is

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -530,12 +530,14 @@ impl HomeView {
 
         // Render dialogs on top
         if self.show_help {
+            let live_on_enter = self.help_live_on_enter();
             HelpOverlay::render(
                 frame,
                 area,
                 theme,
                 self.sort_order,
                 self.strict_hotkeys,
+                live_on_enter,
                 &mut self.help_scroll,
             );
         }

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -530,7 +530,10 @@ impl HomeView {
 
         // Render dialogs on top
         if self.show_help {
-            let live_on_enter = self.help_live_on_enter();
+            let live_on_enter = self.help_live_on_enter().unwrap_or(matches!(
+                self.profile_default_attach_mode,
+                crate::session::NewSessionAttachMode::LiveSend
+            ));
             HelpOverlay::render(
                 frame,
                 area,

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -7715,6 +7715,71 @@ mod default_attach_mode {
         );
     }
 
+    #[test]
+    #[serial]
+    fn help_live_on_enter_returns_none_when_no_session_selected() {
+        // Cursor parked off any session row: the help overlay shouldn't
+        // claim a session-attach behavior, so `help_live_on_enter`
+        // signals "no row" with None and the render path falls back to
+        // the cached profile default.
+        let env = create_test_env_empty();
+        assert!(
+            env.view.selected_session.is_none(),
+            "fresh empty view should have no session selected"
+        );
+        assert_eq!(env.view.help_live_on_enter(), None);
+    }
+
+    #[test]
+    #[serial]
+    fn help_live_on_enter_returns_some_for_selected_session() {
+        // With the historical Tmux default, a selected session row maps
+        // to Some(false): Enter goes to tmux attach, Tab to live mode.
+        let mut env = create_test_env_empty();
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        assert_eq!(env.view.help_live_on_enter(), Some(false));
+    }
+
+    #[test]
+    #[serial]
+    fn help_live_on_enter_reflects_live_send_setting() {
+        // Flipping the user's default to LiveSend must propagate to
+        // help_live_on_enter so the help overlay relabels Enter as
+        // live mode and Tab as tmux attach.
+        let mut env = create_test_env_empty();
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        let _id = add_session(&mut env.view, "session-one");
+        env.view.flat_items = env.view.build_flat_items();
+        env.view.cursor = 0;
+        env.view.update_selected();
+        assert_eq!(env.view.help_live_on_enter(), Some(true));
+    }
+
+    #[test]
+    #[serial]
+    fn profile_default_attach_mode_cache_refreshes_with_config() {
+        // The render path falls back to `profile_default_attach_mode`
+        // when no session is selected, so it has to track the saved
+        // config without re-reading from disk per paint. Saving a new
+        // mode + calling `refresh_from_config` must update the cache.
+        let mut env = create_test_env_empty();
+        assert_eq!(
+            env.view.profile_default_attach_mode,
+            NewSessionAttachMode::Tmux,
+            "cache should initialize to the historical Tmux default"
+        );
+        write_global_default_attach_mode(NewSessionAttachMode::LiveSend);
+        env.view.refresh_from_config();
+        assert_eq!(
+            env.view.profile_default_attach_mode,
+            NewSessionAttachMode::LiveSend,
+            "refresh_from_config must pick up the saved LiveSend default"
+        );
+    }
+
     /// Cockpit sessions short-circuit before the setting is consulted
     /// (the cockpit branch in `activate_selected_session` returns
     /// `OpenCockpit`/transient-status before we get to the view-mode


### PR DESCRIPTION
## Description

The `?` help popup advertised `Enter` as "Attach to session" regardless of the user's `default_attach_mode` setting, and didn't mention `Tab` at all. With `default_attach_mode = LiveSend` the Enter label is wrong, and either way there's no in-help discovery for which key opens live mode vs attaches to the tmux session.

This resolves the selected row's effective `default_attach_mode` (falling back to the active profile's global config when nothing is selected) and uses it to drive the Enter/Tab labels:

- Default (`Tmux`): `Enter` = "Attach to tmux session", `Tab` = "Live mode (send keys to agent)"
- `LiveSend`: the two swap

So the help overlay now matches the actual `Tab`/`Enter` swap behavior in `home/input.rs`.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the affected logic is the label content in the help overlay, which is exercised by a new unit test (`enter_and_tab_swap_descriptions_with_default_attach_mode`) in `src/tui/components/help.rs`. An e2e test would have to pop the help overlay and assert on rendered characters, which the existing buffer-render tests already cover at a lower cost.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (via Claude Code) drafted the patch from a back-and-forth with @njbrake; reasoning and decisions are his.

- [ ] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR fixes incorrect Enter/Tab labels in the TUI help overlay so the help text matches the actual Enter/Tab behavior driven by the user's attach-mode configuration.

## What Changed

- The help overlay is now aware of the effective attach-mode and updates Enter/Tab labels accordingly.
- Home view caches the active profile's `default_attach_mode` and exposes `help_live_on_enter()` to determine whether Enter triggers live-send for the currently selected session (returns None if no session is selected).
- `HomeView::render` computes a `live_on_enter` bool (falling back to the cached profile default when needed) and passes it to the help renderer.
- `HelpOverlay::render` and the help-section/shortcut-building functions were updated to accept a `live_on_enter` parameter and conditionally swap the Enter/Tab descriptions.
- Tests were updated; a new unit test `enter_and_tab_swap_descriptions_with_default_attach_mode` verifies the labels swap correctly. Existing tests and rendering harness updated to the new signatures.
- Avoids per-frame disk/TOML reads by caching the profile default attach mode on HomeView and refreshing it via existing config refresh/switch paths.

## Benefits
- Help overlay labels now reflect actual behavior, improving discoverability and avoiding confusing/misleading help text.
- Respects selected-session overrides and profile-level configuration.
- Adds test coverage to prevent regressions.

## Technical details (concise)
- Resolution chain: selected session's attach-mode → active profile's `default_attach_mode` (cached on HomeView).
- Label mapping:
  - Default (Tmux): Enter = "Attach to tmux session"; Tab = "Live mode (send keys to agent)"
  - LiveSend: Enter/Tab descriptions are swapped
- Public API change: `HelpOverlay::render` gained an extra `live_on_enter: bool` parameter; `HomeView` gained `profile_default_attach_mode` field and `help_live_on_enter()` helper.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1567?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->