### PR TITLE
chore(ci): codecov cleanup (re-resolve YAML, drop matrix uploads, update doc)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,15 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # The codecov-action's `files` input is additive, not restrictive:
+          # with `disable_search: false` (the default), the CLI also walks
+          # the workspace and uploads anything that looks like a coverage
+          # report. That picks up web/tests/coverage-matrix.json and
+          # coverage-matrix.exempt.json (our test-mapping metadata, not
+          # coverage data) and ships them to Codecov on every run.
+          # `disable_search: true` restricts the upload to the explicit
+          # `files:` list.
+          disable_search: true
           files: web/coverage/vitest/lcov.info
           flags: vitest
           name: vitest
@@ -153,6 +162,11 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # See the matching comment in the vitest upload step: without
+          # disable_search the action also picks up the coverage-matrix
+          # JSON files under web/tests/ and ships them as if they were
+          # coverage reports.
+          disable_search: true
           files: web/coverage/merged/lcov.info
           flags: playwright-mocked
           name: playwright-mocked
@@ -234,6 +248,11 @@ jobs:
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # See the matching comment in the vitest upload step: without
+          # disable_search the action also picks up the coverage-matrix
+          # JSON files under web/tests/ and ships them as if they were
+          # coverage reports.
+          disable_search: true
           files: web/coverage/merged/lcov.info
           flags: playwright-live
           name: playwright-live

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,9 +125,9 @@ Coverage runs on every PR via the merge of Vitest + Playwright LCOVs (see `web/s
 - **`codecov/patch`** (target: 75%). The lines your PR adds or changes must hit 75% coverage. This is the strict gate, sized so a small frontend PR with one missed line still passes.
 - **`codecov/project`** (target: auto). Overall repo coverage must not drop below `main`'s current level by more than the 1% threshold.
 
-**Per-component checks (`codecov/project/<Component>`, e.g. App Shell, Auth, Cockpit UI) target 90% and currently report FAIL on every PR by design.** The baseline sits well below 90% and is being lifted by the foundation follow-ups (#1217–#1224, threshold enforcement tracked in #1225). They surface where each user-facing surface stands today; they are not merge blockers right now. Do not chase them on unrelated PRs. When you touch one of those surfaces, add tests that improve its number.
+**Components show up in the PR comment, not as status checks.** `codecov.yml` sets `component_management.default_rules.statuses: []`, so the per-component slices (App Shell, Auth, Cockpit UI, etc.) appear under the components table in the Codecov PR comment but never post a separate GitHub status. The repo-wide `codecov/patch` and `codecov/project` checks are the only Codecov gates on the merge box. The component baselines are still being lifted by the foundation follow-ups (#1217 through #1224, threshold enforcement tracked in #1225); when you touch one of those surfaces, add tests that improve its number, but don't chase the comment-only component numbers on unrelated PRs.
 
-**Rust-only PRs.** Patch coverage is reported against `web/src/**` paths only, so a Rust-only diff is N/A for patch coverage and inherits the previous flag value via `carryforward: true`. The per-component checks still display FAIL for the same baseline reason described above; the aggregate `codecov/patch` and `codecov/project` checks pass.
+**Rust-only PRs.** Patch coverage is reported against `web/src/**` paths only, so a Rust-only diff is N/A for patch coverage and inherits the previous flag value via `carryforward: true`. The aggregate `codecov/patch` and `codecov/project` checks pass.
 
 ## Git Configuration
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -12,7 +12,7 @@
 # merges will run well below this, so the report-only philosophy lives
 # in the Codecov "informational" flag at the project level until the
 # follow-ups (#1217-#1224) lift the baseline.
-# Touched 2026-05-27 to force a YAML re-resolve after the org transfer to agent-of-empires.
+# Touched 2026-05-28 to force another YAML re-resolve after reinstalling the Codecov GitHub App on the agent-of-empires org. The 2026-05-27 touch happened before the App install was completed; per-PR processing was still falling back to defaults (bare-bones comment, missing codecov/project status) because the "Current bot" field on the Codecov repo config page stayed at "none".
 
 comment:
   layout: "header, diff, files, components, sunburst, uncovered, footer"


### PR DESCRIPTION
_Note: this PR was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Three independent codecov fixes surfaced while debugging why `codecov/project` never posts on PRs and why the Codecov PR comment renders the bare-bones default layout instead of the configured one with diff / files / components / sunburst / footer.

### 1. Touch `codecov.yml` again to force a YAML re-resolve

PR #1558's 2026-05-27 touch happened before the Codecov GitHub App was fully reinstalled on the new `agent-of-empires` org, so per-PR processing kept falling back to defaults: no `codecov/project` status check, bare-bones PR comment. The Codecov repo config page (`https://app.codecov.io/gh/agent-of-empires/agent-of-empires/config/yaml`) still shows `Current bot: none` for that reason, even though the resolved YAML on that page is the correct file.

The Codecov GitHub App has since been uninstalled and reinstalled on the org. This second touch forces another YAML re-resolve on the next main-branch upload under the new App identity, so the configured layout / status checks / components table actually take effect.

### 2. Drop matrix JSON uploads from the codecov-action

The action's `files:` input is additive, not restrictive. With `disable_search: false` (the default), the CLI also walks the workspace and uploads anything that looks like a coverage report. CI logs from the Vitest job show four files uploaded per run:

```
Found 4 coverage files to report
> web/tests/coverage-matrix.exempt.json
> web/coverage/vitest/coverage-final.json
> web/coverage/vitest/lcov.info
> web/tests/coverage-matrix.json
```

`coverage-matrix.json` and `coverage-matrix.exempt.json` are the project's test-mapping metadata, not coverage data. Adding `disable_search: true` to all three Codecov upload steps restricts each upload to the explicit LCOV in `files:`.

### 3. Rewrite the stale per-component-checks paragraph in `AGENTS.md`

`codecov.yml` already sets `component_management.default_rules.statuses: []`, so per-component statuses don't post; components only appear in the PR comment under the components table. The doc still described them as failing per-PR statuses by design, which has not been true since #1277 reduced bot noise. Updated the paragraph plus the Rust-only PR note that referenced them.

### What this PR does NOT change

Coverage gates: `codecov/patch` keeps the 75% target, `codecov/project` keeps the `auto` target, both with 1% thresholds.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (no test changes; this is CI config + doc)
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code)

**Any Additional AI Details you'd like to share:**
Investigation and the edits drafted by Claude. njbrake confirmed by inspection that the Codecov GitHub App was reinstalled on the org and that the Codecov config page still shows `Current bot: none`, then asked for a cleanup PR covering this and the other two issues surfaced during the investigation.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## High-Level Overview

This PR makes three targeted improvements to the repository's Codecov configuration and documentation:

### What Changed

1. **codecov.yml** — Updated the file's touch timestamp comment from May 27 to May 28, 2026, to force Codecov to re-resolve the configuration file. This is necessary because the Codecov GitHub App was reinstalled on the organization, and the previous touch occurred before the new app was fully deployed.

2. **.github/workflows/tests.yml** — Added `disable_search: true` to all Codecov upload steps (for Vitest and Playwright test jobs). This prevents unintended uploads of test-mapping JSON artifacts that the workflow doesn't explicitly request.

3. **AGENTS.md** — Removed outdated documentation that incorrectly described component behavior. The file now accurately reflects that components appear only in the PR comment (not as separate GitHub status checks).

### Benefits

- **Correct Codecov processing** — Forces the newly reinstalled Codecov app to apply the full configuration (layout, status checks, and components) instead of falling back to defaults.
- **Cleaner artifact uploads** — Restricts Codecov uploads to explicitly specified coverage files, eliminating accidental inclusion of non-coverage JSON metadata.
- **Accurate documentation** — Ensures developer guidance matches the actual Codecov setup, reducing confusion about component status behavior.

### Technical Details

- No coverage gate thresholds are changed (codecov/patch remains at 75%, codecov/project at auto).
- The `disable_search: false` default behavior was scanning the workspace and picking up `web/tests/coverage-matrix.json` and `web/tests/coverage-matrix.exempt.json`.
- Component management rules were already configured with `statuses: []` in codecov.yml, so components never post individual status checks; the documentation update aligns with this existing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1582?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->