### PR TITLE
fix(ci): build linux releases inside manylinux_2_28 for portable glibc floor

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,16 +117,17 @@ jobs:
         run: |
           # manylinux_2_28 is AlmaLinux 8 (dnf-based). The image ships gcc,
           # binutils, make, and core perl already; we add git for cargo's
-          # git deps, xz for tarball decompression, and one perl module
+          # git deps, xz for tarball decompression, and two perl modules
           # that AlmaLinux 8's minimal perl install does NOT include but
-          # openssl-src's `./Configure` requires:
-          #   perl-IPC-Cmd  - used at OpenSSL's config.pm line ~19 (mandatory)
-          # Ubuntu's perl bundles IPC::Cmd in its base install, which is why
-          # the previous ubuntu-latest runner build didn't trip on this.
-          # FindBin is a core Perl module shipped in the base `perl` package
-          # on AlmaLinux 8, so no separate package is needed for it.
+          # openssl-src needs to build vendored OpenSSL 3.x from source:
+          #   perl-IPC-Cmd     - used at OpenSSL's config.pm (Configure step)
+          #   perl-Time-Piece  - used at OpenSSL's Makefile.in line 37
+          # Both are in Ubuntu's perl-base by default, which is why the
+          # previous ubuntu-latest runner build didn't trip on either.
+          # FindBin and other standard Perl modules are in the base `perl`
+          # package on AlmaLinux 8, so no separate install is needed.
           dnf install -y --setopt=install_weak_deps=False \
-            git curl tar gzip xz perl-IPC-Cmd
+            git curl tar gzip xz perl-IPC-Cmd perl-Time-Piece
           # Node 22 via NodeSource. Node 22 requires glibc 2.28+, which is
           # exactly what manylinux_2_28 ships, so this resolves cleanly.
           curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,18 @@ on:
   push:
     tags:
       - 'v*'
+  # >>> TEMPORARY: REMOVE BEFORE MERGING ISSUE #1578 <<<
+  # Lets the build matrix run against this PR so the new manylinux container
+  # build path and the objdump glibc-floor guard can be verified end-to-end
+  # before publishing. Narrowed to PRs touching the release workflow itself
+  # so we don't run it on every unrelated PR if this trigger accidentally
+  # lands. The validate / release / publish-clawhub jobs are skipped on
+  # pull_request events; only the build job runs.
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/release.yml'
+  # >>> END TEMPORARY <<<
   workflow_dispatch:
     inputs:
       tag:
@@ -33,6 +45,11 @@ jobs:
           persist-credentials: false
 
       - name: Validate version matches tag
+        # TEMPORARY (#1578): on pull_request events there is no tag to
+        # compare against, so we skip this step and let the job complete
+        # green so `build` can proceed. Remove this `if:` when the
+        # pull_request trigger above is removed.
+        if: github.event_name != 'pull_request'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG="${{ github.event.inputs.tag }}"
@@ -55,6 +72,18 @@ jobs:
     name: Build ${{ matrix.target }}
     needs: validate
     runs-on: ${{ matrix.os }}
+    # Linux jobs build inside manylinux_2_28 containers (AlmaLinux 8 base,
+    # glibc 2.28) so the released binary runs on every common server distro
+    # from RHEL 8 / Ubuntu 20.04 / Debian 11 / Amazon Linux 2 forward, instead
+    # of failing on anything older than ubuntu-24.04's glibc 2.39. macOS jobs
+    # leave `matrix.container` unset and run directly on the runner host.
+    # See issue #1578 and Kobzol's "Building Rust binaries in CI that work
+    # with older GLIBC" for context. If the manylinux base is ever bumped,
+    # bump LINUX_GLIBC_FLOOR below, MIN_GLIBC in scripts/install.sh, and the
+    # Prerequisites note in docs/installation.md in the same PR.
+    container: ${{ matrix.container }}
+    env:
+      LINUX_GLIBC_FLOOR: '2.28'
     strategy:
       fail-fast: false
       matrix:
@@ -67,9 +96,14 @@ jobs:
             name: aoe-darwin-arm64
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
+            container: quay.io/pypa/manylinux_2_28_x86_64
             name: aoe-linux-amd64
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            # GitHub-hosted arm64 runner (free for public repos since 2025-08).
+            # Building natively here means we don't need a cross-toolchain
+            # inside the container.
+            os: ubuntu-24.04-arm
+            container: quay.io/pypa/manylinux_2_28_aarch64
             name: aoe-linux-arm64
 
     steps:
