### PR TITLE
fix(server,web): theme picker reverts after reload, narrow elevation gate to safe preference fields

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -177,6 +177,7 @@ The upstream proxy must set `X-Forwarded-For` (or `cf-connecting-ip`); aoe reads
 - **Rate limiting:** 5 failed login attempts from an IP trigger a 15-minute lockout. Uses `Cf-Connecting-IP` / `X-Forwarded-For` from loopback peers (covers `--remote` tunnel mode and `--behind-proxy` reverse-proxy mode) to prevent IP spoofing.
 - **Token rotation:** In `--remote` mode, the token rotates every 4 hours with a 5-minute grace period for active sessions.
 - **Device tracking:** Connected devices (IP, browser, last seen) are visible in Settings > Security.
+- **Step-up elevation:** A "Confirm passphrase" prompt appears on writes whose payload can plant code for the next session spawn: the `sandbox` and `worktree` sections, and dangerous `session` fields (`agent_command_override`, `agent_extra_args`, `extra_env`, `custom_agents`, `agent_detect_as`). Confirmation lasts 15 minutes. User-preference writes (theme, sound, updates, notification toggles, logging filter, profile description, and safe session fields like `yolo_mode_default`) save without the prompt; saving a theme should not feel like signing in again.
 
 ### Security headers
 

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -657,7 +657,7 @@ mod tests {
         assert_eq!(
             ELEVATION_REQUIRED_SECTIONS.len(),
             expected.len(),
-            "ELEVATION_REQUIRED_SECTIONS size changed — widening this list \
+            "ELEVATION_REQUIRED_SECTIONS size changed: widening this list \
              reintroduces passphrase prompts on user-preference saves. See #1510."
         );
         for section in expected {

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -110,6 +110,54 @@ pub(super) const SESSION_BLOCKED_FIELDS: &[&str] = &[
     "agent_detect_as",
 ];
 
+/// Top-level settings sections whose presence in a `PATCH
+/// /api/profiles/{name}/settings` body forces a step-up elevation
+/// check inside the handler. These are the persisted-tamper surfaces:
+/// Docker images, volume mounts, worktree templates, hook
+/// configuration. The path-shape gate in `requires_elevation` exempts
+/// the settings PATCH wholesale so safe preference fields (theme,
+/// sound, updates, web, logging, description, safe session) save
+/// without re-prompting the passphrase; the handler re-imposes the
+/// gate when any key in this list is part of the patch. See #1510.
+pub(super) const ELEVATION_REQUIRED_SECTIONS: &[&str] = &["sandbox", "worktree"];
+
+/// Session fields whose presence in a `session` patch forces a
+/// step-up elevation check inside `update_profile_settings`. These
+/// are the agent-command tamper fields that survive
+/// `SESSION_BLOCKED_FIELDS` filtering (they are stripped from the
+/// web payload, but the body-shape gate runs before stripping so
+/// the client gets a typed 403 instead of a silent no-op when
+/// elevation is missing). Stays in sync with `SESSION_BLOCKED_FIELDS`
+/// by design: the same fields are too dangerous to write without
+/// elevation AND too dangerous to write at all from the dashboard.
+pub(super) const ELEVATION_REQUIRED_SESSION_FIELDS: &[&str] = SESSION_BLOCKED_FIELDS;
+
+/// Returns true when the incoming profile-settings PATCH body
+/// contains any key the handler must gate behind elevation. Walks
+/// `ELEVATION_REQUIRED_SECTIONS` for top-level keys and
+/// `ELEVATION_REQUIRED_SESSION_FIELDS` inside a `session` subobject.
+/// `hooks` is intentionally not in `ALLOWED_PROFILE_SETTINGS_SECTIONS`
+/// (the section-level allowlist rejects it with 400 before this
+/// runs); listing it here would be dead code.
+pub(super) fn body_requires_elevation(body: &serde_json::Value) -> bool {
+    let Some(obj) = body.as_object() else {
+        return false;
+    };
+    for key in obj.keys() {
+        if ELEVATION_REQUIRED_SECTIONS.contains(&key.as_str()) {
+            return true;
+        }
+    }
+    if let Some(session) = obj.get("session").and_then(|v| v.as_object()) {
+        for key in session.keys() {
+            if ELEVATION_REQUIRED_SESSION_FIELDS.contains(&key.as_str()) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Validate that a profile name contains only safe characters.
 /// Rejects path traversal attempts (../, /) and shell metacharacters.
 pub(super) fn validate_profile_name(name: &str) -> Result<(), String> {
@@ -592,6 +640,108 @@ mod tests {
         assert!(validate_profile_name("my-profile").is_ok());
         assert!(validate_profile_name("profile_2").is_ok());
         assert!(validate_profile_name("A").is_ok());
+    }
+
+    #[test]
+    fn elevation_required_sections_are_pinned() {
+        // Persisted-tamper attack class only. Adding a section here
+        // imposes a passphrase re-prompt on the dashboard for every
+        // patch that touches it, so the bar is the same as adding to
+        // SESSION_BLOCKED_FIELDS: arbitrary command on session spawn,
+        // image / mount / template substitution. Theme, sound,
+        // updates, web (notification toggles), logging, description
+        // and safe session fields stay OFF this list by design;
+        // re-prompting for them trained users to dismiss the real
+        // prompt. See #1510.
+        let expected: &[&str] = &["sandbox", "worktree"];
+        assert_eq!(
+            ELEVATION_REQUIRED_SECTIONS.len(),
+            expected.len(),
+            "ELEVATION_REQUIRED_SECTIONS size changed — widening this list \
+             reintroduces passphrase prompts on user-preference saves. See #1510."
+        );
+        for section in expected {
+            assert!(
+                ELEVATION_REQUIRED_SECTIONS.contains(section),
+                "ELEVATION_REQUIRED_SECTIONS lost section {:?}",
+                section
+            );
+        }
+    }
+
+    #[test]
+    fn elevation_required_session_fields_match_blocked_fields() {
+        // ELEVATION_REQUIRED_SESSION_FIELDS == SESSION_BLOCKED_FIELDS by
+        // design. The two lists answer the same question (does this
+        // session field carry the command-injection / agent-binary
+        // tamper surface?) and must stay in sync. If a future field
+        // is dangerous enough to strip but safe enough to allow
+        // unprivileged set, split them then; today they overlap.
+        assert_eq!(ELEVATION_REQUIRED_SESSION_FIELDS, SESSION_BLOCKED_FIELDS);
+    }
+
+    #[test]
+    fn body_requires_elevation_flags_sandbox() {
+        let body = serde_json::json!({"sandbox": {"default_image": "x"}});
+        assert!(body_requires_elevation(&body));
+    }
+
+    #[test]
+    fn body_requires_elevation_flags_worktree() {
+        let body = serde_json::json!({"worktree": {"path_template": "x"}});
+        assert!(body_requires_elevation(&body));
+    }
+
+    #[test]
+    fn body_requires_elevation_flags_dangerous_session_fields() {
+        for field in ELEVATION_REQUIRED_SESSION_FIELDS {
+            let body = serde_json::json!({"session": {*field: "anything"}});
+            assert!(
+                body_requires_elevation(&body),
+                "session field {:?} should require elevation",
+                field
+            );
+        }
+    }
+
+    #[test]
+    fn body_requires_elevation_passes_safe_sections() {
+        // Theme, sound, updates, web, logging, description, and safe
+        // session fields all save without a passphrase re-prompt. This
+        // is the load-bearing user-visible behavior of #1510.
+        for section in ["theme", "sound", "updates", "web", "logging", "description"] {
+            let body = serde_json::json!({section: {"name": "anything"}});
+            assert!(
+                !body_requires_elevation(&body),
+                "section {:?} should NOT require elevation",
+                section
+            );
+        }
+        let body =
+            serde_json::json!({"session": {"yolo_mode_default": true, "strict_hotkeys": false}});
+        assert!(!body_requires_elevation(&body));
+    }
+
+    #[test]
+    fn body_requires_elevation_handles_mixed_payload() {
+        // A patch that touches both a safe section and a tamper-surface
+        // section must elevate. Half-credit ("strip sandbox, save the
+        // theme") would surprise the user and require a partial-success
+        // response shape. Easier to require elevation up front.
+        let body = serde_json::json!({
+            "theme": {"name": "default"},
+            "sandbox": {"default_image": "x"}
+        });
+        assert!(body_requires_elevation(&body));
+    }
+
+    #[test]
+    fn body_requires_elevation_rejects_non_object() {
+        assert!(!body_requires_elevation(&serde_json::json!(null)));
+        assert!(!body_requires_elevation(&serde_json::json!("string")));
+        assert!(!body_requires_elevation(&serde_json::json!([
+            {"sandbox": {}}
+        ])));
     }
 
     #[test]

--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -9,9 +9,10 @@ use serde::{Deserialize, Serialize};
 
 use super::AppState;
 use super::{
-    validate_profile_name, ALLOWED_GLOBAL_SETTINGS_SECTIONS, ALLOWED_PROFILE_SETTINGS_SECTIONS,
-    SESSION_BLOCKED_FIELDS,
+    body_requires_elevation, validate_profile_name, ALLOWED_GLOBAL_SETTINGS_SECTIONS,
+    ALLOWED_PROFILE_SETTINGS_SECTIONS, SESSION_BLOCKED_FIELDS,
 };
+use crate::server::auth::AuthenticatedSession;
 
 // --- Agents ---
 
@@ -922,6 +923,7 @@ pub async fn get_profile_settings(
 pub async fn update_profile_settings(
     State(state): State<Arc<AppState>>,
     axum::extract::Path(name): axum::extract::Path<String>,
+    session: Option<axum::Extension<AuthenticatedSession>>,
     body: Result<Json<serde_json::Value>, axum::extract::rejection::JsonRejection>,
 ) -> impl IntoResponse {
     if state.read_only {
@@ -958,6 +960,39 @@ pub async fn update_profile_settings(
                 )
                     .into_response();
             }
+        }
+    }
+
+    // Body-shape elevation gate. The path-shape gate in
+    // `requires_elevation` exempts this endpoint so safe preference
+    // fields save without a passphrase re-prompt; tamper-surface fields
+    // (sandbox image, worktree templates, dangerous session entries)
+    // re-impose the elevation requirement here. Mirrors the 403
+    // payload shape the path-shape gate returns so the client's
+    // existing `elevation_required` handling (web/src/lib/
+    // fetchInterceptor.ts) fires `ElevationPrompt` unchanged. See
+    // #1510.
+    if state.login_manager.is_enabled() && body_requires_elevation(&body) {
+        let elevated = match session.as_ref() {
+            Some(axum::Extension(AuthenticatedSession(id))) => {
+                state.login_manager.is_elevated(id).await
+            }
+            None => false,
+        };
+        if !elevated {
+            tracing::info!(
+                target: "auth.passphrase",
+                profile = %name,
+                "update_profile_settings: tamper-surface keys in patch without elevation; returning 403"
+            );
+            return (
+                StatusCode::FORBIDDEN,
+                Json(serde_json::json!({
+                    "error": "elevation_required",
+                    "message": "Re-enter the passphrase to continue"
+                })),
+            )
+                .into_response();
         }
     }
 

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -325,6 +325,18 @@ fn post_token_auth_action(
 /// even though the spawn itself is not, because the spawn runs with
 /// the legitimate owner's elevation, not the attacker's.
 ///
+/// `PATCH /api/profiles/{name}/settings` is intentionally exempt at
+/// this layer: the same endpoint accepts both tamper-surface keys
+/// (sandbox, worktree, dangerous session fields) and benign user-
+/// preference keys (theme, sound, updates, web notifications,
+/// logging, description, safe session fields). The handler does a
+/// body-shape elevation check via `body_requires_elevation` and
+/// returns the same `403 elevation_required` payload when a tamper-
+/// surface key is present without elevation. Elevating the whole
+/// endpoint here trained every preference save to re-prompt for the
+/// passphrase, which both broke the theme picker UX and conditioned
+/// users to dismiss the real prompts. See #1510.
+///
 /// Read-only `GET`/`HEAD` on these resources stay open; this is an
 /// allow-list, not a default-deny, so adding a benign read endpoint
 /// never accidentally hides behind a passphrase prompt. When adding
@@ -351,10 +363,17 @@ fn requires_elevation(method: &axum::http::Method, path: &str) -> bool {
     if path == "/api/profiles" && method == Method::POST {
         return true;
     }
-    if path.starts_with("/api/profiles/") {
-        // Per-profile writes: PATCH /api/profiles/{name}/settings,
-        // PATCH .../rename, DELETE /api/profiles/{name}. Read GETs
-        // were filtered out by the GET/HEAD bypass above.
+    if let Some(rest) = path.strip_prefix("/api/profiles/") {
+        // Per-profile writes. `PATCH /api/profiles/{name}/settings`
+        // is body-gated inside the handler so safe preference fields
+        // (theme, sound, etc.) do not pay a passphrase prompt; the
+        // tamper-surface fields still 403 with elevation_required.
+        // Rename + delete stay path-gated. Read GETs were filtered
+        // out by the GET/HEAD bypass above.
+        if method == Method::PATCH && (rest.ends_with("/settings") || rest.ends_with("/settings/"))
+        {
+            return false;
+        }
         return true;
     }
 
@@ -409,6 +428,19 @@ enum TokenSource {
 /// this to filter subscriptions by owner.
 #[derive(Clone, Copy, Debug)]
 pub struct AuthenticatedTokenHash(pub [u8; 32]);
+
+/// Request extension carrying the login session id used to authenticate
+/// the current request. Inserted by `auth_middleware` whenever a valid
+/// `aoe_session` cookie + device binding pair landed (both the
+/// session+binding steady-state path and the `--auth=passphrase` wall).
+/// Absent under `--auth=none` and on bootstrap token-only paths where
+/// no session cookie exists yet. Handlers that need a body-shape
+/// elevation check (e.g. `update_profile_settings`) read this extension
+/// to call `state.login_manager.is_elevated(...)` from inside the
+/// handler instead of relying on the path-shape gate in
+/// `requires_elevation`. See #1510.
+#[derive(Clone, Debug)]
+pub struct AuthenticatedSession(pub String);
 
 /// Passphrase login wall used when the token gate is disabled
 /// (`--auth=passphrase`). Mirrors the session + device-binding check
@@ -483,6 +515,11 @@ async fn run_passphrase_wall(
         )
             .into_response();
     }
+
+    let mut request = request;
+    request
+        .extensions_mut()
+        .insert(AuthenticatedSession(session_id.clone()));
 
     let mut response = next.run(request).await;
 
@@ -830,6 +867,10 @@ async fn handle_session_authenticated(
         )
             .into_response();
     }
+
+    request
+        .extensions_mut()
+        .insert(AuthenticatedSession(session_id.clone()));
 
     let mut response = next.run(request).await;
 
@@ -1280,16 +1321,23 @@ mod tests {
         assert!(requires_elevation(&Method::POST, "/api/profiles"));
         assert!(requires_elevation(
             &Method::PATCH,
-            "/api/profiles/work/settings"
-        ));
-        assert!(requires_elevation(
-            &Method::PATCH,
             "/api/profiles/work/rename"
         ));
         assert!(requires_elevation(&Method::DELETE, "/api/profiles/work"));
         // Trailing slash must not bypass the gate.
         assert!(requires_elevation(&Method::PATCH, "/api/settings/"));
-        assert!(requires_elevation(
+
+        // `PATCH /api/profiles/{name}/settings` is body-gated inside the
+        // handler (`update_profile_settings` calls `body_requires_elevation`
+        // and re-issues the 403 elevation_required payload for tamper-
+        // surface keys). The path-level gate exempts it so safe
+        // preference fields (theme, sound, etc.) do not re-prompt the
+        // passphrase on every save. See #1510.
+        assert!(!requires_elevation(
+            &Method::PATCH,
+            "/api/profiles/work/settings"
+        ));
+        assert!(!requires_elevation(
             &Method::PATCH,
             "/api/profiles/work/settings/"
         ));

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -167,8 +167,8 @@ export function SettingsView({
   }, [loadSettings]);
 
   const sendSave = useCallback(
-    async (section: string, data: Record<string, unknown>) => {
-      if (!selectedProfile) return;
+    async (section: string, data: Record<string, unknown>): Promise<boolean> => {
+      if (!selectedProfile) return false;
       setSaving(true);
       setSaveError(null);
       const ok = await updateProfileSettings(selectedProfile, { [section]: data });
@@ -177,6 +177,7 @@ export function SettingsView({
         setSaveError("Failed to save, please try again");
         loadSettings();
       }
+      return ok;
     },
     [selectedProfile, loadSettings],
   );
@@ -198,15 +199,15 @@ export function SettingsView({
     sectionData: Record<string, unknown>,
     field: string,
     value: unknown,
-  ) => {
+  ): Promise<boolean> => {
     updateLocal({ [section]: { ...sectionData, [field]: value } });
-    sendSave(section, { [field]: value });
+    return sendSave(section, { [field]: value });
   };
 
   const saveSubField = useCallback(
-    (section: string, field: string, value: unknown) => {
+    (section: string, field: string, value: unknown): Promise<boolean> => {
       const sectionData = (settings?.[section] ?? {}) as Record<string, unknown>;
-      saveField(section, sectionData, field, value);
+      return saveField(section, sectionData, field, value);
     },
     [settings, selectedProfile, sendSave, loadSettings],
   );

--- a/web/src/components/settings/ThemeSettings.tsx
+++ b/web/src/components/settings/ThemeSettings.tsx
@@ -5,7 +5,11 @@ import { SelectField } from "./FormFields";
 
 interface Props {
   settings: Record<string, unknown>;
-  onSaveField: (section: string, field: string, value: unknown) => void;
+  onSaveField: (
+    section: string,
+    field: string,
+    value: unknown,
+  ) => Promise<boolean> | void;
   onUpdate: (patch: Record<string, unknown>) => void;
 }
 
@@ -17,15 +21,20 @@ export function ThemeSettings({ settings, onSaveField, onUpdate }: Props) {
     fetchThemes().then(setThemes);
   }, []);
 
-  const save = (field: string, value: unknown) => {
+  const save = async (field: string, value: unknown) => {
     onUpdate({ theme: { ...theme, [field]: value } });
-    onSaveField("theme", field, value);
-    // Repaint the web dashboard immediately on theme pick. The picker
-    // writes config.toml synchronously above; tell useResolvedTheme to
-    // refetch and apply without waiting for a full settings sync.
-    if (field === "name") {
-      dispatchThemePickerChanged(typeof value === "string" ? value : undefined);
-    }
+    const result = onSaveField("theme", field, value);
+    // Only repaint the dashboard chrome after the PATCH lands.
+    // Previously the picker dispatched the repaint event before
+    // awaiting the PATCH, so a failed save (passphrase elevation
+    // missing, read-only mode, network) left the dashboard painted
+    // with a theme that wasn't on disk; a reload then snapped back
+    // to the previous theme and looked like a silent revert.
+    // See #1510.
+    if (field !== "name") return;
+    const ok = result instanceof Promise ? await result : true;
+    if (!ok) return;
+    dispatchThemePickerChanged(typeof value === "string" ? value : undefined);
   };
 
   return (

--- a/web/src/components/settings/__tests__/ThemeSettings.test.tsx
+++ b/web/src/components/settings/__tests__/ThemeSettings.test.tsx
@@ -95,4 +95,61 @@ describe("ThemeSettings contract", () => {
       expect(onSaveField).toHaveBeenCalledWith("theme", "color_mode", mode);
     }
   });
+
+  // Regression for #1510: when the PATCH fails (elevation missing,
+  // read-only, network), the picker event must NOT fire. The previous
+  // code dispatched the repaint synchronously, so a failed save left
+  // the dashboard chrome painted with a theme that did not match what
+  // the server returned on the next reload.
+  it("does not dispatch picker event when onSaveField resolves false", async () => {
+    const onSaveField = vi
+      .fn<(s: string, f: string, v: unknown) => Promise<boolean>>()
+      .mockResolvedValue(false);
+    const onUpdate = vi.fn();
+    const { container } = render(
+      <ThemeSettings
+        settings={{ theme: { name: "default", color_mode: "truecolor" } }}
+        onSaveField={onSaveField}
+        onUpdate={onUpdate}
+      />,
+    );
+    await waitFor(() => {
+      const opts = container.querySelectorAll("select")[0].querySelectorAll(
+        "option",
+      );
+      expect(opts.length).toBeGreaterThan(1);
+    });
+    const themeSelect = container.querySelectorAll("select")[0];
+    fireEvent.change(themeSelect, { target: { value: "modus-vivendi" } });
+    // Settle the promise queue so the await inside save() runs.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(onSaveField).toHaveBeenCalledWith("theme", "name", "modus-vivendi");
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it("dispatches picker event after onSaveField resolves true", async () => {
+    const onSaveField = vi
+      .fn<(s: string, f: string, v: unknown) => Promise<boolean>>()
+      .mockResolvedValue(true);
+    const onUpdate = vi.fn();
+    const { container } = render(
+      <ThemeSettings
+        settings={{ theme: { name: "default", color_mode: "truecolor" } }}
+        onSaveField={onSaveField}
+        onUpdate={onUpdate}
+      />,
+    );
+    await waitFor(() => {
+      const opts = container.querySelectorAll("select")[0].querySelectorAll(
+        "option",
+      );
+      expect(opts.length).toBeGreaterThan(1);
+    });
+    const themeSelect = container.querySelectorAll("select")[0];
+    fireEvent.change(themeSelect, { target: { value: "modus-vivendi" } });
+    await waitFor(() => {
+      expect(dispatchSpy).toHaveBeenCalledWith("modus-vivendi");
+    });
+  });
 });

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -93,6 +93,20 @@
       ]
     },
     {
+      "id": "settings.theme-persistence-passphrase",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/settings-persistence-theme-passphrase.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/components/ElevationPrompt.tsx",
+        "web/src/lib/fetchInterceptor.ts"
+      ]
+    },
+    {
       "id": "settings.sound-payload",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/helpers/liveTest.ts
+++ b/web/tests/helpers/liveTest.ts
@@ -76,7 +76,13 @@ export async function seedAuth(
     const secret = handle.deviceBindingSecret;
     await page.addInitScript((s) => {
       try {
-        window.localStorage.setItem("aoe-device-binding-secret", s);
+        // Storage key must match `STORAGE_KEY` in web/src/lib/deviceBinding.ts.
+        // The SPA reads this on the first authenticated fetch via
+        // `getOrCreateDeviceBindingSecret()`; if it does not find a
+        // matching base64url-32-byte value it generates a fresh one,
+        // which would not match the binding the harness used at
+        // `POST /api/login`, and subsequent requests would 401.
+        window.localStorage.setItem("aoe_device_binding_secret_v1", s);
       } catch {
         // localStorage may be unavailable depending on origin state.
       }

--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -1,0 +1,176 @@
+// Theme persistence under `--auth=passphrase` (#1510).
+//
+// Story 2: a passphrase user picks a theme. The dashboard repaints,
+// the new theme survives a page reload AND an `aoe serve` restart,
+// and NO passphrase re-prompt fires. Locks the body-shape elevation
+// gate in `update_profile_settings`: theme is on the safe list, so
+// the handler must not return 403 elevation_required and the client
+// must not pop ElevationPrompt.
+//
+// Story 3: the same passphrase user PATCHes a sandbox image. The
+// daemon DOES still return 403 elevation_required and the client
+// DOES pop the inline passphrase prompt. Locks the threat-model
+// half of the fix: tamper-surface fields stay gated.
+//
+// Both tests boot a fresh `aoe serve --auth=passphrase` via
+// `spawnAoeServe({ preloginViaHarness: true })` and inject the
+// resulting session cookie + device binding so the browser starts
+// authenticated but NOT elevated. Elevation is the second factor
+// the issue is about.
+
+import { test as base, expect, type Page } from "@playwright/test";
+import {
+  spawnAoeServe,
+  type ServeHandle,
+} from "../helpers/aoeServe";
+import { seedAuth } from "../helpers/liveTest";
+
+const SWITCH_TO = "dracula";
+
+const test = base.extend<{ servePreauthed: ServeHandle }>({
+  servePreauthed: async ({}, use, testInfo) => {
+    const handle = await spawnAoeServe({
+      authMode: "passphrase",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      preloginViaHarness: true,
+    });
+    await use(handle);
+    await handle.stop();
+  },
+});
+
+async function gotoPreauthed(page: Page, handle: ServeHandle, path: string) {
+  await seedAuth(page, handle);
+  await page.goto(`${handle.baseUrl}${path}`);
+}
+
+test("theme picker persists across reload + restart without passphrase prompt", async ({
+  servePreauthed,
+  page,
+}) => {
+  await gotoPreauthed(page, servePreauthed, "/settings/theme");
+
+  const themeSelect = page
+    .locator("label", { hasText: /^Theme$/ })
+    .locator("..")
+    .locator("select");
+  await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+  await expect
+    .poll(
+      async () =>
+        await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+          Array.from(sel.options).some((o) => o.value === target),
+        SWITCH_TO),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+
+  // Listen for the elevation prompt event the fetchInterceptor fires
+  // on 403 elevation_required, so a flaky "dialog never opened" race
+  // can't silently let the test pass.
+  const elevationFired = await page.evaluate(() => {
+    (window as unknown as { __elevationFired?: boolean }).__elevationFired = false;
+    window.addEventListener("aoe:elevation-required", () => {
+      (window as unknown as { __elevationFired?: boolean }).__elevationFired = true;
+    });
+    return true;
+  });
+  expect(elevationFired).toBe(true);
+
+  await themeSelect.selectOption(SWITCH_TO);
+
+  await expect(async () => {
+    const after = await fetch(`${servePreauthed.baseUrl}/api/profiles/default/settings`, {
+      headers: cookieHeader(servePreauthed),
+    }).then((r) => r.json());
+    expect(after?.theme?.name).toBe(SWITCH_TO);
+  }).toPass({ timeout: 5_000 });
+
+  // No elevation prompt fired anywhere. Checks both the DOM dialog
+  // and the event the interceptor would have dispatched.
+  await expect(
+    page.getByRole("dialog", { name: /Confirm passphrase/i }),
+  ).toHaveCount(0);
+  const fired = await page.evaluate(
+    () =>
+      (window as unknown as { __elevationFired?: boolean }).__elevationFired ??
+      false,
+  );
+  expect(fired).toBe(false);
+
+  // Client-side repaint after PATCH resolves.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          document.documentElement.style
+            .getPropertyValue("--color-surface-900")
+            .trim(),
+        ),
+      { timeout: 5_000, intervals: [100, 200, 400] },
+    )
+    .toBe("#282a36");
+
+  await page.reload();
+  const afterReload = await fetch(
+    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
+    { headers: cookieHeader(servePreauthed) },
+  ).then((r) => r.json());
+  expect(afterReload?.theme?.name).toBe(SWITCH_TO);
+
+  await servePreauthed.restart();
+  const afterRestart = await fetch(
+    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
+    { headers: cookieHeader(servePreauthed) },
+  ).then((r) => r.json());
+  expect(afterRestart?.theme?.name).toBe(SWITCH_TO);
+});
+
+test("sandbox image change still requires passphrase elevation", async ({
+  servePreauthed,
+  page,
+}) => {
+  await gotoPreauthed(page, servePreauthed, "/");
+
+  // Fire the PATCH from the page so the fetchInterceptor (installed by
+  // the SPA bootstrap) sees the 403 and dispatches the elevation event.
+  // A direct test-side `fetch` would bypass the interceptor and the
+  // dialog would never open even when the server side is correct.
+  const status = await page.evaluate(async () => {
+    const res = await fetch("/api/profiles/default/settings", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        sandbox: { default_image: "ghcr.io/example/img:tampered" },
+      }),
+    });
+    return res.status;
+  });
+  expect(status).toBe(403);
+
+  // ElevationPrompt opens (from fetchInterceptor dispatching
+  // ELEVATION_REQUIRED_EVENT on the 403 elevation_required payload).
+  await expect(
+    page.getByRole("dialog", { name: /Confirm passphrase/i }),
+  ).toBeVisible({ timeout: 5_000 });
+
+  // Server state did not move: the sandbox image stays at whatever it
+  // was. Use the seeded session cookie on the test-side fetch so the
+  // GET passes the passphrase wall.
+  const after = await fetch(
+    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
+    { headers: cookieHeader(servePreauthed) },
+  ).then((r) => r.json());
+  expect(after?.sandbox?.default_image ?? "").not.toBe(
+    "ghcr.io/example/img:tampered",
+  );
+});
+
+function cookieHeader(handle: ServeHandle): Record<string, string> {
+  if (!handle.sessionCookie) return {};
+  return {
+    Cookie: `${handle.sessionCookie.name}=${handle.sessionCookie.value}`,
+    "X-Aoe-Device-Binding": handle.deviceBindingSecret ?? "",
+  };
+}

--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -65,6 +65,37 @@ function authHeaders(handle: ServeHandle): Record<string, string> {
   return out;
 }
 
+/**
+ * `aoe serve` restart wipes the in-memory `LoginManager` state, so any
+ * cookie minted by the previous process becomes invalid: the device
+ * binding (32 random bytes) was stored in process memory and is gone.
+ * Re-mint a session by POSTing the same passphrase + binding the
+ * harness used during initial preauth. Mutates the handle in place so
+ * `authHeaders(handle)` returns the fresh cookie. Mirrors
+ * `loginWithPassphrase` in `web/tests/helpers/aoeServe.ts`, which is
+ * not exported.
+ */
+async function reLogin(handle: ServeHandle): Promise<void> {
+  if (!handle.passphrase || !handle.deviceBindingSecret) return;
+  const res = await fetch(`${handle.baseUrl}/api/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      passphrase: handle.passphrase,
+      device_binding_secret: handle.deviceBindingSecret,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(`re-login after restart failed: ${res.status} ${await res.text()}`);
+  }
+  const setCookie = res.headers.get("set-cookie") ?? "";
+  const match = /aoe_session=([^;]+)/.exec(setCookie);
+  if (!match) {
+    throw new Error(`re-login did not set aoe_session cookie. Set-Cookie: ${setCookie}`);
+  }
+  handle.sessionCookie = { name: "aoe_session", value: match[1] };
+}
+
 async function resolveDefaultProfile(handle: ServeHandle): Promise<string> {
   const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
     `${handle.baseUrl}/api/profiles`,
@@ -140,7 +171,7 @@ test("theme picker persists across reload + restart without passphrase prompt", 
   // No elevation prompt fired anywhere. Checks both the DOM dialog
   // and the event the interceptor would have dispatched.
   await expect(
-    page.getByRole("dialog", { name: /Confirm passphrase/i }),
+    page.locator('[role="dialog"]').filter({ hasText: /Confirm passphrase/i }),
   ).toHaveCount(0);
   const fired = await page.evaluate(
     () =>
@@ -173,6 +204,7 @@ test("theme picker persists across reload + restart without passphrase prompt", 
   expect(afterReload?.theme?.name).toBe(SWITCH_TO);
 
   await servePreauthed.restart();
+  await reLogin(servePreauthed);
   const afterRestart = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
     (r) => r.json(),
   );
@@ -208,8 +240,12 @@ test("sandbox image change still requires passphrase elevation", async ({
 
   // ElevationPrompt opens (from fetchInterceptor dispatching
   // ELEVATION_REQUIRED_EVENT on the 403 elevation_required payload).
+  // The dialog element has role=dialog + aria-modal=true but no
+  // accessible name (no aria-label, no aria-labelledby pointing at
+  // the "Confirm passphrase" header), so `getByRole("dialog", { name })`
+  // does not match. Locate by role then filter on visible text instead.
   await expect(
-    page.getByRole("dialog", { name: /Confirm passphrase/i }),
+    page.locator('[role="dialog"]').filter({ hasText: /Confirm passphrase/i }),
   ).toBeVisible({ timeout: 5_000 });
 
   // Server state did not move: the sandbox image stays at whatever it

--- a/web/tests/live/settings-persistence-theme-passphrase.spec.ts
+++ b/web/tests/live/settings-persistence-theme-passphrase.spec.ts
@@ -17,6 +17,16 @@
 // resulting session cookie + device binding so the browser starts
 // authenticated but NOT elevated. Elevation is the second factor
 // the issue is about.
+//
+// Direct `page.goto(/settings/...)` is avoided in passphrase mode:
+// the path is not in `is_login_session_exempt`, so a hard browser
+// navigation that carries only the cookie (no device-binding header
+// from the SPA's fetch wrapper) would redirect to `/login`. We
+// always land on `/` first (exempt; serves the SPA shell), let the
+// fetch interceptor authenticate subsequent API calls with cookie +
+// binding, then change the route client-side via history.pushState
+// + popstate so react-router renders the new view without a
+// re-navigation that would 401.
 
 import { test as base, expect, type Page } from "@playwright/test";
 import {
@@ -40,16 +50,69 @@ const test = base.extend<{ servePreauthed: ServeHandle }>({
   },
 });
 
-async function gotoPreauthed(page: Page, handle: ServeHandle, path: string) {
+function authHeaders(handle: ServeHandle): Record<string, string> {
+  // Test-side fetches bypass the SPA's fetch wrapper, so they must
+  // supply the session cookie + device binding header themselves.
+  // Mirrors what `fetchInterceptor.attachAuthHeader` adds in the
+  // browser.
+  const out: Record<string, string> = {};
+  if (handle.sessionCookie) {
+    out["Cookie"] = `${handle.sessionCookie.name}=${handle.sessionCookie.value}`;
+  }
+  if (handle.deviceBindingSecret) {
+    out["X-Aoe-Device-Binding"] = handle.deviceBindingSecret;
+  }
+  return out;
+}
+
+async function resolveDefaultProfile(handle: ServeHandle): Promise<string> {
+  const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+    `${handle.baseUrl}/api/profiles`,
+    { headers: authHeaders(handle) },
+  ).then((r) => r.json());
+  return profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+}
+
+async function bootDashboardAndNavigate(
+  page: Page,
+  handle: ServeHandle,
+  path: string,
+): Promise<void> {
   await seedAuth(page, handle);
-  await page.goto(`${handle.baseUrl}${path}`);
+  await page.goto(handle.baseUrl);
+  // Wait until at least one authenticated API call lands successfully.
+  // /api/about is served unconditionally once auth passes, so once it
+  // resolves the SPA's cookie+binding pair is known good.
+  await page.waitForResponse(
+    (res) => res.url().endsWith("/api/about") && res.status() === 200,
+    { timeout: 10_000 },
+  );
+  if (path !== "/") {
+    await page.evaluate((target) => {
+      window.history.pushState({}, "", target);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }, path);
+  }
 }
 
 test("theme picker persists across reload + restart without passphrase prompt", async ({
   servePreauthed,
   page,
 }) => {
-  await gotoPreauthed(page, servePreauthed, "/settings/theme");
+  const defaultProfile = await resolveDefaultProfile(servePreauthed);
+  const profileUrl = `${servePreauthed.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+
+  await bootDashboardAndNavigate(page, servePreauthed, "/settings/theme");
+
+  // Listen for the elevation prompt event the fetchInterceptor fires
+  // on 403 elevation_required, so a flaky "dialog never opened" race
+  // can't silently let the test pass.
+  await page.evaluate(() => {
+    (window as unknown as { __elevationFired?: boolean }).__elevationFired = false;
+    window.addEventListener("aoe:elevation-required", () => {
+      (window as unknown as { __elevationFired?: boolean }).__elevationFired = true;
+    });
+  });
 
   const themeSelect = page
     .locator("label", { hasText: /^Theme$/ })
@@ -65,25 +128,12 @@ test("theme picker persists across reload + restart without passphrase prompt", 
       { timeout: 5_000 },
     )
     .toBe(true);
-
-  // Listen for the elevation prompt event the fetchInterceptor fires
-  // on 403 elevation_required, so a flaky "dialog never opened" race
-  // can't silently let the test pass.
-  const elevationFired = await page.evaluate(() => {
-    (window as unknown as { __elevationFired?: boolean }).__elevationFired = false;
-    window.addEventListener("aoe:elevation-required", () => {
-      (window as unknown as { __elevationFired?: boolean }).__elevationFired = true;
-    });
-    return true;
-  });
-  expect(elevationFired).toBe(true);
-
   await themeSelect.selectOption(SWITCH_TO);
 
   await expect(async () => {
-    const after = await fetch(`${servePreauthed.baseUrl}/api/profiles/default/settings`, {
-      headers: cookieHeader(servePreauthed),
-    }).then((r) => r.json());
+    const after = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
+      (r) => r.json(),
+    );
     expect(after?.theme?.name).toBe(SWITCH_TO);
   }).toPass({ timeout: 5_000 });
 
@@ -113,17 +163,19 @@ test("theme picker persists across reload + restart without passphrase prompt", 
     .toBe("#282a36");
 
   await page.reload();
-  const afterReload = await fetch(
-    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
-    { headers: cookieHeader(servePreauthed) },
-  ).then((r) => r.json());
+  await page.waitForResponse(
+    (res) => res.url().endsWith("/api/about") && res.status() === 200,
+    { timeout: 10_000 },
+  );
+  const afterReload = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
+    (r) => r.json(),
+  );
   expect(afterReload?.theme?.name).toBe(SWITCH_TO);
 
   await servePreauthed.restart();
-  const afterRestart = await fetch(
-    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
-    { headers: cookieHeader(servePreauthed) },
-  ).then((r) => r.json());
+  const afterRestart = await fetch(profileUrl, { headers: authHeaders(servePreauthed) }).then(
+    (r) => r.json(),
+  );
   expect(afterRestart?.theme?.name).toBe(SWITCH_TO);
 });
 
@@ -131,22 +183,27 @@ test("sandbox image change still requires passphrase elevation", async ({
   servePreauthed,
   page,
 }) => {
-  await gotoPreauthed(page, servePreauthed, "/");
+  const defaultProfile = await resolveDefaultProfile(servePreauthed);
+
+  await bootDashboardAndNavigate(page, servePreauthed, "/");
 
   // Fire the PATCH from the page so the fetchInterceptor (installed by
   // the SPA bootstrap) sees the 403 and dispatches the elevation event.
   // A direct test-side `fetch` would bypass the interceptor and the
   // dialog would never open even when the server side is correct.
-  const status = await page.evaluate(async () => {
-    const res = await fetch("/api/profiles/default/settings", {
-      method: "PATCH",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        sandbox: { default_image: "ghcr.io/example/img:tampered" },
-      }),
-    });
+  const status = await page.evaluate(async (profile) => {
+    const res = await fetch(
+      `/api/profiles/${encodeURIComponent(profile)}/settings`,
+      {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          sandbox: { default_image: "ghcr.io/example/img:tampered" },
+        }),
+      },
+    );
     return res.status;
-  });
+  }, defaultProfile);
   expect(status).toBe(403);
 
   // ElevationPrompt opens (from fetchInterceptor dispatching
@@ -156,21 +213,12 @@ test("sandbox image change still requires passphrase elevation", async ({
   ).toBeVisible({ timeout: 5_000 });
 
   // Server state did not move: the sandbox image stays at whatever it
-  // was. Use the seeded session cookie on the test-side fetch so the
-  // GET passes the passphrase wall.
+  // was. Use the seeded cookie + binding so the GET passes the wall.
   const after = await fetch(
-    `${servePreauthed.baseUrl}/api/profiles/default/settings`,
-    { headers: cookieHeader(servePreauthed) },
+    `${servePreauthed.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`,
+    { headers: authHeaders(servePreauthed) },
   ).then((r) => r.json());
   expect(after?.sandbox?.default_image ?? "").not.toBe(
     "ghcr.io/example/img:tampered",
   );
 });
-
-function cookieHeader(handle: ServeHandle): Record<string, string> {
-  if (!handle.sessionCookie) return {};
-  return {
-    Cookie: `${handle.sessionCookie.name}=${handle.sessionCookie.value}`,
-    "X-Aoe-Device-Binding": handle.deviceBindingSecret ?? "",
-  };
-}

--- a/web/tests/live/settings-persistence-theme.spec.ts
+++ b/web/tests/live/settings-persistence-theme.spec.ts
@@ -53,6 +53,18 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
   serve,
   page,
 }) => {
+  // The dashboard's `selectedProfile` resolves to whichever profile
+  // GET /api/profiles flags `is_default`. On a fresh `aoe serve` that
+  // is "main" (bootstrap profile), not "default", so we cannot
+  // hard-code the path; query the server and use whatever name it
+  // hands back.
+  const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+    `${serve.baseUrl}/api/profiles`,
+  ).then((r) => r.json());
+  const defaultProfile =
+    profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+  const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+
   // Drive the picker through the actual settings UI, not the REST
   // endpoint, so the regression that landed the dispatch-before-PATCH
   // bug would re-fail this test. Lands on /settings/theme directly
@@ -80,9 +92,7 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
 
   // Server-side: PATCH landed and the profile config reflects the pick.
   await expect(async () => {
-    const after = await fetch(
-      `${serve.baseUrl}/api/profiles/default/settings`,
-    ).then((r) => r.json());
+    const after = await fetch(profileUrl).then((r) => r.json());
     expect(after?.theme?.name).toBe(SWITCH_TO);
   }).toPass({ timeout: 5_000 });
 
@@ -107,16 +117,14 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
   // Persistence across page reload.
   await page.reload();
   const afterReload = await page.evaluate(async (url) => {
-    const r = await fetch(`${url}/api/profiles/default/settings`);
+    const r = await fetch(url);
     return r.json();
-  }, serve.baseUrl);
+  }, profileUrl);
   expect(afterReload?.theme?.name).toBe(SWITCH_TO);
 
   // Persistence across `aoe serve` restart (process exits, config.toml
   // is what survives). The restart() helper reuses the same port.
   await serve.restart();
-  const afterRestart = await fetch(
-    `${serve.baseUrl}/api/profiles/default/settings`,
-  ).then((r) => r.json());
+  const afterRestart = await fetch(profileUrl).then((r) => r.json());
   expect(afterRestart?.theme?.name).toBe(SWITCH_TO);
 });

--- a/web/tests/live/settings-persistence-theme.spec.ts
+++ b/web/tests/live/settings-persistence-theme.spec.ts
@@ -111,8 +111,11 @@ test("theme picker repaints, persists across reload and serve restart (#1510)", 
 
   // No passphrase / elevation prompt fired (the daemon does not have a
   // passphrase configured in the `serve` fixture). The elevation prompt
-  // is a role=dialog with the "Confirm passphrase" header.
-  await expect(page.getByRole("dialog", { name: /Confirm passphrase/i })).toHaveCount(0);
+  // is a role=dialog with the "Confirm passphrase" header (no
+  // accessible name; locate by role + text).
+  await expect(
+    page.locator('[role="dialog"]').filter({ hasText: /Confirm passphrase/i }),
+  ).toHaveCount(0);
 
   // Persistence across page reload.
   await page.reload();

--- a/web/tests/live/settings-persistence-theme.spec.ts
+++ b/web/tests/live/settings-persistence-theme.spec.ts
@@ -3,9 +3,16 @@
 // PATCH /api/settings -> GET /api/settings returns the new value; reload
 // the dashboard and the value still applies. Proves the live server
 // persists settings to disk (not just in-memory) and the frontend reads
-// them back on every page load.
+// them back on every page load. The user-story covers #1217.
+//
+// The second test (#1510) is the user-observable form: the dashboard
+// picker drives the change, the dashboard chrome repaints, and the
+// new theme survives both a page reload and an `aoe serve` restart
+// without any passphrase prompt firing (no-auth mode).
 
 import { test, expect } from "../helpers/liveTest";
+
+const SWITCH_TO = "dracula";
 
 test("theme setting persists through PATCH + reload", async ({
   serve,
@@ -40,4 +47,76 @@ test("theme setting persists through PATCH + reload", async ({
     return r.json();
   }, serve.baseUrl);
   expect(fetched?.theme?.name).toBe(newTheme);
+});
+
+test("theme picker repaints, persists across reload and serve restart (#1510)", async ({
+  serve,
+  page,
+}) => {
+  // Drive the picker through the actual settings UI, not the REST
+  // endpoint, so the regression that landed the dispatch-before-PATCH
+  // bug would re-fail this test. Lands on /settings/theme directly
+  // (App.tsx routes settings tabs by URL) and waits for the dropdown.
+  await page.goto(`${serve.baseUrl}/settings/theme`);
+  const themeSelect = page
+    .locator("label", { hasText: /^Theme$/ })
+    .locator("..")
+    .locator("select");
+  await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+
+  // Make sure the picker has the candidate option (themes fetched
+  // asynchronously from /api/themes).
+  await expect
+    .poll(
+      async () =>
+        await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+          Array.from(sel.options).some((o) => o.value === target),
+        SWITCH_TO),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+
+  await themeSelect.selectOption(SWITCH_TO);
+
+  // Server-side: PATCH landed and the profile config reflects the pick.
+  await expect(async () => {
+    const after = await fetch(
+      `${serve.baseUrl}/api/profiles/default/settings`,
+    ).then((r) => r.json());
+    expect(after?.theme?.name).toBe(SWITCH_TO);
+  }).toPass({ timeout: 5_000 });
+
+  // Client-side repaint: the picker dispatches aoe:theme-picker-changed
+  // only after the PATCH resolves, so --color-surface-900 must end up
+  // at dracula's value (#282a36) without us nudging the event ourselves.
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() =>
+          document.documentElement.style.getPropertyValue("--color-surface-900").trim(),
+        ),
+      { timeout: 5_000, intervals: [100, 200, 400] },
+    )
+    .toBe("#282a36");
+
+  // No passphrase / elevation prompt fired (the daemon does not have a
+  // passphrase configured in the `serve` fixture). The elevation prompt
+  // is a role=dialog with the "Confirm passphrase" header.
+  await expect(page.getByRole("dialog", { name: /Confirm passphrase/i })).toHaveCount(0);
+
+  // Persistence across page reload.
+  await page.reload();
+  const afterReload = await page.evaluate(async (url) => {
+    const r = await fetch(`${url}/api/profiles/default/settings`);
+    return r.json();
+  }, serve.baseUrl);
+  expect(afterReload?.theme?.name).toBe(SWITCH_TO);
+
+  // Persistence across `aoe serve` restart (process exits, config.toml
+  // is what survives). The restart() helper reuses the same port.
+  await serve.restart();
+  const afterRestart = await fetch(
+    `${serve.baseUrl}/api/profiles/default/settings`,
+  ).then((r) => r.json());
+  expect(afterRestart?.theme?.name).toBe(SWITCH_TO);
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Picking a theme in the web dashboard repainted immediately but the new theme silently reverted on the next page reload or `aoe serve` restart. Two failure modes shared one underlying cause:

1. **Passphrase set, elevation missing.** `PATCH /api/profiles/{name}/settings` was elevation-gated at the path level, so every preference save (theme, sound, updates, notification toggles, logging filter, profile description) re-prompted for the passphrase. If the user dismissed the prompt, the picker had already painted the new theme synchronously, so the dashboard showed the new theme while disk still held the old one. Reload reverted.
2. **No passphrase.** A failed PATCH for any reason (read-only mode, network blip) hit the same path: picker repainted, save failed, the snap-back via `loadSettings()` only reset the dropdown, and the dashboard chrome stayed painted until the next mount fetch.

Root cause: `requires_elevation` was path-shaped and `PATCH /api/profiles/{name}/settings` is the single endpoint through which both dangerous fields (sandbox image, worktree templates, hooks-equivalent session fields) and benign user-preference fields are written. Elevating the entire endpoint to match the worst payload trained users to dismiss the real prompt.

The fix is the hybrid from the issue's Proposal A:

- **Backend gate narrowing.** `requires_elevation` no longer treats `PATCH /api/profiles/{name}/settings` as elevation-required at the path layer. Rename, delete, and create on profiles stay gated. `PATCH /api/settings` global, `PATCH /api/default-profile`, and `POST /api/profiles` are unchanged.
- **Body-shape handler check.** `update_profile_settings` now calls `body_requires_elevation` on the incoming patch. The new pinned constants `ELEVATION_REQUIRED_SECTIONS = ["sandbox", "worktree"]` and `ELEVATION_REQUIRED_SESSION_FIELDS` (mirrors `SESSION_BLOCKED_FIELDS`) decide which keys re-impose the gate. When the body touches any of them and the session isn't elevated, the handler returns the same `403 elevation_required` JSON the path-shape gate emitted, so the existing client `ElevationPrompt` flow fires unchanged.
- **Session-id plumbing.** `AuthenticatedSession` is a new request extension inserted by both `handle_session_authenticated` and `run_passphrase_wall`, so the handler can call `state.login_manager.is_elevated(...)` without re-extracting cookies.
- **Client awaits before repaint.** `SettingsView.sendSave / saveField / saveSubField` now return `Promise<boolean>`. `ThemeSettings.save` awaits and only dispatches `aoe:theme-picker-changed` when the PATCH resolved successfully, so a failed save no longer leaves the dashboard chrome painted with a theme that disk doesn't agree with.

Closes #1510

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Specifically:
- `web/tests/live/settings-persistence-theme.spec.ts` gains a UI-driven theme switch test that asserts the dashboard CSS var repaints, no `Confirm passphrase` dialog appears (no-auth fixture), and the new theme survives both a page reload and an `aoe serve` restart.
- `web/tests/live/settings-persistence-theme-passphrase.spec.ts` (new) covers the two passphrase user stories: theme save under `--auth=passphrase` does not re-prompt and persists across reload + restart; sandbox image change still returns `403 elevation_required` and pops the inline prompt.
- `web/src/components/settings/__tests__/ThemeSettings.test.tsx` gains regression cases for the dispatch-on-success behavior.
- `web/tests/coverage-matrix.json` records the new live spec.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

User-runnable behavioral steps. Each maps to one of the issue's user stories:

- [x] **No-passphrase repaint + persist.** Run `aoe serve` with no `--passphrase` flag. Open the dashboard, go to Settings > Theme, pick a different theme. The dashboard chrome should repaint instantly. Reload the page; the new theme survives. Restart `aoe serve` (`aoe serve --stop && aoe serve`); reload; new theme still applied. No "Confirm passphrase" prompt should ever appear.
- [x] **Passphrase user, theme picker no longer re-prompts.** Run `aoe serve --auth=passphrase --passphrase <X>`. Log in. Go to Settings > Theme, pick a different theme. The dashboard chrome should repaint instantly; no "Confirm passphrase" dialog should pop. Reload; new theme survives. Restart serve; reload; new theme still applied.
- [x] **Tamper-surface fields still gated.** Same passphrase-mode server. Go to Settings > Sandbox, change "Default container image" to a different value. The "Confirm passphrase" dialog SHOULD pop. Cancel it; the image should not persist. Re-enter the passphrase; the change should now persist on reload.
- [x] **Other preference saves are unblocked too.** Same server. Toggle a sound option, an Updates field, a notification toggle, a logging level: each should save without a passphrase prompt and survive reload.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (Proposal A hybrid over the path-shape rewrite, no client-side auto-retry after elevation, scope per profile not global), and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Overview

This PR fixes a bug where theme and other preference changes appeared saved in the UI but reverted after page reload or server restart. It narrows passphrase/elevation gating to only truly sensitive profile fields and ensures the SPA waits for a successful save before applying visual changes.

What changed (high level)

- Backend: Removed the blanket elevation middleware for PATCH /api/profiles/{name}/settings and implemented body-shaped elevation checks so only tamper-capable sections require step-up (currently sandbox, worktree, and specific dangerous session fields). Handlers return a structured 403/elevation_required when elevation is needed. Introduced an AuthenticatedSession request extension so handlers can check elevation state without re-reading cookies.
- Frontend: Save APIs in SettingsView now return Promise<boolean>; ThemeSettings awaits save success and only dispatches the theme-change repaint on confirmed persistence. This prevents transient UI updates that don’t persist.
- Tests & docs: Added Playwright live tests covering theme persistence in no-auth and passphrase modes, unit tests for elevation logic and ThemeSettings dispatch behavior, and documentation describing step-up elevation behavior.

Benefits

- Fixes false-success appearances: user preferences shown as saved now actually persist across reloads/restarts.
- Better UX for passphrase users: safe preference edits (theme, sound, updates, web, logging, description, safe session fields) no longer trigger unnecessary passphrase prompts.
- Security preserved: truly sensitive/tamper-surface operations still require elevation.
- Clearer failure handling: client surfaces save failures and triggers elevation flow when appropriate.
- Well-covered by tests, reducing regression risk.

Technical details (concise)

- New constants: ELEVATION_REQUIRED_SECTIONS = ["sandbox", "worktree"] and ELEVATION_REQUIRED_SESSION_FIELDS (mirrors SESSION_BLOCKED_FIELDS).
- New helper: body_requires_elevation(&serde_json::Value) -> bool inspects JSON patches for tamper-surface keys.
- update_profile_settings signature updated to accept Option<Extension<AuthenticatedSession>> and enforces body-shaped elevation before merge/persist; responds with 403 elevation_required when not elevated.
- Auth changes: added pub struct AuthenticatedSession(pub String) request extension; revised middleware to exempt profile settings PATCH from path-level elevation gating.
- Frontend: sendSave/saveField/saveSubField → Promise<boolean>; ThemeSettings.save is async and only calls dispatchThemePickerChanged on success.
- Tests: Playwright specs for theme persistence (with/without passphrase), unit tests for body_requires_elevation and ThemeSettings dispatch behavior; coverage matrix updated; docs updated to document step-up behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1575?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->