### PR TITLE
fix(session): keep stopped sessions stopped across aoe relaunches

### DIFF
--- a/src/session/recovery.rs
+++ b/src/session/recovery.rs
@@ -104,21 +104,24 @@ fn recovery_lock_path() -> Result<PathBuf> {
 /// Pure predicate: should this instance go through the startup recovery
 /// cascade? Excludes cockpit-mode sessions (handled by `cockpit_reconciler`),
 /// sessions whose agent has `ResumeStrategy::Unsupported`, sessions without
-/// a valid `agent_session_id`, and sunk rows (archived or currently snoozed).
-/// Live tmux panes are filtered separately by the caller using
-/// `Instance::has_live_tmux_pane()`.
+/// a valid `agent_session_id`, and sunk rows (archived, currently snoozed, or
+/// explicitly stopped). Live tmux panes are filtered separately by the caller
+/// using `Instance::has_live_tmux_pane()`.
 ///
-/// Archive and snooze are explicit "leave this session alone" signals; the
-/// archive path actively kills the tmux pane, so without this guard the next
-/// TUI launch (or daemon startup) would observe a dead pane on a resumable
-/// agent and respawn the row the user just dismissed. Snooze shares the
-/// guard because `is_snoozed()` returns false once the timer expires, so the
-/// row naturally re-enters recovery eligibility on its own schedule rather
-/// than the moment a pane goes missing.
+/// Archive, snooze, and stop are explicit "leave this session alone" signals;
+/// each of them kills the tmux pane, so without this guard the next TUI
+/// launch (or daemon startup) would observe a dead pane on a resumable agent
+/// and respawn the row the user just dismissed. Snooze flips back to
+/// recoverable on its own schedule (`is_snoozed()` returns false once the
+/// timer expires). Stop only flips back to recoverable when the user
+/// explicitly reopens the session (Enter / send-message / live-send), which
+/// transitions `Status::Stopped` to `Status::Starting` before recovery is
+/// consulted.
 pub fn is_recovery_candidate(inst: &Instance) -> bool {
     !inst.is_cockpit_mode()
         && !inst.is_archived()
         && !inst.is_snoozed()
+        && inst.status != super::Status::Stopped
         && should_attempt_resume(inst.agent_session_id.as_deref(), &inst.tool)
 }
 
@@ -317,6 +320,33 @@ mod tests {
         assert!(
             is_recovery_candidate(&inst),
             "unarchive must restore recovery eligibility"
+        );
+    }
+
+    /// Regression for #1583: pressing `x` in the session picker stops a
+    /// session, which sets `Status::Stopped` and kills the tmux pane. The
+    /// next TUI launch (or daemon startup) sees a dead pane on a resume-
+    /// capable agent; without a Stopped guard, the cascade respawns the row
+    /// the user just stopped. Only an explicit user action (Enter / send /
+    /// live-send) transitions Stopped to Starting, which is consulted before
+    /// recovery runs.
+    #[test]
+    fn stopped_instance_is_not_recovery_candidate() {
+        let mut inst = Instance::new("stopped", "/tmp/test");
+        inst.agent_session_id = Some("33333333-3333-4333-8333-333333333333".into());
+        assert!(
+            is_recovery_candidate(&inst),
+            "baseline: claude + valid sid is a recovery candidate"
+        );
+        inst.status = super::super::Status::Stopped;
+        assert!(
+            !is_recovery_candidate(&inst),
+            "stopped sessions must be excluded from startup recovery"
+        );
+        inst.status = super::super::Status::Starting;
+        assert!(
+            is_recovery_candidate(&inst),
+            "transitioning off Stopped (e.g. user reopens) must restore recovery eligibility"
         );
     }
 


### PR DESCRIPTION
## Description

Fixes #1583.

When a user pressed `x` in the session picker to stop a session, the next `aoe` launch auto-restarted it. Stopped sessions should stay stopped until the user explicitly reopens them with Enter.

**Root cause:** `is_recovery_candidate` in `src/session/recovery.rs` guarded against archived and snoozed sessions but not `Status::Stopped`. The stop action correctly set `Status::Stopped` and killed the tmux pane, but on the next launch the recovery predicate observed "no live tmux pane on a resume-capable agent" and respawned the row. Stop is logically the same shape as archive: explicit user dismissal that kills the pane.

**Fix:** add `inst.status != Status::Stopped` to the predicate. One change covers both call sites (TUI `home/mod.rs:1537` and daemon `server/mod.rs:1812`, `:1897`). Manual reopen still works because Enter / send-message / live-send transition `Stopped` -> `Starting` before recovery is consulted.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (predicate docstring updated to cover stop alongside archive/snooze)
- [ ] For UI changes: included screenshot or recording (N/A, behavior change is "session row stays in stopped state across launches")

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the bug lives entirely in a single pure predicate (`is_recovery_candidate`) shared by both startup-recovery call sites (TUI and daemon). The new unit test pins the predicate directly and mirrors the existing `archived_instance_is_not_recovery_candidate` / `snoozed_instance_is_not_recovery_candidate_until_expiry` tests. An e2e would have to spawn a fake agent, drive `x`, restart `aoe`, and reassert status, which exercises the same predicate indirectly and adds no test power.

## How I tested

- `cargo test --lib session::recovery::tests::` -> 4/4 pass, including the new `stopped_instance_is_not_recovery_candidate`
- `cargo fmt --check` clean
- `cargo clippy --lib --no-deps -- -D warnings` clean

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (Opus 4.7, 1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Investigation and fix were done with Claude Code following the gstack /investigate skill (root-cause first, regression test before fix, no symptom patches). I reviewed the diff and the predicate change before commit.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes a bug where sessions manually stopped by users (pressing `x` in the TUI) were automatically restarting on subsequent `aoe` launches, instead of remaining in the stopped state the user intentionally set.

## What Changed

**Modified Files:**
- `src/session/recovery.rs` — Enhanced the session auto-recovery logic

**What Was Added:**
- A safety check to exclude stopped sessions from automatic recovery at startup, treating them like archived/snoozed sessions (lines 124)
- Expanded documentation in the `is_recovery_candidate` function docstring explaining that stopped sessions are excluded from recovery and only become recoverable again when users explicitly reopen them (lines 104-119)
- A new regression test `stopped_instance_is_not_recovery_candidate` that verifies stopped sessions are not auto-recovered and that manual reopening (user-initiated transitions from Stopped to Starting) restores recovery eligibility (lines 333-351)

**What Was Removed:**
- None (this is a backward-compatible fix)

## Code Changes Summary
- **+40 lines, -10 lines** (net +30 lines)
- Changes focused and minimal: one conditional check added to the predicate, documentation expanded, one test added

## Benefits

- **Respects User Intent:** Users can now stop sessions via `x` and have them remain stopped across restarts—a persistent dismissal similar to archiving or snoozing
- **Consistent Behavior:** Stopped, archived, and snoozed sessions are now treated uniformly as "leave me alone" states from the recovery system's perspective
- **Manual Control Preserved:** Users can still explicitly reopen stopped sessions (via Enter, send messages, or live-send) to resume them
- **No Breaking Changes:** All existing functionality continues to work; this only prevents unwanted auto-restarts
- **Regression Prevention:** New test coverage ensures this behavior is maintained in future updates

## Technical Details
The fix adds the condition `inst.status != super::Status::Stopped` to the `is_recovery_candidate` predicate function. This ensures that when `aoe` (TUI) or `aoe serve` (daemon) start up, they skip the automatic recovery cascade for any sessions in the Stopped state. The predicate is consulted at both TUI startup (`home/mod.rs`) and daemon startup (`server/mod.rs`), so the fix covers both execution paths. Manual reopens bypass this by transitioning the session from Stopped → Starting before the recovery check occurs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->