### PR TITLE
fix(worktree): surface fetch failures and apply canonical-remote scoring to explicit base branch

### DIFF
--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -44,17 +44,19 @@ aoe remove <session> --delete-worktree
 ```
 
 `--base-branch` only matters with `--new-branch` / `-b`. The base is
-resolved against the remote first (`origin/<base>`), then against a
-local branch with that name, so passing a teammate's not-yet-fetched
-branch works without a manual `git fetch`. When omitted, the new
-branch is based on the repository's default branch (`main`/`master`).
+resolved against the remote first, then against a local branch with
+that name, so passing a teammate's not-yet-fetched branch works
+without a manual `git fetch`. When omitted, the new branch is based
+on the repository's default branch (`main`/`master`).
 
-Default-branch detection scores every configured remote (not just
-`origin`). In a fork plus `upstream` layout, aoe picks the freshest
-`main`/`master` it can find that HEAD descends from. So if `upstream/main`
-is ahead of `origin/main` and your local `main`, `aoe add` fetches and
-branches off `upstream/main` rather than the stale fork tip. See issue
-\#1029 for the rationale.
+Remote selection scores every configured remote (not just `origin`),
+for both the autodetected default branch (issue \#1029) and an
+explicit `--base-branch` (issue \#1511). In a fork plus `upstream`
+layout where `upstream/main` is ahead of `origin/main`, aoe fetches
+and branches off `upstream/main` even when you typed `main` into the
+wizard's base-branch field. Ties break in favor of `origin` so the
+historical single-remote behavior still applies when there is no
+freshness signal.
 
 ## TUI Keyboard Shortcuts
 
@@ -116,17 +118,31 @@ path_template = "/absolute/path/to/worktrees/{repo-name}/{branch}"
 path_template = "../wt/{branch}-{session-id}"
 ```
 
-## Post-Checkout Hooks
+## Worktree Warnings
 
-Some repos install pre-commit hooks at the `post-checkout` stage (`uv-sync`, `npm install`, LFS smudge, etc.) that fire when `git worktree add` checks out the new branch. If such a hook fails, the worktree directory and its `.git` pointer have already been created, and the worktree is usable. AOE no longer aborts session creation in that case: the hook output is captured and surfaced as a warning.
+Two classes of non-fatal failures surface through the same warning channel during session create. AOE does not abort the session; instead it captures the failure and surfaces it so you know what to investigate.
 
-| Surface | Where the warning appears |
+| Surface | Where warnings appear |
 |---|---|
 | CLI (`aoe add`) | `⚠ <message>` line on stderr after `✓ Worktree created successfully` |
 | TUI | `Worktree warnings` info dialog opens after the session is added |
 | Web | Toast per warning, plus `warnings: string[]` on the `POST /api/sessions` response body |
 
+### Post-checkout hooks
+
+Some repos install pre-commit hooks at the `post-checkout` stage (`uv-sync`, `npm install`, LFS smudge, etc.) that fire when `git worktree add` checks out the new branch. If such a hook fails, the worktree directory and its `.git` pointer have already been created, and the worktree is usable.
+
 Common cause: the hook calls a tool (uv, npm, pip) that needs network access or credentials the new worktree does not yet have. Re-run the hook manually inside the worktree once the environment is set up, or disable it for AOE-created worktrees by configuring `core.hooksPath` per checkout.
+
+### Fetch failures
+
+Before checking out the new branch, AOE runs `git fetch <remote> <branch>` so the worktree starts from the latest remote state. Network errors, missing remotes, SSH key issues, and 10s timeouts no longer pass silently; they surface as warnings shaped like:
+
+```
+git fetch <remote> <branch> failed for <repo>: <stderr>
+```
+
+The session is still created when the fetch fails. The worktree branches off whatever local ref already exists, which may be stale. Multi-repo sessions emit one warning per repo whose fetch failed, so a single bad remote in a workspace of five repos shows up as one toast rather than aborting the whole workspace. See issue \#1511 for the rationale.
 
 ## Performance & Debug Logging
 

--- a/docs/guides/worktrees.md
+++ b/docs/guides/worktrees.md
@@ -138,7 +138,7 @@ Common cause: the hook calls a tool (uv, npm, pip) that needs network access or 
 
 Before checking out the new branch, AOE runs `git fetch <remote> <branch>` so the worktree starts from the latest remote state. Network errors, missing remotes, SSH key issues, and 10s timeouts no longer pass silently; they surface as warnings shaped like:
 
-```
+```text
 git fetch <remote> <branch> failed for <repo>: <stderr>
 ```
 

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -5,10 +5,31 @@
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use regex::Regex;
 
 use super::error::{GitError, Result};
 use super::open_repo_at;
 use super::template::{resolve_template, TemplateVars};
+
+/// Strip embedded credentials from URL-style substrings before stderr
+/// gets logged or surfaced to the user. Git fetch errors typically echo
+/// the remote URL, so a misconfigured `https://user:token@host/repo`
+/// would otherwise leak the token into `debug.log` and into the wizard
+/// toast.
+///
+/// Matches `<scheme>://<userinfo>@<host>` patterns and replaces the
+/// userinfo (everything between `://` and `@`) with `<redacted>`.
+/// Schemes other than the common `http(s)`/`ssh`/`git+ssh` still match
+/// because git accepts arbitrary URL schemes.
+fn sanitize_remote_credentials(s: &str) -> String {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| {
+        Regex::new(r"([a-zA-Z][a-zA-Z0-9+\-.]*://)[^/\s@]+@").expect("static regex always compiles")
+    });
+    re.replace_all(s, "${1}<redacted>@").into_owned()
+}
 
 /// Remote name used as a fallback when no candidate remote can be picked
 /// from the local refs. Real selection happens in
