### PR TITLE
feat(tmux): add configurable history limit

### DIFF
--- a/src/server/api/system.rs
+++ b/src/server/api/system.rs
@@ -149,6 +149,7 @@ pub async fn update_settings(
         }
     }
 
+    let active_profile = state.profile.clone();
     let result = tokio::task::spawn_blocking(move || {
         let config = crate::session::Config::load_or_warn();
         let mut current = serde_json::to_value(&config)?;
@@ -168,6 +169,12 @@ pub async fn update_settings(
         }
         let config: crate::session::Config = serde_json::from_value(current)?;
         crate::session::save_config(&config)?;
+        let effective = crate::session::profile_config::resolve_config_or_warn(&active_profile);
+        if let Err(e) = crate::tmux::status_bar::apply_history_limit_to_live_sessions(
+            effective.tmux.history_limit,
+        ) {
+            tracing::debug!(target: "http.api.system", "Failed to live-apply tmux history-limit: {}", e);
+        }
         Ok::<_, anyhow::Error>(config)
     })
     .await;
@@ -1067,6 +1074,12 @@ pub async fn update_profile_settings(
         }
         let config: crate::session::ProfileConfig = serde_json::from_value(current)?;
         crate::session::save_profile_config(&name, &config)?;
+        let effective = crate::session::profile_config::resolve_config_or_warn(&name);
+        if let Err(e) = crate::tmux::status_bar::apply_history_limit_to_live_sessions(
+            effective.tmux.history_limit,
+        ) {
+            tracing::debug!(target: "http.api.system", "Failed to live-apply tmux history-limit: {}", e);
+        }
         Ok::<_, anyhow::Error>(config)
     })
     .await;

--- a/src/session/config.rs
+++ b/src/session/config.rs
@@ -1254,6 +1254,10 @@ pub struct TmuxConfig {
     /// wrapped agent reaches the terminal.
     #[serde(default)]
     pub clipboard: TmuxClipboardMode,
+
+    /// Number of scrollback lines tmux keeps for each AoE session.
+    #[serde(default = "default_tmux_history_limit")]
+    pub history_limit: u32,
 }
 
 impl Default for TmuxConfig {
@@ -1262,8 +1266,15 @@ impl Default for TmuxConfig {
             status_bar: TmuxStatusBarMode::Auto,
             mouse: TmuxMouseMode::Auto,
             clipboard: TmuxClipboardMode::Auto,
+            history_limit: default_tmux_history_limit(),
         }
     }
+}
+
+pub const DEFAULT_TMUX_HISTORY_LIMIT: u32 = 2000;
+
+fn default_tmux_history_limit() -> u32 {
+    DEFAULT_TMUX_HISTORY_LIMIT
 }
 
 /// Check if user has a tmux configuration file.
@@ -1870,6 +1881,7 @@ mod tests {
         assert_eq!(tmux.status_bar, TmuxStatusBarMode::Auto);
         assert_eq!(tmux.mouse, TmuxMouseMode::Auto);
         assert_eq!(tmux.clipboard, TmuxClipboardMode::Auto);
+        assert_eq!(tmux.history_limit, DEFAULT_TMUX_HISTORY_LIMIT);
     }
 
     #[test]
@@ -1880,9 +1892,13 @@ mod tests {
 
     #[test]
     fn test_tmux_config_deserialize() {
-        let toml = r#"status_bar = "enabled""#;
+        let toml = r#"
+            status_bar = "enabled"
+            history_limit = 50000
+        "#;
         let tmux: TmuxConfig = toml::from_str(toml).unwrap();
         assert_eq!(tmux.status_bar, TmuxStatusBarMode::Enabled);
+        assert_eq!(tmux.history_limit, 50000);
     }
 
     #[test]
@@ -1948,6 +1964,7 @@ mod tests {
         let toml = r#""#;
         let tmux: TmuxConfig = toml::from_str(toml).unwrap();
         assert_eq!(tmux.clipboard, TmuxClipboardMode::Auto);
+        assert_eq!(tmux.history_limit, DEFAULT_TMUX_HISTORY_LIMIT);
     }
 
     #[test]

--- a/src/session/profile_config.rs
+++ b/src/session/profile_config.rs
@@ -218,6 +218,9 @@ pub struct TmuxConfigOverride {
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clipboard: Option<TmuxClipboardMode>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub history_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -520,6 +523,9 @@ pub fn apply_tmux_overrides(target: &mut super::config::TmuxConfig, source: &Tmu
     }
     if let Some(clipboard) = source.clipboard {
         target.clipboard = clipboard;
+    }
+    if let Some(history_limit) = source.history_limit {
+        target.history_limit = history_limit;
     }
 }
 
@@ -869,6 +875,7 @@ mod tests {
                 status_bar: Some(TmuxStatusBarMode::Enabled),
                 mouse: None,
                 clipboard: None,
+                history_limit: None,
             }),
             ..Default::default()
         };
