### PR TITLE
fix(tui): size preview pane around info panel + add i toggle to Terminal/Tool views

### DIFF
--- a/src/tui/components/preview.rs
+++ b/src/tui/components/preview.rs
@@ -37,10 +37,13 @@ impl<'a> CachedPreview<'a> {
 /// Exposed at the module level so callers outside `Preview::render_with_cache`
 /// can compute the same split. In particular, the live-send sync resize
 /// in `HomeView::finalize_live_send_resize` needs to size the tmux pane
-/// to the OUTPUT portion (inner minus this header), not the full inner.
-/// If the agent renders into the full inner while the output portion is
-/// shorter by `agent_info_height` rows, the top of the agent's output
-/// gets clipped on every frame and the user sees content shifted up.
+/// to the OUTPUT portion, not the full inner. The output portion is
+/// `inner.height - agent_info_height(inst) - 1`: subtract the info
+/// header, then subtract one more row for the inner ` Output ` banner
+/// that `render_output_cached` draws on top of the output sub-rect (a
+/// `Borders::TOP` block consumes one row). If the agent renders into a
+/// taller pane than the visible output area, the top of its output gets
+/// clipped on every frame and the user sees content shifted up.
 pub fn agent_info_height(instance: &Instance) -> u16 {
     let base: u16 = 3; // profile+tool / path / status
     let sandbox_lines: u16 = if instance.is_sandboxed() { 1 } else { 0 };
@@ -51,6 +54,24 @@ pub fn agent_info_height(instance: &Instance) -> u16 {
     } else {
         base + sandbox_lines
     }
+}
+
+/// Row count of the Terminal-view (and Tool-view) info header
+/// (title / path / status, plus one optional sandbox row) for
+/// `instance`.
+///
+/// Symmetric with [`agent_info_height`]: the live-send sync resize
+/// against a terminal target needs the OUTPUT portion of the preview
+/// pane, which is `inner.height - terminal_info_height(inst) - 1`
+/// (info header + one row for the inner ` Terminal Output ` banner).
+pub fn terminal_info_height(instance: &Instance) -> u16 {
+    let base: u16 = 3; // title / path / status
+    let sandbox_lines: u16 = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
+        1
+    } else {
+        0
+    };
+    base + sandbox_lines
 }
 
 pub struct Preview;
