### PR TITLE
feat(web): pin, archive, and snooze triage on the sidebar

### DIFF
--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -249,7 +249,7 @@ The sidebar exposes three triage primitives via the right-click (long-press on t
 
 Snooze and archive are mutually exclusive with pin: pinning a sunk row surfaces it, and archiving or snoozing a pinned row removes the pin. The three primitives can be mixed freely across concurrent surfaces (TUI, CLI, web), and the data layer enforces the mutual-exclusion rules in one place so peer writes cannot leave a row in a contradictory state.
 
-The "Snoozed & archived" footer is collapsed by default per repo group; clicking the header expands the list and remembers the choice per group in localStorage. Drag-to-reorder is disabled on pinned and sunk rows since their placement is computed.
+The "Snoozed & archived" section sits at the very bottom of the sidebar and aggregates every sunk workspace across all repo groups. It is collapsed by default; clicking the header expands the list and remembers the choice in localStorage. Drag-to-reorder is disabled on pinned and sunk rows since their placement is computed.
 
 In read-only mode (`aoe serve --read-only`) the three menu entries are hidden, matching the existing read-only gate on Delete.
 

--- a/docs/guides/web-dashboard.md
+++ b/docs/guides/web-dashboard.md
@@ -239,6 +239,20 @@ A sort toggle next to the filter button in the sidebar header switches to **Rece
 
 The toggle's state is per-browser (localStorage), not synced across devices and not tied to your profile. Toggling back to manual restores the stored manual order and re-enables drag. The multi-repo group stays pinned at the bottom in both modes.
 
+### Triage: pin, archive, snooze
+
+The sidebar exposes three triage primitives via the right-click (long-press on touch) context menu on any session row:
+
+- **Pin** floats the workspace to the top of the sidebar in every sort mode (manual and Recent activity). Pin is web-only and intentionally distinct from the TUI's favorite mark, which is a within-tier signal for the Attention sort. The web pin renders as a pushpin glyph next to the row title; the TUI favorite keeps its `*` star marker.
+- **Archive** kills the session's tmux pane (or shuts down the cockpit worker for ACP-cockpit sessions) and sinks the row into the collapsible "Snoozed & archived" footer of its repo group. Sending a message to the row from the dashboard wakes it back into the live list automatically. Daemon restarts and the cockpit worker reconciler both skip archived sessions, so a row stays parked until you explicitly unarchive it.
+- **Snooze** sinks the row into the same footer for a chosen duration. The menu offers the same eight presets as the TUI snooze dialog: 1h, 2h, 3h, 4h, 5h, 6h, 1d, 1w. The row wakes automatically when the timer expires; sending a message wakes it early.
+
+Snooze and archive are mutually exclusive with pin: pinning a sunk row surfaces it, and archiving or snoozing a pinned row removes the pin. The three primitives can be mixed freely across concurrent surfaces (TUI, CLI, web), and the data layer enforces the mutual-exclusion rules in one place so peer writes cannot leave a row in a contradictory state.
+
+The "Snoozed & archived" footer is collapsed by default per repo group; clicking the header expands the list and remembers the choice per group in localStorage. Drag-to-reorder is disabled on pinned and sunk rows since their placement is computed.
+
+In read-only mode (`aoe serve --read-only`) the three menu entries are hidden, matching the existing read-only gate on Delete.
+
 ## Architecture
 
 The server embeds an axum web server that serves a React frontend and provides:

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -451,6 +451,17 @@ pub async fn cockpit_prompt(
     // reconciler stops skipping the session on its next ~2s tick and
     // respawns the worker; the frontend's queue drains as soon as the
     // fresh `AcpSessionAssigned` lands. See #1581.
+    //
+    // The in-memory mutation and the disk persistence are both held
+    // under `state.instance_lock(&id)` so they serialize against
+    // other session-mutating endpoints (archive / snooze / pin /
+    // rename) on the same id. Without this guard, a concurrent
+    // archive PATCH could interleave with the touch and produce a
+    // lost write (archive sets archived_at = Some, touch clears it,
+    // archive's persist lands first, touch's persist lands second
+    // and overwrites the archive).
+    let inst_lock = state.instance_lock(&id).await;
+    let _guard = inst_lock.lock().await;
     let triage_changed = {
         let mut instances = state.instances.write().await;
         if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
@@ -499,6 +510,11 @@ pub async fn cockpit_prompt(
             }
         }
     }
+    // Drop the per-session lock before reaching out to the
+    // supervisor. publish_user_prompt and send_prompt take their own
+    // locks downstream; holding ours across the agent forward would
+    // serialize prompts unnecessarily and stall siblings.
+    drop(_guard);
     // Publish the user's prompt into the event stream BEFORE forwarding
     // to the agent so the replay buffer / on-disk store captures it
     // even if the agent forward fails. The frontend treats UserPromptSent

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -444,6 +444,47 @@ pub async fn cockpit_prompt(
         Ok(j) => j,
         Err(rej) => return rej.into_response(),
     };
+    // Touch the instance before forwarding so an archived or
+    // currently-snoozed session auto-wakes the same way the tmux send
+    // path does (`/api/sessions/{id}/send`). `touch_last_accessed`
+    // clears `archived_at` and `snoozed_until` so the cockpit
+    // reconciler stops skipping the session on its next ~2s tick and
+    // respawns the worker; the frontend's queue drains as soon as the
+    // fresh `AcpSessionAssigned` lands. See #1581.
+    let triage_changed = {
+        let mut instances = state.instances.write().await;
+        if let Some(inst) = instances.iter_mut().find(|i| i.id == id) {
+            let was_sunk = inst.is_archived() || inst.is_snoozed();
+            if was_sunk {
+                inst.touch_last_accessed();
+            }
+            was_sunk
+        } else {
+            false
+        }
+    };
+    if triage_changed {
+        let profile = {
+            let instances = state.instances.read().await;
+            instances
+                .iter()
+                .find(|i| i.id == id)
+                .map(|i| i.source_profile.clone())
+                .unwrap_or_default()
+        };
+        if let Ok(storage) = crate::session::Storage::new(&profile) {
+            let id_clone = id.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                storage.update(|instances, _groups| {
+                    if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                        inst.touch_last_accessed();
+                    }
+                    Ok(())
+                })
+            })
+            .await;
+        }
+    }
     // Publish the user's prompt into the event stream BEFORE forwarding
     // to the agent so the replay buffer / on-disk store captures it
     // even if the agent forward fails. The frontend treats UserPromptSent

--- a/src/server/api/cockpit.rs
+++ b/src/server/api/cockpit.rs
@@ -474,7 +474,8 @@ pub async fn cockpit_prompt(
         };
         if let Ok(storage) = crate::session::Storage::new(&profile) {
             let id_clone = id.clone();
-            let _ = tokio::task::spawn_blocking(move || {
+            let session_id_for_log = id.clone();
+            match tokio::task::spawn_blocking(move || {
                 storage.update(|instances, _groups| {
                     if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
                         inst.touch_last_accessed();
@@ -482,7 +483,20 @@ pub async fn cockpit_prompt(
                     Ok(())
                 })
             })
-            .await;
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    target: "http.api.cockpit",
+                    session = %session_id_for_log,
+                    "failed to save after triage auto-wake: {e}"
+                ),
+                Err(join_err) => tracing::warn!(
+                    target: "http.api.cockpit",
+                    session = %session_id_for_log,
+                    "spawn_blocking join error during triage auto-wake save: {join_err}"
+                ),
+            }
         }
     }
     // Publish the user's prompt into the event stream BEFORE forwarding

--- a/src/server/api/mod.rs
+++ b/src/server/api/mod.rs
@@ -36,7 +36,8 @@ pub use projects::{create_project, delete_project, list_projects};
 pub use sessions::{
     create_session, delete_session, ensure_container_terminal, ensure_session, ensure_terminal,
     list_sessions, read_output, rename_session, send_message, session_diff_file,
-    session_diff_files, update_session_diff_base, update_session_notifications,
+    session_diff_files, update_session_archive, update_session_diff_base,
+    update_session_notifications, update_session_pin, update_session_snooze,
     update_workspace_ordering, CleanupDefaults, OutputQuery, SendMessageRequest, SessionResponse,
 };
 pub use system::{
@@ -235,6 +236,9 @@ mod tests {
                     "ensure_container_terminal",
                     "update_session_notifications",
                     "update_session_diff_base",
+                    "update_session_pin",
+                    "update_session_archive",
+                    "update_session_snooze",
                     "update_workspace_ordering",
                 ],
             ),
@@ -362,6 +366,9 @@ mod tests {
                     "ensure_container_terminal",
                     "update_session_notifications",
                     "update_session_diff_base",
+                    "update_session_pin",
+                    "update_session_archive",
+                    "update_session_snooze",
                     "update_workspace_ordering",
                 ],
             ),

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1213,25 +1213,42 @@ pub async fn update_session_snooze(
     let lock = state.instance_lock(&id).await;
     let _guard = lock.lock().await;
 
-    let mut instances = state.instances.write().await;
-    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
-        return (
-            StatusCode::NOT_FOUND,
-            Json(serde_json::json!({ "message": "Session not found" })),
-        )
-            .into_response();
+    let was_cockpit_mode = {
+        let mut instances = state.instances.write().await;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        };
+
+        match body.minutes {
+            Some(minutes) => inst.snooze(minutes),
+            None => inst.unsnooze(),
+        }
+
+        let cockpit;
+        #[cfg(feature = "serve")]
+        {
+            cockpit = inst.cockpit_mode;
+        }
+        #[cfg(not(feature = "serve"))]
+        {
+            cockpit = false;
+        }
+        cockpit
     };
 
-    match body.minutes {
-        Some(minutes) => inst.snooze(minutes),
-        None => inst.unsnooze(),
-    }
-
-    let response =
-        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
-    let profile = inst.source_profile.clone();
+    let profile = {
+        let instances = state.instances.read().await;
+        instances
+            .iter()
+            .find(|i| i.id == id)
+            .map(|i| i.source_profile.clone())
+            .unwrap_or_default()
+    };
     let minutes = body.minutes;
-    drop(instances);
 
     if let Ok(storage) = Storage::new(&profile) {
         let id_clone = id.clone();
@@ -1260,6 +1277,41 @@ pub async fn update_session_snooze(
         }
     }
 
+    // For cockpit-mode sessions, snoozing tears down the worker the
+    // same way archive does. Snooze is a "temporary archive" in the
+    // data model and the cockpit worker (claude-agent-acp subprocess)
+    // is heavy enough that keeping it idle while the row is sunk is a
+    // resource hog. The reconciler skips snoozed sessions, so the
+    // worker stays down until the snooze expires; the next reconciler
+    // tick after expiry brings it back. Unsnooze just lets the
+    // reconciler re-pick the session naturally, no explicit respawn.
+    #[cfg(feature = "serve")]
+    if was_cockpit_mode && minutes.is_some() {
+        match state.cockpit_supervisor.shutdown(&id).await {
+            Ok(()) | Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {}
+            Err(e) => tracing::warn!(
+                target: "cockpit.supervisor",
+                session = %id,
+                "shutdown during snooze failed: {e}"
+            ),
+        }
+    }
+    #[cfg(not(feature = "serve"))]
+    let _ = was_cockpit_mode;
+
+    let instances = state.instances.read().await;
+    let response = match instances.iter().find(|i| i.id == id) {
+        Some(inst) => {
+            SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
+        }
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        }
+    };
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -56,6 +56,29 @@ pub struct SessionResponse {
     /// favorited rows and render the `*` marker without re-implementing
     /// the predicate. Cross-feature parity with the TUI's `f`/`F` keybind.
     pub favorited: bool,
+    /// RFC3339 timestamp at which the session was web-pinned, or omitted
+    /// when not pinned. Distinct from `favorited`: favorite is the TUI
+    /// within-tier attention-sort signal, while pin is the hard
+    /// top-of-sort surfacing primitive used by the web sidebar. The
+    /// client derives a "pinned" boolean as `pinned_at != null`; no
+    /// separate boolean field is exposed (the timestamp itself is the
+    /// source of truth, matching `archived_at` and `snoozed_until`). See
+    /// #1581.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pinned_at: Option<String>,
+    /// RFC3339 timestamp at which the session was archived, or omitted
+    /// when not archived. The web sidebar sinks archived workspaces into
+    /// the "Snoozed & archived" collapsible section. See #1581.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub archived_at: Option<String>,
+    /// RFC3339 timestamp at which a snooze expires, or omitted when not
+    /// snoozed. The web sidebar treats a non-null future timestamp the
+    /// same as archived (sinks the workspace) and renders the remaining
+    /// duration. Expired timestamps are stale-but-harmless: the
+    /// `Instance::is_snoozed()` predicate returns false past the deadline,
+    /// and the response simply omits the field. See #1581.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snoozed_until: Option<String>,
     pub has_managed_worktree: bool,
     pub has_terminal: bool,
     pub profile: String,
@@ -198,6 +221,20 @@ impl SessionResponse {
             is_sandboxed: inst.is_sandboxed(),
             scratch: inst.scratch,
             favorited: inst.is_favorited(),
+            pinned_at: inst.pinned_at.map(|t| t.to_rfc3339()),
+            archived_at: inst.archived_at.map(|t| t.to_rfc3339()),
+            // Surface `snoozed_until` only when the snooze is still
+            // active. `is_snoozed()` returns false once the timestamp
+            // has expired, even though the persisted field stays set
+            // until the next mutation rewrites it. Mirroring that
+            // semantics on the wire prevents the web sidebar from
+            // showing a "snoozed 0m" chip on rows that have already
+            // woken on disk.
+            snoozed_until: if inst.is_snoozed() {
+                inst.snoozed_until.map(|t| t.to_rfc3339())
+            } else {
+                None
+            },
             has_managed_worktree: inst
                 .worktree_info
                 .as_ref()

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -903,6 +903,366 @@ pub async fn update_session_diff_base(
     (StatusCode::OK, Json(serde_json::json!(response))).into_response()
 }
 
+// --- Triage: pin / archive / snooze ---
+//
+// Three sibling endpoints surface the existing `Instance::pin`, `archive`,
+// and `snooze` mutators to the web dashboard. They all follow the same
+// shape: read-only 403, in-memory write under `state.instance_lock`,
+// persist via `Storage::update` matching the notifications and diff-base
+// precedent above. Archive additionally tears down the tmux pane and (for
+// cockpit sessions) the supervisor's worker so the row is genuinely
+// parked. Mutual-exclusion invariants (e.g. archive clears pin/favorite,
+// pin clears archive+snooze) live in the `Instance` methods, so the
+// handlers never set fields directly. See #1581.
+
+#[derive(Deserialize)]
+pub struct UpdatePinBody {
+    pub pinned: bool,
+}
+
+#[derive(Deserialize)]
+pub struct UpdateArchiveBody {
+    pub archived: bool,
+    /// When `archived = true`, kill the tmux pane (parity with the TUI's
+    /// `z` keybind and the CLI's `aoe session archive` default). Omitted
+    /// or `true` means kill; `false` keeps the pane alive while still
+    /// marking the session archived. Ignored when `archived = false`.
+    #[serde(default = "default_kill_pane")]
+    pub kill_pane: bool,
+}
+
+fn default_kill_pane() -> bool {
+    true
+}
+
+#[derive(Deserialize)]
+pub struct UpdateSnoozeBody {
+    /// `Some(positive minutes)` snoozes for that duration. `None` (or a
+    /// missing field) unsnoozes. Validated against
+    /// `crate::session::validate_snooze_duration` so the same bounds the
+    /// TUI dialog and CLI use also apply here.
+    #[serde(default)]
+    pub minutes: Option<u32>,
+}
+
+pub async fn update_session_pin(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<UpdatePinBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "read_only",
+                "message": "Server is in read-only mode"
+            })),
+        )
+            .into_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    let mut instances = state.instances.write().await;
+    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "message": "Session not found" })),
+        )
+            .into_response();
+    };
+
+    if body.pinned {
+        inst.pin();
+    } else {
+        inst.unpin();
+    }
+
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+    let profile = inst.source_profile.clone();
+    let pinned = body.pinned;
+    drop(instances);
+
+    if let Ok(storage) = Storage::new(&profile) {
+        let id_clone = id.clone();
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    if pinned {
+                        inst.pin();
+                    } else {
+                        inst.unpin();
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(
+                target: "http.api.sessions",
+                "Failed to save after pin update: {e}"
+            ),
+            Err(e) => tracing::error!(
+                target: "http.api.sessions",
+                "Pin persist join failed: {e}"
+            ),
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
+pub async fn update_session_archive(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<UpdateArchiveBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "read_only",
+                "message": "Server is in read-only mode"
+            })),
+        )
+            .into_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    // Snapshot what we need for side effects (kill pane / cockpit
+    // shutdown) before we drop the write lock. Clone the instance once
+    // so we can call its `kill()` method outside the lock without
+    // re-borrowing.
+    let (was_cockpit_mode, inst_clone) = {
+        let mut instances = state.instances.write().await;
+        let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        };
+        if body.archived {
+            inst.archive();
+        } else {
+            inst.unarchive();
+        }
+        let response =
+            SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+        let cockpit;
+        #[cfg(feature = "serve")]
+        {
+            cockpit = inst.cockpit_mode;
+        }
+        #[cfg(not(feature = "serve"))]
+        {
+            cockpit = false;
+        }
+        let inst_snap = inst.clone();
+        // Persist now while we hold the per-instance lock; the side
+        // effects below are best-effort and should not block other
+        // mutations on this session.
+        let profile = inst.source_profile.clone();
+        let archived = body.archived;
+        drop(instances);
+
+        if let Ok(storage) = Storage::new(&profile) {
+            let id_clone = id.clone();
+            match tokio::task::spawn_blocking(move || {
+                storage.update(|instances, _groups| {
+                    if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                        if archived {
+                            inst.archive();
+                        } else {
+                            inst.unarchive();
+                        }
+                    }
+                    Ok(())
+                })
+            })
+            .await
+            {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::error!(
+                    target: "http.api.sessions",
+                    "Failed to save after archive update: {e}"
+                ),
+                Err(e) => tracing::error!(
+                    target: "http.api.sessions",
+                    "Archive persist join failed: {e}"
+                ),
+            }
+        }
+
+        // Stash the cockpit flag + clone + response and break out to do
+        // the side effects below. Return early on the non-archive path
+        // because we have no work left to do.
+        if !body.archived {
+            return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
+        }
+        if !body.kill_pane {
+            return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
+        }
+        (cockpit, inst_snap)
+    };
+
+    // Best-effort tmux pane teardown for tmux-backed sessions. Mirrors
+    // `toggle_archive_at_cursor` in src/tui/home/operations.rs: if the
+    // kill fails (pane already dead, tmux gone), log and continue
+    // because the on-disk archived flag is the source of truth.
+    if !was_cockpit_mode {
+        let inst_for_kill = inst_clone.clone();
+        match tokio::task::spawn_blocking(move || inst_for_kill.kill()).await {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::warn!(
+                target: "http.api.sessions",
+                "Archive: tmux kill failed: {e}"
+            ),
+            Err(e) => tracing::warn!(
+                target: "http.api.sessions",
+                "Archive: tmux kill join failed: {e}"
+            ),
+        }
+    } else {
+        // Cockpit sessions: shut down the worker so the supervisor's
+        // reconciler does not race to respawn it. The reconciler also
+        // skips archived sessions (see cockpit_reconciler.rs), but
+        // shutting down here gives an immediate teardown rather than
+        // waiting for the next poll tick.
+        #[cfg(feature = "serve")]
+        match state.cockpit_supervisor.shutdown(&id).await {
+            Ok(()) | Err(crate::cockpit::supervisor::SupervisorError::UnknownSession(_)) => {}
+            Err(e) => tracing::warn!(
+                target: "cockpit.supervisor",
+                session = %id,
+                "shutdown during archive failed: {e}"
+            ),
+        }
+    }
+
+    // Re-read the in-memory instance so the response reflects the
+    // archived flag (the side effects above did not mutate it, but
+    // re-reading also picks up any peer write that landed during the
+    // unlock window).
+    let instances = state.instances.read().await;
+    let response = match instances.iter().find(|i| i.id == id) {
+        Some(inst) => {
+            SessionResponse::from_instance(inst, crate::claude_settings::read_tui_fullscreen())
+        }
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({ "message": "Session not found" })),
+            )
+                .into_response();
+        }
+    };
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
+pub async fn update_session_snooze(
+    State(state): State<Arc<AppState>>,
+    Path(id): Path<String>,
+    body: Result<Json<UpdateSnoozeBody>, axum::extract::rejection::JsonRejection>,
+) -> impl IntoResponse {
+    if state.read_only {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "read_only",
+                "message": "Server is in read-only mode"
+            })),
+        )
+            .into_response();
+    }
+    let Json(body) = match body {
+        Ok(b) => b,
+        Err(rej) => return rej.into_response(),
+    };
+
+    // Validate the duration up front. The TUI dialog presets, CLI, and
+    // this endpoint all share the same bounds (1..=43200 minutes); see
+    // `crate::session::config::validate_snooze_duration`.
+    if let Some(minutes) = body.minutes {
+        if let Err(msg) = crate::session::validate_snooze_duration(minutes as u64) {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": "validation_failed",
+                    "message": msg,
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    let lock = state.instance_lock(&id).await;
+    let _guard = lock.lock().await;
+
+    let mut instances = state.instances.write().await;
+    let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "message": "Session not found" })),
+        )
+            .into_response();
+    };
+
+    match body.minutes {
+        Some(minutes) => inst.snooze(minutes),
+        None => inst.unsnooze(),
+    }
+
+    let response =
+        SessionResponse::from_instance(&*inst, crate::claude_settings::read_tui_fullscreen());
+    let profile = inst.source_profile.clone();
+    let minutes = body.minutes;
+    drop(instances);
+
+    if let Ok(storage) = Storage::new(&profile) {
+        let id_clone = id.clone();
+        match tokio::task::spawn_blocking(move || {
+            storage.update(|instances, _groups| {
+                if let Some(inst) = instances.iter_mut().find(|i| i.id == id_clone) {
+                    match minutes {
+                        Some(m) => inst.snooze(m),
+                        None => inst.unsnooze(),
+                    }
+                }
+                Ok(())
+            })
+        })
+        .await
+        {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => tracing::error!(
+                target: "http.api.sessions",
+                "Failed to save after snooze update: {e}"
+            ),
+            Err(e) => tracing::error!(
+                target: "http.api.sessions",
+                "Snooze persist join failed: {e}"
+            ),
+        }
+    }
+
+    (StatusCode::OK, Json(serde_json::json!(response))).into_response()
+}
+
 // --- Delete session ---
 
 #[derive(Default, Deserialize)]
@@ -2749,6 +3109,113 @@ mod tests {
     }
 
     #[test]