@@ -78,7 +112,21 @@ jobs:
           ref: ${{ env.RELEASE_REF }}
           persist-credentials: false
 
-      - name: Setup Node.js
+      - name: Install container build dependencies (Linux)
+        if: matrix.container != ''
+        run: |
+          # manylinux_2_28 is AlmaLinux 8 (dnf-based). The image ships gcc,
+          # binutils, make, and perl already; we add git for cargo's git
+          # deps, plus xz which the Node tarball install path may want.
+          dnf install -y --setopt=install_weak_deps=False \
+            git curl tar gzip xz
+          # Node 22 via NodeSource. Node 22 requires glibc 2.28+, which is
+          # exactly what manylinux_2_28 ships, so this resolves cleanly.
+          curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
+          dnf install -y nodejs
+
+      - name: Setup Node.js (macOS)
+        if: matrix.container == ''
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '22'
@@ -91,18 +139,32 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Build
+        run: cargo build --release --features serve --target ${{ matrix.target }}
+
+      - name: Verify Linux binary glibc floor
+        if: matrix.container != ''
         run: |
-          if [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
-            export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          # Hard CI guard against the same regression that produced #1578:
+          # if the binary ever requires GLIBC symbols newer than the
+          # manylinux base ships, fail the release before publishing.
+          # objdump ships in binutils, already present in manylinux_2_28.
+          BIN="target/${{ matrix.target }}/release/aoe"
+          REQUIRED=$(objdump -T "$BIN" \
+              | grep -oE 'GLIBC_[0-9]+\.[0-9]+' \
+              | sed 's/GLIBC_//' \
+              | sort -uV \
+              | tail -1)
+          echo "Highest GLIBC symbol required: ${REQUIRED:-<none>}"
+          echo "Configured floor:              ${LINUX_GLIBC_FLOOR}"
+          if [ -z "$REQUIRED" ]; then
+              echo "::warning::No GLIBC symbols found; binary may be statically linked"
+              exit 0
           fi
-          cargo build --release --features serve --target ${{ matrix.target }}
+          if [ "$(printf '%s\n%s\n' "$LINUX_GLIBC_FLOOR" "$REQUIRED" | sort -V | tail -1)" != "$LINUX_GLIBC_FLOOR" ]; then
+              echo "::error::Binary requires GLIBC_${REQUIRED} but floor is ${LINUX_GLIBC_FLOOR}. The container image or build deps likely changed; bump LINUX_GLIBC_FLOOR + scripts/install.sh MIN_GLIBC + docs/installation.md together, or fix the regression."
+              exit 1
+          fi
 
       - name: Package
         run: |
@@ -110,6 +172,8 @@ jobs:
           cp target/${{ matrix.target }}/release/aoe dist/${{ matrix.name }}
           cd dist
           tar -czvf ${{ matrix.name }}.tar.gz ${{ matrix.name }}
+          # shasum is a perl script and ships in manylinux + macOS; sha256sum
+          # would also work on Linux but is missing on macOS by default.
           shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifact
@@ -123,6 +187,9 @@ jobs:
   release:
     name: Create Release
     needs: build
+    # TEMPORARY (#1578): don't try to cut a GitHub Release on PR events.
+    # Remove this `if:` when the pull_request trigger above is removed.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,18 +4,6 @@ on:
   push:
     tags:
       - 'v*'
-  # >>> TEMPORARY: REMOVE BEFORE MERGING ISSUE #1578 <<<
-  # Lets the build matrix run against this PR so the new manylinux container
-  # build path and the objdump glibc-floor guard can be verified end-to-end
-  # before publishing. Narrowed to PRs touching the release workflow itself
-  # so we don't run it on every unrelated PR if this trigger accidentally
-  # lands. The validate / release / publish-clawhub jobs are skipped on
-  # pull_request events; only the build job runs.
-  pull_request:
-    branches: [main]
-    paths:
-      - '.github/workflows/release.yml'
-  # >>> END TEMPORARY <<<
   workflow_dispatch:
     inputs:
       tag:
@@ -45,11 +33,6 @@ jobs:
           persist-credentials: false
 
       - name: Validate version matches tag
-        # TEMPORARY (#1578): on pull_request events there is no tag to
-        # compare against, so we skip this step and let the job complete
-        # green so `build` can proceed. Remove this `if:` when the
-        # pull_request trigger above is removed.
-        if: github.event_name != 'pull_request'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             TAG="${{ github.event.inputs.tag }}"
@@ -201,9 +184,6 @@ jobs:
   release:
     name: Create Release
     needs: build
-    # TEMPORARY (#1578): don't try to cut a GitHub Release on PR events.
-    # Remove this `if:` when the pull_request trigger above is removed.
-    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,10 +116,17 @@ jobs:
         if: matrix.container != ''
         run: |
           # manylinux_2_28 is AlmaLinux 8 (dnf-based). The image ships gcc,
-          # binutils, make, and perl already; we add git for cargo's git
-          # deps, plus xz which the Node tarball install path may want.
+          # binutils, make, and core perl already; we add git for cargo's
+          # git deps, xz for tarball decompression, and two perl modules
+          # that AlmaLinux 8's minimal perl install does NOT include but
+          # openssl-src's `./Configure` requires:
+          #   perl-IPC-Cmd  - used at `config.pm` line ~19 (mandatory)
+          #   perl-FindBin  - used by Configure's `use FindBin` (mandatory)
+          # Ubuntu's perl bundles both, which is why the previous
+          # ubuntu-latest runner build didn't trip on this. Removing
+          # either one breaks the git2 vendored-openssl build.
           dnf install -y --setopt=install_weak_deps=False \
-            git curl tar gzip xz
+            git curl tar gzip xz perl-IPC-Cmd perl-FindBin
           # Node 22 via NodeSource. Node 22 requires glibc 2.28+, which is
           # exactly what manylinux_2_28 ships, so this resolves cleanly.
           curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,17 +117,20 @@ jobs:
         run: |
           # manylinux_2_28 is AlmaLinux 8 (dnf-based). The image ships gcc,
           # binutils, make, and core perl already; we add git for cargo's
-          # git deps, xz for tarball decompression, and two perl modules
+          # git deps, xz for tarball decompression, and three perl pieces
           # that AlmaLinux 8's minimal perl install does NOT include but
-          # openssl-src needs to build vendored OpenSSL 3.x from source:
-          #   perl-IPC-Cmd     - used at OpenSSL's config.pm (Configure step)
-          #   perl-Time-Piece  - used at OpenSSL's Makefile.in line 37
-          # Both are in Ubuntu's perl-base by default, which is why the
-          # previous ubuntu-latest runner build didn't trip on either.
-          # FindBin and other standard Perl modules are in the base `perl`
-          # package on AlmaLinux 8, so no separate install is needed.
+          # this workflow needs:
+          #   perl-IPC-Cmd     - openssl-src Configure step (config.pm)
+          #   perl-Time-Piece  - openssl-src Makefile.in line 37
+          #   perl-Digest-SHA  - provides the `shasum` command used to
+          #                      write the .sha256 file in Package step
+          # All three are in Ubuntu's perl-base by default, which is why
+          # the previous ubuntu-latest runner build didn't trip on any
+          # of them. FindBin and other standard Perl modules are in the
+          # base `perl` package on AlmaLinux 8, no separate install.
           dnf install -y --setopt=install_weak_deps=False \
-            git curl tar gzip xz perl-IPC-Cmd perl-Time-Piece
+            git curl tar gzip xz \
+            perl-IPC-Cmd perl-Time-Piece perl-Digest-SHA
           # Node 22 via NodeSource. Node 22 requires glibc 2.28+, which is
           # exactly what manylinux_2_28 ships, so this resolves cleanly.
           curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -
@@ -180,8 +183,11 @@ jobs:
           cp target/${{ matrix.target }}/release/aoe dist/${{ matrix.name }}
           cd dist
           tar -czvf ${{ matrix.name }}.tar.gz ${{ matrix.name }}
-          # shasum is a perl script and ships in manylinux + macOS; sha256sum
-          # would also work on Linux but is missing on macOS by default.
+          # shasum is a perl script that ships in macOS by default and is
+          # provided on Linux by perl-Digest-SHA (installed above for the
+          # manylinux jobs). Using shasum keeps the command identical on
+          # all four matrix entries; sha256sum would work on Linux but is
+          # not installed on macOS by default.
           shasum -a 256 ${{ matrix.name }}.tar.gz > ${{ matrix.name }}.tar.gz.sha256
 
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,16 +117,16 @@ jobs:
         run: |
           # manylinux_2_28 is AlmaLinux 8 (dnf-based). The image ships gcc,
           # binutils, make, and core perl already; we add git for cargo's
-          # git deps, xz for tarball decompression, and two perl modules
+          # git deps, xz for tarball decompression, and one perl module
           # that AlmaLinux 8's minimal perl install does NOT include but
           # openssl-src's `./Configure` requires:
-          #   perl-IPC-Cmd  - used at `config.pm` line ~19 (mandatory)
-          #   perl-FindBin  - used by Configure's `use FindBin` (mandatory)
-          # Ubuntu's perl bundles both, which is why the previous
-          # ubuntu-latest runner build didn't trip on this. Removing
-          # either one breaks the git2 vendored-openssl build.
+          #   perl-IPC-Cmd  - used at OpenSSL's config.pm line ~19 (mandatory)
+          # Ubuntu's perl bundles IPC::Cmd in its base install, which is why
+          # the previous ubuntu-latest runner build didn't trip on this.
+          # FindBin is a core Perl module shipped in the base `perl` package
+          # on AlmaLinux 8, so no separate package is needed for it.
           dnf install -y --setopt=install_weak_deps=False \
-            git curl tar gzip xz perl-IPC-Cmd perl-FindBin
+            git curl tar gzip xz perl-IPC-Cmd
           # Node 22 via NodeSource. Node 22 requires glibc 2.28+, which is
           # exactly what manylinux_2_28 ships, so this resolves cleanly.
           curl -fsSL https://rpm.nodesource.com/setup_22.x | bash -

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,12 +6,6 @@
 - [Docker](https://www.docker.com/) (optional, for sandboxing agents in containers)
 - [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features serve`)
 
-### Linux glibc requirement
-
-The published Linux binaries (`aoe-linux-amd64`, `aoe-linux-arm64`) are built inside the `manylinux_2_28` container (AlmaLinux 8 base, **glibc 2.28**) and need that version or newer at runtime. Supported distros include Ubuntu 20.04+, Debian 11+, RHEL/Rocky/Alma 8+, Amazon Linux 2/2023, and Fedora 30+. Anything older (CentOS 7, Ubuntu 18.04, Debian 10) should install via Homebrew (Linuxbrew) or [build from source](#build-from-source).
-
-The install script checks your glibc version before downloading and refuses to install if it's too old, so you won't end up with a broken binary on PATH. The release workflow also runs `objdump` against the built artifact and fails CI if the binary would require a newer glibc than this floor, so the bound here, `scripts/install.sh`, and the runtime symbol requirement stay in sync.
-
 ## Install Agent of Empires
 
 ### Quick Install (Recommended)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,6 +6,12 @@
 - [Docker](https://www.docker.com/) (optional, for sandboxing agents in containers)
 - [Node.js](https://nodejs.org/) (optional, only needed when building the web dashboard from source with `--features serve`)
 
+### Linux glibc requirement
+
+The published Linux binaries (`aoe-linux-amd64`, `aoe-linux-arm64`) are built inside the `manylinux_2_28` container (AlmaLinux 8 base, **glibc 2.28**) and need that version or newer at runtime. Supported distros include Ubuntu 20.04+, Debian 11+, RHEL/Rocky/Alma 8+, Amazon Linux 2/2023, and Fedora 30+. Anything older (CentOS 7, Ubuntu 18.04, Debian 10) should install via Homebrew (Linuxbrew) or [build from source](#build-from-source).
+
+The install script checks your glibc version before downloading and refuses to install if it's too old, so you won't end up with a broken binary on PATH. The release workflow also runs `objdump` against the built artifact and fails CI if the binary would require a newer glibc than this floor, so the bound here, `scripts/install.sh`, and the runtime symbol requirement stay in sync.
+
 ## Install Agent of Empires
 
 ### Quick Install (Recommended)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,10 +6,33 @@ DEFAULT_INSTALL_DIR="$HOME/.local/bin"
 INSTALL_DIR="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
 BINARY_NAME="aoe"
 
+# Matches the manylinux_2_28 container the release workflow builds in
+# (.github/workflows/release.yml, env.LINUX_GLIBC_FLOOR). Bump together.
+MIN_GLIBC="2.28"
+
 info() { printf "\033[34m[info]\033[0m %s\n" "$1"; }
 success() { printf "\033[32m[ok]\033[0m %s\n" "$1"; }
 warn() { printf "\033[33m[warn]\033[0m %s\n" "$1"; }
 error() { printf "\033[31m[error]\033[0m %s\n" "$1" >&2; exit 1; }
+
+# Fail fast if the system's glibc is older than the released binary needs.
+# Without this, the download "succeeds" and the user only finds out at the
+# first `aoe` invocation that libc.so.6 doesn't have GLIBC_2.xx. Skips
+# silently when we can't tell (non-Linux, no ldd, unparseable version).
+check_glibc() {
+    [ "$(uname -s)" = "Linux" ] || return 0
+    command -v ldd >/dev/null 2>&1 || return 0
+    local sys_glibc
+    sys_glibc=$(ldd --version 2>/dev/null | head -1 | grep -oE '[0-9]+\.[0-9]+$' | head -1)
+    [ -n "$sys_glibc" ] || return 0
+    if [ "$(printf '%s\n%s\n' "$MIN_GLIBC" "$sys_glibc" | sort -V | head -1)" != "$MIN_GLIBC" ]; then
+        error "Your system's glibc ($sys_glibc) is older than this binary requires ($MIN_GLIBC).
+Options:
+  - Use a newer distro (Ubuntu 20.04+, Debian 11+, RHEL 8+, Amazon Linux 2/2023)
+  - Install via Homebrew: brew install aoe
+  - Build from source: https://www.agent-of-empires.com/docs/installation/#build-from-source"
+    fi
+}
 
 detect_platform() {
     local os arch
@@ -58,6 +81,8 @@ main() {
     info "Detecting platform..."
     platform=$(detect_platform)
     success "Platform: $platform"
+
+    check_glibc
 
     info "Fetching latest version..."
     version=$(get_latest_version)


### PR DESCRIPTION
_Note: this PR was drafted by Claude (Opus 4.7, 1M context) via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Closes #1578.

The release workflow's Linux jobs ran on `os: ubuntu-latest`, which now resolves to `ubuntu-24.04` (glibc 2.39). Cargo's `x86_64-unknown-linux-gnu` target dynamic-links libc, so the released `aoe-linux-amd64` and `aoe-linux-arm64` binaries baked in a `GLIBC_2.39` requirement and refused to start on Ubuntu 22.04 LTS, Debian 12, RHEL 9, and Amazon Linux 2023, the most common LTS server distros in production today.

This PR moves the Linux build matrix into the `quay.io/pypa/manylinux_2_28_*` containers (AlmaLinux 8 base, glibc 2.28), which is the same approach uv, ruff, and the entire pip-wheel ecosystem use to ship one portable Linux binary. After this lands, the published binary runs on:

- Ubuntu 20.04+ (was: 24.04+)
- Debian 11+ (was: 13+)
- RHEL / Rocky / Alma 8+ (was: nothing)
- Amazon Linux 2 and 2023 (was: 2023 only, broken)
- Fedora 30+ (was: 40+)

### Key changes

- **`.github/workflows/release.yml`**
  - x86_64 Linux job builds inside `quay.io/pypa/manylinux_2_28_x86_64` on `ubuntu-latest`.
  - aarch64 Linux job builds inside `quay.io/pypa/manylinux_2_28_aarch64` natively on `ubuntu-24.04-arm` (GitHub's free public ARM runner, GA since August 2025), so the previous `gcc-aarch64-linux-gnu` cross-toolchain step is gone.
  - New `LINUX_GLIBC_FLOOR: '2.28'` env at the job level, used by:
  - New "Verify Linux binary glibc floor" step that runs `objdump -T` on the built artifact, extracts the highest required `GLIBC_x.y` symbol, and fails the release if it exceeds the floor. This is the regression test for the floor itself: any future runner / container / dep bump that would silently raise the floor fails CI loudly with a message pointing at the three places (workflow env, install-script, docs) that must move in lockstep.
- **`scripts/install.sh`**: new `check_glibc()` preflight with `MIN_GLIBC=2.28`. Users on older systems see an actionable error before the download instead of finding out at first `aoe` invocation. Skips silently on non-Linux, when `ldd` is missing, or when the version string is unparseable.
- **`docs/installation.md`**: new "Linux glibc requirement" subsection under Prerequisites with the new floor, the supported-distros list, and a pointer to Homebrew / build-from-source for older systems.

### Temporary CI trigger (REMOVE BEFORE MERGE)

This PR also temporarily adds a `pull_request:` trigger to `release.yml` (narrowed to PRs touching that file on `main`), plus `if: github.event_name != 'pull_request'` guards on the validate step and the release job. This lets the manylinux build path and the objdump glibc-floor guard be verified end-to-end on this PR without cutting a real tag. All temporary pieces are clearly marked with `TEMPORARY (#1578): REMOVE BEFORE MERGING` comments. I will rip them out in the next commit before this PR moves from draft to ready-for-review.

### Why not just pin `ubuntu-22.04`?

Considered. Trades 1-2 lines of CI diff for a 12-18 month reprieve (GitHub deprecates the 22.04 runner image after Ubuntu 26.04 GAs, likely Q1-Q3 2027) and leaves RHEL 8 / Ubuntu 20.04 / Debian 11 / Amazon Linux 2 users still excluded. manylinux_2_28 is the structurally correct answer the rest of the Rust ecosystem converged on. See Kobzol, "Building Rust binaries in CI that work with older GLIBC", and Astral's [uv platform policy](https://docs.astral.sh/uv/reference/policies/platforms/) for the precedent.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (no Rust tests touched; new `objdump` step is the CI-side regression test for the floor)
- [x] Documentation was updated where necessary (`docs/installation.md` Prerequisites)
- [ ] For UI changes: included screenshot or recording (N/A, no UI changes)

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle. It changes how the release binary is built and adds a preflight to the curl-piped installer. The most meaningful test is the `objdump -T` step the workflow now runs, which fails CI if the binary's glibc floor regresses.

Behavioural test for the `check_glibc()` shell function was run locally against floor=2.28 with mocked `ldd` (7 cases: block 2.17, block 2.27, allow 2.28 boundary, allow 2.31, allow 2.35, allow 2.39, skip when ldd missing) and all passed. Not committed as a test file because the project has no existing bash-test harness and adding one feels out of scope; happy to add a `tests/install-sh.bats` if a reviewer asks.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code, Opus 4.7 (1M context)

**Any Additional AI Details you'd like to share:**

Investigation and drafting were done with Claude Code via the `/investigate` workflow. Initial recommendation was option A (pin to `ubuntu-22.04`) for minimal blast radius; the user pushed back ("do some research online first") and that surfaced the Kobzol post and Astral's platform policy, both of which point past option A. Switched to option B (manylinux_2_28) on that basis.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR addresses a critical compatibility issue where Linux release binaries were failing on older server distributions due to requiring glibc 2.39. The fix ensures that published binaries are compatible with systems running glibc ≥ 2.28, which covers common LTS distributions like Ubuntu 22.04, Debian 12, RHEL 9, and Amazon Linux 2023.

### What Changed

**Release Build Process**
- Linux builds are now executed inside manylinux_2_28 containers instead of directly on the Ubuntu runner, ensuring binaries are compiled against an older glibc version
- x86_64 builds run in the container environment via Docker; aarch64 builds run natively on ubuntu-24.04-arm runners
- Added CI verification step that checks compiled binaries to confirm they don't require a newer glibc version than the floor (2.28)

**Installation Script**
- Added a preflight check that automatically detects the system's glibc version before downloading
- If the system doesn't meet the minimum requirement, users receive a clear error message with installation alternatives (Homebrew, build-from-source)

**Documentation**
- Added guidance in installation docs about Linux glibc requirements
- Listed supported distributions and provided options for systems with older glibc versions

### Benefits

- **Wider Compatibility**: Binaries now work on a significantly broader range of Linux distributions, including older but still-supported LTS versions
- **Better User Experience**: Users on incompatible systems receive helpful, actionable guidance instead of cryptic runtime failures
- **Automatic Enforcement**: CI now automatically verifies that binary compatibility is maintained, preventing accidental regressions
- **Reduced Support Burden**: Clearer documentation and early warnings reduce confusion and support requests from users on unsupported systems

### Technical Details

The PR implements a "portable glibc floor" strategy using industry-standard manylinux_2_28 containers. This approach:
- Uses containers based on quay.io/pypa/manylinux_2_28 which provide glibc 2.28 as the baseline
- Adds runtime verification via `objdump` to ensure final binaries don't exceed the glibc floor
- Introduces `check_glibc()` function in the install script that parses `ldd --version` to detect system compatibility
- Only applies checks on Linux systems and gracefully skips when detection tools are unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1584?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->