### PR TITLE
docs: point project social/roadmap links at agent-of-empires community

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
     <a href="https://clawhub.ai/njbrake/aoe"><img src="https://img.shields.io/badge/ClawHub-aoe-blue" alt="ClawHub"></a>
     <br>
     <a href="https://www.youtube.com/@agent-of-empires"><img src="https://img.shields.io/badge/YouTube-channel-red?logo=youtube" alt="YouTube"></a>
-    <a href="https://x.com/natebrake"><img src="https://img.shields.io/badge/follow-%40natebrake-black?logo=x&logoColor=white" alt="Follow @natebrake"></a>
+    <a href="https://x.com/agentofempires"><img src="https://img.shields.io/badge/follow-%40agentofempires-black?logo=x&logoColor=white" alt="Follow @agentofempires"></a>
     <a href="https://discord.gg/5N3QKX3f6s"><img src="https://img.shields.io/badge/Discord-Mozilla.ai-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   </p>
 </p>
@@ -120,7 +120,7 @@ In the TUI, press `?` for help. The bottom information bar shows all available k
 
 ## Roadmap
 
-The AoE roadmap is public: see the [project board](https://github.com/users/njbrake/projects/1) for what's planned, in progress, and recently shipped. Issues and PRs welcome.
+The AoE roadmap is public: see the [project board](https://github.com/orgs/agent-of-empires/projects/1) for what's planned, in progress, and recently shipped. Issues and PRs welcome.
 
 ## FAQ
 
@@ -204,9 +204,9 @@ unchanged.
 
 Inspired by [agent-deck](https://github.com/asheshgoplani/agent-deck) (Go + Bubble Tea).
 
-## Author
+## Maintainers
 
-Created by [Nate Brake](https://x.com/natebrake) ([@natebrake](https://x.com/natebrake)), Machine Learning Engineer at [Mozilla.ai](https://www.mozilla.ai/).
+Maintained by the Agent of Empires community, with support from [Mozilla.ai](https://www.mozilla.ai/). See [CONTRIBUTORS](https://github.com/agent-of-empires/agent-of-empires/graphs/contributors) for the full list of contributors.
 
 ## License
 

--- a/web/src/components/AboutModal.tsx
+++ b/web/src/components/AboutModal.tsx
@@ -24,7 +24,7 @@ const LINKS: LinkRow[] = [
   },
   {
     label: "Twitter",
-    href: "https://twitter.com/agentofempires",
+    href: "https://x.com/agentofempires",
     display: "@agentofempires",
   },
 ];

--- a/web/src/components/AboutModal.tsx
+++ b/web/src/components/AboutModal.tsx
@@ -24,8 +24,8 @@ const LINKS: LinkRow[] = [
   },
   {
     label: "Twitter",
-    href: "https://twitter.com/natebrake",
-    display: "@natebrake",
+    href: "https://twitter.com/agentofempires",
+    display: "@agentofempires",
   },
 ];
 

--- a/web/tests/top-bar.spec.ts
+++ b/web/tests/top-bar.spec.ts
@@ -43,7 +43,7 @@ test.describe("Top bar", () => {
     await expect(page.getByRole("heading", { name: "Agent of Empires" })).toBeVisible();
     await expect(page.getByRole("link", { name: /agent-of-empires\.com/i })).toBeVisible();
     await expect(page.getByRole("link", { name: /github\.com\/agent-of-empires/i })).toBeVisible();
-    await expect(page.getByRole("link", { name: /@natebrake/i })).toBeVisible();
+    await expect(page.getByRole("link", { name: /@agentofempires/i })).toBeVisible();
   });
 
   test("About modal closes on Escape", async ({ page }) => {

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -40,7 +40,7 @@
         <ul class="space-y-2 text-sm">
           <li><a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-400 hover:text-white transition-colors">GitHub</a></li>
           <li><a href="https://github.com/agent-of-empires/agent-of-empires/issues" class="text-gray-400 hover:text-white transition-colors">Issues</a></li>
-          <li><a href="https://github.com/users/njbrake/projects/1" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
+          <li><a href="https://github.com/orgs/agent-of-empires/projects/1" class="text-gray-400 hover:text-white transition-colors">Roadmap</a></li>
           <li><a href="https://github.com/agent-of-empires/agent-of-empires/blob/main/LICENSE" class="text-gray-400 hover:text-white transition-colors">MIT License</a></li>
         </ul>
       </div>
@@ -48,13 +48,10 @@
 
     <!-- Bottom bar -->
     <div class="border-t border-surface-800/50 pt-6 flex flex-col sm:flex-row items-center justify-between gap-4">
-      <p class="text-gray-600 text-sm">Built by <a href="https://x.com/natebrake" class="text-gray-400 hover:text-white transition-colors">Nathan Brake</a> and the aoe community</p>
+      <p class="text-gray-600 text-sm">Built by the Agent of Empires community</p>
       <div class="flex items-center gap-4">
-        <a href="https://x.com/natebrake" class="text-gray-500 hover:text-white transition-colors" aria-label="Follow on X (Twitter)">
+        <a href="https://x.com/agentofempires" class="text-gray-500 hover:text-white transition-colors" aria-label="Follow on X (Twitter)">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
-        </a>
-        <a href="https://www.linkedin.com/in/njbrake/" class="text-gray-500 hover:text-white transition-colors" aria-label="Connect on LinkedIn">
-          <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
         </a>
         <a href="https://github.com/agent-of-empires/agent-of-empires" class="text-gray-500 hover:text-white transition-colors" aria-label="GitHub repository">
           <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>

--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -36,9 +36,9 @@ const structuredData = {
     "priceCurrency": "USD"
   },
   "author": {
-    "@type": "Person",
-    "name": "Nate Brake",
-    "url": "https://twitter.com/natebrake"
+    "@type": "Organization",
+    "name": "Agent of Empires",
+    "url": "https://agent-of-empires.com"
   },
   "license": "https://github.com/agent-of-empires/agent-of-empires/blob/main/LICENSE",
   "codeRepository": "https://github.com/agent-of-empires/agent-of-empires",
@@ -61,7 +61,7 @@ const structuredData = {
   <title>{title}</title>
   <meta name="description" content={description}>
   <meta name="keywords" content="AI coding agent, terminal session manager, tmux, Claude Code, Codex, OpenCode, Mistral Vibe, Gemini CLI, git worktrees, Docker sandbox, Rust, TUI, CLI, developer tools">
-  <meta name="author" content="Nate Brake">
+  <meta name="author" content="Agent of Empires community">
   <meta name="robots" content="index, follow">
   <link rel="canonical" href={canonicalURL}>
 
@@ -76,8 +76,8 @@ const structuredData = {
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:site" content="@natebrake">
-  <meta name="twitter:creator" content="@natebrake">
+  <meta name="twitter:site" content="@agentofempires">
+  <meta name="twitter:creator" content="@agentofempires">
   <meta name="twitter:title" content={ogTitle}>
   <meta name="twitter:description" content={ogDescription}>
   <meta name="twitter:image" content={ogImage}>


### PR DESCRIPTION
## Description

Switch the project's public links from the maintainer's personal accounts to the new community-owned ones, and reframe attribution to reflect that AoE is a community effort.

**Twitter / X handle** (`@natebrake` → `@agentofempires`):
- `README.md` follow badge
- `web/src/components/AboutModal.tsx` Twitter link in the About modal
- `website/src/components/Footer.astro` social icon
- `website/src/layouts/Base.astro` `twitter:site` and `twitter:creator` meta

**Attribution** (personal → community):
- `README.md` "Author" section becomes "Maintainers" and points at the GitHub contributors page.
- `website/src/components/Footer.astro` drops the "Built by Nathan Brake" line and the personal LinkedIn icon; keeps the project X and GitHub icons.
- `website/src/layouts/Base.astro` schema.org `author` switches from `Person: Nate Brake` to `Organization: Agent of Empires`; `meta name="author"` becomes "Agent of Empires community".

**Roadmap link** (personal user project → org project):
- `README.md` and `website/src/components/Footer.astro` now point at `https://github.com/orgs/agent-of-empires/projects/1`.

**Test update:**
- `web/tests/top-bar.spec.ts` assertion updated to match the new AboutModal handle.

`LICENSE` copyright and the `CHANGELOG.md` PR-authorship attributions are untouched.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

Note: `web/tests/top-bar.spec.ts` was updated to assert the new `@agentofempires` handle. AboutModal is already in `web/tests/coverage-matrix.json` and no new entry is needed for a copy-only change.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 via Claude Code

**Any Additional AI Details you'd like to share:**

Claude drafted the edits and PR body via back-and-forth discussion with @njbrake. The scope decisions (which references are personal attribution that should stay vs project promotion that should change to the community account) were made by @njbrake.

- [x] I am an AI Agent filling out this form (check box if true)

Fixes #1565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

This PR updates the project’s public-facing links and attribution to use community-owned resources rather than the maintainer’s personal accounts.

- Replaced maintainer X/Twitter handle `@natebrake` with the community account `@agentofempires` across:
  - README follow badge
  - About modal (web/src/components/AboutModal.tsx)
  - Website footer (website/src/components/Footer.astro)
  - Twitter card meta tags in the base layout (website/src/layouts/Base.astro)
- Reframed attribution from an individual to the community:
  - README “Author” → “Maintainers” linking to the GitHub contributors page
  - Footer credit changed to “the Agent of Empires community”; personal LinkedIn icon removed
  - JSON-LD structured data author changed from a Person to Organization (Agent of Empires); meta author updated to “Agent of Empires community”
- Roadmap links in README and footer now point to the org project board at https://github.com/orgs/agent-of-empires/projects/1
- Updated test assertion in web/tests/top-bar.spec.ts to expect `@agentofempires`
- LICENSE and CHANGELOG PR-authorship attributions unchanged

## Benefits

- Centralizes project identity under a community-owned account
- Improves long-term sustainability and reduces reliance on a single maintainer’s personal accounts
- Presents clearer, project-focused attribution for users and contributors

## Technical details (short)

Files changed: README.md, web/src/components/AboutModal.tsx, web/tests/top-bar.spec.ts, website/src/components/Footer.astro, website/src/layouts/Base.astro. Changes are documentation/content/meta updates and a single test adjustment; no public API or exported signatures were modified. AI-assisted drafting was used. Fixes issue `#1565`.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1592?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->