@@ -229,12 +250,12 @@ impl GitWorktree {
                         if let Some(mut stderr) = child.stderr.take() {
                             let _ = std::io::Read::read_to_string(&mut stderr, &mut msg);
                         }
-                        let trimmed = msg.trim().to_string();
-                        tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {trimmed}");
-                        let detail = if trimmed.is_empty() {
+                        let sanitized = sanitize_remote_credentials(msg.trim());
+                        tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {sanitized}");
+                        let detail = if sanitized.is_empty() {
                             format!("git fetch exited with {status}")
                         } else {
-                            trimmed
+                            sanitized
                         };
                         return FetchOutcome::Failed(detail);
                     }
@@ -2551,6 +2572,43 @@ mod tests {
     }
 
     // --- fetch_branch tests ---
+
+    #[test]
+    fn test_sanitize_remote_credentials_redacts_https_userinfo() {
+        let s = "fatal: unable to access 'https://alice:supersecret@github.com/foo/bar.git/': 404";
+        let out = sanitize_remote_credentials(s);
+        assert!(!out.contains("supersecret"), "token leaked: {out}");
+        assert!(!out.contains("alice:"), "username leaked: {out}");
+        assert!(
+            out.contains("https://<redacted>@github.com/foo/bar.git/"),
+            "expected redacted URL, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_sanitize_remote_credentials_redacts_ssh_userinfo() {
+        let s = "Could not read from remote ssh://git:tokenval@example.com:22/foo";
+        let out = sanitize_remote_credentials(s);
+        assert!(!out.contains("tokenval"), "token leaked: {out}");
+        assert!(out.contains("ssh://<redacted>@example.com:22/foo"));
+    }
+
+    #[test]
+    fn test_sanitize_remote_credentials_passes_through_when_no_userinfo() {
+        let s = "fatal: 'origin' does not appear to be a git repository";
+        assert_eq!(sanitize_remote_credentials(s), s);
+        let s2 = "fatal: unable to access 'https://github.com/foo/bar.git/'";
+        assert_eq!(sanitize_remote_credentials(s2), s2);
+    }
+
+    #[test]
+    fn test_sanitize_remote_credentials_does_not_touch_scp_style() {
+        // `git@host:path` is the SCP-style ref, not a URL with userinfo.
+        // Without a `scheme://` prefix the regex does not match, which
+        // is correct: there is no embedded password to redact.
+        let s = "fatal: Could not read from remote: git@github.com:foo/bar.git";
+        assert_eq!(sanitize_remote_credentials(s), s);
+    }
 
     #[test]
     fn test_fetch_branch_returns_failed_when_no_remote() {

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -489,7 +489,13 @@ impl GitWorktree {
         // via `record_fetch_warning` so the user knows the new worktree may
         // be starting from a stale local ref instead of failing silently.
         let t = std::time::Instant::now();
-        let resolved_base: Option<(String, Option<String>)> = if create_branch {
+        // (name, remote, explicit) — `explicit` flips the lookup chain
+        // below from "fall through to HEAD" to "return BranchNotFound"
+        // when neither a remote-tracking ref nor a local branch with the
+        // user-typed name exists. A typo in `--base-branch` should
+        // surface as an error, not as a session quietly anchored to a
+        // bystander commit.
+        let resolved_base: Option<(String, Option<String>, bool)> = if create_branch {
             match base_branch {
                 Some(b) if !b.trim().is_empty() => {
                     let base = b.trim().to_string();
@@ -502,7 +508,7 @@ impl GitWorktree {
                     let fetch_remote = remote.as_deref().unwrap_or(FETCH_REMOTE);
                     let outcome = self.fetch_branch(fetch_remote, &base);
                     self.record_fetch_warning(&mut warnings, &outcome, fetch_remote, &base);
-                    Some((base, remote))
+                    Some((base, remote, true))
                 }
                 _ => {
                     let info = self
@@ -514,7 +520,7 @@ impl GitWorktree {
                     let fetch_remote = info.remote.as_deref().unwrap_or(FETCH_REMOTE);
                     let outcome = self.fetch_branch(fetch_remote, &info.name);
                     self.record_fetch_warning(&mut warnings, &outcome, fetch_remote, &info.name);
-                    Some((info.name, info.remote))
+                    Some((info.name, info.remote, false))
                 }
             }
         } else {
@@ -527,17 +533,22 @@ impl GitWorktree {
         let t = std::time::Instant::now();
         let repo = open_repo_at(&self.repo_path)?;
 
-        if let Some((base, base_remote)) = resolved_base {
+        if let Some((base, base_remote, explicit)) = resolved_base {
             // Branch from the picked remote's tip when the auto-detected
             // canonical remote isn't `origin` (issue #1029: fork+upstream
             // layouts). When the caller passed an explicit `--base-branch`,
             // try `origin/<base>` first to preserve historical behavior.
             // Falls back to a local branch with the same name (lets users
             // base off a teammate's local-only branch), then to HEAD,
-            // then to any local branch (bare repo with broken HEAD).
+            // then to any local branch (bare repo with broken HEAD), but
+            // only when the base came from autodetection. An explicit
+            // `--base-branch` that resolves to none of the above is a
+            // user-visible error: surfacing it as BranchNotFound keeps
+            // typos from silently producing a session anchored to a
+            // bystander commit.
             let primary_remote = base_remote.as_deref().unwrap_or(FETCH_REMOTE);
             let remote_ref = format!("{primary_remote}/{base}");
-            let commit_oid = repo
+            let direct_match = repo
                 .find_branch(&remote_ref, git2::BranchType::Remote)
                 .ok()
                 .and_then(|b| b.get().target())
@@ -557,23 +568,31 @@ impl GitWorktree {
                     repo.find_branch(&base, git2::BranchType::Local)
                         .ok()
                         .and_then(|b| b.get().target())
-                })
-                .or_else(|| {
-                    repo.head()
-                        .ok()
-                        .and_then(|h| h.peel_to_commit().ok())
-                        .map(|c| c.id())
-                })
-                .or_else(|| {
-                    repo.branches(Some(git2::BranchType::Local))
-                        .ok()
-                        .and_then(|mut branches| {
-                            branches.find_map(|b| b.ok().and_then(|(b, _)| b.get().target()))
-                        })
-                })
-                .ok_or_else(|| {
-                    GitError::WorktreeCommandFailed("No commits found to branch from".to_string())
-                })?;
+                });
+
+            let commit_oid = if let Some(oid) = direct_match {
+                oid
+            } else if explicit {
+                return Err(GitError::BranchNotFound(base));
+            } else {
+                repo.head()
+                    .ok()
+                    .and_then(|h| h.peel_to_commit().ok())
+                    .map(|c| c.id())
+                    .or_else(|| {
+                        repo.branches(Some(git2::BranchType::Local)).ok().and_then(
+                            |mut branches| {
+                                branches.find_map(|b| b.ok().and_then(|(b, _)| b.get().target()))
+                            },
+                        )
+                    })
+                    .ok_or_else(|| {
+                        GitError::WorktreeCommandFailed(
+                            "No commits found to branch from".to_string(),
+                        )
+                    })?
+            };
+
             let commit = repo.find_commit(commit_oid)?;
             repo.branch(branch, &commit, false)?;
         } else {
@@ -3314,6 +3333,52 @@ mod tests {
             "hotfix-1 should branch off upstream/main ({upstream_tip}), \
              not stale origin/main ({origin_tip})"
         );
+    }
+
+    #[test]
+    fn test_create_worktree_explicit_base_typo_returns_branch_not_found() {
+        // A typo in `--base-branch` must not silently produce a worktree
+        // anchored to HEAD. With no remote-tracking ref and no local
+        // branch by the typo'd name, create_worktree must surface
+        // BranchNotFound so the caller can show the user the typo.
+        let (dir, _repo) = setup_test_repo();
+        let repo_path = dir.path();
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        let wt_parent = TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("hotfix-wt");
+        let result = git_wt.create_worktree("hotfix-1", &wt_path, true, Some("maain"));
+        match result {
+            Err(GitError::BranchNotFound(name)) => {
+                assert_eq!(name, "maain", "error should name the typo'd base");
+            }
+            other => panic!("expected BranchNotFound, got {other:?}"),
+        }
+        assert!(
+            !wt_path.exists(),
+            "no worktree should be created when base resolution fails"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_autodetected_base_still_falls_through_to_head() {
+        // When no explicit base is passed, autodetect runs and may yield
+        // a name that ultimately can't be resolved (e.g. a brand-new
+        // local-only repo where `main` exists but the lookup chain
+        // somehow misses it). The fallback to HEAD must still kick in
+        // so the historical behavior of "create the worktree off HEAD"
+        // is preserved. This is the autodetect twin of the typo test.
+        let (dir, repo) = setup_test_repo();
+        let repo_path = dir.path();
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        let wt_parent = TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("autodetected-wt");
+        git_wt
+            .create_worktree("new-feature", &wt_path, true, None)
+            .expect("autodetect path should still succeed via HEAD fallback");
+        assert!(wt_path.exists(), "worktree should be created");
+        assert!(repo
+            .find_branch("new-feature", git2::BranchType::Local)
+            .is_ok());
     }
 
     #[test]

--- a/src/git/worktree.rs
+++ b/src/git/worktree.rs
@@ -24,6 +24,20 @@ pub struct WorktreeEntry {
     pub is_detached: bool,
 }
 
+/// Result of a `git fetch` attempt initiated by `fetch_branch`. `Ok`
+/// indicates the fetch ran to completion (the remote tip may or may
+/// not have advanced; we do not parse fetch output to distinguish).
+/// The non-`Ok` variants carry a short description that callers
+/// surface to the user as a warning so they know the new worktree may
+/// be starting from a stale local ref.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FetchOutcome {
+    Ok,
+    Failed(String),
+    Skipped(String),
+    TimedOut,
+}
+
 /// Resolved default branch with the remote it came from, if any.
 ///
 /// Returned by `GitWorktree::detect_default_branch_info`. Callers that
@@ -171,11 +185,16 @@ impl GitWorktree {
         Some(git_or_bare_dir.to_path_buf())
     }
 
-    /// Fetch a specific branch from a remote. Fails silently on network errors
-    /// or missing remotes (logs a warning), so callers can fall back to local state.
-    /// Stdin is piped to null to prevent SSH passphrase prompts from hanging.
-    /// Times out after 10 seconds.
-    pub fn fetch_branch(&self, remote: &str, branch: &str) -> Result<()> {
+    /// Fetch a specific branch from a remote. Returns a `FetchOutcome`
+    /// describing whether the fetch ran successfully, failed, was
+    /// skipped (e.g. spawn error), or timed out. Callers that build a
+    /// warnings vector for the user (see `create_worktree`) should
+    /// route non-`Ok` outcomes into it so the user knows the new
+    /// worktree may be starting from a stale local ref.
+    ///
+    /// Stdin is piped to null to prevent SSH passphrase prompts from
+    /// hanging. Times out after 10 seconds.
+    pub fn fetch_branch(&self, remote: &str, branch: &str) -> FetchOutcome {
         let mut child = match std::process::Command::new("git")
             .args(["fetch", remote, branch])
             .current_dir(&self.repo_path)
@@ -193,7 +212,7 @@ impl GitWorktree {
                     error = %e,
                     "git fetch spawn failed"
                 );
-                return Ok(());
+                return FetchOutcome::Skipped(format!("spawn failed: {e}"));
             }
         };
 
@@ -206,15 +225,21 @@ impl GitWorktree {
                 Ok(Some(status)) => {
                     let elapsed = start.elapsed();
                     if !status.success() {
+                        let mut msg = String::new();
                         if let Some(mut stderr) = child.stderr.take() {
-                            let mut msg = String::new();
                             let _ = std::io::Read::read_to_string(&mut stderr, &mut msg);
-                            tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {}", msg.trim());
                         }
-                    } else {
-                        tracing::info!(target: "git.worktree", "git fetch {remote}/{branch} ok in {:?}", elapsed);
+                        let trimmed = msg.trim().to_string();
+                        tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} failed: {trimmed}");
+                        let detail = if trimmed.is_empty() {
+                            format!("git fetch exited with {status}")
+                        } else {
+                            trimmed
+                        };
+                        return FetchOutcome::Failed(detail);
                     }
-                    return Ok(());
+                    tracing::info!(target: "git.worktree", "git fetch {remote}/{branch} ok in {:?}", elapsed);
+                    return FetchOutcome::Ok;
                 }
                 Ok(None) => {
                     if start.elapsed() > timeout {
@@ -224,16 +249,88 @@ impl GitWorktree {
                             "git fetch {remote}/{branch} timed out after {}s",
                             timeout.as_secs()
                         );
-                        return Ok(());
+                        return FetchOutcome::TimedOut;
                     }
                     std::thread::sleep(poll_interval);
                 }
                 Err(e) => {
                     tracing::warn!(target: "git.worktree", "git fetch {remote}/{branch} error: {e}");
-                    return Ok(());
+                    return FetchOutcome::Failed(format!("wait error: {e}"));
                 }
             }
         }
+    }
+
+    /// Format a user-visible warning describing a non-`Ok`
+    /// `FetchOutcome` and push it onto `warnings`. No-op for
+    /// `FetchOutcome::Ok`. Used by `create_worktree` so fetch failures
+    /// reach the wizard toast / CLI stderr / TUI dialog via the
+    /// existing post-checkout warning surface.
+    fn record_fetch_warning(
+        &self,
+        warnings: &mut Vec<String>,
+        outcome: &FetchOutcome,
+        remote: &str,
+        branch: &str,
+    ) {
+        let detail = match outcome {
+            FetchOutcome::Ok => return,
+            FetchOutcome::Failed(msg) => msg.clone(),
+            FetchOutcome::Skipped(msg) => msg.clone(),
+            FetchOutcome::TimedOut => "timed out after 10s".to_string(),
+        };
+        warnings.push(format!(
+            "git fetch {remote} {branch} failed for {repo}: {detail}",
+            repo = self.repo_path.display()
+        ));
+    }
+
+    /// Pick the remote with the freshest copy of `branch_name`. Walks
+    /// every configured remote, looks up
+    /// `refs/remotes/<remote>/<branch_name>`, and returns the remote
+    /// whose ref has the most recent commit time. Ties break in favor
+    /// of `origin`, then alphabetically by remote name.
+    ///
+    /// Returns `None` when no configured remote tracks `branch_name`.
+    ///
+    /// Used by `create_worktree` for the explicit-base-branch arm so a
+    /// fork plus `upstream` layout (issue #1029) fetches the user's
+    /// requested base from the canonical remote rather than a stale
+    /// `origin`. The autodetect arm continues to use
+    /// `detect_default_branch_info`, which scores `main`/`master`
+    /// across remotes with HEAD-ancestry filtering.
+    pub fn pick_remote_for_branch(&self, branch_name: &str) -> Option<String> {
+        let repo = open_repo_at(&self.repo_path).ok()?;
+        let remotes = repo.remotes().ok()?;
+        let mut best: Option<(String, i64)> = None;
+        for remote in remotes.iter().flatten() {
+            let full = format!("{remote}/{branch_name}");
+            let Ok(b) = repo.find_branch(&full, git2::BranchType::Remote) else {
+                continue;
+            };
+            let Ok(commit) = b.get().peel_to_commit() else {
+                continue;
+            };
+            let t = commit.time().seconds();
+            let take = match &best {
+                None => true,
+                Some((cur_name, cur_t)) => {
+                    if t != *cur_t {
+                        t > *cur_t
+                    } else if cur_name == FETCH_REMOTE {
+                        false
+                    } else if remote == FETCH_REMOTE {
+                        true
+                    } else {
+                        remote < cur_name.as_str()
+                    }
+                }
+            };
+            if take {
+                best = Some((remote.to_string(), t));
+            }
+        }
+        best.map(|(name, _)| name)
     }
 
     /// Detect the default branch name by short name only. Wraps
@@ -367,15 +464,24 @@ impl GitWorktree {
         // Fetch from remote so the worktree starts from the latest state.
         // For new branches, fetch the base branch (default branch unless the
         // caller specified one) to use as the base. For existing branches,
-        // fetch the branch itself. Fails silently on network errors, falling
-        // back to local refs.
+        // fetch the branch itself. Fetch failures are surfaced as warnings
+        // via `record_fetch_warning` so the user knows the new worktree may
+        // be starting from a stale local ref instead of failing silently.
         let t = std::time::Instant::now();
         let resolved_base: Option<(String, Option<String>)> = if create_branch {
             match base_branch {
                 Some(b) if !b.trim().is_empty() => {
                     let base = b.trim().to_string();
-                    self.fetch_branch(FETCH_REMOTE, &base)?;
-                    Some((base, None))
+                    // Apply canonical-remote scoring to explicit base
+                    // branches too. On a fork plus `upstream` layout,
+                    // `upstream/<base>` is usually the freshest copy;
+                    // hardcoding `origin/<base>` lands new branches on
+                    // the stale fork tip (issue #1511 / #1029).
+                    let remote = self.pick_remote_for_branch(&base);
+                    let fetch_remote = remote.as_deref().unwrap_or(FETCH_REMOTE);
+                    let outcome = self.fetch_branch(fetch_remote, &base);
+                    self.record_fetch_warning(&mut warnings, &outcome, fetch_remote, &base);
+                    Some((base, remote))
                 }
                 _ => {
                     let info = self
@@ -385,12 +491,14 @@ impl GitWorktree {
                             remote: None,
                         });
                     let fetch_remote = info.remote.as_deref().unwrap_or(FETCH_REMOTE);
-                    self.fetch_branch(fetch_remote, &info.name)?;
+                    let outcome = self.fetch_branch(fetch_remote, &info.name);
+                    self.record_fetch_warning(&mut warnings, &outcome, fetch_remote, &info.name);
                     Some((info.name, info.remote))
                 }
             }
         } else {
-            self.fetch_branch(FETCH_REMOTE, branch)?;
+            let outcome = self.fetch_branch(FETCH_REMOTE, branch);
+            self.record_fetch_warning(&mut warnings, &outcome, FETCH_REMOTE, branch);
             None
         };
         tracing::info!(target: "git.worktree", "worktree create: fetch step done in {:?}", t.elapsed());
@@ -2445,15 +2553,21 @@ mod tests {
     // --- fetch_branch tests ---
 
     #[test]
-    fn test_fetch_branch_ok_when_no_remote() {
+    fn test_fetch_branch_returns_failed_when_no_remote() {
         let (dir, _repo) = setup_test_repo();
         let git_wt = GitWorktree::new(dir.path().to_path_buf()).unwrap();
-        // No remote configured, fetch should return Ok (silent failure)
-        assert!(git_wt.fetch_branch("origin", "main").is_ok());
+        // No remote configured: `git fetch origin main` exits non-zero
+        // with a "remote does not exist" message. Surface as Failed so
+        // callers can write a warning.
+        let outcome = git_wt.fetch_branch("origin", "main");
+        assert!(
+            matches!(outcome, FetchOutcome::Failed(_)),
+            "expected Failed, got {outcome:?}"
+        );
     }
 
     #[test]
-    fn test_fetch_branch_ok_when_branch_missing_on_remote() {
+    fn test_fetch_branch_returns_failed_when_branch_missing_on_remote() {
         let remote_dir = TempDir::new().unwrap();
         let _remote = git2::Repository::init_bare(remote_dir.path()).unwrap();
 
@@ -2463,8 +2577,41 @@ mod tests {
             git2::Repository::clone(remote_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
 
         let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
-        // Fetching a branch that doesn't exist on the remote should succeed silently
-        assert!(git_wt.fetch_branch("origin", "nonexistent-branch").is_ok());
+        // Fetching a branch that doesn't exist on the remote should
+        // surface as Failed (not Ok), so create_worktree can record it
+        // as a warning for the user.
+        let outcome = git_wt.fetch_branch("origin", "nonexistent-branch");
+        assert!(
+            matches!(outcome, FetchOutcome::Failed(_)),
+            "expected Failed, got {outcome:?}"
+        );
+    }
+
+    #[test]
+    fn test_fetch_branch_returns_ok_when_branch_exists_on_remote() {
+        // Sanity: real fetch path returns Ok. Sets up a tiny "remote"
+        // repo with a single commit on main, clones it locally, and
+        // re-runs fetch.
+        let remote_dir = TempDir::new().unwrap();
+        let remote = git2::Repository::init_bare(remote_dir.path()).unwrap();
+        remote.set_head("refs/heads/main").unwrap();
+        let sig = git2::Signature::now("Test", "test@example.com").unwrap();
+        let tree_id = {
+            let blob = remote.blob(b"hello").unwrap();
+            let mut tb = remote.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree = remote.find_tree(tree_id).unwrap();
+        remote
+            .commit(Some("refs/heads/main"), &sig, &sig, "init", &tree, &[])
+            .unwrap();
+
+        let local_dir = TempDir::new().unwrap();
+        git2::Repository::clone(remote_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
+
+        let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
+        assert_eq!(git_wt.fetch_branch("origin", "main"), FetchOutcome::Ok);
     }
 
     // --- create_worktree fetch integration test ---
@@ -2893,5 +3040,258 @@ mod tests {
             "symlinks should not be counted alongside their target"
         );
         assert_eq!(stats.total_bytes, 3);
+    }
+
+    // --- pick_remote_for_branch + fork+upstream explicit-base tests ---
+
+    /// Build a fork plus upstream layout where `upstream/<branch>` is
+    /// strictly ahead of `origin/<branch>`. Returns the temp dirs that
+    /// must outlive the test (else the remotes vanish), the local clone
+    /// path, the commit OID at the upstream tip, and the commit OID at
+    /// the origin tip.
+    ///
+    /// The local clone has `origin` configured (the fork) plus an
+    /// `upstream` remote pointing at the canonical repo, mirroring the
+    /// fork-plus-upstream developer setup.
+    fn setup_fork_upstream_layout(
+        branch: &str,
+    ) -> (TempDir, TempDir, TempDir, git2::Oid, git2::Oid) {
+        let sig_a = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(1_700_000_000, 0),
+        )
+        .unwrap();
+        let sig_b = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(1_700_001_000, 0),
+        )
+        .unwrap();
+
+        let upstream_dir = TempDir::new().unwrap();
+        let upstream = git2::Repository::init_bare(upstream_dir.path()).unwrap();
+        upstream.set_head(&format!("refs/heads/{branch}")).unwrap();
+        let tree_a_id = {
+            let blob = upstream.blob(b"hello").unwrap();
+            let mut tb = upstream.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let tree_a = upstream.find_tree(tree_a_id).unwrap();
+        let commit_a = upstream
+            .commit(
+                Some(&format!("refs/heads/{branch}")),
+                &sig_a,
+                &sig_a,
+                "commit A",
+                &tree_a,
+                &[],
+            )
+            .unwrap();
+
+        let origin_dir = TempDir::new().unwrap();
+        let origin = git2::Repository::init_bare(origin_dir.path()).unwrap();
+        origin.set_head(&format!("refs/heads/{branch}")).unwrap();
+        let origin_tree_id = {
+            let blob = origin.blob(b"hello").unwrap();
+            let mut tb = origin.treebuilder(None).unwrap();
+            tb.insert("file.txt", blob, 0o100644).unwrap();
+            tb.write().unwrap()
+        };
+        let origin_tree = origin.find_tree(origin_tree_id).unwrap();
+        let origin_tip = origin
+            .commit(
+                Some(&format!("refs/heads/{branch}")),
+                &sig_a,
+                &sig_a,
+                "commit A",
+                &origin_tree,
+                &[],
+            )
+            .unwrap();
+
+        let commit_a_obj = upstream.find_commit(commit_a).unwrap();
+        let tree_b = {
+            let blob = upstream.blob(b"world").unwrap();
+            let mut tb = upstream.treebuilder(Some(&tree_a)).unwrap();
+            tb.insert("file2.txt", blob, 0o100644).unwrap();
+            let id = tb.write().unwrap();
+            upstream.find_tree(id).unwrap()
+        };
+        let commit_b = upstream
+            .commit(
+                Some(&format!("refs/heads/{branch}")),
+                &sig_b,
+                &sig_b,
+                "commit B",
+                &tree_b,
+                &[&commit_a_obj],
+            )
+            .unwrap();
+
+        let local_dir = TempDir::new().unwrap();
+        git2::Repository::clone(origin_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
+        run_git(
+            local_dir.path(),
+            &[
+                "remote",
+                "add",
+                "upstream",
+                upstream_dir.path().to_str().unwrap(),
+            ],
+        );
+        run_git(local_dir.path(), &["fetch", "upstream"]);
+
+        (upstream_dir, origin_dir, local_dir, commit_b, origin_tip)
+    }
+
+    #[test]
+    fn test_pick_remote_for_branch_picks_freshest_remote() {
+        let (_upstream, _origin, local, _upstream_tip, _origin_tip) =
+            setup_fork_upstream_layout("release-1");
+        let git_wt = GitWorktree::new(local.path().to_path_buf()).unwrap();
+        let picked = git_wt.pick_remote_for_branch("release-1");
+        assert_eq!(
+            picked.as_deref(),
+            Some("upstream"),
+            "upstream/release-1 is newer than origin/release-1; should pick upstream"
+        );
+    }
+
+    #[test]
+    fn test_pick_remote_for_branch_returns_none_when_branch_not_on_any_remote() {
+        let (_upstream, _origin, local, _upstream_tip, _origin_tip) =
+            setup_fork_upstream_layout("release-1");
+        let git_wt = GitWorktree::new(local.path().to_path_buf()).unwrap();
+        assert_eq!(git_wt.pick_remote_for_branch("does-not-exist"), None);
+    }
+
+    #[test]
+    fn test_pick_remote_for_branch_prefers_origin_on_commit_time_tie() {
+        // Both remotes carry an identical commit (same time, same
+        // tree). Tiebreak rule keeps `origin` as the conservative
+        // default — matches historical behavior before fork+upstream
+        // scoring landed.
+        let sig = git2::Signature::new(
+            "Test",
+            "test@example.com",
+            &git2::Time::new(1_700_000_000, 0),
+        )
+        .unwrap();
+
+        fn seed_branch(
+            sig: &git2::Signature,
+            branch: &str,
+            content: &[u8],
+        ) -> (TempDir, git2::Oid) {
+            let dir = TempDir::new().unwrap();
+            let repo = git2::Repository::init_bare(dir.path()).unwrap();
+            repo.set_head(&format!("refs/heads/{branch}")).unwrap();
+            let tree_id = {
+                let blob = repo.blob(content).unwrap();
+                let mut tb = repo.treebuilder(None).unwrap();
+                tb.insert("file.txt", blob, 0o100644).unwrap();
+                tb.write().unwrap()
+            };
+            let tree = repo.find_tree(tree_id).unwrap();
+            let oid = repo
+                .commit(
+                    Some(&format!("refs/heads/{branch}")),
+                    sig,
+                    sig,
+                    "init",
+                    &tree,
+                    &[],
+                )
+                .unwrap();
+            (dir, oid)
+        }
+
+        let (a_dir, _a_oid) = seed_branch(&sig, "main", b"hello");
+        let (b_dir, _b_oid) = seed_branch(&sig, "main", b"hello");
+
+        let local_dir = TempDir::new().unwrap();
+        git2::Repository::clone(a_dir.path().to_str().unwrap(), local_dir.path()).unwrap();
+        run_git(
+            local_dir.path(),
+            &["remote", "add", "upstream", b_dir.path().to_str().unwrap()],
+        );
+        run_git(local_dir.path(), &["fetch", "upstream"]);
+
+        let git_wt = GitWorktree::new(local_dir.path().to_path_buf()).unwrap();
+        assert_eq!(
+            git_wt.pick_remote_for_branch("main").as_deref(),
+            Some("origin"),
+            "ties on commit_time should fall back to origin"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_explicit_base_branches_off_freshest_remote() {
+        // Fork plus upstream layout, user passes `--base-branch main`.
+        // The new branch must land on upstream/main (the fresh tip),
+        // not origin/main (the stale fork tip). Regression for #1511.
+        let (_upstream, _origin, local, upstream_tip, origin_tip) =
+            setup_fork_upstream_layout("main");
+        assert_ne!(upstream_tip, origin_tip, "test fixture mis-set up");
+
+        let git_wt = GitWorktree::new(local.path().to_path_buf()).unwrap();
+        let wt_parent = TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("hotfix-wt");
+        git_wt
+            .create_worktree("hotfix-1", &wt_path, true, Some("main"))
+            .unwrap();
+
+        let local_repo = git2::Repository::open(local.path()).unwrap();
+        let new_branch_tip = local_repo
+            .find_branch("hotfix-1", git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        assert_eq!(
+            new_branch_tip, upstream_tip,
+            "hotfix-1 should branch off upstream/main ({upstream_tip}), \
+             not stale origin/main ({origin_tip})"
+        );
+    }
+
+    #[test]
+    fn test_create_worktree_surfaces_fetch_failure_as_warning() {
+        // Configure a remote pointing at a non-existent path. The
+        // fetch call inside create_worktree exits non-zero, but the
+        // worktree itself should still get created (from the local
+        // initial commit). The non-fatal failure should land in the
+        // returned warnings vector so the wizard / CLI can show it.
+        let (dir, _repo) = setup_test_repo();
+        let repo_path = dir.path();
+
+        // Point `origin` at a path that doesn't exist; `git fetch`
+        // will exit non-zero with a "Could not read from remote" style
+        // error.
+        let bogus_remote = dir.path().join("does-not-exist.git");
+        run_git(
+            repo_path,
+            &["remote", "add", "origin", bogus_remote.to_str().unwrap()],
+        );
+
+        let git_wt = GitWorktree::new(repo_path.to_path_buf()).unwrap();
+        let wt_parent = TempDir::new().unwrap();
+        let wt_path = wt_parent.path().join("new-feature");
+        let warnings = git_wt
+            .create_worktree("new-feature", &wt_path, true, None)
+            .expect("create_worktree should still succeed when fetch fails");
+
+        assert!(
+            wt_path.exists() && wt_path.join(".git").exists(),
+            "worktree should be created even when fetch fails"
+        );
+        let joined = warnings.join("\n");
+        assert!(
+            joined.contains("git fetch") && joined.contains("failed for"),
+            "warnings should mention the fetch failure; got: {joined}"
+        );
     }
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -296,6 +296,17 @@
       ]
     },
     {
+      "id": "wizard.multi-repo-stale-base",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/multi-repo-stale-base.spec.ts"
+      ],
+      "components": [
+        "web/src/components/session-wizard/SessionWizard.tsx"
+      ]
+    },
+    {
       "id": "wizard.profile-description",
       "kind": "mocked-playwright",
       "risk": "medium",
@@ -444,36 +455,50 @@
       "id": "sidebar.sort-pure",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/lib/__tests__/sidebarSort.test.ts"],
+      "specs": [
+        "src/lib/__tests__/sidebarSort.test.ts"
+      ],
       "components": []
     },
     {
       "id": "sidebar.sort-hook",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/hooks/useSidebarSortMode.test.ts"],
+      "specs": [
+        "src/hooks/useSidebarSortMode.test.ts"
+      ],
       "components": []
     },
     {
       "id": "sidebar.repo-groups-hook",
       "kind": "vitest",
       "risk": "medium",
-      "specs": ["src/hooks/useRepoGroups.test.ts"],
+      "specs": [
+        "src/hooks/useRepoGroups.test.ts"
+      ],
       "components": []
     },
     {
       "id": "sidebar.sort-toggle-ui",
       "kind": "mocked-playwright",
       "risk": "high",
-      "specs": ["tests/sidebar-sort-mode.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/sidebar-sort-mode.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "sidebar.sort-live",
       "kind": "live-playwright",
       "risk": "medium",
-      "specs": ["tests/live/sidebar-sort-mode.spec.ts"],
-      "components": ["web/src/components/WorkspaceSidebar.tsx"]
+      "specs": [
+        "tests/live/sidebar-sort-mode.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     },
     {
       "id": "session.lifecycle",

--- a/web/tests/live/multi-repo-stale-base.spec.ts
+++ b/web/tests/live/multi-repo-stale-base.spec.ts
@@ -346,12 +346,18 @@ base(
       });
 
       const warnings = created.warnings ?? [];
-      const secondaryWarning = warnings.find(
-        (w) => w.includes("git fetch") && w.includes(secondary),
+      // The warning shape comes from `record_fetch_warning` in
+      // src/git/worktree.rs: `git fetch {remote} {branch} failed for
+      // {repo}: {detail}`. Pin the format so a future rewording of
+      // the warning forces this test to be reconsidered (it's a
+      // user-facing string the wizard pipes to a toast).
+      const warningPattern = new RegExp(
+        `^git fetch \\S+ \\S+ failed for ${secondary.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}: .+`,
       );
+      const secondaryWarning = warnings.find((w) => warningPattern.test(w));
       expect(
         secondaryWarning,
-        `expected fetch-failure warning mentioning ${secondary}, got: ${JSON.stringify(warnings)}`,
+        `expected warning matching ${warningPattern} for ${secondary}, got: ${JSON.stringify(warnings)}`,
       ).toBeDefined();
 
       // Workspace was still created. Both worktree dirs exist.

--- a/web/tests/live/multi-repo-stale-base.spec.ts
+++ b/web/tests/live/multi-repo-stale-base.spec.ts
@@ -1,0 +1,374 @@
+// Multi-repo workspace stale-base regression suite (#1511).
+//
+// Three user stories cover the behavior change in src/git/worktree.rs:
+//
+//   1. Single-repo, explicit `base_branch` on a fork + upstream layout:
+//      the new branch lands on upstream/<base>, not on the stale fork tip.
+//
+//   2. Multi-repo, explicit `base_branch` where one secondary repo is
+//      fork + upstream. The same canonical-remote scoring runs per repo;
+//      the secondary's new worktree branches off upstream/<base> too.
+//
+//   3. Multi-repo, one repo with a misconfigured remote. The create-
+//      session response succeeds, but `warnings` includes a per-repo
+//      `git fetch ... failed for ...` entry that the wizard pipes to a
+//      toast on the client (SessionWizard.tsx:201-204).
+//
+// Each test drives the live `aoe serve` backend via the REST API. Repos
+// are seeded on disk before the server boots (so the daemon picks up
+// `extra_repo_paths` on the create call). Worktree HEADs are read with
+// `git rev-parse` from the test process; we do not bring in libgit2 on
+// the JS side.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnAoeServe, type ServeHandle } from "../helpers/aoeServe";
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "t",
+  GIT_AUTHOR_EMAIL: "t@t",
+  GIT_COMMITTER_NAME: "t",
+  GIT_COMMITTER_EMAIL: "t@t",
+  // Quiet down init's hint about default branch + advice
+  GIT_CONFIG_GLOBAL: "/dev/null",
+  GIT_CONFIG_SYSTEM: "/dev/null",
+} as const;
+
+function run(cmd: string, args: string[], cwd: string, extraEnv: Record<string, string> = {}) {
+  const res = spawnSync(cmd, args, {
+    cwd,
+    env: { ...process.env, ...GIT_ENV, ...extraEnv },
+    encoding: "utf8",
+  });
+  if (res.error || res.status !== 0) {
+    const errMsg = res.error ? String(res.error) : "non-zero exit";
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed in ${cwd}: ${errMsg}; status=${res.status}\nstdout=${res.stdout}\nstderr=${res.stderr}`,
+    );
+  }
+  return res.stdout.trim();
+}
+
+interface ForkUpstreamLayout {
+  /** Path the user passes to `aoe add` (the local clone). */
+  localPath: string;
+  /** Commit OID at upstream/<branch>'s tip; the fresh canonical version. */
+  upstreamTip: string;
+  /** Commit OID at origin/<branch>'s tip; the stale fork version. */
+  originTip: string;
+}
+
+/**
+ * Build a fork plus upstream layout under `root`:
+ *
+ *   <root>/<name>-upstream/   bare repo seeded with commits A and B
+ *   <root>/<name>-origin/     bare repo with only commit A (stale fork)
+ *   <root>/<name>/            local clone of origin with `upstream` added
+ *
+ * Returns paths and tip commit OIDs. The local clone is what the user
+ * passes to `aoe add` / `extra_repo_paths`.
+ */
+function seedForkUpstreamLayout(root: string, name: string, branch: string): ForkUpstreamLayout {
+  const upstreamDir = join(root, `${name}-upstream`);
+  const originDir = join(root, `${name}-origin`);
+  const localDir = join(root, name);
+
+  mkdirSync(upstreamDir, { recursive: true });
+  mkdirSync(originDir, { recursive: true });
+
+  run("git", ["init", "--bare", "-q", `--initial-branch=${branch}`, upstreamDir], root);
+  run("git", ["init", "--bare", "-q", `--initial-branch=${branch}`, originDir], root);
+
+  // Seed both with commit A from a scratch clone of upstream.
+  const seedA = join(root, `${name}-seed-a`);
+  run("git", ["clone", "-q", upstreamDir, seedA], root);
+  writeFileSync(join(seedA, "file.txt"), "hello\n");
+  run("git", ["add", "file.txt"], seedA);
+  run("git", ["commit", "-q", "-m", "commit A"], seedA, {
+    GIT_AUTHOR_DATE: "1700000000 +0000",
+    GIT_COMMITTER_DATE: "1700000000 +0000",
+  });
+  run("git", ["push", "-q", "origin", `HEAD:${branch}`], seedA);
+  // Push the same commit to origin so origin/<branch> exists at A too.
+  run("git", ["remote", "add", "fork-origin", originDir], seedA);
+  run("git", ["push", "-q", "fork-origin", `HEAD:${branch}`], seedA);
+
+  // Add commit B only on upstream.
+  writeFileSync(join(seedA, "file2.txt"), "world\n");
+  run("git", ["add", "file2.txt"], seedA);
+  run("git", ["commit", "-q", "-m", "commit B"], seedA, {
+    GIT_AUTHOR_DATE: "1700001000 +0000",
+    GIT_COMMITTER_DATE: "1700001000 +0000",
+  });
+  run("git", ["push", "-q", "origin", `HEAD:${branch}`], seedA);
+
+  const upstreamTip = run("git", ["rev-parse", `${branch}`], seedA);
+  const originTip = run(
+    "git",
+    ["rev-parse", `fork-origin/${branch}`],
+    seedA,
+  );
+  expect(upstreamTip).not.toBe(originTip);
+
+  // Now make the local clone the user will use. Clone from origin (the
+  // stale fork) and add upstream as a second remote. Mirror the typical
+  // developer setup.
+  run("git", ["clone", "-q", originDir, localDir], root);
+  run("git", ["remote", "add", "upstream", upstreamDir], localDir);
+  run("git", ["fetch", "-q", "upstream"], localDir);
+
+  return { localPath: localDir, upstreamTip, originTip };
+}
+
+interface CreatedSession {
+  id: string;
+  warnings?: string[];
+  /** Single-repo sessions: present in main_repo_path / branch. */
+  branch?: string;
+  main_repo_path?: string;
+  /** Multi-repo sessions: per-repo worktree_path is the ground-truth
+   *  location on disk; do not reconstruct from the template. */
+  workspace_repos?: Array<{
+    name: string;
+    main_repo_path: string;
+    worktree_path: string;
+  }>;
+}
+
+async function createSession(
+  serve: ServeHandle,
+  body: Record<string, unknown>,
+): Promise<CreatedSession> {
+  const res = await fetch(`${serve.baseUrl}/api/sessions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`POST /api/sessions failed: ${res.status} ${await res.text()}`);
+  }
+  // Server returns the SessionResponse directly (web/src/lib/api.ts:615
+  // wraps it as `{ session }` client-side). Don't wrap here.
+  return res.json();
+}
+
+/**
+ * Resolve the commit OID currently checked out in a worktree directory.
+ * Mirrors what `git rev-parse HEAD` would return.
+ */
+function worktreeHead(worktreePath: string): string {
+  return run("git", ["rev-parse", "HEAD"], worktreePath);
+}
+
+/**
+ * Resolve the workspace directory the server created for a multi-repo
+ * session. The default template is `../{branch}-workspace-{session-id}`,
+ * but `session-id` here is a fresh UUID minted inside
+ * `create_workspace` (src/session/builder.rs:91), not the SessionResponse.id
+ * the API returns to the caller. Scan the primary repo's parent for the
+ * matching `<branch-slug>-workspace-*` entry instead of trying to
+ * reconstruct it from the session id.
+ */
+function workspaceDir(home: string, branchSlug: string): string {
+  const prefix = `${branchSlug}-workspace-`;
+  const matches = readdirSync(home).filter((name) => name.startsWith(prefix));
+  if (matches.length !== 1) {
+    throw new Error(
+      `expected exactly one ${prefix}* entry in ${home}, got: ${JSON.stringify(matches)}`,
+    );
+  }
+  return join(home, matches[0]);
+}
+
+function multiRepoWorktreePath(
+  home: string,
+  branchSlug: string,
+  repoName: string,
+): string {
+  return join(workspaceDir(home, branchSlug), repoName);
+}
+
+base(
+  "single-repo: explicit base_branch branches off fresh upstream tip, not stale origin",
+  async ({}, testInfo) => {
+    let serve: ServeHandle | undefined;
+    try {
+      serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: ({ home }) => {
+          // Seed the fork+upstream layout under HOME so cleanup wipes
+          // it along with the rest of the isolated tree.
+          seedForkUpstreamLayout(home, "primary", "main");
+        },
+      });
+
+      // Reach into the home dir we just seeded. The harness exposes it
+      // on the handle so the test can compute paths the daemon will
+      // accept.
+      const layout = {
+        localPath: join(serve.home, "primary"),
+      };
+      const upstreamTip = run(
+        "git",
+        ["rev-parse", "upstream/main"],
+        layout.localPath,
+      );
+
+      const created = await createSession(serve, {
+        path: layout.localPath,
+        tool: "claude",
+        title: "stale-base-single",
+        worktree_branch: "feature/stale-base-single",
+        create_new_branch: true,
+        base_branch: "main",
+      });
+
+      expect(created.warnings ?? []).toEqual([]);
+
+      const worktreePath = join(
+        serve.home,
+        "primary-worktrees",
+        "feature-stale-base-single",
+      );
+      const head = worktreeHead(worktreePath);
+      expect(head).toBe(upstreamTip);
+    } finally {
+      await serve?.stop();
+    }
+  },
+);
+
+base(
+  "multi-repo: secondary repo with fork+upstream layout branches off upstream tip",
+  async ({}, testInfo) => {
+    let serve: ServeHandle | undefined;
+    try {
+      serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: ({ home }) => {
+          seedForkUpstreamLayout(home, "primary", "main");
+          seedForkUpstreamLayout(home, "secondary", "main");
+        },
+      });
+
+      const primary = join(serve.home, "primary");
+      const secondary = join(serve.home, "secondary");
+      const primaryUpstream = run("git", ["rev-parse", "upstream/main"], primary);
+      const secondaryUpstream = run("git", ["rev-parse", "upstream/main"], secondary);
+
+      const created = await createSession(serve, {
+        path: primary,
+        tool: "claude",
+        title: "stale-base-multi",
+        worktree_branch: "feature/stale-base-multi",
+        create_new_branch: true,
+        base_branch: "main",
+        extra_repo_paths: [secondary],
+      });
+
+      expect(created.warnings ?? []).toEqual([]);
+      expect(created.workspace_repos).toBeDefined();
+      expect((created.workspace_repos ?? []).length).toBeGreaterThanOrEqual(2);
+
+      // Each repo's worktree must land on its respective upstream tip.
+      // Multi-repo workspaces use the workspace template
+      // `../{branch}-workspace-{session-id}` with per-repo subdirs.
+      const primaryWorktree = multiRepoWorktreePath(
+        serve.home,
+        "feature-stale-base-multi",
+        "primary",
+      );
+      const secondaryWorktree = multiRepoWorktreePath(
+        serve.home,
+        "feature-stale-base-multi",
+        "secondary",
+      );
+      expect(worktreeHead(primaryWorktree)).toBe(primaryUpstream);
+      expect(worktreeHead(secondaryWorktree)).toBe(secondaryUpstream);
+    } finally {
+      await serve?.stop();
+    }
+  },
+);
+
+base(
+  "multi-repo: per-repo fetch failure surfaces as warning, session still created",
+  async ({}, testInfo) => {
+    let serve: ServeHandle | undefined;
+    try {
+      serve = await spawnAoeServe({
+        authMode: "none",
+        workerIndex: testInfo.workerIndex,
+        parallelIndex: testInfo.parallelIndex,
+        seedFn: ({ home }) => {
+          // Primary is a healthy repo with one commit.
+          const primary = join(home, "primary");
+          mkdirSync(primary, { recursive: true });
+          run("git", ["init", "-q", "--initial-branch=main", primary], home);
+          writeFileSync(join(primary, "file.txt"), "hi\n");
+          run("git", ["add", "file.txt"], primary);
+          run("git", ["commit", "-q", "-m", "init"], primary);
+
+          // Secondary repo has a misconfigured `origin` remote pointing
+          // at a non-existent path. `git fetch origin main` exits
+          // non-zero; the new code path surfaces this as a warning
+          // instead of failing the session.
+          const secondary = join(home, "secondary");
+          mkdirSync(secondary, { recursive: true });
+          run("git", ["init", "-q", "--initial-branch=main", secondary], home);
+          writeFileSync(join(secondary, "file.txt"), "hi\n");
+          run("git", ["add", "file.txt"], secondary);
+          run("git", ["commit", "-q", "-m", "init"], secondary);
+          run(
+            "git",
+            ["remote", "add", "origin", join(home, "does-not-exist.git")],
+            secondary,
+          );
+        },
+      });
+
+      const primary = join(serve.home, "primary");
+      const secondary = join(serve.home, "secondary");
+
+      const created = await createSession(serve, {
+        path: primary,
+        tool: "claude",
+        title: "fetch-fail",
+        worktree_branch: "feature/fetch-fail",
+        create_new_branch: true,
+        extra_repo_paths: [secondary],
+      });
+
+      const warnings = created.warnings ?? [];
+      const secondaryWarning = warnings.find(
+        (w) => w.includes("git fetch") && w.includes(secondary),
+      );
+      expect(
+        secondaryWarning,
+        `expected fetch-failure warning mentioning ${secondary}, got: ${JSON.stringify(warnings)}`,
+      ).toBeDefined();
+
+      // Workspace was still created. Both worktree dirs exist.
+      const primaryWorktree = multiRepoWorktreePath(
+        serve.home,
+        "feature-fetch-fail",
+        "primary",
+      );
+      const secondaryWorktree = multiRepoWorktreePath(
+        serve.home,
+        "feature-fetch-fail",
+        "secondary",
+      );
+      expect(worktreeHead(primaryWorktree)).toBeTruthy();
+      expect(worktreeHead(secondaryWorktree)).toBeTruthy();
+    } finally {
+      await serve?.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two layered defects let new multi-repo sessions start from a stale base. The agent reads stale code, runs against old branches, and proposes changes against a base that diverged hours or days ago.

**Defect 1: `fetch_branch` was silent on every error path.** Network failures, missing remotes, dropped ssh keys, branch-not-on-remote, and 10s timeouts all returned `Ok(())`. The user never learned a repo's fetch had failed, and the worktree fell back to whatever local ref happened to exist. `fetch_branch` now returns a `FetchOutcome` enum (`Ok`, `Failed`, `Skipped`, `TimedOut`). `create_worktree` writes the non-`Ok` variants into its existing `warnings` vector, which already plumbs through to the CLI stderr, the TUI dialog, and the web wizard toast (`SessionWizard.tsx:201-204`).

**Defect 2: the explicit `--base-branch` arm hard-coded `origin` as the fetch remote.** On a fork + `upstream` layout, `origin/<base>` is the stale fork tip; the new branch landed on it instead of `upstream/<base>`. Issue #1029 already paid the design cost for the autodetect path; this PR applies the same scoring to the explicit case via a new `pick_remote_for_branch` helper. The existing base-resolution block at `worktree.rs:409` already accepts `Option<String>` for the picked remote, so propagating the choice in was a one-line wiring change.

Both fixes are localized to `src/git/worktree.rs`. No new config field, no on-disk schema change, no migration.

Closes #1511

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Three live specs under `web/tests/live/multi-repo-stale-base.spec.ts`:

- Single-repo, explicit `base_branch` on a fork+upstream layout: new branch lands on `upstream/<base>`, not `origin/<base>`.
- Multi-repo with a secondary fork+upstream repo: per-repo scoring lands each repo on its own upstream tip.
- Multi-repo with a misconfigured secondary remote: response surfaces a per-repo `git fetch ... failed for ...` warning; the workspace is still created.

**TUI / CLI (e2e test)**
- [x] N/A: TUI / CLI paths share the same `create_worktree` primitive, exercised by six new Rust unit + integration tests under `src/git/worktree.rs::tests`.

## How to test

User-runnable verification, one checkbox per acceptance criterion:

- [x] In a fork + upstream repo (`origin` = your fork, `upstream` = canonical), let `origin/main` go stale relative to `upstream/main`. Run `aoe add . -w feat/test -b --base-branch main`. New worktree's `HEAD` matches `upstream/main` tip, not stale `origin/main`.
- [x] Same as above through the web wizard's Advanced > Base branch field. Same result.
- [x] Multi-repo workspace via web wizard, secondary repo also fork+upstream, both repos branch off their respective `upstream/main` tips.
- [x] Multi-repo workspace where one secondary repo has a misconfigured remote URL. Session creation succeeds; a toast appears per failing repo with `git fetch <remote> <branch> failed for <repo>: <stderr>`.
- [x] Default-branch autodetection (no `--base-branch`) still works as before on a single-remote repo (regression check; existing test surface).

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (skip `/debate`, keep `FetchOutcome` enum over a side-channel buffer, scope out fast-forward of existing-branch checkouts), and ran the manual test steps locally.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes two bugs that caused multi-repo sessions to start from stale refs and makes fetch failures visible to users while keeping session creation resilient.

- Fetch failures were previously swallowed; fetch_branch now returns a structured FetchOutcome (Ok / Failed(detail) / Skipped(detail) / TimedOut). Non-Ok outcomes are recorded as per-repo warnings (sanitizing embedded credentials) and surfaced to CLI stderr, the TUI dialog, and the web wizard toast while still allowing worktrees to be created from available local refs.
- Explicit --base-branch no longer hard-codes "origin". A pick_remote_for_branch helper (freshness-based scoring, ties prefer origin) is used so explicit-base flows fetch from the most appropriate remote (e.g., upstream on forks). If an explicit base can’t be resolved after remote attempts, create_worktree returns BranchNotFound instead of falling back to HEAD.

What changed (high level)
- docs/guides/worktrees.md: expanded docs for remote selection, explicit-base behavior, and a new "Worktree Warnings" section describing fetch-failure warnings and where they appear.
- src/git/worktree.rs: fetch_branch now returns FetchOutcome; added sanitize_remote_credentials; added pick_remote_for_branch; create_worktree records fetch outcomes as warnings and uses the chosen remote for explicit-base resolution; explicit-base failures are handled more strictly.
- Tests: six new Rust unit/integration tests and three Playwright live specs (web/tests/live/multi-repo-stale-base.spec.ts) covering fork+upstream selection, per-repo scoring, and fetch-failure warnings.
- web/tests/coverage-matrix.json: adds coverage entry for the new Playwright suite.

Benefits
- Users are informed when a repo fell back to a stale/local ref due to fetch issues (actionable per-repo warnings).
- Explicit base-branch behavior honors per-repo remote topology (fixes fork+upstream cases).
- Sessions remain robust: worktrees are still created on non-fatal fetch failures, with warnings to investigate.
- Extensive tests and docs reduce regression risk.

Technical details (concise)
- New public enum: pub enum FetchOutcome { Ok, Failed(String), Skipped(String), TimedOut }.
- GitWorktree::fetch_branch signature changed from Result<()> → FetchOutcome; fetch timeout set to 10s.
- Added sanitize_remote_credentials to redact URL-style credentials from git stderr included in warnings.
- Added pick_remote_for_branch: chooses remote by freshest commit time, ties prefer origin; propagated into explicit-base resolution.
- create_worktree records non-Ok fetch outcomes into its warnings vector; warnings flow through session builder into session-create responses.
- No config or on-disk schema changes; changes localized to src/git/worktree.rs, docs, and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1574?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->