### PR TITLE
fix(cockpit): always append trailing space when picking slash command

### DIFF
--- a/web/src/components/cockpit/Composer.slashCommand.test.ts
+++ b/web/src/components/cockpit/Composer.slashCommand.test.ts
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+//
+// Regression test for #1512: picking a no-arg slash command (e.g.
+// `/help`) used to leave the composer text as `/help` with no trailing
+// whitespace. assistant-ui's `detectTrigger` scans backward from the
+// cursor and halts on whitespace; without a trailing space the cursor
+// sits inside the `/help` range and the popover re-opens immediately,
+// trapping the next Enter as "re-pick highlighted item" instead of
+// sending the prompt. The fix in `insertSlashCommand` is to always
+// append a trailing space, for both `acceptsInput=true` (cosmetic,
+// positions cursor for arg typing) and `acceptsInput=false` (forces
+// the trigger detector to give up so Enter routes to the send path).
+//
+// Also locks the args-command behaviour so a future refactor cannot
+// silently regress the cursor-at-end-after-space contract for the
+// `acceptsInput=true` branch.
+
+import { describe, expect, it, vi } from "vitest";
+import type { useComposerRuntime } from "@assistant-ui/react";
+
+import { insertSlashCommand } from "./Composer";
+
+type RuntimeStub = ReturnType<typeof useComposerRuntime>;
+
+function makeRuntime(initialText: string) {
+  const setText = vi.fn<(s: string) => void>();
+  const runtime = {
+    getState: () => ({ text: initialText }),
+    setText,
+  } as unknown as RuntimeStub;
+  return { runtime, setText };
+}
+
+function makeItem(id: string, acceptsInput: boolean) {
+  return {
+    id,
+    type: "command" as const,
+    label: `/${id}`,
+    description: "",
+    acceptsInput,
+  } as unknown as Parameters<typeof insertSlashCommand>[1];
+}
+
+describe("insertSlashCommand (#1512)", () => {
+  it("appends a trailing space when picking a no-arg command (acceptsInput=false)", () => {
+    const { runtime, setText } = makeRuntime("");
+    insertSlashCommand(runtime, makeItem("help", false));
+    expect(setText).toHaveBeenCalledExactlyOnceWith("/help ");
+  });
+
+  it("appends a trailing space when picking an args command (acceptsInput=true)", () => {
+    const { runtime, setText } = makeRuntime("");
+    insertSlashCommand(runtime, makeItem("review", true));
+    expect(setText).toHaveBeenCalledExactlyOnceWith("/review ");
+  });
+
+  it("preserves prior buffer text and inserts a separator space when needed", () => {
+    const { runtime, setText } = makeRuntime("draft note");
+    insertSlashCommand(runtime, makeItem("clear", false));
+    expect(setText).toHaveBeenCalledExactlyOnceWith("draft note /clear ");
+  });
+
+  it("does not double up the separator when prior text already ends in a space", () => {
+    const { runtime, setText } = makeRuntime("draft note ");
+    insertSlashCommand(runtime, makeItem("clear", false));
+    expect(setText).toHaveBeenCalledExactlyOnceWith("draft note /clear ");
+  });
+
+  it("is a no-op when the runtime is null", () => {
+    const setText = vi.fn();
+    insertSlashCommand(
+      null as unknown as RuntimeStub,
+      makeItem("help", false),
+    );
+    expect(setText).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -654,24 +654,26 @@ function PopoverItems({ trigger }: { trigger: string }) {
 
 /** Insert the picked slash command into the composer text. The Action
  *  popover already stripped the user's `/<typed>` from the input via
- *  `removeOnExecute`, so we set the canonical `/<name>` form and add
- *  a trailing space when the agent advertised that the command takes
- *  free-form arguments. The user is then free to type args and hit
- *  Enter to send, or hit Enter immediately for a no-arg command. */
-function insertSlashCommand(
+ *  `removeOnExecute`, so we set the canonical `/<name> ` form, always
+ *  with a trailing space. The trailing space serves two roles: for
+ *  `acceptsInput=true` commands it positions the cursor for free-form
+ *  arg typing, and for every command it halts assistant-ui's
+ *  `detectTrigger` backward scan (which keys off whitespace as the
+ *  trigger boundary) so the popover does not immediately re-open on
+ *  the inserted `/<name>` and consume the next Enter as a re-pick.
+ *  See #1512. */
+export function insertSlashCommand(
   runtime: ReturnType<typeof useComposerRuntime>,
   item: Unstable_TriggerItem,
 ) {
   if (!runtime) return;
-  const accepts = (item as { acceptsInput?: boolean }).acceptsInput === true;
   const current = runtime.getState().text;
-  const suffix = accepts ? " " : "";
   // Preserve any text that was already in the buffer (e.g. user typed
   // a long prompt then ran `/foo` mid-message). We just append the
   // command at the end; the typed `/typed` token has already been
   // removed by removeOnExecute, so trailing whitespace is rare.
   const sep = current.length > 0 && !current.endsWith(" ") ? " " : "";
-  runtime.setText(`${current}${sep}/${item.id}${suffix}`);
+  runtime.setText(`${current}${sep}/${item.id} `);
 }
 
 /** Insert a literal "\n" at the textarea's caret. Used by the

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -654,26 +654,26 @@ function PopoverItems({ trigger }: { trigger: string }) {
 
 /** Insert the picked slash command into the composer text. The Action
  *  popover already stripped the user's `/<typed>` from the input via
- *  `removeOnExecute`, so we set the canonical `/<name> ` form, always
- *  with a trailing space. The trailing space serves two roles: for
- *  `acceptsInput=true` commands it positions the cursor for free-form
- *  arg typing, and for every command it halts assistant-ui's
+ *  `removeOnExecute`, so we set the canonical `/<name>` form and add
+ *  a trailing space. The trailing space halts assistant-ui's
  *  `detectTrigger` backward scan (which keys off whitespace as the
  *  trigger boundary) so the popover does not immediately re-open on
- *  the inserted `/<name>` and consume the next Enter as a re-pick.
- *  See #1512. */
+ *  the inserted `/<name>` and consume the next Enter as a re-pick;
+ *  it also positions the cursor for free-form arg typing when the
+ *  agent advertised the command as `acceptsInput=true`. See #1512. */
 export function insertSlashCommand(
   runtime: ReturnType<typeof useComposerRuntime>,
   item: Unstable_TriggerItem,
 ) {
   if (!runtime) return;
   const current = runtime.getState().text;
+  const suffix = " ";
   // Preserve any text that was already in the buffer (e.g. user typed
   // a long prompt then ran `/foo` mid-message). We just append the
   // command at the end; the typed `/typed` token has already been
   // removed by removeOnExecute, so trailing whitespace is rare.
   const sep = current.length > 0 && !current.endsWith(" ") ? " " : "";
-  runtime.setText(`${current}${sep}/${item.id} `);
+  runtime.setText(`${current}${sep}/${item.id}${suffix}`);
 }
 
 /** Insert a literal "\n" at the textarea's caret. Used by the

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1585,6 +1585,18 @@
       ]
     },
     {
+      "id": "cockpit.story.composer-slash-pick-no-arg",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts",
+        "src/components/cockpit/Composer.slashCommand.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.queue-fold-unfold",
       "kind": "live-playwright",
       "risk": "low",

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -332,6 +332,47 @@ async function handleRequest(msg) {
     case "session/new":
     case "session/load": {
       const sessionId = params?.sessionId ?? makeSessionId();
+      // Test hook: when FAKE_ACP_COMMANDS is set, emit an
+      // `available_commands_update` session/update notification right
+      // after the session/new response so the cockpit composer's
+      // slash-command popover is populated for stories that drive the
+      // `/` picker (e.g. composer-slash-pick-no-arg #1512).
+      const commandsJson = process.env.FAKE_ACP_COMMANDS;
+      if (commandsJson) {
+        try {
+          const parsed = JSON.parse(commandsJson);
+          if (Array.isArray(parsed) && parsed.length > 0) {
+            // ACP wire shape (per
+            // agent-client-protocol-schema 0.12 client.rs:447-508):
+            // each AvailableCommand has `name`, `description`, and an
+            // optional `input` of `{ hint: "..." }` for unstructured
+            // free-form args. accepts_input=false serializes as input
+            // omitted.
+            const availableCommands = parsed.map((c) => ({
+              name: c.name,
+              description: c.description ?? "",
+              ...(c.accepts_input ? { input: { hint: c.hint ?? "" } } : {}),
+            }));
+            // Defer emission to the next tick so the session/new
+            // response lands first; the cockpit acp_client wires the
+            // session id from the response before it can route follow-up
+            // session/update notifications.
+            setImmediate(() => {
+              sendNotification("session/update", {
+                sessionId,
+                update: {
+                  sessionUpdate: "available_commands_update",
+                  availableCommands,
+                },
+              });
+            });
+          }
+        } catch (err) {
+          process.stderr.write(
+            `[fakeAcpAgent] bad FAKE_ACP_COMMANDS: ${err}\n`,
+          );
+        }
+      }
       // Mirror claude-agent-acp v0.37.0: the initial set of
       // per-session selectors (model + effort + mode) ships in the
       // session/new and session/load *response*, not as a subsequent

--- a/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
@@ -22,7 +22,11 @@ import {
   listSessions,
   seedSessionViaAoeAdd,
 } from "../../helpers/aoeServe";
-import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+import {
+  waitForCockpitView,
+  enableCockpitAndWait,
+  waitForReplayContains,
+} from "../../helpers/cockpit";
 
 base(
   "picking a no-arg slash command does not trap Enter",
@@ -74,6 +78,17 @@ base(
         throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
       }
 
+      // Block until the fake-ACP's available_commands_update has
+      // reached the replay buffer. Without this, the browser can race
+      // the supervisor handshake and arrive before the cockpit
+      // reducer has applied the commands, leaving the `/` popover
+      // showing "No matches".
+      await waitForReplayContains(
+        serve.baseUrl,
+        sessionId,
+        "AvailableCommandsUpdated",
+      );
+
       await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
       await waitForCockpitView(page);
 
@@ -81,13 +96,19 @@ base(
       await composer.click();
 
       // Type `/h` so the popover surfaces and `/help` is the top
-      // (highlighted) item. fuzzyFilter ranks the prefix match first.
+      // (auto-highlighted index 0) item. fuzzyFilter ranks the prefix
+      // match first.
       await composer.pressSequentially("/h");
 
-      const helpItem = page.locator('[data-highlighted="true"]').filter({
-        hasText: /\/help/,
-      });
-      await expect(helpItem).toBeVisible({ timeout: 10_000 });
+      // assistant-ui renders each popover entry as a button with
+      // role="option". The accessible name combines the trigger glyph,
+      // the label, and the description, so filter by `/help` substring
+      // rather than relying on the visually-only data-highlighted
+      // attribute (which assistant-ui sets to "" not "true").
+      const helpItem = page
+        .getByRole("option")
+        .filter({ hasText: /\/help/ });
+      await expect(helpItem).toBeVisible({ timeout: 15_000 });
 
       // Pick `/help` via Enter. removeOnExecute strips the typed
       // `/h`, then `insertSlashCommand` writes the canonical
@@ -162,6 +183,17 @@ base(
         throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
       }
 
+      // Block until the fake-ACP's available_commands_update has
+      // reached the replay buffer. Without this, the browser can race
+      // the supervisor handshake and arrive before the cockpit
+      // reducer has applied the commands, leaving the `/` popover
+      // showing "No matches".
+      await waitForReplayContains(
+        serve.baseUrl,
+        sessionId,
+        "AvailableCommandsUpdated",
+      );
+
       await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
       await waitForCockpitView(page);
 
@@ -169,10 +201,10 @@ base(
       await composer.click();
       await composer.pressSequentially("/r");
 
-      const reviewItem = page.locator('[data-highlighted="true"]').filter({
-        hasText: /\/review/,
-      });
-      await expect(reviewItem).toBeVisible({ timeout: 10_000 });
+      const reviewItem = page
+        .getByRole("option")
+        .filter({ hasText: /\/review/ });
+      await expect(reviewItem).toBeVisible({ timeout: 15_000 });
 
       await composer.press("Enter");
 

--- a/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
@@ -199,7 +199,14 @@ base(
 
       const composer = page.getByRole("textbox", { name: /Send a message/i });
       await composer.click();
-      await composer.pressSequentially("/r");
+      // Type `/rev` rather than `/r` so the fuzzy filter narrows to
+      // `/review` alone. The cockpit composer always seeds the claude
+      // agent profile's `clearAliases` (`/clear`) into the popover
+      // even when the agent doesn't advertise it (see
+      // Composer.tsx:272-284), and a single `/r` matches `/clear` too;
+      // `/clear` ranks ahead of `/review` and Enter would pick the
+      // wrong command.
+      await composer.pressSequentially("/rev");
 
       const reviewItem = page
         .getByRole("option")

--- a/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts
@@ -1,0 +1,194 @@
+// User story (#1512): picking a no-arg slash command from the cockpit
+// composer's `/` popover does not trap the next Enter.
+//
+// Before the fix in #1512, `insertSlashCommand` left the textarea as
+// `/help` with no trailing whitespace. assistant-ui's `detectTrigger`
+// scans backward from the cursor and halts on whitespace; without a
+// trailing space the cursor sits inside the `/help` range and the
+// popover immediately re-opens with the same item highlighted. The
+// popover's keyboard handler claims Enter and Tab while it's open and
+// runs `selectItem` instead of letting the keystroke reach the send
+// path, so the user is stuck (no send, the popover keeps re-picking).
+//
+// The fix in `web/src/components/cockpit/Composer.tsx` is to always
+// append a trailing space, regardless of `acceptsInput`. This spec
+// drives the live cockpit against a fake ACP agent that advertises a
+// no-arg command, picks it via Enter, and asserts a single Enter
+// thereafter sends the prompt.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base(
+  "picking a no-arg slash command does not trap Enter",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-slash-pick-no-arg" }),
+      extraEnv: {
+        // Causes fakeAcpAgent.mjs to emit an available_commands_update
+        // notification right after session/new, populating the slash
+        // popover with one no-arg command (`/help`) and one args
+        // command (`/review`). See web/tests/helpers/fakeAcpAgent.mjs.
+        FAKE_ACP_COMMANDS: JSON.stringify([
+          { name: "help", description: "Show help", accepts_input: false },
+          {
+            name: "review",
+            description: "Review the diff",
+            accepts_input: true,
+            hint: "what to review",
+          },
+        ]),
+      },
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-slash-pick-no-arg");
+      if (!seeded) {
+        throw new Error("seeded session 'story-slash-pick-no-arg' missing");
+      }
+      const sessionId = seeded.id;
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+      // Explicit spawn so the supervisor's ACP session is attached
+      // before the popover is driven. enable can race the implicit
+      // spawn and the first available_commands_update would land before
+      // any client is subscribed.
+      const spawnRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/spawn`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: "claude" }),
+        },
+      );
+      if (![200, 202, 409].includes(spawnRes.status)) {
+        throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
+      }
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+
+      // Type `/h` so the popover surfaces and `/help` is the top
+      // (highlighted) item. fuzzyFilter ranks the prefix match first.
+      await composer.pressSequentially("/h");
+
+      const helpItem = page.locator('[data-highlighted="true"]').filter({
+        hasText: /\/help/,
+      });
+      await expect(helpItem).toBeVisible({ timeout: 10_000 });
+
+      // Pick `/help` via Enter. removeOnExecute strips the typed
+      // `/h`, then `insertSlashCommand` writes the canonical
+      // `/help ` (with trailing space) back via setText.
+      await composer.press("Enter");
+
+      // Trailing space is the load-bearing fix. Without it,
+      // detectTrigger's backward scan never finds whitespace and the
+      // popover stays open.
+      await expect(composer).toHaveValue("/help ", { timeout: 5_000 });
+
+      // The popover must be closed at this point. If it is still open,
+      // the next Enter will route into the popover's keyboard handler
+      // and re-pick the highlighted item instead of sending.
+      await expect(helpItem).toBeHidden({ timeout: 5_000 });
+
+      // Single Enter should now route to the send path. The fake-ACP
+      // default turn emits one agent_message_chunk with the canonical
+      // "Hello from fake ACP agent." string.
+      await composer.press("Enter");
+
+      await expect(page.getByText("Hello from fake ACP agent.")).toBeVisible({
+        timeout: 10_000,
+      });
+      // assistant-ui clears the composer asynchronously after the send
+      // path resolves; give it a bounded window.
+      await expect(composer).toHaveValue("", { timeout: 5_000 });
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "picking an args slash command leaves trailing space and closes popover",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-slash-pick-args" }),
+      extraEnv: {
+        FAKE_ACP_COMMANDS: JSON.stringify([
+          {
+            name: "review",
+            description: "Review the diff",
+            accepts_input: true,
+            hint: "what to review",
+          },
+        ]),
+      },
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-slash-pick-args");
+      if (!seeded) {
+        throw new Error("seeded session 'story-slash-pick-args' missing");
+      }
+      const sessionId = seeded.id;
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+      const spawnRes = await fetch(
+        `${serve.baseUrl}/api/sessions/${sessionId}/cockpit/spawn`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ agent: "claude" }),
+        },
+      );
+      if (![200, 202, 409].includes(spawnRes.status)) {
+        throw new Error(`cockpit spawn failed: ${spawnRes.status}`);
+      }
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+      await composer.pressSequentially("/r");
+
+      const reviewItem = page.locator('[data-highlighted="true"]').filter({
+        hasText: /\/review/,
+      });
+      await expect(reviewItem).toBeVisible({ timeout: 10_000 });
+
+      await composer.press("Enter");
+
+      // The args branch was already correct before #1512 (its
+      // trailing space served the cursor-positioning role). Lock that
+      // contract: `/review ` plus closed popover, cursor ready for
+      // arg typing.
+      await expect(composer).toHaveValue("/review ", { timeout: 5_000 });
+      await expect(reviewItem).toBeHidden({ timeout: 5_000 });
+
+      // Typing afterward extends the existing token rather than
+      // re-opening the popover.
+      await composer.pressSequentially("scope");
+      await expect(composer).toHaveValue("/review scope");
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the investigation, implementation, and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Picking a no-arg slash command (`acceptsInput=false`, e.g. `/help`, `/clear`, `/compact`, `/new`) from the cockpit composer's `/` popover trapped the next Enter. `insertSlashCommand` set the textarea to `/help` with no trailing whitespace, assistant-ui's `detectTrigger` scanned backward from the cursor and only halted on whitespace, so the popover re-opened immediately with the same item highlighted, and every subsequent Enter was consumed by the popover's keyboard handler as "select highlighted" rather than routing to the send path. The only escapes were the Send button, Escape + Enter, or appending a space.

The fix in `web/src/components/cockpit/Composer.tsx` is one line: drop the `accepts ? " " : ""` ternary in `insertSlashCommand` and always emit a trailing space. The space is harmless on the wire (agents trim, the directive parser ignores it) and serves a dual role: positions the cursor for arg typing on `acceptsInput=true` commands (which already worked), and forces `detectTrigger`'s backward scan to terminate on the no-arg branch so the popover closes and Enter reaches the send handler.

Regression coverage:

- `web/src/components/cockpit/Composer.slashCommand.test.ts`, a new Vitest spec that exports `insertSlashCommand` and exercises the no-arg pick, the args pick, and the prior-buffer separator handling against a stubbed composer runtime.
- `web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts`, a new live Playwright story that picks `/help` via Enter, asserts the textarea reads `/help ` with a closed popover, then confirms a single subsequent Enter renders the agent response. A second story locks the `acceptsInput=true` branch (`/review`) so a future refactor cannot regress the args contract.
- `web/tests/helpers/fakeAcpAgent.mjs` now accepts a `FAKE_ACP_COMMANDS` env var carrying a JSON array of commands. After `session/new`, the fake emits a real `available_commands_update` notification so the popover is populated end-to-end. No existing fake-ACP turn shape covered this surface.
- `web/tests/coverage-matrix.json` adds `cockpit.story.composer-slash-pick-no-arg` referencing both the live story and the Vitest spec.

Closes #1512.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

(The fix restores the intended Enter-sends behavior; no existing doc described the trap or the picker's pick semantics, so docs/ does not need an edit.)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open a cockpit session against an agent that advertises at least one no-arg slash command (e.g. Claude with `/help`). In the composer, type `/`, highlight `/help`, press Enter. The textarea reads `/help ` (trailing space), the popover closes, a single Enter sends and the agent replies.
- [ ] Repeat with `/clear`. Pressing Enter once after the pick clears the conversation; you should not need to click Send, hit Escape first, or append a space.
- [ ] Pick a command that takes args (e.g. `/review` if your agent advertises one with `accepts_input=true`). The textarea reads `/review ` with the cursor ready for typing; the popover is closed; typing arg text does not re-open the popover on the existing token.
- [ ] Pick a slash command in the middle of an existing draft (`hello /` then pick `/help`). The composer reads `hello /help ` with a single space separator and one trailing space; popover stays closed.
- [ ] `cd web && npx vitest run src/components/cockpit/Composer.slashCommand.test.ts` is green (5 cases).
- [ ] `cd web && node tests/validate-coverage-matrix.mjs` reports `Coverage matrix validation passed.`

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design call (Proposal A from the issue: always trailing space, single-character ternary deletion), reviewed each commit, and verified the Vitest + coverage-matrix validation locally. The live Playwright story will be exercised by CI on this PR.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR fixes a UX bug in the cockpit composer where selecting a slash command could leave no trailing space (e.g. selecting /help), causing the slash popover to immediately re-open and consume subsequent Enter presses instead of sending the message.

### Changes Made

- Code
  - web/src/components/cockpit/Composer.tsx — insertSlashCommand exported for testing and changed to always append a single trailing space after the inserted canonical slash command (removes acceptsInput-based branching). Maintains insertion of a separator when prior buffer text exists.
- Tests & infra
  - web/src/components/cockpit/Composer.slashCommand.test.ts — Vitest unit tests for no-arg and args-taking commands, separator handling, and null runtime behavior.
  - web/tests/live/cockpit-stories/composer-slash-pick-no-arg.spec.ts — Playwright live stories verifying /help (no-arg) and /review (accepts input) insert "/help " or "/review ", close the popover, and allow Enter to send or type args.
  - web/tests/helpers/fakeAcpAgent.mjs — supports FAKE_ACP_COMMANDS env var and emits available_commands_update after session/new to seed commands in live tests.
  - web/tests/coverage-matrix.json — registers the new live story/spec in the coverage matrix.

### Benefits

- Fixes the Enter-trapping bug so picking a slash command closes the popover and the next Enter sends the message.
- Simplifies insertion logic by applying a single consistent rule (always append a space), reducing conditional complexity and risk of regressions.
- Coverage added at unit and live-story levels to prevent regressions across buffer edge cases.

---

## Technical Details

The composer’s detectTrigger scans backward until it finds whitespace; without a trailing space a picked no-arg command left the caret inside the trigger region so the popover reopened and intercepted Enter. The fix unconditionally appends " " to the inserted "/<name>" token. The trailing space is harmless to agent parsing, positions the caret for argument entry for acceptsInput=true commands, forces detectTrigger’s backward scan to terminate for no-arg commands, closes the popover, and allows Enter to reach the send path.

Potential follow-ups:
- Centralize trigger/insert behavior into a shared utility if other pickers require identical semantics.
- Optionally add an integration test documenting server-side trimming/handling of trailing spaces.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1573?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->