### PR TITLE
fix(ci): gate release workflows behind a required-reviewer environment

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,11 @@ jobs:
   prepare:
     name: Bump Version & Tag
     runs-on: ubuntu-latest
+    # Required-reviewer gate. The `release` environment has njbrake as the
+    # only reviewer, so any workflow_dispatch trigger pauses until he clicks
+    # approve in the Actions UI. Prevents non-maintainer collaborators from
+    # firing the version bump + tag push via the Actions UI.
+    environment: release
     permissions:
       contents: write
     # Hoist the version input out of every run: step's shell, so it lands in

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,10 @@ jobs:
   validate:
     name: Validate Version
     runs-on: ubuntu-latest
+    # Required-reviewer gate. Pauses every release (tag push or manual
+    # dispatch) until njbrake approves in the Actions UI. The whole pipeline
+    # waits here, so no build compute or release publish runs without sign-off.
+    environment: release
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
## Description

Add `environment: release` to the first job of `release.yml` and `prepare-release.yml` so every `workflow_dispatch` and tag-push trigger pauses for a required-reviewer approval before any build compute, secret access, or publish step runs.

**Why now.** Any collaborator with write permission today can fire `prepare-release.yml` (which bumps the version and pushes a tag using `RELEASE_TOKEN`) or `release.yml` (which builds and publishes the GitHub Release for an arbitrary tag) from the Actions UI. CODEOWNERS gates the PR-based path (Cargo.toml is `@njbrake`-only), but `workflow_dispatch` bypasses CODEOWNERS entirely. The environment gate closes that hole.

**Scope.**

- `release.yml` -> gate on `validate` (first job, so the build matrix and publish wait too).
- `prepare-release.yml` -> gate on `prepare` (only job).
- `open-release-pr.yml` left ungated. The PR it opens still needs codeowner approval to merge, so a manual trigger by a non-maintainer is contained.

**Required follow-up in repo settings.** YAML alone does not enforce anything; the environment must exist:

1. `Settings -> Environments -> New environment` named exactly `release`.
2. Add a required reviewer (`@njbrake`).
3. Save.

Until that environment exists with reviewers attached, the gate is a no-op (workflows run as before).

**Side effect to be aware of.** Once the environment is configured, scheduled tag pushes from the weekly `tag-release-pr.yml` flow will also pause for approval on `release.yml`. That's intentional, a final eyeball before every release ships, but the cadence shifts from fully-automated to one-click-per-release.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [x] Infrastructure / CI

## Checklist

- [x] New and existing tests pass (no code paths touched; `cargo fmt` + `cargo clippy` ran via pre-commit hook)
- [x] Documentation was updated where necessary (N/A, internal workflow change with no user-visible behavior until env is configured)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Opus 4.7 (1M context) via Claude Code

**Any Additional AI Details you'd like to share:** Drafted via back-and-forth with @njbrake after a discussion about restricting Seluj78's ability to merge / ship releases outside cockpit/web scope. The discussion concluded that the only `workflow_dispatch`-reachable surface that meaningfully bypasses CODEOWNERS is the release pipeline, hence the targeted gate here.

- [ ] I am an AI Agent filling out this form (check box if true)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What Changed

Two GitHub Actions release workflows now require manual approval before executing:
- **prepare-release.yml**: Added approval gate to the `prepare` job
- **release.yml**: Added approval gate to the `validate` job (the first step in the release pipeline)

## What Was Added

An `environment: release` designation was added to these workflow jobs, which enforces a required-reviewer checkpoint in the GitHub Actions UI before any build, secret access, or publish actions occur.

## Benefits

**Security & Access Control:**
- Closes a permission gap where any collaborator with write access could bypass CODEOWNERS and trigger automated releases
- Ensures release workflows require explicit approval from designated reviewers before execution
- Secrets and publish actions are only accessible after approval

**Release Flow:**
- Transforms fully automated releases into a single-click approval workflow
- Applies to both manual dispatch triggers and tag-push events (including scheduled releases like weekly tag-release-pr.yml)

## Notes

The environment gate only becomes active after manual setup in GitHub Settings:
1. Create an environment named `release` in Settings → Environments
2. Add required reviewer(s)

Until this repository configuration is completed, the YAML additions have no effect. The PR itself only provides the workflow configuration; the environment and reviewer list must be set up separately.

The open-release-pr.yml workflow remains unchanged and continues to rely on CODEOWNERS for merge protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1594?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->