+    fn session_response_surfaces_pinned_at() {
+        let mut inst = make_test_instance();
+
+        // Default: no pin -> field omitted from the JSON body.
+        let json = serde_json::to_value(SessionResponse::from_instance(&inst, false)).unwrap();
+        assert!(
+            json.get("pinned_at").is_none(),
+            "pinned_at should be omitted when None, got: {json}"
+        );
+
+        inst.pin();
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(resp.pinned_at.is_some(), "pinned_at must surface when set");
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(
+            json.get("pinned_at").is_some(),
+            "pinned_at must appear in JSON when set"
+        );
+    }
+
+    #[test]
+    fn session_response_surfaces_archived_at() {
+        let mut inst = make_test_instance();
+        let json = serde_json::to_value(SessionResponse::from_instance(&inst, false)).unwrap();
+        assert!(json.get("archived_at").is_none());
+
+        inst.archive();
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(resp.archived_at.is_some());
+    }
+
+    #[test]
+    fn session_response_gates_snoozed_until_on_active_snooze() {
+        let mut inst = make_test_instance();
+
+        // Not snoozed -> field omitted.
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(resp.snoozed_until.is_none());
+
+        // Active snooze -> field surfaced.
+        inst.snooze(30);
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(resp.snoozed_until.is_some());
+
+        // Expired snooze -> stays on disk for the next mutation to rewrite,
+        // but the API gates on `is_snoozed()` so the wire value is None.
+        // This prevents the web from rendering "snoozed 0m" on rows that
+        // have already woken on the server.
+        inst.snoozed_until = Some(chrono::Utc::now() - chrono::Duration::seconds(1));
+        let resp = SessionResponse::from_instance(&inst, false);
+        assert!(
+            resp.snoozed_until.is_none(),
+            "expired snooze must be filtered out on the wire even though the persisted field stays set"
+        );
+    }
+
+    #[test]
+    fn update_pin_body_parses() {
+        let body: UpdatePinBody = serde_json::from_str(r#"{"pinned": true}"#).unwrap();
+        assert!(body.pinned);
+        let body: UpdatePinBody = serde_json::from_str(r#"{"pinned": false}"#).unwrap();
+        assert!(!body.pinned);
+    }
+
+    #[test]
+    fn update_archive_body_defaults_kill_pane_to_true() {
+        let body: UpdateArchiveBody = serde_json::from_str(r#"{"archived": true}"#).unwrap();
+        assert!(body.archived);
+        assert!(
+            body.kill_pane,
+            "kill_pane must default to true so callers that omit the field get TUI/CLI parity"
+        );
+
+        let body: UpdateArchiveBody =
+            serde_json::from_str(r#"{"archived": true, "kill_pane": false}"#).unwrap();
+        assert!(body.archived);
+        assert!(!body.kill_pane);
+    }
+
+    #[test]
+    fn update_snooze_body_parses_minutes_and_null() {
+        let body: UpdateSnoozeBody = serde_json::from_str(r#"{"minutes": 60}"#).unwrap();
+        assert_eq!(body.minutes, Some(60));
+
+        // `{"minutes": null}` and an empty body both mean unsnooze.
+        let body: UpdateSnoozeBody = serde_json::from_str(r#"{"minutes": null}"#).unwrap();
+        assert_eq!(body.minutes, None);
+        let body: UpdateSnoozeBody = serde_json::from_str(r#"{}"#).unwrap();
+        assert_eq!(body.minutes, None);
+    }
+
+    #[test]
+    fn update_snooze_validates_against_shared_bounds() {
+        // The handler uses `validate_snooze_duration` to reject 0 and >
+        // SNOOZE_MAX_MINUTES. Mirror the assertions here so a regression in
+        // the validator shape (or in the dialog presets at
+        // src/tui/dialogs/snooze_duration.rs) is caught locally.
+        assert!(crate::session::validate_snooze_duration(0).is_err());
+        for &m in &[60u64, 120, 180, 240, 300, 360, 1440, 7 * 1440] {
+            assert!(
+                crate::session::validate_snooze_duration(m).is_ok(),
+                "preset {m} min must pass validator (matches TUI dialog presets)"
+            );
+        }
+    }
+
+    #[test]
     fn claude_fullscreen_unset_for_non_claude_even_when_enabled() {
         let mut inst = make_test_instance();
         inst.tool = "cursor".to_string();
@@ -3687,6 +4154,9 @@ mod workspace_ordering_tests {
             next_wakeup_at: None,
             next_wakeup_reason: None,
             favorited: false,
+            pinned_at: None,
+            archived_at: None,
+            snoozed_until: None,
         }
     }
 

--- a/src/server/api/sessions.rs
+++ b/src/server/api/sessions.rs
@@ -1046,8 +1046,10 @@ pub async fn update_session_archive(
     // Snapshot what we need for side effects (kill pane / cockpit
     // shutdown) before we drop the write lock. Clone the instance once
     // so we can call its `kill()` method outside the lock without
-    // re-borrowing.
-    let (was_cockpit_mode, inst_clone) = {
+    // re-borrowing. The outer tuple also carries `kill_pane` so the
+    // tmux branch below can gate the pane teardown without re-reading
+    // the body; cockpit shutdown is unconditional on archive=true.
+    let (was_cockpit_mode, inst_clone, kill_pane) = {
         let mut instances = state.instances.write().await;
         let Some(inst) = instances.iter_mut().find(|i| i.id == id) else {
             return (
@@ -1110,32 +1112,37 @@ pub async fn update_session_archive(
 
         // Stash the cockpit flag + clone + response and break out to do
         // the side effects below. Return early on the non-archive path
-        // because we have no work left to do.
+        // because we have no work left to do; the kill_pane=false case
+        // is NOT a short-circuit because cockpit shutdown still has to
+        // run for cockpit-mode sessions (kill_pane is a tmux-only
+        // switch, per the request-body documentation).
         if !body.archived {
             return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
         }
-        if !body.kill_pane {
-            return (StatusCode::OK, Json(serde_json::json!(response))).into_response();
-        }
-        (cockpit, inst_snap)
+        (cockpit, inst_snap, body.kill_pane)
     };
 
     // Best-effort tmux pane teardown for tmux-backed sessions. Mirrors
     // `toggle_archive_at_cursor` in src/tui/home/operations.rs: if the
     // kill fails (pane already dead, tmux gone), log and continue
-    // because the on-disk archived flag is the source of truth.
+    // because the on-disk archived flag is the source of truth. The
+    // kill_pane=false body opt-out applies only here, so a caller can
+    // archive a tmux session without killing its pane while still
+    // unconditionally stopping a cockpit worker on the other branch.
     if !was_cockpit_mode {
-        let inst_for_kill = inst_clone.clone();
-        match tokio::task::spawn_blocking(move || inst_for_kill.kill()).await {
-            Ok(Ok(())) => {}
-            Ok(Err(e)) => tracing::warn!(
-                target: "http.api.sessions",
-                "Archive: tmux kill failed: {e}"
-            ),
-            Err(e) => tracing::warn!(
-                target: "http.api.sessions",
-                "Archive: tmux kill join failed: {e}"
-            ),
+        if kill_pane {
+            let inst_for_kill = inst_clone.clone();
+            match tokio::task::spawn_blocking(move || inst_for_kill.kill()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => tracing::warn!(
+                    target: "http.api.sessions",
+                    "Archive: tmux kill failed: {e}"
+                ),
+                Err(e) => tracing::warn!(
+                    target: "http.api.sessions",
+                    "Archive: tmux kill join failed: {e}"
+                ),
+            }
         }
     } else {
         // Cockpit sessions: shut down the worker so the supervisor's

--- a/src/server/cockpit_reconciler.rs
+++ b/src/server/cockpit_reconciler.rs
@@ -106,11 +106,19 @@ pub async fn reconcile_cockpit_workers(state: &Arc<AppState>, attempted: &mut Ha
     // Snapshot per-target resume inputs under the instances read lock.
     // We then drop the lock so the parallel resume tasks (each ~3s for
     // a fresh spawn) don't pin it.
+    //
+    // Triaged sessions (archived or currently-snoozed) are excluded from
+    // the resume targets so the reconciler does not race the web
+    // archive/snooze handler's worker teardown. Without this skip, the
+    // 2s tick would respawn an archived cockpit worker immediately after
+    // the API handler shuts it down, defeating the archive semantics.
+    // Expired snoozes naturally rejoin via `is_snoozed()` returning
+    // false past the deadline. See #1581.
     let raw_targets: Vec<RawTargetTuple> = {
         let instances = state.instances.read().await;
         instances
             .iter()
-            .filter(|i| i.cockpit_mode)
+            .filter(|i| i.cockpit_mode && !i.is_archived() && !i.is_snoozed())
             .map(|i| {
                 (
                     i.id.clone(),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1106,6 +1106,15 @@ fn build_router(state: Arc<AppState>) -> Router {
             "/api/sessions/{id}/diff-base",
             patch(api::update_session_diff_base),
         )
+        .route("/api/sessions/{id}/pin", patch(api::update_session_pin))
+        .route(
+            "/api/sessions/{id}/archive",
+            patch(api::update_session_archive),
+        )
+        .route(
+            "/api/sessions/{id}/snooze",
+            patch(api::update_session_snooze),
+        )
         .route("/api/sessions/{id}/terminal", post(api::ensure_terminal))
         .route(
             "/api/sessions/{id}/container-terminal",

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -804,9 +804,10 @@ impl Instance {
         // (TUI-side or peer-side) dethrones a concurrent archive.
         let touched = self.last_accessed_at > pre.last_accessed_at;
 
-        // archive(): archived=Some => favorited=None, pinned=None
+        // archive(): archived=Some => favorited=None, snoozed=None, pinned=None
         if archived_changed && post.archived_at.is_some() {
             self.favorited_at = None;
+            self.snoozed_until = None;
             self.pinned_at = None;
         }
         // favorite(): favorited=Some => archived=None, snoozed=None
@@ -830,20 +831,32 @@ impl Instance {
             self.archived_at = None;
             self.snoozed_until = None;
         }
+        // Final-state invariant: archive is the strongest dismiss and
+        // wins over snooze. The per-mutation rules above clear other
+        // flags on the change side, but the diff can also leave disk
+        // archived (pre-existing) AND snoozed (added by post); without
+        // this check the row would persist both and the web sidebar's
+        // tier comparator (which assumes exactly one active triage
+        // state) would render contradictory chips. See #1581.
+        if self.archived_at.is_some() {
+            self.snoozed_until = None;
+        }
     }
 
     /// Mark the session archived. Archived sessions sink to the bottom of
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.
     ///
-    /// Mutual exclusion with `favorite` and `pin`: archiving clears both
-    /// `favorited_at` and `pinned_at`. Archive is the strongest dismiss;
-    /// keeping a stale favorite or pin marker on a row the user just sunk
-    /// produces contradictory state. The user's explicit rule: "archived
-    /// removes fav." Pin extends the same rule (see #1581).
+    /// Mutual exclusion with `favorite`, `snooze`, and `pin`: archiving
+    /// clears `favorited_at`, `snoozed_until`, and `pinned_at`. Archive
+    /// is the strongest dismiss; keeping any other triage flag on a row
+    /// the user just sunk produces contradictory state, and the web
+    /// sidebar's tier comparator already assumes the server enforces a
+    /// single active triage state (see `sidebarSort.ts` in #1581).
     pub fn archive(&mut self) {
         self.archived_at = Some(Utc::now());
         self.favorited_at = None;
+        self.snoozed_until = None;
         self.pinned_at = None;
     }
 
@@ -3265,7 +3278,13 @@ mod tests {
     }
 
     #[test]
-    fn test_merge_diff_archive_and_snooze_coexist() {
+    fn test_merge_diff_peer_archive_clears_concurrent_tui_snooze() {
+        // The web/TUI/CLI contract treats pinned/archived/snoozed as
+        // mutually exclusive (the sidebar tier comparator assumes a
+        // single active triage state, see #1581). When a TUI snooze
+        // races a peer archive, archive wins: snooze is a temporary
+        // sink and archive is the indefinite one, so leaving both set
+        // would surface contradictory triage state on the next render.
         let pre = Instance::new("s", "/tmp/x");
         let mut post = pre.clone();
         post.snooze(15);
@@ -3276,7 +3295,26 @@ mod tests {
         disk.merge_user_action_diff(&pre, &post);
 
         assert!(disk.archived_at.is_some(), "peer archive survives");
-        assert!(disk.snoozed_until.is_some(), "TUI snooze landed");
+        assert!(
+            disk.snoozed_until.is_none(),
+            "archive() invariant must clear a concurrent TUI snooze"
+        );
+    }
+
+    #[test]
+    fn test_archive_clears_snooze() {
+        // Direct mutator test (no merge): the data-layer contract is
+        // that archive is mutually exclusive with every other triage
+        // flag. The sidebar tier comparator in `sidebarSort.ts`
+        // assumes the server enforces exactly one active state, so a
+        // snooze-then-archive transition must leave only archive
+        // behind. See #1581.
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.snooze(15);
+        assert!(inst.is_snoozed());
+        inst.archive();
+        assert!(inst.is_archived());
+        assert!(!inst.is_snoozed());
     }
 
     #[test]

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -325,6 +325,19 @@ pub struct Instance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snoozed_until: Option<DateTime<Utc>>,
 
+    /// Web-only pin marker. Distinct from `favorited_at`: favorite is the
+    /// TUI attention-sort within-tier pin, while pin is a hard top-of-sort
+    /// surfacing primitive surfaced through the web sidebar (where the TUI's
+    /// Attention sort does not exist). Mutually exclusive with the sink
+    /// states (`archived_at`, `snoozed_until`) via the `pin()` mutator and
+    /// the inverse clear in `archive()` / `snooze()`. Orthogonal to
+    /// `favorited_at` (both can be set; they drive different surfaces).
+    /// Unlike archive/snooze, `pin` is NOT cleared by `touch_last_accessed`
+    /// because it is an explicit persistent surfacing signal, not a sink
+    /// state that "user is engaging" implicitly contradicts. See #1581.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pinned_at: Option<DateTime<Utc>>,
+
     /// Scratch-session marker. When true, `project_path` points at an
     /// auto-provisioned directory under `<app_dir>/scratch/<id>/` that the
     /// deletion path removes on `aoe rm` (unless the user opts in to keeping
@@ -659,6 +672,7 @@ impl Instance {
             archived_at: None,
             favorited_at: None,
             snoozed_until: None,
+            pinned_at: None,
             scratch: false,
             worktree_info: None,
             workspace_info: None,
@@ -771,6 +785,9 @@ impl Instance {
         if pre.snoozed_until != post.snoozed_until {
             self.snoozed_until = post.snoozed_until;
         }
+        if pre.pinned_at != post.pinned_at {
+            self.pinned_at = post.pinned_at;
+        }
         if pre.base_branch_override != post.base_branch_override {
             self.base_branch_override = post.base_branch_override.clone();
         }
@@ -781,20 +798,34 @@ impl Instance {
 
         let archived_changed = pre.archived_at != post.archived_at;
         let favorited_changed = pre.favorited_at != post.favorited_at;
+        let snoozed_changed = pre.snoozed_until != post.snoozed_until;
+        let pinned_changed = pre.pinned_at != post.pinned_at;
         // Touch is an event invariant: any advance of last_accessed_at
         // (TUI-side or peer-side) dethrones a concurrent archive.
         let touched = self.last_accessed_at > pre.last_accessed_at;
 
-        // archive(): archived=Some => favorited=None
+        // archive(): archived=Some => favorited=None, pinned=None
         if archived_changed && post.archived_at.is_some() {
             self.favorited_at = None;
+            self.pinned_at = None;
         }
         // favorite(): favorited=Some => archived=None, snoozed=None
         if favorited_changed && post.favorited_at.is_some() {
             self.archived_at = None;
             self.snoozed_until = None;
         }
-        // touch_last_accessed(): clears archived + snoozed.
+        // snooze(): snoozed=Some => pinned=None (sink clears surface).
+        if snoozed_changed && post.snoozed_until.is_some() {
+            self.pinned_at = None;
+        }
+        // pin(): pinned=Some => archived=None, snoozed=None (surface clears sinks).
+        if pinned_changed && post.pinned_at.is_some() {
+            self.archived_at = None;
+            self.snoozed_until = None;
+        }
+        // touch_last_accessed(): clears archived + snoozed. Does NOT clear
+        // favorite or pin (both are explicit user-surfacing signals, not
+        // sink states).
         if touched {
             self.archived_at = None;
             self.snoozed_until = None;
@@ -805,13 +836,15 @@ impl Instance {
     /// the Attention sort and render in italic+dim style, but remain
     /// visible. Auto-cleared by the attention-signal hook on Waiting/Error.
     ///
-    /// Mutual exclusion with `favorite`: archiving clears `favorited_at`.
-    /// Archive is the strongest dismiss; keeping a stale favorite pin on a
-    /// row the user just sunk produces contradictory "pinned + dismissed"
-    /// state. The user's explicit rule: "archived removes fav."
+    /// Mutual exclusion with `favorite` and `pin`: archiving clears both
+    /// `favorited_at` and `pinned_at`. Archive is the strongest dismiss;
+    /// keeping a stale favorite or pin marker on a row the user just sunk
+    /// produces contradictory state. The user's explicit rule: "archived
+    /// removes fav." Pin extends the same rule (see #1581).
     pub fn archive(&mut self) {
         self.archived_at = Some(Utc::now());
         self.favorited_at = None;
+        self.pinned_at = None;
     }
 
     pub fn unarchive(&mut self) {
@@ -869,8 +902,15 @@ impl Instance {
     /// tick); no timer task needed. Resolution of `minutes` happens at
     /// snooze time, not render time, so changing the config default mid-
     /// snooze does NOT extend currently-sleeping rows.
+    ///
+    /// Clears `pinned_at` for the same reason archive does: snooze is a
+    /// sink state, and a pinned-yet-snoozed row is contradictory. The
+    /// existing favorite mutator is intentionally NOT touched here
+    /// (favorite is the TUI within-tier signal, snoozed favorites keep
+    /// their star when they wake; see field doc for `favorited_at`).
     pub fn snooze(&mut self, minutes: u32) {
         self.snoozed_until = Some(Utc::now() + chrono::Duration::minutes(minutes as i64));
+        self.pinned_at = None;
     }
 
     pub fn unsnooze(&mut self) {
@@ -897,6 +937,30 @@ impl Instance {
                 None
             }
         })
+    }
+
+    /// Mark this session pinned. Pin is a web-only surfacing primitive:
+    /// pinned workspaces sort to the top of the web sidebar (across all
+    /// sort modes), regardless of last-activity. Distinct from
+    /// `favorited_at`, which drives the TUI Attention sort's within-tier
+    /// pin and stays unchanged here (see #1581).
+    ///
+    /// Mutual exclusion with the sink states: pinning clears
+    /// `archived_at` and `snoozed_until`. A pinned-yet-sunk row would
+    /// contradict the entire point of pinning (surface this), so the
+    /// sinks come off, identical to how `favorite()` handles it.
+    pub fn pin(&mut self) {
+        self.pinned_at = Some(Utc::now());
+        self.archived_at = None;
+        self.snoozed_until = None;
+    }
+
+    pub fn unpin(&mut self) {
+        self.pinned_at = None;
+    }
+
+    pub fn is_pinned(&self) -> bool {
+        self.pinned_at.is_some()
     }
 
     /// Time elapsed since this session most recently transitioned into
@@ -3254,6 +3318,148 @@ mod tests {
     }
 
     #[test]
+    fn test_pin_clears_archive_and_snooze() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.archive();
+        assert!(inst.is_archived());
+        inst.pin();
+        assert!(inst.is_pinned());
+        assert!(!inst.is_archived());
+        assert!(!inst.is_snoozed());
+
+        inst.snooze(15);
+        assert!(inst.is_snoozed());
+        inst.pin();
+        assert!(inst.is_pinned());
+        assert!(!inst.is_snoozed());
+    }
+
+    #[test]
+    fn test_archive_clears_pin() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.pin();
+        assert!(inst.is_pinned());
+        inst.archive();
+        assert!(inst.is_archived());
+        assert!(!inst.is_pinned());
+    }
+
+    #[test]
+    fn test_snooze_clears_pin() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.pin();
+        assert!(inst.is_pinned());
+        inst.snooze(30);
+        assert!(inst.is_snoozed());
+        assert!(!inst.is_pinned());
+    }
+
+    #[test]
+    fn test_touch_last_accessed_preserves_pin() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.pin();
+        assert!(inst.is_pinned());
+        inst.touch_last_accessed();
+        // Pin is an explicit user surfacing signal, not a sink state.
+        // User interaction (send, attach) must NOT clear it.
+        assert!(inst.is_pinned());
+    }
+
+    #[test]
+    fn test_pin_and_favorite_coexist() {
+        let mut inst = Instance::new("s", "/tmp/x");
+        inst.favorite();
+        assert!(inst.is_favorited());
+        inst.pin();
+        // Pin and favorite drive different surfaces (TUI Attention vs web
+        // sidebar). They must coexist; pinning does NOT clear favorite.
+        assert!(inst.is_pinned());
+        assert!(inst.is_favorited());
+
+        let mut inst2 = Instance::new("s2", "/tmp/x");
+        inst2.pin();
+        inst2.favorite();
+        // Same in reverse: favoriting does NOT clear pin.
+        assert!(inst2.is_pinned());
+        assert!(inst2.is_favorited());
+    }
+
+    #[test]
+    fn test_merge_diff_peer_archive_loses_to_tui_pin() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.pin();
+
+        let mut disk = pre.clone();
+        disk.archive();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.pinned_at.is_some(), "TUI pin landed");
+        assert!(
+            disk.archived_at.is_none(),
+            "pin() invariant must clear concurrent peer archive"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_pin_loses_to_tui_archive() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.archive();
+
+        let mut disk = pre.clone();
+        disk.pin();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.archived_at.is_some(), "TUI archive landed");
+        assert!(
+            disk.pinned_at.is_none(),
+            "archive() invariant must clear concurrent peer pin"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_pin_loses_to_tui_snooze() {
+        let pre = Instance::new("s", "/tmp/x");
+        let mut post = pre.clone();
+        post.snooze(30);
+
+        let mut disk = pre.clone();
+        disk.pin();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        assert!(disk.snoozed_until.is_some(), "TUI snooze landed");
+        assert!(
+            disk.pinned_at.is_none(),
+            "snooze() invariant must clear concurrent peer pin"
+        );
+    }
+
+    #[test]
+    fn test_merge_diff_peer_touch_preserves_pin() {
+        let mut pre = Instance::new("s", "/tmp/x");
+        pre.last_accessed_at = Some(Utc::now() - chrono::Duration::seconds(60));
+
+        let mut post = pre.clone();
+        post.pin();
+
+        let mut disk = pre.clone();
+        disk.touch_last_accessed();
+
+        disk.merge_user_action_diff(&pre, &post);
+
+        // Touch dethrones archive/snooze but NOT pin: pin is an explicit
+        // surfacing signal that the user's interaction does not contradict.
+        assert!(
+            disk.pinned_at.is_some(),
+            "peer touch must NOT clear concurrent TUI pin"
+        );
+    }
+
+    #[test]
     fn test_merge_from_tui_copies_status_pipeline() {
         let mut stored = Instance::new("session", "/tmp/test");
         stored.status = Status::Idle;
@@ -3300,11 +3506,13 @@ mod tests {
         let peer_archived = Some(Utc::now());
         let peer_favorited = Some(Utc::now() - chrono::Duration::minutes(2));
         let peer_snoozed = Some(Utc::now() + chrono::Duration::minutes(30));
+        let peer_pinned = Some(Utc::now() - chrono::Duration::minutes(1));
 
         let mut stored = Instance::new("session", "/tmp/test");
         stored.archived_at = peer_archived;
         stored.favorited_at = peer_favorited;
         stored.snoozed_until = peer_snoozed;
+        stored.pinned_at = peer_pinned;
         stored.title = "peer-renamed".to_string();
         stored.group_path = "peer/group".to_string();
         stored.agent_session_id = Some("daemon-sid".to_string());
@@ -3316,6 +3524,7 @@ mod tests {
         src.archived_at = None;
         src.favorited_at = None;
         src.snoozed_until = None;
+        src.pinned_at = None;
         src.title = "tui-stale".to_string();
         src.group_path = "tui/stale".to_string();
         src.agent_session_id = Some("tui-stale-sid".to_string());
@@ -3327,6 +3536,7 @@ mod tests {
         assert_eq!(stored.archived_at, peer_archived);
         assert_eq!(stored.favorited_at, peer_favorited);
         assert_eq!(stored.snoozed_until, peer_snoozed);
+        assert_eq!(stored.pinned_at, peer_pinned);
         assert_eq!(stored.title, "peer-renamed");
         assert_eq!(stored.group_path, "peer/group");
         assert_eq!(stored.agent_session_id.as_deref(), Some("daemon-sid"));

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8096,7 +8096,13 @@ mod save_field_merge {
 
     #[test]
     #[serial]
-    fn test_apply_user_action_preserves_peer_user_action_field() {
+    fn test_apply_user_action_archive_clears_peer_snooze() {
+        // The web/TUI/CLI contract treats pinned / archived / snoozed
+        // as mutually exclusive (see Instance::archive and the sidebar
+        // tier comparator in #1581). When a peer snoozes a row that
+        // the TUI then archives, archive wins because it is the
+        // indefinite sink; leaving both flags persisted would surface
+        // contradictory triage state on the next render.
         let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
 
         let peer_storage = Storage::new("test").unwrap();
@@ -8109,8 +8115,6 @@ mod save_field_merge {
             })
             .unwrap();
 
-        // archive() touches archived_at + favorited_at only; the peer-set
-        // snoozed_until must NOT be clobbered by the diff-splice.
         view.apply_user_action(&id, |inst| inst.archive())
             .expect("archive must persist");
 
@@ -8118,8 +8122,40 @@ mod save_field_merge {
         let row = reloaded.iter().find(|i| i.id == id).expect("row present");
         assert!(row.archived_at.is_some(), "TUI archive landed");
         assert!(
-            row.snoozed_until.is_some(),
-            "peer-written snoozed_until must survive a TUI archive that does not touch the field"
+            row.snoozed_until.is_none(),
+            "archive() invariant must clear a concurrent peer snooze",
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_apply_user_action_preserves_peer_user_action_field() {
+        // Field-level merge regression: a TUI snooze must not clobber
+        // an unrelated peer write (group_path here). Uses snooze
+        // instead of archive so the snoozed_until field IS touched on
+        // both sides and the test isolates the peer-field-survival
+        // invariant from the archive XOR rules tested above.
+        let (_temp, mut view, id) = boot_view_with_one_session("session", "/tmp/race");
+
+        let peer_storage = Storage::new("test").unwrap();
+        peer_storage
+            .update(|insts, _| {
+                if let Some(inst) = insts.iter_mut().find(|i| i.id == id) {
+                    inst.group_path = "peer/group".to_string();
+                }
+                Ok(())
+            })
+            .unwrap();
+
+        view.apply_user_action(&id, |inst| inst.snooze(30))
+            .expect("snooze must persist");
+
+        let reloaded = Storage::new("test").unwrap().load().unwrap();
+        let row = reloaded.iter().find(|i| i.id == id).expect("row present");
+        assert!(row.snoozed_until.is_some(), "TUI snooze landed");
+        assert_eq!(
+            row.group_path, "peer/group",
+            "peer-written group_path must survive a TUI snooze that does not touch the field",
         );
     }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -734,6 +734,8 @@ function AppContent({ loginRequired, onLogout }: { loginRequired: boolean; onLog
                       sessionId={activeSessionId!}
                       cockpitWorkerState={activeSession.cockpit_worker_state ?? "absent"}
                       tool={activeSession.tool}
+                      archivedAt={activeSession.archived_at ?? null}
+                      snoozedUntil={activeSession.snoozed_until ?? null}
                     />
                   </Suspense>
                 ) : (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -79,7 +79,7 @@ const MAX_WIDTH = 480;
  *  the same set of choices. The TUI extends past these via a manual
  *  numeric entry; the web sidebar omits that path in v1 (the menu
  *  stays flat). See #1581. */
-const SNOOZE_PRESETS: readonly { label: string; minutes: number }[] = [
+export const SNOOZE_PRESETS: readonly { label: string; minutes: number }[] = [
   { label: "1 hour", minutes: 60 },
   { label: "2 hours", minutes: 120 },
   { label: "3 hours", minutes: 180 },
@@ -283,7 +283,7 @@ function formatDurationSecondsShort(seconds: number): string {
  *  closure, not a render. The exact value is throwaway (the server's
  *  response on the next poll is the source of truth), so a few ms
  *  of jitter is harmless. See #1581. */
-function makeOptimisticSnoozedUntil(minutes: number): string {
+export function makeOptimisticSnoozedUntil(minutes: number): string {
   return new Date(Date.now() + minutes * 60_000).toISOString();
 }
 
@@ -298,7 +298,7 @@ function makeOptimisticSnoozedUntil(minutes: number): string {
  *   - else       : "Nd" (rounded down)
  *  Past timestamps return "soon" since the wake-up has expired but the
  *  next poll has not yet cleared the row. */
-function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
+export function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
   const target = Date.parse(snoozedUntilIso);
   if (!Number.isFinite(target)) return "snoozed";
   const remainingMs = target - Date.now();
@@ -1109,7 +1109,7 @@ function snoozeUnitToMinutes(value: number, unit: SnoozeUnit): number {
  *   - Custom duration: number + unit (m/h/d/w).
  *   - Until a specific date+time (HTML5 datetime-local input).
  *  Backdrop click and Escape both dismiss. See #1581. */
-function SnoozeModal({
+export function SnoozeModal({
   title,
   onCancel,
   onPick,

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -57,6 +57,7 @@ import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
+  resolveEffectiveSnoozedUntil,
   triageMenuShape,
   triageStateOf,
   workspaceIsPinned,
@@ -275,6 +276,17 @@ function formatDurationSecondsShort(seconds: number): string {
   return remM === 0 ? `${h}h` : `${h}h ${remM}m`;
 }
 
+/** Wall-clock target for an optimistic snooze: `Date.now() + minutes
+ *  * 60_000` as an RFC3339 ISO string. Sits outside the component so
+ *  the `Date.now()` call doesn't trip
+ *  `react-hooks/purity`; the event handler that calls it is itself a
+ *  closure, not a render. The exact value is throwaway (the server's
+ *  response on the next poll is the source of truth), so a few ms
+ *  of jitter is harmless. See #1581. */
+function makeOptimisticSnoozedUntil(minutes: number): string {
+  return new Date(Date.now() + minutes * 60_000).toISOString();
+}
+
 /** Compact "time remaining" label for the snooze chip computed once at
  *  render time (no per-second timer, by design: snooze rows poll the
  *  sessions API at the existing cadence and the static label is more
@@ -485,7 +497,6 @@ const SessionRow = memo(function SessionRow({
   const isArchived = workspace.sessions.some((s) => s.archived_at != null);
   const snoozedUntil = workspace.sessions.find((s) => s.snoozed_until)
     ?.snoozed_until ?? null;
-  const isSnoozed = snoozedUntil != null;
   const sessionId = firstSession?.id;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
   const sessionPath = navigationSessionId
@@ -524,6 +535,14 @@ const SessionRow = memo(function SessionRow({
   const [optimisticArchived, setOptimisticArchived] = useState<boolean | null>(
     null,
   );
+  // Optimistic `snoozed_until` override. `undefined` = no override
+  // (use the prop), a string = pretend the server already returned
+  // this RFC3339 timestamp, `null` = pretend the server already
+  // unsnoozed. Clears once the prop matches the override on the next
+  // poll, matching the pin / archive pattern above.
+  const [optimisticSnoozedUntil, setOptimisticSnoozedUntil] = useState<
+    string | null | undefined
+  >(undefined);
   // Snooze duration picker. Lives in its own portal-rendered modal,
   // independent of the context menu's lifecycle so the parent-menu
   // dismissal listener cannot close the picker out from under us.
@@ -538,6 +557,15 @@ const SessionRow = memo(function SessionRow({
       setOptimisticArchived(null);
     }
   }, [isArchived, optimisticArchived]);
+  useEffect(() => {
+    if (
+      optimisticSnoozedUntil !== undefined &&
+      ((optimisticSnoozedUntil === null && snoozedUntil == null) ||
+        (optimisticSnoozedUntil != null && snoozedUntil != null))
+    ) {
+      setOptimisticSnoozedUntil(undefined);
+    }
+  }, [snoozedUntil, optimisticSnoozedUntil]);
 
   const togglePin = async () => {
     setContextMenu(null);
@@ -569,8 +597,17 @@ const SessionRow = memo(function SessionRow({
     setContextMenu(null);
     setSnoozeModalOpen(false);
     if (!sessionId) return;
+    // Optimistic flip: render the snooze chip + sink the row before
+    // the PATCH round-trip lands, matching the pin / archive
+    // affordance. For positive minutes we synthesise a target
+    // timestamp; the server is the source of truth and the value is
+    // discarded on the next poll, so a few ms of drift is harmless.
+    const optimisticUntil =
+      minutes == null ? null : makeOptimisticSnoozedUntil(minutes);
+    setOptimisticSnoozedUntil(optimisticUntil);
     const result = await setSessionSnooze(sessionId, minutes);
     if (!result) {
+      setOptimisticSnoozedUntil(undefined);
       reportError(
         minutes == null ? "Failed to unsnooze session" : "Failed to snooze session",
       );
@@ -589,6 +626,11 @@ const SessionRow = memo(function SessionRow({
   // prop catches up (cleared in the effects above).
   const effectivePinned = optimisticPinned ?? isPinned;
   const effectiveArchived = optimisticArchived ?? isArchived;
+  const effectiveSnoozedUntil = resolveEffectiveSnoozedUntil(
+    optimisticSnoozedUntil,
+    snoozedUntil,
+  );
+  const effectiveSnoozed = effectiveSnoozedUntil != null;
 
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
@@ -770,7 +812,7 @@ const SessionRow = memo(function SessionRow({
             />
           </span>
           <div className="min-w-0 flex-1">
-            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || isSnoozed ? "italic opacity-70" : ""}`}>
+            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || effectiveSnoozed ? "italic opacity-70" : ""}`}>
               {effectivePinned && (
                 <span
                   title="Pinned"
@@ -809,14 +851,14 @@ const SessionRow = memo(function SessionRow({
                   <span className="hidden sm:inline">archived</span>
                 </span>
               )}
-              {!isArchived && isSnoozed && snoozedUntil && (
+              {!effectiveArchived && effectiveSnoozed && effectiveSnoozedUntil && (
                 <span
-                  title={`Snoozed until ${new Date(snoozedUntil).toLocaleString()}`}
+                  title={`Snoozed until ${new Date(effectiveSnoozedUntil).toLocaleString()}`}
                   aria-label="Snoozed"
                   className="shrink-0 inline-flex items-center gap-0.5 rounded border border-surface-700/40 bg-surface-800/40 px-1 py-0 text-[10px] font-mono font-medium text-text-dim"
                 >
                   <Moon className="h-3 w-3" />
-                  <span>{formatSnoozeRemainingShort(snoozedUntil)}</span>
+                  <span>{formatSnoozeRemainingShort(effectiveSnoozedUntil)}</span>
                 </span>
               )}
               {firstSession?.cockpit_mode &&
@@ -938,7 +980,7 @@ const SessionRow = memo(function SessionRow({
                   triageStateOf({
                     isPinned: effectivePinned,
                     isArchived: effectiveArchived,
-                    isSnoozed,
+                    isSnoozed: effectiveSnoozed,
                   }),
                 );
                 return (

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -58,6 +58,7 @@ import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
   resolveEffectiveSnoozedUntil,
+  snoozeTimestampCloseEnough,
   triageMenuShape,
   triageStateOf,
   workspaceIsPinned,
@@ -558,10 +559,22 @@ export const SessionRow = memo(function SessionRow({
     }
   }, [isArchived, optimisticArchived]);
   useEffect(() => {
+    if (optimisticSnoozedUntil === undefined) return;
+    // Clear the override only when the server value actually matches
+    // it. A naive "both non-null" check used to fire prematurely
+    // when the user re-snoozed an already-snoozed row: the prop
+    // was still the OLD timestamp but non-null, the override was
+    // the NEW timestamp, the effect treated them as a match, and
+    // the chip snapped back to the stale time until the next
+    // poll. See #1581 CodeRabbit review.
+    if (optimisticSnoozedUntil === null && snoozedUntil == null) {
+      setOptimisticSnoozedUntil(undefined);
+      return;
+    }
     if (
-      optimisticSnoozedUntil !== undefined &&
-      ((optimisticSnoozedUntil === null && snoozedUntil == null) ||
-        (optimisticSnoozedUntil != null && snoozedUntil != null))
+      optimisticSnoozedUntil != null &&
+      snoozedUntil != null &&
+      snoozeTimestampCloseEnough(optimisticSnoozedUntil, snoozedUntil)
     ) {
       setOptimisticSnoozedUntil(undefined);
     }

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -322,7 +322,7 @@ export function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
 // see each other through a module-scoped global. The document
 // listener checks `ref.current` on every click; rows write to it
 // while dragging and on release.
-const DragSuppressContext = createContext<MutableRefObject<number> | null>(null);
+export const DragSuppressContext = createContext<MutableRefObject<number> | null>(null);
 function useDragSuppressRef(): MutableRefObject<number> {
   const ref = useContext(DragSuppressContext);
   if (!ref) {
@@ -439,7 +439,7 @@ function SortableSessionRow(props: {
   );
 }
 
-const SessionRow = memo(function SessionRow({
+export const SessionRow = memo(function SessionRow({
   workspace,
   isActive,
   onClick,

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -57,6 +57,8 @@ import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
+  triageMenuShape,
+  triageStateOf,
   workspaceIsPinned,
   workspaceIsSunk,
   type SidebarSortMode,
@@ -925,41 +927,85 @@ const SessionRow = memo(function SessionRow({
               <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
                 Triage
               </div>
-              <button
-                onClick={() => void togglePin()}
-                data-testid="sidebar-context-menu-pin"
-                className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
-              >
-                <Pin className="h-3.5 w-3.5 shrink-0 -rotate-45" />
-                {effectivePinned ? "Unpin" : "Pin"}
-              </button>
-              <button
-                onClick={() => void toggleArchive()}
-                data-testid="sidebar-context-menu-archive"
-                className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
-              >
-                <Archive className="h-3.5 w-3.5 shrink-0" />
-                {effectiveArchived ? "Unarchive" : "Archive"}
-              </button>
-              {isSnoozed ? (
-                <button
-                  onClick={() => void applySnooze(null)}
-                  data-testid="sidebar-context-menu-unsnooze"
-                  className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
-                >
-                  <Moon className="h-3.5 w-3.5 shrink-0" />
-                  Unsnooze
-                </button>
-              ) : (
-                <button
-                  onClick={openSnoozeModal}
-                  data-testid="sidebar-context-menu-snooze"
-                  className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
-                >
-                  <Moon className="h-3.5 w-3.5 shrink-0" />
-                  Snooze…
-                </button>
-              )}
+              {(() => {
+                // Menu actions are gated by the row's current triage
+                // state so contradictory transitions never appear in
+                // the UI: an archived row only offers Unarchive, a
+                // pinned row only offers Unpin, etc. The shape helper
+                // lives in `lib/sidebarSort.ts` so it can be unit
+                // tested. See #1581.
+                const shape = triageMenuShape(
+                  triageStateOf({
+                    isPinned: effectivePinned,
+                    isArchived: effectiveArchived,
+                    isSnoozed,
+                  }),
+                );
+                return (
+                  <>
+                    {shape.showPin && (
+                      <button
+                        onClick={() => void togglePin()}
+                        data-testid="sidebar-context-menu-pin"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Pin className="h-3.5 w-3.5 shrink-0 -rotate-45" />
+                        Pin
+                      </button>
+                    )}
+                    {shape.showUnpin && (
+                      <button
+                        onClick={() => void togglePin()}
+                        data-testid="sidebar-context-menu-pin"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Pin className="h-3.5 w-3.5 shrink-0 -rotate-45" />
+                        Unpin
+                      </button>
+                    )}
+                    {shape.showArchive && (
+                      <button
+                        onClick={() => void toggleArchive()}
+                        data-testid="sidebar-context-menu-archive"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Archive className="h-3.5 w-3.5 shrink-0" />
+                        Archive
+                      </button>
+                    )}
+                    {shape.showUnarchive && (
+                      <button
+                        onClick={() => void toggleArchive()}
+                        data-testid="sidebar-context-menu-archive"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Archive className="h-3.5 w-3.5 shrink-0" />
+                        Unarchive
+                      </button>
+                    )}
+                    {shape.showSnooze && (
+                      <button
+                        onClick={openSnoozeModal}
+                        data-testid="sidebar-context-menu-snooze"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Moon className="h-3.5 w-3.5 shrink-0" />
+                        Snooze…
+                      </button>
+                    )}
+                    {shape.showUnsnooze && (
+                      <button
+                        onClick={() => void applySnooze(null)}
+                        data-testid="sidebar-context-menu-unsnooze"
+                        className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                      >
+                        <Moon className="h-3.5 w-3.5 shrink-0" />
+                        Unsnooze
+                      </button>
+                    )}
+                  </>
+                );
+              })()}
               <div className="border-t border-surface-700/20 my-1" />
               <button
                 onClick={handleDelete}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -65,6 +65,7 @@ import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 
 const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
+const SUNK_EXPANDED_KEY = "aoe-sidebar-sunk-expanded";
 const DEFAULT_WIDTH = 280;
 const MIN_WIDTH = 200;
 const MAX_WIDTH = 480;
@@ -169,6 +170,23 @@ function loadSavedWidth(): number {
     if (w >= MIN_WIDTH && w <= MAX_WIDTH) return w;
   }
   return DEFAULT_WIDTH;
+}
+
+/** Hydrate the per-group expanded state for the "Snoozed & archived"
+ *  footer from localStorage. Defaults to all-collapsed (TUI parity
+ *  with the `toggle_archived_section` keybind starting collapsed). */
+function loadSunkExpanded(): Record<string, boolean> {
+  const raw = safeGetItem(SUNK_EXPANDED_KEY);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as Record<string, boolean>;
+    }
+  } catch {
+    // Fall through to default.
+  }
+  return {};
 }
 
 /** One-line sidebar affordance showing plan progress for cockpit
@@ -1256,6 +1274,15 @@ export function WorkspaceSidebar({
   const [width, setWidth] = useState(loadSavedWidth);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
+  const [sunkExpanded, setSunkExpanded] =
+    useState<Record<string, boolean>>(loadSunkExpanded);
+  const toggleSunkExpanded = useCallback((groupId: string) => {
+    setSunkExpanded((prev) => {
+      const next = { ...prev, [groupId]: !prev[groupId] };
+      safeSetItem(SUNK_EXPANDED_KEY, JSON.stringify(next));
+      return next;
+    });
+  }, []);
   const [optimisticActive, setOptimisticActive] = useState<{
     id: string;
     fromActiveId: string | null;
@@ -1524,42 +1551,106 @@ export function WorkspaceSidebar({
                     }
                     offline={offline}
                   />
-                  {showExpanded && (
-                    <SortableContext
-                      items={group.workspaces.map((ws) => ws.id)}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      {group.workspaces.map((ws) => (
-                        <SortableSessionRow
-                          key={ws.id}
-                          workspace={ws}
-                          isActive={ws.id === displayedActiveId}
-                          onClick={() => {
-                            setOptimisticActive({ id: ws.id, fromActiveId: activeId });
-                            onSelect(ws.id);
-                          }}
-                          onDelete={onDeleteSession}
-                          readOnly={readOnly}
-                          // Drag is disabled when the tier comparator
-                          // already controls placement: lastActivity
-                          // mode has no manual concept, pinned rows
-                          // always float to the top of their group,
-                          // and sunk (archived + snoozed) rows are
-                          // ordered by tier-2 placement. Allowing a
-                          // drag in any of those cases would let the
-                          // user rearrange the persisted
-                          // workspace_ordering against the visual
-                          // tier and produce a no-op release, see
-                          // #1581.
-                          dragDisabled={
-                            sortMode === "lastActivity" ||
-                            workspaceIsPinned(ws) ||
-                            workspaceIsSunk(ws)
-                          }
-                        />
-                      ))}
-                    </SortableContext>
-                  )}
+                  {showExpanded && (() => {
+                    // Partition into a live tier (rendered inline with
+                    // the existing SortableContext drag-reorder) and a
+                    // sunk tier (archived or actively snoozed across
+                    // every session in the workspace). The sunk tier
+                    // lives in a collapsible footer per repo group,
+                    // default-collapsed, so the active list stays
+                    // focused. See #1581.
+                    const liveWorkspaces = group.workspaces.filter(
+                      (ws) => !workspaceIsSunk(ws),
+                    );
+                    const sunkWorkspaces = group.workspaces.filter(
+                      (ws) => workspaceIsSunk(ws),
+                    );
+                    const isSunkOpen = !!sunkExpanded[group.id];
+                    return (
+                      <>
+                        <SortableContext
+                          items={liveWorkspaces.map((ws) => ws.id)}
+                          strategy={verticalListSortingStrategy}
+                        >
+                          {liveWorkspaces.map((ws) => (
+                            <SortableSessionRow
+                              key={ws.id}
+                              workspace={ws}
+                              isActive={ws.id === displayedActiveId}
+                              onClick={() => {
+                                setOptimisticActive({
+                                  id: ws.id,
+                                  fromActiveId: activeId,
+                                });
+                                onSelect(ws.id);
+                              }}
+                              onDelete={onDeleteSession}
+                              readOnly={readOnly}
+                              // Drag is disabled when the tier comparator
+                              // already controls placement: lastActivity
+                              // mode has no manual concept, pinned rows
+                              // always float to the top of their group.
+                              // See #1581.
+                              dragDisabled={
+                                sortMode === "lastActivity" ||
+                                workspaceIsPinned(ws)
+                              }
+                            />
+                          ))}
+                        </SortableContext>
+                        {sunkWorkspaces.length > 0 && (
+                          <div data-testid="sidebar-sunk-section" data-group-id={group.id}>
+                            <button
+                              onClick={() => toggleSunkExpanded(group.id)}
+                              data-testid="sidebar-sunk-toggle"
+                              aria-expanded={isSunkOpen}
+                              className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-secondary hover:bg-surface-800/40 cursor-pointer transition-colors"
+                            >
+                              <svg
+                                width="10"
+                                height="10"
+                                viewBox="0 0 10 10"
+                                fill="currentColor"
+                                className={`shrink-0 transition-transform duration-75 ${
+                                  isSunkOpen ? "" : "-rotate-90"
+                                }`}
+                              >
+                                <path
+                                  d="M2 3 L5 6.5 L8 3"
+                                  fill="none"
+                                  stroke="currentColor"
+                                  strokeWidth="1.5"
+                                  strokeLinecap="round"
+                                  strokeLinejoin="round"
+                                />
+                              </svg>
+                              <span>
+                                Snoozed &amp; archived ({sunkWorkspaces.length})
+                              </span>
+                            </button>
+                            {isSunkOpen &&
+                              sunkWorkspaces.map((ws) => (
+                                <SessionRow
+                                  key={ws.id}
+                                  workspace={ws}
+                                  isActive={ws.id === displayedActiveId}
+                                  onClick={() => {
+                                    setOptimisticActive({
+                                      id: ws.id,
+                                      fromActiveId: activeId,
+                                    });
+                                    onSelect(ws.id);
+                                  }}
+                                  onDelete={onDeleteSession}
+                                  readOnly={readOnly}
+                                  indented
+                                />
+                              ))}
+                          </div>
+                        )}
+                      </>
+                    );
+                  })()}
                 </div>
               );
             })}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -841,7 +841,7 @@ export const SessionRow = memo(function SessionRow({
                   <Pencil className="h-3 w-3 text-amber-400/90" />
                 </span>
               )}
-              {isArchived && (
+              {effectiveArchived && (
                 <span
                   title="Archived"
                   aria-label="Archived"

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -528,7 +528,10 @@ const SessionRow = memo(function SessionRow({
   const [optimisticArchived, setOptimisticArchived] = useState<boolean | null>(
     null,
   );
-  const [snoozeMenuOpen, setSnoozeMenuOpen] = useState(false);
+  // Snooze duration picker. Lives in its own portal-rendered modal,
+  // independent of the context menu's lifecycle so the parent-menu
+  // dismissal listener cannot close the picker out from under us.
+  const [snoozeModalOpen, setSnoozeModalOpen] = useState(false);
   useEffect(() => {
     if (optimisticPinned !== null && optimisticPinned === isPinned) {
       setOptimisticPinned(null);
@@ -542,7 +545,6 @@ const SessionRow = memo(function SessionRow({
 
   const togglePin = async () => {
     setContextMenu(null);
-    setSnoozeMenuOpen(false);
     if (!sessionId) return;
     const next = !isPinned;
     setOptimisticPinned(next);
@@ -555,7 +557,6 @@ const SessionRow = memo(function SessionRow({
 
   const toggleArchive = async () => {
     setContextMenu(null);
-    setSnoozeMenuOpen(false);
     if (!sessionId) return;
     const next = !isArchived;
     setOptimisticArchived(next);
@@ -570,7 +571,7 @@ const SessionRow = memo(function SessionRow({
 
   const applySnooze = async (minutes: number | null) => {
     setContextMenu(null);
-    setSnoozeMenuOpen(false);
+    setSnoozeModalOpen(false);
     if (!sessionId) return;
     const result = await setSessionSnooze(sessionId, minutes);
     if (!result) {
@@ -578,6 +579,14 @@ const SessionRow = memo(function SessionRow({
         minutes == null ? "Failed to unsnooze session" : "Failed to snooze session",
       );
     }
+  };
+
+  // Close the context menu first, then open the modal in the next
+  // tick so the menu's document-click dismiss listener does not race
+  // with the modal's mount.
+  const openSnoozeModal = () => {
+    setContextMenu(null);
+    setSnoozeModalOpen(true);
   };
 
   // Effective state for rendering: optimistic overrides win until the
@@ -605,13 +614,7 @@ const SessionRow = memo(function SessionRow({
   }, [renaming]);
 
   useEffect(() => {
-    // Reset the snooze-preset sub-list whenever the menu closes; otherwise
-    // re-opening would jump straight back into the preset list, surprising
-    // the user.
-    if (!contextMenu) {
-      setSnoozeMenuOpen(false);
-      return;
-    }
+    if (!contextMenu) return;
     const close = () => setContextMenu(null);
     const onDocClick = (e: MouseEvent) => {
       // Clicks inside the menu should be handled by item onClick
@@ -953,28 +956,9 @@ const SessionRow = memo(function SessionRow({
                   <Moon className="h-3.5 w-3.5 shrink-0" />
                   Unsnooze
                 </button>
-              ) : snoozeMenuOpen ? (
-                <>
-                  <div
-                    className="pl-6 pr-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted"
-                    data-testid="sidebar-context-menu-snooze-presets"
-                  >
-                    Snooze for
-                  </div>
-                  {SNOOZE_PRESETS.map((preset) => (
-                    <button
-                      key={preset.minutes}
-                      onClick={() => void applySnooze(preset.minutes)}
-                      data-testid={`sidebar-context-menu-snooze-${preset.minutes}`}
-                      className="w-full text-left pl-9 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
-                    >
-                      {preset.label}
-                    </button>
-                  ))}
-                </>
               ) : (
                 <button
-                  onClick={() => setSnoozeMenuOpen(true)}
+                  onClick={openSnoozeModal}
                   data-testid="sidebar-context-menu-snooze"
                   className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
                 >
@@ -995,9 +979,88 @@ const SessionRow = memo(function SessionRow({
         </div>,
         document.body,
       )}
+      {snoozeModalOpen &&
+        createPortal(
+          <SnoozeModal
+            title={label}
+            onCancel={() => setSnoozeModalOpen(false)}
+            onPick={(minutes) => void applySnooze(minutes)}
+          />,
+          document.body,
+        )}
     </>
   );
 });
+
+/** Centered modal duration picker rendered as a separate portal so it
+ *  is independent of the row's context menu. Lists the eight TUI
+ *  presets (matching `src/tui/dialogs/snooze_duration.rs`) plus a
+ *  Cancel; backdrop click and Escape both dismiss. See #1581. */
+function SnoozeModal({
+  title,
+  onCancel,
+  onPick,
+}: {
+  title: string;
+  onCancel: () => void;
+  onPick: (minutes: number) => void;
+}) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onCancel]);
+  return (
+    <div
+      data-testid="snooze-modal-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onCancel();
+      }}
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 px-4"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Snooze session"
+    >
+      <div
+        data-testid="snooze-modal"
+        className="w-full max-w-sm rounded-lg border border-surface-700 bg-surface-800 shadow-xl"
+      >
+        <div className="px-4 py-3 border-b border-surface-700/40">
+          <div className="text-sm font-mono text-text-primary truncate" title={title}>
+            Snooze
+            <span className="text-text-muted"> · {title}</span>
+          </div>
+          <div className="mt-1 text-[11px] text-text-dim">
+            How long should this session sit out?
+          </div>
+        </div>
+        <div className="flex flex-col py-2">
+          {SNOOZE_PRESETS.map((preset) => (
+            <button
+              key={preset.minutes}
+              onClick={() => onPick(preset.minutes)}
+              data-testid={`snooze-modal-preset-${preset.minutes}`}
+              className="w-full text-left px-4 py-2 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+            >
+              {preset.label}
+            </button>
+          ))}
+        </div>
+        <div className="px-4 py-3 border-t border-surface-700/40 flex justify-end">
+          <button
+            onClick={onCancel}
+            data-testid="snooze-modal-cancel"
+            className="text-sm text-text-dim hover:text-text-primary cursor-pointer transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const RepoGroupHeader = memo(function RepoGroupHeader({
   group,

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -992,10 +992,41 @@ const SessionRow = memo(function SessionRow({
   );
 });
 
+/** Bounds for `validate_snooze_duration` on the server. Mirrored
+ *  client-side so the modal can pre-validate and disable the submit
+ *  button rather than round-trip a 400. See
+ *  `src/session/config.rs::SNOOZE_MAX_MINUTES`. */
+const SNOOZE_MIN_MINUTES = 1;
+const SNOOZE_MAX_MINUTES = 30 * 24 * 60;
+
+type SnoozeUnit = "m" | "h" | "d" | "w";
+
+const SNOOZE_UNIT_LABELS: Record<SnoozeUnit, string> = {
+  m: "minutes",
+  h: "hours",
+  d: "days",
+  w: "weeks",
+};
+
+function snoozeUnitToMinutes(value: number, unit: SnoozeUnit): number {
+  switch (unit) {
+    case "m":
+      return value;
+    case "h":
+      return value * 60;
+    case "d":
+      return value * 60 * 24;
+    case "w":
+      return value * 60 * 24 * 7;
+  }
+}
+
 /** Centered modal duration picker rendered as a separate portal so it
- *  is independent of the row's context menu. Lists the eight TUI
- *  presets (matching `src/tui/dialogs/snooze_duration.rs`) plus a
- *  Cancel; backdrop click and Escape both dismiss. See #1581. */
+ *  is independent of the row's context menu. Three submit paths:
+ *   - 8 TUI presets (matching `src/tui/dialogs/snooze_duration.rs`).
+ *   - Custom duration: number + unit (m/h/d/w).
+ *   - Until a specific date+time (HTML5 datetime-local input).
+ *  Backdrop click and Escape both dismiss. See #1581. */
 function SnoozeModal({
   title,
   onCancel,
@@ -1005,6 +1036,12 @@ function SnoozeModal({
   onCancel: () => void;
   onPick: (minutes: number) => void;
 }) {
+  const [customValue, setCustomValue] = useState("");
+  const [customUnit, setCustomUnit] = useState<SnoozeUnit>("h");
+  const [untilValue, setUntilValue] = useState("");
+  const [customError, setCustomError] = useState<string | null>(null);
+  const [untilError, setUntilError] = useState<string | null>(null);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onCancel();
@@ -1012,13 +1049,58 @@ function SnoozeModal({
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [onCancel]);
+
+  const submitCustom = () => {
+    setCustomError(null);
+    const n = Number.parseInt(customValue, 10);
+    if (!Number.isFinite(n) || n <= 0) {
+      setCustomError("Enter a positive whole number.");
+      return;
+    }
+    const minutes = snoozeUnitToMinutes(n, customUnit);
+    if (minutes < SNOOZE_MIN_MINUTES || minutes > SNOOZE_MAX_MINUTES) {
+      setCustomError(
+        `Must be between 1 minute and 30 days (got ${minutes} minutes).`,
+      );
+      return;
+    }
+    onPick(minutes);
+  };
+
+  const submitUntil = () => {
+    setUntilError(null);
+    if (!untilValue) {
+      setUntilError("Pick a date and time.");
+      return;
+    }
+    // datetime-local values are wall-clock (no zone). Date.parse
+    // interprets them as local time, which matches user expectation
+    // (snooze "until 9am tomorrow" means 9am in the user's TZ).
+    const target = Date.parse(untilValue);
+    if (!Number.isFinite(target)) {
+      setUntilError("Invalid date.");
+      return;
+    }
+    const deltaMs = target - Date.now();
+    if (deltaMs <= 0) {
+      setUntilError("Pick a time in the future.");
+      return;
+    }
+    const minutes = Math.max(1, Math.round(deltaMs / 60_000));
+    if (minutes > SNOOZE_MAX_MINUTES) {
+      setUntilError("Maximum snooze is 30 days from now.");
+      return;
+    }
+    onPick(minutes);
+  };
+
   return (
     <div
       data-testid="snooze-modal-backdrop"
       onClick={(e) => {
         if (e.target === e.currentTarget) onCancel();
       }}
-      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 px-4"
+      className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 px-4 py-8 overflow-y-auto"
       role="dialog"
       aria-modal="true"
       aria-label="Snooze session"
@@ -1047,6 +1129,90 @@ function SnoozeModal({
               {preset.label}
             </button>
           ))}
+        </div>
+        <div className="px-4 py-3 border-t border-surface-700/40">
+          <div className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+            Custom duration
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              value={customValue}
+              onChange={(e) => setCustomValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitCustom();
+              }}
+              placeholder="3"
+              data-testid="snooze-modal-custom-value"
+              aria-label="Custom snooze duration"
+              className="w-20 rounded border border-surface-700 bg-surface-900 px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+            />
+            <select
+              value={customUnit}
+              onChange={(e) => setCustomUnit(e.target.value as SnoozeUnit)}
+              data-testid="snooze-modal-custom-unit"
+              aria-label="Custom snooze unit"
+              className="rounded border border-surface-700 bg-surface-900 px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+            >
+              {(Object.keys(SNOOZE_UNIT_LABELS) as SnoozeUnit[]).map((u) => (
+                <option key={u} value={u}>
+                  {SNOOZE_UNIT_LABELS[u]}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={submitCustom}
+              data-testid="snooze-modal-custom-submit"
+              className="ml-auto rounded bg-brand-600 px-3 py-1 text-sm font-medium text-text-primary hover:bg-brand-500 cursor-pointer transition-colors"
+            >
+              Snooze
+            </button>
+          </div>
+          {customError && (
+            <div
+              role="alert"
+              data-testid="snooze-modal-custom-error"
+              className="mt-1 text-[11px] text-status-error"
+            >
+              {customError}
+            </div>
+          )}
+        </div>
+        <div className="px-4 py-3 border-t border-surface-700/40">
+          <div className="text-[11px] font-mono uppercase tracking-widest text-text-muted mb-2">
+            Until
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="datetime-local"
+              value={untilValue}
+              onChange={(e) => setUntilValue(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submitUntil();
+              }}
+              data-testid="snooze-modal-until-value"
+              aria-label="Snooze until"
+              className="flex-1 min-w-0 rounded border border-surface-700 bg-surface-900 px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none"
+            />
+            <button
+              onClick={submitUntil}
+              data-testid="snooze-modal-until-submit"
+              className="rounded bg-brand-600 px-3 py-1 text-sm font-medium text-text-primary hover:bg-brand-500 cursor-pointer transition-colors"
+            >
+              Snooze
+            </button>
+          </div>
+          {untilError && (
+            <div
+              role="alert"
+              data-testid="snooze-modal-until-error"
+              className="mt-1 text-[11px] text-status-error"
+            >
+              {untilError}
+            </div>
+          )}
         </div>
         <div className="px-4 py-3 border-t border-surface-700/40 flex justify-end">
           <button

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -10,7 +10,7 @@ import {
   type MutableRefObject,
 } from "react";
 import { createPortal } from "react-dom";
-import { Clock, ListOrdered, Pencil } from "lucide-react";
+import { Archive, Clock, ListOrdered, Moon, Pencil, Pin } from "lucide-react";
 import {
   DndContext,
   MouseSensor,
@@ -46,9 +46,16 @@ import {
   isSessionActive,
 } from "../lib/session";
 import { useIdleDecayWindowMs } from "../lib/idleDecay";
-import { renameSession, setSessionNotifications } from "../lib/api";
+import {
+  renameSession,
+  setSessionArchive,
+  setSessionNotifications,
+  setSessionPin,
+  setSessionSnooze,
+} from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
+import { reportError } from "../lib/toastBus";
 import type { SidebarSortMode } from "../lib/sidebarSort";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
@@ -57,6 +64,23 @@ const SIDEBAR_WIDTH_KEY = "aoe-sidebar-width";
 const DEFAULT_WIDTH = 280;
 const MIN_WIDTH = 200;
 const MAX_WIDTH = 480;
+
+/** Snooze duration presets surfaced by the sidebar context menu. Order
+ *  and values mirror the TUI dialog presets at
+ *  `src/tui/dialogs/snooze_duration.rs`, so the two surfaces describe
+ *  the same set of choices. The TUI extends past these via a manual
+ *  numeric entry; the web sidebar omits that path in v1 (the menu
+ *  stays flat). See #1581. */
+const SNOOZE_PRESETS: readonly { label: string; minutes: number }[] = [
+  { label: "1 hour", minutes: 60 },
+  { label: "2 hours", minutes: 120 },
+  { label: "3 hours", minutes: 180 },
+  { label: "4 hours", minutes: 240 },
+  { label: "5 hours", minutes: 300 },
+  { label: "6 hours", minutes: 360 },
+  { label: "1 day", minutes: 1440 },
+  { label: "1 week", minutes: 10080 },
+];
 
 // Module-level bus for closing any open SessionRow context menu when a
 // new one opens. Each SessionRow manages its own menu state; without
@@ -231,6 +255,30 @@ function formatDurationSecondsShort(seconds: number): string {
   const h = Math.floor(m / 60);
   const remM = m % 60;
   return remM === 0 ? `${h}h` : `${h}h ${remM}m`;
+}
+
+/** Compact "time remaining" label for the snooze chip computed once at
+ *  render time (no per-second timer, by design: snooze rows poll the
+ *  sessions API at the existing cadence and the static label is more
+ *  battery-friendly than a 1s ticker on phones, see #1581 design
+ *  discussion). Bucket sizes:
+ *   - < 1 minute : "<1m"
+ *   - < 1 hour   : "Nm"
+ *   - < 1 day    : "Nh" (rounded down)
+ *   - else       : "Nd" (rounded down)
+ *  Past timestamps return "soon" since the wake-up has expired but the
+ *  next poll has not yet cleared the row. */
+function formatSnoozeRemainingShort(snoozedUntilIso: string): string {
+  const target = Date.parse(snoozedUntilIso);
+  if (!Number.isFinite(target)) return "snoozed";
+  const remainingMs = target - Date.now();
+  if (remainingMs <= 0) return "soon";
+  const minutes = Math.floor(remainingMs / 60_000);
+  if (minutes < 1) return "<1m";
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h`;
+  return `${Math.floor(hours / 24)}d`;
 }
 
 // Wraps a SessionRow with @dnd-kit sortable plumbing. The row itself
@@ -410,6 +458,16 @@ const SessionRow = memo(function SessionRow({
   // row visually so the user can find their starred work fast. Toggled
   // via TUI `f`/`F` or `aoe session favorite|unfavorite`.
   const isFavorited = workspace.sessions.some((s) => s.favorited);
+  // Web-only triage signals. `pinned` floats the workspace to the top
+  // of every sort mode; `archived` and `snoozedUntil` mark the row as
+  // sunk (the parent splits sunk workspaces into a separate collapsible
+  // section). Aggregators mirror the matching helpers in
+  // `lib/sidebarSort.ts` to keep render and sort in sync. See #1581.
+  const isPinned = workspace.sessions.some((s) => s.pinned_at != null);
+  const isArchived = workspace.sessions.some((s) => s.archived_at != null);
+  const snoozedUntil = workspace.sessions.find((s) => s.snoozed_until)
+    ?.snoozed_until ?? null;
+  const isSnoozed = snoozedUntil != null;
   const sessionId = firstSession?.id;
   const navigationSessionId = runningSession?.id ?? firstSession?.id ?? null;
   const sessionPath = navigationSessionId
@@ -437,6 +495,74 @@ const SessionRow = memo(function SessionRow({
     await setSessionNotifications(sessionId, preset);
   };
 
+  // Triage actions (pin / archive / snooze). Optimistic state lets the
+  // glyph, chip, and tier flip immediately on click; on PATCH failure we
+  // revert and surface a toast. The optimistic snap clears itself once
+  // the next sessions-poll reflects the same value, so a successful
+  // round-trip is invisible to the user (just feels fast).
+  const [optimisticPinned, setOptimisticPinned] = useState<boolean | null>(
+    null,
+  );
+  const [optimisticArchived, setOptimisticArchived] = useState<boolean | null>(
+    null,
+  );
+  const [snoozeMenuOpen, setSnoozeMenuOpen] = useState(false);
+  useEffect(() => {
+    if (optimisticPinned !== null && optimisticPinned === isPinned) {
+      setOptimisticPinned(null);
+    }
+  }, [isPinned, optimisticPinned]);
+  useEffect(() => {
+    if (optimisticArchived !== null && optimisticArchived === isArchived) {
+      setOptimisticArchived(null);
+    }
+  }, [isArchived, optimisticArchived]);
+
+  const togglePin = async () => {
+    setContextMenu(null);
+    setSnoozeMenuOpen(false);
+    if (!sessionId) return;
+    const next = !isPinned;
+    setOptimisticPinned(next);
+    const result = await setSessionPin(sessionId, next);
+    if (!result) {
+      setOptimisticPinned(null);
+      reportError(next ? "Failed to pin session" : "Failed to unpin session");
+    }
+  };
+
+  const toggleArchive = async () => {
+    setContextMenu(null);
+    setSnoozeMenuOpen(false);
+    if (!sessionId) return;
+    const next = !isArchived;
+    setOptimisticArchived(next);
+    const result = await setSessionArchive(sessionId, next);
+    if (!result) {
+      setOptimisticArchived(null);
+      reportError(
+        next ? "Failed to archive session" : "Failed to unarchive session",
+      );
+    }
+  };
+
+  const applySnooze = async (minutes: number | null) => {
+    setContextMenu(null);
+    setSnoozeMenuOpen(false);
+    if (!sessionId) return;
+    const result = await setSessionSnooze(sessionId, minutes);
+    if (!result) {
+      reportError(
+        minutes == null ? "Failed to unsnooze session" : "Failed to snooze session",
+      );
+    }
+  };
+
+  // Effective state for rendering: optimistic overrides win until the
+  // prop catches up (cleared in the effects above).
+  const effectivePinned = optimisticPinned ?? isPinned;
+  const effectiveArchived = optimisticArchived ?? isArchived;
+
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number } | null>(null);
   const [renaming, setRenaming] = useState(false);
   const [renameValue, setRenameValue] = useState(label);
@@ -457,7 +583,13 @@ const SessionRow = memo(function SessionRow({
   }, [renaming]);
 
   useEffect(() => {
-    if (!contextMenu) return;
+    // Reset the snooze-preset sub-list whenever the menu closes; otherwise
+    // re-opening would jump straight back into the preset list, surprising
+    // the user.
+    if (!contextMenu) {
+      setSnoozeMenuOpen(false);
+      return;
+    }
     const close = () => setContextMenu(null);
     const onDocClick = (e: MouseEvent) => {
       // Clicks inside the menu should be handled by item onClick
@@ -617,7 +749,16 @@ const SessionRow = memo(function SessionRow({
             />
           </span>
           <div className="min-w-0 flex-1">
-            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited ? "font-semibold" : ""}`}>
+            <span className={`flex items-center gap-1.5 text-[13px] md:text-[14px] ${isSessionActive({ status: sessionStatus, idle_entered_at: idleEnteredAt }, idleDecayWindowMs) ? textClass : isActive ? "text-text-primary" : "text-text-secondary"} ${isFavorited || effectivePinned ? "font-semibold" : ""} ${effectiveArchived || isSnoozed ? "italic opacity-70" : ""}`}>
+              {effectivePinned && (
+                <span
+                  title="Pinned"
+                  aria-label="Pinned"
+                  className="shrink-0 inline-flex text-brand-400"
+                >
+                  <Pin className="h-3 w-3 -rotate-45" />
+                </span>
+              )}
               {isFavorited && (
                 <span
                   title="Favorited"
@@ -635,6 +776,26 @@ const SessionRow = memo(function SessionRow({
                   className="inline-flex shrink-0"
                 >
                   <Pencil className="h-3 w-3 text-amber-400/90" />
+                </span>
+              )}
+              {isArchived && (
+                <span
+                  title="Archived"
+                  aria-label="Archived"
+                  className="shrink-0 inline-flex items-center gap-0.5 rounded border border-surface-700/40 bg-surface-800/40 px-1 py-0 text-[10px] font-mono font-medium text-text-dim"
+                >
+                  <Archive className="h-3 w-3" />
+                  <span className="hidden sm:inline">archived</span>
+                </span>
+              )}
+              {!isArchived && isSnoozed && snoozedUntil && (
+                <span
+                  title={`Snoozed until ${new Date(snoozedUntil).toLocaleString()}`}
+                  aria-label="Snoozed"
+                  className="shrink-0 inline-flex items-center gap-0.5 rounded border border-surface-700/40 bg-surface-800/40 px-1 py-0 text-[10px] font-mono font-medium text-text-dim"
+                >
+                  <Moon className="h-3 w-3" />
+                  <span>{formatSnoozeRemainingShort(snoozedUntil)}</span>
                 </span>
               )}
               {firstSession?.cockpit_mode &&
@@ -741,6 +902,64 @@ const SessionRow = memo(function SessionRow({
           })}
           {!readOnly && (
             <>
+              <div className="border-t border-surface-700/20 my-1" />
+              <div className="px-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted">
+                Triage
+              </div>
+              <button
+                onClick={() => void togglePin()}
+                data-testid="sidebar-context-menu-pin"
+                className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+              >
+                <Pin className="h-3.5 w-3.5 shrink-0 -rotate-45" />
+                {effectivePinned ? "Unpin" : "Pin"}
+              </button>
+              <button
+                onClick={() => void toggleArchive()}
+                data-testid="sidebar-context-menu-archive"
+                className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+              >
+                <Archive className="h-3.5 w-3.5 shrink-0" />
+                {effectiveArchived ? "Unarchive" : "Archive"}
+              </button>
+              {isSnoozed ? (
+                <button
+                  onClick={() => void applySnooze(null)}
+                  data-testid="sidebar-context-menu-unsnooze"
+                  className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                >
+                  <Moon className="h-3.5 w-3.5 shrink-0" />
+                  Unsnooze
+                </button>
+              ) : snoozeMenuOpen ? (
+                <>
+                  <div
+                    className="pl-6 pr-3 py-1 text-[11px] font-mono uppercase tracking-widest text-text-muted"
+                    data-testid="sidebar-context-menu-snooze-presets"
+                  >
+                    Snooze for
+                  </div>
+                  {SNOOZE_PRESETS.map((preset) => (
+                    <button
+                      key={preset.minutes}
+                      onClick={() => void applySnooze(preset.minutes)}
+                      data-testid={`sidebar-context-menu-snooze-${preset.minutes}`}
+                      className="w-full text-left pl-9 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors"
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                </>
+              ) : (
+                <button
+                  onClick={() => setSnoozeMenuOpen(true)}
+                  data-testid="sidebar-context-menu-snooze"
+                  className="w-full text-left pl-6 pr-3 py-2 md:py-2 max-md:py-3 text-sm text-text-secondary hover:bg-surface-700/50 cursor-pointer transition-colors flex items-center gap-2"
+                >
+                  <Moon className="h-3.5 w-3.5 shrink-0" />
+                  Snooze…
+                </button>
+              )}
               <div className="border-t border-surface-700/20 my-1" />
               <button
                 onClick={handleDelete}

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -56,7 +56,11 @@ import {
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
-import type { SidebarSortMode } from "../lib/sidebarSort";
+import {
+  workspaceIsPinned,
+  workspaceIsSunk,
+  type SidebarSortMode,
+} from "../lib/sidebarSort";
 import { StatusGlyph } from "./StatusGlyph";
 import { OwnerAvatar } from "./OwnerAvatar";
 
@@ -1536,7 +1540,22 @@ export function WorkspaceSidebar({
                           }}
                           onDelete={onDeleteSession}
                           readOnly={readOnly}
-                          dragDisabled={sortMode === "lastActivity"}
+                          // Drag is disabled when the tier comparator
+                          // already controls placement: lastActivity
+                          // mode has no manual concept, pinned rows
+                          // always float to the top of their group,
+                          // and sunk (archived + snoozed) rows are
+                          // ordered by tier-2 placement. Allowing a
+                          // drag in any of those cases would let the
+                          // user rearrange the persisted
+                          // workspace_ordering against the visual
+                          // tier and produce a no-op release, see
+                          // #1581.
+                          dragDisabled={
+                            sortMode === "lastActivity" ||
+                            workspaceIsPinned(ws) ||
+                            workspaceIsSunk(ws)
+                          }
                         />
                       ))}
                     </SortableContext>

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -172,21 +172,15 @@ function loadSavedWidth(): number {
   return DEFAULT_WIDTH;
 }
 
-/** Hydrate the per-group expanded state for the "Snoozed & archived"
- *  footer from localStorage. Defaults to all-collapsed (TUI parity
- *  with the `toggle_archived_section` keybind starting collapsed). */
-function loadSunkExpanded(): Record<string, boolean> {
+/** Hydrate the single global "Snoozed & archived" footer expanded
+ *  state from localStorage. Defaults to collapsed (TUI parity with
+ *  the `toggle_archived_section` keybind starting collapsed). An
+ *  earlier iteration kept a per-group dict here; any leftover dict
+ *  is treated as collapsed. */
+function loadSunkExpanded(): boolean {
   const raw = safeGetItem(SUNK_EXPANDED_KEY);
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
-      return parsed as Record<string, boolean>;
-    }
-  } catch {
-    // Fall through to default.
-  }
-  return {};
+  if (raw === "true") return true;
+  return false;
 }
 
 /** One-line sidebar affordance showing plan progress for cockpit
@@ -1503,12 +1497,11 @@ export function WorkspaceSidebar({
   const [width, setWidth] = useState(loadSavedWidth);
   const [filterOpen, setFilterOpen] = useState(false);
   const [filterQuery, setFilterQuery] = useState("");
-  const [sunkExpanded, setSunkExpanded] =
-    useState<Record<string, boolean>>(loadSunkExpanded);
-  const toggleSunkExpanded = useCallback((groupId: string) => {
+  const [sunkExpanded, setSunkExpanded] = useState<boolean>(loadSunkExpanded);
+  const toggleSunkExpanded = useCallback(() => {
     setSunkExpanded((prev) => {
-      const next = { ...prev, [groupId]: !prev[groupId] };
-      safeSetItem(SUNK_EXPANDED_KEY, JSON.stringify(next));
+      const next = !prev;
+      safeSetItem(SUNK_EXPANDED_KEY, next ? "true" : "false");
       return next;
     });
   }, []);
@@ -1781,103 +1774,46 @@ export function WorkspaceSidebar({
                     offline={offline}
                   />
                   {showExpanded && (() => {
-                    // Partition into a live tier (rendered inline with
-                    // the existing SortableContext drag-reorder) and a
-                    // sunk tier (archived or actively snoozed across
-                    // every session in the workspace). The sunk tier
-                    // lives in a collapsible footer per repo group,
-                    // default-collapsed, so the active list stays
-                    // focused. See #1581.
+                    // Each group renders only its live tier. Sunk
+                    // workspaces (archived or actively snoozed across
+                    // every session) are pulled out into a single
+                    // global "Snoozed & archived" section at the very
+                    // bottom of the sidebar, rather than one footer
+                    // per repo group. See #1581.
                     const liveWorkspaces = group.workspaces.filter(
                       (ws) => !workspaceIsSunk(ws),
                     );
-                    const sunkWorkspaces = group.workspaces.filter(
-                      (ws) => workspaceIsSunk(ws),
-                    );
-                    const isSunkOpen = !!sunkExpanded[group.id];
                     return (
-                      <>
-                        <SortableContext
-                          items={liveWorkspaces.map((ws) => ws.id)}
-                          strategy={verticalListSortingStrategy}
-                        >
-                          {liveWorkspaces.map((ws) => (
-                            <SortableSessionRow
-                              key={ws.id}
-                              workspace={ws}
-                              isActive={ws.id === displayedActiveId}
-                              onClick={() => {
-                                setOptimisticActive({
-                                  id: ws.id,
-                                  fromActiveId: activeId,
-                                });
-                                onSelect(ws.id);
-                              }}
-                              onDelete={onDeleteSession}
-                              readOnly={readOnly}
-                              // Drag is disabled when the tier comparator
-                              // already controls placement: lastActivity
-                              // mode has no manual concept, pinned rows
-                              // always float to the top of their group.
-                              // See #1581.
-                              dragDisabled={
-                                sortMode === "lastActivity" ||
-                                workspaceIsPinned(ws)
-                              }
-                            />
-                          ))}
-                        </SortableContext>
-                        {sunkWorkspaces.length > 0 && (
-                          <div data-testid="sidebar-sunk-section" data-group-id={group.id}>
-                            <button
-                              onClick={() => toggleSunkExpanded(group.id)}
-                              data-testid="sidebar-sunk-toggle"
-                              aria-expanded={isSunkOpen}
-                              className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-secondary hover:bg-surface-800/40 cursor-pointer transition-colors"
-                            >
-                              <svg
-                                width="10"
-                                height="10"
-                                viewBox="0 0 10 10"
-                                fill="currentColor"
-                                className={`shrink-0 transition-transform duration-75 ${
-                                  isSunkOpen ? "" : "-rotate-90"
-                                }`}
-                              >
-                                <path
-                                  d="M2 3 L5 6.5 L8 3"
-                                  fill="none"
-                                  stroke="currentColor"
-                                  strokeWidth="1.5"
-                                  strokeLinecap="round"
-                                  strokeLinejoin="round"
-                                />
-                              </svg>
-                              <span>
-                                Snoozed &amp; archived ({sunkWorkspaces.length})
-                              </span>
-                            </button>
-                            {isSunkOpen &&
-                              sunkWorkspaces.map((ws) => (
-                                <SessionRow
-                                  key={ws.id}
-                                  workspace={ws}
-                                  isActive={ws.id === displayedActiveId}
-                                  onClick={() => {
-                                    setOptimisticActive({
-                                      id: ws.id,
-                                      fromActiveId: activeId,
-                                    });
-                                    onSelect(ws.id);
-                                  }}
-                                  onDelete={onDeleteSession}
-                                  readOnly={readOnly}
-                                  indented
-                                />
-                              ))}
-                          </div>
-                        )}
-                      </>
+                      <SortableContext
+                        items={liveWorkspaces.map((ws) => ws.id)}
+                        strategy={verticalListSortingStrategy}
+                      >
+                        {liveWorkspaces.map((ws) => (
+                          <SortableSessionRow
+                            key={ws.id}
+                            workspace={ws}
+                            isActive={ws.id === displayedActiveId}
+                            onClick={() => {
+                              setOptimisticActive({
+                                id: ws.id,
+                                fromActiveId: activeId,
+                              });
+                              onSelect(ws.id);
+                            }}
+                            onDelete={onDeleteSession}
+                            readOnly={readOnly}
+                            // Drag is disabled when the tier comparator
+                            // already controls placement: lastActivity
+                            // mode has no manual concept, pinned rows
+                            // always float to the top of their group.
+                            // See #1581.
+                            dragDisabled={
+                              sortMode === "lastActivity" ||
+                              workspaceIsPinned(ws)
+                            }
+                          />
+                        ))}
+                      </SortableContext>
                     );
                   })()}
                 </div>
@@ -1885,6 +1821,70 @@ export function WorkspaceSidebar({
             })}
           </DndContext>
           </DragSuppressContext.Provider>
+          {(() => {
+            // Single global "Snoozed & archived" section at the very
+            // bottom of the sidebar. Aggregates sunk workspaces from
+            // every repo group (live filtered) so users see one
+            // collapsible bucket rather than one footer per repo.
+            // Rows are listed flat in the order they appear inside
+            // their respective groups; each row's SessionRow already
+            // surfaces the title/branch/repo chips that anchor it to
+            // its project. See #1581.
+            const sunkWorkspaces = filteredGroups.flatMap((g) =>
+              g.workspaces.filter(workspaceIsSunk),
+            );
+            if (sunkWorkspaces.length === 0) return null;
+            return (
+              <div data-testid="sidebar-sunk-section">
+                <button
+                  onClick={toggleSunkExpanded}
+                  data-testid="sidebar-sunk-toggle"
+                  aria-expanded={sunkExpanded}
+                  className="w-full flex items-center gap-2 px-3 py-1.5 text-[11px] font-mono uppercase tracking-widest text-text-muted hover:text-text-secondary hover:bg-surface-800/40 cursor-pointer transition-colors border-t border-surface-800/60"
+                >
+                  <svg
+                    width="10"
+                    height="10"
+                    viewBox="0 0 10 10"
+                    fill="currentColor"
+                    className={`shrink-0 transition-transform duration-75 ${
+                      sunkExpanded ? "" : "-rotate-90"
+                    }`}
+                  >
+                    <path
+                      d="M2 3 L5 6.5 L8 3"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <span>
+                    Snoozed &amp; archived ({sunkWorkspaces.length})
+                  </span>
+                </button>
+                {sunkExpanded &&
+                  sunkWorkspaces.map((ws) => (
+                    <SessionRow
+                      key={ws.id}
+                      workspace={ws}
+                      isActive={ws.id === displayedActiveId}
+                      onClick={() => {
+                        setOptimisticActive({
+                          id: ws.id,
+                          fromActiveId: activeId,
+                        });
+                        onSelect(ws.id);
+                      }}
+                      onDelete={onDeleteSession}
+                      readOnly={readOnly}
+                      indented
+                    />
+                  ))}
+              </div>
+            );
+          })()}
 
           {!hasResults && filterQuery && (
             <div className="px-4 py-8 text-center">

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -278,6 +278,28 @@ describe("SessionRow triage actions", () => {
     });
   });
 
+  it("optimistically shows the Archived chip immediately on click", async () => {
+    // Regression: the chip render used `isArchived` (the prop)
+    // instead of `effectiveArchived` (the optimistic override). On
+    // click the chip didn't appear until the next sessions-poll
+    // confirmed the archive, which felt laggy compared to the
+    // immediate pin glyph flip. See CodeRabbit review on #1585.
+    const ws = workspace("w-live", [session({ id: "sess-opt-archive" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-archive"));
+    // The chip should appear synchronously from the optimistic
+    // state flip, before the PATCH response would have time to
+    // round-trip.
+    await vi.waitFor(() =>
+      expect(screen.queryByLabelText("Archived")).not.toBeNull(),
+    );
+  });
+
   it("Snooze… opens the modal (does NOT POST until a preset is picked)", () => {
     const ws = workspace("w-live", [session({ id: "sess-snooze-it" })]);
     render(

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -1,0 +1,311 @@
+// @vitest-environment jsdom
+//
+// RTL coverage for the new triage affordances on the sidebar
+// `SessionRow`: the Pin glyph, the Archive chip, the Snooze chip
+// (with the static remaining-time label), and the optimistic flip
+// invariants. Each case wires the smallest possible Workspace + a
+// DragSuppressContext stub so the row mounts without dragging into
+// the dnd-kit plumbing that the production tree provides.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { useRef, type ReactNode } from "react";
+
+import {
+  DragSuppressContext,
+  SessionRow,
+} from "../WorkspaceSidebar";
+import type { SessionResponse, Workspace } from "../../lib/types";
+
+function session(over: Partial<SessionResponse> = {}): SessionResponse {
+  return {
+    id: "s1",
+    title: "row title",
+    project_path: "/p",
+    group_path: "/p",
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: "2025-01-01T00:00:00Z",
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: null,
+    main_repo_path: null,
+    is_sandboxed: false,
+    favorited: false,
+    has_managed_worktree: false,
+    has_terminal: true,
+    profile: "default",
+    cleanup_defaults: {
+      delete_worktree: false,
+      delete_branch: false,
+      delete_sandbox: false,
+    },
+    remote_owner: null,
+    notify_on_waiting: null,
+    notify_on_idle: null,
+    notify_on_error: null,
+    claude_fullscreen: false,
+    workspace_repos: [],
+    ...over,
+  };
+}
+
+function workspace(id: string, sessions: SessionResponse[]): Workspace {
+  return {
+    id,
+    branch: null,
+    projectPath: "/p",
+    displayName: id,
+    agents: ["claude"],
+    primaryAgent: "claude",
+    status: "idle",
+    sessions,
+  };
+}
+
+function Wrap({ children }: { children: ReactNode }) {
+  const ref = useRef(0);
+  return (
+    <DragSuppressContext.Provider value={ref}>
+      {children}
+    </DragSuppressContext.Provider>
+  );
+}
+
+const fetchSpy = vi.fn<typeof fetch>();
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+  vi.stubGlobal("fetch", fetchSpy);
+  fetchSpy.mockImplementation(async () =>
+    new Response(JSON.stringify({ id: "s1" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("SessionRow chips", () => {
+  it("renders the Pin glyph when any session is pinned", () => {
+    const ws = workspace("w-pinned", [
+      session({ pinned_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Pinned")).not.toBeNull();
+    expect(screen.queryByLabelText("Archived")).toBeNull();
+    expect(screen.queryByLabelText("Snoozed")).toBeNull();
+  });
+
+  it("renders the Archived chip when any session is archived", () => {
+    const ws = workspace("w-archived", [
+      session({ archived_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Archived")).not.toBeNull();
+    expect(screen.queryByLabelText("Pinned")).toBeNull();
+    expect(screen.queryByLabelText("Snoozed")).toBeNull();
+  });
+
+  it("renders the Snoozed chip with a remaining-time label", () => {
+    const future = new Date(Date.now() + 90 * 60 * 1000).toISOString();
+    const ws = workspace("w-snoozed", [session({ snoozed_until: future })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    const chip = screen.queryByLabelText("Snoozed");
+    expect(chip).not.toBeNull();
+    // Bucket sizes: < 1h → minutes, ≥ 1h → "Nh". 90 minutes falls
+    // into the 1h bucket. Allow ±1 due to rounding.
+    expect(chip!.textContent).toMatch(/1h/);
+    expect(screen.queryByLabelText("Archived")).toBeNull();
+  });
+
+  it("hides the Snoozed chip when archived (archive wins visually)", () => {
+    const ws = workspace("w-both", [
+      session({
+        archived_at: "2026-01-01T00:00:00Z",
+        snoozed_until: "2099-01-01T00:00:00Z",
+      }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    expect(screen.queryByLabelText("Archived")).not.toBeNull();
+    // Visual gate: chip only renders for !effectiveArchived &&
+    // effectiveSnoozed. The data layer prevents both flags from
+    // coexisting at the session level, but defensive rendering
+    // hides the snooze chip if the workspace surfaces both.
+    expect(screen.queryByLabelText("Snoozed")).toBeNull();
+  });
+});
+
+describe("SessionRow context menu", () => {
+  it("shows only the Unpin toggle when pinned", () => {
+    const ws = workspace("w-pinned", [
+      session({ pinned_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    const row = screen.getByTestId("sidebar-session-row");
+    fireEvent.contextMenu(row);
+    const menu = screen.getByTestId("sidebar-context-menu");
+    expect(menu.textContent).toContain("Unpin");
+    expect(menu.textContent).not.toContain("Archive");
+    expect(menu.textContent).not.toContain("Snooze");
+  });
+
+  it("shows only the Unarchive toggle when archived", () => {
+    const ws = workspace("w-archived", [
+      session({ archived_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    const menu = screen.getByTestId("sidebar-context-menu");
+    expect(menu.textContent).toContain("Unarchive");
+    expect(menu.textContent).not.toContain("Pin");
+    expect(menu.textContent).not.toContain("Snooze");
+  });
+
+  it("shows only the Unsnooze toggle when snoozed", () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const ws = workspace("w-snoozed", [session({ snoozed_until: future })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    const menu = screen.getByTestId("sidebar-context-menu");
+    expect(menu.textContent).toContain("Unsnooze");
+    expect(menu.textContent).not.toContain("Pin");
+    expect(menu.textContent).not.toContain("Archive");
+  });
+
+  it("shows Pin / Archive / Snooze… for a live row", () => {
+    const ws = workspace("w-live", [session({})]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    const menu = screen.getByTestId("sidebar-context-menu");
+    expect(menu.textContent).toContain("Pin");
+    expect(menu.textContent).toContain("Archive");
+    expect(menu.textContent).toContain("Snooze…");
+  });
+
+  it("hides the triage section in read-only mode", () => {
+    const ws = workspace("w-live", [session({})]);
+    render(
+      <Wrap>
+        <SessionRow
+          workspace={ws}
+          isActive={false}
+          onClick={() => {}}
+          readOnly
+        />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    const menu = screen.getByTestId("sidebar-context-menu");
+    expect(menu.textContent).not.toContain("Pin");
+    expect(menu.textContent).not.toContain("Archive");
+    expect(menu.textContent).not.toContain("Snooze");
+    expect(menu.textContent).not.toContain("Delete");
+  });
+});
+
+describe("SessionRow triage actions", () => {
+  it("Pin click fires PATCH /api/sessions/:id/pin with { pinned: true }", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-pin-it" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-pin"));
+    // Wait for the async handler.
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-pin-it/pin");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({ pinned: true });
+  });
+
+  it("Archive click fires PATCH /api/sessions/:id/archive with { archived: true, kill_pane: true }", async () => {
+    const ws = workspace("w-live", [session({ id: "sess-arch-it" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-archive"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-arch-it/archive");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      archived: true,
+      kill_pane: true,
+    });
+  });
+
+  it("Snooze… opens the modal (does NOT POST until a preset is picked)", () => {
+    const ws = workspace("w-live", [session({ id: "sess-snooze-it" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-snooze"));
+    expect(screen.queryByTestId("snooze-modal")).not.toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("Unsnooze click fires PATCH /api/sessions/:id/snooze with { minutes: null }", async () => {
+    const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const ws = workspace("w-snoozed", [
+      session({ id: "sess-unsnooze-it", snoozed_until: future }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-unsnooze"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-unsnooze-it/snooze");
+    expect(JSON.parse(init!.body as string)).toEqual({ minutes: null });
+  });
+});

--- a/web/src/components/__tests__/SessionRowTriage.test.tsx
+++ b/web/src/components/__tests__/SessionRowTriage.test.tsx
@@ -313,6 +313,82 @@ describe("SessionRow triage actions", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("Unpin click fires PATCH /api/sessions/:id/pin with { pinned: false }", async () => {
+    const ws = workspace("w-pinned", [
+      session({ id: "sess-unpin", pinned_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-pin"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-unpin/pin");
+    expect(JSON.parse(init!.body as string)).toEqual({ pinned: false });
+  });
+
+  it("Unarchive click fires PATCH /api/sessions/:id/archive with { archived: false }", async () => {
+    const ws = workspace("w-archived", [
+      session({ id: "sess-unarc", archived_at: "2026-01-01T00:00:00Z" }),
+    ]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-archive"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-unarc/archive");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      archived: false,
+      kill_pane: true,
+    });
+  });
+
+  it("reverts optimistic pin override on PATCH failure", async () => {
+    // Branch coverage: the wake-call-failed path through togglePin.
+    fetchSpy.mockImplementation(async () =>
+      new Response("nope", { status: 500 }),
+    );
+    const ws = workspace("w-live", [session({ id: "sess-pin-fail" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-pin"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    // The optimistic pin flipped on, then reverted off. The glyph
+    // should not be visible after the failure settles.
+    await vi.waitFor(() =>
+      expect(screen.queryByLabelText("Pinned")).toBeNull(),
+    );
+  });
+
+  it("reverts optimistic archive override on PATCH failure", async () => {
+    fetchSpy.mockImplementation(async () =>
+      new Response("nope", { status: 500 }),
+    );
+    const ws = workspace("w-live", [session({ id: "sess-arch-fail" })]);
+    render(
+      <Wrap>
+        <SessionRow workspace={ws} isActive={false} onClick={() => {}} />
+      </Wrap>,
+    );
+    fireEvent.contextMenu(screen.getByTestId("sidebar-session-row"));
+    fireEvent.click(screen.getByTestId("sidebar-context-menu-archive"));
+    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(screen.queryByLabelText("Archived")).toBeNull(),
+    );
+  });
+
   it("Unsnooze click fires PATCH /api/sessions/:id/snooze with { minutes: null }", async () => {
     const future = new Date(Date.now() + 60 * 60 * 1000).toISOString();
     const ws = workspace("w-snoozed", [

--- a/web/src/components/__tests__/SnoozeModal.test.tsx
+++ b/web/src/components/__tests__/SnoozeModal.test.tsx
@@ -1,0 +1,312 @@
+// @vitest-environment jsdom
+//
+// Component coverage for the sidebar snooze modal added in #1581.
+// The modal is the only interactive surface inside WorkspaceSidebar
+// that does not require the dnd-kit + AgentProfileProvider plumbing
+// the rest of the file needs to mount, so we exercise it directly via
+// React Testing Library to lock in the eight preset list, the custom
+// duration input + unit converter, the datetime-local "until" path,
+// and the validation error surfaces.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import {
+  SnoozeModal,
+  SNOOZE_PRESETS,
+  formatSnoozeRemainingShort,
+  makeOptimisticSnoozedUntil,
+} from "../WorkspaceSidebar";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SnoozeModal preset buttons", () => {
+  it("renders the same 8 presets as the TUI dialog and the matching minutes", () => {
+    // Regression: any drift between the web modal and
+    // `src/tui/dialogs/snooze_duration.rs` confuses users who switch
+    // between surfaces. See #1581.
+    const minutes = SNOOZE_PRESETS.map((p) => p.minutes);
+    expect(minutes).toEqual([60, 120, 180, 240, 300, 360, 1440, 10080]);
+  });
+
+  it("clicks fire onPick with the preset minutes", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="my session" onCancel={() => {}} onPick={onPick} />,
+    );
+    for (const preset of SNOOZE_PRESETS) {
+      fireEvent.click(
+        screen.getByTestId(`snooze-modal-preset-${preset.minutes}`),
+      );
+    }
+    expect(onPick).toHaveBeenCalledTimes(SNOOZE_PRESETS.length);
+    for (let i = 0; i < SNOOZE_PRESETS.length; i++) {
+      expect(onPick).toHaveBeenNthCalledWith(i + 1, SNOOZE_PRESETS[i]!.minutes);
+    }
+  });
+});
+
+describe("SnoozeModal dismissal", () => {
+  it("Cancel button calls onCancel", () => {
+    const onCancel = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={onCancel} onPick={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("snooze-modal-cancel"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape dismisses the modal", () => {
+    const onCancel = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={onCancel} onPick={() => {}} />,
+    );
+    // Modal's useEffect attaches keydown to document, so the event
+    // needs to bubble there. document.body is the typical bubble
+    // source under jsdom.
+    document.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+    );
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("backdrop click dismisses the modal", () => {
+    const onCancel = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={onCancel} onPick={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("snooze-modal-backdrop"));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("inside-modal click does NOT dismiss", () => {
+    const onCancel = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={onCancel} onPick={() => {}} />,
+    );
+    fireEvent.click(screen.getByTestId("snooze-modal"));
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});
+
+describe("SnoozeModal custom duration", () => {
+  it("converts hours by default and fires onPick with minutes", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "3" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).toHaveBeenCalledWith(180);
+  });
+
+  it("respects the unit selector for minutes", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "45" },
+    });
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-unit"), {
+      target: { value: "m" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).toHaveBeenCalledWith(45);
+  });
+
+  it("converts days correctly", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "2" },
+    });
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-unit"), {
+      target: { value: "d" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).toHaveBeenCalledWith(2 * 24 * 60);
+  });
+
+  it("converts weeks correctly", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "1" },
+    });
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-unit"), {
+      target: { value: "w" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).toHaveBeenCalledWith(7 * 24 * 60);
+  });
+
+  it("rejects 0 and surfaces an inline error", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("snooze-modal-custom-error")).not.toBeNull();
+  });
+
+  it("rejects > 30 days and surfaces an inline error", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-value"), {
+      target: { value: "5" },
+    });
+    fireEvent.change(screen.getByTestId("snooze-modal-custom-unit"), {
+      target: { value: "w" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-custom-submit"));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("snooze-modal-custom-error")).not.toBeNull();
+  });
+
+  it("submits on Enter", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    const input = screen.getByTestId("snooze-modal-custom-value");
+    fireEvent.change(input, { target: { value: "2" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onPick).toHaveBeenCalledWith(120);
+  });
+});
+
+describe("SnoozeModal datetime-local 'until' path", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("converts a future datetime to minutes-from-now and fires onPick", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    // datetime-local values are wall-clock in the user's timezone.
+    // jsdom inherits the host TZ, so use a date 5 days out to make
+    // the test robust against any reasonable TZ offset; the bound
+    // assertion below has wide enough tolerance.
+    fireEvent.change(screen.getByTestId("snooze-modal-until-value"), {
+      target: { value: "2026-06-06T12:00" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-until-submit"));
+    expect(onPick).toHaveBeenCalledTimes(1);
+    const minutes = onPick.mock.calls[0]![0] as number;
+    // 5 days minus up to 14h TZ offset is at least ~4 days of
+    // minutes; the upper bound stays under the 30-day server limit.
+    expect(minutes).toBeGreaterThan(4 * 24 * 60);
+    expect(minutes).toBeLessThan(30 * 24 * 60);
+  });
+
+  it("rejects an empty datetime input", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.click(screen.getByTestId("snooze-modal-until-submit"));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("snooze-modal-until-error")).not.toBeNull();
+  });
+
+  it("rejects a datetime in the past", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-until-value"), {
+      target: { value: "2026-05-01T12:00" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-until-submit"));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("snooze-modal-until-error")).not.toBeNull();
+  });
+
+  it("rejects a datetime more than 30 days from now", () => {
+    const onPick = vi.fn();
+    render(
+      <SnoozeModal title="t" onCancel={() => {}} onPick={onPick} />,
+    );
+    fireEvent.change(screen.getByTestId("snooze-modal-until-value"), {
+      target: { value: "2099-01-01T00:00" },
+    });
+    fireEvent.click(screen.getByTestId("snooze-modal-until-submit"));
+    expect(onPick).not.toHaveBeenCalled();
+    expect(screen.queryByTestId("snooze-modal-until-error")).not.toBeNull();
+  });
+});
+
+describe("makeOptimisticSnoozedUntil", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns now + minutes as an RFC3339 string", () => {
+    expect(makeOptimisticSnoozedUntil(60)).toBe("2026-06-01T13:00:00.000Z");
+    expect(makeOptimisticSnoozedUntil(24 * 60)).toBe(
+      "2026-06-02T12:00:00.000Z",
+    );
+  });
+});
+
+describe("formatSnoozeRemainingShort", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00Z"));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders sub-minute as '<1m'", () => {
+    expect(formatSnoozeRemainingShort("2026-06-01T12:00:30Z")).toBe("<1m");
+  });
+
+  it("renders sub-hour as minutes", () => {
+    expect(formatSnoozeRemainingShort("2026-06-01T12:30:00Z")).toBe("30m");
+  });
+
+  it("renders sub-day as hours (rounded down)", () => {
+    expect(formatSnoozeRemainingShort("2026-06-01T15:30:00Z")).toBe("3h");
+  });
+
+  it("renders ≥ day as days (rounded down)", () => {
+    expect(formatSnoozeRemainingShort("2026-06-04T12:00:00Z")).toBe("3d");
+  });
+
+  it("returns 'soon' for an already-expired timestamp", () => {
+    // The server gates `snoozed_until` on `is_snoozed()` so we
+    // should not normally hit this branch on the wire, but the
+    // optimistic state can briefly out-stale the prop.
+    expect(formatSnoozeRemainingShort("2026-05-31T12:00:00Z")).toBe("soon");
+  });
+
+  it("returns 'snoozed' for an unparseable timestamp (defensive)", () => {
+    expect(formatSnoozeRemainingShort("not-a-date")).toBe("snoozed");
+  });
+});

--- a/web/src/components/cockpit/CockpitRuntime.tsx
+++ b/web/src/components/cockpit/CockpitRuntime.tsx
@@ -47,6 +47,14 @@ interface Props {
    *  Threaded through to `useCockpit` so the drain effect parks queued
    *  prompts while the reconciler is mid-resume. See #1088. */
   cockpitWorkerState?: "absent" | "resuming" | "running";
+  /** RFC3339 archived-at timestamp, or null. Threaded into `useCockpit`
+   *  so `sendPrompt` can auto-unarchive the session before enqueueing,
+   *  matching the `touch_last_accessed` invariant the server enforces
+   *  for tmux sends. See #1581. */
+  archivedAt?: string | null;
+  /** RFC3339 snoozed-until timestamp, or null. Same auto-wake purpose
+   *  as `archivedAt`. See #1581. */
+  snoozedUntil?: string | null;
   /** When true, every row is rendered including those preceding the
    *  most recent `/clear`. When false (the default), rows before the
    *  latest `session_cleared` divider are folded out of the message
@@ -96,10 +104,12 @@ export interface CockpitContext {
 export function CockpitRuntime({
   sessionId,
   cockpitWorkerState = "running",
+  archivedAt = null,
+  snoozedUntil = null,
   showClearedTurns = false,
   children,
 }: Props) {
-  const cockpit = useCockpit(sessionId, cockpitWorkerState);
+  const cockpit = useCockpit(sessionId, cockpitWorkerState, archivedAt, snoozedUntil);
   // Memoise the activity → ThreadMessageLike conversion. The function
   // walks the entire activity array, allocates a new AssistantBuilder
   // per turn, and produces brand-new message objects. Without

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -122,6 +122,8 @@ export function CockpitView({
       <CockpitRuntime
         sessionId={sessionId}
         cockpitWorkerState={cockpitWorkerState}
+        archivedAt={archivedAt}
+        snoozedUntil={snoozedUntil}
         showClearedTurns={showClearedTurns}
       >
         {(ctx) => (

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -1486,7 +1486,11 @@ function WorkerStoppedBanner({ sessionId }: { sessionId: string }) {
  *  startup recovery path both skip archived sessions, so a fresh
  *  spawn would not survive the next reconciliation tick. The user
  *  unblocks by unarchiving from the sidebar context menu. See #1581. */
-function ArchivedWorkerStoppedBanner({ sessionId }: { sessionId: string }) {
+export function ArchivedWorkerStoppedBanner({
+  sessionId,
+}: {
+  sessionId: string;
+}) {
   return (
     <div
       className="border-b border-amber-900/60 bg-amber-950/40 px-4 py-3 text-amber-200"
@@ -1507,7 +1511,7 @@ function ArchivedWorkerStoppedBanner({ sessionId }: { sessionId: string }) {
  *  so the user knows when the worker will come back on its own;
  *  Unsnooze from the sidebar context menu wakes it sooner. See
  *  #1581. */
-function SnoozedWorkerStoppedBanner({
+export function SnoozedWorkerStoppedBanner({
   sessionId,
   snoozedUntil,
 }: {

--- a/web/src/components/cockpit/CockpitView.tsx
+++ b/web/src/components/cockpit/CockpitView.tsx
@@ -47,6 +47,7 @@ import {
   queuedStripLayout,
 } from "./queuedPromptsLayout";
 import { StartupErrorScreen } from "./StartupErrorScreen";
+import { pickWorkerStoppedVariant } from "./workerStoppedBanner";
 import { SubagentCard, ToolCard, ToolGroupCard } from "./ToolCards";
 import { DiffCommentsUserCard } from "../diff/comments/DiffCommentsUserCard";
 import { parseDiffCommentsSentinel } from "../diff/comments/buildPrompt";
@@ -84,6 +85,18 @@ interface Props {
    *  / etc.). Resolves the active AgentProfile that drives card
    *  dispatch and claude-specific capability gates. */
   tool: string | null | undefined;
+  /** RFC3339 archived-at timestamp, or null. Drives the
+   *  archived-specific "worker stopped" banner that replaces the
+   *  generic `aoe cockpit stop`-style message when the user has
+   *  explicitly parked the session via the sidebar archive action.
+   *  See #1581. */
+  archivedAt: string | null;
+  /** RFC3339 snoozed-until timestamp, or null. Drives the
+   *  snoozed-specific "worker stopped" banner with a wake-time
+   *  readout. Server gates this on `is_snoozed()` so expired
+   *  timestamps come back as null and we fall through to the live
+   *  variant. See #1581. */
+  snoozedUntil: string | null;
 }
 
 const STARTER_PROMPTS = [
@@ -92,7 +105,13 @@ const STARTER_PROMPTS = [
   "What does the build pipeline do?",
 ];
 
-export function CockpitView({ sessionId, cockpitWorkerState, tool }: Props) {
+export function CockpitView({
+  sessionId,
+  cockpitWorkerState,
+  tool,
+  archivedAt,
+  snoozedUntil,
+}: Props) {
   // Folds rows above the most recent `/clear` divider out of the
   // thread by default; the disclosure banner toggles this. Lives on
   // the view (not the reducer) because it's a UI preference, not
@@ -111,6 +130,8 @@ export function CockpitView({ sessionId, cockpitWorkerState, tool }: Props) {
             cockpitWorkerState={cockpitWorkerState}
             showClearedTurns={showClearedTurns}
             onToggleClearedTurns={() => setShowClearedTurns((v) => !v)}
+            archivedAt={archivedAt}
+            snoozedUntil={snoozedUntil}
             {...ctx}
           />
         )}
@@ -124,6 +145,8 @@ function CockpitChrome({
   cockpitWorkerState,
   showClearedTurns,
   onToggleClearedTurns,
+  archivedAt,
+  snoozedUntil,
   state,
   status,
   hasEverOpened,
@@ -150,6 +173,8 @@ function CockpitChrome({
   cockpitWorkerState: "absent" | "resuming" | "running";
   showClearedTurns: boolean;
   onToggleClearedTurns: () => void;
+  archivedAt: string | null;
+  snoozedUntil: string | null;
 }) {
   // Count how many activity rows precede the latest `session_cleared`
   // divider so the banner can say "12 earlier turns hidden". The
@@ -280,9 +305,29 @@ function CockpitChrome({
       {state.startupError && (
         <StartupErrorBanner sessionId={sessionId} message={state.startupError} />
       )}
-      {state.workerStopped && !state.startupError && (
-        <WorkerStoppedBanner sessionId={sessionId} />
-      )}
+      {(() => {
+        const variant = pickWorkerStoppedVariant({
+          workerStopped: state.workerStopped,
+          startupError: state.startupError,
+          archivedAt,
+          snoozedUntil,
+        });
+        if (variant === "archived") {
+          return <ArchivedWorkerStoppedBanner sessionId={sessionId} />;
+        }
+        if (variant === "snoozed" && snoozedUntil) {
+          return (
+            <SnoozedWorkerStoppedBanner
+              sessionId={sessionId}
+              snoozedUntil={snoozedUntil}
+            />
+          );
+        }
+        if (variant === "generic") {
+          return <WorkerStoppedBanner sessionId={sessionId} />;
+        }
+        return null;
+      })()}
       {state.workerRestarting && !state.startupError && !state.workerStopped && (
         <WorkerRestartingBanner
           agentUnresponsive={state.agentUnresponsive}
@@ -1429,6 +1474,60 @@ function WorkerStoppedBanner({ sessionId }: { sessionId: string }) {
           Reconnect failed: {retryError}
         </div>
       )}
+    </div>
+  );
+}
+
+/** Replacement for `WorkerStoppedBanner` when the worker was torn
+ *  down because the user archived the session from the sidebar. The
+ *  reconnect button would be misleading here: the reconciler and the
+ *  startup recovery path both skip archived sessions, so a fresh
+ *  spawn would not survive the next reconciliation tick. The user
+ *  unblocks by unarchiving from the sidebar context menu. See #1581. */
+function ArchivedWorkerStoppedBanner({ sessionId }: { sessionId: string }) {
+  return (
+    <div
+      className="border-b border-amber-900/60 bg-amber-950/40 px-4 py-3 text-amber-200"
+      data-testid={`cockpit-archived-banner-${sessionId}`}
+    >
+      <div className="text-sm font-medium">Session archived</div>
+      <div className="mt-1 text-xs text-amber-100/90">
+        This session is parked. The cockpit worker was shut down and the
+        reconciler will not respawn it. Unarchive from the sidebar
+        (right-click the row, then Unarchive) to bring it back.
+      </div>
+    </div>
+  );
+}
+
+/** Replacement for `WorkerStoppedBanner` when the worker was torn
+ *  down because the user snoozed the session. Surfaces the wake time
+ *  so the user knows when the worker will come back on its own;
+ *  Unsnooze from the sidebar context menu wakes it sooner. See
+ *  #1581. */
+function SnoozedWorkerStoppedBanner({
+  sessionId,
+  snoozedUntil,
+}: {
+  sessionId: string;
+  snoozedUntil: string;
+}) {
+  const target = new Date(snoozedUntil);
+  const wallClock = Number.isFinite(target.getTime())
+    ? target.toLocaleString()
+    : snoozedUntil;
+  return (
+    <div
+      className="border-b border-amber-900/60 bg-amber-950/40 px-4 py-3 text-amber-200"
+      data-testid={`cockpit-snoozed-banner-${sessionId}`}
+    >
+      <div className="text-sm font-medium">Session snoozed</div>
+      <div className="mt-1 text-xs text-amber-100/90">
+        The cockpit worker was shut down until{" "}
+        <span className="font-mono">{wallClock}</span>. The reconciler will
+        respawn it automatically once the snooze expires, or you can
+        Unsnooze from the sidebar (right-click the row) to wake it sooner.
+      </div>
     </div>
   );
 }

--- a/web/src/components/cockpit/__tests__/TriageBanners.test.tsx
+++ b/web/src/components/cockpit/__tests__/TriageBanners.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+//
+// Vitest coverage for the cockpit-view banner variants introduced in
+// #1581. Each banner is a tiny presentational component, but they
+// own the copy the user sees the moment they archive or snooze a
+// session, and any drift between the testid + the banner switch in
+// CockpitView's variant picker would silently swap which message
+// renders.
+
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+
+import {
+  ArchivedWorkerStoppedBanner,
+  SnoozedWorkerStoppedBanner,
+} from "../CockpitView";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ArchivedWorkerStoppedBanner", () => {
+  it("renders the archived copy with the sessionId-scoped testid", () => {
+    render(<ArchivedWorkerStoppedBanner sessionId="abc-123" />);
+    const banner = screen.getByTestId("cockpit-archived-banner-abc-123");
+    expect(banner).not.toBeNull();
+    expect(banner.textContent).toContain("Session archived");
+    // Mentions the sidebar path so users know how to unblock.
+    expect(banner.textContent).toContain("Unarchive");
+  });
+
+  it("isolates banners by sessionId", () => {
+    render(<ArchivedWorkerStoppedBanner sessionId="alpha" />);
+    expect(
+      screen.queryByTestId("cockpit-archived-banner-alpha"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("cockpit-archived-banner-beta")).toBeNull();
+  });
+});
+
+describe("SnoozedWorkerStoppedBanner", () => {
+  it("renders the snoozed copy with a localized wake-time", () => {
+    render(
+      <SnoozedWorkerStoppedBanner
+        sessionId="abc-123"
+        snoozedUntil="2099-01-01T00:00:00Z"
+      />,
+    );
+    const banner = screen.getByTestId("cockpit-snoozed-banner-abc-123");
+    expect(banner).not.toBeNull();
+    expect(banner.textContent).toContain("Session snoozed");
+    // The wake time renders via `Date#toLocaleString`. We can't
+    // assert the exact string (depends on host TZ + locale), but
+    // we can confirm a year fragment appears so the wall-clock
+    // formatting path ran instead of falling through to the raw
+    // ISO.
+    expect(banner.textContent).toMatch(/2099|2098/);
+  });
+
+  it("mentions the Unsnooze affordance", () => {
+    render(
+      <SnoozedWorkerStoppedBanner
+        sessionId="abc-123"
+        snoozedUntil="2099-01-01T00:00:00Z"
+      />,
+    );
+    const banner = screen.getByTestId("cockpit-snoozed-banner-abc-123");
+    expect(banner.textContent).toContain("Unsnooze");
+  });
+
+  it("falls through to the raw ISO when the timestamp is unparseable", () => {
+    // Defensive: the server gates snoozed_until on `is_snoozed()`,
+    // but an unparseable string would otherwise crash
+    // `Date.toLocaleString`. We render the raw value instead.
+    render(
+      <SnoozedWorkerStoppedBanner
+        sessionId="abc-123"
+        snoozedUntil="not-a-date"
+      />,
+    );
+    const banner = screen.getByTestId("cockpit-snoozed-banner-abc-123");
+    expect(banner.textContent).toContain("not-a-date");
+  });
+});

--- a/web/src/components/cockpit/workerStoppedBanner.test.ts
+++ b/web/src/components/cockpit/workerStoppedBanner.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { pickWorkerStoppedVariant } from "./workerStoppedBanner";
+
+describe("pickWorkerStoppedVariant", () => {
+  it("returns 'none' when the worker is not stopped", () => {
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: false,
+        startupError: null,
+        archivedAt: null,
+        snoozedUntil: null,
+      }),
+    ).toBe("none");
+  });
+
+  it("returns 'none' when a startup error is in flight (its own banner wins)", () => {
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: "missing API key",
+        archivedAt: null,
+        snoozedUntil: null,
+      }),
+    ).toBe("none");
+  });
+
+  it("returns 'archived' when the session is archived", () => {
+    // Regression: an archived cockpit session must not show the
+    // generic `aoe cockpit stop` reconnect banner. Reconnecting from
+    // the cockpit view would race the reconciler, which skips
+    // archived sessions, and the user would see the spawn flicker
+    // and then disappear. See #1581.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: null,
+        archivedAt: "2026-01-01T00:00:00Z",
+        snoozedUntil: null,
+      }),
+    ).toBe("archived");
+  });
+
+  it("returns 'snoozed' when the session is snoozed", () => {
+    // Regression: same problem as archived, but with the snooze
+    // wake-up path. The snoozed banner surfaces the wake time and
+    // points at Unsnooze in the sidebar context menu instead. See
+    // #1581.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: null,
+        archivedAt: null,
+        snoozedUntil: "2026-01-01T00:00:00Z",
+      }),
+    ).toBe("snoozed");
+  });
+
+  it("prefers 'archived' over 'snoozed' (defensive multi-flag fallback)", () => {
+    // The server's XOR rules prevent both flags from being set on
+    // the same session at once, but workspace-level aggregators can
+    // surface both via different sessions. Archive is the stronger
+    // signal (no automatic wake), so the variant prefers it.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: null,
+        archivedAt: "2026-01-01T00:00:00Z",
+        snoozedUntil: "2026-02-01T00:00:00Z",
+      }),
+    ).toBe("archived");
+  });
+
+  it("returns 'generic' for the `aoe cockpit stop` / external-teardown case", () => {
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: null,
+        archivedAt: null,
+        snoozedUntil: null,
+      }),
+    ).toBe("generic");
+  });
+});

--- a/web/src/components/cockpit/workerStoppedBanner.test.ts
+++ b/web/src/components/cockpit/workerStoppedBanner.test.ts
@@ -80,4 +80,48 @@ describe("pickWorkerStoppedVariant", () => {
       }),
     ).toBe("generic");
   });
+
+  it("returns 'generic' when only snoozedUntil is null but archivedAt is null too (branch combo)", () => {
+    // Branch coverage: the snoozedUntil-falsy leg of the third `if`
+    // (after archivedAt also falsy). The "generic" test above hits
+    // this path with all-null; this case uses an empty string on
+    // startupError to confirm that branch's falsy side as well.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: "",
+        archivedAt: null,
+        snoozedUntil: null,
+      }),
+    ).toBe("generic");
+  });
+
+  it("returns 'archived' when startupError is empty string (not truthy)", () => {
+    // Branch coverage: a non-null but falsy startupError must fall
+    // through to the archived check rather than short-circuiting on
+    // the second `if`.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: "",
+        archivedAt: "2026-01-01T00:00:00Z",
+        snoozedUntil: null,
+      }),
+    ).toBe("archived");
+  });
+
+  it("returns 'snoozed' when archivedAt is null and snoozedUntil is non-null", () => {
+    // Mirror of the 'archived' branch with the third `if` taking the
+    // falsy side and the fourth `if` taking truthy. Ensures the
+    // archivedAt-null leg is exercised independently of the
+    // archived-wins-over-snoozed defensive case.
+    expect(
+      pickWorkerStoppedVariant({
+        workerStopped: true,
+        startupError: null,
+        archivedAt: null,
+        snoozedUntil: "2099-01-01T00:00:00Z",
+      }),
+    ).toBe("snoozed");
+  });
 });

--- a/web/src/components/cockpit/workerStoppedBanner.ts
+++ b/web/src/components/cockpit/workerStoppedBanner.ts
@@ -1,0 +1,37 @@
+/** Which "worker stopped" banner variant to render in the cockpit
+ *  view, given the session's triage state. The variant matches the
+ *  reason the worker was torn down so the user sees a banner that
+ *  actually explains their situation (and offers the right next
+ *  step) instead of the generic `aoe cockpit stop` message. See
+ *  #1581.
+ *
+ *  Returns:
+ *   - `"none"`     : worker is not stopped, no banner.
+ *   - `"archived"` : worker was torn down by the sidebar archive
+ *                    action; reconnect is not the right next step
+ *                    (the user must unarchive first).
+ *   - `"snoozed"`  : worker was torn down by the sidebar snooze
+ *                    action; the reconciler will respawn it when
+ *                    the snooze expires.
+ *   - `"generic"`  : everything else (`aoe cockpit stop`, manual
+ *                    teardown, etc.).
+ *
+ *  `startupError` takes precedence over every "stopped" banner
+ *  variant because the startup-error banner has its own retry path;
+ *  callers should bail before invoking this helper when a startup
+ *  error is in flight, but we still defensively return `"none"` to
+ *  stay safe under refactors. */
+export type WorkerStoppedVariant = "none" | "archived" | "snoozed" | "generic";
+
+export function pickWorkerStoppedVariant(args: {
+  workerStopped: boolean;
+  startupError: string | null;
+  archivedAt: string | null;
+  snoozedUntil: string | null;
+}): WorkerStoppedVariant {
+  if (!args.workerStopped) return "none";
+  if (args.startupError) return "none";
+  if (args.archivedAt) return "archived";
+  if (args.snoozedUntil) return "snoozed";
+  return "generic";
+}

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -1052,10 +1052,24 @@ export function useCockpit(
       // it client-side; the reconciler picks the session back up on
       // its next ~2s tick and the queue drains as soon as a fresh
       // `AcpSessionAssigned` lands. See #1581.
-      if (archivedAtRef.current) {
-        await setSessionArchive(sessionId, false);
-      } else if (snoozedUntilRef.current) {
-        await setSessionSnooze(sessionId, null);
+      if (archivedAtRef.current || snoozedUntilRef.current) {
+        const wakeResult = archivedAtRef.current
+          ? await setSessionArchive(sessionId, false)
+          : await setSessionSnooze(sessionId, null);
+        if (!wakeResult) {
+          // Wake PATCH failed (network drop / 5xx / 4xx). Surfacing
+          // an error is the only safe move: enqueueing locally would
+          // park the prompt in a queue that never drains, because
+          // the reconciler keeps skipping the still-sunk session.
+          // Route through the reducer's `error` action so the
+          // existing `InteractionErrorBanner` renders it. See #1581.
+          dispatch({
+            kind: "error",
+            message:
+              "Could not wake this session. Please retry, or unarchive / unsnooze from the sidebar.",
+          });
+          return;
+        }
       }
       const wsClosed = statusRef.current !== "open";
       const workerNotRunning = workerStateRef.current !== "running";

--- a/web/src/hooks/useCockpit.ts
+++ b/web/src/hooks/useCockpit.ts
@@ -25,6 +25,7 @@ import { useAgentProfile } from "../lib/agentProfileContext";
 import { getOrCreateDeviceBindingSecret } from "../lib/deviceBinding";
 import { safeSetItem } from "../lib/safeStorage";
 import { getToken } from "../lib/token";
+import { setSessionArchive, setSessionSnooze } from "../lib/api";
 
 export type Action =
   | { kind: "frame"; frame: CockpitFrame }
@@ -483,6 +484,15 @@ export function useCockpit(
    *  don't dispatch into a worker that isn't online yet. Defaults to
    *  `"running"` so non-cockpit / pre-#1088 call sites keep working. */
   workerState: "absent" | "resuming" | "running" = "running",
+  /** RFC3339 archived-at, or null. `sendPrompt` clears this server-side
+   *  (via PATCH /api/sessions/{id}/archive) before enqueueing so the
+   *  reconciler stops skipping the session and respawns the worker.
+   *  See #1581. */
+  archivedAt: string | null = null,
+  /** RFC3339 snoozed-until, or null. Same wake purpose as
+   *  `archivedAt`, via PATCH /api/sessions/{id}/snooze with
+   *  `{ minutes: null }`. See #1581. */
+  snoozedUntil: string | null = null,
 ) {
   // Sweep stale persisted state entries on first hook mount in this
   // module's lifetime. Idempotent (guarded by `sweptStorage`) so the
@@ -496,6 +506,18 @@ export function useCockpit(
   useEffect(() => {
     workerStateRef.current = workerState;
   }, [workerState]);
+  // Mirror the triage timestamps onto refs so `sendPrompt`'s wake
+  // step always sees the freshest value without forcing a re-create
+  // of the callback (the dep churn would also blow `dispatchPromptNow`
+  // away on every poll). See #1581.
+  const archivedAtRef = useRef(archivedAt);
+  const snoozedUntilRef = useRef(snoozedUntil);
+  useEffect(() => {
+    archivedAtRef.current = archivedAt;
+  }, [archivedAt]);
+  useEffect(() => {
+    snoozedUntilRef.current = snoozedUntil;
+  }, [snoozedUntil]);
   // Drain mode is sourced from the daemon's resolved `[cockpit]` config
   // and republished via `CockpitPrefsProvider` (App.tsx). Held in a ref
   // so the drain effect's pop logic always sees the latest value
@@ -1021,6 +1043,20 @@ export function useCockpit(
   const sendPrompt = useCallback(
     async (text: string) => {
       if (!sessionId) return;
+      // Auto-wake an archived or actively-snoozed session before
+      // routing. The tmux send path runs this via
+      // `Instance::touch_last_accessed` on the server side, but the
+      // cockpit composer enqueues locally while the worker is down
+      // (which is true precisely BECAUSE the row is sunk), so the
+      // server never sees the prompt and the flag stays set. Clear
+      // it client-side; the reconciler picks the session back up on
+      // its next ~2s tick and the queue drains as soon as a fresh
+      // `AcpSessionAssigned` lands. See #1581.
+      if (archivedAtRef.current) {
+        await setSessionArchive(sessionId, false);
+      } else if (snoozedUntilRef.current) {
+        await setSessionSnooze(sessionId, null);
+      }
       const wsClosed = statusRef.current !== "open";
       const workerNotRunning = workerStateRef.current !== "running";
       const shouldEnqueue = wsClosed || workerNotRunning || state.turnActive || state.workerStopped || state.workerRestarting;

--- a/web/src/hooks/useCockpit.wake.test.ts
+++ b/web/src/hooks/useCockpit.wake.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+//
+// Regression tests for #1581: sending a prompt to an archived or
+// snoozed cockpit session must auto-clear that flag client-side
+// before enqueueing locally. Without the wake, the cockpit
+// reconciler keeps skipping the session (its respawn predicate
+// excludes archived + actively-snoozed rows), the worker stays
+// down, and the queued prompt never drains.
+
+import { act, renderHook } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AgentProfileProvider } from "../lib/agentProfileContext";
+import { useCockpit } from "./useCockpit";
+
+interface FakeSocket {
+  url: string;
+  readyState: number;
+  onopen: ((ev: Event) => void) | null;
+  onclose: ((ev: CloseEvent) => void) | null;
+  onerror: ((ev: Event) => void) | null;
+  onmessage: ((ev: MessageEvent) => void) | null;
+  close: () => void;
+  send: (data: string | ArrayBufferLike | Blob | ArrayBufferView) => void;
+}
+
+const sockets: FakeSocket[] = [];
+let originalWebSocket: typeof WebSocket;
+
+class FakeWebSocket implements FakeSocket {
+  url: string;
+  readyState: number = 0;
+  onopen: ((ev: Event) => void) | null = null;
+  onclose: ((ev: CloseEvent) => void) | null = null;
+  onerror: ((ev: Event) => void) | null = null;
+  onmessage: ((ev: MessageEvent) => void) | null = null;
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  constructor(url: string) {
+    this.url = url;
+    sockets.push(this);
+  }
+  close(): void {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+  send(): void {
+    /* no-op */
+  }
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 8; i++) {
+      await Promise.resolve();
+    }
+  });
+}
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(
+    AgentProfileProvider,
+    { toolKey: "claude" },
+    children,
+  );
+
+describe("useCockpit auto-wake on sendPrompt (#1581)", () => {
+  interface Call {
+    url: string;
+    method: string;
+    body: unknown;
+  }
+  let calls: Call[];
+
+  beforeEach(() => {
+    sockets.length = 0;
+    calls = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        let body: unknown = null;
+        if (typeof init?.body === "string") {
+          try {
+            body = JSON.parse(init.body);
+          } catch {
+            body = init.body;
+          }
+        }
+        calls.push({ url, method, body });
+        if (url.includes("/cockpit/replay")) {
+          return new Response(
+            JSON.stringify({ frames: [], lost: false, highest_seq: 0 }),
+            { status: 200 },
+          );
+        }
+        if (url.endsWith("/archive") && method === "PATCH") {
+          return new Response(
+            JSON.stringify({ id: "sess-wake-PLACEHOLDER", archived_at: null }),
+            { status: 200 },
+          );
+        }
+        if (url.endsWith("/snooze") && method === "PATCH") {
+          return new Response(
+            JSON.stringify({ id: "sess-wake-PLACEHOLDER", snoozed_until: null }),
+            { status: 200 },
+          );
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+    originalWebSocket = global.WebSocket;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  afterEach(() => {
+    global.WebSocket = originalWebSocket;
+    vi.unstubAllGlobals();
+  });
+
+  it("clears the archived flag via PATCH before enqueueing the prompt", async () => {
+    const sessionId = "sess-wake-archive";
+    const { result } = renderHook(
+      () => useCockpit(sessionId, "absent", "2026-01-01T00:00:00Z", null),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    const archiveCalls = calls.filter(
+      (c) => c.url.endsWith("/archive") && c.method === "PATCH",
+    );
+    expect(archiveCalls).toHaveLength(1);
+    expect(archiveCalls[0]!.body).toEqual({
+      archived: false,
+      kill_pane: true,
+    });
+    // Worker is "absent", so the prompt enqueues rather than POSTs.
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+    expect(result.current.state.queuedPrompts[0]!.text).toBe("wake me up");
+  });
+
+  it("clears the snoozed flag via PATCH before enqueueing the prompt", async () => {
+    const sessionId = "sess-wake-snooze";
+    const { result } = renderHook(
+      () => useCockpit(sessionId, "absent", null, "2099-01-01T00:00:00Z"),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    const snoozeCalls = calls.filter(
+      (c) => c.url.endsWith("/snooze") && c.method === "PATCH",
+    );
+    expect(snoozeCalls).toHaveLength(1);
+    expect(snoozeCalls[0]!.body).toEqual({ minutes: null });
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+  });
+
+  it("does not call wake endpoints when the session is live", async () => {
+    const sessionId = "sess-wake-live";
+    const { result } = renderHook(
+      () => useCockpit(sessionId, "absent", null, null),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("just a prompt");
+    });
+    await flushAsync();
+
+    const wakeCalls = calls.filter(
+      (c) =>
+        c.method === "PATCH" &&
+        (c.url.endsWith("/archive") || c.url.endsWith("/snooze")),
+    );
+    expect(wakeCalls).toHaveLength(0);
+    expect(result.current.state.queuedPrompts).toHaveLength(1);
+  });
+
+  it("prefers archive over snooze when both are somehow set (defensive)", async () => {
+    // The server's XOR rules prevent both flags from co-existing on
+    // the same session, but a defensive client should still do
+    // exactly one wake call rather than two. Archive wins because
+    // it is the stronger signal (no auto-wake) and clearing it
+    // implies snooze should also clear via touch_last_accessed in
+    // merge_user_action_diff on the server side.
+    const sessionId = "sess-wake-both";
+    const { result } = renderHook(
+      () =>
+        useCockpit(
+          sessionId,
+          "absent",
+          "2026-01-01T00:00:00Z",
+          "2099-01-01T00:00:00Z",
+        ),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    const archiveCalls = calls.filter(
+      (c) => c.url.endsWith("/archive") && c.method === "PATCH",
+    );
+    const snoozeCalls = calls.filter(
+      (c) => c.url.endsWith("/snooze") && c.method === "PATCH",
+    );
+    expect(archiveCalls).toHaveLength(1);
+    expect(snoozeCalls).toHaveLength(0);
+  });
+});

--- a/web/src/hooks/useCockpit.wake.test.ts
+++ b/web/src/hooks/useCockpit.wake.test.ts
@@ -190,6 +190,101 @@ describe("useCockpit auto-wake on sendPrompt (#1581)", () => {
     expect(result.current.state.queuedPrompts).toHaveLength(1);
   });
 
+  it("does NOT enqueue when the archive wake call fails", async () => {
+    // Regression: a failed wake PATCH used to fall through to the
+    // local enqueue, which left the prompt parked in a queue that
+    // never drains (the reconciler kept skipping the still-archived
+    // session). Surface an error instead so the user knows to retry
+    // or unarchive manually. See #1581 CodeRabbit review.
+    const sessionId = "sess-wake-fail-arch";
+    // Override the default fetch to fail the archive PATCH.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        let body: unknown = null;
+        if (typeof init?.body === "string") {
+          try {
+            body = JSON.parse(init.body);
+          } catch {
+            body = init.body;
+          }
+        }
+        calls.push({ url, method, body });
+        if (url.includes("/cockpit/replay")) {
+          return new Response(
+            JSON.stringify({ frames: [], lost: false, highest_seq: 0 }),
+            { status: 200 },
+          );
+        }
+        if (url.endsWith("/archive") && method === "PATCH") {
+          return new Response("simulated failure", { status: 500 });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    const { result } = renderHook(
+      () => useCockpit(sessionId, "absent", "2026-01-01T00:00:00Z", null),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    expect(result.current.state.queuedPrompts).toHaveLength(0);
+    expect(result.current.state.lastError).toMatch(/wake/i);
+  });
+
+  it("does NOT enqueue when the snooze wake call fails", async () => {
+    const sessionId = "sess-wake-fail-snooze";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        const method = init?.method ?? "GET";
+        let body: unknown = null;
+        if (typeof init?.body === "string") {
+          try {
+            body = JSON.parse(init.body);
+          } catch {
+            body = init.body;
+          }
+        }
+        calls.push({ url, method, body });
+        if (url.includes("/cockpit/replay")) {
+          return new Response(
+            JSON.stringify({ frames: [], lost: false, highest_seq: 0 }),
+            { status: 200 },
+          );
+        }
+        if (url.endsWith("/snooze") && method === "PATCH") {
+          return new Response("simulated failure", { status: 500 });
+        }
+        return new Response("{}", { status: 200 });
+      }),
+    );
+
+    const { result } = renderHook(
+      () =>
+        useCockpit(sessionId, "absent", null, "2099-01-01T00:00:00Z"),
+      { wrapper },
+    );
+    await flushAsync();
+
+    await act(async () => {
+      await result.current.sendPrompt("wake me up");
+    });
+    await flushAsync();
+
+    expect(result.current.state.queuedPrompts).toHaveLength(0);
+    expect(result.current.state.lastError).toMatch(/wake/i);
+  });
+
   it("prefers archive over snooze when both are somehow set (defensive)", async () => {
     // The server's XOR rules prevent both flags from co-existing on
     // the same session, but a defensive client should still do

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -71,7 +71,17 @@ export function useRepoGroups(
         const aTier = workspaceTriageTier(a);
         const bTier = workspaceTriageTier(b);
         if (aTier !== bTier) return aTier - bTier;
-        return rankOf(a.id) - rankOf(b.id);
+        // Two unranked workspaces both yield `Infinity`, and
+        // `Infinity - Infinity` is `NaN`; `Array.sort` treats NaN
+        // like equality and silently skips the tie-break, leaving
+        // ordering at the mercy of input order. Compare with `<`/`>`
+        // and fall through to a deterministic id tie-break so the
+        // render order is stable across re-renders.
+        const ar = rankOf(a.id);
+        const br = rankOf(b.id);
+        if (ar < br) return -1;
+        if (ar > br) return 1;
+        return a.id.localeCompare(b.id);
       });
     const sortByActivity = (list: Workspace[]) =>
       [...list].sort(compareWorkspacesByLastActivityDesc);

--- a/web/src/hooks/useRepoGroups.ts
+++ b/web/src/hooks/useRepoGroups.ts
@@ -10,6 +10,7 @@ import {
 import {
   compareWorkspacesByLastActivityDesc,
   repoGroupLastActivityMs,
+  workspaceTriageTier,
   type SidebarSortMode,
 } from "../lib/sidebarSort";
 
@@ -61,8 +62,17 @@ export function useRepoGroups(
   const groups = useMemo(() => {
     const rank = new Map(workspaceOrdering.map((id, i) => [id, i] as const));
     const rankOf = (id: string) => rank.get(id) ?? Infinity;
+    // Triage tier (pinned at top, sunk at bottom) wins over every sort
+    // mode, so both rank-based and activity-based comparators apply it
+    // first and fall back to their respective within-tier comparison.
+    // See #1581.
     const sortByRank = (list: Workspace[]) =>
-      [...list].sort((a, b) => rankOf(a.id) - rankOf(b.id));
+      [...list].sort((a, b) => {
+        const aTier = workspaceTriageTier(a);
+        const bTier = workspaceTriageTier(b);
+        if (aTier !== bTier) return aTier - bTier;
+        return rankOf(a.id) - rankOf(b.id);
+      });
     const sortByActivity = (list: Workspace[]) =>
       [...list].sort(compareWorkspacesByLastActivityDesc);
     const sortWorkspaces =

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -8,6 +8,8 @@ import {
   loadSidebarSortMode,
   repoGroupLastActivityMs,
   saveSidebarSortMode,
+  triageMenuShape,
+  triageStateOf,
   workspaceIsPinned,
   workspaceIsSunk,
   workspaceLastActivityMs,
@@ -291,6 +293,93 @@ describe("compareWorkspacesByLastActivityDesc triage tier", () => {
     ]);
     const list = [livesB, livesA].sort(compareWorkspacesByLastActivityDesc);
     expect(list.map((w) => w.id)).toEqual(["live-a", "live-b"]);
+  });
+});
+
+describe("triageStateOf", () => {
+  it("returns 'live' when no flag is set", () => {
+    expect(
+      triageStateOf({ isPinned: false, isArchived: false, isSnoozed: false }),
+    ).toBe("live");
+  });
+
+  it("returns 'pinned' when isPinned is set", () => {
+    expect(
+      triageStateOf({ isPinned: true, isArchived: false, isSnoozed: false }),
+    ).toBe("pinned");
+  });
+
+  it("returns 'archived' when only archived is set", () => {
+    expect(
+      triageStateOf({ isPinned: false, isArchived: true, isSnoozed: false }),
+    ).toBe("archived");
+  });
+
+  it("returns 'snoozed' when only snoozed is set", () => {
+    expect(
+      triageStateOf({ isPinned: false, isArchived: false, isSnoozed: true }),
+    ).toBe("snoozed");
+  });
+
+  it("prefers pinned over archived and snoozed (defensive priority)", () => {
+    // The server's XOR rules make pinned + archived impossible at the
+    // session level, but a multi-session workspace can still surface
+    // both via the any-pinned / any-archived aggregators. The state
+    // function picks pinned so the menu does not show contradictory
+    // toggles.
+    expect(
+      triageStateOf({ isPinned: true, isArchived: true, isSnoozed: false }),
+    ).toBe("pinned");
+    expect(
+      triageStateOf({ isPinned: true, isArchived: false, isSnoozed: true }),
+    ).toBe("pinned");
+  });
+});
+
+describe("triageMenuShape", () => {
+  it("a live row offers Pin / Archive / Snooze and no 'Un…' toggles", () => {
+    const shape = triageMenuShape("live");
+    expect(shape.showPin).toBe(true);
+    expect(shape.showArchive).toBe(true);
+    expect(shape.showSnooze).toBe(true);
+    expect(shape.showUnpin).toBe(false);
+    expect(shape.showUnarchive).toBe(false);
+    expect(shape.showUnsnooze).toBe(false);
+  });
+
+  it("a pinned row only offers Unpin", () => {
+    // Regression: a pinned row used to show Archive and Snooze
+    // alongside Unpin, letting the user trigger contradictory
+    // transitions from the menu. See #1581.
+    const shape = triageMenuShape("pinned");
+    expect(shape.showUnpin).toBe(true);
+    expect(shape.showPin).toBe(false);
+    expect(shape.showArchive).toBe(false);
+    expect(shape.showUnarchive).toBe(false);
+    expect(shape.showSnooze).toBe(false);
+    expect(shape.showUnsnooze).toBe(false);
+  });
+
+  it("an archived row only offers Unarchive", () => {
+    // Regression: an archived row used to show Pin and Snooze in
+    // the same menu. See #1581.
+    const shape = triageMenuShape("archived");
+    expect(shape.showUnarchive).toBe(true);
+    expect(shape.showPin).toBe(false);
+    expect(shape.showUnpin).toBe(false);
+    expect(shape.showArchive).toBe(false);
+    expect(shape.showSnooze).toBe(false);
+    expect(shape.showUnsnooze).toBe(false);
+  });
+
+  it("a snoozed row only offers Unsnooze", () => {
+    const shape = triageMenuShape("snoozed");
+    expect(shape.showUnsnooze).toBe(true);
+    expect(shape.showPin).toBe(false);
+    expect(shape.showUnpin).toBe(false);
+    expect(shape.showArchive).toBe(false);
+    expect(shape.showUnarchive).toBe(false);
+    expect(shape.showSnooze).toBe(false);
   });
 });
 

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -9,6 +9,7 @@ import {
   repoGroupLastActivityMs,
   resolveEffectiveSnoozedUntil,
   saveSidebarSortMode,
+  snoozeTimestampCloseEnough,
   triageMenuShape,
   triageStateOf,
   workspaceIsPinned,
@@ -279,6 +280,46 @@ describe("resolveEffectiveSnoozedUntil", () => {
     expect(
       resolveEffectiveSnoozedUntil(null, "2099-01-01T00:00:00Z"),
     ).toBeNull();
+  });
+});
+
+describe("snoozeTimestampCloseEnough", () => {
+  it("treats equal timestamps as a match", () => {
+    expect(
+      snoozeTimestampCloseEnough(
+        "2099-01-01T00:00:00Z",
+        "2099-01-01T00:00:00Z",
+      ),
+    ).toBe(true);
+  });
+
+  it("tolerates a 30-second skew", () => {
+    expect(
+      snoozeTimestampCloseEnough(
+        "2099-01-01T00:00:00Z",
+        "2099-01-01T00:00:30Z",
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a 5-minute skew (re-snooze case)", () => {
+    // Regression: re-snoozing an already-snoozed row used to drop
+    // the optimistic override because the prop and override were
+    // both non-null. The new helper compares actual timestamps so
+    // a 1h re-snooze on a row already sitting on a 1h snooze
+    // (where the server hasn't acked the new duration yet) keeps
+    // the optimistic chip visible. See #1581 CodeRabbit review.
+    expect(
+      snoozeTimestampCloseEnough(
+        "2099-01-01T00:00:00Z",
+        "2099-01-01T00:05:00Z",
+      ),
+    ).toBe(false);
+  });
+
+  it("falls back to literal equality for unparseable strings", () => {
+    expect(snoozeTimestampCloseEnough("not-a-date", "not-a-date")).toBe(true);
+    expect(snoozeTimestampCloseEnough("not-a-date", "also-bad")).toBe(false);
   });
 });
 

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -224,6 +224,37 @@ describe("workspaceIsSunk", () => {
     const ws = workspace("w", []);
     expect(workspaceIsSunk(ws)).toBe(false);
   });
+
+  it("returns true when every session is archived-only (no snooze)", () => {
+    // Branch coverage on the lambda: `archived_at != null` true side
+    // alone, no snoozed_until contribution.
+    const ws = workspace("w", [
+      session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2", archived_at: "2025-02-01T00:00:00Z" }),
+    ]);
+    expect(workspaceIsSunk(ws)).toBe(true);
+  });
+
+  it("returns true when every session is snoozed-only (no archive)", () => {
+    // Branch coverage on the lambda: `snoozed_until != null` true
+    // side alone, after archived_at false short-circuits the `||`.
+    const ws = workspace("w", [
+      session({ id: "s1", snoozed_until: "2099-01-01T00:00:00Z" }),
+      session({ id: "s2", snoozed_until: "2099-02-01T00:00:00Z" }),
+    ]);
+    expect(workspaceIsSunk(ws)).toBe(true);
+  });
+
+  it("returns false when one session has neither flag", () => {
+    // Branch coverage: the lambda's `archived_at != null` false side
+    // AND `snoozed_until != null` false side both fire, then `every`
+    // short-circuits with false.
+    const ws = workspace("w", [
+      session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2" }), // live session breaks the every().
+    ]);
+    expect(workspaceIsSunk(ws)).toBe(false);
+  });
 });
 
 describe("workspaceTriageTier", () => {
@@ -320,6 +351,36 @@ describe("snoozeTimestampCloseEnough", () => {
   it("falls back to literal equality for unparseable strings", () => {
     expect(snoozeTimestampCloseEnough("not-a-date", "not-a-date")).toBe(true);
     expect(snoozeTimestampCloseEnough("not-a-date", "also-bad")).toBe(false);
+  });
+
+  it("covers both `||` short-circuit branches when only one side is unparseable", () => {
+    // Branch coverage: the `!Number.isFinite(a) || !Number.isFinite(b)`
+    // check has 4 outcomes (a/b each parseable or not). The other
+    // cases above hit both-finite and both-unparseable; these two
+    // exercise the mixed cases so v8 sees every branch leg.
+    expect(
+      snoozeTimestampCloseEnough("2099-01-01T00:00:00Z", "not-a-date"),
+    ).toBe(false);
+    expect(
+      snoozeTimestampCloseEnough("not-a-date", "2099-01-01T00:00:00Z"),
+    ).toBe(false);
+  });
+
+  it("rejects exactly at the 2-minute tolerance boundary", () => {
+    // Inclusive boundary at 2 minutes (= 120_000 ms). Just-over
+    // counts as different snoozes; just-under counts as the same.
+    expect(
+      snoozeTimestampCloseEnough(
+        "2099-01-01T00:00:00Z",
+        "2099-01-01T00:02:00Z",
+      ),
+    ).toBe(true);
+    expect(
+      snoozeTimestampCloseEnough(
+        "2099-01-01T00:00:00Z",
+        "2099-01-01T00:02:00.001Z",
+      ),
+    ).toBe(false);
   });
 });
 
@@ -420,6 +481,17 @@ describe("triageStateOf", () => {
     expect(
       triageStateOf({ isPinned: false, isArchived: false, isSnoozed: true }),
     ).toBe("snoozed");
+  });
+
+  it("returns 'archived' when archived + snoozed are both set (no pin)", () => {
+    // Branch coverage: the archived/snoozed branch combo without
+    // pin. Archive wins because the data layer makes it impossible
+    // for a session to be both at once, but workspace aggregators
+    // can surface both via different sessions. Archive is the
+    // stronger sink so the menu picks it.
+    expect(
+      triageStateOf({ isPinned: false, isArchived: true, isSnoozed: true }),
+    ).toBe("archived");
   });
 
   it("prefers pinned over archived and snoozed (defensive priority)", () => {

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -7,6 +7,7 @@ import {
   compareWorkspacesByLastActivityDesc,
   loadSidebarSortMode,
   repoGroupLastActivityMs,
+  resolveEffectiveSnoozedUntil,
   saveSidebarSortMode,
   triageMenuShape,
   triageStateOf,
@@ -245,6 +246,65 @@ describe("workspaceTriageTier", () => {
       session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
     ]);
     expect(workspaceTriageTier(ws)).toBe(2);
+  });
+});
+
+describe("resolveEffectiveSnoozedUntil", () => {
+  it("returns the server value when no optimistic override is set", () => {
+    // Regression: snooze had no optimistic state; the chip waited
+    // for the next sessions-poll to flip, which read laggy compared
+    // to pin / archive's instant feedback. See #1581 CodeRabbit
+    // review. `undefined` on the optimistic side means "no override,
+    // fall through to the server value."
+    expect(resolveEffectiveSnoozedUntil(undefined, null)).toBeNull();
+    expect(
+      resolveEffectiveSnoozedUntil(undefined, "2099-01-01T00:00:00Z"),
+    ).toBe("2099-01-01T00:00:00Z");
+  });
+
+  it("uses an optimistic string to render the snooze chip pre-PATCH", () => {
+    // Regression: clicking a preset must flip the chip immediately,
+    // not wait for the round-trip. Optimistic value wins over the
+    // (still-null) server prop until the next poll mirrors it.
+    expect(
+      resolveEffectiveSnoozedUntil("2099-01-01T00:00:00Z", null),
+    ).toBe("2099-01-01T00:00:00Z");
+  });
+
+  it("uses an explicit null override to hide the chip pre-PATCH on unsnooze", () => {
+    // Clicking Unsnooze flips the chip away while the PATCH is in
+    // flight. The optimistic null wins until the server prop also
+    // returns null and the clear-on-prop-sync effect drops the
+    // override.
+    expect(
+      resolveEffectiveSnoozedUntil(null, "2099-01-01T00:00:00Z"),
+    ).toBeNull();
+  });
+});
+
+describe("rank-based comparator with two unranked workspaces", () => {
+  it("compares with `<`/`>` instead of subtraction to avoid NaN", () => {
+    // Regression: two workspaces missing from the persisted ordering
+    // both resolve to `Infinity`; `Infinity - Infinity` is `NaN`,
+    // which `Array.prototype.sort` treats like equality and silently
+    // skips the id tie-break, leaving order at the mercy of input
+    // order. This test simulates the same rank-based comparator used
+    // by `useRepoGroups.sortByRank` and asserts deterministic order
+    // by id ascending. See #1581 CodeRabbit review.
+    const rank = new Map<string, number>();
+    const rankOf = (id: string) => rank.get(id) ?? Infinity;
+    const cmp = (a: Workspace, b: Workspace) => {
+      const ar = rankOf(a.id);
+      const br = rankOf(b.id);
+      if (ar < br) return -1;
+      if (ar > br) return 1;
+      return a.id.localeCompare(b.id);
+    };
+    const wsZ = workspace("z", [session({ id: "sz" })]);
+    const wsA = workspace("a", [session({ id: "sa" })]);
+    const wsM = workspace("m", [session({ id: "sm" })]);
+    const sorted = [wsZ, wsA, wsM].sort(cmp);
+    expect(sorted.map((w) => w.id)).toEqual(["a", "m", "z"]);
   });
 });
 

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -8,7 +8,10 @@ import {
   loadSidebarSortMode,
   repoGroupLastActivityMs,
   saveSidebarSortMode,
+  workspaceIsPinned,
+  workspaceIsSunk,
   workspaceLastActivityMs,
+  workspaceTriageTier,
 } from "../sidebarSort";
 
 function session(over: Partial<SessionResponse> = {}): SessionResponse {
@@ -176,6 +179,118 @@ describe("repoGroupLastActivityMs", () => {
 
   it("returns NEGATIVE_INFINITY on an empty group", () => {
     expect(repoGroupLastActivityMs([])).toBe(Number.NEGATIVE_INFINITY);
+  });
+});
+
+describe("workspaceIsPinned", () => {
+  it("returns true when any session has pinned_at set", () => {
+    const ws = workspace("w", [
+      session({ id: "s1" }),
+      session({ id: "s2", pinned_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    expect(workspaceIsPinned(ws)).toBe(true);
+  });
+
+  it("returns false when no session is pinned", () => {
+    const ws = workspace("w", [session({ id: "s1" }), session({ id: "s2" })]);
+    expect(workspaceIsPinned(ws)).toBe(false);
+  });
+});
+
+describe("workspaceIsSunk", () => {
+  it("returns true when every session is archived or snoozed", () => {
+    const ws = workspace("w", [
+      session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2", snoozed_until: "2026-01-01T00:00:00Z" }),
+    ]);
+    expect(workspaceIsSunk(ws)).toBe(true);
+  });
+
+  it("returns false when even one session is live", () => {
+    // A multi-session workspace with one live session must stay in the
+    // active tier rather than sinking the whole group out of sight.
+    const ws = workspace("w", [
+      session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2" }),
+    ]);
+    expect(workspaceIsSunk(ws)).toBe(false);
+  });
+
+  it("returns false on an empty workspace", () => {
+    const ws = workspace("w", []);
+    expect(workspaceIsSunk(ws)).toBe(false);
+  });
+});
+
+describe("workspaceTriageTier", () => {
+  it("returns 0 (pinned) for any pinned session, overriding sink fields", () => {
+    // Pin clears archive/snooze server-side, but a sibling session in
+    // the same workspace could still be archived. Any-pinned wins.
+    const ws = workspace("w", [
+      session({ id: "s1", pinned_at: "2025-01-01T00:00:00Z" }),
+      session({ id: "s2", archived_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    expect(workspaceTriageTier(ws)).toBe(0);
+  });
+
+  it("returns 1 (live) when neither pinned nor fully sunk", () => {
+    const ws = workspace("w", [session({ id: "s1" })]);
+    expect(workspaceTriageTier(ws)).toBe(1);
+  });
+
+  it("returns 2 (sunk) when every session is archived or snoozed", () => {
+    const ws = workspace("w", [
+      session({ id: "s1", archived_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    expect(workspaceTriageTier(ws)).toBe(2);
+  });
+});
+
+describe("compareWorkspacesByLastActivityDesc triage tier", () => {
+  it("sinks fully-archived workspaces below live ones regardless of activity", () => {
+    // The archived workspace has the most recent activity timestamp; if
+    // the comparator naively used activity only it would sort first.
+    // Triage tier forces it to the bottom.
+    const archived = workspace("archived-newer", [
+      session({
+        id: "sa",
+        created_at: "2025-09-01T00:00:00Z",
+        archived_at: "2025-09-02T00:00:00Z",
+      }),
+    ]);
+    const live = workspace("live-older", [
+      session({ id: "sl", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const list = [archived, live].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["live-older", "archived-newer"]);
+  });
+
+  it("lifts pinned workspaces above live ones regardless of activity", () => {
+    // The pinned workspace has the older activity timestamp; without
+    // the tier prefix the live one would sort first.
+    const pinned = workspace("pinned-older", [
+      session({
+        id: "sp",
+        created_at: "2025-01-01T00:00:00Z",
+        pinned_at: "2025-01-02T00:00:00Z",
+      }),
+    ]);
+    const live = workspace("live-newer", [
+      session({ id: "sl", created_at: "2025-09-01T00:00:00Z" }),
+    ]);
+    const list = [live, pinned].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["pinned-older", "live-newer"]);
+  });
+
+  it("preserves activity order within the same tier", () => {
+    const livesA = workspace("live-a", [
+      session({ id: "sa", created_at: "2025-09-01T00:00:00Z" }),
+    ]);
+    const livesB = workspace("live-b", [
+      session({ id: "sb", created_at: "2025-01-01T00:00:00Z" }),
+    ]);
+    const list = [livesB, livesA].sort(compareWorkspacesByLastActivityDesc);
+    expect(list.map((w) => w.id)).toEqual(["live-a", "live-b"]);
   });
 });
 

--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -16,7 +16,14 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { fetchAbout, isDebugBuild, type ServerAbout } from "./api";
+import {
+  fetchAbout,
+  isDebugBuild,
+  setSessionArchive,
+  setSessionPin,
+  setSessionSnooze,
+  type ServerAbout,
+} from "./api";
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -92,6 +99,91 @@ describe("fetchAbout", () => {
     fetchSpy.mockResolvedValueOnce(jsonResponse(makeAbout()));
     await fetchAbout();
     expect(fetchSpy).toHaveBeenCalledWith("/api/about", undefined);
+  });
+});
+
+describe("setSessionPin", () => {
+  it("PATCHes /api/sessions/{id}/pin with the pinned bool", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      jsonResponse({ id: "sess-1", pinned_at: "2026-01-01T00:00:00Z" }),
+    );
+    await setSessionPin("sess-1", true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-1/pin");
+    expect(init?.method).toBe("PATCH");
+    expect(JSON.parse(init!.body as string)).toEqual({ pinned: true });
+  });
+
+  it("forwards `pinned: false` for the unpin path", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionPin("sess-1", false);
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      pinned: false,
+    });
+  });
+
+  it("returns null on non-2xx", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 500 }));
+    expect(await setSessionPin("sess-1", true)).toBeNull();
+  });
+
+  it("returns null on network failure", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("offline"));
+    expect(await setSessionPin("sess-1", true)).toBeNull();
+  });
+});
+
+describe("setSessionArchive", () => {
+  it("defaults kill_pane to true (TUI/CLI parity)", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionArchive("sess-1", true);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-1/archive");
+    expect(JSON.parse(init!.body as string)).toEqual({
+      archived: true,
+      kill_pane: true,
+    });
+  });
+
+  it("forwards an explicit kill_pane=false", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionArchive("sess-1", true, false);
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      archived: true,
+      kill_pane: false,
+    });
+  });
+
+  it("PATCHes archived=false to unarchive", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionArchive("sess-1", false);
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      archived: false,
+      kill_pane: true,
+    });
+  });
+});
+
+describe("setSessionSnooze", () => {
+  it("PATCHes minutes as a positive integer", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionSnooze("sess-1", 60);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("/api/sessions/sess-1/snooze");
+    expect(JSON.parse(init!.body as string)).toEqual({ minutes: 60 });
+  });
+
+  it("PATCHes minutes=null to unsnooze", async () => {
+    fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "sess-1" }));
+    await setSessionSnooze("sess-1", null);
+    expect(JSON.parse(fetchSpy.mock.calls[0]![1]!.body as string)).toEqual({
+      minutes: null,
+    });
+  });
+
+  it("returns null on 400 (server rejected an out-of-range duration)", async () => {
+    fetchSpy.mockResolvedValueOnce(new Response("", { status: 400 }));
+    expect(await setSessionSnooze("sess-1", 0)).toBeNull();
   });
 });
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -883,6 +883,73 @@ export async function setSessionDiffBase(
   }
 }
 
+/** Toggle the web-only "pin" marker on a session. Pinned workspaces sink
+ *  to the top of the sidebar in all sort modes (manual and lastActivity).
+ *  Distinct from the TUI favorite signal. See #1581. */
+export async function setSessionPin(
+  id: string,
+  pinned: boolean,
+): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/pin`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ pinned }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** Archive or unarchive a session. On archive, the server kills the tmux
+ *  pane (when `killPane` is true or omitted, matching TUI/CLI semantics)
+ *  and shuts down the cockpit worker for cockpit-mode sessions; the
+ *  reconciler will not respawn it because archived sessions are excluded
+ *  from the resume target list. Sending a message via the dashboard
+ *  auto-unarchives via the existing `touch_last_accessed` invariant in
+ *  the send handler. See #1581. */
+export async function setSessionArchive(
+  id: string,
+  archived: boolean,
+  killPane = true,
+): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/archive`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archived, kill_pane: killPane }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
+/** Snooze or unsnooze a session. Pass `null` to unsnooze, or a positive
+ *  number of minutes between 1 and 43200 (30 days) to snooze. The server
+ *  validates against the shared `validate_snooze_duration` so the bounds
+ *  match the TUI dialog presets and the CLI's `aoe session snooze`. See
+ *  #1581. */
+export async function setSessionSnooze(
+  id: string,
+  minutes: number | null,
+): Promise<SessionResponse | null> {
+  try {
+    const res = await fetch(`/api/sessions/${id}/snooze`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ minutes }),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as SessionResponse;
+  } catch {
+    return null;
+  }
+}
+
 export interface DeleteSessionOptions {
   delete_worktree?: boolean;
   delete_branch?: boolean;

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -85,6 +85,22 @@ export function workspaceTriageTier(ws: Workspace): 0 | 1 | 2 {
   return 1;
 }
 
+/** Resolve the "effective" snoozed_until value the row should render
+ *  with, given a server-derived prop and an optimistic local
+ *  override. `undefined` on the optimistic side means "no override,
+ *  fall through"; `null` means "pretend the server already
+ *  unsnoozed"; a string means "pretend the server already snoozed
+ *  until then." Extracted as a pure helper so the optimistic
+ *  resolution is unit-testable without mounting the whole sidebar.
+ *  See #1581 CodeRabbit review. */
+export function resolveEffectiveSnoozedUntil(
+  optimistic: string | null | undefined,
+  serverValue: string | null | undefined,
+): string | null | undefined {
+  if (optimistic === undefined) return serverValue;
+  return optimistic;
+}
+
 /** Triage state of a single session row, used by the sidebar context
  *  menu to decide which actions to show. The state machine is
  *  mutually exclusive: only one of pinned/archived/snoozed can be the

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -54,17 +54,54 @@ export function repoGroupLastActivityMs(
   return best;
 }
 
-/** Stable, deterministic comparator. Activity descending, tie-break by id
- *  ascending so equal timestamps never flake the render order. The two
- *  activity keys are compared with `<` / `>` rather than subtraction
- *  because workspaces with no usable timestamp return
- *  `Number.NEGATIVE_INFINITY`; `-Infinity - -Infinity` is `NaN`, which
- *  `Array.prototype.sort` treats like `0` (equal) and would silently skip
- *  the id tie-break, leaving ordering at the mercy of input order. */
+/** True when at least one of the workspace's sessions has been
+ *  web-pinned. Mirrors the aggregator shape used for `isFavorited` in
+ *  `WorkspaceSidebar.tsx`. See #1581. */
+export function workspaceIsPinned(ws: Workspace): boolean {
+  return ws.sessions.some((s) => s.pinned_at != null);
+}
+
+/** True when every one of the workspace's sessions is in a sink state
+ *  (archived or currently snoozed). Uses an "all sessions sunk"
+ *  aggregator on purpose: a multi-session workspace with one running
+ *  session must not disappear into the collapsible footer just because
+ *  a sibling session was archived. See #1581. */
+export function workspaceIsSunk(ws: Workspace): boolean {
+  if (ws.sessions.length === 0) return false;
+  return ws.sessions.every(
+    (s) => s.archived_at != null || s.snoozed_until != null,
+  );
+}
+
+/** Triage tier for a workspace: 0 = pinned (top of every sort), 1 =
+ *  live (default), 2 = sunk (bottom of every sort, target of the
+ *  collapsible "Snoozed & archived" section). A workspace cannot be
+ *  both pinned and sunk because `Instance::pin()` clears the sink
+ *  fields server-side, so any pinned session keeps the whole workspace
+ *  in tier 0 even if a sibling session is archived. See #1581. */
+export function workspaceTriageTier(ws: Workspace): 0 | 1 | 2 {
+  if (workspaceIsPinned(ws)) return 0;
+  if (workspaceIsSunk(ws)) return 2;
+  return 1;
+}
+
+/** Stable, deterministic comparator. Triage tier wins first (pinned at
+ *  the top, sunk at the bottom, regardless of sort mode); within tier
+ *  the comparator falls back to last-activity descending, with id
+ *  ascending as the tie-break so equal timestamps never flake the
+ *  render order. The two activity keys are compared with `<` / `>`
+ *  rather than subtraction because workspaces with no usable timestamp
+ *  return `Number.NEGATIVE_INFINITY`; `-Infinity - -Infinity` is
+ *  `NaN`, which `Array.prototype.sort` treats like `0` (equal) and
+ *  would silently skip the id tie-break, leaving ordering at the mercy
+ *  of input order. */
 export function compareWorkspacesByLastActivityDesc(
   a: Workspace,
   b: Workspace,
 ): number {
+  const aTier = workspaceTriageTier(a);
+  const bTier = workspaceTriageTier(b);
+  if (aTier !== bTier) return aTier - bTier;
   const aMs = workspaceLastActivityMs(a);
   const bMs = workspaceLastActivityMs(b);
   if (aMs < bMs) return 1;

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -85,6 +85,24 @@ export function workspaceTriageTier(ws: Workspace): 0 | 1 | 2 {
   return 1;
 }
 
+/** Whether two RFC3339 snooze timestamps are close enough to count
+ *  as the same snooze deadline, given some unavoidable skew between
+ *  the client's `Date.now()` (used to mint the optimistic preview)
+ *  and the server's `Utc::now()` (used by `Instance::snooze`). A 2
+ *  minute tolerance covers serialization rounding, daemon RTT, and
+ *  small clock drift without letting a brand-new snooze get swapped
+ *  back to a stale one. Unparseable strings fall back to literal
+ *  equality so the helper is defensive. See #1581. */
+export function snoozeTimestampCloseEnough(
+  aIso: string,
+  bIso: string,
+): boolean {
+  const a = Date.parse(aIso);
+  const b = Date.parse(bIso);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return aIso === bIso;
+  return Math.abs(a - b) <= 2 * 60_000;
+}
+
 /** Resolve the "effective" snoozed_until value the row should render
  *  with, given a server-derived prop and an optimistic local
  *  override. `undefined` on the optimistic side means "no override,

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -85,6 +85,83 @@ export function workspaceTriageTier(ws: Workspace): 0 | 1 | 2 {
   return 1;
 }
 
+/** Triage state of a single session row, used by the sidebar context
+ *  menu to decide which actions to show. The state machine is
+ *  mutually exclusive: only one of pinned/archived/snoozed can be the
+ *  active state at a time (the server's XOR rules in
+ *  `Instance::pin/archive/snooze` enforce this), so the menu only
+ *  offers the corresponding "Un…" toggle plus Rename / Notifications
+ *  / Delete. Live rows get the full Pin / Archive / Snooze… set.
+ *  See #1581. */
+export type TriageState = "live" | "pinned" | "archived" | "snoozed";
+
+/** Action visibility from a triage state. The state machine assumes
+ *  the server has already enforced mutual exclusion, so a row that is
+ *  archived simply cannot also be pinned: the menu would show two
+ *  contradictory toggles. Priority for the (impossible-but-defensive)
+ *  case where a workspace aggregator surfaces more than one tier:
+ *  pinned > archived > snoozed > live. */
+export interface TriageMenuShape {
+  showPin: boolean;
+  showUnpin: boolean;
+  showArchive: boolean;
+  showUnarchive: boolean;
+  showSnooze: boolean;
+  showUnsnooze: boolean;
+}
+
+export function triageStateOf(input: {
+  isPinned: boolean;
+  isArchived: boolean;
+  isSnoozed: boolean;
+}): TriageState {
+  if (input.isPinned) return "pinned";
+  if (input.isArchived) return "archived";
+  if (input.isSnoozed) return "snoozed";
+  return "live";
+}
+
+export function triageMenuShape(state: TriageState): TriageMenuShape {
+  switch (state) {
+    case "pinned":
+      return {
+        showPin: false,
+        showUnpin: true,
+        showArchive: false,
+        showUnarchive: false,
+        showSnooze: false,
+        showUnsnooze: false,
+      };
+    case "archived":
+      return {
+        showPin: false,
+        showUnpin: false,
+        showArchive: false,
+        showUnarchive: true,
+        showSnooze: false,
+        showUnsnooze: false,
+      };
+    case "snoozed":
+      return {
+        showPin: false,
+        showUnpin: false,
+        showArchive: false,
+        showUnarchive: false,
+        showSnooze: false,
+        showUnsnooze: true,
+      };
+    case "live":
+      return {
+        showPin: true,
+        showUnpin: false,
+        showArchive: true,
+        showUnarchive: false,
+        showSnooze: true,
+        showUnsnooze: false,
+      };
+  }
+}
+
 /** Stable, deterministic comparator. Triage tier wins first (pinned at
  *  the top, sunk at the bottom, regardless of sort mode); within tier
  *  the comparator falls back to last-activity descending, with id

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -41,6 +41,24 @@ export interface SessionResponse {
    *  rows and prepends a `*` marker. Toggled via the TUI `f`/`F` keybind
    *  or `aoe session favorite|unfavorite`. */
   favorited: boolean;
+  /** RFC3339 timestamp at which the session was web-pinned, or null /
+   *  undefined when not pinned. Distinct from `favorited`: favorite is
+   *  the TUI within-tier attention-sort signal; pin is the hard
+   *  top-of-sort surfacing primitive used by the web sidebar. Derive
+   *  `isPinned = pinned_at != null` client-side; no separate boolean is
+   *  exposed (the timestamp itself is the source of truth). See #1581. */
+  pinned_at?: string | null;
+  /** RFC3339 timestamp at which the session was archived, or null /
+   *  undefined when not archived. Archived workspaces sink into the
+   *  collapsible "Snoozed & archived" footer of their repo group and
+   *  their tmux pane is killed by the archive handler. See #1581. */
+  archived_at?: string | null;
+  /** RFC3339 timestamp at which an active snooze expires, or null /
+   *  undefined when not snoozed. The server gates this on
+   *  `Instance::is_snoozed()` so an expired snooze that is still on disk
+   *  comes back as null on the wire; the web therefore only needs to
+   *  treat any non-null value as an active snooze. See #1581. */
+  snoozed_until?: string | null;
   has_managed_worktree: boolean;
   has_terminal: boolean;
   profile: string;

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1916,6 +1916,17 @@
       "components": [
         "web/src/lib/api.ts"
       ]
+    },
+    {
+      "id": "triage.snooze-modal",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SnoozeModal.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1871,6 +1871,51 @@
         "web/src/components/session-wizard/sessionNames.ts",
         "web/src/components/session-wizard/steps/ReviewStep.tsx"
       ]
+    },
+    {
+      "id": "triage.pin-toggle",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/triage-pin.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx",
+        "web/src/lib/sidebarSort.ts"
+      ]
+    },
+    {
+      "id": "triage.archive-toggle",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/triage-archive.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "triage.snooze-toggle",
+      "kind": "live-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/live/triage-snooze.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "triage.api-wire-format",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/api.test.ts"
+      ],
+      "components": [
+        "web/src/lib/api.ts"
+      ]
     }
   ]
 }

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1927,6 +1927,28 @@
       "components": [
         "web/src/components/WorkspaceSidebar.tsx"
       ]
+    },
+    {
+      "id": "triage.session-row-chips",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/__tests__/SessionRowTriage.test.tsx"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "triage.cockpit-banners",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/__tests__/TriageBanners.test.tsx"
+      ],
+      "components": [
+        "web/src/components/cockpit/CockpitView.tsx"
+      ]
     }
   ]
 }

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -1,0 +1,142 @@
+// Live coverage for the sidebar archive flow (#1581):
+//   - Right-click a session row → context menu → Archive.
+//   - PATCH /api/sessions/{id}/archive lands with { archived: true, kill_pane: true }.
+//   - The row moves into the collapsible "Snoozed & archived" footer.
+//   - `archived_at` is set on the server and survives a reload.
+//   - Unarchive via the menu (after expanding the footer) round-trips back to live.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("sidebar archive via context menu (#1581)", () => {
+  base("archive sinks the row into the collapsible footer and persists", async ({ page }, testInfo) => {
+    const title = "archive-target";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
+
+      // ---- Archive ----
+      await row.click({ button: "right" });
+      const archivePatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/archive`) &&
+          res.request().method() === "PATCH",
+      );
+      await page
+        .locator("[data-testid='sidebar-context-menu-archive']")
+        .click();
+      const response = await archivePatch;
+      expect(response.ok()).toBe(true);
+      expect(response.request().postDataJSON()).toEqual({
+        archived: true,
+        kill_pane: true,
+      });
+
+      // Server reflects the archive in the next list response.
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.archived_at;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeTruthy();
+
+      // The row is no longer in the live tier; the collapsible footer
+      // appears with the archived count.
+      const sunkSection = page.locator("[data-testid='sidebar-sunk-section']");
+      await expect(sunkSection).toBeVisible({ timeout: 5_000 });
+
+      // Default collapsed: the archived row is not visible until the
+      // footer is expanded.
+      const archivedRowInFooter = sunkSection.locator(
+        "[data-testid='sidebar-session-row']",
+      );
+      await expect(archivedRowInFooter).toHaveCount(0);
+
+      // Expand and find the row.
+      await sunkSection.locator("[data-testid='sidebar-sunk-toggle']").click();
+      await expect(archivedRowInFooter).toContainText(title);
+      await expect(
+        archivedRowInFooter.locator("[aria-label='Archived']"),
+      ).toBeVisible();
+
+      // Reload: archive state survives the persistence layer; the
+      // footer is still default-collapsed if the per-group localStorage
+      // entry was not set yet, but the row's archived_at remains.
+      await page.reload();
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.archived_at;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeTruthy();
+
+      // ---- Unarchive (after expanding the footer post-reload) ----
+      const reloadedFooter = page.locator(
+        "[data-testid='sidebar-sunk-section']",
+      );
+      // The footer may already be expanded if localStorage saved the
+      // toggle from the earlier expand; only click the toggle when the
+      // archived row isn't yet visible.
+      const reloadedArchivedRow = reloadedFooter.locator(
+        "[data-testid='sidebar-session-row']",
+      );
+      if ((await reloadedArchivedRow.count()) === 0) {
+        await reloadedFooter
+          .locator("[data-testid='sidebar-sunk-toggle']")
+          .click();
+      }
+      await expect(reloadedArchivedRow).toContainText(title);
+
+      const unarchivePatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/archive`) &&
+          res.request().method() === "PATCH",
+      );
+      await reloadedArchivedRow.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-archive']")
+        .click();
+      const unResponse = await unarchivePatch;
+      expect(unResponse.ok()).toBe(true);
+      expect(unResponse.request().postDataJSON()).toEqual({
+        archived: false,
+        kill_pane: true,
+      });
+
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.archived_at ?? null;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeNull();
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -97,18 +97,25 @@ base.describe("sidebar archive via context menu (#1581)", () => {
       const reloadedFooter = page.locator(
         "[data-testid='sidebar-sunk-section']",
       );
-      // The footer may already be expanded if localStorage saved the
-      // toggle from the earlier expand; only click the toggle when the
-      // archived row isn't yet visible.
+      await expect(reloadedFooter).toBeVisible({ timeout: 10_000 });
+
+      // Use the toggle's `aria-expanded` attribute as the source of
+      // truth for the footer state; the previous `count() === 0`
+      // pre-check raced against hydration and could flip the toggle
+      // CLOSED when localStorage had already auto-expanded it.
+      const reloadedToggle = reloadedFooter.locator(
+        "[data-testid='sidebar-sunk-toggle']",
+      );
+      const expanded = await reloadedToggle.getAttribute("aria-expanded");
+      if (expanded !== "true") {
+        await reloadedToggle.click();
+      }
       const reloadedArchivedRow = reloadedFooter.locator(
         "[data-testid='sidebar-session-row']",
       );
-      if ((await reloadedArchivedRow.count()) === 0) {
-        await reloadedFooter
-          .locator("[data-testid='sidebar-sunk-toggle']")
-          .click();
-      }
-      await expect(reloadedArchivedRow).toContainText(title);
+      await expect(reloadedArchivedRow).toContainText(title, {
+        timeout: 10_000,
+      });
 
       const unarchivePatch = page.waitForResponse(
         (res) =>

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -79,6 +79,19 @@ base.describe("sidebar archive via context menu (#1581)", () => {
         archivedRowInFooter.locator("[aria-label='Archived']"),
       ).toBeVisible();
 
+      // Regression: an archived row's menu only offers Unarchive, not
+      // the contradictory Pin or Snooze toggles. See #1581.
+      await archivedRowInFooter.click({ button: "right" });
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-archive']"),
+      ).toContainText("Unarchive");
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-pin']"),
+      ).toHaveCount(0);
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-snooze']"),
+      ).toHaveCount(0);
+
       // Reload: archive state survives the persistence layer; the
       // footer is still default-collapsed if the per-group localStorage
       // entry was not set yet, but the row's archived_at remains.

--- a/web/tests/live/triage-pin.spec.ts
+++ b/web/tests/live/triage-pin.spec.ts
@@ -60,6 +60,22 @@ base.describe("sidebar pin via context menu (#1581)", () => {
         timeout: 5_000,
       });
 
+      // Regression: a pinned row's menu only offers Unpin, not the
+      // contradictory Archive or Snooze toggles. The Pin button still
+      // exists because its testid is shared with Unpin; the others
+      // must be hidden entirely. See #1581. The reload below resets
+      // the page so we don't need to dismiss the menu by hand.
+      await row.click({ button: "right" });
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-pin']"),
+      ).toContainText("Unpin");
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-archive']"),
+      ).toHaveCount(0);
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-snooze']"),
+      ).toHaveCount(0);
+
       // Server reflects the pin in the next list response.
       await expect
         .poll(

--- a/web/tests/live/triage-pin.spec.ts
+++ b/web/tests/live/triage-pin.spec.ts
@@ -1,0 +1,108 @@
+// Live coverage for the sidebar pin flow (#1581):
+//   - Right-click a session row → context menu → Pin.
+//   - PATCH /api/sessions/{id}/pin lands with { pinned: true }.
+//   - The row immediately renders the Pin glyph (optimistic) and
+//     `pinned_at` survives a hard reload through the persistence layer.
+//   - Unpin via the same menu round-trips back to `pinned_at == null`.
+//
+// The PATCH handler lives in `src/server/api/sessions.rs::update_session_pin`;
+// the render path is in `web/src/components/WorkspaceSidebar.tsx` (the Pin
+// glyph plus the `Pin/Unpin` menu entry). Live coverage catches wire-format
+// drift on either side that mocked specs miss.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("sidebar pin via context menu (#1581)", () => {
+  base("pin → unpin round-trip lands on the server and survives reload", async ({ page }, testInfo) => {
+    const title = "pin-target";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toHaveCount(1, { timeout: 10_000 });
+      await expect(row).toContainText(title, { timeout: 10_000 });
+
+      // ---- Pin ----
+      await row.click({ button: "right" });
+      const menu = page.locator("[data-testid='sidebar-context-menu']");
+      await expect(menu).toBeVisible();
+
+      const pinPatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/pin`) &&
+          res.request().method() === "PATCH",
+      );
+
+      await menu.locator("[data-testid='sidebar-context-menu-pin']").click();
+
+      const pinResponse = await pinPatch;
+      expect(pinResponse.ok()).toBe(true);
+      expect(pinResponse.request().postDataJSON()).toEqual({ pinned: true });
+
+      // Pin glyph appears on the row (aria-label is the stable hook).
+      await expect(row.locator("[aria-label='Pinned']")).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // Server reflects the pin in the next list response.
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.pinned_at;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeTruthy();
+
+      // Reload: pin survives the persistence layer (no in-memory only state).
+      await page.reload();
+      const reloadedRow = page.locator("[data-testid='sidebar-session-row']");
+      await expect(reloadedRow.locator("[aria-label='Pinned']")).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // ---- Unpin ----
+      await reloadedRow.click({ button: "right" });
+      const unpinPatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/pin`) &&
+          res.request().method() === "PATCH",
+      );
+      await page
+        .locator("[data-testid='sidebar-context-menu-pin']")
+        .click();
+      const unpinResponse = await unpinPatch;
+      expect(unpinResponse.ok()).toBe(true);
+      expect(unpinResponse.request().postDataJSON()).toEqual({ pinned: false });
+
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.pinned_at ?? null;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeNull();
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/triage-snooze.spec.ts
+++ b/web/tests/live/triage-snooze.spec.ts
@@ -87,6 +87,21 @@ base.describe("sidebar snooze via context menu (#1581)", () => {
       await expect(snoozedRow).toContainText(title);
       await expect(snoozedRow.locator("[aria-label='Snoozed']")).toBeVisible();
 
+      // Regression: a snoozed row's menu only offers Unsnooze, not
+      // the contradictory Pin or Archive toggles. See #1581.
+      await snoozedRow.click({ button: "right" });
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-unsnooze']"),
+      ).toBeVisible();
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-pin']"),
+      ).toHaveCount(0);
+      await expect(
+        page.locator("[data-testid='sidebar-context-menu-archive']"),
+      ).toHaveCount(0);
+      // Close the menu before clicking Unsnooze in the next step.
+      await page.mouse.click(5, 5);
+
       // ---- Unsnooze ----
       const unsnoozePatch = page.waitForResponse(
         (res) =>

--- a/web/tests/live/triage-snooze.spec.ts
+++ b/web/tests/live/triage-snooze.spec.ts
@@ -1,0 +1,115 @@
+// Live coverage for the sidebar snooze flow (#1581):
+//   - Right-click a session row → context menu → Snooze….
+//   - Eight flat presets render (60 / 120 / 180 / 240 / 300 / 360 / 1440 /
+//     10080 minutes) matching `src/tui/dialogs/snooze_duration.rs`.
+//   - Picking "1 hour" PATCHes /api/sessions/{id}/snooze with { minutes: 60 },
+//     sets `snoozed_until` on the server, and sinks the row into the
+//     collapsible footer.
+//   - Unsnooze via the menu round-trips back to live.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../helpers/aoeServe";
+
+base.describe("sidebar snooze via context menu (#1581)", () => {
+  base("snooze preset list + 1h pick + unsnooze round-trip", async ({ page }, testInfo) => {
+    const title = "snooze-target";
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      expect(sessions).toHaveLength(1);
+      const sessionId = sessions[0]!.id as string;
+
+      await page.goto(`${serve.baseUrl}/`);
+
+      const row = page.locator("[data-testid='sidebar-session-row']");
+      await expect(row).toContainText(title, { timeout: 10_000 });
+
+      // ---- Open snooze submenu, confirm 8 presets ----
+      await row.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-snooze']")
+        .click();
+
+      const presets = [60, 120, 180, 240, 300, 360, 1440, 10080];
+      for (const m of presets) {
+        await expect(
+          page.locator(`[data-testid='sidebar-context-menu-snooze-${m}']`),
+        ).toBeVisible();
+      }
+
+      // ---- Pick 1 hour ----
+      const snoozePatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/snooze`) &&
+          res.request().method() === "PATCH",
+      );
+      const issuedAt = Date.now();
+      await page
+        .locator("[data-testid='sidebar-context-menu-snooze-60']")
+        .click();
+      const response = await snoozePatch;
+      expect(response.ok()).toBe(true);
+      expect(response.request().postDataJSON()).toEqual({ minutes: 60 });
+
+      // Server reflects the snooze; `snoozed_until` lands within ~60min
+      // of issue time (tolerance for clock skew + network latency).
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            const ts = list[0]?.snoozed_until as string | undefined;
+            if (!ts) return null;
+            return Date.parse(ts);
+          },
+          { timeout: 5_000 },
+        )
+        .toBeGreaterThan(issuedAt + 55 * 60_000);
+
+      // Row sinks into the collapsible "Snoozed & archived" footer.
+      const sunkSection = page.locator("[data-testid='sidebar-sunk-section']");
+      await expect(sunkSection).toBeVisible({ timeout: 5_000 });
+      await sunkSection.locator("[data-testid='sidebar-sunk-toggle']").click();
+      const snoozedRow = sunkSection.locator(
+        "[data-testid='sidebar-session-row']",
+      );
+      await expect(snoozedRow).toContainText(title);
+      await expect(snoozedRow.locator("[aria-label='Snoozed']")).toBeVisible();
+
+      // ---- Unsnooze ----
+      const unsnoozePatch = page.waitForResponse(
+        (res) =>
+          res.url().endsWith(`/api/sessions/${sessionId}/snooze`) &&
+          res.request().method() === "PATCH",
+      );
+      await snoozedRow.click({ button: "right" });
+      await page
+        .locator("[data-testid='sidebar-context-menu-unsnooze']")
+        .click();
+      const unResponse = await unsnoozePatch;
+      expect(unResponse.ok()).toBe(true);
+      expect(unResponse.request().postDataJSON()).toEqual({ minutes: null });
+
+      await expect
+        .poll(
+          async () => {
+            const list = await listSessions(serve.baseUrl);
+            return list[0]?.snoozed_until ?? null;
+          },
+          { timeout: 5_000 },
+        )
+        .toBeNull();
+    } finally {
+      await serve.stop();
+    }
+  });
+});

--- a/web/tests/live/triage-snooze.spec.ts
+++ b/web/tests/live/triage-snooze.spec.ts
@@ -1,11 +1,12 @@
 // Live coverage for the sidebar snooze flow (#1581):
-//   - Right-click a session row → context menu → Snooze….
-//   - Eight flat presets render (60 / 120 / 180 / 240 / 300 / 360 / 1440 /
-//     10080 minutes) matching `src/tui/dialogs/snooze_duration.rs`.
+//   - Right-click a session row → context menu → "Snooze…".
+//   - A modal opens with the eight TUI presets (60 / 120 / 180 / 240 /
+//     300 / 360 / 1440 / 10080 minutes) matching
+//     `src/tui/dialogs/snooze_duration.rs`.
 //   - Picking "1 hour" PATCHes /api/sessions/{id}/snooze with { minutes: 60 },
 //     sets `snoozed_until` on the server, and sinks the row into the
 //     collapsible footer.
-//   - Unsnooze via the menu round-trips back to live.
+//   - Unsnooze via the context menu round-trips back to live.
 
 import { test as base, expect } from "@playwright/test";
 import {
@@ -34,16 +35,19 @@ base.describe("sidebar snooze via context menu (#1581)", () => {
       const row = page.locator("[data-testid='sidebar-session-row']");
       await expect(row).toContainText(title, { timeout: 10_000 });
 
-      // ---- Open snooze submenu, confirm 8 presets ----
+      // ---- Open context menu → Snooze… → modal with 8 presets ----
       await row.click({ button: "right" });
       await page
         .locator("[data-testid='sidebar-context-menu-snooze']")
         .click();
 
+      const modal = page.locator("[data-testid='snooze-modal']");
+      await expect(modal).toBeVisible();
+
       const presets = [60, 120, 180, 240, 300, 360, 1440, 10080];
       for (const m of presets) {
         await expect(
-          page.locator(`[data-testid='sidebar-context-menu-snooze-${m}']`),
+          modal.locator(`[data-testid='snooze-modal-preset-${m}']`),
         ).toBeVisible();
       }
 
@@ -54,9 +58,7 @@ base.describe("sidebar snooze via context menu (#1581)", () => {
           res.request().method() === "PATCH",
       );
       const issuedAt = Date.now();
-      await page
-        .locator("[data-testid='sidebar-context-menu-snooze-60']")
-        .click();
+      await modal.locator("[data-testid='snooze-modal-preset-60']").click();
       const response = await snoozePatch;
       expect(response.ok()).toBe(true);
       expect(response.request().postDataJSON()).toEqual({ minutes: 60 });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Brings snooze, archive, and a new web-only **pin** primitive to the web dashboard sidebar so dashboard-only users (phone, remote, read-only viewer) get the same triage surface that TUI and CLI users have had. Adds three sibling REST endpoints, an in-row Pin glyph + archive / snooze chips, a collapsible "Snoozed & archived" footer per repo group, and a tier-aware sort that lifts pinned workspaces to the top and sinks sunk workspaces to the bottom regardless of the active sort mode.

Per [discord pivot with @Nathan Brake](https://discord.com/), "pin" is a deliberately new concept on the web side. The TUI's `favorited_at` stays exactly as it is — a within-tier signal for the Attention sort. The web adds a separate `pinned_at: Option<DateTime<Utc>>` on `Instance` whose semantic is "float to the top of the sidebar in every sort mode." Pin and favorite coexist freely (different surfaces, different intents); pin is mutually exclusive with archive and snooze, with `Instance::pin/archive/snooze` enforcing the XOR rules in one place so concurrent TUI / CLI / web writes converge cleanly through `merge_user_action_diff`.

The archive handler tears down the tmux pane (and the cockpit worker for ACP-cockpit sessions) and the cockpit reconciler skips archived / snoozed sessions so the 2-second reconciler poll cannot respawn an archived worker. The recovery path already excluded sunk sessions (`src/session/recovery.rs::is_recovery_candidate`), so daemon restarts also leave archived rows parked.

Closes #1581

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Three new live Playwright specs cover the round-trips end-to-end:
- `tests/live/triage-pin.spec.ts` — pin / unpin, glyph render, persistence across reload
- `tests/live/triage-archive.spec.ts` — archive → footer sink, server `archived_at`, post-reload state, unarchive round-trip
- `tests/live/triage-snooze.spec.ts` — submenu shows all 8 presets, picking "1 hour" lands `snoozed_until ≈ now + 60m`, row sinks into footer, unsnooze round-trips

Plus four matrix entries (`triage.pin-toggle`, `triage.archive-toggle`, `triage.snooze-toggle`, `triage.api-wire-format`) and wire-format vitest coverage on the new API wrappers in `src/lib/api.test.ts`.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

The TUI / CLI surface is intentionally untouched. Pin is web-only by design (per the discord pivot, "favorite" stays the TUI Attention-sort signal; pin is the web sidebar's hard top-of-sort primitive). No new keybinds, no `aoe session pin/unpin` command.

## How to test

User-runnable verification steps:

- [x] Build with `cargo build --features serve`, run `./target/debug/aoe serve`, open the dashboard, right-click any session row in the sidebar. Confirm the new "Triage" section in the context menu with Pin, Archive, and Snooze… entries.
- [x] Click Pin. Confirm the row immediately gains a pushpin glyph next to the title and (after a moment) floats to the top of its repo group. Reload the page; confirm the pin survives.
- [x] Click Unpin on the same row. Confirm the glyph disappears and the workspace drops back into its activity-ordered position.
- [x] Click Archive on a running session. Confirm `has_terminal` flips false on the next `/api/sessions` poll (the session's tmux pane is killed), the row sinks into a "Snoozed & archived (1)" collapsible footer at the bottom of the repo group, and the footer starts collapsed.
- [x] Expand the footer, send a message to the archived session via the dashboard. Confirm the row auto-unarchives and rejoins the live list at the top (existing `touch_last_accessed` invariant).
- [ ] Right-click another session, choose Snooze…. Confirm all 8 presets are visible (1h / 2h / 3h / 4h / 5h / 6h / 1d / 1w). Pick 1 hour. Confirm the row sinks into the footer with a "1h" chip; check `/api/sessions` shows `snoozed_until` set to roughly now + 60 minutes.
- [ ] Right-click the snoozed row, click Unsnooze. Confirm `snoozed_until` clears and the row rejoins the live list.
- [x] (Cockpit only) Repeat the archive step on a cockpit-mode session. Confirm the worker stays down through at least one reconciler tick (~2s) and that the cockpit panel does not respawn it.
- [x] In manual sort mode, try drag-reordering a pinned row or a sunk row. Confirm the drag is disabled (no-op). Live rows still drag normally; pinned rows always render at the top regardless of where you "drop" a live row.
- [x] Run `aoe serve --read-only` and open the dashboard. Confirm the Pin / Archive / Snooze entries are hidden under read-only (matches the existing Delete behaviour); the three endpoints also return 403 when called directly.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code with the `/aoe-implement` skill and a 4-LLM `/debate` round (Gemini 3.1 Pro, GPT-5.5, Claude Opus 4.7, Grok 4.3) on the design choices.

**Any Additional AI Details you'd like to share:**
Investigation, design plan, and implementation were drafted by Claude under my direction. I drove the discord-side pivot from "favorite" to "pin" (with Nathan), made the four open-question calls (three endpoints over one unified handler, drop the parallel boolean field, context-menu over hover icons, collapsible footer over plain sink, static snooze chip over a 1s tick), and ran the manual verification steps. The debate round, the `merge_user_action_diff` XOR extension, the cockpit reconciler skip, and the live Playwright specs are all Claude-drafted; I reviewed each commit before it landed.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds web-dashboard session triage: pin, archive, and snooze controls in the sidebar with end-to-end server support, optimistic UI, safe teardown of resources, and tests/docs.

What changed (high-level)
- UI: per-row triage controls (Pin glyph, Archive and Snooze chips), a Snooze modal with presets and custom/until input, optimistic updates with revert + toasts, and a collapsible “Snoozed & archived” footer that groups sunk sessions and persists its expanded state.
- API: three idempotent PATCH endpoints for pin/archive/snooze and SessionResponse fields exposing RFC3339 timestamps: pinned_at, archived_at, snoozed_until.
- Model/persistence: Instance gained persisted pinned_at plus pin/unpin/is_pinned; mutators and merge logic enforce XOR semantics so pin vs archive/snooze are mutually exclusive.
- Runtime/teardown: Archiving (and snoozing for cockpit) tears down tmux panes or stops cockpit workers; the cockpit reconciler and recovery skip archived/snoozed sessions so workers aren’t respawned.
- Sorting/behavior: Sidebar sorting uses triage tiers (pinned → live → sunk), floating pinned workspaces and sinking archived/snoozed ones regardless of active sort mode; drag-to-reorder is disabled for pinned/sunk rows as appropriate.
- Read-only: Triage UI hidden and mutation handlers return 403 in read-only mode.
- Tests & docs: Playwright live specs for pin/archive/snooze, extensive Vitest/RTL/unit tests (including wire-format and timestamp tolerance checks), coverage-matrix updated, and web-dashboard guide updated.

Benefits
- Surface important workspaces via pinning and reduce sidebar noise by sinking archived/snoozed sessions.
- Safer resource management: archiving/snoozing stops workers/panes and avoids accidental respawns.
- Smoother UX: optimistic UI with revert behavior, auto-wake on send (auto-unarchive/unsnooze), and context-aware menus minimize friction.
- Centralized server-side logic ensures consistent, convergent behavior under concurrent updates.

Notable technical details (concise)
- Server handlers: PATCH endpoints acquire per-instance locks, enforce read-only → 403, validate snooze bounds, call Instance mutators, and persist via Storage::update on a blocking thread.
- Concurrency: merge_user_action_diff and Instance mutators enforce final-state XOR (archive/snooze clear pin; pin clears sinks) so concurrent writes converge.
- Cockpit/send flow: send auto-clears archived/snoozed flags by calling touch_last_accessed (best-effort persisted update) before enqueueing; if the wake PATCH fails, the prompt is not enqueued and an error is surfaced.
- UI libraries/helpers: new exported Sidebar helpers (workspaceIsPinned/workspaceIsSunk/workspaceTriageTier), snooze helpers (makeOptimisticSnoozedUntil, formatSnoozeRemainingShort, snoozeTimestampCloseEnough, resolveEffectiveSnoozedUntil), SessionRow, and SnoozeModal.
- Tests: added Playwright live specs (triage-pin, triage-archive, triage-snooze), many Vitest/RTL suites covering UI flows, timestamp tolerance, optimistic reverts, and new unit tests for Instance behavior and merge edge cases.

Potential areas for further enhancement
- Unified client/server timestamp reconciliation strategy to reduce “close-enough” heuristics.
- Expose analytics hooks or telemetry for triage actions to track usage and surface UX improvements.
- Consider an admin-side view for bulk unarchive/unsnooze workflows or retention automation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1585?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->