### PR TITLE
fix(session): anchor sandboxed Claude poller to its own session id (followup to #1523)

### DIFF
--- a/src/session/capture.rs
+++ b/src/session/capture.rs
@@ -268,35 +268,79 @@ pub(crate) fn claude_poll_fn(
     }
 }
 
+/// Pick the active Claude session UUID from the container shell snippet's
+/// stdout in [`capture_claude_session_id_in_container`].
+///
+/// Stdout is expected to be UUID basenames, one per line, in newest-first
+/// order, already filtered to files modified within the last 5 minutes.
+///
+/// Mirrors the host-side anchor preference (issue #1522): when several AoE
+/// sessions share one container/cwd, the bare "most recent" heuristic makes
+/// every poller report whichever session wrote last and cross-assign ids.
+/// If our `known_session_id` is among the fresh candidates, prefer it;
+/// otherwise fall back to the most-recent (first in the list). With no
+/// candidates, return an error so the caller can surface it the same way
+/// the previous "no active session" path did.
+fn select_claude_session_in_container(
+    stdout_bytes: &[u8],
+    known_session_id: Option<&str>,
+) -> Result<String> {
+    let text = String::from_utf8_lossy(stdout_bytes);
+    let candidates: Vec<&str> = text
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && Uuid::parse_str(l).is_ok())
+        .collect();
+
+    if candidates.is_empty() {
+        anyhow::bail!("No active Claude session found in container");
+    }
+
+    if let Some(k) = known_session_id {
+        if candidates.contains(&k) {
+            return Ok(k.to_string());
+        }
+    }
+
+    Ok(candidates[0].to_string())
+}
+
 /// Capture Claude Code session ID inside a Docker container.
 ///
 /// Claude in a sandboxed AoE session writes its `.jsonl` files to the
 /// container's `~/.claude/projects/{encoded-cwd}/` directory, not the host's.
