### PR TITLE
fix(tui): make w jump to next waiting in Attention

### DIFF
--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1247,29 +1247,15 @@ impl HomeView {
                 self.view_mode = ViewMode::Agent;
             }
             KeyCode::Char('q') => return Some(Action::Quit),
-            // `w` / `W` (snooze), `h` / `H` (snooze alias), and `f` / `F`
-            // (favorite) are gated to Attention sort. Snooze and favorite
-            // are triage primitives; they only have a visible effect
-            // (and a sort impact) in Attention mode. Outside Attention,
-            // mutating these flags would silently change persisted state
-            // with no on-screen feedback, so we ignore the press
-            // entirely. Other sort modes fall through to the existing
-            // fallback bindings (`h` collapses; `w` is jump-to-next-
-            // waiting in non-strict mode).
-            KeyCode::Char('w')
-                if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_snooze_at_cursor() {
-                    tracing::error!("toggle_snooze_at_cursor failed: {}", e);
-                }
-            }
-            KeyCode::Char('W')
-                if self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
-            {
-                if let Err(e) = self.toggle_snooze_at_cursor() {
-                    tracing::error!("toggle_snooze_at_cursor failed: {}", e);
-                }
-            }
+            // `h` / `H` (snooze) and `f` / `F` (favorite) are gated to
+            // Attention sort. Snooze and favorite are triage primitives; they
+            // only have a visible effect (and a sort impact) in Attention mode.
+            // Outside Attention, mutating these flags would silently change
+            // persisted state with no on-screen feedback, so we ignore the
+            // press entirely (`h` then falls through to the group-collapse
+            // binding). Snooze used to also live on `w` / `W`, which shadowed
+            // the jump-to-next-waiting binding below in Attention sort; #1524
+            // moved it off so `w` is navigation again.
             KeyCode::Char('h')
                 if !self.strict_hotkeys && self.sort_order == SortOrder::Attention =>
             {
@@ -2247,12 +2233,11 @@ impl HomeView {
                     }
                 }
             }
-            // Upstream PR #796 added `w` for jump-to-next-waiting after the
-            // snooze feature (a19337b) had already taken `w`/`W`. In non-strict
-            // mode the snooze arm at line 707 catches first, so this jump arm
-            // was always dead. In strict mode it leaked through and preempted
-            // the typing-guard below; bare `w` jumped the cursor instead of
-            // opening compose like every other lowercase letter. Gate it.
+            // Jump to the next waiting/idle session (PR #796). Snooze moved off
+            // `w`/`W` onto `h`/`H` (#1524), so in Attention sort `w` is no
+            // longer shadowed by a snooze arm and this finally fires across
+            // every sort mode. Strict mode keeps bare lowercase `w` for the
+            // typing-guard below.
             KeyCode::Char('w') if !self.strict_hotkeys => {
                 self.jump_to_next_waiting();
             }

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -1907,6 +1907,84 @@ fn test_non_strict_h_snoozes_only_in_attention_sort() {
     }
 }
 
