### PR TITLE
feat(tui): mouse click + hover support across dialogs, settings, diff

### DIFF
--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -626,7 +626,19 @@ impl App {
                                                     // draining keystrokes). A user double-clicking
                                                     // during dictation can click again after the burst
                                                     // ends.
-                                                    MouseEventKind::Down(MouseButton::Left) if hit_list => { let _ = self.home.handle_click(mouse.column, mouse.row); }
+                                                    MouseEventKind::Down(MouseButton::Left) => {
+                                                        if self.home.handle_context_menu_click(mouse.column, mouse.row) {
+                                                            // Click consumed by the context menu
+                                                            // (item dispatched, kept open, or
+                                                            // dismissed on outside-click).
+                                                        } else if hit_list {
+                                                            let action = self.home.handle_click(mouse.column, mouse.row);
+                                                            if action.is_none() {
+                                                                let _ = self.home.handle_empty_list_click(mouse.column, mouse.row);
+                                                            }
+                                                        }
+                                                    }
+                                                    MouseEventKind::Down(MouseButton::Right) if hit_list => { self.home.handle_right_click(mouse.column, mouse.row); }
                                                     MouseEventKind::Moved => { self.home.handle_hover(mouse.column, mouse.row); }
                                                     _ => {}
                                                 }
@@ -709,10 +721,11 @@ impl App {
                             // before dispatching the action.
                             //
                             // Priority order for `Down(Left)`:
-                            //   1. modal dialog click (e.g. delete Yes/No)
-                            //   2. drag-start (divider, or preview text
+                            //   1. context menu outside-click (close it)
+                            //   2. modal dialog click (e.g. delete Yes/No)
+                            //   3. drag-start (divider, or preview text
                             //      selection)
-                            //   3. list row click (existing select/activate)
+                            //   4. list row click (existing select/activate)
                             // A bare press on the preview seeds a 1x1
                             // PreviewSelect; `handle_drag_end` collapses it
                             // back to no selection on release if the cursor
@@ -721,7 +734,17 @@ impl App {
                                 mouse.kind,
                                 MouseEventKind::Down(MouseButton::Left)
                             ) {
-                                if self.home.handle_dialog_click(mouse.column, mouse.row)
+                                if self
+                                    .home
+                                    .handle_context_menu_click(mouse.column, mouse.row)
+                                {
+                                    // Click consumed by the context menu:
+                                    // either dispatched an item (Rename /
+                                    // Delete), kept the menu open (border
+                                    // hit), or dismissed it (click outside).
+                                    self.draw(terminal)?;
+                                    None
+                                } else if self.home.handle_dialog_click(mouse.column, mouse.row)
                                 {
                                     // A modal swallowed the click — drop any
                                     // leftover preview highlight so it doesn't
@@ -747,8 +770,26 @@ impl App {
                                     let action = self
                                         .home
                                         .handle_click(mouse.column, mouse.row);
+                                    // A click inside the list area that
+                                    // didn't resolve to a row (empty space
+                                    // below the last session) opens the
+                                    // new-session dialog, mirroring `n`.
+                                    if action.is_none() {
+                                        let _ = self
+                                            .home
+                                            .handle_empty_list_click(mouse.column, mouse.row);
+                                    }
                                     self.draw(terminal)?;
                                     action
+                                } else if hit_diff {
+                                    // The diff view file-list panel
+                                    // accepts clicks to select files,
+                                    // matching j/k navigation. Other
+                                    // diff regions are no-op.
+                                    let _ = self.home.clear_preview_selection();
+                                    self.home.handle_diff_click(mouse.column, mouse.row);
+                                    self.draw(terminal)?;
+                                    None
                                 } else {
                                     let _ = self.home.clear_preview_selection();
                                     None
@@ -779,13 +820,33 @@ impl App {
                                     // sees empty cells).
                                     self.home.handle_drag_end()
                                 }
+                                // Right-click opens the sidebar context menu
+                                // (Rename / Delete) for the clicked row.
+                                // hit_list is the only place it makes sense
+                                // today; other surfaces fall through.
+                                MouseEventKind::Down(MouseButton::Right) if hit_list => {
+                                    self.home.handle_right_click(mouse.column, mouse.row)
+                                }
                                 // Moved events are dispatched unconditionally
                                 // (no `hit_list` guard) so the handler can
                                 // clear the hover state the moment the
                                 // cursor leaves the list, even when the new
                                 // position lands on the preview or border.
                                 MouseEventKind::Moved => {
-                                    self.home.handle_hover(mouse.column, mouse.row)
+                                    // Route hover to the diff view's
+                                    // file list when one is open AND
+                                    // the mouse is over it; that's an
+                                    // OR with the home view's own hover
+                                    // (which already covers list +
+                                    // overlay dialogs).
+                                    let mut changed =
+                                        self.home.handle_hover(mouse.column, mouse.row);
+                                    if hit_diff {
+                                        changed |= self
+                                            .home
+                                            .handle_diff_hover(mouse.column, mouse.row);
+                                    }
+                                    changed
                                 }
                                 _ => false,
                             };
@@ -812,6 +873,14 @@ impl App {
                                 if let Some(session_id) = self.pending_cockpit_open.take() {
                                     self.run_cockpit_view(&session_id, terminal).await?;
                                 }
+                            }
+                            // Drain any Action stashed by a modal-dialog
+                            // click (e.g. clicking `[Yes]` on a stop or
+                            // quit confirm). The keyboard path returns
+                            // these through handle_key; the click path
+                            // can't, so it stashes them here.
+                            if let Some(action) = self.home.pending_dialog_click_action.take() {
+                                self.execute_action(action, terminal)?;
                             }
                             continue;
                         }

--- a/src/tui/components/list_picker.rs
+++ b/src/tui/components/list_picker.rs
@@ -21,6 +21,17 @@ pub struct ListPicker {
     selected: usize,
     items: Vec<String>,
     title: String,
+    /// Rect of the rendered dialog (border + content). Captured by
+    /// `render` so a click outside the dialog can dismiss it the way
+    /// a desktop popup would, and clicks inside the list area are
+    /// gated cleanly.
+    dialog_area: Rect,
+    /// Rect of the visible list area + offset of the first rendered
+    /// item into the filtered list. Together they let `handle_click`
+    /// and `handle_hover` map a `(col, row)` straight to an item
+    /// index without re-deriving the scroll math.
+    list_area: Rect,
+    list_scroll_offset: usize,
 }
 
 impl ListPicker {
@@ -31,7 +42,63 @@ impl ListPicker {
             selected: 0,
             items: Vec::new(),
             title: title.into(),
+            dialog_area: Rect::default(),
+            list_area: Rect::default(),
+            list_scroll_offset: 0,
         }
+    }
+
+    /// Resolve a `(col, row)` to a filtered-list index using the last
+    /// rendered list area + scroll offset. `None` for clicks outside
+    /// the list rows.
+    fn row_to_filtered_idx(&self, col: u16, row: u16) -> Option<usize> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if !self.list_area.contains(pos) {
+            return None;
+        }
+        let row_in_list = (row - self.list_area.y) as usize;
+        let abs_idx = self.list_scroll_offset + row_in_list;
+        let filtered = self.filtered_items();
+        if abs_idx >= filtered.len() {
+            return None;
+        }
+        Some(abs_idx)
+    }
+
+    /// Route a left-click. Returns:
+    ///   - `Selected(value)` when the click lands on a list row,
+    ///   - `Cancelled` when the click lands outside the dialog
+    ///     (matches the desktop "click-outside dismisses popup" idiom),
+    ///   - `Continue` when the click lands on the dialog border /
+    ///     filter input / hints (keep the picker open so a stray
+    ///     click on the title doesn't drop the user's filter).
+    pub fn handle_click(&mut self, col: u16, row: u16) -> ListPickerResult {
+        if !self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            self.active = false;
+            return ListPickerResult::Cancelled;
+        }
+        if let Some(idx) = self.row_to_filtered_idx(col, row) {
+            let value = self.filtered_items()[idx].clone();
+            self.active = false;
+            return ListPickerResult::Selected(value);
+        }
+        ListPickerResult::Continue
+    }
+
+    /// Move the highlight to whatever row the mouse is hovering.
+    /// Returns true when the selection actually changed.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let Some(idx) = self.row_to_filtered_idx(col, row) else {
+            return false;
+        };
+        if self.selected == idx {
+            return false;
+        }
+        self.selected = idx;
+        true
     }
 
     pub fn is_active(&self) -> bool {
@@ -98,15 +165,25 @@ impl ListPicker {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
-        let filtered = self.filtered_items();
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Compute the dialog rect first (only needs the filtered count)
+        // and stash it before calling `filtered_items()` again below.
+        // The cached `filtered_items()` borrow holds self immutably for
+        // its whole lifetime, which conflicts with the `&mut self`
+        // assignment to `dialog_area` if we keep one Vec around.
         let max_visible: usize = 8;
-        let list_height = filtered.len().min(max_visible) as u16;
+        let filtered_count = self.filtered_items().len();
+        let list_height = filtered_count.min(max_visible) as u16;
         // filter input (1) + border gap (1) + list + hint (1) + borders (2) + margin (2)
         let dialog_height = (list_height + 7).min(area.height);
         let dialog_width: u16 = 50;
 
         let dialog_area = crate::tui::dialogs::centered_rect(area, dialog_width, dialog_height);
+        self.dialog_area = dialog_area;
+        // Own the filtered list (Vec<String>) instead of borrowing
+        // (Vec<&String>) so subsequent `&mut self` writes below don't
+        // conflict with the borrow.
+        let filtered: Vec<String> = self.filtered_items().into_iter().cloned().collect();
         frame.render_widget(Clear, dialog_area);
 
         let title = format!(" {} ", self.title);
@@ -148,6 +225,8 @@ impl ListPicker {
         } else {
             0
         };
+        self.list_area = chunks[2];
+        self.list_scroll_offset = scroll_offset;
 
         let mut lines: Vec<Line> = Vec::new();
         if filtered.is_empty() {

--- a/src/tui/dialogs/changelog.rs
+++ b/src/tui/dialogs/changelog.rs
@@ -25,6 +25,7 @@ use crate::update::{get_cached_releases, ReleaseInfo};
 pub struct ChangelogDialog {
     scroll_offset: usize,
     display_lines: Vec<DisplayLine>,
+    dialog_area: Rect,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -89,6 +90,22 @@ impl ChangelogDialog {
         Self {
             scroll_offset: 0,
             display_lines,
+            dialog_area: Rect::default(),
+        }
+    }
+
+    /// A click anywhere inside the changelog dialog dismisses it,
+    /// matching the keyboard's "any of Enter/Esc/q/Space submits"
+    /// model. Returns None for clicks outside so the caller can decide
+    /// whether to swallow them.
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<()>> {
+        if self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            Some(DialogResult::Submit(()))
+        } else {
+            None
         }
     }
 
@@ -129,10 +146,11 @@ impl ChangelogDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width = (area.width * 80 / 100).clamp(60, 100);
         let dialog_height = (area.height * 80 / 100).clamp(16, 40);
         let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
+        self.dialog_area = dialog_area;
 
         frame.render_widget(Clear, dialog_area);
 
@@ -497,6 +515,7 @@ mod tests {
         ChangelogDialog {
             scroll_offset: 0,
             display_lines: lines,
+            dialog_area: Rect::default(),
         }
     }
 

--- a/src/tui/dialogs/command_palette.rs
+++ b/src/tui/dialogs/command_palette.rs
@@ -334,6 +334,14 @@ pub struct CommandPaletteDialog {
     matches: Vec<usize>,
     /// Cursor within `matches`.
     selected: usize,
+    /// Captured by `render`: the screen row of each visible (non-header)
+    /// item along with its `matches` index. Drives click + hover routing
+    /// without having to re-derive the scroll math.
+    visible_item_rows: Vec<(u16, usize)>,
+    /// Rect of the rendered dialog frame. Used by click routing to
+    /// distinguish "inside dialog but missed a row" (no-op) from
+    /// "outside dialog" (cancel).
+    dialog_area: Rect,
 }
 
 impl CommandPaletteDialog {
@@ -343,9 +351,54 @@ impl CommandPaletteDialog {
             entries,
             matches: Vec::new(),
             selected: 0,
+            visible_item_rows: Vec::new(),
+            dialog_area: Rect::default(),
         };
         dialog.recompute_matches();
         dialog
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> DialogResult<PaletteAction> {
+        if !self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return DialogResult::Cancel;
+        }
+        // Hit-test the visible item rows.
+        let Some(display_idx) = self
+            .visible_item_rows
+            .iter()
+            .find(|(r, _)| *r == row)
+            .map(|(_, idx)| *idx)
+        else {
+            return DialogResult::Continue;
+        };
+        self.selected = display_idx;
+        let Some(&entry_idx) = self.matches.get(self.selected) else {
+            return DialogResult::Continue;
+        };
+        let cmd = self.entries.swap_remove(entry_idx);
+        DialogResult::Submit(cmd.payload)
+    }
+
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        if col == 0 && row == 0 {
+            return false;
+        }
+        let Some(display_idx) = self
+            .visible_item_rows
+            .iter()
+            .find(|(r, _)| *r == row)
+            .map(|(_, idx)| *idx)
+        else {
+            return false;
+        };
+        if self.selected == display_idx {
+            return false;
+        }
+        self.selected = display_idx;
+        true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<PaletteAction> {
@@ -427,10 +480,12 @@ impl CommandPaletteDialog {
         self.selected = 0;
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.visible_item_rows.clear();
         let dialog_width: u16 = area.width.saturating_sub(8).clamp(40, 70);
         let dialog_height: u16 = area.height.saturating_sub(6).clamp(10, 20);
         let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
+        self.dialog_area = dialog_area;
 
         frame.render_widget(Clear, dialog_area);
 
@@ -482,12 +537,16 @@ impl CommandPaletteDialog {
         let visible = list_area.height as usize;
 
         let mut lines: Vec<Line> = Vec::new();
+        // Parallel to `lines`: None for a group-header line, Some(idx)
+        // for an item line where idx is the `matches` index.
+        let mut line_to_display_idx: Vec<Option<usize>> = Vec::new();
         let mut selected_line: usize = 0;
         if self.matches.is_empty() {
             lines.push(Line::from(Span::styled(
                 "  No matches",
                 Style::default().fg(theme.dimmed),
             )));
+            line_to_display_idx.push(None);
         } else {
             let mut last_group: Option<PaletteGroup> = None;
             for (display_idx, &entry_idx) in self.matches.iter().enumerate() {
@@ -501,6 +560,7 @@ impl CommandPaletteDialog {
                         cmd.group.label(),
                         Style::default().fg(theme.accent).bold(),
                     )));
+                    line_to_display_idx.push(None);
                     last_group = Some(cmd.group);
                 }
 
@@ -539,10 +599,18 @@ impl CommandPaletteDialog {
                     spans.push(Span::styled(cmd.hotkey, Style::default().fg(theme.hint)));
                 }
                 lines.push(Line::from(spans));
+                line_to_display_idx.push(Some(display_idx));
             }
         }
         let start = selected_line.saturating_sub(visible.saturating_sub(1));
         let end = (start + visible).min(lines.len());
+        // Capture screen rows for visible item lines so a click can map
+        // directly back to the `matches` display index.
+        for (i, line_idx) in (start..end).enumerate() {
+            if let Some(idx) = line_to_display_idx.get(line_idx).copied().flatten() {
+                self.visible_item_rows.push((list_area.y + i as u16, idx));
+            }
+        }
         frame.render_widget(Paragraph::new(lines[start..end].to_vec()), list_area);
 
         // Hint footer

--- a/src/tui/dialogs/confirm.rs
+++ b/src/tui/dialogs/confirm.rs
@@ -13,6 +13,8 @@ pub struct ConfirmDialog {
     message: String,
     action: String,
     selected: bool, // true = Yes, false = No
+    yes_button_area: Rect,
+    no_button_area: Rect,
 }
 
 impl ConfirmDialog {
@@ -22,7 +24,32 @@ impl ConfirmDialog {
             message: message.to_string(),
             action: action.to_string(),
             selected: false,
+            yes_button_area: Rect::default(),
+            no_button_area: Rect::default(),
         }
+    }
+
+    /// Route a left-click. `Some(Submit)` for `[Yes]`, `Some(Cancel)`
+    /// for `[No]`, `None` for clicks that hit elsewhere inside the
+    /// dialog. Mirrors UnifiedDeleteDialog so the home view's
+    /// `handle_dialog_click` can fan out the same way.
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<()>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.yes_button_area.contains(pos) {
+            return Some(DialogResult::Submit(()));
+        }
+        if self.no_button_area.contains(pos) {
+            return Some(DialogResult::Cancel);
+        }
+        None
+    }
+
+    /// Hover does not change the Yes/No selection. Otherwise the mouse
+    /// drifting over the opposite button between the user reading the
+    /// prompt and pressing Enter would silently flip which action
+    /// fires. Click commits explicitly via `handle_click`.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
     }
 
     pub fn action(&self) -> &str {
@@ -56,7 +83,7 @@ impl ConfirmDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_area = super::centered_rect(area, 50, 8);
 
         frame.render_widget(Clear, dialog_area);
@@ -83,7 +110,9 @@ impl ConfirmDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        let _ = render_yes_no(frame, chunks[1], theme, self.selected);
+        let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+        self.yes_button_area = yes;
+        self.no_button_area = no;
     }
 }
 

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -1,0 +1,404 @@
+//! Small popup menu anchored at a screen position, used for right-click
+//! context actions on the sidebar list (Rename / Delete).
+
+use crossterm::event::{KeyCode, KeyEvent};
+use ratatui::prelude::*;
+use ratatui::widgets::*;
+
+use super::DialogResult;
+use crate::tui::styles::Theme;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextMenuAction {
+    Rename,
+    Delete,
+}
+
+pub struct ContextMenuDialog {
+    items: Vec<(ContextMenuAction, &'static str)>,
+    selected: usize,
+    /// Anchor where the popup's top-left corner wants to sit. The renderer
+    /// clamps this into the visible area so a click near the bottom-right
+    /// edge of the screen doesn't push the menu off-frame.
+    anchor: (u16, u16),
+    /// Last rendered rect, captured so click-outside detection can run
+    /// without re-deriving the layout.
+    last_area: Rect,
+}
+
+/// Resolve a `(col, row)` mouse position to the menu item index it
+/// would hit, given the last rendered `area` and the number of items.
+/// `None` for clicks on the border, inside the menu but past the last
+/// item, or anywhere outside the menu area.
+fn row_to_item_idx(area: Rect, items_len: usize, col: u16, row: u16) -> Option<usize> {
+    if !area.contains(Position::from((col, row))) {
+        return None;
+    }
+    let inner_y = area.y.saturating_add(1);
+    let last_item_y = inner_y.saturating_add(items_len as u16);
+    if row < inner_y || row >= last_item_y {
+        return None;
+    }
+    Some((row - inner_y) as usize)
+}
+
+impl ContextMenuDialog {
+    pub fn for_session(anchor: (u16, u16)) -> Self {
+        Self::new(
+            anchor,
+            vec![
+                (ContextMenuAction::Rename, "Rename"),
+                (ContextMenuAction::Delete, "Delete"),
+            ],
+        )
+    }
+
+    pub fn for_group(anchor: (u16, u16)) -> Self {
+        Self::new(
+            anchor,
+            vec![
+                (ContextMenuAction::Rename, "Rename Group"),
+                (ContextMenuAction::Delete, "Delete Group"),
+            ],
+        )
+    }
+
+    fn new(anchor: (u16, u16), items: Vec<(ContextMenuAction, &'static str)>) -> Self {
+        Self {
+            items,
+            selected: 0,
+            anchor,
+            last_area: Rect::default(),
+        }
+    }
+
+    pub fn selected_action(&self) -> ContextMenuAction {
+        self.items[self.selected].0
+    }
+
+    /// Returns true when `(col, row)` falls outside the last rendered area.
+    /// Lets the mouse router close the menu on any click that isn't on it,
+    /// matching the sidebar's web behavior in `WorkspaceSidebar.tsx`.
+    pub fn click_is_outside(&self, col: u16, row: u16) -> bool {
+        !self.last_area.contains(Position::from((col, row)))
+    }
+
+    /// Route a left-click at `(col, row)` to the menu. Returns:
+    ///   - `Some(Submit(action))` when the click lands on an item row,
+    ///   - `Some(Continue)` when the click lands on the menu but not on
+    ///     an item (e.g. the rounded border), so the menu stays open,
+    ///   - `None` when the click is outside the menu area, so the caller
+    ///     can close it or fall through to underlying handlers.
+    ///
+    /// Hover-style selection moves with the click first so a near-miss
+    /// still tracks where the user pointed.
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<ContextMenuAction>> {
+        if !self.last_area.contains(Position::from((col, row))) {
+            return None;
+        }
+        match row_to_item_idx(self.last_area, self.items.len(), col, row) {
+            None => {
+                // Click on top/bottom border or anywhere inside the menu
+                // that isn't an item row. Keep the menu open so the user
+                // can try again without re-opening it.
+                Some(DialogResult::Continue)
+            }
+            Some(idx) => {
+                self.selected = idx;
+                Some(DialogResult::Submit(self.items[idx].0))
+            }
+        }
+    }
+
+    /// Move the selection (and thus the highlighted row) to whichever
+    /// item the mouse is hovering, so the visual cue tracks the cursor
+    /// the same way a desktop menu does. Returns true when the
+    /// highlight actually changed, so the caller can skip a redraw on
+    /// every pixel-level mouse twitch.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let Some(idx) = row_to_item_idx(self.last_area, self.items.len(), col, row) else {
+            return false;
+        };
+        if self.selected == idx {
+            return false;
+        }
+        self.selected = idx;
+        true
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<ContextMenuAction> {
+        match key.code {
+            KeyCode::Esc => DialogResult::Cancel,
+            KeyCode::Enter => DialogResult::Submit(self.items[self.selected].0),
+            KeyCode::Up | KeyCode::Char('k') => {
+                if self.selected == 0 {
+                    self.selected = self.items.len() - 1;
+                } else {
+                    self.selected -= 1;
+                }
+                DialogResult::Continue
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                self.selected = (self.selected + 1) % self.items.len();
+                DialogResult::Continue
+            }
+            // Quick-pick hotkeys mirror the underlying actions' home-view
+            // bindings, so a power user never has to arrow + Enter.
+            KeyCode::Char('r') | KeyCode::Char('R') => {
+                DialogResult::Submit(ContextMenuAction::Rename)
+            }
+            KeyCode::Char('d') | KeyCode::Char('D') => {
+                DialogResult::Submit(ContextMenuAction::Delete)
+            }
+            _ => DialogResult::Continue,
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        let label_width = self
+            .items
+            .iter()
+            .map(|(_, label)| label.chars().count() as u16)
+            .max()
+            .unwrap_or(0);
+        // Two columns of inner padding, plus borders.
+        let width = (label_width + 4).max(14);
+        let height = self.items.len() as u16 + 2;
+
+        let mut x = self.anchor.0;
+        let mut y = self.anchor.1;
+        if x + width > area.right() {
+            x = area.right().saturating_sub(width);
+        }
+        if y + height > area.bottom() {
+            y = area.bottom().saturating_sub(height);
+        }
+        x = x.max(area.x);
+        y = y.max(area.y);
+        let dialog_area = Rect {
+            x,
+            y,
+            width: width.min(area.width),
+            height: height.min(area.height),
+        };
+        self.last_area = dialog_area;
+
+        frame.render_widget(Clear, dialog_area);
+
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(theme.accent));
+
+        let inner = block.inner(dialog_area);
+        frame.render_widget(block, dialog_area);
+
+        let rows: Vec<Line> = self
+            .items
+            .iter()
+            .enumerate()
+            .map(|(idx, (_, label))| {
+                let style = if idx == self.selected {
+                    Style::default()
+                        .fg(theme.background)
+                        .bg(theme.accent)
+                        .bold()
+                } else {
+                    Style::default().fg(theme.text)
+                };
+                Line::from(format!(" {label} ")).style(style)
+            })
+            .collect();
+
+        frame.render_widget(Paragraph::new(rows), inner);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn session_menu_starts_on_rename() {
+        let menu = ContextMenuDialog::for_session((0, 0));
+        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+    }
+
+    #[test]
+    fn down_then_enter_selects_delete() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        assert!(matches!(
+            menu.handle_key(key(KeyCode::Down)),
+            DialogResult::Continue
+        ));
+        let result = menu.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Delete)
+        ));
+    }
+
+    #[test]
+    fn enter_on_default_submits_rename() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        let result = menu.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Rename)
+        ));
+    }
+
+    #[test]
+    fn esc_cancels() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        let result = menu.handle_key(key(KeyCode::Esc));
+        assert!(matches!(result, DialogResult::Cancel));
+    }
+
+    #[test]
+    fn up_wraps_from_first_to_last() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        menu.handle_key(key(KeyCode::Up));
+        let result = menu.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Delete)
+        ));
+    }
+
+    #[test]
+    fn down_wraps_from_last_to_first() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        menu.handle_key(key(KeyCode::Down));
+        menu.handle_key(key(KeyCode::Down));
+        let result = menu.handle_key(key(KeyCode::Enter));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Rename)
+        ));
+    }
+
+    #[test]
+    fn r_hotkey_submits_rename() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        // Pre-select Delete to prove the hotkey wins over the cursor.
+        menu.handle_key(key(KeyCode::Down));
+        let result = menu.handle_key(key(KeyCode::Char('r')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Rename)
+        ));
+    }
+
+    #[test]
+    fn d_hotkey_submits_delete() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        let result = menu.handle_key(key(KeyCode::Char('d')));
+        assert!(matches!(
+            result,
+            DialogResult::Submit(ContextMenuAction::Delete)
+        ));
+    }
+
+    #[test]
+    fn unknown_key_is_continue() {
+        let mut menu = ContextMenuDialog::for_session((0, 0));
+        let result = menu.handle_key(key(KeyCode::Char('x')));
+        assert!(matches!(result, DialogResult::Continue));
+    }
+
+    #[test]
+    fn click_is_outside_before_render_is_true() {
+        let menu = ContextMenuDialog::for_session((10, 10));
+        // Before a render captures `last_area`, every point should count
+        // as "outside" so a stray click can't be mis-classified as "inside
+        // the menu" and accidentally kept open.
+        assert!(menu.click_is_outside(10, 10));
+    }
+
+    /// Stub last_area as if render had run, so click routing can be
+    /// tested without spinning up a full Frame.
+    fn stub_render(menu: &mut ContextMenuDialog, x: u16, y: u16, w: u16, h: u16) {
+        menu.last_area = Rect::new(x, y, w, h);
+    }
+
+    #[test]
+    fn click_on_first_row_submits_rename() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        // Item rows live inside the bordered block, so row y+1 is the
+        // first item and y+2 is the second.
+        let result = menu.handle_click(12, 11);
+        assert!(matches!(
+            result,
+            Some(DialogResult::Submit(ContextMenuAction::Rename))
+        ));
+    }
+
+    #[test]
+    fn click_on_second_row_submits_delete() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        let result = menu.handle_click(12, 12);
+        assert!(matches!(
+            result,
+            Some(DialogResult::Submit(ContextMenuAction::Delete))
+        ));
+    }
+
+    #[test]
+    fn click_on_border_keeps_menu_open() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        // Top border row is y itself.
+        let result = menu.handle_click(12, 10);
+        assert!(matches!(result, Some(DialogResult::Continue)));
+    }
+
+    #[test]
+    fn click_outside_returns_none() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        let result = menu.handle_click(40, 40);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn hover_moves_highlight() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+        let changed = menu.handle_hover(12, 12);
+        assert!(changed, "hover onto second row should change highlight");
+        assert_eq!(menu.selected_action(), ContextMenuAction::Delete);
+    }
+
+    #[test]
+    fn hover_on_same_row_returns_false() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        // First hover lands on row 1 (Rename, already selected).
+        assert!(!menu.handle_hover(12, 11));
+        // Same row again -> still no change.
+        assert!(!menu.handle_hover(12, 11));
+    }
+
+    #[test]
+    fn hover_off_menu_leaves_selection_alone() {
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        menu.handle_hover(12, 12); // Delete
+        assert_eq!(menu.selected_action(), ContextMenuAction::Delete);
+        assert!(!menu.handle_hover(40, 40));
+        assert_eq!(
+            menu.selected_action(),
+            ContextMenuAction::Delete,
+            "hover outside menu must not snap the highlight back"
+        );
+    }
+}

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -12,6 +12,12 @@ use crate::tui::styles::Theme;
 pub enum ContextMenuAction {
     Rename,
     Delete,
+    /// Open the new-session dialog (mirrors the `'n'` hotkey).
+    NewSession,
+    /// Open the sort-order picker (mirrors `'o'`).
+    OpenSortPicker,
+    /// Open the group-by mode picker (mirrors `'g'`).
+    OpenGroupPicker,
 }
 
 pub struct ContextMenuDialog {
@@ -72,6 +78,22 @@ impl ContextMenuDialog {
         )
     }
 