-/// This shells `docker exec` into the running container to find the most
-/// recently modified UUID-named jsonl in that directory, with a 5-minute
-/// staleness guard.
+/// This shells `docker exec` into the running container, lists every fresh
+/// (≤5 min mtime) UUID-named jsonl in that directory newest-first, and
+/// delegates per-pane attribution to [`select_claude_session_in_container`]
+/// — which prefers `known_session_id` when it's still fresh, falling back
+/// to the most-recent file otherwise. This mirrors the host path's anchor
+/// (issue #1522) so fleets sharing a single container/cwd don't
+/// cross-assign session ids.
 pub(crate) fn capture_claude_session_id_in_container(
     container_name: &str,
     container_cwd: &str,
+    known_session_id: Option<&str>,
 ) -> Result<String> {
     let dir_name = encode_claude_project_path(container_cwd);
 
-    // Shell snippet:
+    // Shell snippet (POSIX-portable):
     //   - resolve $CLAUDE_CONFIG_DIR or $HOME/.claude
     //   - walk projects/<encoded>/ for *.jsonl files
     //   - keep ones with mtime within 5 minutes
-    //   - emit basename (without .jsonl) of the most recent
+    //   - emit basenames (without .jsonl) in newest-first order
     //
-    // Using POSIX `find -mmin -5` and `ls -t` to avoid GNU-only `printf '%T@ %f'`.
+    // We emit every fresh candidate (not just `head -1`) so the Rust
+    // selector can apply per-instance anchor preference (issue #1522).
+    // Using POSIX `find -mmin -5` and `ls -t` to avoid GNU-only flags.
     let snippet = format!(
         r#"
 CLAUDE_HOME="${{CLAUDE_CONFIG_DIR:-$HOME/.claude}}"
 DIR="$CLAUDE_HOME/projects/{dir_name}"
 [ -d "$DIR" ] || exit 0
-NEWEST=$(ls -t "$DIR"/*.jsonl 2>/dev/null | head -1)
-[ -z "$NEWEST" ] && exit 0
-[ -n "$(find "$NEWEST" -mmin -5 2>/dev/null)" ] || exit 0
-basename "$NEWEST" .jsonl
+for f in $(ls -t "$DIR"/*.jsonl 2>/dev/null); do
+  [ -n "$(find "$f" -mmin -5 2>/dev/null)" ] || continue
+  basename "$f" .jsonl
+done
 "#
     );
 
@@ -310,31 +354,42 @@ basename "$NEWEST" .jsonl
         anyhow::bail!("docker exec returned non-zero: {}", stderr.trim());
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let id = stdout.trim();
-    if id.is_empty() {
-        anyhow::bail!(
-            "No active Claude session found in container {}",
-            container_name
-        );
-    }
-    if Uuid::parse_str(id).is_err() {
-        anyhow::bail!("Container returned non-UUID session ID: {:?}", id);
-    }
-
-    Ok(id.to_string())
+    select_claude_session_in_container(&output.stdout, known_session_id)
+        .map_err(|e| anyhow::anyhow!("{} (container {})", e, container_name))
 }
 
 /// Polling closure for sandboxed (Docker) Claude Code session tracking.
+///
+/// Mirrors [`claude_poll_fn`]'s issue #1522 anchor: holds the
+/// `known_session_id` in a `Mutex` and promotes the last successful capture
+/// into it so the poller stays attached to its session's actual current id
+/// over its lifetime (matches the host-path behaviour PR #1523 landed).
 pub(crate) fn claude_poll_fn_sandboxed(
     container_name: String,
     container_cwd: String,
+    known_session_id: Option<String>,
 ) -> impl Fn() -> Option<String> + Send + 'static {
+    let last_known = std::sync::Mutex::new(known_session_id);
     move || {
-        capture_claude_session_id_in_container(&container_name, &container_cwd)
-            .map_err(|e| tracing::debug!(target: "session.capture", "Claude container scan failed: {}", e))
-            .ok()
-            .and_then(validated_session_id)
+        let current_known = last_known.lock().ok().and_then(|g| g.clone());
+        let captured = capture_claude_session_id_in_container(
+            &container_name,
+            &container_cwd,
+            current_known.as_deref(),
+        )
+        .map_err(
+            |e| tracing::debug!(target: "session.capture", "Claude container scan failed: {}", e),
+        )
+        .ok()
+        .and_then(validated_session_id);
+
+        if let Some(id) = captured.as_ref() {
+            if let Ok(mut guard) = last_known.lock() {
+                *guard = Some(id.clone());
+            }
+        }
+
+        captured
     }
 }
 
@@ -2337,8 +2392,77 @@ mod tests {
         let result = capture_claude_session_id_in_container(
             "aoe-test-nonexistent-container-xyz",
             "/workspace/test",
+            None,
         );
         assert!(result.is_err());
+    }
+
+    // --- issue #1522 mirror: anchor preference inside the container path ---
+    //
+    // The shell snippet emits UUID basenames in newest-first order. We feed
+    // synthetic stdout into the pure selector to verify that the anchor wins
+    // when fresh, that we fall back to most-recent otherwise, and that the
+    // single-session-per-container case is preserved.
+
+    #[test]
+    fn test_select_claude_session_in_container_most_recent_when_no_anchor() {
+        let uuid_new = "11111111-2222-3333-4444-555555555555";
+        let uuid_old = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let stdout = format!("{uuid_new}\n{uuid_old}\n"); // newest-first
+        let id = select_claude_session_in_container(stdout.as_bytes(), None).unwrap();
+        assert_eq!(id, uuid_new);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_prefers_anchor() {
+        // Two fresh candidates; B is newer. With no anchor every session in a
+        // shared container would resolve to B and cross-assign. With anchor=A,
+        // each session keeps its own id (issue #1522 mirror of the host fix).
+        let uuid_a = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let uuid_b = "11111111-2222-3333-4444-555555555555";
+        let stdout = format!("{uuid_b}\n{uuid_a}\n"); // B newer
+        assert_eq!(
+            select_claude_session_in_container(stdout.as_bytes(), Some(uuid_a)).unwrap(),
+            uuid_a,
+            "anchor A must win even though B is newer"
+        );
+        assert_eq!(
+            select_claude_session_in_container(stdout.as_bytes(), Some(uuid_b)).unwrap(),
+            uuid_b,
+        );
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_anchor_absent_falls_back_to_newest() {
+        // Anchor points at a session whose file isn't fresh here (or never
+        // existed in this container); fall back to most-recent.
+        let uuid_new = "11111111-2222-3333-4444-555555555555";
+        let uuid_other = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let absent = "99999999-9999-9999-9999-999999999999";
+        let stdout = format!("{uuid_new}\n{uuid_other}\n");
+        assert_eq!(
+            select_claude_session_in_container(stdout.as_bytes(), Some(absent)).unwrap(),
+            uuid_new,
+        );
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_no_candidates_errors() {
+        let result = select_claude_session_in_container(b"", None);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No active Claude session"),);
+    }
+
+    #[test]
+    fn test_select_claude_session_in_container_ignores_non_uuid_lines() {
+        // Defensive: blank lines and any stray output must not be picked.
+        let uuid = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+        let stdout = format!("\n  \nnot-a-uuid\n{uuid}\nstill-not-a-uuid\n");
+        let id = select_claude_session_in_container(stdout.as_bytes(), None).unwrap();
+        assert_eq!(id, uuid);
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -1784,6 +1784,7 @@ impl Instance {
                     Box::new(claude_poll_fn_sandboxed(
                         container_name,
                         self.container_workdir(),
+                        initial_known.clone(),
                     ))
                 } else {
                     Box::new(claude_poll_fn(


### PR DESCRIPTION
## Description

Follow-up to #1523 (merged as bbceca5). That PR fixed the **host** path's session-id cascade by anchoring the Claude poller to its own session id. The maintainer's review explicitly invited a mirror for the **sandboxed/container** path:

> The sandboxed path (`capture_claude_session_id_in_container`) has the same root cause and is intentionally deferred. Filing a follow-up so sandboxed-fleet users get the fix would be valuable.

This PR is that follow-up.

`capture_claude_session_id_in_container` previously shelled `ls -t "$DIR"/*.jsonl | head -1` inside the container — picking the most-recently-modified jsonl with no per-pane attribution. The same cross-assignment bug as the host path: multiple AoE sessions sharing a container/cwd would all resolve to whichever session wrote last.

### Fix

Refactored to mirror the host path:

- Shell snippet now emits every fresh (≤5 min mtime) UUID jsonl basename in **newest-first** order rather than just `head -1`.
- New pure function `select_claude_session_in_container(stdout_bytes, known_session_id)` does the per-instance attribution: prefer the anchor if it's among the fresh candidates, otherwise fall back to most-recent. Fully unit-testable without docker — same pattern the codex/vibe/pi/gemini/hermes container selectors already use.
- `capture_claude_session_id_in_container` and `claude_poll_fn_sandboxed` now accept `known_session_id`, threaded from `Instance::maybe_start_poller`'s `initial_known`.
- `claude_poll_fn_sandboxed` mirrors the host's `Mutex<Option<String>>` anchor promotion (from the maintainer's follow-up commit `fc1b242`): each successful capture is promoted into the anchor so the poller stays attached to the session's actual current id over its lifetime, not just the startup value.

### Reproducing the bug

Locally verified the bug exists *and* the fix resolves it by toggling the anchor-preference block in `select_claude_session_in_container`:

- Without the `if let Some(k) = known_session_id { ... }` branch (i.e. equivalent to the previous `head -1` behaviour): `test_select_claude_session_in_container_prefers_anchor` **fails** — the selector returns the most-recent UUID instead of the anchor, exactly the cascade in shared-container fleets.
- With the branch restored: test passes.

The new tests are the regression coverage so this can't silently regress.

### Behaviour preservation

- Single-session-per-container is unchanged: with one fresh candidate, the anchor (if present) *is* that candidate, so the same id is returned as before.
- The 5-minute staleness window and the "no fresh jsonl → error" semantics are preserved.
- Same fork-lag caveat noted in #1523: if a session legitimately forks while its old jsonl is still fresh, the new id is detected when the old goes stale (≤5 min). Acceptable; rare in practice.

### What changed

- `src/session/capture.rs`:
  - New `select_claude_session_in_container` (pure, testable).
  - `capture_claude_session_id_in_container` gains `known_session_id: Option<&str>`; snippet emits all fresh candidates; selector handles attribution.
  - `claude_poll_fn_sandboxed` gains `known_session_id: Option<String>` and mirrors the host's `Mutex` anchor promotion.
  - 5 new unit tests for the selector + 1 existing in-container test updated for the new signature.
- `src/session/instance.rs`:
  - Sandboxed branch of `maybe_start_poller` passes `initial_known.clone()` to `claude_poll_fn_sandboxed`, mirroring the host branch.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (function doc comments)
- [ ] For UI changes: included screenshot or recording (N/A — internal session-tracking)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

(Coverage lives at the selector level via unit tests in `src/session/capture.rs`, matching the established pattern for other agents' `select_X_session_in_container` functions.)

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Claude Code), collaborating with @itisaevalex who is driving the work, reviewing the diff, and submitting the PR.

**Any Additional AI Details you'd like to share:**
Same collaboration model as #1523. Diagnosis, code, and tests drafted with AI assistance; @itisaevalex reviewed before submission and will respond personally on any review threads (not via copy/paste from the AI).

- [x] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug in the sandboxed/container session handling where multiple sessions sharing the same container would incorrectly resolve to whichever one was most recently created. The fix implements intelligent session identification to ensure each session is correctly anchored to its own ID.

## What Changed
- **Added session selection logic**: Introduced a new helper function that picks the correct session ID from multiple candidates, prioritizing a "known" session ID if it's still valid, otherwise falling back to the most recent one.
- **Enhanced container polling**: Modified the container session capture mechanism to emit all valid session candidates instead of just picking the newest, then letting the new selection logic choose the right one.
- **Session anchoring**: Updated the background polling mechanism to maintain and promote the chosen session ID across multiple poll cycles, ensuring consistency throughout the session's lifetime.
- **Updated function signatures**: Added an optional `known_session_id` parameter to session capture functions to pass the anchor information through the call chain.

## Benefits
- **Correctness**: Sessions are now reliably identified even when multiple instances share the same container environment
- **Consistency**: Session tracking is anchored and maintained across the lifetime of the poller, preventing drift to other sessions
- **Robustness**: Mirrors the successful approach from a prior fix (`#1523`), using proven patterns for the container-based workflow
- **Backward compatible**: Single-session-per-container scenarios work unchanged; only multi-session scenarios benefit from the fix

## Technical Details
- Added `select_claude_session_in_container()` function that parses UUID basenames from stdout (newest-first order) and intelligently selects either the provided `known_session_id` (if present among fresh ≤5 min old candidates) or the most recent candidate
- Modified `capture_claude_session_id_in_container()` to accept optional `known_session_id` parameter and changed the Docker shell snippet to emit all fresh UUID candidates instead of just the single most recent
- Modified `claude_poll_fn_sandboxed()` to accept `known_session_id` and maintain an anchored `last_known` value across polls using a Mutex, with promotion logic when captures succeed
- Added 5 new unit tests covering anchor preference, fallback behavior, error conditions, and non-UUID line filtering
- Changes span 151 lines added, 27 lines removed across two files: `src/session/capture.rs` and `src/session/instance.rs`

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1572?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->