### PR TITLE
feat(agents): add gajae-code support

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 # aoe-sandbox: Docker image for Agent of Empires sandbox sessions
-# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, and Qwen Code in an isolated environment
+# This image provides Claude Code, OpenCode, Mistral Vibe, Hermes, Codex CLI, Gemini CLI, Antigravity CLI, Cursor CLI, Copilot CLI, Pi, Kiro CLI, Qwen Code, and Gajae Code in an isolated environment
 
 FROM ubuntu:26.04
 
@@ -70,6 +70,9 @@ RUN curl -fsSL https://cli.kiro.dev/install | bash
 # Install Qwen Code (Alibaba / QwenLM)
 RUN npm install -g @qwen-code/qwen-code
 
+# Install Gajae Code
+RUN npm install -g gajae-code
+
 # Install ACP adapters used by `aoe`'s cockpit mode when the session is
 # sandboxed. The cockpit runner `docker exec`s these by their bare binary
 # name (see `src/cockpit/agent_registry.rs`); if they aren't present in
@@ -98,6 +101,7 @@ RUN mkdir -p /root/.claude \
     /root/.factory \
     /root/.kiro \
     /root/.qwen \
+    /root/.gjc/agent \
     /root/.ssh
 
 # Allow Claude Code to use --dangerously-skip-permissions as root

--- a/src/agents.rs
+++ b/src/agents.rs
@@ -472,6 +472,22 @@ pub const AGENTS: &[AgentDef] = &[
         install_hint: "npm install -g @qwen-code/qwen-code",
     },
     AgentDef {
+        name: "gajae-code",
+        binary: "gjc",
+        aliases: &["gjc", "gajae"],
+        detection: DetectionMethod::Which("gjc"),
+        yolo: Some(YoloMode::AlwaysYolo),
+        instruction_flag: Some("--append-system-prompt {}"),
+        set_default_command: true,
+        detect_status: status_detection::detect_gajae_code_status,
+        container_env: &[],
+        hook_config: None,
+        resume_strategy: ResumeStrategy::Flag("--resume"),
+        host_only: false,
+        send_keys_enter_delay_ms: 0,
+        install_hint: "npm install -g gajae-code",
+    },
+    AgentDef {
         name: "antigravity",
         binary: "agy",
         aliases: &["agy"],
@@ -572,6 +588,7 @@ mod tests {
         assert_eq!(get_agent("hermes").unwrap().binary, "hermes");
         assert_eq!(get_agent("kiro").unwrap().binary, "kiro-cli");
         assert_eq!(get_agent("qwen").unwrap().binary, "qwen");
+        assert_eq!(get_agent("gajae-code").unwrap().binary, "gjc");
         assert_eq!(get_agent("antigravity").unwrap().binary, "agy");
     }
 
@@ -616,6 +633,7 @@ mod tests {
                 "hermes",
                 "kiro",
                 "qwen",
+                "gajae-code",
                 "antigravity"
             ]
         );