+    /// Menu shown when the user right-clicks the empty area of the
+    /// sidebar (below the last session row, or in an empty list).
+    /// Holds the entry points the user would otherwise have to reach
+    /// via `'n'` / `'o'` / `'g'`, so the mouse-only path matches the
+    /// keyboard.
+    pub fn for_empty_sidebar(anchor: (u16, u16)) -> Self {
+        Self::new(
+            anchor,
+            vec![
+                (ContextMenuAction::NewSession, "New Session"),
+                (ContextMenuAction::OpenSortPicker, "Change Sort"),
+                (ContextMenuAction::OpenGroupPicker, "Change Grouping"),
+            ],
+        )
+    }
+
     fn new(anchor: (u16, u16), items: Vec<(ContextMenuAction, &'static str)>) -> Self {
         Self {
             items,
@@ -83,6 +105,22 @@ impl ContextMenuDialog {
 
     pub fn selected_action(&self) -> ContextMenuAction {
         self.items[self.selected].0
+    }
+
+    /// Test-only accessor: returns the (action, label) pairs in order
+    /// so cross-module tests can assert on which menu variant opened
+    /// without spinning up a render. Not part of the runtime API.
+    #[cfg(test)]
+    pub fn items_for_test(&self) -> &[(ContextMenuAction, &'static str)] {
+        &self.items
+    }
+
+    /// Test-only accessor: returns the area the menu rendered into
+    /// last frame. Lets a cross-module test compute the row of a given
+    /// item without re-deriving the layout math.
+    #[cfg(test)]
+    pub fn last_area_for_test(&self) -> Rect {
+        self.last_area
     }
 
     /// Returns true when `(col, row)` falls outside the last rendered area.
@@ -152,12 +190,26 @@ impl ContextMenuDialog {
                 DialogResult::Continue
             }
             // Quick-pick hotkeys mirror the underlying actions' home-view
-            // bindings, so a power user never has to arrow + Enter.
-            KeyCode::Char('r') | KeyCode::Char('R') => {
-                DialogResult::Submit(ContextMenuAction::Rename)
-            }
-            KeyCode::Char('d') | KeyCode::Char('D') => {
-                DialogResult::Submit(ContextMenuAction::Delete)
+            // bindings (r/d for Rename/Delete; n/o/g for New / Sort /
+            // Grouping). The hotkey only fires when the corresponding
+            // action is actually in the current menu's item list, so the
+            // session menu's `r` doesn't accidentally fire on the
+            // empty-sidebar menu (which has different items).
+            KeyCode::Char(c) => {
+                let action = match c {
+                    'r' | 'R' => Some(ContextMenuAction::Rename),
+                    'd' | 'D' => Some(ContextMenuAction::Delete),
+                    'n' | 'N' => Some(ContextMenuAction::NewSession),
+                    'o' | 'O' => Some(ContextMenuAction::OpenSortPicker),
+                    'g' | 'G' => Some(ContextMenuAction::OpenGroupPicker),
+                    _ => None,
+                };
+                match action {
+                    Some(a) if self.items.iter().any(|(item, _)| *item == a) => {
+                        DialogResult::Submit(a)
+                    }
+                    _ => DialogResult::Continue,
+                }
             }
             _ => DialogResult::Continue,
         }

--- a/src/tui/dialogs/context_menu.rs
+++ b/src/tui/dialogs/context_menu.rs
@@ -28,10 +28,19 @@ pub struct ContextMenuDialog {
 
 /// Resolve a `(col, row)` mouse position to the menu item index it
 /// would hit, given the last rendered `area` and the number of items.
-/// `None` for clicks on the border, inside the menu but past the last
-/// item, or anywhere outside the menu area.
+/// `None` for clicks on any border (top, bottom, or vertical), inside
+/// the menu but past the last item, or anywhere outside the menu area.
+/// All four border directions must be excluded; otherwise a click on
+/// the right-hand vertical border at an item's row would dispatch
+/// Rename/Delete the same as clicking the item text, which is not
+/// what the user intends when they target the border.
 fn row_to_item_idx(area: Rect, items_len: usize, col: u16, row: u16) -> Option<usize> {
     if !area.contains(Position::from((col, row))) {
+        return None;
+    }
+    let inner_x = area.x.saturating_add(1);
+    let last_inner_x = area.right().saturating_sub(1);
+    if col < inner_x || col >= last_inner_x {
         return None;
     }
     let inner_y = area.y.saturating_add(1);
@@ -161,8 +170,9 @@ impl ContextMenuDialog {
             .map(|(_, label)| label.chars().count() as u16)
             .max()
             .unwrap_or(0);
-        // Two columns of inner padding, plus borders.
-        let width = (label_width + 4).max(14);
+        // Border columns (2) + horizontal Padding (2) + breathing
+        // room for the selection chevron (2).
+        let width = (label_width + 6).max(16);
         let height = self.items.len() as u16 + 2;
 
         let mut x = self.anchor.0;
@@ -188,6 +198,7 @@ impl ContextMenuDialog {
         let block = Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
+            .padding(Padding::horizontal(1))
             .border_style(Style::default().fg(theme.accent));
 
         let inner = block.inner(dialog_area);
@@ -358,6 +369,29 @@ mod tests {
         // Top border row is y itself.
         let result = menu.handle_click(12, 10);
         assert!(matches!(result, Some(DialogResult::Continue)));
+    }
+
+    #[test]
+    fn click_on_vertical_border_at_item_row_does_not_dispatch() {
+        // Regression: the left and right border columns sit on the
+        // same row as items, so `row` alone can't distinguish "click
+        // on item text" from "click on the border next to the item."
+        // The router must reject both vertical borders or a click on
+        // the right edge of the menu, at an item's y, would fire
+        // Rename / Delete the same as clicking the label.
+        let mut menu = ContextMenuDialog::for_session((10, 10));
+        stub_render(&mut menu, 10, 10, 14, 4);
+        // (10, 11) = left vertical border, first item's row.
+        assert!(matches!(
+            menu.handle_click(10, 11),
+            Some(DialogResult::Continue)
+        ));
+        // (23, 11) = right vertical border, first item's row
+        // (area.right() - 1 with width 14 starting at x=10).
+        assert!(matches!(
+            menu.handle_click(23, 11),
+            Some(DialogResult::Continue)
+        ));
     }
 
     #[test]

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -795,7 +795,7 @@ mod tests {
         dialog.yes_button_area = Rect::new(10, 8, 5, 1);
         dialog.no_button_area = Rect::new(19, 8, 4, 1);
         // simple_dialog has no worktree/sandbox/scratch, so the only
-        // focusable elements are the two buttons — no checkbox rects.
+        // focusable elements are the two buttons; no checkbox rects.
     }
 
     fn stage_rects_for_full(dialog: &mut UnifiedDeleteDialog) {
@@ -820,13 +820,13 @@ mod tests {
 
     #[test]
     fn hover_never_changes_focus() {
-        // Hover must leave focus alone — otherwise mouse drift between
+        // Hover must leave focus alone; otherwise mouse drift between
         // reading the dialog and pressing Enter / Space silently shifts
         // which element the next keystroke targets.
         let mut dialog = simple_dialog();
         stage_rects_for_simple(&mut dialog);
         dialog.focus = FocusElement::NoButton;
-        // Over Yes, over No, over checkbox row, off-rects — all no-ops.
+        // Over Yes, over No, over checkbox row, off-rects; all no-ops.
         for (col, row) in [(12, 8), (20, 8), (10, 5), (50, 50)] {
             assert!(!dialog.handle_hover(col, row), "hover at ({col},{row})");
             assert_eq!(dialog.focus, FocusElement::NoButton);

--- a/src/tui/dialogs/delete_options.rs
+++ b/src/tui/dialogs/delete_options.rs
@@ -61,6 +61,11 @@ pub struct UnifiedDeleteDialog {
     /// Screen rect of the rendered `[No]` button, paired with
     /// `yes_button_area`.
     no_button_area: Rect,
+    /// Per-focusable hit rect captured during `render`. Drives both
+    /// hover (move focus) and click (toggle / submit). Yes/No still
+    /// have dedicated fields above because the renderer returns them
+    /// from `render_yes_no` already; everything else lives here.
+    focusable_rects: Vec<(FocusElement, Rect)>,
 }
 
 impl UnifiedDeleteDialog {
@@ -104,16 +109,18 @@ impl UnifiedDeleteDialog {
             focusable_elements,
             yes_button_area: Rect::default(),
             no_button_area: Rect::default(),
+            focusable_rects: Vec::new(),
         }
     }
 
-    /// Route a left-click. Returns `Some(Submit)` when the user clicked
-    /// the `[Yes]` button, `Some(Cancel)` for `[No]`, and `None` for
-    /// clicks that landed elsewhere inside the dialog (those are
-    /// silently absorbed by the modal, no fall-through to the list).
-    /// Rects are written during `render`; before the first render both
-    /// rects are zero-sized so `contains()` returns false.
-    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<DeleteOptions>> {
+    /// Route a left-click. Returns `Some(Submit)` for `[Yes]`,
+    /// `Some(Cancel)` for `[No]`, `Some(Continue)` for a click on a
+    /// checkbox row (which is treated as a focus-then-toggle), and
+    /// `None` for clicks that landed elsewhere inside the dialog
+    /// (those are silently absorbed by the modal, no fall-through to
+    /// the list). Rects are written during `render`; before the first
+    /// render every rect is zero-sized so `contains()` returns false.
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<DeleteOptions>> {
         let pos = ratatui::layout::Position::from((col, row));
         if self.yes_button_area.contains(pos) {
             return Some(DialogResult::Submit(self.options.clone()));
@@ -121,7 +128,56 @@ impl UnifiedDeleteDialog {
         if self.no_button_area.contains(pos) {
             return Some(DialogResult::Cancel);
         }
+        if let Some(element) = self.hit_focusable(col, row) {
+            self.focus = element;
+            self.toggle_focused_checkbox();
+            return Some(DialogResult::Continue);
+        }
         None
+    }
+
+    /// Hover does not change focus on the checkboxes or Yes/No buttons.
+    /// See `ConfirmDialog::handle_hover` for the rationale. Click still
+    /// moves focus and (for checkboxes) toggles state.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
+    }
+
+    fn hit_focusable(&self, col: u16, row: u16) -> Option<FocusElement> {
+        let pos = ratatui::layout::Position::from((col, row));
+        self.focusable_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(element, _)| *element)
+    }
+
+    /// Toggle whichever checkbox the focus is currently on. No-op for
+    /// the Yes/No buttons, which use Submit/Cancel from `handle_key`
+    /// instead. Mirrors the Space key handler so click and Space
+    /// produce byte-identical state changes.
+    fn toggle_focused_checkbox(&mut self) {
+        match self.focus {
+            FocusElement::WorktreeCheckbox => {
+                self.options.delete_worktree = !self.options.delete_worktree;
+                if !self.options.delete_worktree {
+                    self.options.force_delete = false;
+                }
+                self.rebuild_focusable_elements();
+            }
+            FocusElement::ForceCheckbox => {
+                self.options.force_delete = !self.options.force_delete;
+            }
+            FocusElement::BranchCheckbox => {
+                self.options.delete_branch = !self.options.delete_branch;
+            }
+            FocusElement::SandboxCheckbox => {
+                self.options.delete_sandbox = !self.options.delete_sandbox;
+            }
+            FocusElement::KeepScratchCheckbox => {
+                self.options.keep_scratch = !self.options.keep_scratch;
+            }
+            FocusElement::YesButton | FocusElement::NoButton => {}
+        }
     }
 
     fn build_focusable_elements(
@@ -191,56 +247,17 @@ impl UnifiedDeleteDialog {
             KeyCode::Enter => match self.focus {
                 FocusElement::YesButton => DialogResult::Submit(self.options.clone()),
                 FocusElement::NoButton => DialogResult::Cancel,
-                // Enter on checkbox toggles it (same as Space) rather than submitting
-                FocusElement::WorktreeCheckbox => {
-                    self.options.delete_worktree = !self.options.delete_worktree;
-                    if !self.options.delete_worktree {
-                        self.options.force_delete = false;
-                    }
-                    self.rebuild_focusable_elements();
-                    DialogResult::Continue
-                }
-                FocusElement::ForceCheckbox => {
-                    self.options.force_delete = !self.options.force_delete;
-                    DialogResult::Continue
-                }
-                FocusElement::BranchCheckbox => {
-                    self.options.delete_branch = !self.options.delete_branch;
-                    DialogResult::Continue
-                }
-                FocusElement::SandboxCheckbox => {
-                    self.options.delete_sandbox = !self.options.delete_sandbox;
-                    DialogResult::Continue
-                }
-                FocusElement::KeepScratchCheckbox => {
-                    self.options.keep_scratch = !self.options.keep_scratch;
+                // Enter on a checkbox toggles it (same as Space) rather
+                // than submitting; share the toggle logic with the
+                // Space key handler and mouse click handler.
+                _ => {
+                    self.toggle_focused_checkbox();
                     DialogResult::Continue
                 }
             },
 
             KeyCode::Char(' ') => {
-                match self.focus {
-                    FocusElement::WorktreeCheckbox => {
-                        self.options.delete_worktree = !self.options.delete_worktree;
-                        if !self.options.delete_worktree {
-                            self.options.force_delete = false;
-                        }
-                        self.rebuild_focusable_elements();
-                    }
-                    FocusElement::ForceCheckbox => {
-                        self.options.force_delete = !self.options.force_delete;
-                    }
-                    FocusElement::BranchCheckbox => {
-                        self.options.delete_branch = !self.options.delete_branch;
-                    }
-                    FocusElement::SandboxCheckbox => {
-                        self.options.delete_sandbox = !self.options.delete_sandbox;
-                    }
-                    FocusElement::KeepScratchCheckbox => {
-                        self.options.keep_scratch = !self.options.keep_scratch;
-                    }
-                    FocusElement::YesButton | FocusElement::NoButton => {}
-                }
+                self.toggle_focused_checkbox();
                 DialogResult::Continue
             }
 
@@ -279,6 +296,10 @@ impl UnifiedDeleteDialog {
     }
 
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Rebuilt every frame so a layout change (e.g. focusing the
+        // worktree checkbox unhides the force-delete row) doesn't leave
+        // stale hit rects pointing at the wrong cells.
+        self.focusable_rects.clear();
         let has_worktree = self.config.worktree_branch.is_some();
         let has_sandbox = self.config.has_sandbox;
         let is_scratch = self.config.is_scratch;
@@ -346,69 +367,84 @@ impl UnifiedDeleteDialog {
 
         if checkbox_count > 0 {
             if let Some(branch) = &self.config.worktree_branch {
+                let area = chunks[chunk_idx];
                 let focused = self.focus == FocusElement::WorktreeCheckbox;
                 self.render_checkbox(
                     frame,
-                    chunks[chunk_idx],
+                    area,
                     theme,
                     "Delete worktree",
                     Some(branch),
                     self.options.delete_worktree,
                     focused,
                 );
+                self.focusable_rects
+                    .push((FocusElement::WorktreeCheckbox, area));
                 chunk_idx += 1;
 
                 if show_force {
+                    let area = chunks[chunk_idx];
                     let force_focused = self.focus == FocusElement::ForceCheckbox;
                     self.render_indented_checkbox(
                         frame,
-                        chunks[chunk_idx],
+                        area,
                         theme,
                         "Force delete",
                         self.options.force_delete,
                         force_focused,
                     );
+                    self.focusable_rects
+                        .push((FocusElement::ForceCheckbox, area));
                     chunk_idx += 1;
                 }
 
+                let area = chunks[chunk_idx];
                 let branch_focused = self.focus == FocusElement::BranchCheckbox;
                 self.render_checkbox(
                     frame,
-                    chunks[chunk_idx],
+                    area,
                     theme,
                     "Delete branch",
                     Some(branch),
                     self.options.delete_branch,
                     branch_focused,
                 );
+                self.focusable_rects
+                    .push((FocusElement::BranchCheckbox, area));
                 chunk_idx += 1;
             }
 
             if has_sandbox {
+                let area = chunks[chunk_idx];
                 let focused = self.focus == FocusElement::SandboxCheckbox;
                 self.render_checkbox(
                     frame,
-                    chunks[chunk_idx],
+                    area,
                     theme,
                     "Delete container",
                     None,
                     self.options.delete_sandbox,
                     focused,
                 );
+                self.focusable_rects
+                    .push((FocusElement::SandboxCheckbox, area));
                 chunk_idx += 1;
             }
 
             if is_scratch {
+                let area = chunks[chunk_idx];
                 let focused = self.focus == FocusElement::KeepScratchCheckbox;
                 self.render_checkbox(
                     frame,
-                    chunks[chunk_idx],
+                    area,
                     theme,
                     "Keep scratch directory",
                     None,
                     self.options.keep_scratch,
                     focused,
                 );
+                self.focusable_rects
+                    .push((FocusElement::KeepScratchCheckbox, area));
                 chunk_idx += 1;
             }
 
@@ -682,7 +718,7 @@ mod tests {
         // Both button rects default to Rect::default() (zero-sized) so
         // the contains() check returns false until the dialog has been
         // painted at least once.
-        let dialog = simple_dialog();
+        let mut dialog = simple_dialog();
         assert!(dialog.handle_click(5, 5).is_none());
     }
 
@@ -751,5 +787,100 @@ mod tests {
             }
             _ => panic!("Expected Submit"),
         }
+    }
+
+    /// Stage button + checkbox rects manually (the real ones come from
+    /// `render`, which is impractical to invoke in a unit test).
+    fn stage_rects_for_simple(dialog: &mut UnifiedDeleteDialog) {
+        dialog.yes_button_area = Rect::new(10, 8, 5, 1);
+        dialog.no_button_area = Rect::new(19, 8, 4, 1);
+        // simple_dialog has no worktree/sandbox/scratch, so the only
+        // focusable elements are the two buttons — no checkbox rects.
+    }
+
+    fn stage_rects_for_full(dialog: &mut UnifiedDeleteDialog) {
+        dialog.focusable_rects.clear();
+        dialog
+            .focusable_rects
+            .push((FocusElement::WorktreeCheckbox, Rect::new(5, 3, 30, 1)));
+        if dialog.options.delete_worktree {
+            dialog
+                .focusable_rects
+                .push((FocusElement::ForceCheckbox, Rect::new(5, 4, 30, 1)));
+        }
+        dialog
+            .focusable_rects
+            .push((FocusElement::BranchCheckbox, Rect::new(5, 5, 30, 1)));
+        dialog
+            .focusable_rects
+            .push((FocusElement::SandboxCheckbox, Rect::new(5, 6, 30, 1)));
+        dialog.yes_button_area = Rect::new(10, 10, 5, 1);
+        dialog.no_button_area = Rect::new(19, 10, 4, 1);
+    }
+
+    #[test]
+    fn hover_never_changes_focus() {
+        // Hover must leave focus alone — otherwise mouse drift between
+        // reading the dialog and pressing Enter / Space silently shifts
+        // which element the next keystroke targets.
+        let mut dialog = simple_dialog();
+        stage_rects_for_simple(&mut dialog);
+        dialog.focus = FocusElement::NoButton;
+        // Over Yes, over No, over checkbox row, off-rects — all no-ops.
+        for (col, row) in [(12, 8), (20, 8), (10, 5), (50, 50)] {
+            assert!(!dialog.handle_hover(col, row), "hover at ({col},{row})");
+            assert_eq!(dialog.focus, FocusElement::NoButton);
+        }
+    }
+
+    #[test]
+    fn hover_on_checkbox_row_does_not_steal_focus() {
+        let mut dialog = full_dialog();
+        stage_rects_for_full(&mut dialog);
+        dialog.focus = FocusElement::YesButton;
+        assert!(!dialog.handle_hover(10, 5));
+        assert_eq!(dialog.focus, FocusElement::YesButton);
+    }
+
+    #[test]
+    fn click_on_checkbox_toggles_and_focuses() {
+        let mut dialog = full_dialog();
+        stage_rects_for_full(&mut dialog);
+        let before = dialog.options.delete_branch;
+        let result = dialog
+            .handle_click(10, 5)
+            .expect("checkbox click should return Continue");
+        assert!(matches!(result, DialogResult::Continue));
+        assert_eq!(dialog.focus, FocusElement::BranchCheckbox);
+        assert_eq!(dialog.options.delete_branch, !before);
+    }
+
+    #[test]
+    fn click_on_worktree_checkbox_toggles_and_rebuilds_focusables() {
+        let mut dialog = full_dialog();
+        // Force a known starting state so the test doesn't depend on
+        // whatever the default config's `worktree.auto_cleanup` is.
+        dialog.options.delete_worktree = true;
+        dialog.options.force_delete = true;
+        dialog.rebuild_focusable_elements();
+        stage_rects_for_full(&mut dialog);
+
+        let before_focusables = dialog.focusable_elements.len();
+        let result = dialog
+            .handle_click(10, 3)
+            .expect("worktree click should return Continue");
+        assert!(matches!(result, DialogResult::Continue));
+        assert!(
+            !dialog.options.delete_worktree,
+            "worktree click should toggle the option off"
+        );
+        assert!(
+            !dialog.options.force_delete,
+            "turning worktree off also clears force_delete"
+        );
+        assert!(
+            dialog.focusable_elements.len() < before_focusables,
+            "ForceCheckbox should drop out of focusables when worktree is off"
+        );
     }
 }

--- a/src/tui/dialogs/group_delete_options.rs
+++ b/src/tui/dialogs/group_delete_options.rs
@@ -24,6 +24,10 @@ pub struct GroupDeleteOptionsDialog {
     has_containers: bool,
     options: GroupDeleteOptions,
     focused_field: usize,
+    /// Captured rect per focusable field, populated by `render`.
+    /// Drives both click (set focus + toggle) and hover (set focus
+    /// only).
+    focusable_rects: Vec<(usize, Rect)>,
 }
 
 impl GroupDeleteOptionsDialog {
@@ -40,6 +44,59 @@ impl GroupDeleteOptionsDialog {
             has_containers,
             options: GroupDeleteOptions::default(),
             focused_field: 0,
+            focusable_rects: Vec::new(),
+        }
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<GroupDeleteOptions>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        let hit = self
+            .focusable_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(field, _)| *field)?;
+        self.focused_field = hit;
+        self.toggle_focused_field();
+        Some(DialogResult::Continue)
+    }
+
+    /// Hover does not change focus on the radios / checkboxes. See
+    /// `ConfirmDialog::handle_hover` for the rationale. Click still
+    /// moves focus and toggles state.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
+    }
+
+    /// Mirror the Space-key branch's per-field toggle / radio logic so a
+    /// click produces byte-identical state changes.
+    fn toggle_focused_field(&mut self) {
+        match self.focused_field {
+            0 => {
+                self.options.delete_sessions = false;
+                self.options.delete_worktrees = false;
+                self.options.force_delete_worktrees = false;
+                self.options.delete_branches = false;
+                self.options.delete_containers = false;
+            }
+            1 => {
+                self.options.delete_sessions = true;
+            }
+            f if Some(f) == self.worktree_field_index() => {
+                self.options.delete_worktrees = !self.options.delete_worktrees;
+                if !self.options.delete_worktrees {
+                    self.options.force_delete_worktrees = false;
+                }
+            }
+            f if Some(f) == self.force_field_index() => {
+                self.options.force_delete_worktrees = !self.options.force_delete_worktrees;
+            }
+            f if Some(f) == self.branch_field_index() => {
+                self.options.delete_branches = !self.options.delete_branches;
+            }
+            f if Some(f) == self.container_field_index() => {
+                self.options.delete_containers = !self.options.delete_containers;
+            }
+            _ => {}
         }
     }
 
@@ -125,34 +182,7 @@ impl GroupDeleteOptionsDialog {
                 DialogResult::Continue
             }
             KeyCode::Char(' ') => {
-                match self.focused_field {
-                    0 => {
-                        self.options.delete_sessions = false;
-                        self.options.delete_worktrees = false;
-                        self.options.force_delete_worktrees = false;
-                        self.options.delete_branches = false;
-                        self.options.delete_containers = false;
-                    }
-                    1 => {
-                        self.options.delete_sessions = true;
-                    }
-                    f if Some(f) == self.worktree_field_index() => {
-                        self.options.delete_worktrees = !self.options.delete_worktrees;
-                        if !self.options.delete_worktrees {
-                            self.options.force_delete_worktrees = false;
-                        }
-                    }
-                    f if Some(f) == self.force_field_index() => {
-                        self.options.force_delete_worktrees = !self.options.force_delete_worktrees;
-                    }
-                    f if Some(f) == self.branch_field_index() => {
-                        self.options.delete_branches = !self.options.delete_branches;
-                    }
-                    f if Some(f) == self.container_field_index() => {
-                        self.options.delete_containers = !self.options.delete_containers;
-                    }
-                    _ => {}
-                }
+                self.toggle_focused_field();
                 DialogResult::Continue
             }
             KeyCode::Up | KeyCode::Char('k') => {
@@ -172,7 +202,8 @@ impl GroupDeleteOptionsDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.focusable_rects.clear();
         let show_worktree_option = self.options.delete_sessions && self.has_managed_worktrees;
         let show_force_option = show_worktree_option && self.options.delete_worktrees;
         let show_container_option = self.options.delete_sessions && self.has_containers;
@@ -261,6 +292,7 @@ impl GroupDeleteOptionsDialog {
             Span::styled(" Move sessions to default group", move_style),
         ]);
         frame.render_widget(Paragraph::new(move_line), chunks[2]);
+        self.focusable_rects.push((0, chunks[2]));
 
         // Delete sessions option
         let delete_focused = self.focused_field == 1;
@@ -278,6 +310,7 @@ impl GroupDeleteOptionsDialog {
             Span::styled(" Delete all sessions", delete_style),
         ]);
         frame.render_widget(Paragraph::new(delete_line), chunks[3]);
+        self.focusable_rects.push((1, chunks[3]));
 
         // Track current chunk index for optional checkboxes
         let mut next_chunk = 4;
@@ -297,6 +330,9 @@ impl GroupDeleteOptionsDialog {
                 style,
             );
             frame.render_widget(Paragraph::new(wt_line), chunks[next_chunk]);
+            if let Some(idx) = self.worktree_field_index() {
+                self.focusable_rects.push((idx, chunks[next_chunk]));
+            }
             next_chunk += 1;
 
             if show_force_option {
@@ -311,6 +347,9 @@ impl GroupDeleteOptionsDialog {
                     style,
                 );
                 frame.render_widget(Paragraph::new(fc_line), chunks[next_chunk]);
+                if let Some(idx) = self.force_field_index() {
+                    self.focusable_rects.push((idx, chunks[next_chunk]));
+                }
                 next_chunk += 1;
             }
 
@@ -326,6 +365,9 @@ impl GroupDeleteOptionsDialog {
                 style,
             );
             frame.render_widget(Paragraph::new(br_line), chunks[next_chunk]);
+            if let Some(idx) = self.branch_field_index() {
+                self.focusable_rects.push((idx, chunks[next_chunk]));
+            }
             next_chunk += 1;
         }
 
@@ -342,6 +384,9 @@ impl GroupDeleteOptionsDialog {
                 style,
             );
             frame.render_widget(Paragraph::new(ct_line), chunks[next_chunk]);
+            if let Some(idx) = self.container_field_index() {
+                self.focusable_rects.push((idx, chunks[next_chunk]));
+            }
             next_chunk += 1;
         }
 

--- a/src/tui/dialogs/group_picker.rs
+++ b/src/tui/dialogs/group_picker.rs
@@ -13,12 +13,58 @@ const OPTIONS: &[GroupByMode] = &[GroupByMode::Manual, GroupByMode::Project];
 pub struct GroupPickerDialog {
     selected: usize,
     current: GroupByMode,
+    list_area: Rect,
+    dialog_area: Rect,
 }
 
 impl GroupPickerDialog {
     pub fn new(current: GroupByMode) -> Self {
         let selected = OPTIONS.iter().position(|m| *m == current).unwrap_or(0);
-        Self { selected, current }
+        Self {
+            selected,
+            current,
+            list_area: Rect::default(),
+            dialog_area: Rect::default(),
+        }
+    }
+
+    fn row_to_idx(&self, col: u16, row: u16) -> Option<usize> {
+        if !self
+            .list_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return None;
+        }
+        let i = (row - self.list_area.y) as usize;
+        if i >= OPTIONS.len() {
+            return None;
+        }
+        Some(i)
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> DialogResult<GroupByMode> {
+        if !self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return DialogResult::Cancel;
+        }
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return DialogResult::Continue;
+        };
+        self.selected = idx;
+        DialogResult::Submit(OPTIONS[idx])
+    }
+
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return false;
+        };
+        if self.selected == idx {
+            return false;
+        }
+        self.selected = idx;
+        true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<GroupByMode> {
@@ -41,12 +87,13 @@ impl GroupPickerDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width: u16 = 32;
         // list (OPTIONS.len()) + hint (1) + borders (2) + margin (2)
         let dialog_height: u16 = OPTIONS.len() as u16 + 5;
 
         let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
+        self.dialog_area = dialog_area;
         frame.render_widget(Clear, dialog_area);
 
         let block = Block::default()
@@ -86,6 +133,7 @@ impl GroupPickerDialog {
             }
             lines.push(Line::from(spans));
         }
+        self.list_area = chunks[0];
         frame.render_widget(Paragraph::new(lines), chunks[0]);
 
         let hint = Line::from(vec![

--- a/src/tui/dialogs/hook_trust.rs
+++ b/src/tui/dialogs/hook_trust.rs
@@ -14,6 +14,9 @@ pub struct HookTrustDialog {
     project_path: String,
     selected: bool, // true = Trust, false = Skip
     scroll_offset: u16,
+    trust_button_area: Rect,
+    skip_button_area: Rect,
+    cancel_button_area: Rect,
 }
 
 /// Result from the hook trust dialog.
@@ -36,7 +39,34 @@ impl HookTrustDialog {
             project_path,
             selected: false,
             scroll_offset: 0,
+            trust_button_area: Rect::default(),
+            skip_button_area: Rect::default(),
+            cancel_button_area: Rect::default(),
         }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<HookTrustAction>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.trust_button_area.contains(pos) {
+            return Some(DialogResult::Submit(HookTrustAction::Trust {
+                hooks: self.hooks.clone(),
+                hooks_hash: self.hooks_hash.clone(),
+                project_path: self.project_path.clone(),
+            }));
+        }
+        if self.skip_button_area.contains(pos) {
+            return Some(DialogResult::Submit(HookTrustAction::Skip));
+        }
+        if self.cancel_button_area.contains(pos) {
+            return Some(DialogResult::Cancel);
+        }
+        None
+    }
+
+    /// Hover does not change the Trust/Skip selection. See
+    /// `ConfirmDialog::handle_hover` for the rationale.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<HookTrustAction> {
@@ -128,7 +158,7 @@ impl HookTrustDialog {
         lines
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let hook_lines = self.build_hook_lines();
         let content_height = hook_lines.len() as u16 + 4; // +4 for header, spacing, buttons
 
@@ -191,18 +221,42 @@ impl HookTrustDialog {
             Style::default().fg(theme.dimmed)
         };
 
+        let trust_label = "[Trust & Run (y)]";
+        let skip_label = "[Skip (n)]";
+        let cancel_label = "[Cancel (Esc)]";
+        let gap: u16 = 4;
+        let prefix: u16 = 2;
+        let trust_w = trust_label.chars().count() as u16;
+        let skip_w = skip_label.chars().count() as u16;
+        let cancel_w = cancel_label.chars().count() as u16;
+        let total = prefix + trust_w + gap + skip_w + gap + cancel_w;
+        let button_area = chunks[2];
+        if button_area.width >= total {
+            let left_pad = (button_area.width - total) / 2;
+            let trust_x = button_area.x + left_pad + prefix;
+            let skip_x = trust_x + trust_w + gap;
+            let cancel_x = skip_x + skip_w + gap;
+            self.trust_button_area = Rect::new(trust_x, button_area.y, trust_w, 1);
+            self.skip_button_area = Rect::new(skip_x, button_area.y, skip_w, 1);
+            self.cancel_button_area = Rect::new(cancel_x, button_area.y, cancel_w, 1);
+        } else {
+            self.trust_button_area = Rect::default();
+            self.skip_button_area = Rect::default();
+            self.cancel_button_area = Rect::default();
+        }
+
         let buttons = Line::from(vec![
             Span::raw("  "),
-            Span::styled("[Trust & Run (y)]", trust_style),
+            Span::styled(trust_label, trust_style),
             Span::raw("    "),
-            Span::styled("[Skip (n)]", skip_style),
+            Span::styled(skip_label, skip_style),
             Span::raw("    "),
-            Span::styled("[Cancel (Esc)]", Style::default().fg(theme.dimmed)),
+            Span::styled(cancel_label, Style::default().fg(theme.dimmed)),
         ]);
 
         frame.render_widget(
             Paragraph::new(buttons).alignment(Alignment::Center),
-            chunks[2],
+            button_area,
         );
     }
 }

--- a/src/tui/dialogs/hooks_install.rs
+++ b/src/tui/dialogs/hooks_install.rs
@@ -13,6 +13,8 @@ pub struct HooksInstallDialog {
     needs_codex_trust_note: bool,
     selected: bool, // true = Accept, false = Cancel
     scroll_offset: u16,
+    accept_button_area: Rect,
+    cancel_button_area: Rect,
 }
 
 impl HooksInstallDialog {
@@ -55,7 +57,26 @@ impl HooksInstallDialog {
             needs_codex_trust_note,
             selected: true,
             scroll_offset: 0,
+            accept_button_area: Rect::default(),
+            cancel_button_area: Rect::default(),
         }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<bool>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.accept_button_area.contains(pos) {
+            return Some(DialogResult::Submit(true));
+        }
+        if self.cancel_button_area.contains(pos) {
+            return Some(DialogResult::Cancel);
+        }
+        None
+    }
+
+    /// Hover does not change the Accept / Cancel selection. See
+    /// `ConfirmDialog::handle_hover` for the rationale.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<bool> {
@@ -145,7 +166,7 @@ impl HooksInstallDialog {
         lines
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let content_lines = self.build_content_lines();
         let content_height = content_lines.len() as u16 + 6; // header + spacing + buttons
 
@@ -208,16 +229,35 @@ impl HooksInstallDialog {
             Style::default().fg(theme.dimmed)
         };
 
+        let accept_label = "[Accept (y)]";
+        let cancel_label = "[Cancel (Esc)]";
+        let gap: u16 = 4;
+        let prefix: u16 = 2;
+        let accept_w = accept_label.chars().count() as u16;
+        let cancel_w = cancel_label.chars().count() as u16;
+        let total = prefix + accept_w + gap + cancel_w;
+        let button_area = chunks[2];
+        if button_area.width >= total {
+            let left_pad = (button_area.width - total) / 2;
+            let accept_x = button_area.x + left_pad + prefix;
+            let cancel_x = accept_x + accept_w + gap;
+            self.accept_button_area = Rect::new(accept_x, button_area.y, accept_w, 1);
+            self.cancel_button_area = Rect::new(cancel_x, button_area.y, cancel_w, 1);
+        } else {
+            self.accept_button_area = Rect::default();
+            self.cancel_button_area = Rect::default();
+        }
+
         let buttons = Line::from(vec![
             Span::raw("  "),
-            Span::styled("[Accept (y)]", accept_style),
+            Span::styled(accept_label, accept_style),
             Span::raw("    "),
-            Span::styled("[Cancel (Esc)]", cancel_style),
+            Span::styled(cancel_label, cancel_style),
         ]);
 
         frame.render_widget(
             Paragraph::new(buttons).alignment(Alignment::Center),
-            chunks[2],
+            button_area,
         );
     }
 }

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -12,11 +12,6 @@ pub struct InfoDialog {
     message: String,
     width: u16,
     height: u16,
-    /// Rect of the rendered `[OK]` button, captured during `render`.
-    /// Lets `handle_click` accept either a click on the button OR a
-    /// click anywhere on the dialog area (the latter is a quick
-    /// "dismiss" gesture matching the keyboard's bare-Space behavior).
-    ok_button_area: Rect,
     dialog_area: Rect,
 }
 
@@ -27,7 +22,6 @@ impl InfoDialog {
             message: message.to_string(),
             width: 50,
             height: 9,
-            ok_button_area: Rect::default(),
             dialog_area: Rect::default(),
         }
     }
@@ -91,24 +85,16 @@ impl InfoDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        // OK button. Centered inside the bottom chunk; the rect
-        // tracks where the glyph actually lands so a click on the
-        // button is targeted (not just "click anywhere to dismiss").
+        // OK button rendered for visual affordance; click is handled
+        // by the whole-dialog hit region in `handle_click`, so the
+        // button's own rect doesn't need to be captured.
         let button = Line::from(vec![Span::styled(
             "[OK]",
             Style::default().fg(theme.accent).bold(),
         )]);
-        let button_area = chunks[1];
-        if button_area.width >= 4 {
-            let left_pad = (button_area.width - 4) / 2;
-            self.ok_button_area = Rect::new(button_area.x + left_pad, button_area.y, 4, 1);
-        } else {
-            self.ok_button_area = Rect::default();
-        }
-
         frame.render_widget(
             Paragraph::new(button).alignment(Alignment::Center),
-            button_area,
+            chunks[1],
         );
     }
 }

--- a/src/tui/dialogs/info.rs
+++ b/src/tui/dialogs/info.rs
@@ -12,6 +12,12 @@ pub struct InfoDialog {
     message: String,
     width: u16,
     height: u16,
+    /// Rect of the rendered `[OK]` button, captured during `render`.
+    /// Lets `handle_click` accept either a click on the button OR a
+    /// click anywhere on the dialog area (the latter is a quick
+    /// "dismiss" gesture matching the keyboard's bare-Space behavior).
+    ok_button_area: Rect,
+    dialog_area: Rect,
 }
 
 impl InfoDialog {
@@ -21,6 +27,23 @@ impl InfoDialog {
             message: message.to_string(),
             width: 50,
             height: 9,
+            ok_button_area: Rect::default(),
+            dialog_area: Rect::default(),
+        }
+    }
+
+    /// A left-click anywhere inside the info dialog dismisses it,
+    /// matching the keyboard's "any of Esc/Enter/Space closes" model.
+    /// `None` when the click landed outside the dialog area, so the
+    /// caller can decide whether to swallow it anyway.
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<()>> {
+        if self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            Some(DialogResult::Cancel)
+        } else {
+            None
         }
     }
 
@@ -40,8 +63,9 @@ impl InfoDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_area = super::centered_rect(area, self.width, self.height);
+        self.dialog_area = dialog_area;
 
         frame.render_widget(Clear, dialog_area);
 
@@ -67,15 +91,24 @@ impl InfoDialog {
             .wrap(Wrap { trim: true });
         frame.render_widget(message, chunks[0]);
 
-        // OK button
+        // OK button. Centered inside the bottom chunk; the rect
+        // tracks where the glyph actually lands so a click on the
+        // button is targeted (not just "click anywhere to dismiss").
         let button = Line::from(vec![Span::styled(
             "[OK]",
             Style::default().fg(theme.accent).bold(),
         )]);
+        let button_area = chunks[1];
+        if button_area.width >= 4 {
+            let left_pad = (button_area.width - 4) / 2;
+            self.ok_button_area = Rect::new(button_area.x + left_pad, button_area.y, 4, 1);
+        } else {
+            self.ok_button_area = Rect::default();
+        }
 
         frame.render_widget(
             Paragraph::new(button).alignment(Alignment::Center),
-            chunks[1],
+            button_area,
         );
     }
 }

--- a/src/tui/dialogs/mod.rs
+++ b/src/tui/dialogs/mod.rs
@@ -3,6 +3,7 @@
 mod changelog;
 mod command_palette;
 mod confirm;
+mod context_menu;
 mod custom_instruction;
 mod delete_options;
 mod group_delete_options;
@@ -30,6 +31,7 @@ pub use command_palette::{
     builtin_commands, CommandPaletteDialog, PaletteAction, PaletteCommand, PaletteGroup,
 };
 pub use confirm::ConfirmDialog;
+pub use context_menu::{ContextMenuAction, ContextMenuDialog};
 pub use custom_instruction::CustomInstructionDialog;
 pub use delete_options::{DeleteDialogConfig, DeleteOptions, UnifiedDeleteDialog};
 pub use group_delete_options::{GroupDeleteOptions, GroupDeleteOptionsDialog};

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -858,10 +858,64 @@ impl NewSessionDialog {
     /// group/branch/projects picker, help) are still keyboard-only;
     /// `handle_click` only fires on the top-level form.
     pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<NewSessionData>> {
+        let pos = ratatui::layout::Position::from((col, row));
+
+        // List pickers (group / branch / projects) float over every
+        // other surface (main form AND config overlays), so route their
+        // clicks first. Otherwise the worktree config overlay below
+        // would swallow clicks meant for the branch picker that pops
+        // up from inside it.
+        if self.group_picker.is_active() {
+            match self.group_picker.handle_click(col, row) {
+                ListPickerResult::Continue | ListPickerResult::Cancelled => {
+                    return Some(DialogResult::Continue);
+                }
+                ListPickerResult::Selected(value) => {
+                    self.group = Input::new(value);
+                    self.clear_group_ghost();
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+        if self.branch_picker.is_active() {
+            match self.branch_picker.handle_click(col, row) {
+                ListPickerResult::Continue | ListPickerResult::Cancelled => {
+                    return Some(DialogResult::Continue);
+                }
+                ListPickerResult::Selected(value) => {
+                    self.worktree_branch = Input::new(value);
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+        if self.projects_picker.is_active() {
+            match self.projects_picker.handle_click(col, row) {
+                ListPickerResult::Continue | ListPickerResult::Cancelled => {
+                    return Some(DialogResult::Continue);
+                }
+                ListPickerResult::Selected(value) => {
+                    // Mirror the Enter-key handler in the worktree-config
+                    // path: resolve the display name back to a project
+                    // path via `available_projects` and append to
+                    // `workspace_repos` if not already present.
+                    if let Some(project) = self
+                        .available_projects
+                        .iter()
+                        .find(|p| project_picker_label(p) == value)
+                    {
+                        let path = project.path.clone();
+                        if !self.workspace_repos.iter().any(|p| p == &path) {
+                            self.workspace_repos.push(path);
+                        }
+                    }
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+
         // Config overlays (sandbox / tool / worktree) take precedence
         // over the main form: their rects are populated only while
         // their mode is active.
-        let pos = ratatui::layout::Position::from((col, row));
         if self.sandbox_config_mode {
             if let Some(hit) = self
                 .sandbox_config_rects
@@ -902,46 +956,6 @@ impl NewSessionDialog {
             return Some(DialogResult::Continue);
         }
 
-        // List pickers (group / branch / projects) sit over the main
-        // form when active; route their clicks first so the user can
-        // click an item to select it.
-        if self.group_picker.is_active() {
-            match self.group_picker.handle_click(col, row) {
-                ListPickerResult::Continue => return Some(DialogResult::Continue),
-                ListPickerResult::Cancelled => return Some(DialogResult::Continue),
-                ListPickerResult::Selected(value) => {
-                    self.group = Input::new(value);
-                    self.clear_group_ghost();
-                    return Some(DialogResult::Continue);
-                }
-            }
-        }
-        if self.branch_picker.is_active() {
-            match self.branch_picker.handle_click(col, row) {
-                ListPickerResult::Continue => return Some(DialogResult::Continue),
-                ListPickerResult::Cancelled => return Some(DialogResult::Continue),
-                ListPickerResult::Selected(value) => {
-                    self.worktree_branch = Input::new(value);
-                    return Some(DialogResult::Continue);
-                }
-            }
-        }
-        if self.projects_picker.is_active() {
-            // Mirror the Enter-key handler in the worktree-config path,
-            // but defensively: the picker's value is the project's
-            // display name; the keyboard path resolves that back to a
-            // path via `available_projects`. We don't replicate the
-            // append-to-workspace_repos logic on click here to keep
-            // diff scoped; the picker still closes cleanly.
-            match self.projects_picker.handle_click(col, row) {
-                ListPickerResult::Continue => return Some(DialogResult::Continue),
-                ListPickerResult::Cancelled | ListPickerResult::Selected(_) => {
-                    return Some(DialogResult::Continue);
-                }
-            }
-        }
-
-        let pos = ratatui::layout::Position::from((col, row));
         let hit_field = self
             .focusable_rects
             .iter()
@@ -954,7 +968,7 @@ impl NewSessionDialog {
 
     /// Hover only updates the active picker's row highlight (menu-style
     /// behavior the user expects). It deliberately does NOT move focus
-    /// between form fields — main form or any of the config overlays.
+    /// between form fields; main form or any of the config overlays.
     /// Stealing focus from the field the user is typing into just
     /// because the mouse cursor drifts across the dialog is jarring.
     /// Click still sets focus.
@@ -1007,7 +1021,7 @@ impl NewSessionDialog {
             usize::MAX
         };
         let sandbox_field = if has_sandbox {
-            // No `fi += 1` here — sandbox is the last index we need to
+            // No `fi += 1` here; sandbox is the last index we need to
             // resolve, and the unused assignment trips clippy.
             fi
         } else {
@@ -1015,9 +1029,32 @@ impl NewSessionDialog {
         };
 
         if self.focused_field == profile_field {
-            self.profile_index = (self.profile_index + 1) % self.available_profiles.len().max(1);
+            if self.available_profiles.len() > 1 {
+                self.profile_index = (self.profile_index + 1) % self.available_profiles.len();
+                // Mirror the keyboard cycle: pick up the new profile's
+                // defaults (sandbox, yolo, hooks, tool override) so the
+                // dialog reflects what a submit would actually create.
+                self.reload_config_defaults();
+            }
         } else if self.focused_field == tool_field {
-            self.tool_index = (self.tool_index + 1) % self.available_tools.len().max(1);
+            if self.available_tools.len() > 1 {
+                self.tool_index = (self.tool_index + 1) % self.available_tools.len();
+                // Same side effects the Space/Left/Right tool handler
+                // applies: always-yolo tools force the toggle, host-only
+                // tools clear sandbox + worktree, and the per-tool config
+                // overlay (and its branch override) get re-resolved.
+                if self.selected_tool_always_yolo() {
+                    self.yolo_mode = true;
+                } else {
+                    self.yolo_mode = self.yolo_mode_default;
+                }
+                if self.selected_tool_host_only() {
+                    self.sandbox_enabled = false;
+                    self.worktree_enabled = false;
+                    self.worktree_branch.reset();
+                }
+                self.reload_tool_config();
+            }
         } else if self.focused_field == yolo_mode_field {
             self.yolo_mode = !self.yolo_mode;
         } else if self.focused_field == worktree_field {

--- a/src/tui/dialogs/new_session/mod.rs
+++ b/src/tui/dialogs/new_session/mod.rs
@@ -216,6 +216,23 @@ pub struct NewSessionDialog {
     /// provisions a fresh scratch directory. Toggled with Ctrl+T from
     /// anywhere in the form. Mutually exclusive with worktree mode.
     pub(super) scratch: bool,
+    /// Per-field hit rect captured by the renderer of the main form
+    /// so a mouse click / hover can target the same cells the user
+    /// sees. Each entry is `(focused_field_index, rect)`. Cleared and
+    /// repopulated every frame; empty while an overlay (sandbox config,
+    /// tool config, worktree config, loading, dir picker, etc.) is up,
+    /// so a stray click during one of those modes won't snap focus to
+    /// the underlying main-form field that used to sit there.
+    pub(super) focusable_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Rects for the sandbox-config overlay, keyed by
+    /// `sandbox_focused_field`. Populated only when that overlay is up.
+    pub(super) sandbox_config_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Rects for the tool-config overlay, keyed by
+    /// `tool_config_focused_field`.
+    pub(super) tool_config_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Rects for the worktree-config overlay, keyed by
+    /// `worktree_config_focused_field`.
+    pub(super) worktree_config_rects: Vec<(usize, ratatui::layout::Rect)>,
 }
 
 /// Shared logic for handling key events in an editable list (env keys or env values).
@@ -469,6 +486,10 @@ impl NewSessionDialog {
             group_ghost: None,
             confirm_create_dir: None,
             scratch: false,
+            focusable_rects: Vec::new(),
+            sandbox_config_rects: Vec::new(),
+            tool_config_rects: Vec::new(),
+            worktree_config_rects: Vec::new(),
         }
     }
 
@@ -736,6 +757,10 @@ impl NewSessionDialog {
             group_ghost: None,
             confirm_create_dir: None,
             scratch: false,
+            focusable_rects: Vec::new(),
+            sandbox_config_rects: Vec::new(),
+            tool_config_rects: Vec::new(),
+            worktree_config_rects: Vec::new(),
         }
     }
 
@@ -801,6 +826,10 @@ impl NewSessionDialog {
             group_ghost: None,
             confirm_create_dir: None,
             scratch: false,
+            focusable_rects: Vec::new(),
+            sandbox_config_rects: Vec::new(),
+            tool_config_rects: Vec::new(),
+            worktree_config_rects: Vec::new(),
         }
     }
 
@@ -817,6 +846,213 @@ fn project_picker_label(p: &crate::session::Project) -> String {
 }
 
 impl NewSessionDialog {
+    /// Route a left-click on the main form. Returns `Some(Continue)`
+    /// when the click landed on a focusable field (focus moves and,
+    /// for checkbox / cycler rows, the value advances the same way
+    /// Space / Left+Right would). Returns `None` when the click missed
+    /// every captured rect or when the dialog is in an overlay mode
+    /// where the main-form rects don't apply (the renderer leaves
+    /// `focusable_rects` empty in those modes).
+    ///
+    /// The overlay modes (sandbox/tool/worktree config, dir picker,
+    /// group/branch/projects picker, help) are still keyboard-only;
+    /// `handle_click` only fires on the top-level form.
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<NewSessionData>> {
+        // Config overlays (sandbox / tool / worktree) take precedence
+        // over the main form: their rects are populated only while
+        // their mode is active.
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.sandbox_config_mode {
+            if let Some(hit) = self
+                .sandbox_config_rects
+                .iter()
+                .find(|(_, rect)| rect.contains(pos))
+                .map(|(f, _)| *f)
+            {
+                self.sandbox_focused_field = hit;
+            }
+            return Some(DialogResult::Continue);
+        }
+        if self.tool_config_mode {
+            if let Some(hit) = self
+                .tool_config_rects
+                .iter()
+                .find(|(_, rect)| rect.contains(pos))
+                .map(|(f, _)| *f)
+            {
+                self.tool_config_focused_field = hit;
+            }
+            return Some(DialogResult::Continue);
+        }
+        if self.worktree_config_mode {
+            if let Some(hit) = self
+                .worktree_config_rects
+                .iter()
+                .find(|(_, rect)| rect.contains(pos))
+                .map(|(f, _)| *f)
+            {
+                self.worktree_config_focused_field = hit;
+                // Field index 1 is the new-branch checkbox in the
+                // worktree-config overlay; a click toggles it like Space
+                // would on the keyboard.
+                if hit == 1 {
+                    self.create_new_branch = !self.create_new_branch;
+                }
+            }
+            return Some(DialogResult::Continue);
+        }
+
+        // List pickers (group / branch / projects) sit over the main
+        // form when active; route their clicks first so the user can
+        // click an item to select it.
+        if self.group_picker.is_active() {
+            match self.group_picker.handle_click(col, row) {
+                ListPickerResult::Continue => return Some(DialogResult::Continue),
+                ListPickerResult::Cancelled => return Some(DialogResult::Continue),
+                ListPickerResult::Selected(value) => {
+                    self.group = Input::new(value);
+                    self.clear_group_ghost();
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+        if self.branch_picker.is_active() {
+            match self.branch_picker.handle_click(col, row) {
+                ListPickerResult::Continue => return Some(DialogResult::Continue),
+                ListPickerResult::Cancelled => return Some(DialogResult::Continue),
+                ListPickerResult::Selected(value) => {
+                    self.worktree_branch = Input::new(value);
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+        if self.projects_picker.is_active() {
+            // Mirror the Enter-key handler in the worktree-config path,
+            // but defensively: the picker's value is the project's
+            // display name; the keyboard path resolves that back to a
+            // path via `available_projects`. We don't replicate the
+            // append-to-workspace_repos logic on click here to keep
+            // diff scoped; the picker still closes cleanly.
+            match self.projects_picker.handle_click(col, row) {
+                ListPickerResult::Continue => return Some(DialogResult::Continue),
+                ListPickerResult::Cancelled | ListPickerResult::Selected(_) => {
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+
+        let pos = ratatui::layout::Position::from((col, row));
+        let hit_field = self
+            .focusable_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(field, _)| *field)?;
+        self.focused_field = hit_field;
+        self.activate_focused_field();
+        Some(DialogResult::Continue)
+    }
+
+    /// Hover only updates the active picker's row highlight (menu-style
+    /// behavior the user expects). It deliberately does NOT move focus
+    /// between form fields — main form or any of the config overlays.
+    /// Stealing focus from the field the user is typing into just
+    /// because the mouse cursor drifts across the dialog is jarring.
+    /// Click still sets focus.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        if self.group_picker.is_active() {
+            return self.group_picker.handle_hover(col, row);
+        }
+        if self.branch_picker.is_active() {
+            return self.branch_picker.handle_hover(col, row);
+        }
+        if self.projects_picker.is_active() {
+            return self.projects_picker.handle_hover(col, row);
+        }
+        false
+    }
+
+    /// Perform the focused field's primary action: toggle a checkbox,
+    /// cycle a picker. Text fields (path, title, group) have no primary
+    /// action and are left alone. Mirrors the per-field branches of
+    /// `handle_key`'s Space / Left / Right handlers so a click produces
+    /// byte-identical state changes.
+    fn activate_focused_field(&mut self) {
+        let has_profile_selection = self.available_profiles.len() > 1;
+        let has_tool_selection = self.available_tools.len() > 1;
+        let is_host_only = self.selected_tool_host_only();
+        let has_sandbox = self.docker_available && !is_host_only;
+        let has_yolo = !self.selected_tool_always_yolo();
+        let profile_field = if has_profile_selection { 0 } else { usize::MAX };
+        let mut fi = if has_profile_selection { 1 } else { 0 };
+        fi += 2; // title + path
+        let tool_field = if has_tool_selection {
+            let f = fi;
+            fi += 1;
+            f
+        } else {
+            usize::MAX
+        };
+        let yolo_mode_field = if has_yolo {
+            let f = fi;
+            fi += 1;
+            f
+        } else {
+            usize::MAX
+        };
+        let worktree_field = if !is_host_only {
+            let f = fi;
+            fi += 1;
+            f
+        } else {
+            usize::MAX
+        };
+        let sandbox_field = if has_sandbox {
+            // No `fi += 1` here — sandbox is the last index we need to
+            // resolve, and the unused assignment trips clippy.
+            fi
+        } else {
+            usize::MAX
+        };
+
+        if self.focused_field == profile_field {
+            self.profile_index = (self.profile_index + 1) % self.available_profiles.len().max(1);
+        } else if self.focused_field == tool_field {
+            self.tool_index = (self.tool_index + 1) % self.available_tools.len().max(1);
+        } else if self.focused_field == yolo_mode_field {
+            self.yolo_mode = !self.yolo_mode;
+        } else if self.focused_field == worktree_field {
+            // Mirror the keyboard handler: worktree and scratch are
+            // mutually exclusive, so a click on the worktree row while
+            // scratch is on surfaces an inline hint rather than
+            // silently toggling.
+            if self.scratch {
+                self.error_message = Some(
+                    "Worktree is disabled in scratch mode. Press Ctrl+T to leave scratch first."
+                        .to_string(),
+                );
+            } else {
+                self.worktree_enabled = !self.worktree_enabled;
+                if !self.worktree_enabled {
+                    self.worktree_config_mode = false;
+                }
+            }
+        } else if self.focused_field == sandbox_field {
+            self.sandbox_enabled = !self.sandbox_enabled;
+            if self.sandbox_enabled {
+                let config = resolve_config_or_warn(&self.profile);
+                self.extra_env = config.sandbox.environment.clone();
+                self.inherited_settings = build_inherited_settings(&config.sandbox);
+            } else {
+                self.extra_env.clear();
+                self.env_list_expanded = false;
+                self.env_editing_input = None;
+                self.inherited_settings.clear();
+                self.sandbox_config_mode = false;
+            }
+        }
+        // Path / Title / Group: focus change only, no toggle action.
+    }
+
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<NewSessionData> {
         // When loading, only allow Esc to cancel
         if self.loading {

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -54,6 +54,14 @@ impl NewSessionDialog {
         let has_sandbox = self.docker_available && !is_host_only;
         let has_yolo = !self.selected_tool_always_yolo();
         let dialog_width = 80;
+        // Capture the full overlay area up front so the centered-pop
+        // pickers at the bottom of this function don't accidentally
+        // use a per-field `area` that the loop below shadows on every
+        // row. Without this the dir / group / branch / projects
+        // pickers anchor against whichever Layout chunk the local
+        // `area` last pointed at (typically the Group row) and render
+        // as a tiny strip inside the underlying dialog.
+        let full_area = area;
         // When the selected profile has a description, the profile row needs
         // an extra line to render it beneath the name. We compute this once
         // here so the layout constraint and the renderer agree on height.
@@ -495,23 +503,23 @@ impl NewSessionDialog {
         }
 
         if self.show_help {
-            self.render_help_overlay(frame, area, theme);
+            self.render_help_overlay(frame, full_area, theme);
         }
 
         if self.group_picker.is_active() {
-            self.group_picker.render(frame, area, theme);
+            self.group_picker.render(frame, full_area, theme);
         }
 
         if self.branch_picker.is_active() {
-            self.branch_picker.render(frame, area, theme);
+            self.branch_picker.render(frame, full_area, theme);
         }
 
         if self.projects_picker.is_active() {
-            self.projects_picker.render(frame, area, theme);
+            self.projects_picker.render(frame, full_area, theme);
         }
 
         if self.dir_picker.is_active() {
-            self.dir_picker.render(frame, area, theme);
+            self.dir_picker.render(frame, full_area, theme);
         }
     }
 

--- a/src/tui/dialogs/new_session/render.rs
+++ b/src/tui/dialogs/new_session/render.rs
@@ -14,7 +14,16 @@ use crate::tui::components::{
 use crate::tui::styles::Theme;
 
 impl NewSessionDialog {
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Rebuilt every frame: layout changes (a profile gains/loses
+        // its description row, scratch toggles off worktree, etc.) move
+        // every subsequent field, so stale rects would point at the
+        // wrong row. Clearing here also wipes rects when an overlay
+        // mode replaces the main form, so a click during sandbox /
+        // tool / worktree config mode doesn't snap focus to whatever
+        // main-form field used to be under that cell.
+        self.focusable_rects.clear();
+
         // If loading, render the loading overlay instead
         if self.loading {
             self.render_loading(frame, area, theme);
@@ -156,30 +165,37 @@ impl NewSessionDialog {
 
         // Profile picker (only when multiple profiles)
         if has_profile_selection {
-            self.render_profile_field(frame, chunks[ci], theme);
+            let area = chunks[ci];
+            self.render_profile_field(frame, area, theme);
+            self.focusable_rects.push((0, area));
             ci += 1;
         }
 
         // Path (rendered first so the user picks the working directory
         // before naming the session).
-        let path_placeholder = if self.focused_field == self.path_field() {
+        let path_field_idx = self.path_field();
+        let path_placeholder = if self.focused_field == path_field_idx {
             Some("(Ctrl+P to browse directories)")
         } else {
             None
         };
-        self.render_path_field(frame, chunks[ci], path_placeholder, theme);
+        let area = chunks[ci];
+        self.render_path_field(frame, area, path_placeholder, theme);
+        self.focusable_rects.push((path_field_idx, area));
         ci += 1;
 
         // Title
+        let area = chunks[ci];
         render_text_field(
             frame,
-            chunks[ci],
+            area,
             "Title:",
             &self.title,
             self.focused_field == title_field,
             Some("(random civ)"),
             theme,
         );
+        self.focusable_rects.push((title_field, area));
         ci += 1;
 
         // Tool (always shown, interactive or read-only). The cycler itself is
@@ -213,7 +229,13 @@ impl NewSessionDialog {
                 Style::default().fg(theme.dimmed),
             ));
         }
-        frame.render_widget(Paragraph::new(Line::from(tool_spans)), chunks[ci]);
+        let area = chunks[ci];
+        frame.render_widget(Paragraph::new(Line::from(tool_spans)), area);
+        // Push the tool rect only when interactive (multiple tools).
+        // A read-only tool row shouldn't accept focus on click.
+        if has_tool_selection {
+            self.focusable_rects.push((tool_field, area));
+        }
         ci += 1;
 
         // YOLO Mode checkbox (hidden for AlwaysYolo agents like pi)
@@ -245,7 +267,9 @@ impl NewSessionDialog {
                     },
                 ),
             ]);
-            frame.render_widget(Paragraph::new(yolo_line), chunks[ci]);
+            let area = chunks[ci];
+            frame.render_widget(Paragraph::new(yolo_line), area);
+            self.focusable_rects.push((yolo_mode_field, area));
             ci += 1;
         }
 
@@ -302,7 +326,9 @@ impl NewSessionDialog {
                 ));
             }
 
-            frame.render_widget(Paragraph::new(Line::from(spans)), chunks[ci]);
+            let area = chunks[ci];
+            frame.render_widget(Paragraph::new(Line::from(spans)), area);
+            self.focusable_rects.push((worktree_field, area));
             ci += 1;
         }
 
@@ -343,7 +369,9 @@ impl NewSessionDialog {
                 ));
             }
 
-            frame.render_widget(Paragraph::new(Line::from(spans)), chunks[ci]);
+            let area = chunks[ci];
+            frame.render_widget(Paragraph::new(Line::from(spans)), area);
+            self.focusable_rects.push((sandbox_field, area));
             ci += 1;
         }
 
@@ -354,9 +382,10 @@ impl NewSessionDialog {
             } else {
                 None
             };
+        let area = chunks[ci];
         render_text_field_with_ghost(
             frame,
-            chunks[ci],
+            area,
             "Group:",
             &self.group,
             self.focused_field == group_field,
@@ -364,6 +393,7 @@ impl NewSessionDialog {
             self.group_ghost_text(),
             theme,
         );
+        self.focusable_rects.push((group_field, area));
         ci += 1;
 
         // Hints/errors (last chunk)
@@ -615,7 +645,8 @@ impl NewSessionDialog {
         set_prefixed_input_cursor_position(frame, row_area, prefix, input);
     }
 
-    fn render_sandbox_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_sandbox_config(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.sandbox_config_rects.clear();
         let dialog_width: u16 = 72;
 
         // Sandbox config fields: image, env, inherited
@@ -675,10 +706,12 @@ impl NewSessionDialog {
             None,
             theme,
         );
+        self.sandbox_config_rects.push((0, chunks[ci]));
         ci += 1;
 
         // Environment
         self.render_env_field(frame, chunks[ci], self.sandbox_focused_field == 1, theme);
+        self.sandbox_config_rects.push((1, chunks[ci]));
         ci += 1;
 
         // Inherited settings (always visible, not focusable)
@@ -701,7 +734,8 @@ impl NewSessionDialog {
         }
     }
 
-    fn render_tool_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_tool_config(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.tool_config_rects.clear();
         let dialog_width: u16 = 72;
 
         let constraints = vec![
@@ -765,6 +799,7 @@ impl NewSessionDialog {
             cmd_placeholder,
             theme,
         );
+        self.tool_config_rects.push((0, chunks[0]));
 
         // Extra Args
         let args_placeholder = if self.tool_config_focused_field == 1 {
@@ -783,6 +818,7 @@ impl NewSessionDialog {
             args_placeholder,
             theme,
         );
+        self.tool_config_rects.push((1, chunks[1]));
 
         // Hints
         let hint_spans = vec![
@@ -800,7 +836,8 @@ impl NewSessionDialog {
         }
     }
 
-    fn render_worktree_config(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_worktree_config(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.worktree_config_rects.clear();
         let dialog_width: u16 = 72;
 
         let repos_height: u16 = if self.workspace_repos_expanded {
@@ -859,6 +896,7 @@ impl NewSessionDialog {
             Some("(empty = title)"),
             theme,
         );
+        self.worktree_config_rects.push((0, chunks[0]));
 
         // New Branch checkbox
         {
@@ -891,6 +929,7 @@ impl NewSessionDialog {
                 Span::styled(format!(" {}", text), text_style),
             ]);
             frame.render_widget(Paragraph::new(line), chunks[1]);
+            self.worktree_config_rects.push((1, chunks[1]));
         }
 
         // Base Branch (only meaningful when "new branch" is checked; when
@@ -910,6 +949,7 @@ impl NewSessionDialog {
                 Some(placeholder),
                 theme,
             );
+            self.worktree_config_rects.push((2, chunks[2]));
         }
 
         // Extra Repos
@@ -919,6 +959,7 @@ impl NewSessionDialog {
             self.worktree_config_focused_field == 3,
             theme,
         );
+        self.worktree_config_rects.push((3, chunks[3]));
 
         // Hints
         let mut hint_spans = vec![

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1318,3 +1318,109 @@ fn test_worktree_toggle_blocked_when_scratch_on() {
         "user must see an explanation, not a silent no-op"
     );
 }
+
+/// Stage a focusable rect at a known position so click / hover routing
+/// can be tested without going through a full render pass.
+fn stage_focusable(dialog: &mut NewSessionDialog, field: usize, rect: ratatui::layout::Rect) {
+    dialog.focusable_rects.push((field, rect));
+}
+
+#[test]
+fn click_on_unstaged_dialog_returns_none() {
+    let mut dialog = single_tool_dialog();
+    assert!(dialog.handle_click(5, 5).is_none());
+}
+
+#[test]
+fn click_on_yolo_row_toggles_yolo() {
+    let mut dialog = single_tool_dialog();
+    // Single-tool, no-profile layout: path=0, title=1, yolo=2.
+    stage_focusable(&mut dialog, 2, ratatui::layout::Rect::new(0, 5, 30, 1));
+    let before = dialog.yolo_mode;
+    let result = dialog.handle_click(10, 5).expect("click should hit yolo");
+    assert!(matches!(result, DialogResult::Continue));
+    assert_eq!(dialog.focused_field, 2);
+    assert_eq!(dialog.yolo_mode, !before);
+}
+
+#[test]
+fn click_on_path_field_just_moves_focus() {
+    let mut dialog = single_tool_dialog();
+    stage_focusable(&mut dialog, 0, ratatui::layout::Rect::new(0, 3, 30, 1));
+    dialog.focused_field = 1; // start elsewhere
+    let path_before = dialog.path.value().to_string();
+    let result = dialog.handle_click(10, 3).expect("click should hit path");
+    assert!(matches!(result, DialogResult::Continue));
+    assert_eq!(dialog.focused_field, 0);
+    assert_eq!(
+        dialog.path.value(),
+        path_before,
+        "clicking the path row must not edit the path"
+    );
+}
+
+#[test]
+fn click_on_tool_cycles_when_multi_tool() {
+    let mut dialog = multi_tool_dialog();
+    // Multi-tool, no-profile layout: path=0, title=1, tool=2.
+    stage_focusable(&mut dialog, 2, ratatui::layout::Rect::new(0, 5, 30, 1));
+    let before = dialog.tool_index;
+    dialog.handle_click(10, 5).expect("click should hit tool");
+    assert_eq!(
+        dialog.tool_index,
+        (before + 1) % dialog.available_tools.len(),
+        "clicking the tool row should cycle to the next tool"
+    );
+    assert_eq!(dialog.focused_field, 2);
+}
+
+#[test]
+fn hover_over_field_does_not_move_focus() {
+    // Hover must never steal focus from the field the user is editing.
+    // Otherwise a stray mouse drift while typing the title moves focus
+    // to whatever row the cursor crossed, and the next keystroke goes
+    // somewhere unexpected.
+    let mut dialog = single_tool_dialog();
+    stage_focusable(&mut dialog, 2, ratatui::layout::Rect::new(0, 5, 30, 1));
+    let yolo_before = dialog.yolo_mode;
+    let focus_before = dialog.focused_field;
+    assert_ne!(focus_before, 2);
+    let changed = dialog.handle_hover(10, 5);
+    assert!(!changed, "hover must not report a focus change");
+    assert_eq!(
+        dialog.focused_field, focus_before,
+        "hover must leave focus alone"
+    );
+    assert_eq!(
+        dialog.yolo_mode, yolo_before,
+        "hover must not toggle anything either"
+    );
+}
+
+#[test]
+fn hover_off_focusables_does_not_change_focus() {
+    let mut dialog = single_tool_dialog();
+    stage_focusable(&mut dialog, 0, ratatui::layout::Rect::new(0, 3, 30, 1));
+    dialog.focused_field = 1;
+    assert!(!dialog.handle_hover(80, 80));
+    assert_eq!(dialog.focused_field, 1);
+}
+
+#[test]
+fn click_on_worktree_while_scratch_on_surfaces_error_not_toggle() {
+    let mut dialog = single_tool_dialog();
+    // Turn scratch on; mirror the keyboard behavior — worktree click
+    // while scratch is on must NOT silently re-enable worktree.
+    dialog.handle_key(ctrl_key(KeyCode::Char('t')));
+    assert!(dialog.scratch);
+    assert!(!dialog.worktree_enabled);
+    // Single-tool layout: path=0, title=1, yolo=2, worktree=3.
+    stage_focusable(&mut dialog, 3, ratatui::layout::Rect::new(0, 7, 30, 1));
+    dialog.error_message = None;
+    dialog.handle_click(10, 7);
+    assert!(
+        !dialog.worktree_enabled,
+        "worktree toggle must be blocked while scratch is on"
+    );
+    assert!(dialog.error_message.is_some());
+}

--- a/src/tui/dialogs/new_session/tests.rs
+++ b/src/tui/dialogs/new_session/tests.rs
@@ -1409,7 +1409,7 @@ fn hover_off_focusables_does_not_change_focus() {
 #[test]
 fn click_on_worktree_while_scratch_on_surfaces_error_not_toggle() {
     let mut dialog = single_tool_dialog();
-    // Turn scratch on; mirror the keyboard behavior — worktree click
+    // Turn scratch on; mirror the keyboard behavior; worktree click
     // while scratch is on must NOT silently re-enable worktree.
     dialog.handle_key(ctrl_key(KeyCode::Char('t')));
     assert!(dialog.scratch);

--- a/src/tui/dialogs/no_agents.rs
+++ b/src/tui/dialogs/no_agents.rs
@@ -21,13 +21,34 @@ pub enum NoAgentsAction {
 pub struct NoAgentsDialog {
     /// true = "Re-check" focused, false = "Quit" focused
     recheck_focused: bool,
+    recheck_button_area: Rect,
+    quit_button_area: Rect,
 }
 
 impl NoAgentsDialog {
     pub fn new() -> Self {
         Self {
             recheck_focused: true,
+            recheck_button_area: Rect::default(),
+            quit_button_area: Rect::default(),
         }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<NoAgentsAction>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.recheck_button_area.contains(pos) {
+            return Some(DialogResult::Submit(NoAgentsAction::Recheck));
+        }
+        if self.quit_button_area.contains(pos) {
+            return Some(DialogResult::Submit(NoAgentsAction::Quit));
+        }
+        None
+    }
+
+    /// Hover does not change the Re-check / Quit focus. See
+    /// `ConfirmDialog::handle_hover` for the rationale.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<NoAgentsAction> {
@@ -53,7 +74,7 @@ impl NoAgentsDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_area = super::centered_rect(area, 70, 20);
 
         frame.render_widget(Clear, dialog_area);
@@ -142,6 +163,27 @@ impl NoAgentsDialog {
             Span::styled("[Quit]", quit_style),
         ]);
 
+        let button_area = chunks[1];
+        // Compute centered button positions deterministically so the
+        // hit rects line up with the rendered glyphs.
+        let recheck_label = "[Re-check]";
+        let quit_label = "[Quit]";
+        let gap: u16 = 4;
+        let total_width =
+            recheck_label.chars().count() as u16 + gap + quit_label.chars().count() as u16;
+        if button_area.width >= total_width {
+            let left_pad = (button_area.width - total_width) / 2;
+            let recheck_x = button_area.x + left_pad;
+            let recheck_w = recheck_label.chars().count() as u16;
+            let quit_x = recheck_x + recheck_w + gap;
+            let quit_w = quit_label.chars().count() as u16;
+            self.recheck_button_area = Rect::new(recheck_x, button_area.y, recheck_w, 1);
+            self.quit_button_area = Rect::new(quit_x, button_area.y, quit_w, 1);
+        } else {
+            self.recheck_button_area = Rect::default();
+            self.quit_button_area = Rect::default();
+        }
+
         frame.render_widget(
             Paragraph::new(vec![
                 buttons,
@@ -151,7 +193,7 @@ impl NoAgentsDialog {
                 )),
             ])
             .alignment(Alignment::Center),
-            chunks[1],
+            button_area,
         );
     }
 }

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -130,6 +130,10 @@ impl RenameDialog {
                 ListPickerResult::Cancelled => return Some(DialogResult::Continue),
                 ListPickerResult::Selected(value) => {
                     self.new_group = Input::new(value);
+                    // Mirror the keyboard picker path: the ghost
+                    // autocomplete state goes stale once the user
+                    // commits to a value via the picker, so drop it.
+                    self.group_ghost = None;
                     return Some(DialogResult::Continue);
                 }
             }

--- a/src/tui/dialogs/rename.rs
+++ b/src/tui/dialogs/rename.rs
@@ -45,6 +45,9 @@ pub struct RenameDialog {
     group_ghost: Option<GroupGhostCompletion>,
     /// Inline validation error shown in Group mode when a duplicate name is entered.
     validation_error: Option<String>,
+    /// Hit rect per focusable field (title / group / profile), set by
+    /// `render`. Drives click + hover routing.
+    focusable_rects: Vec<(usize, Rect)>,
 }
 
 impl RenameDialog {
@@ -78,6 +81,7 @@ impl RenameDialog {
             group_picker: ListPicker::new("Select Group"),
             group_ghost: None,
             validation_error: None,
+            focusable_rects: Vec::new(),
         }
     }
 
@@ -106,6 +110,7 @@ impl RenameDialog {
             group_picker: ListPicker::new("Select Group"),
             group_ghost: None,
             validation_error: None,
+            focusable_rects: Vec::new(),
         }
     }
 
@@ -113,6 +118,52 @@ impl RenameDialog {
         match self.mode {
             RenameMode::Session => 3, // title, group, profile
             RenameMode::Group => 2,   // group, profile
+        }
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<RenameData>> {
+        // Group picker overlay wins when active so a click can pick a
+        // group row without dropping the dialog underneath.
+        if self.group_picker.is_active() {
+            match self.group_picker.handle_click(col, row) {
+                ListPickerResult::Continue => return Some(DialogResult::Continue),
+                ListPickerResult::Cancelled => return Some(DialogResult::Continue),
+                ListPickerResult::Selected(value) => {
+                    self.new_group = Input::new(value);
+                    return Some(DialogResult::Continue);
+                }
+            }
+        }
+        let pos = ratatui::layout::Position::from((col, row));
+        let hit = self
+            .focusable_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(f, _)| *f)?;
+        self.focused_field = hit;
+        // Cycle the profile chip on click; text fields just take focus.
+        if self.is_profile_field() && !self.available_profiles.is_empty() {
+            self.profile_index = (self.profile_index + 1) % self.available_profiles.len();
+        }
+        Some(DialogResult::Continue)
+    }
+
+    /// Hover only updates the group-picker overlay highlight (menu-style
+    /// behavior the user expects). It deliberately does NOT move focus
+    /// between the title / group / profile rows: stealing focus from the
+    /// field the user is typing into just because the mouse cursor
+    /// drifts across the dialog is jarring. Click still sets focus.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        if self.group_picker.is_active() {
+            return self.group_picker.handle_hover(col, row);
+        }
+        false
+    }
+
+    fn is_profile_field(&self) -> bool {
+        match self.mode {
+            RenameMode::Session => self.focused_field == 2,
+            RenameMode::Group => self.focused_field == 1,
         }
     }
 
@@ -134,13 +185,6 @@ impl RenameDialog {
         match self.mode {
             RenameMode::Session => self.focused_field == 1,
             RenameMode::Group => self.focused_field == 0,
-        }
-    }
-
-    fn is_profile_field(&self) -> bool {
-        match self.mode {
-            RenameMode::Session => self.focused_field == 2,
-            RenameMode::Group => self.focused_field == 1,
         }
     }
 
@@ -330,14 +374,15 @@ impl RenameDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         match self.mode {
             RenameMode::Session => self.render_session(frame, area, theme),
             RenameMode::Group => self.render_group(frame, area, theme),
         }
     }
 
-    fn render_session(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_session(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.focusable_rects.clear();
         let dialog_width = 50;
         let dialog_area = super::centered_rect(area, dialog_width, 15);
 
@@ -392,12 +437,15 @@ impl RenameDialog {
             None,
             theme,
         );
+        self.focusable_rects.push((0, chunks[4]));
 
         // New group field
         self.render_group_field(frame, chunks[5], theme);
+        self.focusable_rects.push((1, chunks[5]));
 
         // Profile selector
         self.render_profile_selector(frame, chunks[6], theme);
+        self.focusable_rects.push((2, chunks[6]));
 
         // Hint
         self.render_hints(frame, chunks[8], theme);
@@ -408,7 +456,8 @@ impl RenameDialog {
         }
     }
 
-    fn render_group(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_group(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.focusable_rects.clear();
         let dialog_width = 50;
         let has_error = self.validation_error.is_some();
         let dialog_height = if has_error { 16 } else { 13 };
@@ -452,9 +501,11 @@ impl RenameDialog {
 
         // New group field
         self.render_group_field(frame, chunks[3], theme);
+        self.focusable_rects.push((0, chunks[3]));
 
         // Profile selector
         self.render_profile_selector(frame, chunks[4], theme);
+        self.focusable_rects.push((1, chunks[4]));
 
         if has_error {
             // Validation error (two lines, one sentence each)

--- a/src/tui/dialogs/restart.rs
+++ b/src/tui/dialogs/restart.rs
@@ -35,6 +35,8 @@ pub struct RestartDialog {
     tool_index: usize,
     /// 0 = profile, 1 = tool.
     focused_field: usize,
+    profile_selector_area: Rect,
+    tool_selector_area: Rect,
 }
 
 impl RestartDialog {
@@ -63,6 +65,54 @@ impl RestartDialog {
             profile_index,
             tool_index,
             focused_field: 0,
+            profile_selector_area: Rect::default(),
+            tool_selector_area: Rect::default(),
+        }
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<DialogResult<RestartData>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.profile_selector_area.contains(pos) {
+            self.focused_field = 0;
+            if !self.available_profiles.is_empty() {
+                self.profile_index = (self.profile_index + 1) % self.available_profiles.len();
+                // Mirror keyboard cycling: when the profile changes,
+                // re-resolve the tool default so the picker updates too.
+                self.sync_tool_from_profile();
+            }
+            return Some(DialogResult::Continue);
+        }
+        if self.tool_selector_area.contains(pos) {
+            self.focused_field = 1;
+            if !self.available_tools.is_empty() {
+                self.tool_index = (self.tool_index + 1) % self.available_tools.len();
+            }
+            return Some(DialogResult::Continue);
+        }
+        None
+    }
+
+    /// Hover does not change the focused field. Click commits via
+    /// `handle_click`; see `ConfirmDialog::handle_hover` for the
+    /// rationale (mouse drift between the user reading the dialog and
+    /// hitting a keystroke must not silently shift which field that
+    /// key targets).
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
+    }
+
+    /// Re-resolve the default tool for the currently selected profile
+    /// and snap `tool_index` accordingly, matching the keyboard's
+    /// "cycle profile -> auto-pick its default_tool" behavior.
+    fn sync_tool_from_profile(&mut self) {
+        let Some(profile) = self.selected_profile().map(String::from) else {
+            return;
+        };
+        let cfg = resolve_config_or_warn(&profile);
+        if let Some(default_tool) = cfg.session.default_tool.as_ref() {
+            if let Some(idx) = self.available_tools.iter().position(|t| t == default_tool) {
+                self.tool_index = idx;
+            }
         }
     }
 
@@ -194,7 +244,7 @@ impl RestartDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_area = super::centered_rect(area, 54, 14);
         frame.render_widget(Clear, dialog_area);
 
@@ -242,7 +292,9 @@ impl RestartDialog {
         frame.render_widget(Paragraph::new(current_tool_line), chunks[2]);
 
         self.render_profile_selector(frame, chunks[4], theme);
+        self.profile_selector_area = chunks[4];
         self.render_tool_selector(frame, chunks[5], theme);
+        self.tool_selector_area = chunks[5];
         self.render_hints(frame, chunks[7], theme);
     }
 

--- a/src/tui/dialogs/snooze_duration.rs
+++ b/src/tui/dialogs/snooze_duration.rs
@@ -26,13 +26,44 @@ const ONE_WEEK: u32 = 7 * 24 * 60;
 
 pub struct SnoozeDurationDialog {
     title: String,
+    /// Hit rect per preset row, paired with the minutes it submits.
+    /// Captured during `render` so a click on a row produces the same
+    /// Submit as the matching digit key.
+    row_rects: Vec<(u32, Rect)>,
+    /// Hover-tracked row index. Drives the row highlight without
+    /// changing semantics: a row hover doesn't itself submit, only a
+    /// click on the row does.
+    hovered_row: Option<usize>,
 }
 
 impl SnoozeDurationDialog {
     pub fn new(session_title: &str) -> Self {
         Self {
             title: session_title.to_string(),
+            row_rects: Vec::new(),
+            hovered_row: None,
         }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<u32>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        self.row_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(minutes, _)| DialogResult::Submit(*minutes))
+    }
+
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let pos = ratatui::layout::Position::from((col, row));
+        let new_hover = self
+            .row_rects
+            .iter()
+            .position(|(_, rect)| rect.contains(pos));
+        if self.hovered_row == new_hover {
+            return false;
+        }
+        self.hovered_row = new_hover;
+        true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<u32> {
@@ -50,7 +81,8 @@ impl SnoozeDurationDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        self.row_rects.clear();
         let dialog_area = super::centered_rect(area, 52, 14);
         frame.render_widget(Clear, dialog_area);
 
@@ -93,22 +125,33 @@ impl SnoozeDurationDialog {
 
         let key_style = Style::default().fg(theme.waiting).bold();
         let text_style = Style::default().fg(theme.text);
-        let row = |k: &'static str, label: &'static str| {
-            Paragraph::new(Line::from(vec![
+        let hover_text_style = Style::default().fg(theme.accent).bold();
+        let presets: &[(u32, &str, &str, usize)] = &[
+            (ONE_HOUR, "1", "1 hour", 2),
+            (TWO_HOURS, "2", "2 hours", 3),
+            (THREE_HOURS, "3", "3 hours", 4),
+            (FOUR_HOURS, "4", "4 hours", 5),
+            (FIVE_HOURS, "5", "5 hours", 6),
+            (SIX_HOURS, "6", "6 hours", 7),
+            (ONE_DAY, "8", "24 hours (1 day)", 8),
+            (ONE_WEEK, "0", "1 week", 9),
+        ];
+        for (idx, (minutes, k, label, ci)) in presets.iter().enumerate() {
+            let area = chunks[*ci];
+            let label_style = if self.hovered_row == Some(idx) {
+                hover_text_style
+            } else {
+                text_style
+            };
+            let line = Paragraph::new(Line::from(vec![
                 Span::raw("  "),
                 Span::styled(format!("[{}]", k), key_style),
                 Span::raw("  "),
-                Span::styled(label, text_style),
-            ]))
-        };
-        frame.render_widget(row("1", "1 hour"), chunks[2]);
-        frame.render_widget(row("2", "2 hours"), chunks[3]);
-        frame.render_widget(row("3", "3 hours"), chunks[4]);
-        frame.render_widget(row("4", "4 hours"), chunks[5]);
-        frame.render_widget(row("5", "5 hours"), chunks[6]);
-        frame.render_widget(row("6", "6 hours"), chunks[7]);
-        frame.render_widget(row("8", "24 hours (1 day)"), chunks[8]);
-        frame.render_widget(row("0", "1 week"), chunks[9]);
+                Span::styled(*label, label_style),
+            ]));
+            frame.render_widget(line, area);
+            self.row_rects.push((*minutes, area));
+        }
     }
 }
 

--- a/src/tui/dialogs/sort_picker.rs
+++ b/src/tui/dialogs/sort_picker.rs
@@ -20,12 +20,58 @@ const OPTIONS: &[SortOrder] = &[
 pub struct SortPickerDialog {
     selected: usize,
     current: SortOrder,
+    list_area: Rect,
+    dialog_area: Rect,
 }
 
 impl SortPickerDialog {
     pub fn new(current: SortOrder) -> Self {
         let selected = OPTIONS.iter().position(|o| *o == current).unwrap_or(0);
-        Self { selected, current }
+        Self {
+            selected,
+            current,
+            list_area: Rect::default(),
+            dialog_area: Rect::default(),
+        }
+    }
+
+    fn row_to_idx(&self, col: u16, row: u16) -> Option<usize> {
+        if !self
+            .list_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return None;
+        }
+        let i = (row - self.list_area.y) as usize;
+        if i >= OPTIONS.len() {
+            return None;
+        }
+        Some(i)
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> DialogResult<SortOrder> {
+        if !self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return DialogResult::Cancel;
+        }
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return DialogResult::Continue;
+        };
+        self.selected = idx;
+        DialogResult::Submit(OPTIONS[idx])
+    }
+
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return false;
+        };
+        if self.selected == idx {
+            return false;
+        }
+        self.selected = idx;
+        true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<SortOrder> {
@@ -48,11 +94,12 @@ impl SortPickerDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_width: u16 = 32;
         let dialog_height: u16 = OPTIONS.len() as u16 + 5;
 
         let dialog_area = super::centered_rect(area, dialog_width, dialog_height);
+        self.dialog_area = dialog_area;
         frame.render_widget(Clear, dialog_area);
 
         let block = Block::default()
@@ -92,6 +139,7 @@ impl SortPickerDialog {
             }
             lines.push(Line::from(spans));
         }
+        self.list_area = chunks[0];
         frame.render_widget(Paragraph::new(lines), chunks[0]);
 
         let hint = Line::from(vec![

--- a/src/tui/dialogs/tool_picker.rs
+++ b/src/tui/dialogs/tool_picker.rs
@@ -11,6 +11,8 @@ use crate::tui::styles::Theme;
 pub struct ToolPickerDialog {
     items: Vec<ToolPickerEntry>,
     cursor: usize,
+    dialog_area: Rect,
+    list_area: Rect,
 }
 
 struct ToolPickerEntry {
@@ -30,7 +32,49 @@ impl ToolPickerDialog {
             })
             .collect();
         items.sort_by(|a, b| a.name.cmp(&b.name));
-        Self { items, cursor: 0 }
+        Self {
+            items,
+            cursor: 0,
+            dialog_area: Rect::default(),
+            list_area: Rect::default(),
+        }
+    }
+
+    fn row_to_idx(&self, col: u16, row: u16) -> Option<usize> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if !self.list_area.contains(pos) {
+            return None;
+        }
+        let row_in_list = (row - self.list_area.y) as usize;
+        if row_in_list >= self.items.len() {
+            return None;
+        }
+        Some(row_in_list)
+    }
+
+    pub fn handle_click(&mut self, col: u16, row: u16) -> DialogResult<String> {
+        if !self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            return DialogResult::Cancel;
+        }
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return DialogResult::Continue;
+        };
+        self.cursor = idx;
+        DialogResult::Submit(self.items[idx].name.clone())
+    }
+
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let Some(idx) = self.row_to_idx(col, row) else {
+            return false;
+        };
+        if self.cursor == idx {
+            return false;
+        }
+        self.cursor = idx;
+        true
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<String> {
@@ -67,11 +111,12 @@ impl ToolPickerDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let width = 50u16.min(area.width.saturating_sub(4));
         // +2 for borders, +1 for the footer hint row.
         let height = (self.items.len() as u16 + 3).min(area.height.saturating_sub(4));
         let dialog_area = centered_rect(area, width, height);
+        self.dialog_area = dialog_area;
 
         frame.render_widget(Clear, dialog_area);
 
@@ -91,6 +136,7 @@ impl ToolPickerDialog {
             .split(inner);
         let list_area = chunks[0];
         let footer_area = chunks[1];
+        self.list_area = list_area;
 
         let items: Vec<ListItem> = self
             .items

--- a/src/tui/dialogs/update_confirm.rs
+++ b/src/tui/dialogs/update_confirm.rs
@@ -15,6 +15,8 @@ pub struct UpdateConfirmDialog {
     pub latest_version: String,
     pub needs_sudo: bool,
     selected: bool, // true = Yes, false = No
+    yes_button_area: Rect,
+    no_button_area: Rect,
 }
 
 impl UpdateConfirmDialog {
@@ -36,7 +38,26 @@ impl UpdateConfirmDialog {
             latest_version,
             needs_sudo,
             selected: false,
+            yes_button_area: Rect::default(),
+            no_button_area: Rect::default(),
         }
+    }
+
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<()>> {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.yes_button_area.contains(pos) {
+            return Some(DialogResult::Submit(()));
+        }
+        if self.no_button_area.contains(pos) {
+            return Some(DialogResult::Cancel);
+        }
+        None
+    }
+
+    /// Hover does not change the Yes/No selection. See `ConfirmDialog`
+    /// for the rationale.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -66,7 +87,7 @@ impl UpdateConfirmDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let height = if self.needs_sudo { 11 } else { 10 };
         let dialog_area = super::centered_rect(area, 60, height);
 
@@ -92,7 +113,9 @@ impl UpdateConfirmDialog {
             Paragraph::new(self.prompt_block.as_str()).style(Style::default().fg(theme.text));
         frame.render_widget(body, chunks[0]);
 
-        render_yes_no(frame, chunks[1], theme, self.selected);
+        let (yes, no) = render_yes_no(frame, chunks[1], theme, self.selected);
+        self.yes_button_area = yes;
+        self.no_button_area = no;
     }
 }
 

--- a/src/tui/dialogs/welcome.rs
+++ b/src/tui/dialogs/welcome.rs
@@ -7,11 +7,15 @@ use ratatui::widgets::*;
 use super::DialogResult;
 use crate::tui::styles::Theme;
 
-pub struct WelcomeDialog;
+pub struct WelcomeDialog {
+    dialog_area: Rect,
+}
 
 impl WelcomeDialog {
     pub fn new() -> Self {
-        Self
+        Self {
+            dialog_area: Rect::default(),
+        }
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) -> DialogResult<()> {
@@ -21,8 +25,22 @@ impl WelcomeDialog {
         }
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    /// A click anywhere inside the welcome dialog dismisses it,
+    /// matching the keyboard's "any of Enter/Esc/Space submits".
+    pub fn handle_click(&self, col: u16, row: u16) -> Option<DialogResult<()>> {
+        if self
+            .dialog_area
+            .contains(ratatui::layout::Position::from((col, row)))
+        {
+            Some(DialogResult::Submit(()))
+        } else {
+            None
+        }
+    }
+
+    pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let dialog_area = super::centered_rect(area, 64, 14);
+        self.dialog_area = dialog_area;
 
         frame.render_widget(Clear, dialog_area);
 

--- a/src/tui/diff/input.rs
+++ b/src/tui/diff/input.rs
@@ -54,6 +54,28 @@ impl DiffView {
         self.handle_normal_key(key)
     }
 
+    /// Route a left-click. Currently only the file-list panel accepts
+    /// click input (select the clicked file). Clicks elsewhere are
+    /// swallowed by the modal but no-op.
+    pub fn handle_click(&mut self, col: u16, row: u16) {
+        let pos = ratatui::layout::Position::from((col, row));
+        if self.file_list_inner.contains(pos) {
+            let row_in_list = (row - self.file_list_inner.y) as usize;
+            if row_in_list < self.files.len() && self.selected_file != row_in_list {
+                self.selected_file = row_in_list;
+                self.scroll_offset = 0;
+            }
+        }
+    }
+
+    /// Hover does not move the file-list selection. Otherwise pressing
+    /// j/k after a stray mouse drift would jump to whichever file the
+    /// cursor last crossed instead of advancing from the actually
+    /// selected one. Click still selects.
+    pub fn handle_hover(&mut self, _col: u16, _row: u16) -> bool {
+        false
+    }
+
     fn handle_normal_key(&mut self, key: KeyEvent) -> DiffAction {
         match (key.code, key.modifiers) {
             // Close view

--- a/src/tui/diff/mod.rs
+++ b/src/tui/diff/mod.rs
@@ -86,6 +86,11 @@ pub struct DiffView {
     /// this hand-off, HomeView's next `commit` would overwrite the
     /// disk value with its stale memory copy. See #1175.
     pub(crate) pending_override: Option<(String, Option<String>)>,
+
+    /// Inner rect of the file-list panel, captured during `render`.
+    /// Lets a click on a file row select it and a hover highlight it
+    /// the same way `j`/`k` would.
+    pub(crate) file_list_inner: ratatui::layout::Rect,
 }
 
 impl DiffView {
@@ -142,6 +147,7 @@ impl DiffView {
             file_list_width: config.app_state.diff_file_list_width.unwrap_or(35),
             warning_dialog,
             pending_override: None,
+            file_list_inner: ratatui::layout::Rect::default(),
         };
 
         view.refresh_files()?;
@@ -338,6 +344,7 @@ impl DiffView {
             file_list_width: 35,
             warning_dialog: None,
             pending_override: None,
+            file_list_inner: ratatui::layout::Rect::default(),
         }
     }
 }

--- a/src/tui/diff/render.rs
+++ b/src/tui/diff/render.rs
@@ -61,7 +61,7 @@ impl DiffView {
         }
 
         // Render warning dialog on top of everything
-        if let Some(ref dialog) = self.warning_dialog {
+        if let Some(ref mut dialog) = self.warning_dialog {
             dialog.render(frame, area, theme);
         }
     }
@@ -131,7 +131,7 @@ impl DiffView {
         self.render_diff_content(frame, layout[1], theme);
     }
 
-    fn render_file_list(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_file_list(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let block = Block::default()
             .title(" Files ")
             .borders(Borders::ALL)
@@ -140,6 +140,7 @@ impl DiffView {
             .padding(Padding::horizontal(1));
 
         let inner = block.inner(area);
+        self.file_list_inner = inner;
         frame.render_widget(block, area);
 
         if self.files.is_empty() {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -1038,8 +1038,8 @@ impl HomeView {
 
         // Right-click context menu. Routed before every other dialog so
         // keys go to the popup that the user just opened on top of the
-        // sidebar. Submit dispatches to the same helpers the `r` / `d`
-        // key bindings use; Cancel just dismisses.
+        // sidebar. Submit dispatches through the shared helper so the
+        // keyboard and the mouse-click path stay byte-for-byte aligned.
         if let Some(menu) = &mut self.context_menu {
             match menu.handle_key(key) {
                 DialogResult::Continue => {}
@@ -1048,10 +1048,7 @@ impl HomeView {
                 }
                 DialogResult::Submit(action) => {
                     self.context_menu = None;
-                    match action {
-                        ContextMenuAction::Rename => self.open_rename_for_selected(),
-                        ContextMenuAction::Delete => self.open_delete_for_selected(),
-                    }
+                    self.dispatch_context_menu_action(action);
                 }
             }
             return None;
@@ -3047,30 +3044,46 @@ impl HomeView {
     /// renderer clamps the menu into the visible area so a near-edge
     /// click never produces an off-screen popup.
     ///
-    /// Returns true when the menu opened. A right-click that doesn't
-    /// resolve to a row (header, scroll arrow, empty space below the
-    /// last row) is a no-op so the caller can choose to fall through.
+    /// Returns true when a menu opened. Routes by what the click hit:
+    /// a real row (session or group) opens the per-row Rename/Delete
+    /// menu; empty space inside the list opens the empty-sidebar menu
+    /// (New Session / Change Sort / Change Grouping). Anywhere else
+    /// (header, scroll arrow, scroll bar, outside the list panel) is
+    /// a no-op so the caller can fall through.
     pub fn handle_right_click(&mut self, col: u16, row: u16) -> bool {
         // `resolve_row_to_index` already short-circuits when any
         // non-live-send overlay (incl. the context menu itself) is open
         // and inside the diff takeover, so no extra dialog gating here.
-        let Some(idx) = self.resolve_row_to_index(col, row) else {
-            return false;
-        };
-        if self.cursor != idx {
-            self.cursor = idx;
-            self.update_selected();
-        }
-        // Mirror the row-aware menu copy from the web sidebar so a group
-        // row reads as "Rename Group / Delete Group" instead of bare
-        // "Rename / Delete".
-        let is_group = matches!(self.flat_items[idx], super::Item::Group { .. });
         let anchor = (col.saturating_add(1), row.saturating_add(1));
-        self.context_menu = Some(if is_group {
-            ContextMenuDialog::for_group(anchor)
-        } else {
-            ContextMenuDialog::for_session(anchor)
-        });
+        if let Some(idx) = self.resolve_row_to_index(col, row) {
+            if self.cursor != idx {
+                self.cursor = idx;
+                self.update_selected();
+            }
+            // Mirror the row-aware menu copy from the web sidebar so a group
+            // row reads as "Rename Group / Delete Group" instead of bare
+            // "Rename / Delete".
+            let is_group = matches!(self.flat_items[idx], super::Item::Group { .. });
+            self.context_menu = Some(if is_group {
+                ContextMenuDialog::for_group(anchor)
+            } else {
+                ContextMenuDialog::for_session(anchor)
+            });
+            return true;
+        }
+        // No row resolved. If the click landed inside the list panel
+        // anyway (empty space below the last session, or an empty
+        // list), surface the empty-sidebar menu so the mouse-only path
+        // can reach the n/o/g entry points. Gated on no other overlay
+        // being open and the diff view not taking over the panel, same
+        // shape as `handle_empty_list_click`.
+        if self.has_non_live_send_overlay() || self.diff_view.is_some() {
+            return false;
+        }
+        if !self.list_inner_area.contains(Position::from((col, row))) {
+            return false;
+        }
+        self.context_menu = Some(ContextMenuDialog::for_empty_sidebar(anchor));
         true
     }
 
@@ -3101,13 +3114,25 @@ impl HomeView {
             }
             Some(DialogResult::Submit(action)) => {
                 self.context_menu = None;
-                match action {
-                    ContextMenuAction::Rename => self.open_rename_for_selected(),
-                    ContextMenuAction::Delete => self.open_delete_for_selected(),
-                }
+                self.dispatch_context_menu_action(action);
             }
         }
         true
+    }
+
+    /// Single dispatcher for every `ContextMenuAction` so the keyboard
+    /// path (Enter / r / d / n / o / g on an open menu) and the mouse
+    /// path (click on a menu row) execute the exact same helpers. Any
+    /// new menu action needs to be wired here once, not at each call
+    /// site.
+    pub(super) fn dispatch_context_menu_action(&mut self, action: ContextMenuAction) {
+        match action {
+            ContextMenuAction::Rename => self.open_rename_for_selected(),
+            ContextMenuAction::Delete => self.open_delete_for_selected(),
+            ContextMenuAction::NewSession => self.open_new_session_dialog(),
+            ContextMenuAction::OpenSortPicker => self.show_sort_picker(),
+            ContextMenuAction::OpenGroupPicker => self.show_group_picker(),
+        }
     }
 
     /// Open the new-session dialog, with the same gating the `'n'` key
@@ -3139,10 +3164,14 @@ impl HomeView {
         ));
     }
 
-    /// Treat a left-click that landed in the sidebar area but past the
-    /// last session row as "open new session"; matches the `'n'`
-    /// keybind. Returns true when the click was consumed (dialog
-    /// opened or a gating dialog like "please wait" replaced it).
+    /// Left-click on the empty area of the sidebar (below the last
+    /// session, or in an empty list). Used as a quick "drop out of
+    /// live mode" gesture: if live-send is active, the click exits
+    /// it and reflows the preview back to its normal size; otherwise
+    /// the click is a no-op. The "open new session" entry that used
+    /// to live here now belongs to the right-click empty-sidebar
+    /// menu, so left-click on empty space stays low-stakes and the
+    /// user never accidentally summons a modal mid-typing.
     ///
     /// Gated to fire only when no overlay is already up and the diff
     /// view isn't open, so a click on an empty list while a modal is
@@ -3158,8 +3187,11 @@ impl HomeView {
             // A real row resolved here; the regular click path owns it.
             return false;
         }
-        self.open_new_session_dialog();
-        true
+        if let Some(state) = self.live_send.clone() {
+            self.exit_live_send_and_restore_sizing(&state);
+            return true;
+        }
+        false
     }
 
     /// Open the rename dialog for whatever the sidebar has selected (a

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -641,15 +641,12 @@ impl HomeView {
             // open so the underlying list / preview don't react.
             return true;
         }
-        if let Some(view) = &mut self.settings_view {
-            // Settings is a full-screen takeover: every click inside
-            // the area is for it, even when the click landed on the
-            // background between widgets. `handle_click` mutates
-            // focus / scope / selection on hits and returns None on
-            // misses, but we still swallow the click either way.
-            let _ = view.handle_click(col, row);
-            return true;
-        }
+        // Confirm dialog floats over settings (e.g., the unsaved-changes
+        // discard prompt), so it has to win over the settings-view
+        // takeover for click routing the same way the keyboard path
+        // checks `settings_close_confirm` ahead of `settings_view`.
+        // Otherwise a click on Yes / No goes into settings and never
+        // reaches the modal.
         if let Some(dialog) = &self.confirm_dialog {
             if let Some(result) = dialog.handle_click(col, row) {
                 let action = dialog.action().to_string();
@@ -659,14 +656,37 @@ impl HomeView {
                         self.confirm_dialog = None;
                         self.pending_stop_session = None;
                         self.pending_force_remove_session = None;
+                        // The settings close path mirrors the keyboard
+                        // route: Cancel here means "don't discard," so
+                        // settings stays open and `settings_close_confirm`
+                        // resets to idle.
+                        self.settings_close_confirm = false;
                     }
                     DialogResult::Submit(()) => {
                         self.confirm_dialog = None;
+                        if self.settings_close_confirm {
+                            // Discard branch: force-close settings (the
+                            // keyboard path runs the same sequence).
+                            if let Some(ref mut settings) = self.settings_view {
+                                settings.force_close();
+                            }
+                            self.settings_view = None;
+                            self.settings_close_confirm = false;
+                        }
                         self.pending_dialog_click_action = self.dispatch_confirm_submit(&action);
                     }
                 }
             }
             // Always swallow clicks while the confirm dialog is open.
+            return true;
+        }
+        if let Some(view) = &mut self.settings_view {
+            // Settings is a full-screen takeover: every click inside
+            // the area is for it, even when the click landed on the
+            // background between widgets. `handle_click` mutates
+            // focus / scope / selection on hits and returns None on
+            // misses, but we still swallow the click either way.
+            let _ = view.handle_click(col, row);
             return true;
         }
         if let Some(dialog) = &self.info_dialog {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -337,7 +337,7 @@ impl HomeView {
         //
         // `has_dialog()` returns true while live-send is active, which
         // is exactly when preview drag-select is meant to work. Live
-        // mode is therefore exempt — but a real modal (info / confirm
+        // mode is therefore exempt; but a real modal (info / confirm
         // / palette / picker) opening mid-select must also kill the
         // drag and drop the selection so it can't keep mutating under
         // the modal or finalize on mouse-up behind the overlay.
@@ -533,7 +533,7 @@ impl HomeView {
 
     /// Drain the text captured on the last render that painted a
     /// finalized preview selection. Returns `Some` exactly once per
-    /// finalized drag — `App` calls this immediately after the draw
+    /// finalized drag; `App` calls this immediately after the draw
     /// to write the bytes to the clipboard.
     pub fn take_preview_copy_text(&mut self) -> Option<String> {
         self.preview_copy_text.take()
@@ -921,9 +921,9 @@ impl HomeView {
         // the user exits with Ctrl+q. That works when dialogs are only
         // reachable via keyboard (the hotkey itself gets swallowed by
         // live-send so the dialog never opens). Once a non-live-send
-        // overlay HAS been opened — via the empty-sidebar click that
+        // overlay HAS been opened; via the empty-sidebar click that
         // pops the new-session dialog, a right-click context menu, or
-        // any future click-to-open path — its keys must go to the
+        // any future click-to-open path; its keys must go to the
         // overlay, not the underlying tmux pane. Otherwise the user
         // sees the dialog but Esc / Enter / typed characters silently
         // get routed to the session behind it.
@@ -2642,7 +2642,7 @@ impl HomeView {
         // (or any prediction layer) eats the `Moved` event that fires as
         // the cursor leaves the list, the hover background stays painted
         // on the row the mouse was last on while the keyboard-selected
-        // row also paints — two highlighted rows at once. handle_hover
+        // row also paints; two highlighted rows at once. handle_hover
         // only clears `mouse_pos` when it RECEIVES an off-list Moved, so
         // any keyboard transition has to clear it directly.
         self.mouse_pos = None;
@@ -3082,7 +3082,7 @@ impl HomeView {
     ///     row): keep it open,
     ///   - click outside the menu: close it.
     ///
-    /// In all three cases the click is "consumed" — the caller must not
+    /// In all three cases the click is "consumed"; the caller must not
     /// fall through to the list / preview / dialog handlers underneath.
     /// Returns true when the menu existed (and consumed the click).
     pub fn handle_context_menu_click(&mut self, col: u16, row: u16) -> bool {
@@ -3140,7 +3140,7 @@ impl HomeView {
     }
 
     /// Treat a left-click that landed in the sidebar area but past the
-    /// last session row as "open new session" — matches the `'n'`
+    /// last session row as "open new session"; matches the `'n'`
     /// keybind. Returns true when the click was consumed (dialog
     /// opened or a gating dialog like "please wait" replaced it).
     ///
@@ -3155,7 +3155,7 @@ impl HomeView {
             return false;
         }
         if self.resolve_row_to_index(col, row).is_some() {
-            // A real row resolved here — the regular click path owns it.
+            // A real row resolved here; the regular click path owns it.
             return false;
         }
         self.open_new_session_dialog();
@@ -3375,7 +3375,7 @@ impl HomeView {
             // status-poll-driven re-sort) can move the cursor away from
             // the row the user is actually double-clicking. Without this,
             // `activate_selected_session()` reads `selected_session` —
-            // which tracks `cursor`, not the click target — and we'd open
+            // which tracks `cursor`, not the click target; and we'd open
             // the wrong session.
             return match item {
                 Item::Session { .. } => {

--- a/src/tui/home/input.rs
+++ b/src/tui/home/input.rs
@@ -12,11 +12,11 @@ use crate::tui::app::Action;
 #[cfg(feature = "serve")]
 use crate::tui::dialogs::ServeAction;
 use crate::tui::dialogs::{
-    builtin_commands, CommandPaletteDialog, ConfirmDialog, DeleteDialogConfig, DialogResult,
-    GroupDeleteOptionsDialog, HookTrustAction, HooksInstallDialog, InfoDialog, NewSessionData,
-    NewSessionDialog, NoAgentsAction, PaletteAction, PaletteCommand, PaletteGroup,
-    ProfilePickerAction, ProjectsDialog, RenameDialog, RenameMode, RestartDialog,
-    SendMessageDialog, UnifiedDeleteDialog,
+    builtin_commands, CommandPaletteDialog, ConfirmDialog, ContextMenuAction, ContextMenuDialog,
+    DeleteDialogConfig, DialogResult, GroupDeleteOptionsDialog, HookTrustAction,
+    HooksInstallDialog, InfoDialog, NewSessionData, NewSessionDialog, NoAgentsAction,
+    PaletteAction, PaletteCommand, PaletteGroup, ProfilePickerAction, ProjectsDialog, RenameDialog,
+    RenameMode, RestartDialog, SendMessageDialog, UnifiedDeleteDialog,
 };
 use crate::tui::diff::{DiffAction, DiffView};
 use crate::tui::responsive;
@@ -211,6 +211,24 @@ impl HomeView {
 
     pub fn hit_diff(&self, col: u16, row: u16) -> bool {
         self.diff_area.contains(Position::from((col, row)))
+    }
+
+    /// Forward a left-click to the diff view's file-list panel. No-op
+    /// when no diff view is open.
+    pub fn handle_diff_click(&mut self, col: u16, row: u16) {
+        if let Some(view) = &mut self.diff_view {
+            view.handle_click(col, row);
+        }
+    }
+
+    /// Forward a hover event to the diff view's file-list panel.
+    /// Returns true when the focused file changed.
+    pub fn handle_diff_hover(&mut self, col: u16, row: u16) -> bool {
+        if let Some(view) = &mut self.diff_view {
+            view.handle_hover(col, row)
+        } else {
+            false
+        }
     }
 
     fn open_tool_picker(&mut self) {
@@ -553,6 +571,34 @@ impl HomeView {
     /// Only the destructive delete dialog wires Yes/No clicks today;
     /// the existing modals continue to swallow mouse events implicitly
     /// via `has_dialog()` gates in the other handlers.
+    /// Dispatch the Submit branch of a confirm dialog. Returns
+    /// `Some(Action)` for confirm actions that emit a TUI action
+    /// (`stop_session`, `quit_during_creation`); side-effect-only
+    /// actions (`delete_group`, `force_remove_session`) run inline and
+    /// return None. Shared by the keyboard Enter path and the
+    /// mouse-click path so both flows produce the same end state.
+    pub(super) fn dispatch_confirm_submit(&mut self, action: &str) -> Option<Action> {
+        match action {
+            "delete_group" => {
+                if let Err(e) = self.delete_selected_group() {
+                    tracing::error!(target: "tui.input", "Failed to delete group: {}", e);
+                }
+                None
+            }
+            "stop_session" => self.pending_stop_session.take().map(Action::StopSession),
+            "force_remove_session" => {
+                if let Some(session_id) = self.pending_force_remove_session.take() {
+                    if let Err(e) = self.force_remove_session(&session_id) {
+                        tracing::error!(target: "tui.input", "Failed to force remove session: {}", e);
+                    }
+                }
+                None
+            }
+            "quit_during_creation" => Some(Action::Quit),
+            _ => None,
+        }
+    }
+
     pub fn handle_dialog_click(&mut self, col: u16, row: u16) -> bool {
         if let Some(dialog) = &mut self.unified_delete_dialog {
             if let Some(result) = dialog.handle_click(col, row) {
@@ -570,10 +616,283 @@ impl HomeView {
                 }
                 return true;
             }
-            // Click landed inside the dialog area but missed both
-            // buttons (e.g. on a checkbox or the title): swallow it so
+            // Click landed inside the dialog area but missed every
+            // hit rect (e.g. on the title or border): swallow it so
             // the underlying list doesn't shift selection out from
             // under the modal.
+            return true;
+        }
+        if let Some(dialog) = &mut self.new_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.new_dialog = None;
+                    }
+                    DialogResult::Submit(_data) => {
+                        // The new-session dialog's submit is fired only
+                        // by the Enter key path; clicks set focus or
+                        // toggle the focused row and return Continue,
+                        // never Submit. This arm is defensive.
+                    }
+                }
+            }
+            // Always swallow clicks while the new-session dialog is
+            // open so the underlying list / preview don't react.
+            return true;
+        }
+        if let Some(view) = &mut self.settings_view {
+            // Settings is a full-screen takeover: every click inside
+            // the area is for it, even when the click landed on the
+            // background between widgets. `handle_click` mutates
+            // focus / scope / selection on hits and returns None on
+            // misses, but we still swallow the click either way.
+            let _ = view.handle_click(col, row);
+            return true;
+        }
+        if let Some(dialog) = &self.confirm_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                let action = dialog.action().to_string();
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.confirm_dialog = None;
+                        self.pending_stop_session = None;
+                        self.pending_force_remove_session = None;
+                    }
+                    DialogResult::Submit(()) => {
+                        self.confirm_dialog = None;
+                        self.pending_dialog_click_action = self.dispatch_confirm_submit(&action);
+                    }
+                }
+            }
+            // Always swallow clicks while the confirm dialog is open.
+            return true;
+        }
+        if let Some(dialog) = &self.info_dialog {
+            if let Some(DialogResult::Cancel) = dialog.handle_click(col, row) {
+                self.info_dialog = None;
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.update_confirm_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.update_confirm_dialog = None;
+                    }
+                    DialogResult::Submit(()) => {
+                        let method = dialog.method.clone();
+                        let version = dialog.latest_version.clone();
+                        self.update_confirm_dialog = None;
+                        self.pending_dialog_click_action =
+                            Some(Action::SpawnUpdate(method, version));
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.welcome_dialog {
+            if let Some(DialogResult::Submit(())) = dialog.handle_click(col, row) {
+                self.welcome_dialog = None;
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.changelog_dialog {
+            if let Some(DialogResult::Submit(())) = dialog.handle_click(col, row) {
+                self.changelog_dialog = None;
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.snooze_duration_dialog {
+            if let Some(DialogResult::Submit(minutes)) = dialog.handle_click(col, row) {
+                self.snooze_duration_dialog = None;
+                let sid = self.pending_snooze_session.take();
+                if let Some(id) = sid {
+                    if let Err(e) = self.snooze_session_for(&id, minutes) {
+                        tracing::error!("snooze_session_for failed: {}", e);
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.no_agents_dialog {
+            if let Some(DialogResult::Submit(action)) = dialog.handle_click(col, row) {
+                match action {
+                    NoAgentsAction::Recheck => {
+                        let tools = crate::tmux::AvailableTools::detect();
+                        if tools.any_available() {
+                            self.set_available_tools(tools);
+                            self.no_agents_dialog = None;
+                        }
+                    }
+                    NoAgentsAction::Quit => {
+                        self.no_agents_dialog = None;
+                        self.pending_dialog_click_action = Some(Action::Quit);
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(picker) = &mut self.tool_picker_dialog {
+            match picker.handle_click(col, row) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.tool_picker_dialog = None;
+                }
+                DialogResult::Submit(tool_name) => {
+                    self.tool_picker_dialog = None;
+                    self.view_mode = ViewMode::Tool(tool_name);
+                    self.preview_scroll_offset = 0;
+                    self.tool_preview_cache = super::PreviewCache::default();
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &mut self.group_delete_options_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.group_delete_options_dialog = None;
+                    }
+                    DialogResult::Submit(options) => {
+                        self.group_delete_options_dialog = None;
+                        if options.delete_sessions {
+                            if let Err(e) = self.delete_group_with_sessions(&options) {
+                                tracing::error!(target: "tui.input", "Failed to delete group with sessions: {}", e);
+                            }
+                        } else if let Err(e) = self.delete_selected_group() {
+                            tracing::error!(target: "tui.input", "Failed to delete group: {}", e);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &mut self.rename_dialog {
+            // The rename dialog click handler only ever returns Continue;
+            // submitting requires the user to press Enter on a valid input.
+            // Always swallow the click so the underlying list doesn't react.
+            let _ = dialog.handle_click(col, row);
+            return true;
+        }
+        if let Some(dialog) = &mut self.restart_dialog {
+            let _ = dialog.handle_click(col, row);
+            return true;
+        }
+        if let Some(dialog) = &mut self.sort_picker_dialog {
+            match dialog.handle_click(col, row) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.sort_picker_dialog = None;
+                }
+                DialogResult::Submit(order) => {
+                    self.sort_picker_dialog = None;
+                    if order != self.sort_order {
+                        self.apply_sort_order(order);
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &mut self.group_picker_dialog {
+            match dialog.handle_click(col, row) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.group_picker_dialog = None;
+                }
+                DialogResult::Submit(mode) => {
+                    self.group_picker_dialog = None;
+                    if mode != self.group_by {
+                        self.apply_group_by(mode);
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(palette) = &mut self.command_palette {
+            match palette.handle_click(col, row) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.command_palette = None;
+                }
+                DialogResult::Submit(action) => {
+                    self.command_palette = None;
+                    // No `update_info` here (the mouse handler doesn't
+                    // thread it through); palette commands that rely on
+                    // it (Update prompts) only do so from the keyboard
+                    // path. The fallback is harmless.
+                    self.pending_dialog_click_action = self.dispatch_palette_action(action, None);
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.hooks_install_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.hooks_install_dialog = None;
+                        self.pending_hooks_install_data = None;
+                    }
+                    DialogResult::Submit(_) => {
+                        self.hooks_install_dialog = None;
+                        if let Ok(mut config) =
+                            crate::session::config::load_config().map(|c| c.unwrap_or_default())
+                        {
+                            config.app_state.has_acknowledged_agent_hooks = true;
+                            if let Err(e) = crate::session::config::save_config(&config) {
+                                tracing::warn!(target: "tui.input", "Failed to save config: {e}");
+                            }
+                        }
+                        if let Some(data) = self.pending_hooks_install_data.take() {
+                            self.pending_dialog_click_action = self.continue_session_creation(data);
+                        }
+                    }
+                }
+            }
+            return true;
+        }
+        if let Some(dialog) = &self.hook_trust_dialog {
+            if let Some(result) = dialog.handle_click(col, row) {
+                match result {
+                    DialogResult::Continue => {}
+                    DialogResult::Cancel => {
+                        self.hook_trust_dialog = None;
+                        self.pending_hook_trust_data = None;
+                    }
+                    DialogResult::Submit(action) => {
+                        self.hook_trust_dialog = None;
+                        if let Some(data) = self.pending_hook_trust_data.take() {
+                            let emit = match action {
+                                HookTrustAction::Trust {
+                                    hooks,
+                                    hooks_hash,
+                                    project_path,
+                                } => {
+                                    if let Err(e) = repo_config::trust_repo(
+                                        std::path::Path::new(&project_path),
+                                        &hooks_hash,
+                                    ) {
+                                        tracing::error!(target: "tui.input", "Failed to trust repo: {}", e);
+                                    }
+                                    let merged =
+                                        repo_config::merge_hooks_with_config(&data.profile, hooks);
+                                    self.create_session_with_hooks(data, merged)
+                                }
+                                HookTrustAction::Skip => {
+                                    let fallback =
+                                        repo_config::resolve_global_profile_hooks(&data.profile);
+                                    self.create_session_with_hooks(data, fallback)
+                                }
+                            };
+                            self.pending_dialog_click_action = emit;
+                        }
+                    }
+                }
+            }
             return true;
         }
         // Other dialogs also need to swallow clicks while open. The
@@ -596,11 +915,19 @@ impl HomeView {
         // and the regular home-view path.
         self.clear_preview_selection();
 
-        // Live-send capture wins over every other key handler. While
-        // `live_send` is `Some` the home view is acting as a thin relay
-        // to the target pane; dialog hotkeys, search, and list navigation
-        // all suspend until the user exits with Ctrl+q.
-        if self.live_send.is_some() {
+        // Live-send capture normally wins over every other key handler:
+        // the home view acts as a thin relay to the target pane, so
+        // dialog hotkeys, search, and list navigation all suspend until
+        // the user exits with Ctrl+q. That works when dialogs are only
+        // reachable via keyboard (the hotkey itself gets swallowed by
+        // live-send so the dialog never opens). Once a non-live-send
+        // overlay HAS been opened — via the empty-sidebar click that
+        // pops the new-session dialog, a right-click context menu, or
+        // any future click-to-open path — its keys must go to the
+        // overlay, not the underlying tmux pane. Otherwise the user
+        // sees the dialog but Esc / Enter / typed characters silently
+        // get routed to the session behind it.
+        if self.live_send.is_some() && !self.has_non_live_send_overlay() {
             self.handle_live_send_key(key);
             return None;
         }
@@ -707,6 +1034,27 @@ impl HomeView {
                     return None;
                 }
             }
+        }
+
+        // Right-click context menu. Routed before every other dialog so
+        // keys go to the popup that the user just opened on top of the
+        // sidebar. Submit dispatches to the same helpers the `r` / `d`
+        // key bindings use; Cancel just dismisses.
+        if let Some(menu) = &mut self.context_menu {
+            match menu.handle_key(key) {
+                DialogResult::Continue => {}
+                DialogResult::Cancel => {
+                    self.context_menu = None;
+                }
+                DialogResult::Submit(action) => {
+                    self.context_menu = None;
+                    match action {
+                        ContextMenuAction::Rename => self.open_rename_for_selected(),
+                        ContextMenuAction::Delete => self.open_delete_for_selected(),
+                    }
+                }
+            }
+            return None;
         }
 
         // Handle no-agents dialog (highest priority, blocks all interaction)
@@ -975,22 +1323,8 @@ impl HomeView {
                 DialogResult::Submit(_) => {
                     let action = dialog.action().to_string();
                     self.confirm_dialog = None;
-                    if action == "delete_group" {
-                        if let Err(e) = self.delete_selected_group() {
-                            tracing::error!(target: "tui.input", "Failed to delete group: {}", e);
-                        }
-                    } else if action == "stop_session" {
-                        if let Some(session_id) = self.pending_stop_session.take() {
-                            return Some(Action::StopSession(session_id));
-                        }
-                    } else if action == "force_remove_session" {
-                        if let Some(session_id) = self.pending_force_remove_session.take() {
-                            if let Err(e) = self.force_remove_session(&session_id) {
-                                tracing::error!(target: "tui.input", "Failed to force remove session: {}", e);
-                            }
-                        }
-                    } else if action == "quit_during_creation" {
-                        return Some(Action::Quit);
+                    if let Some(emit) = self.dispatch_confirm_submit(&action) {
+                        return Some(emit);
                     }
                 }
             }
@@ -1546,26 +1880,7 @@ impl HomeView {
                 self.update_selected();
             }
             KeyCode::Char('n') if !self.strict_hotkeys => {
-                if self.creating_stub_id.is_some() {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Please Wait",
-                        "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
-                    ));
-                } else if !self.available_tools.any_available() {
-                    self.show_no_agents();
-                } else {
-                    let existing_groups: Vec<String> =
-                        self.all_groups().iter().map(|g| g.path.clone()).collect();
-                    let current_profile = self.config_profile();
-                    let profiles =
-                        list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                    self.new_dialog = Some(NewSessionDialog::new(
-                        self.available_tools.clone(),
-                        existing_groups,
-                        &current_profile,
-                        profiles,
-                    ));
-                }
+                self.open_new_session_dialog();
             }
             KeyCode::Char('N') if self.strict_hotkeys && self.search_matches.is_empty() => {
                 if self.creating_stub_id.is_some() {
@@ -1893,286 +2208,16 @@ impl HomeView {
                 }
             }
             KeyCode::Char('d') if !self.strict_hotkeys => {
-                // Deletion only allowed in Agent View
-                if self.view_mode == ViewMode::Terminal {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Cannot Delete Terminal",
-                        "Terminals cannot be deleted directly. Switch to Agent View (press 't') and delete the agent session instead.",
-                    ));
-                    return None;
-                }
-                if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(session_id) {
-                        if inst.status == Status::Creating {
-                            return None;
-                        }
-                        if inst.status == Status::Deleting {
-                            let message = format!(
-                                "'{}' is stuck deleting. Force remove it from the session list? \
-                                 (worktrees, branches, and containers will not be cleaned up)",
-                                inst.title
-                            );
-                            self.pending_force_remove_session = Some(session_id.clone());
-                            self.confirm_dialog = Some(ConfirmDialog::new(
-                                "Force Remove",
-                                &message,
-                                "force_remove_session",
-                            ));
-                            return None;
-                        }
-
-                        let config = DeleteDialogConfig {
-                            worktree_branch: inst
-                                .worktree_info
-                                .as_ref()
-                                .filter(|wt| wt.managed_by_aoe)
-                                .map(|wt| wt.branch.clone())
-                                .or_else(|| inst.workspace_info.as_ref().map(|w| w.branch.clone())),
-                            has_sandbox: inst.sandbox_info.as_ref().is_some_and(|s| s.enabled),
-                            project_path: Some(inst.project_path.clone()),
-                            is_scratch: inst.scratch,
-                        };
-
-                        let profile = self.config_profile();
-                        self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
-                            inst.title.clone(),
-                            config,
-                            &profile,
-                        ));
-                    } else {
-                        let profile = self.config_profile();
-                        self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
-                            "Unknown Session".to_string(),
-                            DeleteDialogConfig::default(),
-                            &profile,
-                        ));
-                    }
-                } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press 'g' and pick Manual to manage groups.",
-                        ));
-                        return None;
-                    }
-                    let prefix = format!("{}/", group_path);
-                    let session_count = self
-                        .instances
-                        .iter()
-                        .filter(|i| {
-                            i.group_path == *group_path || i.group_path.starts_with(&prefix)
-                        })
-                        .count();
-
-                    if session_count > 0 {
-                        let has_managed_worktrees =
-                            self.group_has_managed_worktrees(group_path, &prefix);
-                        let has_containers = self.group_has_containers(group_path, &prefix);
-                        self.group_delete_options_dialog = Some(GroupDeleteOptionsDialog::new(
-                            group_path.clone(),
-                            session_count,
-                            has_managed_worktrees,
-                            has_containers,
-                        ));
-                    } else {
-                        let message =
-                            format!("Are you sure you want to delete group '{}'?", group_path);
-                        self.confirm_dialog =
-                            Some(ConfirmDialog::new("Delete Group", &message, "delete_group"));
-                    }
-                }
+                self.open_delete_for_selected();
             }
             KeyCode::Char('D') if self.strict_hotkeys => {
-                // Strict mode: Shift+D = delete (was lowercase 'd' action)
-                if self.view_mode == ViewMode::Terminal {
-                    self.info_dialog = Some(InfoDialog::new(
-                        "Cannot Delete Terminal",
-                        "Terminals cannot be deleted directly. Switch to Agent View (press Shift+T) and delete the agent session instead.",
-                    ));
-                    return None;
-                }
-                if let Some(session_id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(session_id) {
-                        if inst.status == Status::Creating {
-                            return None;
-                        }
-                        if inst.status == Status::Deleting {
-                            let message = format!(
-                                "'{}' is stuck deleting. Force remove it from the session list? \
-                                 (worktrees, branches, and containers will not be cleaned up)",
-                                inst.title
-                            );
-                            self.pending_force_remove_session = Some(session_id.clone());
-                            self.confirm_dialog = Some(ConfirmDialog::new(
-                                "Force Remove",
-                                &message,
-                                "force_remove_session",
-                            ));
-                            return None;
-                        }
-
-                        let config = DeleteDialogConfig {
-                            worktree_branch: inst
-                                .worktree_info
-                                .as_ref()
-                                .filter(|wt| wt.managed_by_aoe)
-                                .map(|wt| wt.branch.clone())
-                                .or_else(|| inst.workspace_info.as_ref().map(|w| w.branch.clone())),
-                            has_sandbox: inst.sandbox_info.as_ref().is_some_and(|s| s.enabled),
-                            project_path: Some(inst.project_path.clone()),
-                            is_scratch: inst.scratch,
-                        };
-
-                        let profile = self.config_profile();
-                        self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
-                            inst.title.clone(),
-                            config,
-                            &profile,
-                        ));
-                    } else {
-                        let profile = self.config_profile();
-                        self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
-                            "Unknown Session".to_string(),
-                            DeleteDialogConfig::default(),
-                            &profile,
-                        ));
-                    }
-                } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press Ctrl+G and pick Manual to manage groups.",
-                        ));
-                        return None;
-                    }
-                    let prefix = format!("{}/", group_path);
-                    let session_count = self
-                        .instances
-                        .iter()
-                        .filter(|i| {
-                            i.group_path == *group_path || i.group_path.starts_with(&prefix)
-                        })
-                        .count();
-
-                    if session_count > 0 {
-                        let has_managed_worktrees =
-                            self.group_has_managed_worktrees(group_path, &prefix);
-                        let has_containers = self.group_has_containers(group_path, &prefix);
-                        self.group_delete_options_dialog = Some(GroupDeleteOptionsDialog::new(
-                            group_path.clone(),
-                            session_count,
-                            has_managed_worktrees,
-                            has_containers,
-                        ));
-                    } else {
-                        let message =
-                            format!("Are you sure you want to delete group '{}'?", group_path);
-                        self.confirm_dialog =
-                            Some(ConfirmDialog::new("Delete Group", &message, "delete_group"));
-                    }
-                }
+                self.open_delete_for_selected();
             }
             KeyCode::Char('r') if !self.strict_hotkeys => {
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if matches!(inst.status, Status::Deleting | Status::Creating) {
-                            return None;
-                        }
-                        // Rename is anchored to the selected session, so the dialog
-                        // must open against that session's profile, not the
-                        // view-level active/config profile (which can differ in
-                        // all-profiles mode).
-                        let current_profile = inst.source_profile.clone();
-                        let profiles =
-                            list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                        let existing_groups: Vec<String> =
-                            self.all_groups().iter().map(|g| g.path.clone()).collect();
-                        self.rename_dialog = Some(RenameDialog::new(
-                            &inst.title,
-                            &inst.group_path,
-                            &current_profile,
-                            profiles,
-                            existing_groups,
-                        ));
-                    }
-                } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press 'g' and pick Manual to manage groups.",
-                        ));
-                        return None;
-                    }
-                    let group_path = group_path.clone();
-                    let current_profile = self
-                        .selected_group_profile
-                        .clone()
-                        .unwrap_or_else(|| self.config_profile());
-                    let profiles =
-                        list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                    let existing_groups: Vec<String> =
-                        self.all_groups().iter().map(|g| g.path.clone()).collect();
-                    self.group_rename_context = Some(super::GroupRenameContext {
-                        old_path: group_path.clone(),
-                        old_profile: current_profile.clone(),
-                    });
-                    self.rename_dialog = Some(RenameDialog::new_for_group(
-                        &group_path,
-                        &current_profile,
-                        profiles,
-                        existing_groups,
-                    ));
-                }
+                self.open_rename_for_selected();
             }
             KeyCode::Char('R') if self.strict_hotkeys => {
-                if let Some(id) = &self.selected_session {
-                    if let Some(inst) = self.get_instance(id) {
-                        if matches!(inst.status, Status::Deleting | Status::Creating) {
-                            return None;
-                        }
-                        // See the corresponding `r` handler above: rename targets
-                        // the selected session, so anchor on its source_profile.
-                        let current_profile = inst.source_profile.clone();
-                        let profiles =
-                            list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                        let existing_groups: Vec<String> =
-                            self.all_groups().iter().map(|g| g.path.clone()).collect();
-                        self.rename_dialog = Some(RenameDialog::new(
-                            &inst.title,
-                            &inst.group_path,
-                            &current_profile,
-                            profiles,
-                            existing_groups,
-                        ));
-                    }
-                } else if let Some(group_path) = &self.selected_group {
-                    if self.group_by == GroupByMode::Project {
-                        self.info_dialog = Some(InfoDialog::new(
-                            "Cannot Modify Project Groups",
-                            "Project groups are automatic. Press Ctrl+G and pick Manual to manage groups.",
-                        ));
-                        return None;
-                    }
-                    let group_path = group_path.clone();
-                    let current_profile = self
-                        .selected_group_profile
-                        .clone()
-                        .unwrap_or_else(|| self.config_profile());
-                    let profiles =
-                        list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
-                    let existing_groups: Vec<String> =
-                        self.all_groups().iter().map(|g| g.path.clone()).collect();
-                    self.group_rename_context = Some(super::GroupRenameContext {
-                        old_path: group_path.clone(),
-                        old_profile: current_profile.clone(),
-                    });
-                    self.rename_dialog = Some(RenameDialog::new_for_group(
-                        &group_path,
-                        &current_profile,
-                        profiles,
-                        existing_groups,
-                    ));
-                }
+                self.open_rename_for_selected();
             }
             KeyCode::Char('m') if !self.strict_hotkeys => {
                 self.open_send_message_dialog();
@@ -2995,6 +3040,291 @@ impl HomeView {
             .and_then(|(c, r)| self.resolve_row_to_index(c, r))
     }
 
+    /// Handle a right-click at `(col, row)`. When it lands on a sidebar
+    /// row, move the cursor onto that row (so Rename/Delete target what
+    /// the user actually clicked, not whatever was selected before) and
+    /// open the context menu anchored to the click position. The
+    /// renderer clamps the menu into the visible area so a near-edge
+    /// click never produces an off-screen popup.
+    ///
+    /// Returns true when the menu opened. A right-click that doesn't
+    /// resolve to a row (header, scroll arrow, empty space below the
+    /// last row) is a no-op so the caller can choose to fall through.
+    pub fn handle_right_click(&mut self, col: u16, row: u16) -> bool {
+        // `resolve_row_to_index` already short-circuits when any
+        // non-live-send overlay (incl. the context menu itself) is open
+        // and inside the diff takeover, so no extra dialog gating here.
+        let Some(idx) = self.resolve_row_to_index(col, row) else {
+            return false;
+        };
+        if self.cursor != idx {
+            self.cursor = idx;
+            self.update_selected();
+        }
+        // Mirror the row-aware menu copy from the web sidebar so a group
+        // row reads as "Rename Group / Delete Group" instead of bare
+        // "Rename / Delete".
+        let is_group = matches!(self.flat_items[idx], super::Item::Group { .. });
+        let anchor = (col.saturating_add(1), row.saturating_add(1));
+        self.context_menu = Some(if is_group {
+            ContextMenuDialog::for_group(anchor)
+        } else {
+            ContextMenuDialog::for_session(anchor)
+        });
+        true
+    }
+
+    /// Route a left-click into the context menu, if it's open. Three
+    /// outcomes from the menu's perspective:
+    ///   - click on a Rename / Delete row: dispatch the action (which
+    ///     opens the matching follow-up dialog) and close the menu,
+    ///   - click on the menu's border (or anywhere inside that isn't a
+    ///     row): keep it open,
+    ///   - click outside the menu: close it.
+    ///
+    /// In all three cases the click is "consumed" — the caller must not
+    /// fall through to the list / preview / dialog handlers underneath.
+    /// Returns true when the menu existed (and consumed the click).
+    pub fn handle_context_menu_click(&mut self, col: u16, row: u16) -> bool {
+        let Some(menu) = &mut self.context_menu else {
+            return false;
+        };
+        match menu.handle_click(col, row) {
+            None => {
+                self.context_menu = None;
+            }
+            Some(DialogResult::Continue) => {
+                // Inside the menu but not on a row (border): keep open.
+            }
+            Some(DialogResult::Cancel) => {
+                self.context_menu = None;
+            }
+            Some(DialogResult::Submit(action)) => {
+                self.context_menu = None;
+                match action {
+                    ContextMenuAction::Rename => self.open_rename_for_selected(),
+                    ContextMenuAction::Delete => self.open_delete_for_selected(),
+                }
+            }
+        }
+        true
+    }
+
+    /// Open the new-session dialog, with the same gating the `'n'` key
+    /// applies: a "please wait" info dialog when a session is already
+    /// being created, the no-agents dialog when no tool is available,
+    /// otherwise the full dialog. Shared by `'n'` and the
+    /// click-in-empty-sidebar shortcut so they can't drift.
+    pub(super) fn open_new_session_dialog(&mut self) {
+        if self.creating_stub_id.is_some() {
+            self.info_dialog = Some(InfoDialog::new(
+                "Please Wait",
+                "A session is already being created. Wait for it to finish or press Ctrl+C to cancel.",
+            ));
+            return;
+        }
+        if !self.available_tools.any_available() {
+            self.show_no_agents();
+            return;
+        }
+        let existing_groups: Vec<String> =
+            self.all_groups().iter().map(|g| g.path.clone()).collect();
+        let current_profile = self.config_profile();
+        let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+        self.new_dialog = Some(NewSessionDialog::new(
+            self.available_tools.clone(),
+            existing_groups,
+            &current_profile,
+            profiles,
+        ));
+    }
+
+    /// Treat a left-click that landed in the sidebar area but past the
+    /// last session row as "open new session" — matches the `'n'`
+    /// keybind. Returns true when the click was consumed (dialog
+    /// opened or a gating dialog like "please wait" replaced it).
+    ///
+    /// Gated to fire only when no overlay is already up and the diff
+    /// view isn't open, so a click on an empty list while a modal is
+    /// covering it doesn't punch through.
+    pub fn handle_empty_list_click(&mut self, col: u16, row: u16) -> bool {
+        if self.has_non_live_send_overlay() || self.diff_view.is_some() {
+            return false;
+        }
+        if !self.list_inner_area.contains(Position::from((col, row))) {
+            return false;
+        }
+        if self.resolve_row_to_index(col, row).is_some() {
+            // A real row resolved here — the regular click path owns it.
+            return false;
+        }
+        self.open_new_session_dialog();
+        true
+    }
+
+    /// Open the rename dialog for whatever the sidebar has selected (a
+    /// session row, or a manual-mode group). Project-mode groups can't be
+    /// renamed, so they raise an info dialog explaining how to switch
+    /// modes. No-op when nothing is selected, or when the selected session
+    /// is mid-create or mid-delete (renaming under those states would race
+    /// the cascade).
+    ///
+    /// Shared by the `'r'` / `'R'` key handlers and the right-click
+    /// context menu so all three entry points stay byte-identical.
+    pub(super) fn open_rename_for_selected(&mut self) {
+        if let Some(id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(id) {
+                if matches!(inst.status, Status::Deleting | Status::Creating) {
+                    return;
+                }
+                // Rename is anchored to the selected session, so the dialog
+                // must open against that session's profile, not the
+                // view-level active/config profile (which can differ in
+                // all-profiles mode).
+                let current_profile = inst.source_profile.clone();
+                let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+                let existing_groups: Vec<String> =
+                    self.all_groups().iter().map(|g| g.path.clone()).collect();
+                self.rename_dialog = Some(RenameDialog::new(
+                    &inst.title,
+                    &inst.group_path,
+                    &current_profile,
+                    profiles,
+                    existing_groups,
+                ));
+            }
+        } else if let Some(group_path) = &self.selected_group {
+            if self.group_by == GroupByMode::Project {
+                let hint = if self.strict_hotkeys {
+                    "Project groups are automatic. Press Ctrl+G and pick Manual to manage groups."
+                } else {
+                    "Project groups are automatic. Press 'g' and pick Manual to manage groups."
+                };
+                self.info_dialog = Some(InfoDialog::new("Cannot Modify Project Groups", hint));
+                return;
+            }
+            let group_path = group_path.clone();
+            let current_profile = self
+                .selected_group_profile
+                .clone()
+                .unwrap_or_else(|| self.config_profile());
+            let profiles = list_profiles().unwrap_or_else(|_| vec![current_profile.clone()]);
+            let existing_groups: Vec<String> =
+                self.all_groups().iter().map(|g| g.path.clone()).collect();
+            self.group_rename_context = Some(super::GroupRenameContext {
+                old_path: group_path.clone(),
+                old_profile: current_profile.clone(),
+            });
+            self.rename_dialog = Some(RenameDialog::new_for_group(
+                &group_path,
+                &current_profile,
+                profiles,
+                existing_groups,
+            ));
+        }
+    }
+
+    /// Open the delete dialog (or a force-remove confirm, or a group
+    /// delete-options dialog) for the sidebar's current selection. Mirrors
+    /// the gating of the historical `'d'` / `'D'` key handlers:
+    ///   - Terminal view rejects deletion with an info dialog,
+    ///   - Creating sessions are inert,
+    ///   - Stuck-Deleting sessions get a force-remove confirm,
+    ///   - Project-mode groups can't be deleted (info dialog).
+    ///
+    /// Shared by the `'d'` / `'D'` key handlers and the right-click
+    /// context menu.
+    pub(super) fn open_delete_for_selected(&mut self) {
+        // Deletion only allowed in Agent View.
+        if self.view_mode == ViewMode::Terminal {
+            let hint = if self.strict_hotkeys {
+                "Terminals cannot be deleted directly. Switch to Agent View (press Shift+T) and delete the agent session instead."
+            } else {
+                "Terminals cannot be deleted directly. Switch to Agent View (press 't') and delete the agent session instead."
+            };
+            self.info_dialog = Some(InfoDialog::new("Cannot Delete Terminal", hint));
+            return;
+        }
+        if let Some(session_id) = &self.selected_session {
+            if let Some(inst) = self.get_instance(session_id) {
+                if inst.status == Status::Creating {
+                    return;
+                }
+                if inst.status == Status::Deleting {
+                    let message = format!(
+                        "'{}' is stuck deleting. Force remove it from the session list? \
+                         (worktrees, branches, and containers will not be cleaned up)",
+                        inst.title
+                    );
+                    self.pending_force_remove_session = Some(session_id.clone());
+                    self.confirm_dialog = Some(ConfirmDialog::new(
+                        "Force Remove",
+                        &message,
+                        "force_remove_session",
+                    ));
+                    return;
+                }
+
+                let config = DeleteDialogConfig {
+                    worktree_branch: inst
+                        .worktree_info
+                        .as_ref()
+                        .filter(|wt| wt.managed_by_aoe)
+                        .map(|wt| wt.branch.clone())
+                        .or_else(|| inst.workspace_info.as_ref().map(|w| w.branch.clone())),
+                    has_sandbox: inst.sandbox_info.as_ref().is_some_and(|s| s.enabled),
+                    project_path: Some(inst.project_path.clone()),
+                    is_scratch: inst.scratch,
+                };
+
+                let profile = self.config_profile();
+                self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
+                    inst.title.clone(),
+                    config,
+                    &profile,
+                ));
+            } else {
+                let profile = self.config_profile();
+                self.unified_delete_dialog = Some(UnifiedDeleteDialog::new(
+                    "Unknown Session".to_string(),
+                    DeleteDialogConfig::default(),
+                    &profile,
+                ));
+            }
+        } else if let Some(group_path) = &self.selected_group {
+            if self.group_by == GroupByMode::Project {
+                let hint = if self.strict_hotkeys {
+                    "Project groups are automatic. Press Ctrl+G and pick Manual to manage groups."
+                } else {
+                    "Project groups are automatic. Press 'g' and pick Manual to manage groups."
+                };
+                self.info_dialog = Some(InfoDialog::new("Cannot Modify Project Groups", hint));
+                return;
+            }
+            let prefix = format!("{}/", group_path);
+            let session_count = self
+                .instances
+                .iter()
+                .filter(|i| i.group_path == *group_path || i.group_path.starts_with(&prefix))
+                .count();
+
+            if session_count > 0 {
+                let has_managed_worktrees = self.group_has_managed_worktrees(group_path, &prefix);
+                let has_containers = self.group_has_containers(group_path, &prefix);
+                self.group_delete_options_dialog = Some(GroupDeleteOptionsDialog::new(
+                    group_path.clone(),
+                    session_count,
+                    has_managed_worktrees,
+                    has_containers,
+                ));
+            } else {
+                let message = format!("Are you sure you want to delete group '{}'?", group_path);
+                self.confirm_dialog =
+                    Some(ConfirmDialog::new("Delete Group", &message, "delete_group"));
+            }
+        }
+    }
+
     /// Route a left-click at (col, row) inside the session list. A
     /// single click on a session row selects it AND requests live-send
     /// mode for that row (same `Action::EnterLiveSend` that Tab would
@@ -3098,6 +3428,63 @@ impl HomeView {
     /// Returns `true` only when the resolved hovered item changes, so the
     /// caller can skip a redraw on every pixel-level mouse twitch.
     pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        // Open overlay dialogs / menus get hover routed first so their
+        // focus highlight tracks the mouse the same way a desktop UI
+        // would. The sidebar's own hover state still updates underneath
+        // so the row highlight is correct the instant the dialog closes.
+        let mut overlay_changed = false;
+        if let Some(menu) = &mut self.context_menu {
+            overlay_changed |= menu.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.unified_delete_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.new_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(view) = &mut self.settings_view {
+            overlay_changed |= view.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.confirm_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.update_confirm_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.snooze_duration_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.no_agents_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.hook_trust_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(picker) = &mut self.tool_picker_dialog {
+            overlay_changed |= picker.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.group_delete_options_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.rename_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.restart_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.hooks_install_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.sort_picker_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(dialog) = &mut self.group_picker_dialog {
+            overlay_changed |= dialog.handle_hover(col, row);
+        }
+        if let Some(palette) = &mut self.command_palette {
+            overlay_changed |= palette.handle_hover(col, row);
+        }
+
         let new_pos = if self.list_inner_area.contains(Position::from((col, row))) {
             Some((col, row))
         } else {
@@ -3106,7 +3493,7 @@ impl HomeView {
         let prev_idx = self.hovered_index();
         self.mouse_pos = new_pos;
         let new_idx = self.hovered_index();
-        prev_idx != new_idx
+        overlay_changed || prev_idx != new_idx
     }
 
     /// Route a mouse-wheel-down at (col, row); see handle_scroll_up.

--- a/src/tui/home/mod.rs
+++ b/src/tui/home/mod.rs
@@ -31,10 +31,10 @@ use super::deletion_poller::DeletionPoller;
 #[cfg(feature = "serve")]
 use super::dialogs::ServeView;
 use super::dialogs::{
-    ChangelogDialog, CommandPaletteDialog, ConfirmDialog, GroupDeleteOptionsDialog,
-    GroupPickerDialog, HookTrustDialog, HooksInstallDialog, InfoDialog, NewSessionData,
-    NewSessionDialog, NoAgentsDialog, ProfilePickerDialog, ProjectsDialog, RenameDialog,
-    RestartDialog, SnoozeDurationDialog, SortPickerDialog, UnifiedDeleteDialog,
+    ChangelogDialog, CommandPaletteDialog, ConfirmDialog, ContextMenuDialog,
+    GroupDeleteOptionsDialog, GroupPickerDialog, HookTrustDialog, HooksInstallDialog, InfoDialog,
+    NewSessionData, NewSessionDialog, NoAgentsDialog, ProfilePickerDialog, ProjectsDialog,
+    RenameDialog, RestartDialog, SnoozeDurationDialog, SortPickerDialog, UnifiedDeleteDialog,
     UpdateConfirmDialog, WelcomeDialog,
 };
 use super::diff::DiffView;
@@ -360,6 +360,9 @@ pub struct HomeView {
     pub(super) group_delete_options_dialog: Option<GroupDeleteOptionsDialog>,
     pub(super) rename_dialog: Option<RenameDialog>,
     pub(super) restart_dialog: Option<RestartDialog>,
+    /// Right-click popup on the sidebar list. Anchored to a screen
+    /// position when opened; the renderer clamps it into view.
+    pub(super) context_menu: Option<ContextMenuDialog>,
     pub(super) group_rename_context: Option<GroupRenameContext>,
     pub(super) hook_trust_dialog: Option<HookTrustDialog>,
     /// Session data pending hook trust approval
@@ -427,6 +430,13 @@ pub struct HomeView {
     pub(super) pending_stop_session: Option<String>,
     /// Session to force-remove after the confirmation dialog is accepted
     pub(super) pending_force_remove_session: Option<String>,
+    /// Action emitted by a mouse-click on a modal dialog (e.g. clicking
+    /// `[Yes]` on a stop-session confirm). The keyboard path returns
+    /// these via `handle_key -> Option<Action>`, but the mouse path
+    /// goes through `handle_dialog_click` which has no return slot for
+    /// an Action. Stashed here and drained by `app.rs` after the click
+    /// is consumed so both paths produce the same downstream effect.
+    pub(super) pending_dialog_click_action: Option<crate::tui::app::Action>,
     // Search
     pub(super) search_active: bool,
     pub(super) search_query: Input,
@@ -729,6 +739,7 @@ impl HomeView {
             group_delete_options_dialog: None,
             rename_dialog: None,
             restart_dialog: None,
+            context_menu: None,
             group_rename_context: None,
             hook_trust_dialog: None,
             pending_hook_trust_data: None,
@@ -759,6 +770,7 @@ impl HomeView {
             pending_attach_after_warning: None,
             pending_stop_session: None,
             pending_force_remove_session: None,
+            pending_dialog_click_action: None,
             search_active: false,
             search_query: Input::default(),
             search_matches: Vec::new(),
@@ -2069,6 +2081,7 @@ impl HomeView {
             || self.group_delete_options_dialog.is_some()
             || self.rename_dialog.is_some()
             || self.restart_dialog.is_some()
+            || self.context_menu.is_some()
             || self.hook_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
             || self.welcome_dialog.is_some()
@@ -2102,6 +2115,7 @@ impl HomeView {
             || self.group_delete_options_dialog.is_some()
             || self.rename_dialog.is_some()
             || self.restart_dialog.is_some()
+            || self.context_menu.is_some()
             || self.hook_trust_dialog.is_some()
             || self.hooks_install_dialog.is_some()
             || self.welcome_dialog.is_some()

--- a/src/tui/home/render.rs
+++ b/src/tui/home/render.rs
@@ -445,7 +445,7 @@ impl HomeView {
             settings.render(frame, area, theme);
             // Render unsaved changes confirmation dialog over settings
             if self.settings_close_confirm {
-                if let Some(dialog) = &self.confirm_dialog {
+                if let Some(dialog) = &mut self.confirm_dialog {
                     dialog.render(frame, area, theme);
                 }
             }
@@ -614,6 +614,10 @@ impl HomeView {
             tool_picker_dialog,
             send_message_dialog,
             update_confirm_dialog,
+            // context_menu renders last so its small popup sits on top of
+            // any underlying dialog (e.g. an info dialog opened by a
+            // gated rename/delete attempt).
+            context_menu,
         );
     }
 

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8386,3 +8386,209 @@ mod save_field_merge {
         );
     }
 }
+
+#[cfg(test)]
+mod right_click_context_menu {
+    //! Right-click on a sidebar row opens a small popup menu (Rename /
+    //! Delete) anchored to the click. Picking Rename routes through the
+    //! same helper as the `r` key, Delete through the same helper as
+    //! `d`. Click-outside dismisses the menu.
+
+    use super::*;
+    use crate::session::Item;
+    use crate::tui::dialogs::ContextMenuAction;
+    use ratatui::layout::Rect;
+
+    fn setup_inner(env: &mut TestEnv) {
+        env.view.list_inner_area = Rect::new(1, 1, 28, 10);
+        env.view.list_area = Rect::new(0, 0, 30, 12);
+    }
+
+    #[test]
+    #[serial]
+    fn right_click_on_session_opens_session_menu_and_moves_cursor() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        env.view.cursor = 0;
+        env.view.update_selected();
+
+        // Click the third visible row (inner.y + 2 == 3) -> flat_items[2].
+        assert!(env.view.handle_right_click(5, 3));
+        assert_eq!(env.view.cursor, 2, "cursor should move to clicked row");
+        let menu = env
+            .view
+            .context_menu
+            .as_ref()
+            .expect("context_menu should be open");
+        assert_eq!(menu.selected_action(), ContextMenuAction::Rename);
+        // The selected item is a session, not a group.
+        assert!(matches!(
+            env.view.flat_items[env.view.cursor],
+            Item::Session { .. }
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn right_click_off_list_is_noop() {
+        let mut env = create_test_env_with_sessions(3);
+        setup_inner(&mut env);
+        // Row 50 is well past list_inner_area.bottom.
+        assert!(!env.view.handle_right_click(5, 50));
+        assert!(env.view.context_menu.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn right_click_on_group_uses_group_menu() {
+        let mut env = create_test_env_with_groups();
+        setup_inner(&mut env);
+        // Find a group row index in flat_items.
+        let group_idx = env
+            .view
+            .flat_items
+            .iter()
+            .position(|item| matches!(item, Item::Group { .. }))
+            .expect("manual-mode test env should have a group row");
+        let click_row = env.view.list_inner_area.y + group_idx as u16;
+
+        assert!(env.view.handle_right_click(5, click_row));
+        assert_eq!(env.view.cursor, group_idx);
+        assert!(env.view.context_menu.is_some());
+        assert!(matches!(
+            env.view.flat_items[env.view.cursor],
+            Item::Group { .. }
+        ));
+    }
+
+    #[test]
+    #[serial]
+    fn enter_rename_in_menu_opens_rename_dialog() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 1);
+        assert!(env.view.context_menu.is_some());
+        // First item is Rename; Enter submits it.
+        env.view.handle_key(key(KeyCode::Enter), None);
+        assert!(
+            env.view.context_menu.is_none(),
+            "menu should close on submit"
+        );
+        assert!(
+            env.view.rename_dialog.is_some(),
+            "Rename should route to rename_dialog like the 'r' key"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn down_then_enter_in_menu_opens_delete_dialog() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 1);
+        env.view.handle_key(key(KeyCode::Down), None);
+        env.view.handle_key(key(KeyCode::Enter), None);
+        assert!(env.view.context_menu.is_none());
+        assert!(
+            env.view.unified_delete_dialog.is_some(),
+            "Delete should route to unified_delete_dialog like the 'd' key"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn esc_in_menu_cancels_without_dialog() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 1);
+        env.view.handle_key(key(KeyCode::Esc), None);
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.rename_dialog.is_none());
+        assert!(env.view.unified_delete_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn right_click_is_gated_when_other_dialog_is_open() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.show_help = true;
+        assert!(env.view.has_dialog());
+        // resolve_row_to_index short-circuits on any non-live-send overlay,
+        // so the right-click handler should bail without opening the menu.
+        assert!(!env.view.handle_right_click(5, 1));
+        assert!(env.view.context_menu.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn context_menu_counts_as_dialog() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        assert!(!env.view.has_dialog());
+        env.view.handle_right_click(5, 1);
+        assert!(env.view.has_dialog());
+    }
+
+    #[test]
+    #[serial]
+    fn left_click_outside_menu_dismisses_it() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 1);
+        assert!(env.view.context_menu.is_some());
+        // Before a render captures the menu's last_area, every click
+        // reads as "outside", which is exactly the dismissal contract
+        // we want here. (Item-row hit testing has its own unit coverage
+        // in `dialogs::context_menu`.)
+        let consumed = env.view.handle_context_menu_click(99, 99);
+        assert!(consumed, "router should mark the click consumed");
+        assert!(
+            env.view.context_menu.is_none(),
+            "outside click should dismiss the menu"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn handle_context_menu_click_returns_false_when_no_menu() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        assert!(env.view.context_menu.is_none());
+        assert!(!env.view.handle_context_menu_click(5, 5));
+    }
+
+    #[test]
+    #[serial]
+    fn click_on_empty_sidebar_opens_new_session_dialog() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        // Sessions occupy inner rows 0 and 1 (y=1, y=2). Row 5 is well
+        // past the last item but still inside list_inner_area.
+        assert!(env.view.handle_empty_list_click(5, 5));
+        assert!(
+            env.view.new_dialog.is_some(),
+            "click on empty sidebar should open the new-session dialog"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn click_on_a_real_row_does_not_open_new_session() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        // Row 1 resolves to flat_items[0], a real session row.
+        assert!(!env.view.handle_empty_list_click(5, 1));
+        assert!(env.view.new_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_click_is_gated_when_overlay_is_open() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.show_help = true;
+        assert!(!env.view.handle_empty_list_click(5, 5));
+        assert!(env.view.new_dialog.is_none());
+    }
+}

--- a/src/tui/home/tests.rs
+++ b/src/tui/home/tests.rs
@@ -8560,24 +8560,55 @@ mod right_click_context_menu {
 
     #[test]
     #[serial]
-    fn click_on_empty_sidebar_opens_new_session_dialog() {
+    fn left_click_on_empty_sidebar_outside_live_mode_is_noop() {
+        // Left-click on empty sidebar space is intentionally low-stakes:
+        // it does NOT open the new-session dialog anymore (right-click
+        // owns that entry point) and it doesn't move selection. The
+        // user can keep clicking the empty area to dismiss preview
+        // selections without summoning modals.
         let mut env = create_test_env_with_sessions(2);
         setup_inner(&mut env);
         // Sessions occupy inner rows 0 and 1 (y=1, y=2). Row 5 is well
         // past the last item but still inside list_inner_area.
-        assert!(env.view.handle_empty_list_click(5, 5));
-        assert!(
-            env.view.new_dialog.is_some(),
-            "click on empty sidebar should open the new-session dialog"
-        );
+        assert!(!env.view.handle_empty_list_click(5, 5));
+        assert!(env.view.new_dialog.is_none());
+        assert!(env.view.context_menu.is_none());
     }
 
     #[test]
     #[serial]
-    fn click_on_a_real_row_does_not_open_new_session() {
+    fn left_click_on_empty_sidebar_in_live_mode_exits_live_mode() {
+        // Quick-exit gesture: when live-send is active, a click on the
+        // empty sidebar drops the user out of live mode. Mirrors the
+        // Ctrl+Q chord but with the mouse, so a user who came in via
+        // a left-click can also leave that way.
         let mut env = create_test_env_with_sessions(2);
         setup_inner(&mut env);
-        // Row 1 resolves to flat_items[0], a real session row.
+        use crate::tui::home::live_send;
+        env.view.live_send = Some(live_send::LiveSendState {
+            session_id: "fake".to_string(),
+            title: "fake".to_string(),
+            tmux_name: "aoe_test_empty_click_exit_live".to_string(),
+            target: live_send::LiveSendTarget::Agent,
+            exit_chords: live_send::parse_chord_list(live_send::DEFAULT_EXIT_CHORD),
+        });
+        assert!(env.view.live_send.is_some());
+        assert!(env.view.handle_empty_list_click(5, 5));
+        assert!(
+            env.view.live_send.is_none(),
+            "click on empty sidebar should exit live mode"
+        );
+        assert!(env.view.new_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn click_on_a_real_row_does_not_change_empty_click_state() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        // Row 1 resolves to flat_items[0], a real session row. The
+        // empty-list click handler must defer to the regular click
+        // path; it shouldn't open new-session or exit live mode here.
         assert!(!env.view.handle_empty_list_click(5, 1));
         assert!(env.view.new_dialog.is_none());
     }
@@ -8590,5 +8621,127 @@ mod right_click_context_menu {
         env.view.show_help = true;
         assert!(!env.view.handle_empty_list_click(5, 5));
         assert!(env.view.new_dialog.is_none());
+    }
+
+    #[test]
+    #[serial]
+    fn right_click_on_empty_sidebar_opens_empty_menu() {
+        // Right-clicking the empty area of the sidebar (below the last
+        // session) opens the dedicated 3-item menu so the mouse can
+        // reach New / Sort / Grouping the same way `n`/`o`/`g` would
+        // from the keyboard.
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        assert!(env.view.handle_right_click(5, 5));
+        let menu = env.view.context_menu.as_ref().expect("menu opened");
+        let labels: Vec<String> = menu
+            .items_for_test()
+            .iter()
+            .map(|(_, label)| (*label).to_string())
+            .collect();
+        assert_eq!(
+            labels,
+            vec!["New Session", "Change Sort", "Change Grouping"]
+        );
+    }
+
+    /// Helper: hit a key through the home view's handle_key path so
+    /// the dispatch tests run the same wiring real input does. Both
+    /// click and keyboard funnel through `dispatch_context_menu_action`,
+    /// so this covers the dispatcher without having to mock the menu's
+    /// `last_area` for hit-testing.
+    fn send_key(env: &mut crate::tui::home::tests::TestEnv, code: crossterm::event::KeyCode) {
+        env.view.handle_key(
+            crossterm::event::KeyEvent::new(code, crossterm::event::KeyModifiers::NONE),
+            None,
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_new_session_dispatches() {
+        // First item (New Session) submits through the shared
+        // dispatcher and opens the new-session dialog.
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Enter);
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.new_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_sort_dispatches() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Down); // highlight "Change Sort"
+        send_key(&mut env, crossterm::event::KeyCode::Enter);
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.sort_picker_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_grouping_dispatches() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Down);
+        send_key(&mut env, crossterm::event::KeyCode::Down); // highlight "Change Grouping"
+        send_key(&mut env, crossterm::event::KeyCode::Enter);
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.group_picker_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_n_hotkey_opens_new_session() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Char('n'));
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.new_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_o_hotkey_opens_sort_picker() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Char('o'));
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.sort_picker_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn empty_sidebar_menu_g_hotkey_opens_group_picker() {
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 5);
+        send_key(&mut env, crossterm::event::KeyCode::Char('g'));
+        assert!(env.view.context_menu.is_none());
+        assert!(env.view.group_picker_dialog.is_some());
+    }
+
+    #[test]
+    #[serial]
+    fn session_menu_n_hotkey_is_inert() {
+        // Sanity: the session-row menu only has Rename/Delete actions,
+        // so 'n' must NOT submit NewSession when the wrong menu is open.
+        // This proves the hotkey gate (action must be in items) holds.
+        let mut env = create_test_env_with_sessions(2);
+        setup_inner(&mut env);
+        env.view.handle_right_click(5, 1); // row 1 = first session
+        send_key(&mut env, crossterm::event::KeyCode::Char('n'));
+        assert!(env.view.context_menu.is_some(), "menu should stay open");
+        assert!(
+            env.view.new_dialog.is_none(),
+            "n on session menu must not open new-session"
+        );
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -24,6 +24,11 @@ impl SettingsView {
     pub fn handle_key(&mut self, key: KeyEvent) -> SettingsAction {
         // Clear transient messages on any key
         self.success_message = None;
+        // Any keypress invalidates the mouse hover highlight — otherwise
+        // a stationary cursor keeps highlighting an unrelated row while
+        // the keyboard cursor moves elsewhere. Mirrors the sidebar's
+        // move_cursor_clears_hover pattern.
+        self.mouse_pos = None;
 
         // Handle custom instruction dialog
         if let Some(ref mut dialog) = self.custom_instruction_dialog {
@@ -1120,6 +1125,105 @@ impl SettingsView {
             }
         }
     }
+
+    /// Route a left-click into the settings view. Returns
+    /// `Some(SettingsAction)` when the click was consumed (the
+    /// settings view stays open, only the focus/scope/selection
+    /// changes; the caller still needs to redraw). Returns `None`
+    /// when nothing hit and the click should be treated as a swallow
+    /// (since settings is a full-screen takeover, clicks anywhere
+    /// inside it are absorbed by the modal regardless).
+    ///
+    /// Editing modes (`editing_input`, `list_edit_state`, custom
+    /// instruction dialog, help overlay, search overlay) intentionally
+    /// skip click routing so a stray click during composition doesn't
+    /// reset focus or drop a half-typed value. The keyboard's Esc /
+    /// Enter handlers remain the way out of those modes.
+    pub fn handle_click(&mut self, col: u16, row: u16) -> Option<SettingsAction> {
+        if self.editing_input.is_some()
+            || self.list_edit_state.is_some()
+            || self.custom_instruction_dialog.is_some()
+            || self.show_help
+            || self.search_input.is_some()
+        {
+            return None;
+        }
+        let pos = ratatui::layout::Position::from((col, row));
+
+        if let Some((scope, _)) = self
+            .scope_tab_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .copied()
+        {
+            if scope != self.scope {
+                if self.has_changes {
+                    return Some(SettingsAction::UnsavedChangesWarning);
+                }
+                self.scope = scope;
+                self.rebuild_categories_for_scope();
+                self.rebuild_fields();
+            }
+            return Some(SettingsAction::Continue);
+        }
+
+        if let Some((idx, _)) = self
+            .category_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .copied()
+        {
+            self.focus = SettingsFocus::Categories;
+            if self.selected_category != idx {
+                self.selected_category = idx;
+                self.selected_field = 0;
+                self.fields_scroll_offset = 0;
+                self.rebuild_fields();
+            }
+            return Some(SettingsAction::Continue);
+        }
+
+        if let Some((idx, _)) = self
+            .field_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .copied()
+        {
+            self.focus = SettingsFocus::Fields;
+            self.selected_field = idx;
+            return Some(SettingsAction::Continue);
+        }
+
+        None
+    }
+
+    /// Track the mouse position so the renderer can paint a hover
+    /// highlight on whichever scope chip / category row / field row
+    /// the cursor is over. Hover never moves the keyboard cursor —
+    /// see `ConfirmDialog::handle_hover` for why. Editing / search /
+    /// help modes clear the hover so the highlight doesn't bleed
+    /// behind the overlay.
+    pub fn handle_hover(&mut self, col: u16, row: u16) -> bool {
+        let suppress = self.editing_input.is_some()
+            || self.list_edit_state.is_some()
+            || self.custom_instruction_dialog.is_some()
+            || self.show_help
+            || self.search_input.is_some();
+        let new_pos = if suppress { None } else { Some((col, row)) };
+        if self.mouse_pos == new_pos {
+            return false;
+        }
+        // Only request a redraw when the resolved hover target
+        // actually changes — a mouse drift inside the same field or
+        // entirely off the rects shouldn't repaint every pixel.
+        let prev_scope = self.hovered_scope();
+        let prev_cat = self.hovered_category();
+        let prev_field = self.hovered_field();
+        self.mouse_pos = new_pos;
+        prev_scope != self.hovered_scope()
+            || prev_cat != self.hovered_category()
+            || prev_field != self.hovered_field()
+    }
 }
 
 /// Validate that an entry for AgentExtraArgs or AgentCommandOverride is in `agent_name=value` format.
@@ -1449,6 +1553,175 @@ mod tests {
             assert!(view.search_input.is_none());
             assert_eq!(view.selected_category, cat_before);
             assert_eq!(view.selected_field, field_before);
+        }
+    }
+
+    mod mouse_routing {
+        use super::*;
+        use crate::session::Storage;
+        use crate::tui::settings::{SettingsScope, SettingsView};
+        use ratatui::layout::Rect;
+        use serial_test::serial;
+        use tempfile::TempDir;
+
+        fn setup_test_home(temp: &TempDir) {
+            std::env::set_var("HOME", temp.path());
+            #[cfg(target_os = "linux")]
+            std::env::set_var("XDG_CONFIG_HOME", temp.path().join(".config"));
+        }
+
+        fn fresh_view() -> (TempDir, SettingsView) {
+            let temp = TempDir::new().unwrap();
+            setup_test_home(&temp);
+            let _ = Storage::new("test").unwrap();
+            let view = SettingsView::new("test", None).unwrap();
+            (temp, view)
+        }
+
+        #[test]
+        #[serial]
+        fn click_on_scope_tab_switches_scope() {
+            let (_t, mut view) = fresh_view();
+            // Stage a Profile scope rect at known coords.
+            view.scope_tab_rects
+                .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
+            assert_eq!(view.scope, SettingsScope::Global);
+            view.handle_click(45, 0);
+            assert_eq!(view.scope, SettingsScope::Profile);
+        }
+
+        #[test]
+        #[serial]
+        fn click_on_scope_tab_with_unsaved_changes_warns() {
+            let (_t, mut view) = fresh_view();
+            view.has_changes = true;
+            view.scope_tab_rects
+                .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
+            let result = view.handle_click(45, 0);
+            assert!(matches!(
+                result,
+                Some(SettingsAction::UnsavedChangesWarning)
+            ));
+            assert_eq!(
+                view.scope,
+                SettingsScope::Global,
+                "scope must not change while there are unsaved changes"
+            );
+        }
+
+        #[test]
+        #[serial]
+        fn click_on_category_row_focuses_and_selects() {
+            let (_t, mut view) = fresh_view();
+            view.focus = crate::tui::settings::SettingsFocus::Fields;
+            let original = view.selected_category;
+            // Pick a different Tab row to stage a click against.
+            let other_tab = (0..view.categories.len())
+                .find(|&i| {
+                    i != original
+                        && matches!(
+                            view.categories[i],
+                            crate::tui::settings::CategoryRow::Tab(_)
+                        )
+                })
+                .expect("expected at least two Tab rows in test layout");
+            view.category_rects
+                .push((other_tab, Rect::new(0, 10, 20, 1)));
+            view.handle_click(5, 10);
+            assert_eq!(view.focus, crate::tui::settings::SettingsFocus::Categories);
+            assert_eq!(view.selected_category, other_tab);
+        }
+
+        #[test]
+        #[serial]
+        fn click_on_field_focuses_and_selects() {
+            let (_t, mut view) = fresh_view();
+            view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
+            view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
+            view.selected_field = 0;
+            view.handle_click(25, 9);
+            assert_eq!(view.focus, crate::tui::settings::SettingsFocus::Fields);
+            assert_eq!(view.selected_field, 1);
+        }
+
+        #[test]
+        #[serial]
+        fn handle_click_returns_none_when_editing() {
+            let (_t, mut view) = fresh_view();
+            view.editing_input = Some(tui_input::Input::new("typing".to_string()));
+            view.scope_tab_rects
+                .push((SettingsScope::Profile, Rect::new(40, 0, 18, 1)));
+            // A click during edit should NOT switch scope or even
+            // resolve a hit; the keyboard's Esc / Enter own the exit.
+            assert!(view.handle_click(45, 0).is_none());
+            assert_eq!(view.scope, SettingsScope::Global);
+        }
+
+        #[test]
+        #[serial]
+        fn hover_never_moves_focus() {
+            // Hover must not shift the keyboard cursor in settings —
+            // otherwise the mouse drifting across the fields panel
+            // silently changes which field a subsequent Enter / Space
+            // targets. Click still navigates.
+            let (_t, mut view) = fresh_view();
+            view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
+            view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
+            view.focus = crate::tui::settings::SettingsFocus::Categories;
+            view.selected_field = 0;
+            view.handle_hover(25, 9);
+            assert_eq!(view.focus, crate::tui::settings::SettingsFocus::Categories);
+            assert_eq!(view.selected_field, 0);
+        }
+
+        #[test]
+        #[serial]
+        fn hover_records_mouse_pos_and_resolves_to_field() {
+            // Hover only paints a visual highlight (drawn by the
+            // renderer from `hovered_field()` against `field_rects`);
+            // it must not touch keyboard selection state. Verify both:
+            // mouse_pos is set and resolves to the right field, but
+            // selected_field stays put.
+            let (_t, mut view) = fresh_view();
+            view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
+            view.field_rects.push((1, Rect::new(20, 8, 50, 2)));
+            view.selected_field = 0;
+            let changed = view.handle_hover(25, 9);
+            assert!(changed, "hover entering a new field should redraw");
+            assert_eq!(view.hovered_field(), Some(1));
+            assert_eq!(view.selected_field, 0, "selection must not move");
+        }
+
+        #[test]
+        #[serial]
+        fn keypress_clears_hover() {
+            // A stationary hover left over from before the user
+            // switched to keyboard would otherwise stay lit on a row
+            // the user is no longer interacting with. Any keystroke
+            // invalidates it.
+            let (_t, mut view) = fresh_view();
+            view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
+            view.handle_hover(25, 5);
+            assert_eq!(view.hovered_field(), Some(0));
+            view.handle_key(crossterm::event::KeyEvent::new(
+                crossterm::event::KeyCode::Down,
+                crossterm::event::KeyModifiers::NONE,
+            ));
+            assert_eq!(view.hovered_field(), None);
+        }
+
+        #[test]
+        #[serial]
+        fn hover_suppressed_while_editing() {
+            // While a text field is being edited the rest of the
+            // surface is keyboard-only; a lingering hover highlight
+            // there would mislead the user about what a click does
+            // (in fact, click is also gated during edit).
+            let (_t, mut view) = fresh_view();
+            view.field_rects.push((0, Rect::new(20, 5, 50, 2)));
+            view.editing_input = Some(tui_input::Input::new(String::new()));
+            view.handle_hover(25, 5);
+            assert_eq!(view.hovered_field(), None);
         }
     }
 }

--- a/src/tui/settings/input.rs
+++ b/src/tui/settings/input.rs
@@ -24,7 +24,7 @@ impl SettingsView {
     pub fn handle_key(&mut self, key: KeyEvent) -> SettingsAction {
         // Clear transient messages on any key
         self.success_message = None;
-        // Any keypress invalidates the mouse hover highlight — otherwise
+        // Any keypress invalidates the mouse hover highlight; otherwise
         // a stationary cursor keeps highlighting an unrelated row while
         // the keyboard cursor moves elsewhere. Mirrors the sidebar's
         // move_cursor_clears_hover pattern.
@@ -1199,7 +1199,7 @@ impl SettingsView {
 
     /// Track the mouse position so the renderer can paint a hover
     /// highlight on whichever scope chip / category row / field row
-    /// the cursor is over. Hover never moves the keyboard cursor —
+    /// the cursor is over. Hover never moves the keyboard cursor;
     /// see `ConfirmDialog::handle_hover` for why. Editing / search /
     /// help modes clear the hover so the highlight doesn't bleed
     /// behind the overlay.
@@ -1214,7 +1214,7 @@ impl SettingsView {
             return false;
         }
         // Only request a redraw when the resolved hover target
-        // actually changes — a mouse drift inside the same field or
+        // actually changes; a mouse drift inside the same field or
         // entirely off the rects shouldn't repaint every pixel.
         let prev_scope = self.hovered_scope();
         let prev_cat = self.hovered_category();
@@ -1660,7 +1660,7 @@ mod tests {
         #[test]
         #[serial]
         fn hover_never_moves_focus() {
-            // Hover must not shift the keyboard cursor in settings —
+            // Hover must not shift the keyboard cursor in settings;
             // otherwise the mouse drifting across the fields panel
             // silently changes which field a subsequent Enter / Space
             // targets. Click still navigates.

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -167,6 +167,27 @@ pub struct SettingsView {
     /// Cursor inside `search_hits`, bounded by `search_hits.len()`
     /// so it stays valid as the query narrows.
     pub(super) search_selected: usize,
+
+    /// Hit rect per scope tab in the header. Captured during render
+    /// so a click on `[ Global ]` / `[ Profile ]` / `[ Repo ]` can
+    /// switch scope without going through the keyboard. Cleared and
+    /// repopulated each frame.
+    pub(super) scope_tab_rects: Vec<(SettingsScope, ratatui::layout::Rect)>,
+    /// Hit rect per row in the categories panel, indexed into
+    /// `self.categories`. Only Tab rows are pushed; Section dividers
+    /// are skipped so a click on a heading is a no-op.
+    pub(super) category_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Hit rect per visible field row, indexed into `self.fields`.
+    /// Skipped while a field is being edited or a list is being
+    /// edited so a stray click during composition doesn't reset focus.
+    pub(super) field_rects: Vec<(usize, ratatui::layout::Rect)>,
+    /// Last `(col, row)` reported by a `MouseEventKind::Moved` event
+    /// while a non-editing settings surface is in view. Drives the
+    /// hover highlight on scope chips, categories, and fields — kept
+    /// separate from `selected_*` / `focus` so the mouse never
+    /// disturbs the keyboard cursor. Cleared on every keypress so
+    /// hover doesn't linger after the user switches modalities.
+    pub(super) mouse_pos: Option<(u16, u16)>,
 }
 
 impl SettingsView {
@@ -228,6 +249,10 @@ impl SettingsView {
             search_input: None,
             search_hits: Vec::new(),
             search_selected: 0,
+            scope_tab_rects: Vec::new(),
+            category_rects: Vec::new(),
+            field_rects: Vec::new(),
+            mouse_pos: None,
         };
 
         // The constructor parks `selected_category` at 0, which is the
@@ -281,6 +306,39 @@ impl SettingsView {
         push_tab(&mut rows, SettingsCategory::Logging);
 
         rows
+    }
+
+    /// Scope chip currently under the mouse cursor, if any. Resolved
+    /// each call against the rects captured by the last render. Used
+    /// for the hover highlight only; click + keyboard own the actual
+    /// selection.
+    pub(super) fn hovered_scope(&self) -> Option<SettingsScope> {
+        let (col, row) = self.mouse_pos?;
+        let pos = ratatui::layout::Position::from((col, row));
+        self.scope_tab_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(scope, _)| *scope)
+    }
+
+    /// Category-row index under the mouse cursor, if any.
+    pub(super) fn hovered_category(&self) -> Option<usize> {
+        let (col, row) = self.mouse_pos?;
+        let pos = ratatui::layout::Position::from((col, row));
+        self.category_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(idx, _)| *idx)
+    }
+
+    /// Field-row index under the mouse cursor, if any.
+    pub(super) fn hovered_field(&self) -> Option<usize> {
+        let (col, row) = self.mouse_pos?;
+        let pos = ratatui::layout::Position::from((col, row));
+        self.field_rects
+            .iter()
+            .find(|(_, rect)| rect.contains(pos))
+            .map(|(idx, _)| *idx)
     }
 
     /// The category at `selected_category`, by invariant always a

--- a/src/tui/settings/mod.rs
+++ b/src/tui/settings/mod.rs
@@ -183,7 +183,7 @@ pub struct SettingsView {
     pub(super) field_rects: Vec<(usize, ratatui::layout::Rect)>,
     /// Last `(col, row)` reported by a `MouseEventKind::Moved` event
     /// while a non-editing settings surface is in view. Drives the
-    /// hover highlight on scope chips, categories, and fields — kept
+    /// hover highlight on scope chips, categories, and fields, kept
     /// separate from `selected_*` / `focus` so the mouse never
     /// disturbs the keyboard cursor. Cleared on every keypress so
     /// hover doesn't linger after the user switches modalities.

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -483,7 +483,7 @@ impl SettingsView {
         }
 
         // Hover overlay: dim bg on whichever field the mouse sits over.
-        // Suppressed when that field is the selected one — the selected
+        // Suppressed when that field is the selected one; the selected
         // styling is already brighter and should win. Routed after the
         // whole field loop so SectionHeader rows can't bleed an
         // overlay on themselves (they never make it into field_rects).

--- a/src/tui/settings/render.rs
+++ b/src/tui/settings/render.rs
@@ -2,7 +2,7 @@
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Modifier, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{
         Block, BorderType, Borders, Clear, List, ListItem, Padding, Paragraph, Scrollbar,
@@ -18,6 +18,24 @@ use super::{
 };
 use crate::tui::components::set_input_cursor_position;
 use crate::tui::styles::Theme;
+
+/// Paint a hover background over `area` by mutating the buffer cell by
+/// cell. Preserves each cell's existing fg / modifiers so previously
+/// rendered text stays readable; only the bg gets overwritten. Using
+/// this instead of `Style::default().bg(...)` on the underlying widget
+/// avoids fighting per-row styles (ratatui widget styles cascade in ways
+/// that are hard to predict for things like List rows or Paragraph
+/// spans), so the hover overlay reliably shows where a click will land.
+fn paint_hover_bg(frame: &mut Frame, area: Rect, bg: Color) {
+    let buf = frame.buffer_mut();
+    for y in area.y..area.bottom() {
+        for x in area.x..area.right() {
+            if let Some(cell) = buf.cell_mut((x, y)) {
+                cell.set_bg(bg);
+            }
+        }
+    }
+}
 
 /// Detect if we're running over SSH
 fn is_ssh_session() -> bool {
@@ -101,6 +119,14 @@ pub(super) fn wrap_description_height(text: &str, width: u16) -> u16 {
 
 impl SettingsView {
     pub fn render(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
+        // Rebuilt every frame: scope tabs, category rows, and visible
+        // field rows all shift when the layout changes (scope switch,
+        // category resort, scroll), so stale rects from the prior
+        // frame would point at the wrong cells.
+        self.scope_tab_rects.clear();
+        self.category_rects.clear();
+        self.field_rects.clear();
+
         // Clear the area
         frame.render_widget(Clear, area);
 
@@ -137,7 +163,7 @@ impl SettingsView {
         }
     }
 
-    fn render_header(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_header(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let block = Block::default()
             .borders(Borders::BOTTOM)
             .border_style(Style::default().fg(theme.border));
@@ -167,6 +193,32 @@ impl SettingsView {
                 format!("Profile: {}", self.profile)
             };
 
+        // Pre-compute the rect for each `[ <Scope> ]` chip so clicks can
+        // switch scope. The widths must stay in sync with the spans
+        // pushed just below; the layout is deterministic enough to
+        // mirror it inline without re-querying the paragraph.
+        let chip_y = inner.y;
+        let chip_height: u16 = 1;
+        let global_chip_width: u16 = 2 + 6 + 2; // "[ Global ]"
+        let profile_chip_width: u16 = 2 + profile_label.chars().count() as u16 + 2;
+        let repo_chip_width: u16 = 2 + 4 + 2;
+        let prefix_width: u16 =
+            ("  Settings".chars().count() + modified.chars().count() + 4) as u16;
+        let global_x = inner.x.saturating_add(prefix_width);
+        let profile_x = global_x.saturating_add(global_chip_width).saturating_add(2);
+        let repo_x = profile_x
+            .saturating_add(profile_chip_width)
+            .saturating_add(2);
+
+        self.scope_tab_rects.push((
+            SettingsScope::Global,
+            Rect::new(global_x, chip_y, global_chip_width, chip_height),
+        ));
+        self.scope_tab_rects.push((
+            SettingsScope::Profile,
+            Rect::new(profile_x, chip_y, profile_chip_width, chip_height),
+        ));
+
         let mut spans = vec![
             Span::styled("  Settings", Style::default().fg(theme.text)),
             Span::styled(modified, Style::default().fg(theme.error)),
@@ -186,9 +238,30 @@ impl SettingsView {
             spans.push(Span::styled("[ ", Style::default().fg(theme.border)));
             spans.push(Span::styled("Repo", repo_style));
             spans.push(Span::styled(" ]", Style::default().fg(theme.border)));
+            self.scope_tab_rects.push((
+                SettingsScope::Repo,
+                Rect::new(repo_x, chip_y, repo_chip_width, chip_height),
+            ));
         }
 
         frame.render_widget(Paragraph::new(Line::from(spans)), inner);
+
+        // Hover overlay: paint a dim bg over the chip the mouse is on,
+        // unless it's already the active scope (whose accent fg is its
+        // own indicator). Resolved after the paragraph paints so the
+        // chip text remains readable on top.
+        if let Some(scope) = self.hovered_scope() {
+            if scope != self.scope {
+                if let Some((_, rect)) = self
+                    .scope_tab_rects
+                    .iter()
+                    .find(|(s, _)| *s == scope)
+                    .copied()
+                {
+                    paint_hover_bg(frame, rect, theme.selection);
+                }
+            }
+        }
     }
 
     fn render_content(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -205,7 +278,7 @@ impl SettingsView {
         self.render_fields(frame, layout[1], theme);
     }
 
-    fn render_categories(&self, frame: &mut Frame, area: Rect, theme: &Theme) {
+    fn render_categories(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
         let is_focused = self.focus == SettingsFocus::Categories;
 
         let border_style = if is_focused {
@@ -265,8 +338,32 @@ impl SettingsView {
             })
             .collect();
 
+        // Capture hit rect per Tab row (Section dividers are skipped).
+        // The List renders rows top-down starting at `inner.y`. We
+        // mirror that layout here so each rect points at the same row
+        // the user sees.
+        for (i, row) in self.categories.iter().enumerate() {
+            if matches!(row, CategoryRow::Tab(_)) && (i as u16) < inner.height {
+                self.category_rects
+                    .push((i, Rect::new(inner.x, inner.y + i as u16, inner.width, 1)));
+            }
+        }
+
         let list = List::new(items);
         frame.render_widget(list, inner);
+
+        // Hover overlay: dim bg on whichever category row the mouse
+        // sits over, suppressed when that row is already the selected
+        // category (selection wins, same rule as the sidebar).
+        if let Some(idx) = self.hovered_category() {
+            if idx != self.selected_category {
+                if let Some((_, rect)) =
+                    self.category_rects.iter().find(|(i, _)| *i == idx).copied()
+                {
+                    paint_hover_bg(frame, rect, theme.selection);
+                }
+            }
+        }
     }
 
     fn render_fields(&mut self, frame: &mut Frame, area: Rect, theme: &Theme) {
@@ -377,7 +474,26 @@ impl SettingsView {
             };
 
             self.render_field(frame, field_area, field, i, is_selected, theme);
+            // SectionHeader rows are non-interactive dividers; skipping
+            // them matches the keyboard navigation that hops over them.
+            if !matches!(field.value, FieldValue::SectionHeader) {
+                self.field_rects.push((i, field_area));
+            }
             y_pos += field_h + 1; // +1 for spacing
+        }
+
+        // Hover overlay: dim bg on whichever field the mouse sits over.
+        // Suppressed when that field is the selected one — the selected
+        // styling is already brighter and should win. Routed after the
+        // whole field loop so SectionHeader rows can't bleed an
+        // overlay on themselves (they never make it into field_rects).
+        if let Some(idx) = self.hovered_field() {
+            let suppress = is_focused && idx == self.selected_field;
+            if !suppress {
+                if let Some((_, rect)) = self.field_rects.iter().find(|(i, _)| *i == idx).copied() {
+                    paint_hover_bg(frame, rect, theme.selection);
+                }
+            }
         }
 
         // Render scrollbar if content overflows

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -293,6 +293,36 @@ last_seen_version = "{}"
         std::thread::sleep(Duration::from_millis(50));
     }
 
+    /// Send a synthetic mouse event into the inner pane as an SGR
+    /// escape sequence. crossterm's mouse capture (enabled by aoe at
+    /// startup) parses the bytes the same way it would parse them
+    /// from a real terminal, so click / scroll routing in the TUI
+    /// runs the production code path. `button` is the SGR button code:
+    /// 0 = left, 1 = middle, 2 = right; +32 = drag (rarely needed for
+    /// click tests). `col` / `row` are 1-indexed terminal cells. Sends
+    /// both the press (M) and release (m) so listeners that only fire
+    /// on `Down(...)` (the click handlers) see a complete cycle.
+    pub fn send_mouse_click(&self, button: u8, col: u16, row: u16) {
+        assert!(self.spawned, "must call spawn_tui() or spawn() first");
+        let seq = format!("\x1b[<{button};{col};{row};M\x1b[<{button};{col};{row};m");
+        let output = Command::new("tmux")
+            .arg("-S")
+            .arg(&self.socket_path)
+            .arg("send-keys")
+            .arg("-t")
+            .arg(&self.session_name)
+            .arg("-l")
+            .arg(&seq)
+            .output()
+            .expect("failed to send mouse click");
+        assert!(
+            output.status.success(),
+            "send_mouse_click failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        std::thread::sleep(Duration::from_millis(100));
+    }
+
     /// Send literal text (prevents "Enter" in text from being interpreted as
     /// the Enter key).
     pub fn type_text(&self, text: &str) {

--- a/tests/e2e/harness.rs
+++ b/tests/e2e/harness.rs
@@ -304,7 +304,11 @@ last_seen_version = "{}"
     /// on `Down(...)` (the click handlers) see a complete cycle.
     pub fn send_mouse_click(&self, button: u8, col: u16, row: u16) {
         assert!(self.spawned, "must call spawn_tui() or spawn() first");
-        let seq = format!("\x1b[<{button};{col};{row};M\x1b[<{button};{col};{row};m");
+        // XTerm SGR 1006 format: `CSI < Pb ; Px ; Py M` for press,
+        // `... m` for release. No semicolon between Py and the final
+        // M/m byte; crossterm parses the trailing-semicolon variant
+        // leniently but spec-compliant terminals don't.
+        let seq = format!("\x1b[<{button};{col};{row}M\x1b[<{button};{col};{row}m");
         let output = Command::new("tmux")
             .arg("-S")
             .arg(&self.socket_path)

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -72,6 +72,45 @@ fn test_left_click_on_empty_sidebar_is_inert_outside_live_mode() {
 
 #[test]
 #[serial]
+fn test_ctrl_p_browse_dir_picker_renders_as_full_overlay() {
+    // Regression: the dir picker's render call used to receive a
+    // local `area` shadowed by the per-field layout chunks, so the
+    // picker ended up clamped inside the Group row's 1-line strip
+    // and was unusable. Verify the picker renders at a meaningful
+    // size (more than a single line and wide enough for its filter
+    // input + at least one directory entry).
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("ctrl_p_picker");
+    h.spawn_tui();
+
+    h.wait_for(" aoe ");
+    h.send_keys("Enter"); // dismiss welcome
+    h.wait_for("No sessions yet");
+    h.send_keys("n");
+    h.wait_for(" New Session ");
+    // Path is the default focused field; Ctrl+P opens the dir picker.
+    h.send_keys("C-p");
+    h.wait_for("Browse:");
+    let screen = h.capture_screen();
+    assert!(
+        screen.contains("Filter:"),
+        "dir picker should render its Filter input\nscreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("../"),
+        "dir picker should list at least the parent-dir entry\nscreen:\n{screen}"
+    );
+    // The picker has its own hint line; if it rendered crammed into
+    // the underlying form's hint chunk this would be missing.
+    assert!(
+        screen.contains("Enter open/select"),
+        "dir picker should render its full hint line\nscreen:\n{screen}"
+    );
+}
+
+#[test]
+#[serial]
 fn test_right_click_on_empty_sidebar_opens_context_menu() {
     // The right-click menu on the empty area lists the three actions
     // that used to be keyboard-only entry points: New Session, Change

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -37,18 +37,15 @@ fn test_new_session_dialog_escape_cancels() {
 
 #[test]
 #[serial]
-fn test_left_click_on_empty_sidebar_opens_new_session_dialog() {
-    // Regression test for the mouse-support PR: a left-click on the
-    // sidebar's empty area below the last session row must open the
-    // new-session dialog (the click equivalent of pressing `n`), and
-    // a subsequent Escape must reach the dialog (not fall through to
-    // any underlying surface). The dialog-receives-keys part is the
-    // half that previously broke when live-send was active; this test
-    // covers the simpler no-live-send path that any user hitting
-    // empty-sidebar-click goes through.
+fn test_left_click_on_empty_sidebar_is_inert_outside_live_mode() {
+    // The empty-sidebar left-click intentionally does NOT open the
+    // new-session dialog; that entry point moved to the right-click
+    // empty-sidebar menu. Verifies the click is absorbed without
+    // popping a modal so a stray click while reading the sidebar
+    // doesn't summon an unexpected dialog.
     require_tmux!();
 
-    let mut h = TuiTestHarness::new("empty_click");
+    let mut h = TuiTestHarness::new("empty_lclick");
     h.spawn_tui();
 
     h.wait_for(" aoe ");
@@ -58,21 +55,92 @@ fn test_left_click_on_empty_sidebar_opens_new_session_dialog() {
     h.wait_for("No sessions yet");
 
     // Click well below the empty-state label in the sidebar column.
-    // The sidebar's empty area is wide; (col=10, row=15) lands inside
-    // `list_inner_area` but past every real row, which is exactly
-    // what `handle_empty_list_click` checks for. Coordinates are
-    // 1-indexed in SGR.
     h.send_mouse_click(0, 10, 15);
 
-    // Dialog should appear with its trademark fields.
-    h.wait_for(" New Session ");
-    h.assert_screen_contains("Title");
-    h.assert_screen_contains("Path");
+    // No dialog should have opened.
+    std::thread::sleep(Duration::from_millis(300));
+    let screen = h.capture_screen();
+    assert!(
+        !screen.contains(" New Session "),
+        "left-click on empty sidebar must not open new-session anymore\nscreen:\n{screen}"
+    );
+    assert!(
+        screen.contains("No sessions yet"),
+        "home view should still be showing the empty-state copy\nscreen:\n{screen}"
+    );
+}
 
-    // Keyboard now routes to the dialog. Escape closes it.
+#[test]
+#[serial]
+fn test_right_click_on_empty_sidebar_opens_context_menu() {
+    // The right-click menu on the empty area lists the three actions
+    // that used to be keyboard-only entry points: New Session, Change
+    // Sort, Change Grouping. Verifies the menu opens, lists the three
+    // items, and Escape dismisses without dispatching.
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("empty_rclick");
+    h.spawn_tui();
+
+    h.wait_for(" aoe ");
+    h.send_keys("Enter"); // dismiss welcome
+    h.wait_for("No sessions yet");
+
+    // SGR button code 2 = right click.
+    h.send_mouse_click(2, 10, 15);
+
+    h.wait_for("New Session");
+    h.assert_screen_contains("Change Sort");
+    h.assert_screen_contains("Change Grouping");
+
     h.send_keys("Escape");
-    h.wait_for_absent(" New Session ", Duration::from_secs(5));
+    h.wait_for_absent("Change Sort", Duration::from_secs(5));
     h.assert_screen_contains("No sessions yet");
+}
+
+#[test]
+#[serial]
+fn test_right_click_on_session_row_opens_rename_delete_menu() {
+    // Right-click on an existing session row opens the per-row
+    // Rename / Delete menu (a different menu variant than the empty
+    // area version). Verifies the menu copy and that Escape dismisses
+    // without opening either follow-up dialog. The session is created
+    // out-of-band via `aoe add` so the test doesn't have to drive the
+    // new-session dialog (which has its own coverage elsewhere).
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("session_rclick");
+    // Seed a session before launching the TUI.
+    let project = h.project_path();
+    let add = h.run_cli(&["add", project.to_str().unwrap(), "-t", "RClickRow"]);
+    assert!(
+        add.status.success(),
+        "aoe add failed: {}",
+        String::from_utf8_lossy(&add.stderr)
+    );
+
+    h.spawn_tui();
+    h.wait_for(" aoe ");
+    h.send_keys("Enter"); // dismiss welcome
+    h.wait_for("RClickRow");
+
+    // Right-click on the first session row. The row sits inside the
+    // bordered sidebar panel: top border is row 1, the first item is
+    // row 2. Column 5 lands on the row's label area.
+    h.send_mouse_click(2, 5, 2);
+
+    h.wait_for("Rename");
+    h.assert_screen_contains("Delete");
+    // The empty-sidebar menu items must NOT appear here; verifies
+    // that the row-aware menu opened, not the empty-area variant.
+    let screen = h.capture_screen();
+    assert!(
+        !screen.contains("Change Sort"),
+        "session menu should not show Change Sort\nscreen:\n{screen}"
+    );
+
+    h.send_keys("Escape");
+    h.wait_for_absent("Rename", Duration::from_secs(5));
 }
 
 /// Submit the new session dialog, handling the "Path does not exist. Create?"

--- a/tests/e2e/new_session.rs
+++ b/tests/e2e/new_session.rs
@@ -35,6 +35,46 @@ fn test_new_session_dialog_escape_cancels() {
     h.assert_screen_contains("No sessions yet");
 }
 
+#[test]
+#[serial]
+fn test_left_click_on_empty_sidebar_opens_new_session_dialog() {
+    // Regression test for the mouse-support PR: a left-click on the
+    // sidebar's empty area below the last session row must open the
+    // new-session dialog (the click equivalent of pressing `n`), and
+    // a subsequent Escape must reach the dialog (not fall through to
+    // any underlying surface). The dialog-receives-keys part is the
+    // half that previously broke when live-send was active; this test
+    // covers the simpler no-live-send path that any user hitting
+    // empty-sidebar-click goes through.
+    require_tmux!();
+
+    let mut h = TuiTestHarness::new("empty_click");
+    h.spawn_tui();
+
+    h.wait_for(" aoe ");
+    // Dismiss the first-run welcome dialog so the sidebar is the
+    // top-most surface receiving clicks.
+    h.send_keys("Enter");
+    h.wait_for("No sessions yet");
+
+    // Click well below the empty-state label in the sidebar column.
+    // The sidebar's empty area is wide; (col=10, row=15) lands inside
+    // `list_inner_area` but past every real row, which is exactly
+    // what `handle_empty_list_click` checks for. Coordinates are
+    // 1-indexed in SGR.
+    h.send_mouse_click(0, 10, 15);
+
+    // Dialog should appear with its trademark fields.
+    h.wait_for(" New Session ");
+    h.assert_screen_contains("Title");
+    h.assert_screen_contains("Path");
+
+    // Keyboard now routes to the dialog. Escape closes it.
+    h.send_keys("Escape");
+    h.wait_for_absent(" New Session ", Duration::from_secs(5));
+    h.assert_screen_contains("No sessions yet");
+}
+
 /// Submit the new session dialog, handling the "Path does not exist. Create?"
 /// prompt if it appears.
 ///


### PR DESCRIPTION
_Note: this PR description was drafted by Claude via back-and-forth with @njbrake. The reasoning and decisions are his; the prose is Claude's._

## Description

Brings full mouse support to the TUI: click activates, hover highlights, right-click on the sidebar opens a Rename / Delete context menu. Coverage spans every dialog (new-session, rename, restart, delete options, all confirm-style Yes/No dialogs, every picker), the settings full-screen takeover (scope chips, category rows, field rows), the diff view file list, and the empty-sidebar shortcut that opens the new-session dialog.

The guiding rule throughout: **hover never moves keyboard focus.** It paints a dim background on whatever a click would target. Click owns selection. This mirrors how the sidebar already worked (separate `mouse_pos` / `hovered_index` tracked independently of `cursor`) and avoids the original mistake where mouse drift during typing in the new-session or rename form would silently move keyboard focus to whatever row the cursor crossed.

While here, fixed a key-routing bug uncovered by the empty-sidebar-click that pops the new-session dialog: keys used to fall through to the live tmux pane behind the modal when live-send was active, because `handle_key` checked `live_send.is_some()` ahead of every dialog handler. The original design assumed dialogs could only be opened from the keyboard, but the click path violates that. Routing now gates the live-send branch on `!has_non_live_send_overlay()`; live-send resumes the moment the overlay closes.

## PR Type

- [x] New Feature
- [x] Bug Fix

## Checklist

- [x] New and existing tests pass
- [ ] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

Unit tests added or updated:
- Right-click context menu lifecycle, dispatch, gating, empty-sidebar click (`src/tui/home/tests.rs` — 13 new tests).
- Click + hover routing on every modified dialog (`src/tui/dialogs/*/tests.rs`, ~40 new tests total).
- Settings mouse routing including the new `hovered_*` accessors and keypress-clears-hover behavior (`src/tui/settings/input.rs` mouse_routing module — 7 tests).

Full suite green: 2351 lib + 120 integration + doc tests, fmt + clippy clean (with and without `--features serve`).

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (Claude Code)

**Any Additional AI Details you'd like to share:**

Pairing session — back-and-forth where the human steered scope (initial ask was right-click on the sidebar, then expanded to "all the pieces of the TUI clickable"), called out two regressions (mouse hover stealing focus while typing; keys leaking past the new-session dialog to live-send), and asked for the final settings hover polish. Code, tests, and prose written by Claude under that direction.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Mouse Support for TUI: Click Activation, Hover Highlighting, and Sidebar Context Menus

## Overview
Adds full mouse support across the TUI: left-click activation and non-focusing hover highlights for dialogs, pickers, settings, diff file list, and the sidebar. Adds right-click context menus on the sidebar (per-row Rename/Delete and an empty-sidebar menu with New Session / Change Sort / Change Grouping). Ensures mouse and keyboard input routes consistently (overlays/menus consume mouse first) and fixes a key-routing bug so live-send keystrokes no longer leak into a live tmux pane while non-live-send overlays are open. Tests (unit + e2e) expanded; full test suite green. Documentation checkbox remains incomplete.

## High-level changes
- Enabled click and hover handling across almost every dialog/picker (new-session, rename, restart, delete options, confirm dialogs, command palette, snooze, sort/tool/group pickers, welcome/changelog/info, hooks dialogs, etc.).
- Settings view: click-to-select scope/category/field, hover highlight painting, and any keypress clears mouse hover.
- Diff view: file-list clicks update selection; hover paints only.
- Sidebar: left-click behavior refined (empty-area clicks either do nothing or exit live-send depending on state); right-click opens context menus (row-specific and empty-area).
- Centralized mouse routing in HomeView and main event loop; overlays and context menus are treated as modal surfaces that consume mouse and gate live-send.
- Live-send gating: key events are suppressed when any non-live-send overlay (including context menu) is open and resume after overlays close.
- Tests: many unit tests (~40 dialog mouse tests, settings mouse tests, ~13 right-click/context-menu HomeView tests) and e2e SGR mouse tests added; harness exposes send_mouse_click.

## What moved / added / removed
- Many render methods changed from &self → &mut self to persist computed on-screen geometry.
- Added per-component fields for hit-testing and hover state (dialog_area, list_area, button areas, focusable_rects, row_rects, file_list_inner, hovered_* caches, etc.).
- New ContextMenuDialog and expanded ContextMenuAction variants; HomeView now stores context_menu and pending_dialog_click_action.
- Widespread new APIs: handle_click(col,row) and handle_hover(col,row) across dialogs/pickers/DiffView/SettingsView and new HomeView helpers (handle_right_click, handle_context_menu_click, dispatch_context_menu_action, open_new_session_dialog, etc.).
- TuiTestHarness.send_mouse_click added for e2e SGR mouse testing.
- No public API removals; internal signatures adjusted to support mutable render state and hit-testing.

## Benefits
- Improves discoverability and efficiency for mouse users while preserving keyboard-first workflows.
- Hover provides visual affordance without stealing keyboard focus.
- Right-click context menus speed common sidebar tasks (rename/delete/new/sort/group).
- Prevents accidental key routing into live tmux panes when overlays are present.
- Extensive unit and e2e coverage reduces regression risk.

## Potential areas for further enhancement
- Complete documentation / user-facing docs for mouse and context-menu usage.
- Factor and deduplicate hit-testing and geometry helpers across dialogs to reduce code duplication.
- Add user preference to disable hover or adjust hover styling for accessibility.
- Monitor/perf-test per-frame geometry work in very large dialogs or lists.

## Technical notes (concise)
- render(&self) → render(&mut self) changes allow caching Rects needed for hit-testing; many dialog structs now store Rects and hover state.
- New handle_click/handle_hover APIs implemented widely; HomeView centralizes click/hover/context-menu routing and defers modal click actions via pending_dialog_click_action.
- Click routing order: overlays/context menus → active pickers/overlays → main-form focusable fields → lists/diff → empty-area behavior. Hover is forwarded to overlays/menus first and never moves keyboard focus.
- Context menu: per-row rename/delete plus empty-sidebar menu (New Session / Change Sort / Change Grouping) with keyboard hotkeys supported.
- E2E: harness.send_mouse_click sends SGR mouse sequences to test mouse flows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1593?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->