+/// Build a flat list of one Running and one Waiting session in the given mode.
+/// Returns the env plus the flat index of each so callers can park the cursor.
+/// Statuses are seeded in storage before construction so both `instances` and
+/// the `instance_map` that `get_instance`/`jump_to_next_waiting` read agree.
+fn attention_env_running_then_waiting() -> (TestEnv, usize, usize) {
+    use crate::session::config::{GroupByMode, SortOrder};
+    use crate::session::Status;
+
+    let temp = TempDir::new().unwrap();
+    setup_test_home(&temp);
+    let storage = Storage::new("test").unwrap();
+
+    let mut running = Instance::new("running", "/tmp/running");
+    running.status = Status::Running;
+    let mut waiting = Instance::new("waiting", "/tmp/waiting");
+    waiting.status = Status::Waiting;
+    let instances = vec![running, waiting];
+    storage
+        .update(|i, g| {
+            *i = instances.to_vec();
+            *g = GroupTree::new_with_groups(&instances, &[]).get_all_groups();
+            Ok(())
+        })
+        .unwrap();
+
+    let tools = AvailableTools::with_tools(&["claude"]);
+    let mut view = HomeView::new(Some("test".to_string()), tools).unwrap();
+    view.strict_hotkeys = false;
+    view.group_by = GroupByMode::Manual;
+    view.sort_order = SortOrder::Attention;
+    view.flat_items = view.build_flat_items();
+    view.update_selected();
+    let env = TestEnv { _temp: temp, view };
+
+    let status_at = |env: &TestEnv, idx: usize| match env.view.flat_items.get(idx) {
+        Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
+        _ => None,
+    };
+    let running = (0..env.view.flat_items.len())
+        .find(|&i| status_at(&env, i) == Some(Status::Running))
+        .expect("a Running session row");
+    let waiting = (0..env.view.flat_items.len())
+        .find(|&i| status_at(&env, i) == Some(Status::Waiting))
+        .expect("a Waiting session row");
+    (env, running, waiting)
+}
+
+#[test]
+#[serial]
+fn test_non_strict_w_jumps_to_next_waiting_in_attention_sort() {
+    // Regression for #1524: in non-strict Attention sort, `w` must jump to the
+    // next waiting/idle session (the #796 behavior) instead of snoozing the
+    // cursor's session. Snooze lives on `h`/`H`; `w` is navigation. Previously
+    // the snooze arm shadowed the jump arm in exactly the sort users triage in,
+    // so `w` never felt like a navigation key.
+    use crate::session::Status;
+
+    let (mut env, running, _waiting) = attention_env_running_then_waiting();
+    env.view.cursor = running;
+    env.view.update_selected();
+
+    env.view.handle_key(key(KeyCode::Char('w')), None);
+
+    assert!(
+        env.view.snooze_duration_dialog.is_none(),
+        "`w` in Attention sort must jump, not open the snooze dialog"
+    );
+    let landed = match env.view.flat_items.get(env.view.cursor) {
+        Some(Item::Session { id, .. }) => env.view.get_instance(id).map(|i| i.status),
+        _ => None,
+    };
+    assert_eq!(
+        landed,
+        Some(Status::Waiting),
+        "`w` should land the cursor on the Waiting session"
+    );
+}
+
 #[test]
 #[serial]
 fn test_strict_mode_ctrl_g_opens_group_picker() {


### PR DESCRIPTION
## Description

In the home TUI, `w` snoozed the session under the cursor instead of
jumping to the next idle/waiting session. In non-strict Attention sort
the snooze arm shadowed the jump-to-next-waiting binding (#796), so in
the sort people triage in most, `w` never acted as a navigation key.

This moves snooze off `w`/`W` entirely (Option 1 in #1524). Snooze stays
on `h`/`H` (the existing "Hide" alias), and `w` falls through to the
existing jump binding, which now fires in every sort mode.

Fixes #1524.

## PR Type

- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] Skipped a full e2e: covered by a deterministic input-handler
  regression test in `src/tui/home/tests.rs`
  (`test_non_strict_w_jumps_to_next_waiting_in_attention_sort`), which
  exercises the keybinding without a tmux harness.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7)

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug in the home TUI where the `w` key was snoozzing the current session instead of jumping to the next waiting/idle session when using Attention sort mode. The fix resolves a keybinding conflict by moving the snooze functionality entirely off `w`/`W` (reassigning it to the existing `h`/`H` "Hide" alias) and ensuring `w` consistently performs the jump-to-next-waiting action across all sort modes.

## Changes Made

### Updated Keybinding Logic (`src/tui/home/input.rs`)
- Removed the snooze/favorite triage arms from the `w`/`W` key handlers that were shadowing the jump-to-next-waiting binding
- Updated hotkey dispatch comments and documentation to reflect the new keybinding arrangement
- Clarified in comments that strict mode still reserves lowercase `w` for the typing-guard behavior

### Added Test Coverage (`src/tui/home/tests.rs`)
- Introduced a helper function (`attention_env_running_then_waiting`) to construct test environments with explicitly seeded session statuses
- Added a new regression test (`test_non_strict_w_jumps_to_next_waiting_in_attention_sort`) that verifies pressing `w` in non-strict Attention sort mode jumps to the next waiting session instead of opening the snooze dialog

## Benefits
- **Consistent behavior**: The `w` key now reliably jumps to the next waiting/idle session regardless of sort mode
- **Cleaner keybinding**: Snooze/favorite operations are consolidated under `h`/`H`, which already existed as a "Hide" alias, reducing redundant keybindings
- **Better UX**: Users get the expected behavior documented in issue `#1524` and implemented in previous work (`#796`)
- **Regression prevention**: New test ensures this specific bug doesn't reoccur in future changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1571?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->