@@ -641,6 +659,9 @@ mod tests {
         assert_eq!(resolve_tool_name("kiro"), Some("kiro"));
         assert_eq!(resolve_tool_name("kiro-cli"), Some("kiro"));
         assert_eq!(resolve_tool_name("qwen"), Some("qwen"));
+        assert_eq!(resolve_tool_name("gajae-code"), Some("gajae-code"));
+        assert_eq!(resolve_tool_name("gjc"), Some("gajae-code"));
+        assert_eq!(resolve_tool_name("gajae"), Some("gajae-code"));
         assert_eq!(resolve_tool_name("antigravity"), Some("antigravity"));
         assert_eq!(resolve_tool_name("agy"), Some("antigravity"));
         assert_eq!(resolve_tool_name(""), Some("claude"));
@@ -661,7 +682,8 @@ mod tests {
         assert_eq!(settings_index_from_name(Some("hermes")), 11);
         assert_eq!(settings_index_from_name(Some("kiro")), 12);
         assert_eq!(settings_index_from_name(Some("qwen")), 13);
-        assert_eq!(settings_index_from_name(Some("antigravity")), 14);
+        assert_eq!(settings_index_from_name(Some("gajae-code")), 14);
+        assert_eq!(settings_index_from_name(Some("antigravity")), 15);
 
         assert_eq!(name_from_settings_index(0), None);
         assert_eq!(name_from_settings_index(1), Some("claude"));
@@ -674,7 +696,8 @@ mod tests {
         assert_eq!(name_from_settings_index(11), Some("hermes"));
         assert_eq!(name_from_settings_index(12), Some("kiro"));
         assert_eq!(name_from_settings_index(13), Some("qwen"));
-        assert_eq!(name_from_settings_index(14), Some("antigravity"));
+        assert_eq!(name_from_settings_index(14), Some("gajae-code"));
+        assert_eq!(name_from_settings_index(15), Some("antigravity"));
         assert_eq!(name_from_settings_index(99), None);
     }
 
@@ -698,6 +721,7 @@ mod tests {
         assert_eq!(send_keys_enter_delay("opencode"), 0);
         assert_eq!(send_keys_enter_delay("hermes"), 0);
         assert_eq!(send_keys_enter_delay("kiro"), 0);
+        assert_eq!(send_keys_enter_delay("gajae-code"), 0);
         assert_eq!(send_keys_enter_delay("antigravity"), 0);
         assert_eq!(send_keys_enter_delay("unknown_agent"), 0);
     }
@@ -742,6 +766,10 @@ mod tests {
         assert_eq!(
             install_hint("kiro"),
             Some("curl -fsSL https://cli.kiro.dev/install | bash")
+        );
+        assert_eq!(
+            install_hint("gajae-code"),
+            Some("npm install -g gajae-code")
         );
         assert_eq!(
             install_hint("antigravity"),

--- a/src/session/container_config.rs
+++ b/src/session/container_config.rs
@@ -257,6 +257,18 @@ const AGENT_CONFIG_MOUNTS: &[AgentConfigMount] = &[
         clean_files: &[],
     },
     AgentConfigMount {
+        tool_name: "gajae-code",
+        host_rel: ".gjc/agent",
+        container_suffix: ".gjc/agent",
+        skip_entries: &["sandbox", "sessions", "terminal-sessions", "logs"],
+        seed_files: &[],
+        copy_dirs: &["skills"],
+        keychain_credential: None,
+        home_seed_files: &[],
+        preserve_files: &[],
+        clean_files: &[],
+    },
+    AgentConfigMount {
         tool_name: "antigravity",
         host_rel: ".gemini/antigravity-cli",
         container_suffix: ".gemini/antigravity-cli",
@@ -1955,6 +1967,13 @@ mod tests {
             .collect();
         assert_eq!(hermes_mounts.len(), 1);
         assert_eq!(hermes_mounts[0].host_rel, ".hermes");
+
+        let gajae_mounts: Vec<_> = AGENT_CONFIG_MOUNTS
+            .iter()
+            .filter(|m| m.tool_name == "gajae-code")
+            .collect();
+        assert_eq!(gajae_mounts.len(), 1);
+        assert_eq!(gajae_mounts[0].host_rel, ".gjc/agent");
 
         let antigravity_mounts: Vec<_> = AGENT_CONFIG_MOUNTS
             .iter()

--- a/src/session/instance.rs
+++ b/src/session/instance.rs
@@ -2708,7 +2708,10 @@ fn format_env_var_prefix(key: &str, value: &str, cmd: &str) -> String {
 /// `COLORTERM=truecolor` at launch keeps color on without leaking the override
 /// to other agents.
 fn apply_agent_launch_env(cmd: &mut String, agent: Option<&'static crate::agents::AgentDef>) {
-    if !matches!(agent.map(|a| a.name), Some("antigravity" | "codex")) {
+    if !matches!(
+        agent.map(|a| a.name),
+        Some("antigravity" | "codex" | "gajae-code")
+    ) {
         return;
     }
 
@@ -4340,6 +4343,20 @@ mod tests {
         assert!(cmd_str.contains("FORCE_COLOR=1"));
         assert!(cmd_str.contains("COLORTERM=truecolor"));
         assert!(cmd_str.contains("codex"));
+    }
+
+    #[test]
+    fn test_build_host_command_gajae_code_forces_color() {
+        let mut inst = Instance::new("test", "/tmp/test");
+        inst.tool = "gajae-code".to_string();
+        let cmd = inst.build_host_command(crate::agents::get_agent("gajae-code"), &None);
+        let cmd_str = cmd.unwrap();
+
+        assert!(cmd_str.contains("env -u NO_COLOR"));
+        assert!(cmd_str.contains("TERM=xterm-256color"));
+        assert!(cmd_str.contains("FORCE_COLOR=1"));
+        assert!(cmd_str.contains("COLORTERM=truecolor"));
+        assert!(cmd_str.contains("gjc"));
     }
 
     #[test]

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1272,6 +1272,32 @@ pub fn detect_qwen_status(raw_content: &str) -> Status {
 }
 
 pub fn detect_antigravity_status(raw_content: &str) -> Status {
+    detect_gajae_like_status(
+        raw_content,
+        &[
+            "not signed in",
+            "signing in",
+            "authorization url",
+            "authorization code",
+            "google sign-in",
+        ],
+    )
+}
+
+pub fn detect_gajae_code_status(raw_content: &str) -> Status {
+    detect_gajae_like_status(
+        raw_content,
+        &[
+            "api key",
+            "anthropic_api_key",
+            "openai_api_key",
+            "select provider",
+            "sign in",
+        ],
+    )
+}
+
+fn detect_gajae_like_status(raw_content: &str, auth_markers: &[&str]) -> Status {
     let content = raw_content.to_lowercase();
     let lines: Vec<&str> = content.lines().collect();
     let non_empty_lines: Vec<&str> = lines
@@ -1289,11 +1315,9 @@ pub fn detect_antigravity_status(raw_content: &str) -> Status {
         .collect::<Vec<&str>>()
         .join("\n");
 
-    if last_lines_lower.contains("not signed in")
-        || last_lines_lower.contains("signing in")
-        || last_lines_lower.contains("authorization url")
-        || last_lines_lower.contains("authorization code")
-        || last_lines_lower.contains("google sign-in")
+    if auth_markers
+        .iter()
+        .any(|marker| last_lines_lower.contains(marker))
     {
         return Status::Waiting;
     }
@@ -2881,6 +2905,45 @@ path: /workspace/secrets.env
         assert_eq!(
             detect_antigravity_status("random output text"),
             Status::Idle
+        );
+    }
+
+    #[test]
+    fn test_detect_gajae_code_status_idle_on_ready_prompt() {
+        let content = "\
+╭─── gjc v0.1.3 · GJC forge ─────────────────────────────╮
+│                                                        │
+╰────────────────────────────────────────────────────────╯
+
+> Type your message...";
+        assert_eq!(detect_gajae_code_status(content), Status::Idle);
+    }
+
+    #[test]
+    fn test_detect_gajae_code_status_running() {
+        assert_eq!(
+            detect_gajae_code_status("processing request\nesc to interrupt"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_gajae_code_status("⠋ Thinking about your request"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_gajae_code_status("Editing src/session/instance.rs"),
+            Status::Running
+        );
+    }
+
+    #[test]
+    fn test_detect_gajae_code_status_waiting() {
+        assert_eq!(
+            detect_gajae_code_status("run command?\nenter to select"),
+            Status::Waiting
+        );
+        assert_eq!(
+            detect_gajae_code_status("OPENAI_API_KEY is required"),
+            Status::Waiting
         );
     }
 

--- a/src/tmux/status_detection.rs
+++ b/src/tmux/status_detection.rs
@@ -1288,11 +1288,13 @@ pub fn detect_gajae_code_status(raw_content: &str) -> Status {
     detect_gajae_like_status(
         raw_content,
         &[
-            "api key",
-            "anthropic_api_key",
-            "openai_api_key",
-            "select provider",
-            "sign in",
+            "api key is required",
+            "anthropic_api_key is required",
+            "openai_api_key is required",
+            "select provider:",
+            "not signed in",
+            "please sign in",
+            "sign in to",
         ],
     )
 }
@@ -2931,6 +2933,14 @@ path: /workspace/secrets.env
         );
         assert_eq!(
             detect_gajae_code_status("Editing src/session/instance.rs"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_gajae_code_status("Thinking about API key rotation\nesc to interrupt"),
+            Status::Running
+        );
+        assert_eq!(
+            detect_gajae_code_status("Processing sign in docs\nesc to interrupt"),
             Status::Running
         );
     }


### PR DESCRIPTION
## Description
Adds Gajae Code support as a first-class AoE agent.

This registers the `gajae-code` agent around the `gjc` binary, with `gjc` and `gajae` aliases, install detection, session launch support, status detection, color-preserving launch environment, sandbox config sync, and sandbox image installation.

The launch command intentionally uses bare `gjc`, not `gjc --tmux`, so AoE does not nest the agent's own tmux mode inside AoE-managed tmux sessions.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: this is covered by agent registry, status detection, launch command, and sandbox mount unit tests plus a local `cargo run -- agents` smoke check. A full e2e would require external Gajae Code provider/auth setup.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to implement and validate a focused agent integration split from unrelated local work.

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `gjc --version`
- `cargo fmt --check`
- `cargo test gajae --lib`
- `cargo test agents::tests --lib`
- `cargo test test_agent_config_mounts --lib`
- `cargo check --features serve`
- `cargo clippy --features serve -- -D warnings`
- `cargo clippy -- -D warnings` via commit hook
- `cargo test --lib`
- `git diff --check`
- `cargo run --quiet -- agents`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview
This PR adds Gajae Code as a first-class Agent of Empires (AoE) agent, integrating the `gjc` binary (aliases `gjc`, `gajae`) with full session, sandbox, and status-detection support.

## What Changed (high-level)
- Added a new agent entry `gajae-code` in the central agent registry with binary/aliases, detection, YOLO options, resume strategy, enter-delay, and install hint.
- Implemented pane status detection for Gajae Code (Idle/Running/Waiting) and factored Antigravity/Gajae auth detection into a shared helper.
- Enabled color-preserving host launch environment for Gajae Code (forces color via env prefix).
- Added sandbox support: Docker image now installs `gajae-code` globally and the sandbox mounts a credentials/config directory at `/root/.gjc/agent`; container config sync/mounts updated to include Gajae Code.
- Updated unit tests across agents, container mounts, status detection, and launch-env behavior to include and validate the new agent.
- Narrowed auth-prompt matching to avoid false Waiting detections by matching explicit auth-prompt phrases.

## Technical details
- src/agents.rs: inserted new AgentDef for `gajae-code`, affecting registry ordering and settings-index mappings.
- src/tmux/status_detection.rs: added `detect_gajae_code_status(raw_content: &str) -> Status` and a shared auth-marker-based helper for waiting detection.
- src/session/instance.rs: updated apply_agent_launch_env to force color for `gajae-code` (removed `codex` from that set); added unit test asserting color-forcing prefix.
- src/session/container_config.rs: added AgentConfigMount entry for `gajae-code` with host_rel `.gjc/agent` and container mount behavior (copying `skills`).
- docker/Dockerfile: documents Gajae Code in image description and adds `npm install -g gajae-code`; creates `/root/.gjc/agent` as part of sandbox credential-mount setup.
- Tests: added/updated targeted unit tests (registry lookup, name resolution, settings index shifts, mount filtering, status detection, launch env).

## Benefits
- Enables users to run Gajae Code as an integrated AoE agent with correct session lifecycle handling and sandboxed credential management.
- Preserves terminal color output for consistent UX.
- Shared auth-marker helper reduces duplication and improves maintainability.
- Sandbox image supports out-of-the-box use of Gajae Code in isolated sessions.
- New tests increase confidence in integration correctness.

## Potential enhancements / follow-ups
- Review settings-index-dependent consumers to ensure registry-order changes don't break external references.
- Validate sandbox credential migration/permission semantics for `.gjc/agent` across platforms.
- Consider documenting the deliberate choice to invoke bare `gjc` (not `gjc --tmux`) and any user-facing implications in the README or agent docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1587?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->