@@ -910,6 +917,22 @@ mod tests {
 
         let merged = merge_configs(global, &profile);
         assert_eq!(merged.tmux.clipboard, TmuxClipboardMode::Disabled);
+    }
+
+    #[test]
+    fn test_merge_configs_with_tmux_history_limit_override() {
+        let global = Config::default();
+
+        let profile = ProfileConfig {
+            tmux: Some(TmuxConfigOverride {
+                history_limit: Some(50000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let merged = merge_configs(global, &profile);
+        assert_eq!(merged.tmux.history_limit, 50000);
     }
 
     #[test]
@@ -995,6 +1018,7 @@ mod tests {
                 status_bar: Some(TmuxStatusBarMode::Enabled),
                 mouse: Some(TmuxMouseMode::Enabled),
                 clipboard: Some(TmuxClipboardMode::Enabled),
+                history_limit: Some(50000),
             }),
             ..Default::default()
         };
@@ -1002,11 +1026,16 @@ mod tests {
         let serialized = toml::to_string_pretty(&config).unwrap();
         assert!(serialized.contains("[tmux]"));
         assert!(serialized.contains(r#"mouse = "enabled""#));
+        assert!(serialized.contains("history_limit = 50000"));
 
         let deserialized: ProfileConfig = toml::from_str(&serialized).unwrap();
         assert_eq!(
             deserialized.tmux.as_ref().unwrap().mouse,
             Some(TmuxMouseMode::Enabled)
+        );
+        assert_eq!(
+            deserialized.tmux.as_ref().unwrap().history_limit,
+            Some(50000)
         );
     }
 

--- a/src/tmux/session.rs
+++ b/src/tmux/session.rs
@@ -8,14 +8,15 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use super::{
     refresh_session_cache, session_exists_from_cache,
     utils::{
-        append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
-        append_remain_on_exit_args, append_window_size_args, is_pane_dead, is_pane_running_shell,
+        append_clipboard_passthrough_args, append_history_limit_args, append_mouse_on_args,
+        append_pane_base_index_args, append_remain_on_exit_args, append_window_size_args,
+        is_pane_dead, is_pane_running_shell,
     },
     SESSION_PREFIX,
 };
 use crate::cli::truncate_id;
 use crate::process;
-use crate::session::config::should_apply_tmux_clipboard;
+use crate::session::config::{should_apply_tmux_clipboard, Config};
 use crate::session::Status;
 
 pub struct Session {
@@ -76,6 +77,11 @@ impl Session {
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
+        append_history_limit_args(
+            &mut args,
+            &self.name,
+            Config::load_or_warn().tmux.history_limit,
+        );
         if should_apply_tmux_clipboard() {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }

--- a/src/tmux/status_bar.rs
+++ b/src/tmux/status_bar.rs
@@ -98,6 +98,40 @@ pub fn apply_mouse_option(session_name: &str, enabled: bool) -> Result<()> {
     set_session_option(session_name, "mouse", value)
 }
 
+/// Apply the configured tmux scrollback limit to a session.
+pub fn apply_history_limit_option(session_name: &str, history_limit: u32) -> Result<()> {
+    set_session_option(session_name, "history-limit", &history_limit.to_string())
+}
+
+fn is_aoe_tmux_session_name(session_name: &str) -> bool {
+    session_name.starts_with(crate::tmux::SESSION_PREFIX)
+        || session_name.starts_with(crate::tmux::TERMINAL_PREFIX)
+        || session_name.starts_with(crate::tmux::CONTAINER_TERMINAL_PREFIX)
+        || session_name.starts_with(crate::tmux::TOOL_PREFIX)
+}
+
+/// Apply the configured scrollback limit to all currently running AoE tmux sessions.
+pub fn apply_history_limit_to_live_sessions(history_limit: u32) -> Result<usize> {
+    let output = Command::new("tmux")
+        .args(["list-sessions", "-F", "#{session_name}"])
+        .output()?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        tracing::debug!(target: "tmux.status", "Failed to list tmux sessions for history-limit apply: {}", stderr);
+        return Ok(0);
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut applied = 0;
+    for session_name in stdout.lines().filter(|name| is_aoe_tmux_session_name(name)) {
+        apply_history_limit_option(session_name, history_limit)?;
+        applied += 1;
+    }
+    crate::tmux::refresh_session_cache();
+    Ok(applied)
+}
+
 /// Apply all configured tmux options to a session.
 /// This is a unified entry point that applies status bar styling and mouse settings.
 pub fn apply_all_tmux_options(
@@ -106,11 +140,12 @@ pub fn apply_all_tmux_options(
     branch: Option<&str>,
     sandbox: Option<&SandboxDisplay>,
 ) {
-    use crate::session::config::{should_apply_tmux_mouse, should_apply_tmux_status_bar};
+    use crate::session::config::{should_apply_tmux_mouse, should_apply_tmux_status_bar, Config};
     use crate::tui::styles::load_theme;
 
+    let config = Config::load_or_warn();
+
     if should_apply_tmux_status_bar() {
-        let config = crate::session::config::Config::load_or_warn();
         let theme_name = if config.theme.name.is_empty() {
             "empire"
         } else {
@@ -130,6 +165,10 @@ pub fn apply_all_tmux_options(
         if let Err(e) = apply_mouse_option(session_name, mouse_enabled) {
             tracing::debug!(target: "tmux.status", "Failed to apply tmux mouse option: {}", e);
         }
+    }
+
+    if let Err(e) = apply_history_limit_option(session_name, config.tmux.history_limit) {
+        tracing::debug!(target: "tmux.status", "Failed to apply tmux history-limit option: {}", e);
     }
 }
 
@@ -234,6 +273,27 @@ mod tests {
     #[test]
     fn test_color_to_tmux_non_rgb_fallback() {
         assert_eq!(color_to_tmux(Color::Red), "default");
+    }
+
+    #[test]
+    fn test_is_aoe_tmux_session_name_matches_managed_prefixes() {
+        assert!(is_aoe_tmux_session_name(&format!(
+            "{}Example_12345678",
+            crate::tmux::SESSION_PREFIX
+        )));
+        assert!(is_aoe_tmux_session_name(&format!(
+            "{}Example_12345678",
+            crate::tmux::TERMINAL_PREFIX
+        )));
+        assert!(is_aoe_tmux_session_name(&format!(
+            "{}Example_12345678",
+            crate::tmux::CONTAINER_TERMINAL_PREFIX
+        )));
+        assert!(is_aoe_tmux_session_name(&format!(
+            "{}Example_12345678",
+            crate::tmux::TOOL_PREFIX
+        )));
+        assert!(!is_aoe_tmux_session_name("user_session"));
     }
 
     #[test]

--- a/src/tmux/terminal_session.rs
+++ b/src/tmux/terminal_session.rs
@@ -8,15 +8,16 @@ use anyhow::{bail, Result};
 use std::process::Command;
 
 use super::utils::{
-    append_clipboard_passthrough_args, append_mouse_on_args, append_pane_base_index_args,
-    append_remain_on_exit_args, append_window_size_args, is_pane_dead, sanitize_session_name,
+    append_clipboard_passthrough_args, append_history_limit_args, append_mouse_on_args,
+    append_pane_base_index_args, append_remain_on_exit_args, append_window_size_args, is_pane_dead,
+    sanitize_session_name,
 };
 use super::{
     refresh_session_cache, session_exists_from_cache, CONTAINER_TERMINAL_PREFIX, TERMINAL_PREFIX,
 };
 use crate::cli::truncate_id;
 use crate::process;
-use crate::session::config::should_apply_tmux_clipboard;
+use crate::session::config::{should_apply_tmux_clipboard, Config};
 
 /// Classifies a paired terminal: adjusts the tmux session prefix and the
 /// human-readable label used in error messages.
@@ -94,6 +95,11 @@ impl PairedTerminal {
         append_pane_base_index_args(&mut args, &self.name);
         append_mouse_on_args(&mut args, &self.name);
         append_window_size_args(&mut args, &self.name);
+        append_history_limit_args(
+            &mut args,
+            &self.name,
+            Config::load_or_warn().tmux.history_limit,
+        );
         if should_apply_tmux_clipboard() {
             append_clipboard_passthrough_args(&mut args, &self.name);
         }

--- a/src/tmux/utils.rs
+++ b/src/tmux/utils.rs
@@ -143,6 +143,19 @@ pub fn append_window_size_args(args: &mut Vec<String>, target: &str) {
     ]);
 }
 
+/// Append `; set-option -t <target> history-limit <lines>` so scrollback
+/// capacity is set atomically with session creation.
+pub fn append_history_limit_args(args: &mut Vec<String>, target: &str, history_limit: u32) {
+    args.extend([
+        ";".to_string(),
+        "set-option".to_string(),
+        "-t".to_string(),
+        target.to_string(),
+        "history-limit".to_string(),
+        history_limit.to_string(),
+    ]);
+}
+
 /// Append the two tmux options required for OSC 52 clipboard escapes from
 /// the wrapped agent (Claude Code, OpenCode, Codex, etc.) to reach the outer
 /// terminal. Without these, "select to copy" inside the agent silently fails
@@ -487,6 +500,24 @@ mod tests {
                 "aoe_test",
                 "allow-passthrough",
                 "on",
+            ]
+        );
+    }
+
+    #[test]
+    fn test_append_history_limit_args() {
+        let mut args: Vec<String> = vec!["new-session".into()];
+        append_history_limit_args(&mut args, "aoe_test", 50000);
+        assert_eq!(
+            args,
+            vec![
+                "new-session",
+                ";",
+                "set-option",
+                "-t",
+                "aoe_test",
+                "history-limit",
+                "50000",
             ]
         );
     }

--- a/src/tui/settings/fields.rs
+++ b/src/tui/settings/fields.rs
@@ -92,6 +92,7 @@ pub enum FieldKey {
     StatusBar,
     Mouse,
     Clipboard,
+    HistoryLimit,
     // Session
     DefaultTool,
     StrictHotkeys,
@@ -1461,6 +1462,12 @@ fn build_tmux_fields(
     let (clipboard, clipboard_override) =
         resolve_value(scope, global.tmux.clipboard, tmux.and_then(|t| t.clipboard));
 
+    let (history_limit, history_limit_override) = resolve_value(
+        scope,
+        global.tmux.history_limit,
+        tmux.and_then(|t| t.history_limit),
+    );
+
     let status_bar_selected = match status_bar {
         TmuxStatusBarMode::Auto => 0,
         TmuxStatusBarMode::Enabled => 1,
@@ -1549,6 +1556,18 @@ fn build_tmux_fields(
                     selected: global_clipboard_selected,
                     options: tmux_options,
                 },
+            ),
+        },
+        SettingField {
+            key: FieldKey::HistoryLimit,
+            label: "History Limit",
+            description: "Scrollback lines kept by tmux for each AoE session",
+            value: FieldValue::Number(u64::from(history_limit)),
+            category: SettingsCategory::Tmux,
+            has_override: history_limit_override,
+            inherited_display: inherited_if(
+                history_limit_override,
+                FieldValue::Number(u64::from(global.tmux.history_limit)),
             ),
         },
     ]
@@ -2590,6 +2609,9 @@ fn apply_field_to_global(field: &SettingField, config: &mut Config) {
                 _ => TmuxClipboardMode::Disabled,
             };
         }
+        (FieldKey::HistoryLimit, FieldValue::Number(v)) => {
+            config.tmux.history_limit = (*v).min(u64::from(u32::MAX)) as u32;
+        }
         // Session
         (FieldKey::DefaultTool, FieldValue::Select { selected, .. }) => {
             config.session.default_tool =
@@ -2977,6 +2999,10 @@ fn apply_field_to_profile(field: &SettingField, _global: &Config, config: &mut P
                 _ => TmuxClipboardMode::Disabled,
             };
             set_profile_override(mode, &mut config.tmux, |s, val| s.clipboard = val);
+        }
+        (FieldKey::HistoryLimit, FieldValue::Number(v)) => {
+            let limit = (*v).min(u64::from(u32::MAX)) as u32;
+            set_profile_override(limit, &mut config.tmux, |s, val| s.history_limit = val);
         }
         // Session
         (FieldKey::DefaultTool, FieldValue::Select { selected, .. }) => {

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -736,6 +736,11 @@ impl SettingsView {
                     t.clipboard = None;
                 }
             }
+            FieldKey::HistoryLimit => {
+                if let Some(ref mut t) = config.tmux {
+                    t.history_limit = None;
+                }
+            }
             // Session
             FieldKey::DefaultTool => {
                 if let Some(ref mut s) = config.session {

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -471,9 +471,21 @@ impl SettingsView {
                 crate::session::poller::set_session_id_poller_max_threads(
                     self.global_config.session.session_id_poller_max_threads,
                 );
+                if let Err(e) = crate::tmux::status_bar::apply_history_limit_to_live_sessions(
+                    self.resolved_base.tmux.history_limit,
+                ) {
+                    tracing::debug!(target: "tui.settings", "Failed to live-apply tmux history-limit: {}", e);
+                }
             }
             SettingsScope::Profile => {
                 save_profile_config(&self.profile, &self.profile_config)?;
+                let resolved =
+                    crate::session::profile_config::resolve_config_or_warn(&self.profile);
+                if let Err(e) = crate::tmux::status_bar::apply_history_limit_to_live_sessions(
+                    resolved.tmux.history_limit,
+                ) {
+                    tracing::debug!(target: "tui.settings", "Failed to live-apply tmux history-limit: {}", e);
+                }
             }
             SettingsScope::Repo => {
                 if let (Some(ref project_path), Some(ref repo_config)) =

--- a/web/src/components/settings/TmuxSettings.tsx
+++ b/web/src/components/settings/TmuxSettings.tsx
@@ -1,4 +1,17 @@
-import { SelectField } from "./FormFields";
+import { NumberField, SelectField } from "./FormFields";
+
+const DEFAULT_TMUX_HISTORY_LIMIT = 2000;
+const MAX_TMUX_HISTORY_LIMIT = 200000;
+
+function readHistoryLimit(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : DEFAULT_TMUX_HISTORY_LIMIT;
+}
+
+function normalizeHistoryLimit(value: number): number {
+  return Math.max(0, Math.min(MAX_TMUX_HISTORY_LIMIT, Math.floor(value)));
+}
 
 interface Props {
   settings: Record<string, unknown>;
@@ -40,6 +53,14 @@ export function TmuxSettings({ settings, onSaveField, onUpdate }: Props) {
         value={(tmux.mouse as string) ?? "auto"}
         onChange={(v) => save("mouse", v)}
         options={modeOptions}
+      />
+      <NumberField
+        label="History limit"
+        description="Scrollback lines kept by tmux for each AoE session"
+        value={readHistoryLimit(tmux.history_limit)}
+        min={0}
+        max={MAX_TMUX_HISTORY_LIMIT}
+        onChange={(v) => save("history_limit", normalizeHistoryLimit(v))}
       />
     </div>
   );

--- a/web/src/components/settings/__tests__/TmuxSettings.test.tsx
+++ b/web/src/components/settings/__tests__/TmuxSettings.test.tsx
@@ -72,11 +72,12 @@ describe("TmuxSettings contract", () => {
     const { onUpdate, container } = mount({
       status_bar: "auto",
       mouse: "enabled",
+      history_limit: 2000,
     });
     const select = container.querySelectorAll("select")[0];
     fireEvent.change(select, { target: { value: "disabled" } });
     expect(onUpdate).toHaveBeenCalledWith({
-      tmux: { status_bar: "disabled", mouse: "enabled" },
+      tmux: { status_bar: "disabled", mouse: "enabled", history_limit: 2000 },
     });
   });
 
@@ -87,5 +88,55 @@ describe("TmuxSettings contract", () => {
     ) as NodeListOf<HTMLSelectElement>;
     expect(selects[0].value).toBe("auto");
     expect(selects[1].value).toBe("auto");
+  });
+
+  it("defaults history_limit to 2000 when absent on initial mount", () => {
+    const { container } = mount({});
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+
+    expect(input.value).toBe("2000");
+  });
+
+  it("history_limit emits tmux.history_limit with a normalized integer", () => {
+    const { onSaveField, onUpdate, container } = mount({
+      status_bar: "auto",
+      mouse: "enabled",
+      history_limit: 2000,
+    });
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "50000.8" } });
+    fireEvent.blur(input);
+
+    expect(onSaveField).toHaveBeenCalledWith("tmux", "history_limit", 50000);
+    expect(onUpdate).toHaveBeenCalledWith({
+      tmux: { status_bar: "auto", mouse: "enabled", history_limit: 50000 },
+    });
+  });
+
+  it("history_limit clamps to the maximum supported value", () => {
+    const { onSaveField, container } = mount({
+      status_bar: "auto",
+      mouse: "enabled",
+      history_limit: 2000,
+    });
+    const input = container.querySelector(
+      'input[type="number"]',
+    ) as HTMLInputElement;
+
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "999999" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onSaveField).toHaveBeenCalledWith(
+      "tmux",
+      "history_limit",
+      200000,
+    );
   });
 });


### PR DESCRIPTION
## Description
Adds a configurable tmux history limit while preserving the existing 2000-line default. The setting is available from config/profile data, the TUI settings screen, and the web Tmux settings panel, and settings saves apply the configured limit to existing AoE tmux sessions as well as new sessions.

This gives users with browser attach/scrollback pressure a supported way to lower scrollback locally without changing the project default for everyone else.

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [x] Skipped a test, because: this is a settings payload/control change covered by the existing React settings contract tests; no browser-only interaction path changed.

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [x] Skipped a test, because: the new setting is covered by TUI field/input unit paths, config/profile merge tests, tmux command construction tests, and live-apply helper tests; a full interactive tmux settings e2e would add environment coupling for the same behavior.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:**

Codex

**Any Additional AI Details you'd like to share:**

Used to isolate the tmux history-limit work into a focused branch and validate it against Rust and web settings tests.

- [x] I am an AI Agent filling out this form (check box if true)

## Validation

- `cargo fmt --check`
- `cargo test history_limit --lib`
- `cargo test tmux_config --lib`
- `cargo test is_aoe_tmux_session_name --lib`
- `cargo check --features serve`
- `cargo clippy --features serve -- -D warnings`
- `cargo test --lib`
- `cd web && npm run test:unit -- src/components/settings/__tests__/TmuxSettings.test.tsx`
- `cd web && npx eslint src/components/settings/TmuxSettings.tsx src/components/settings/__tests__/TmuxSettings.test.tsx`
- `cd web && npm run build`
- `git diff --cached --check`
- commit hook: `cargo clippy -- -D warnings`, `cargo fmt -- --check`

Note: `npm run build` passed with the existing Vite large-chunk/dynamic-import warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds a configurable tmux scrollback history limit across all layers of the application, while maintaining the existing 2000-line default. Users can now customize this setting globally, per-profile, or per-repository without changing the project-wide default.

### What Was Added

**Configuration Layer:**
- New `history_limit` field to tmux configuration (defaults to 2000 lines)
- Support for per-profile history limit overrides

**Session Management:**
- Automatic application of configured history limit to both new tmux sessions and existing running sessions
- Helper functions to apply the limit across all managed AoE tmux sessions

**User Interface:**
- New "History limit" field in the TUI Settings screen under the Tmux category
- New "History limit" number field in the web Tmux settings panel
- Input validation and clamping to enforce reasonable limits (0 to 200,000)

**API Layer:**
- Updated settings update handlers to automatically apply the configured limit to running sessions when settings are saved
- Support for both global and profile-level live application

### What Changed

- Settings update paths now resolve the active profile and live-apply the history limit after persisting configuration changes
- New tmux argument helpers to construct proper tmux commands for setting the history limit
- TUI settings apply logic now includes history limit live-application for both global and profile scopes

### Benefits

- Users can reduce browser attach/scrollback pressure by lowering the history limit locally without affecting the project default
- Settings are immediately applied to existing sessions—no need to restart or recreate sessions
- Full support across configuration tiers (global, profile, repository) with inheritance and override capabilities
- Comprehensive validation ensures safe input ranges across all UI surfaces

### Technical Details

The implementation spans configuration (`TmuxConfig`, `TmuxConfigOverride`), session creation (`PairedTerminal`, tmux session builders), live session management (`apply_history_limit_option`, `apply_history_limit_to_live_sessions`), and UI layers (TUI fields/input, web NumberField). The history limit is applied via `tmux set-option -t <session> history-limit <lines>` during both session creation and live application to running sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->