@@ -66,18 +87,17 @@ impl Preview {
         scroll_offset: u16,
         theme: &Theme,
         compact: bool,
+        show_info: bool,
     ) {
         // Compact mode (narrow viewports) skips the info header entirely:
         // the outer block title already carries the session name + status,
-        // and on a phone every row of vertical space matters.
-        let output_area = if compact {
-            area
-        } else {
-            let info_height = if instance.sandbox_info.as_ref().is_some_and(|s| s.enabled) {
-                4 // title + path + status + sandbox
-            } else {
-                3 // title + path + status
-            };
+        // and on a phone every row of vertical space matters. The user
+        // toggle `show_info` collapses the same chrome on a normal-width
+        // viewport so the output area can claim the rows the header would
+        // have taken. Symmetric with `render_with_cache` in the Agent view.
+        let render_info_section = !compact && show_info;
+        let output_area = if render_info_section {
+            let info_height = terminal_info_height(instance);
             let chunks = Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
@@ -126,6 +146,8 @@ impl Preview {
             let paragraph = Paragraph::new(info_lines);
             frame.render_widget(paragraph, chunks[0]);
             chunks[1]
+        } else {
+            area
         };
 
         // Output section
@@ -140,11 +162,13 @@ impl Preview {
         };
         let line_count = parsed_output.map_or(0, |t| t.lines.len());
 
-        // Compact mode: no inner separator/title; the outer block already
-        // names the session. Scroll indicator is dropped to save a row.
-        let inner = if compact {
-            output_area
-        } else {
+        // Inner ` Terminal Output ` banner is paired with the info
+        // section: when the info section is hidden (compact or the user
+        // toggled it off), the outer block title already names the view
+        // and the scroll indicator is hoisted to that outer title by the
+        // caller, so we drop the inner banner here too. Drops one row of
+        // chrome and frees it for output.
+        let inner = if render_info_section {
             let mut block = Block::default()
                 .borders(Borders::TOP)
                 .border_style(Style::default().fg(theme.border))
@@ -162,6 +186,8 @@ impl Preview {
             let inner = block.inner(output_area);
             frame.render_widget(block, output_area);
             inner
+        } else {
+            output_area
         };
 
         if !terminal_running {
@@ -673,6 +699,64 @@ mod tests {
             sandbox.enabled = false;
             inst.sandbox_info = Some(sandbox);
             assert_eq!(agent_info_height(&inst), 3);
+        }
+    }
+
+    // Terminal-view counterpart of `agent_info_height`. Same drift-guard
+    // motivation: the live-send sync resize against a terminal target
+    // sizes the tmux pane to `inner - terminal_info_height - 1`. A wrong
+    // formula here brings the shifted-preview bug back in Terminal view.
+    mod terminal_info_height {
+        use super::super::terminal_info_height;
+        use crate::session::{Instance, SandboxInfo, WorktreeInfo};
+        use chrono::Utc;
+
+        fn enabled_sandbox() -> SandboxInfo {
+            SandboxInfo {
+                enabled: true,
+                container_id: None,
+                image: "img".into(),
+                container_name: "ctr".into(),
+                extra_env: None,
+                custom_instruction: None,
+            }
+        }
+
+        #[test]
+        fn plain_session_is_three_rows() {
+            let inst = Instance::new("plain", "/tmp/plain");
+            assert_eq!(terminal_info_height(&inst), 3);
+        }
+
+        #[test]
+        fn sandboxed_adds_one_row() {
+            let mut inst = Instance::new("sandboxed", "/tmp/sandboxed");
+            inst.sandbox_info = Some(enabled_sandbox());
+            assert_eq!(terminal_info_height(&inst), 4);
+        }
+
+        #[test]
+        fn disabled_sandbox_does_not_count() {
+            let mut inst = Instance::new("disabled", "/tmp/disabled");
+            let mut sandbox = enabled_sandbox();
+            sandbox.enabled = false;
+            inst.sandbox_info = Some(sandbox);
+            assert_eq!(terminal_info_height(&inst), 3);
+        }
+
+        #[test]
+        fn worktree_info_does_not_count() {
+            // Worktree info is an Agent-view-only block; the terminal
+            // view doesn't render it, so the height stays at 3.
+            let mut inst = Instance::new("wt", "/tmp/wt");
+            inst.worktree_info = Some(WorktreeInfo {
+                branch: "feature/x".into(),
+                main_repo_path: "/repo".into(),
+                managed_by_aoe: true,
+                created_at: Utc::now(),
+                base_branch: Some("main".into()),
+            });
+            assert_eq!(terminal_info_height(&inst), 3);
         }
     }
 }

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -2748,12 +2748,16 @@ impl HomeView {
     /// for why the two are split.
     ///
     /// `preview_pane_area` is the cached OUTPUT sub-rect: the full inner
-    /// (after border + padding) minus the Agent-view info header when the
-    /// user has it expanded. Sizing to the full inner instead would leave
-    /// the top `info_height` rows of the agent's output outside the
-    /// visible window; tail-clip semantics in the preview's `Paragraph`
-    /// render then drop those rows on every frame, which the user
-    /// perceives as content shifted up.
+    /// (after border + padding) minus the info header AND minus the
+    /// inner ` Output ` / ` Terminal Output ` banner row when the user
+    /// has the header expanded. Sizing to the full inner instead would
+    /// leave the top `info_height + 1` rows of the agent's output
+    /// outside the visible window; tail-clip semantics in the preview's
+    /// `Paragraph` render then drop those rows on every frame, which
+    /// the user perceives as content shifted up. The math is shared
+    /// with the per-frame resize in `refresh_preview_cache_if_needed`
+    /// and friends; the helper that computes it lives in
+    /// `tui::home::render::split_off_info_section`.
     pub fn finalize_live_send_resize(&mut self) {
         let Some(state) = self.live_send.as_ref() else {
             return;

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -62,6 +62,33 @@ fn compose_list_title(
 /// requested scroll.
 const CAPTURE_BUFFER: u16 = 20;
 
+/// Shrink `inner` to the OUTPUT sub-rect that sits below the info
+/// header AND below the inner ` Output ` / ` Terminal Output ` banner.
+///
+/// `info_height` is the row count of the rendered info header
+/// (computed by `preview::agent_info_height` for Agent view or
+/// `preview::terminal_info_height` for Terminal/Tool view). The
+/// banner is a single `Borders::TOP` row above the agent's actual
+/// output, so the OUTPUT pane is `info_height + 1` rows shorter than
+/// `inner`, not `info_height` as a naive split would suggest.
+///
+/// This matches what `render_with_cache` / `render_terminal_preview`
+/// actually paint into; live-send sizes the tmux pane to the returned
+/// rect so the agent's content lands pixel-aligned with the visible
+/// Paragraph instead of bleeding off the bottom row.
+fn split_off_info_section(inner: Rect, info_height: u16) -> Rect {
+    // `+ 1` for the inner banner row. Clamp so a tiny pane (smaller
+    // than the chrome it would draw) returns a zero-height rect rather
+    // than wrapping past zero.
+    let chrome = info_height.saturating_add(1).min(inner.height);
+    Rect {
+        x: inner.x,
+        y: inner.y + chrome,
+        width: inner.width,
+        height: inner.height - chrome,
+    }
+}
+
 /// Trim `text` to fit within `max_width` display cells, appending '…'
 /// if anything was dropped. Used by the live-send banners so a long
 /// session title never pushes the exit-chord hint off-screen on a
@@ -1233,6 +1260,16 @@ impl HomeView {
         // vs. tmux writing bytes straight into your terminal.
         const PREVIEW_REFRESH_MS_IDLE: u128 = 250;
         let in_live = self.live_send.is_some();
+        // The per-frame resize only fires when live-send's target IS
+        // the agent pane this refresh is named after. Without the
+        // target gate, viewing Agent view while live-on-Terminal would
+        // resize the *terminal* pane (the worker is bound to it) to
+        // Agent-view dimensions, mis-fitting the shell that the user
+        // is actually typing into.
+        let resize_target_matches = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::Agent));
 
         // While in live-send mode, keep the tmux pane geometry in sync
         // with the preview's actual cell dimensions so the agent
@@ -1240,7 +1277,7 @@ impl HomeView {
         // UI). Deduped against live_send_last_resize so we only fire
         // when the user first enters live mode or the preview pane is
         // resized (terminal resize, divider drag, layout flip).
-        if in_live && width > 0 && height > 0 {
+        if resize_target_matches && width > 0 && height > 0 {
             let next = (width, height);
             if self.live_send_last_resize != Some(next) {
                 if let Some(worker) = &self.live_send_worker {
@@ -1351,6 +1388,25 @@ impl HomeView {
     fn refresh_terminal_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250;
 
+        // Symmetric with `refresh_preview_cache_if_needed`: when live-send
+        // is pointed at the host-terminal pane, keep the tmux pane sized
+        // to the visible output area on every render so a window resize
+        // or info-header toggle reflows the shell instead of waiting for
+        // the user to re-enter live mode.
+        let resize_target_matches = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::Terminal));
+        if resize_target_matches && width > 0 && height > 0 {
+            let next = (width, height);
+            if self.live_send_last_resize != Some(next) {
+                if let Some(worker) = &self.live_send_worker {
+                    worker.resize(width, height);
+                }
+                self.live_send_last_resize = Some(next);
+            }
+        }
+
         let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
             Some(id) => {
@@ -1398,6 +1454,24 @@ impl HomeView {
     /// Refresh container terminal preview cache if needed
     fn refresh_container_terminal_preview_cache_if_needed(&mut self, width: u16, height: u16) {
         const PREVIEW_REFRESH_MS: u128 = 250;
+
+        // Symmetric with `refresh_preview_cache_if_needed`: when
+        // live-send is pointed at the in-container shell, keep the
+        // tmux pane sized to the visible output area so a window
+        // resize or info-header toggle reflows immediately.
+        let resize_target_matches = self
+            .live_send
+            .as_ref()
+            .is_some_and(|s| matches!(s.target, live_send::LiveSendTarget::ContainerTerminal));
+        if resize_target_matches && width > 0 && height > 0 {
+            let next = (width, height);
+            if self.live_send_last_resize != Some(next) {
+                if let Some(worker) = &self.live_send_worker {
+                    worker.resize(width, height);
+                }
+                self.live_send_last_resize = Some(next);
+            }
+        }
 
         let scroll_offset = self.preview_scroll_offset;
         let needs_refresh = match &self.selected_session {
@@ -1566,44 +1640,66 @@ impl HomeView {
                 .title(title)
                 .title_style(Style::default().fg(title_color));
 
-            // Advertise the info-header toggle. Only meaningful in Agent view
-            // (Terminal/Tool views have their own minimal header that isn't
-            // bound to `show_preview_info`), and the compact branch above
-            // already owns the title slot.
-            if matches!(self.view_mode, ViewMode::Agent) {
-                let key = if self.strict_hotkeys { "I" } else { "i" };
-                let hint_text = if self.show_preview_info {
-                    format!(" hide info with {key} ")
-                } else {
-                    format!(" show info with {key} ")
-                };
-                let hint_style = Style::default().fg(theme.dimmed).italic();
+            // Advertise the info-header toggle. The `i` key toggles
+            // `show_preview_info`, which gates the info header in every
+            // view mode now (Agent uses the worktree-flavored header,
+            // Terminal/Tool use the minimal header in `render_terminal_preview`),
+            // so the hint applies everywhere except the compact branch
+            // above, where the outer title is already taken.
+            let key = if self.strict_hotkeys { "I" } else { "i" };
+            let hint_text = if self.show_preview_info {
+                format!(" hide info with {key} ")
+            } else {
+                format!(" show info with {key} ")
+            };
+            let hint_style = Style::default().fg(theme.dimmed).italic();
 
-                // When the info section is hidden, the inner " Output " banner
-                // (which usually carries the scroll indicator) is also gone.
-                // Surface the indicator here so users still see how far back
-                // they've scrolled. With borders::ALL the inner is area - 2;
-                // render_output_cached then drops one more row before painting
-                // (its compact branch uses height-1 for visible_height), so we
-                // match that to keep the count stable as the user scrolls.
-                let scroll_indicator = if !self.show_preview_info {
-                    let inner_height = area.height.saturating_sub(2);
-                    let visible_height = inner_height.saturating_sub(1) as usize;
-                    format_scroll_indicator(
-                        self.preview_cache.captured_lines,
-                        visible_height,
-                        self.preview_scroll_offset,
-                    )
-                } else {
-                    None
+            // When the info section is hidden, the inner ` Output ` /
+            // ` Terminal Output ` banner (which usually carries the
+            // scroll indicator) is also gone. Surface the indicator
+            // here so users still see how far back they've scrolled.
+            // With borders::ALL the inner is area - 2; render_output_cached
+            // / render_terminal_preview then drops one more row before
+            // painting (their compact / info-hidden branches use
+            // height-1 for visible_height), so we match that to keep the
+            // count stable as the user scrolls.
+            let scroll_indicator = if !self.show_preview_info {
+                let inner_height = area.height.saturating_sub(2);
+                let visible_height = inner_height.saturating_sub(1) as usize;
+                let captured_lines = match &self.view_mode {
+                    ViewMode::Agent => self.preview_cache.captured_lines,
+                    ViewMode::Tool(_) => self.tool_preview_cache.captured_lines,
+                    ViewMode::Terminal => {
+                        let mode = self
+                            .selected_session
+                            .as_ref()
+                            .and_then(|id| self.get_instance(id).map(|inst| (id, inst)))
+                            .map(|(id, inst)| {
+                                if inst.is_sandboxed() {
+                                    self.get_terminal_mode(id)
+                                } else {
+                                    TerminalMode::Host
+                                }
+                            })
+                            .unwrap_or(TerminalMode::Host);
+                        match mode {
+                            TerminalMode::Container => {
+                                self.container_terminal_preview_cache.captured_lines
+                            }
+                            TerminalMode::Host => self.terminal_preview_cache.captured_lines,
+                        }
+                    }
                 };
+                format_scroll_indicator(captured_lines, visible_height, self.preview_scroll_offset)
+            } else {
+                None
+            };
 
-                let mut hint_spans = vec![Span::styled(hint_text, hint_style)];
-                if let Some(ind) = scroll_indicator {
-                    hint_spans.push(Span::styled(ind, hint_style));
-                }
-                block = block.title_top(Line::from(hint_spans).right_aligned());
+            let mut hint_spans = vec![Span::styled(hint_text, hint_style)];
+            if let Some(ind) = scroll_indicator {
+                hint_spans.push(Span::styled(ind, hint_style));
             }
+            block = block.title_top(Line::from(hint_spans).right_aligned());
         }
 
         let inner = block.inner(area);
@@ -1643,6 +1739,14 @@ impl HomeView {
                     // leaves the top `info_height` rows of the agent's
                     // pane outside the displayed window, where they get
                     // tail-clipped on every frame.
+                    //
+                    // After the info header, `render_output_cached` wraps
+                    // the output in a `Borders::TOP` block (the ` Output `
+                    // banner) which consumes one more row from the top.
+                    // The pane therefore shrinks by `info_h + 1` rows so
+                    // the tmux pane matches the visible Paragraph area
+                    // exactly; off by one and the agent's content scrolls
+                    // up by a row on every frame.
                     let pane_area = if compact || !self.show_preview_info {
                         inner
                     } else {
@@ -1650,13 +1754,7 @@ impl HomeView {
                             .as_ref()
                             .and_then(|id| self.get_instance(id))
                             .map(|inst| {
-                                let info_h = preview::agent_info_height(inst).min(inner.height);
-                                Rect {
-                                    x: inner.x,
-                                    y: inner.y + info_h,
-                                    width: inner.width,
-                                    height: inner.height - info_h,
-                                }
+                                split_off_info_section(inner, preview::agent_info_height(inst))
                             })
                             .unwrap_or(inner)
                     };
@@ -1708,6 +1806,26 @@ impl HomeView {
                         TerminalMode::Host
                     };
 
+                    // Compute the output sub-rect symmetric with Agent
+                    // view: when the info header is visible we strip the
+                    // header rows + one banner row off `inner`, so the
+                    // tmux pane resizes match what the user actually
+                    // sees. Without this, live-send against a terminal
+                    // pane sizes tmux to `inner.height` while only
+                    // `inner.height - info_h - 1` rows are visible, and
+                    // the top of the shell output gets clipped on every
+                    // frame.
+                    let pane_area = if compact || !self.show_preview_info {
+                        inner
+                    } else {
+                        self.get_instance(&id)
+                            .map(|inst| {
+                                split_off_info_section(inner, preview::terminal_info_height(inst))
+                            })
+                            .unwrap_or(inner)
+                    };
+                    self.preview_pane_area = pane_area;
+
                     // Refresh the appropriate cache, then warm the
                     // matching `parsed_text` so the render call below
                     // can read it via a shared borrow alongside
@@ -1715,15 +1833,15 @@ impl HomeView {
                     match terminal_mode {
                         TerminalMode::Container => {
                             self.refresh_container_terminal_preview_cache_if_needed(
-                                inner.width,
-                                inner.height,
+                                pane_area.width,
+                                pane_area.height,
                             );
                             self.container_terminal_preview_cache.ensure_parsed();
                         }
                         TerminalMode::Host => {
                             self.refresh_terminal_preview_cache_if_needed(
-                                inner.width,
-                                inner.height,
+                                pane_area.width,
+                                pane_area.height,
                             );
                             self.terminal_preview_cache.ensure_parsed();
                         }
@@ -1760,6 +1878,7 @@ impl HomeView {
                             self.preview_scroll_offset,
                             theme,
                             compact,
+                            self.show_preview_info,
                         );
                     }
                 } else {
@@ -1774,9 +1893,20 @@ impl HomeView {
                 let selected_id = self.selected_session.clone();
 
                 if let Some(id) = selected_id {
+                    let pane_area = if compact || !self.show_preview_info {
+                        inner
+                    } else {
+                        self.get_instance(&id)
+                            .map(|inst| {
+                                split_off_info_section(inner, preview::terminal_info_height(inst))
+                            })
+                            .unwrap_or(inner)
+                    };
+                    self.preview_pane_area = pane_area;
+
                     self.refresh_tool_preview_cache_if_needed(
-                        inner.width,
-                        inner.height,
+                        pane_area.width,
+                        pane_area.height,
                         &tool_name,
                     );
                     self.tool_preview_cache.ensure_parsed();
@@ -1795,6 +1925,7 @@ impl HomeView {
                             self.preview_scroll_offset,
                             theme,
                             compact,
+                            self.show_preview_info,
                         );
                     }
                 } else {
@@ -2272,6 +2403,46 @@ impl HomeView {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn split_off_info_section_subtracts_header_plus_banner() {
+        // The split must drop info_h ROWS for the info section AND one
+        // more row for the inner ` Output ` / ` Terminal Output ` banner
+        // that the renderer draws on top of the output area. Off by one
+        // here resurrects the "agent output scrolled up by a row" bug
+        // that lived before this helper existed.
+        let inner = Rect {
+            x: 2,
+            y: 3,
+            width: 80,
+            height: 30,
+        };
+        let out = split_off_info_section(inner, 4);
+        assert_eq!(out.x, 2);
+        assert_eq!(out.width, 80);
+        // y shifts down past 4 header rows + 1 banner row.
+        assert_eq!(out.y, 3 + 5);
+        // height shrinks by the same 5 rows.
+        assert_eq!(out.height, 30 - 5);
+    }
+
+    #[test]
+    fn split_off_info_section_clamps_when_pane_smaller_than_chrome() {
+        // A pane shorter than the chrome it would draw must return a
+        // zero-height rect rather than wrapping past zero. Without the
+        // clamp, a very narrow vertical layout (split panes, popped
+        // toasts) would panic on subtraction overflow during live mode.
+        let inner = Rect {
+            x: 0,
+            y: 0,
+            width: 80,
+            height: 3,
+        };
+        // Info header alone is 4 rows; combined chrome (5) exceeds
+        // inner.height (3). The helper should clamp to height 0.
+        let out = split_off_info_section(inner, 4);
+        assert_eq!(out.height, 0);
+    }
 
     #[test]
     fn truncate_to_width_passthrough_when_fits() {

--- a/tests/integration/common/mod.rs
+++ b/tests/integration/common/mod.rs
@@ -3,12 +3,18 @@
 //! Declared once from `tests/integration/main.rs`; consumers import via
 //! `use crate::common::...`.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use tempfile::TempDir;
 
 /// Path to the Node ACP test shim used by cockpit_* integration tests.
-pub fn shim_path() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+///
+/// Gated on `feature = "serve"` because its only consumers are the
+/// cockpit modules, which themselves only compile under that feature.
+/// Without the gate, `cargo clippy --all-targets` builds the integration
+/// suite WITHOUT serve and these helpers register as dead code.
+#[cfg(feature = "serve")]
+pub fn shim_path() -> std::path::PathBuf {
+    std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("cockpit-worker")
         .join("test-shim")
         .join("shim.mjs")
@@ -19,6 +25,7 @@ pub fn shim_path() -> PathBuf {
 /// that callers print before skipping. CI installs deps via `npm ci` in
 /// `cockpit-worker/test-shim/` before running the integration leg; local
 /// runs need the same one-shot setup, which the message points at.
+#[cfg(feature = "serve")]
 pub fn shim_ready() -> Result<(), String> {
     let node_ok = std::process::Command::new("node")
         .arg("--version")


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Three related issues in the preview pane's info-vs-output layout:

1. **Agent live pane was one row taller than the visible output area** when the info panel was expanded. `preview_pane_area` subtracted `info_h` rows for the info header but missed the `Borders::TOP` banner row that `render_output_cached` draws on top of the output sub-rect. Tmux sized the agent's pane one row past what `Paragraph` painted, and the top of agent output got tail-clipped on every frame.

2. **Terminal/Tool views never refined `preview_pane_area` at all** (it defaulted to the full `inner`), so live-send against a terminal pane sized tmux to `inner.height` while only `inner.height - info_h - 1` rows were visible. The shell rendered into a window 4-5 rows taller than what the user saw. The terminal cache refresh also lacked the live-mode `worker.resize()` that the agent path has, so a window resize or info toggle never reflowed mid-live-mode.

3. **Pressing `i` in Terminal/Tool view silently toggled `show_preview_info`** with no visual effect: `render_terminal_preview` did not consult the flag, and the "show/hide info with i" title hint was gated to `ViewMode::Agent`.

### What the fix does

- Adds a `split_off_info_section` helper in `render.rs` that subtracts `info_h + 1` (header + banner row), used by all three view branches so the math is consistent.
- Adds `terminal_info_height` symmetric with `agent_info_height`.
- Threads `show_info: bool` through `render_terminal_preview`. When it's off, both the info section AND the inner banner collapse together, symmetric with `render_with_cache`.
- Hoists the "show/hide info with i" title hint and the outer-title scroll indicator beyond the `ViewMode::Agent` gate so all three views advertise the toggle and surface the indicator when info is hidden.
- Wires per-frame live-mode `worker.resize()` into `refresh_terminal_preview_cache_if_needed` and the container variant so window resizes / info toggles reflow the shell live, instead of waiting for the user to re-enter live mode.
- Gates the per-frame resize on the live-send target matching the cache being refreshed. Previously, viewing Agent while live-on-Terminal (or vice versa) would resize the wrong pane to the wrong dims.

### Drive-by

`tests/integration/common/mod.rs` gates `shim_path` / `shim_ready` on `feature = \"serve\"` to match their only consumers (the `cockpit_*` modules). Stops `cargo clippy --all-targets` from flagging them as dead in the non-serve build.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (`agent_info_height` and `finalize_live_send_resize` doc comments now acknowledge the +1 banner row)
- [ ] For UI changes: included screenshot or recording

Screenshot deferred: this is a layout one-row math fix plus a toggle plumbing change. Behavior is easiest to verify by entering live mode with info expanded (no clipping at top), pressing `i` in Terminal view (info collapses), and entering live-on-Terminal (shell now sized to the visible area, reflows on window resize).

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Added or updated a Playwright spec under `web/tests/`
- [x] Skipped a test, because: existing unit tests pin the math (`split_off_info_section` two cases, `terminal_info_height` four cases). An e2e for the visual layout would require driving tmux + ratatui to compare cell-by-cell output across the toggle state; happy to add if reviewers want it.

New tests:
- `src/tui/home/render.rs::tests::split_off_info_section_subtracts_header_plus_banner`
- `src/tui/home/render.rs::tests::split_off_info_section_clamps_when_pane_smaller_than_chrome`
- `src/tui/components/preview.rs::tests::terminal_info_height::*` (4 cases)

Pre-flight:
- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` clean (no features)
- `cargo clippy --all-targets --features serve -- -D warnings` clean
- `cargo test --lib`: 2276 passed
- `cargo test --test integration`: 120 passed, 5 ignored

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7, 1M context)

**Any Additional AI Details you'd like to share:**

Investigation, fix, tests, and this PR description were drafted by Claude via the `/investigate` skill against the symptoms I described. I reviewed each finding and the fix shape before approving it.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR fixes layout and display issues in the TUI preview pane, specifically addressing how the info header and output area are sized and rendered across different view types (Agent, Terminal, and Tool).

## What Changed

**Files Modified:**
- `src/tui/components/preview.rs` - Updated Terminal preview rendering logic and added height calculation function
- `src/tui/home/render.rs` - Introduced layout helper and updated preview rendering across all view types
- `src/tui/home/mod.rs` - Clarified documentation for preview pane area calculation
- `tests/integration/common/mod.rs` - Added feature gate to integration test helpers

**What Was Added:**
- `split_off_info_section()` helper function to correctly compute the output display area by accounting for both the info header and the banner row
- `terminal_info_height()` function to unify height calculations for Terminal/Tool views
- `show_info: bool` parameter to `render_terminal_preview()` method
- Unit tests for the new helper functions (6 test cases total)

**What Was Fixed:**
1. Agent live pane now correctly accounts for the info header AND the banner row when sizing output
2. Terminal/Tool views now properly resize their output area when the info header is toggled
3. The `i` key to toggle the info header now visually collapses/expands the info section in Terminal and Tool views
4. Live-send resize operations now only resize the correct pane type (preventing cross-pane interference)
5. The "show/hide info with i" tooltip is now shown consistently across all view types

## Benefits

- **Visual Consistency**: Output areas no longer drift or get clipped when toggling the info header
- **Responsive Layout**: Window resizes and info toggles now properly reflow content in Terminal/Tool views
- **Functional Parity**: Terminal and Tool views now have the same info-toggle behavior as Agent view
- **Robustness**: Unified math for calculating preview pane areas reduces off-by-one errors across different view types
- **Cleaner Code**: New helper functions make the layout logic more maintainable and prevent future regressions

## Technical Details

The core issue was that `preview_pane_area` calculations were inconsistent and incomplete:
- Agent view was subtracting the info header height but not the "Output" banner row drawn by `render_output_cached`
- Terminal/Tool views weren't refining the pane area at all
- `render_terminal_preview` didn't accept or respect the info-visibility flag

The fixes introduce:
- `split_off_info_section(area, info_h)` - Computes the content sub-rect by subtracting `info_h + 1` (header + banner)
- `terminal_info_height(instance)` - Calculates Terminal/Tool info header size consistent with rendering
- Updated live-send resize gating to only trigger for the active pane type, preventing unintended side effects
- Pass-through of `show_preview_info` flag to `render_terminal_preview` so the banner row is suppressed when info is hidden

Lines changed: +342/-76 across all modified files

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1570?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->