### PR TITLE
fix(web): cut first-session-open WS retry storm from ~60s to <5s

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -250,6 +250,22 @@ The server embeds an axum web server that serves a React frontend and provides:
 
 Each terminal connection spawns `tmux attach-session` inside a PTY and relays the raw byte stream bidirectionally over WebSocket. This gives the browser a real terminal experience identical to SSH.
 
+### Terminal WebSocket close codes
+
+When the browser fails to reach a working terminal, the disconnect banner shows the close code returned by the server. Decoder ring:
+
+| Code | Reason string             | Meaning                                                                                                                                              | Client behavior              |
+| ---- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------- |
+| 1001 | `server shutdown`         | Daemon is shutting down (SIGINT/SIGTERM).                                                                                                            | Retry with normal backoff.   |
+| 1011 | `openpty_failed`          | Server could not allocate a PTY.                                                                                                                     | Retry with normal backoff.   |
+| 1011 | `attach_spawn_failed`     | Server could not spawn the `tmux attach-session` child process.                                                                                      | Retry with normal backoff.   |
+| 1011 | `pty_reader_failed`       | Server could not clone the PTY reader handle.                                                                                                        | Retry with normal backoff.   |
+| 1011 | `pty_writer_failed`       | Server could not take the PTY writer handle.                                                                                                         | Retry with normal backoff.   |
+| 1013 | `tmux_not_ready`          | Server polled `tmux has-session` / `list-panes` for up to 2s and the pane did not become attachable. Usually a benign warm-up on first session open. | Retry with normal backoff.   |
+| 4001 | `pty_dead`                | PTY relay was running but the pane permanently exited. Continuing to retry would just hammer a dead session.                                         | Show "Click retry" banner.   |
+
+The browser uses a fast-start retry ladder (200ms, 400ms, 800ms, 1.5s, 3s, 6s, 10s) so transient warm-up failures recover in well under 5 seconds end-to-end. Permanently dead panes short-circuit on 4001 and surface a manual reconnect button.
+
 ## Frontend development
 
 The React frontend lives in `web/`:

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -426,16 +426,29 @@ async fn handle_terminal_ws(
     // would let the first attach exit with PTY EOF, the send task would
     // close 4001 (pty_dead), and the client would burn its retry budget
     // on a session that was about to become healthy. See #1455.
-    if !wait_for_tmux_ready(&tmux_name).await {
-        warn!(
-            target: "terminal.ws",
-            client = %client_id,
-            tmux = %tmux_name,
-            timeout_ms = TMUX_READY_TIMEOUT.as_millis() as u64,
-            "tmux not ready within bounded wait, closing 1013"
-        );
-        close_early(&mut socket, CLOSE_CODE_TRY_AGAIN_LATER, "tmux_not_ready").await;
-        return;
+    match wait_for_tmux_ready(&tmux_name).await {
+        PaneReadiness::Ready => {}
+        PaneReadiness::Dead => {
+            warn!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                "all panes reported dead during readiness wait, closing 4001"
+            );
+            close_early(&mut socket, CLOSE_CODE_PTY_DEAD, "pty_dead").await;
+            return;
+        }
+        PaneReadiness::NotReady => {
+            warn!(
+                target: "terminal.ws",
+                client = %client_id,
+                tmux = %tmux_name,
+                timeout_ms = TMUX_READY_TIMEOUT.as_millis() as u64,
+                "tmux not ready within bounded wait, closing 1013"
+            );
+            close_early(&mut socket, CLOSE_CODE_TRY_AGAIN_LATER, "tmux_not_ready").await;
+            return;
+        }
     }
 
     // Spawn tmux attach inside a PTY
@@ -1272,19 +1285,20 @@ fn parse_pane_dead_output(output: &str) -> PaneReadiness {
 
 /// Poll `tmux has-session` + `tmux list-panes` at TMUX_READY_POLL until
 /// the session has at least one alive pane, or until TMUX_READY_TIMEOUT
-/// expires. Returns true if a live pane was observed. Returns false on
-/// timeout. Treats "every pane dead" as a hard failure (returns false
-/// immediately rather than polling further).
-async fn wait_for_tmux_ready(tmux_name: &str) -> bool {
+/// expires. Returns the final outcome so the caller can distinguish a
+/// transient warm-up (`NotReady` -> retryable 1013) from a permanently
+/// dead pane (`Dead` -> 4001 short-circuit). Bails out early on `Dead`
+/// rather than polling further because no amount of waiting will make
+/// an exited pane reattachable.
+async fn wait_for_tmux_ready(tmux_name: &str) -> PaneReadiness {
     let deadline = Instant::now() + TMUX_READY_TIMEOUT;
     loop {
-        let probe = probe_tmux_readiness(tmux_name).await;
-        match probe {
-            PaneReadiness::Ready => return true,
-            PaneReadiness::Dead => return false,
+        match probe_tmux_readiness(tmux_name).await {
+            PaneReadiness::Ready => return PaneReadiness::Ready,
+            PaneReadiness::Dead => return PaneReadiness::Dead,
             PaneReadiness::NotReady => {
                 if Instant::now() >= deadline {
-                    return false;
+                    return PaneReadiness::NotReady;
                 }
                 tokio::time::sleep(TMUX_READY_POLL).await;
             }

--- a/src/server/ws.rs
+++ b/src/server/ws.rs
@@ -31,6 +31,32 @@ const CLOSE_CODE_PTY_DEAD: u16 = 4001;
 /// a transient transport error and skip its reconnect backoff for one
 /// cycle. See #1198.
 const CLOSE_CODE_GOING_AWAY: u16 = 1001;
+
+/// WebSocket close code 1011 ("internal server error"). Sent on the
+/// OS-level early-return paths in `handle_terminal_ws` (openpty,
+/// attach-session spawn, PTY reader/writer clone). Browser falls through
+/// to its standard retry ladder with a parseable reason. Beats the
+/// opaque 1006 that early `return;` would otherwise produce. See #1455.
+const CLOSE_CODE_INTERNAL_ERROR: u16 = 1011;
+
+/// WebSocket close code 1013 ("try again later"). Sent when the tmux
+/// pane is not ready within the bounded readiness window. Browser
+/// retries on the fast-start ladder. Distinct from 1011 (internal
+/// server fault) and 4001 (permanently dead pane) so logs separate
+/// transient warm-up from genuine failure. See #1455.
+const CLOSE_CODE_TRY_AGAIN_LATER: u16 = 1013;
+
+/// Total time we'll spend waiting for the tmux session + pane to be
+/// attachable before giving up and closing 1013. 2s covers tmux warm-up
+/// across the slow machines we've seen reports from while staying short
+/// enough that a truly dead pane doesn't hold the upgrade open for the
+/// user. See #1455.
+const TMUX_READY_TIMEOUT: Duration = Duration::from_millis(2000);
+
+/// Poll interval for the readiness wait. 50ms gives ~40 probes inside
+/// the 2s window; each probe shells out to `tmux has-session` and (if
+/// that passes) `tmux list-panes`, which is cheap.
+const TMUX_READY_POLL: Duration = Duration::from_millis(50);
 use portable_pty::{CommandBuilder, NativePtySystem, PtySize, PtySystem};
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -367,7 +393,7 @@ type SessionPrimaries = Arc<RwLock<std::collections::HashMap<String, String>>>;
 type SessionPauseCounts = Arc<tokio::sync::Mutex<std::collections::HashMap<String, u32>>>;
 
 async fn handle_terminal_ws(
-    socket: WebSocket,
+    mut socket: WebSocket,
     tmux_name: String,
     read_only: bool,
     primaries: SessionPrimaries,
@@ -391,6 +417,27 @@ async fn handle_terminal_ws(
         "ws upgrade complete, starting PTY relay"
     );
 
+    // Wait for tmux session + at least one live pane to be attachable
+    // before spawning `tmux attach-session`. Closes the race where the
+    // browser dialed in fractions of a second after the session was
+    // created and the attach raced the tmux daemon's pane bookkeeping.
+    // The `terminal_ws` (agent main) route lacks an analog of
+    // `respawn_paired_if_dead`, so without this poll a fresh `aoe serve`
+    // would let the first attach exit with PTY EOF, the send task would
+    // close 4001 (pty_dead), and the client would burn its retry budget
+    // on a session that was about to become healthy. See #1455.
+    if !wait_for_tmux_ready(&tmux_name).await {
+        warn!(
+            target: "terminal.ws",
+            client = %client_id,
+            tmux = %tmux_name,
+            timeout_ms = TMUX_READY_TIMEOUT.as_millis() as u64,
+            "tmux not ready within bounded wait, closing 1013"
+        );
+        close_early(&mut socket, CLOSE_CODE_TRY_AGAIN_LATER, "tmux_not_ready").await;
+        return;
+    }
+
     // Spawn tmux attach inside a PTY
     let pty_system = NativePtySystem::default();
     let pair = match pty_system.openpty(PtySize {
@@ -407,6 +454,7 @@ async fn handle_terminal_ws(
                 tmux = %tmux_name,
                 "openpty failed, aborting ws: {}", e
             );
+            close_early(&mut socket, CLOSE_CODE_INTERNAL_ERROR, "openpty_failed").await;
             return;
         }
     };
@@ -426,6 +474,12 @@ async fn handle_terminal_ws(
                 tmux = %tmux_name,
                 "spawn tmux attach-session failed: {}", e
             );
+            close_early(
+                &mut socket,
+                CLOSE_CODE_INTERNAL_ERROR,
+                "attach_spawn_failed",
+            )
+            .await;
             return;
         }
     };
@@ -455,6 +509,7 @@ async fn handle_terminal_ws(
             );
             let _ = child.kill();
             let _ = child.wait();
+            close_early(&mut socket, CLOSE_CODE_INTERNAL_ERROR, "pty_reader_failed").await;
             return;
         }
     };
@@ -470,6 +525,7 @@ async fn handle_terminal_ws(
             );
             let _ = child.kill();
             let _ = child.wait();
+            close_early(&mut socket, CLOSE_CODE_INTERNAL_ERROR, "pty_writer_failed").await;
             return;
         }
     };
@@ -1171,6 +1227,102 @@ async fn resize_pty(
     .await;
 }
 
+/// Send a Close frame on an early-return path that hasn't split the
+/// socket yet. The `let _ = ` discards send errors: if the peer is
+/// already gone the close frame is moot, and we're returning anyway.
+async fn close_early(socket: &mut WebSocket, code: u16, reason: &'static str) {
+    let _ = socket
+        .send(Message::Close(Some(CloseFrame {
+            code,
+            reason: reason.into(),
+        })))
+        .await;
+}
+
+/// Outcome of one tmux-readiness probe. `Ready` lets the caller proceed
+/// to `tmux attach-session`; `NotReady` means try again after the poll
+/// interval; `Dead` short-circuits the wait when every pane is reported
+/// dead (no point in polling further).
+#[derive(Debug, PartialEq, Eq)]
+enum PaneReadiness {
+    Ready,
+    NotReady,
+    Dead,
+}
+
+/// Parse `tmux list-panes -F "#{pane_dead}"` output: one line per pane,
+/// each line `0` (alive) or `1` (dead). Empty output means the session
+/// exists but has no panes yet (not ready). All-dead means the pane has
+/// permanently exited.
+fn parse_pane_dead_output(output: &str) -> PaneReadiness {
+    let lines: Vec<&str> = output
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return PaneReadiness::NotReady;
+    }
+    if lines.contains(&"0") {
+        PaneReadiness::Ready
+    } else {
+        PaneReadiness::Dead
+    }
+}
+
+/// Poll `tmux has-session` + `tmux list-panes` at TMUX_READY_POLL until
+/// the session has at least one alive pane, or until TMUX_READY_TIMEOUT
+/// expires. Returns true if a live pane was observed. Returns false on
+/// timeout. Treats "every pane dead" as a hard failure (returns false
+/// immediately rather than polling further).
+async fn wait_for_tmux_ready(tmux_name: &str) -> bool {
+    let deadline = Instant::now() + TMUX_READY_TIMEOUT;
+    loop {
+        let probe = probe_tmux_readiness(tmux_name).await;
+        match probe {
+            PaneReadiness::Ready => return true,
+            PaneReadiness::Dead => return false,
+            PaneReadiness::NotReady => {
+                if Instant::now() >= deadline {
+                    return false;
+                }
+                tokio::time::sleep(TMUX_READY_POLL).await;
+            }
+        }
+    }
+}
+
+/// One probe iteration: `tmux has-session` then (on success) `tmux
+/// list-panes -F "#{pane_dead}"`. Both shell out to the tmux binary;
+/// they're cheap (microseconds in the happy path) so the 50ms poll
+/// floor dominates wall time, not subprocess overhead.
+async fn probe_tmux_readiness(tmux_name: &str) -> PaneReadiness {
+    let name = tmux_name.to_string();
+    tokio::task::spawn_blocking(move || {
+        let has_session = std::process::Command::new("tmux")
+            .args(["has-session", "-t", &name])
+            .output();
+        let has_session_ok = match has_session {
+            Ok(o) => o.status.success(),
+            Err(_) => false,
+        };
+        if !has_session_ok {
+            return PaneReadiness::NotReady;
+        }
+        let panes = std::process::Command::new("tmux")
+            .args(["list-panes", "-t", &name, "-F", "#{pane_dead}"])
+            .output();
+        match panes {
+            Ok(o) if o.status.success() => {
+                parse_pane_dead_output(&String::from_utf8_lossy(&o.stdout))
+            }
+            _ => PaneReadiness::NotReady,
+        }
+    })
+    .await
+    .unwrap_or(PaneReadiness::NotReady)
+}
+
 #[derive(serde::Deserialize)]
 #[serde(tag = "type")]
 enum ControlMessage {
@@ -1267,6 +1419,37 @@ mod tests {
         let p = make_primaries();
         release_primary(&p, "session-1", "ws-0").await;
         assert!(p.read().await.is_empty());
+    }
+
+    #[test]
+    fn parse_pane_dead_empty_is_not_ready() {
+        // `list-panes` succeeded but the session has no panes yet
+        // (transient state during tmux session creation).
+        assert_eq!(parse_pane_dead_output(""), PaneReadiness::NotReady);
+        assert_eq!(parse_pane_dead_output("   \n\n  "), PaneReadiness::NotReady);
+    }
+
+    #[test]
+    fn parse_pane_dead_single_alive_is_ready() {
+        assert_eq!(parse_pane_dead_output("0\n"), PaneReadiness::Ready);
+        assert_eq!(parse_pane_dead_output("0"), PaneReadiness::Ready);
+    }
+
+    #[test]
+    fn parse_pane_dead_single_dead_is_dead() {
+        assert_eq!(parse_pane_dead_output("1\n"), PaneReadiness::Dead);
+    }
+
+    #[test]
+    fn parse_pane_dead_mixed_is_ready() {
+        // One alive pane is enough; tmux attach finds the alive one.
+        assert_eq!(parse_pane_dead_output("1\n0\n"), PaneReadiness::Ready);
+        assert_eq!(parse_pane_dead_output("0\n1\n1\n"), PaneReadiness::Ready);
+    }
+
+    #[test]
+    fn parse_pane_dead_all_dead_is_dead() {
+        assert_eq!(parse_pane_dead_output("1\n1\n1\n"), PaneReadiness::Dead);
     }
 
     #[tokio::test]

--- a/web/src/hooks/useTerminal.backoff.test.ts
+++ b/web/src/hooks/useTerminal.backoff.test.ts
@@ -1,28 +1,41 @@
 // @vitest-environment jsdom
 //
 // Unit tests for retryDelayMs. The function drives the WS reconnect
-// backoff schedule (1s, 2s, 4s, 8s, 16s, 30s, 30s); a regression here
-// would either hammer a dead server every second or stretch the first
-// retry past the user-perceptible threshold.
+// backoff schedule. A regression here would either hammer a dead server
+// or stretch the first retry past the user-perceptible threshold.
+//
+// Schedule was tightened from the old exponential curve (1s, 2s, 4s, 8s,
+// 16s, 30s, 30s; worst case ~91s) to a fast-start array (200ms, 400ms,
+// 800ms, 1.5s, 3s, 6s, 10s; worst case ~22s) to absorb tmux warm-up
+// during first-session-open without keeping the client asleep on a 30s
+// timer once the server is finally ready. See #1455.
 
 import { describe, expect, it } from "vitest";
 import { retryDelayMs } from "./useTerminal";
 
 describe("retryDelayMs", () => {
-  it("doubles each attempt up to the 30s cap", () => {
-    expect(retryDelayMs(1)).toBe(1000);
-    expect(retryDelayMs(2)).toBe(2000);
-    expect(retryDelayMs(3)).toBe(4000);
-    expect(retryDelayMs(4)).toBe(8000);
-    expect(retryDelayMs(5)).toBe(16000);
+  it("uses the fast-start schedule for the first attempts", () => {
+    expect(retryDelayMs(1)).toBe(200);
+    expect(retryDelayMs(2)).toBe(400);
+    expect(retryDelayMs(3)).toBe(800);
+    expect(retryDelayMs(4)).toBe(1500);
+    expect(retryDelayMs(5)).toBe(3000);
   });
 
-  it("caps at 30s for the tail of the backoff", () => {
-    expect(retryDelayMs(6)).toBe(30000);
-    expect(retryDelayMs(7)).toBe(30000);
+  it("caps at 10s for the tail of the backoff", () => {
+    expect(retryDelayMs(6)).toBe(6000);
+    expect(retryDelayMs(7)).toBe(10000);
     // Defense against an off-by-one: even an out-of-range attempt
-    // never exceeds the cap, so the retry handler can't accidentally
-    // schedule a 60s+ timeout if MAX_RETRIES creeps up.
-    expect(retryDelayMs(20)).toBe(30000);
+    // never exceeds the tail value, so the retry handler can't
+    // accidentally schedule a 30s+ timeout if MAX_RETRIES creeps up.
+    expect(retryDelayMs(20)).toBe(10000);
+  });
+
+  it("clamps non-positive attempts to the first delay", () => {
+    // Defensive: the call site always passes attempt >= 1, but a future
+    // change to retry-state machine arithmetic shouldn't drop a 0 into
+    // retryDelayMs and produce undefined.
+    expect(retryDelayMs(0)).toBe(200);
+    expect(retryDelayMs(-1)).toBe(200);
   });
 });

--- a/web/src/hooks/useTerminal.lifecycle.test.ts
+++ b/web/src/hooks/useTerminal.lifecycle.test.ts
@@ -654,6 +654,141 @@ describe("useTerminal lifecycle", () => {
     }
   });
 
+  it("session change nulls the old socket's handlers before close (no ghost retry)", async () => {
+    // Regression for #1455: a session change must detach the previous
+    // socket's onopen/onmessage/onclose/onerror BEFORE close(), otherwise
+    // the still-bound onclose closure runs after cleanup and schedules a
+    // setTimeout that calls connect() on the OLD sessionId, dialing a
+    // ghost socket and overwriting wsRef.current for the new session.
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      const { rerender } = renderHook(
+        (props: { id: string | null }) => {
+          const term = useTerminal(props.id, "ws", false, false);
+          if (term.containerRef && !term.containerRef.current) {
+            (
+              term.containerRef as unknown as {
+                current: HTMLDivElement | null;
+              }
+            ).current = div;
+          }
+          return term;
+        },
+        { initialProps: { id: "s-old" } },
+      );
+      await flushAsync();
+      const oldWs = sockets[0]!;
+      expect(oldWs.url).toContain("/sessions/s-old/ws");
+      expect(oldWs.onclose).not.toBeNull();
+
+      // Switch sessions. Cleanup should detach handlers before close().
+      rerender({ id: "s-new" });
+      await flushAsync();
+
+      // All four lifecycle handlers must be cleared on the orphaned socket.
+      expect(oldWs.onopen).toBeNull();
+      expect(oldWs.onmessage).toBeNull();
+      expect(oldWs.onclose).toBeNull();
+      expect(oldWs.onerror).toBeNull();
+
+      // Even if the browser had a queued close event for the old socket,
+      // with onclose nulled it cannot schedule a setTimeout retry. Advance
+      // past every retry delay and confirm no third (ghost) socket was
+      // dialed for the OLD sessionId.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12_000);
+      });
+      await flushAsync();
+      const ghostForOldSession = sockets
+        .slice(1)
+        .find((s) => s.url.includes("/sessions/s-old/ws"));
+      expect(ghostForOldSession).toBeUndefined();
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("server close code 1011 falls through to the standard retry path", async () => {
+    // Regression for #1455: the server now sends 1011 <reason> close
+    // frames on openpty/spawn/clone-reader/take-writer failures instead
+    // of opaque 1006. The client must treat 1011 as a regular retryable
+    // failure (not the 4001 short-circuit).
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      const { result } = renderHook(() => {
+        const term = useTerminal("s-1011", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.CLOSED;
+        ws.onclose?.({
+          code: 1011,
+          reason: "openpty_failed",
+          wasClean: false,
+        } as CloseEvent);
+      });
+      await flushAsync();
+      expect(result.current.state.reconnecting).toBe(true);
+      expect(result.current.state.retryCount).toBe(1);
+      expect(result.current.state.retryCount).toBeLessThan(
+        result.current.maxRetries,
+      );
+    } finally {
+      div.remove();
+    }
+  });
+
+  it("server close code 1013 (tmux_not_ready) falls through to the standard retry path", async () => {
+    // Regression for #1455: server's pane-readiness poll closes with
+    // 1013 tmux_not_ready when the bounded wait elapses. Client must
+    // retry on the fast-start ladder, NOT short-circuit to exhausted.
+    const div = document.createElement("div");
+    document.body.appendChild(div);
+    try {
+      const { result } = renderHook(() => {
+        const term = useTerminal("s-1013", "ws", false, false);
+        if (term.containerRef && !term.containerRef.current) {
+          (
+            term.containerRef as unknown as { current: HTMLDivElement | null }
+          ).current = div;
+        }
+        return term;
+      });
+      await flushAsync();
+      const ws = sockets[0]!;
+      act(() => {
+        ws.readyState = FakeWebSocket.CLOSED;
+        ws.onclose?.({
+          code: 1013,
+          reason: "tmux_not_ready",
+          wasClean: false,
+        } as CloseEvent);
+      });
+      await flushAsync();
+      expect(result.current.state.reconnecting).toBe(true);
+      expect(result.current.state.retryCount).toBe(1);
+      // The next retry must fire on the fast-start ladder, not on the
+      // old 1s+ exponential delay.
+      const before = sockets.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+      await flushAsync();
+      expect(sockets.length).toBeGreaterThan(before);
+    } finally {
+      div.remove();
+    }
+  });
+
   it("Ctrl+wheel zooms the font size and persists it after the debounce", async () => {
     const div = document.createElement("div");
     document.body.appendChild(div);

--- a/web/src/hooks/useTerminal.ts
+++ b/web/src/hooks/useTerminal.ts
@@ -47,19 +47,22 @@ const twarn = (...args: unknown[]) => {
   console.warn("[terminal.ws]", ...args);
 };
 
-// Exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s, 30s (cap). Seven attempts
-// cover typical tunnel restarts and transient WiFi drops without flooding
-// the server or burning the user's battery on a truly dead backend.
-const MAX_RETRIES = 7;
-const RETRY_BASE_MS = 1000;
-const RETRY_CAP_MS = 30000;
+// Fast-start retry schedule: 200ms, 400ms, 800ms, 1.5s, 3s, 6s, 10s. Total
+// to exhaustion ~22s vs the old exponential ladder's ~91s. The old 1s/30s
+// curve magnified first-session-open pain when tmux warm-up briefly bounced
+// the upgrade: by the time the server was ready, the client was asleep on
+// a 30s timer. See #1455.
+const RETRY_DELAYS_MS = [200, 400, 800, 1500, 3000, 6000, 10000] as const;
+const MAX_RETRIES = RETRY_DELAYS_MS.length;
 /** Server-side close code that signals "PTY relay permanently broken,
  *  stop retrying immediately." Mirrors `CLOSE_CODE_PTY_DEAD` in
  *  `src/server/ws.rs`. Picked from the application-reserved 4000-4999
  *  range. See #1107. */
 const CLOSE_CODE_PTY_DEAD = 4001;
-export const retryDelayMs = (attempt: number) =>
-  Math.min(RETRY_CAP_MS, RETRY_BASE_MS * 2 ** (attempt - 1));
+export const retryDelayMs = (attempt: number) => {
+  const idx = Math.max(1, Math.min(RETRY_DELAYS_MS.length, attempt)) - 1;
+  return RETRY_DELAYS_MS[idx]!;
+};
 const MIN_FONT_SIZE = 6;
 const MAX_FONT_SIZE = 28;
 const DEFAULT_FONT_SIZE = 14;
@@ -1246,7 +1249,20 @@ export function useTerminal(
       if (wheelPersistTimer) clearTimeout(wheelPersistTimer);
       if (resizeDebounceTimer) clearTimeout(resizeDebounceTimer);
       if (fontSizeRaf !== null) cancelAnimationFrame(fontSizeRaf);
-      wsRef.current?.close();
+      // Detach handlers BEFORE closing so the soon-to-fire onclose closure
+      // can't schedule a retry that races the next session's connect path.
+      // Without this, the old onclose runs after cleanup, calls setTimeout
+      // -> connect() in the captured (now stale) sessionId scope, and
+      // overwrites wsRef.current with a ghost socket for the previous
+      // session. See #1455.
+      const owned = wsRef.current;
+      if (owned) {
+        owned.onopen = null;
+        owned.onmessage = null;
+        owned.onclose = null;
+        owned.onerror = null;
+        owned.close();
+      }
       term.dispose();
       if (retryTimerRef.current) clearTimeout(retryTimerRef.current);
       if (countdownRef.current) clearInterval(countdownRef.current);

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -27,6 +27,17 @@
       ]
     },
     {
+      "id": "terminal.ws-reconnect",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/ws-reconnect.spec.ts"
+      ],
+      "components": [
+        "web/src/hooks/useTerminal.ts"
+      ]
+    },
+    {
       "id": "auth.no-auth",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/ws-reconnect.spec.ts
+++ b/web/tests/ws-reconnect.spec.ts
@@ -3,8 +3,9 @@ import type { Page } from "@playwright/test";
 import { clickSidebarSession } from "./helpers/sidebar";
 
 // Verifies useTerminal.ts reconnects after a WS drop and that the first
-// retry fires within the expected ~1s exponential-backoff window (not the
-// old fixed 5s). Guards against regressions to the backoff constants.
+// retry fires within the expected fast-start window (200ms first delay).
+// Guards against regressions of the backoff constants away from #1455's
+// fast-start schedule back toward the old slow 1s exponential ladder.
 //
 // Note: we can't use installTerminalSpies here, because Playwright's
 // page.routeWebSocket installs its own WebSocket proxy AFTER addInitScript
@@ -119,21 +120,25 @@ test.describe("Terminal WebSocket reconnection", () => {
 
     await openSession(page, title);
 
-    // Wait for the reconnect to fire. First retry should be ~1s after the
-    // drop. 5s upper bound fails fast if we regressed to the old 5s delay.
+    // Wait for the reconnect to fire. First retry is scheduled at 200ms
+    // under the fast-start ladder; 5s upper bound still fails fast if we
+    // regressed to a slow exponential delay.
     await expect.poll(() => attempts, { timeout: 5_000 }).toBeGreaterThanOrEqual(2);
 
     // Guard: both timestamps must have been set. Without this check, a 0
-    // firstClosedAt would make elapsed comically large and the < 3000
+    // firstClosedAt would make elapsed comically large and the < 1500
     // assertion would dominate with a misleading message.
     expect(firstClosedAt).toBeGreaterThan(0);
     expect(secondOpenedAt).toBeGreaterThan(0);
 
-    // First retry is scheduled at 1s backoff. Allow 500-3000ms to absorb
-    // Playwright latency while still catching a regression to the old 5s.
+    // First retry is scheduled at 200ms backoff. Allow 50-2500ms to
+    // absorb Playwright/browser scheduling and WebGL warm-up jitter
+    // under parallel CI load while still catching a regression to the
+    // old 1s+ exponential first-retry delay (which produced 4s+ first
+    // retries in measurement and was the user-visible #1455 symptom).
     const elapsed = secondOpenedAt - firstClosedAt;
-    expect(elapsed).toBeGreaterThan(500);
-    expect(elapsed).toBeLessThan(3_000);
+    expect(elapsed).toBeGreaterThan(50);
+    expect(elapsed).toBeLessThan(2_500);
 
     // Second connection should be stable, no further reconnects.
     await page.waitForTimeout(1_500);
@@ -143,9 +148,9 @@ test.describe("Terminal WebSocket reconnection", () => {
   test("'online' event short-circuits the backoff and dials immediately", async ({
     page,
   }) => {
-    // After the first retry fires (~1s), the second backoff is ~2s. We
-    // close attempt #2 mid-flight, then dispatch a window 'online' event
-    // during the 4s backoff window before attempt #3 would normally fire.
+    // Drop attempts 1-4 so the next scheduled backoff is the longer 3s
+    // delay (200+400+800+1500 = 2.9s of total wait under the fast-start
+    // schedule). Dispatch a window 'online' event during that 3s window.
     // With the #1009 fix this triggers manualReconnect → connect()
     // immediately; without it, the listener never reconnects on a CLOSED
     // socket.
@@ -167,10 +172,7 @@ test.describe("Terminal WebSocket reconnection", () => {
       const attemptNum = attempts;
       openTimes.push(Date.now());
       ws.onMessage(() => {});
-      // Drop attempts 1 and 2 quickly to drive the retry path; let
-      // attempts 3+ stay open so the test can see the third connect
-      // arrive promptly after the 'online' kick.
-      if (attemptNum <= 2) {
+      if (attemptNum <= 4) {
         setTimeout(() => {
           closeTimes.push(Date.now());
           try {
@@ -184,29 +186,30 @@ test.describe("Terminal WebSocket reconnection", () => {
 
     await openSession(page, title);
 
-    // Wait for two retry cycles to land (attempts 1 + 2 closed).
-    await expect.poll(() => closeTimes.length, { timeout: 6_000 }).toBe(2);
+    // Wait for four retry cycles to land. Budget: ~50+200+50+400+50+800+50+1500 ≈ 3.1s.
+    await expect.poll(() => closeTimes.length, { timeout: 8_000 }).toBe(4);
 
-    // Fire 'online' while the third backoff is still pending (~4s).
-    // Wait a short moment so the listener is firmly armed and the WS is
+    // Fire 'online' while the fifth backoff (3s) is still pending. Wait
+    // a short moment so the listener is firmly armed and the WS is
     // CLOSED, then dispatch.
     await page.waitForTimeout(200);
     const beforeOnline = Date.now();
     await page.evaluate(() => window.dispatchEvent(new Event("online")));
 
-    // Attempt 3 should arrive well under the 4s backoff that would
+    // Attempt 5 should arrive well under the 3s backoff that would
     // otherwise gate it.
-    await expect.poll(() => attempts, { timeout: 2_000 }).toBeGreaterThanOrEqual(3);
-    const thirdOpenedAt = openTimes[2];
-    expect(thirdOpenedAt).toBeDefined();
-    expect(thirdOpenedAt! - beforeOnline).toBeLessThan(1_500);
+    await expect.poll(() => attempts, { timeout: 2_000 }).toBeGreaterThanOrEqual(5);
+    const fifthOpenedAt = openTimes[4];
+    expect(fifthOpenedAt).toBeDefined();
+    expect(fifthOpenedAt! - beforeOnline).toBeLessThan(1_500);
   });
 
   test("retries more than the old max of 3", async ({ page }) => {
-    // The old hardcoded MAX_RETRIES was 3. The new value is 7 with
-    // exponential backoff (1s, 2s, 4s, …). We don't wait the full schedule;
-    // we just verify the counter climbs past the old limit to prove the new
-    // constant is in effect. Budget: ~1+2+4 = 7s for 4 total attempts.
+    // The old hardcoded MAX_RETRIES was 3. The new value is 7 with the
+    // fast-start ladder (200ms, 400ms, 800ms, ...). We don't wait the
+    // full schedule; we just verify the counter climbs past the old limit
+    // to prove the new constant is in effect. Budget: 200+400+800 = 1.4s
+    // for 4 total attempts.
     const title = "retry-test";
     await mockApisExceptWs(page, title);
 
@@ -233,7 +236,144 @@ test.describe("Terminal WebSocket reconnection", () => {
     await openSession(page, title);
 
     await expect
-      .poll(() => attempts, { timeout: 15_000, intervals: [100, 250] })
+      .poll(() => attempts, { timeout: 5_000, intervals: [100, 250] })
       .toBeGreaterThanOrEqual(4);
+  });
+
+  test("switching sessions mid-retry does not resurrect the old session's socket", async ({
+    page,
+  }) => {
+    // Regression for #1455. User story: a session drops its WS and the
+    // client schedules a retry. Before the retry fires, the user clicks
+    // a different session in the sidebar. The old session's onclose
+    // closure must not be allowed to dial a ghost socket against the
+    // OLD sessionId after the effect cleanup has run.
+    const oldTitle = "old-session";
+    const newTitle = "new-session";
+    await page.route("**/api/login/status", (r) =>
+      r.fulfill({ json: { required: false, authenticated: true } }),
+    );
+    await page.route("**/api/sessions", (r) => {
+      if (r.request().method() === "POST") return r.fulfill({ status: 400 });
+      return r.fulfill({
+        json: {
+          sessions: [oldTitle, newTitle].map((t) => ({
+            id: t,
+            title: t,
+            project_path: `/tmp/${t}`,
+            group_path: "/tmp",
+            tool: "claude",
+            status: "Running",
+            yolo_mode: false,
+            created_at: new Date().toISOString(),
+            last_accessed_at: null,
+            last_error: null,
+            branch: null,
+            main_repo_path: null,
+            is_sandboxed: false,
+            has_terminal: true,
+            profile: "default",
+            workspace_repos: [],
+          })),
+          workspace_ordering: [],
+        },
+      });
+    });
+    await page.route("**/api/sessions/*/ensure", (r) =>
+      r.fulfill({ json: { ok: true } }),
+    );
+    await page.route("**/api/sessions/*/terminal", (r) =>
+      r.fulfill({ status: 200, body: "" }),
+    );
+    await page.route("**/api/sessions/*/diff/files", (r) =>
+      r.fulfill({ json: { files: [], per_repo_bases: [], warning: null } }),
+    );
+    for (const path of [
+      "settings",
+      "themes",
+      "agents",
+      "profiles",
+      "groups",
+      "devices",
+      "docker/status",
+      "about",
+    ]) {
+      await page.route(`**/api/${path}`, (r) =>
+        r.fulfill({ json: path === "docker/status" ? {} : [] }),
+      );
+    }
+
+    await page.routeWebSocket(
+      /\/sessions\/[^/]+\/(terminal\/ws|container-ws)$/,
+      (ws) => {
+        ws.onMessage(() => {});
+      },
+    );
+
+    // Tuple of (sessionId, dialedAtMs) per attempt so we can assert
+    // "no NEW old-session attempts after the switch moment", independent
+    // of how many retries the client legitimately fired before the user
+    // clicked away.
+    const dials: { id: string; at: number }[] = [];
+    await page.routeWebSocket(/\/sessions\/[^/]+\/ws$/, (ws) => {
+      const url = new URL(ws.url());
+      const match = url.pathname.match(/\/sessions\/([^/]+)\/ws$/);
+      const id = match?.[1] ?? "";
+      dials.push({ id, at: Date.now() });
+      ws.onMessage(() => {});
+      if (id === oldTitle) {
+        // Drop old-session attempts fast so the client keeps scheduling
+        // retries. Without the cleanup fix, the OLD socket's onclose
+        // closure fires after the session-switch cleanup runs and
+        // schedules a setTimeout that calls connect() against the OLD
+        // sessionId, producing ghost dials we detect with `switchAt`.
+        setTimeout(() => {
+          try {
+            ws.close({ code: 1011, reason: "openpty_failed" });
+          } catch {
+            /* already closed */
+          }
+        }, 30);
+      } else {
+        setTimeout(() => {
+          try {
+            ws.send(Buffer.from("new$ "));
+          } catch {
+            /* may be closed */
+          }
+        }, 20);
+      }
+    });
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto("/");
+    await clickSidebarSession(page, oldTitle);
+    await page.locator(".xterm").first().waitFor({ state: "visible", timeout: 10_000 });
+
+    // Wait for at least one old-session attempt to land.
+    await expect
+      .poll(() => dials.filter((d) => d.id === oldTitle).length, {
+        timeout: 3_000,
+      })
+      .toBeGreaterThanOrEqual(1);
+
+    // Switch sessions, then wait for the new-session WS to dial. That
+    // proves the React commit phase ran (cleanup + new-effect ordered
+    // synchronously inside commit), so any subsequent old-session dial
+    // is unambiguously a ghost.
+    await clickSidebarSession(page, newTitle);
+    await expect
+      .poll(() => dials.some((d) => d.id === newTitle), { timeout: 5_000 })
+      .toBe(true);
+
+    const oldCountAtSwitch = dials.filter((d) => d.id === oldTitle).length;
+
+    // Wait long enough to absorb every fast-start retry the OLD effect
+    // could have scheduled before cleanup (worst case 200+400+800+1500
+    // = 2.9s).
+    await page.waitForTimeout(3_000);
+
+    const oldCountFinal = dials.filter((d) => d.id === oldTitle).length;
+    expect(oldCountFinal).toBe(oldCountAtSwitch);
   });
 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Cuts first-session-open from up to ~60s down to <5s in the typical case, and gives the browser real close-frame information when the server's PTY relay can't start. Before this change, the client's exponential retry ladder (1s, 2s, 4s, 8s, 16s, 30s, 30s, worst case ~91s) magnified a few fast-start tmux warm-up bounces into a long visible wait while the server quietly returned without sending a close frame and the browser logged a storm of `code:1006`.

Two halves of the fix:

1. **Server side (`src/server/ws.rs`).** `handle_terminal_ws` now polls `tmux has-session` + `tmux list-panes -F "#{pane_dead}"` at 50ms intervals up to 2s before spawning `tmux attach-session`. This closes the race where the upgrade arrived before the tmux daemon had wired the pane (the agent main terminal route had no respawn-if-dead analog and would otherwise fast-exit to PTY EOF and `4001 pty_dead`, prematurely surfacing the manual reconnect banner). All four OS-allocation early returns (openpty, spawn, clone-reader, take-writer) now send a `1011 <reason>` close frame instead of dropping the connection silently as `1006`. Bounded readiness timeout closes `1013 tmux_not_ready` so the client retries fast; an explicitly dead pane closes `4001 pty_dead` so the client short-circuits.

2. **Client side (`web/src/hooks/useTerminal.ts`).** The retry ladder switches to an explicit fast-start array `[200, 400, 800, 1500, 3000, 6000, 10000]` ms (~22s worst case). The effect cleanup now nulls `oldWs.onopen/onmessage/onclose/onerror` before `close()`; without this, a session switch lets the old socket's onclose closure run after cleanup, schedule a setTimeout retry, and dial a ghost socket against the stale sessionId while the new effect's socket is already running.

Acceptance criteria from the issue:

- Fresh `aoe serve` restart + dashboard reload + click a session: terminal interactive in <2s on LAN / Tailscale (down from up to 60s).
- Genuine PTY-relay failures surface `code=1011 <reason>` in the banner (or `code=1013 tmux_not_ready`) instead of opaque `code=1006`.
- Rapid sidebar session switching no longer leaves ghost retries that show `[Disconnected... reconnecting in Ns]` on the new session.

Closes #1455

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

User-runnable steps. Tick each one after you observe the behavior.

- [x] `aoe serve --daemon`, then in the browser load the dashboard. Click any session in the sidebar. Confirm the terminal becomes interactive within ~2 seconds.
- [x] `aoe serve --stop`, restart `aoe serve --daemon`, reload the dashboard once `aoe url` reports a live URL. Click a session. Confirm `[Disconnected... reconnecting in Ns]` flashes briefly (or not at all) and the terminal lands within ~5 seconds (the worst-case path is `tmux has-session` polling for up to 2s + a couple of fast-start retries).
- [x] With the dashboard open, kill the underlying tmux session for an agent by hand (e.g. `tmux kill-session -t aoe_<id>_<title>` from another terminal). Reload, click the session. Confirm the banner reports `code=1013 tmux_not_ready` (transient) once or twice and then succeeds OR `code=4001 pty_dead` (permanent) with a "Click retry" banner. Not `code=1006`.
- [x] Open two sessions in the sidebar. Click session A. While the terminal is still warming, click session B. Confirm session B's terminal connects cleanly and session A's WebSocket does not produce any retry banner inside session B's pane (no `[Disconnected... reconnecting]` for the wrong session).
- [x] Re-open the dashboard a second time. Confirm subsequent session opens are fast (no regression for the steady-state).
- [x] In DevTools Network, open a WebSocket frame view. Trigger a failure (e.g. `aoe serve --stop` while the dashboard is open). Confirm the close frame has a reason string (e.g. `tmux_not_ready`, `openpty_failed`, or `pty_dead`) rather than an empty close.

## Checklist

- [x] I understand the code I am submitting
- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## AI Usage

- [ ] No AI was used
- [x] AI was used for drafting/refactoring
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill, with `/debate` consultation between Gemini 3.1 Pro and GPT-5.5 for the design trade-offs)

**Any Additional AI Details you'd like to share:**

I drove the investigation and decisions. Claude read the code, drafted the plan, ran an external multi-LLM debate to stress-test design choices (premature-close detector vs stable-open vs neither; readiness poll vs no poll; 1011 for everything vs split 1011/1013/4001; generation guards vs handler-nulling), synthesized a verdict, and implemented + tested. Each commit is small and conventional. The local `coderabbit review --prompt-only` pass surfaced one valid finding (PaneReadiness::Dead was being collapsed into 1013 instead of 4001) and that fix is its own commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Pull Request Summary

### What Changed

This PR addresses the problem of long, painful delays when opening terminal sessions for the first time. Previously, users experienced retry storms lasting up to 60 seconds while waiting for the server to be ready. The fix reduces this to under 5 seconds by making both the server and client smarter about waiting and retrying.

**Server side (`src/server/ws.rs`):**
- Added a readiness check that polls the tmux session for up to 2 seconds before accepting the WebSocket connection, ensuring the PTY is actually ready
- Changed error responses from silent disconnections to informative close codes:
  - `1011` for server setup failures
  - `1013` for "tmux not ready" (client should retry quickly)
  - `4001` for permanently dead PTY (client should not retry)
- Added unit tests for the polling logic

**Client side (`web/src/hooks/useTerminal.ts`):**
- Replaced the slow exponential backoff (1s → 2s → 4s → 8s → 16s → 30s) with a much faster schedule (200ms → 400ms → 800ms → 1.5s → 3s → 6s → 10s)
- Fixed a race condition where switching between sessions could cause "ghost" retries from the old session by properly cleaning up WebSocket handlers before closing
- Updated `maxRetries` count to reflect the new schedule

**Tests and Documentation:**
- Added comprehensive test coverage for the new backoff schedule, session switching, and close code behavior
- Added Playwright E2E tests for WebSocket reconnection scenarios
- Added documentation explaining the new WebSocket close codes and what they mean

### Benefits

- **Faster terminal startup:** Interactive terminals now appear in under 2 seconds on typical networks (LAN/Tailscale) instead of 60+ seconds
- **Better observability:** Clear, meaningful close codes replace opaque "1006" errors, making it easier to diagnose connection issues
- **No more ghost retries:** Switching between sessions no longer triggers mysterious reconnection attempts to the old session
- **More resilient retry logic:** Different error types (server busy vs. permanently dead) get appropriate retry strategies

---

## Technical Details

### Server Changes
- Implemented bounded tmux readiness polling (`tmux has-session` + `tmux list-panes -F "#{pane_dead}"`) with 50ms intervals up to 2 seconds
- Differentiated three readiness states: `Ready` (at least one pane alive), `Dead` (no alive panes), `NotReady` (session or panes not ready)
- Updated four early-error paths to send WebSocket close frames with reason strings (`openpty_failed`, `attach_spawn_failed`, `pty_reader_failed`, `pty_writer_failed`)

### Client Changes
- Replaced exponential backoff formula with fixed `RETRY_DELAYS_MS` array
- `retryDelayMs(attempt)` now performs array indexing with clamping instead of computation
- Added nulling of WebSocket event handlers (`onopen`, `onmessage`, `onclose`, `onerror`) in effect cleanup before closing the socket
- Changed `MAX_RETRIES` from hardcoded `7` to `RETRY_DELAYS_MS.length`

### Testing
- Unit tests cover `parse_pane_dead_output`, new backoff schedule, and handler cleanup
- Playwright tests verify fast-start timing, session switching without ghost retries, and handling of 1011/1013 close codes
- Added coverage matrix entry for `terminal.ws-reconnect` surface with high risk rating

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1577?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->