### PR TITLE
fix(web): stack settings header into two rows on mobile

### DIFF
--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -496,22 +496,25 @@ export function SettingsView({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
-      {/* Header */}
-      <div className="h-12 bg-surface-850 border-b border-surface-700 flex items-center px-4 shrink-0">
+      {/* Header: ProfileSelector wraps onto its own row on mobile via basis-full so the Back affordance and title keep their space */}
+      <div
+        data-testid="settings-header"
+        className="bg-surface-850 border-b border-surface-700 shrink-0 flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2 md:flex-nowrap md:h-12 md:py-0"
+      >
         <button
           onClick={onClose}
-          className="text-brand-500 mr-3 cursor-pointer text-sm"
+          className="text-brand-500 cursor-pointer text-sm shrink-0"
         >
           &larr; Back
         </button>
-        <span className="text-sm font-semibold text-text-bright">Settings</span>
+        <span className="text-sm font-semibold text-text-bright shrink-0">Settings</span>
         {saving && (
-          <span className="ml-2 text-xs text-text-dim">Saving...</span>
+          <span className="text-xs text-text-dim shrink-0">Saving...</span>
         )}
         {saveError && (
-          <span className="ml-2 text-xs text-red-400">{saveError}</span>
+          <span className="text-xs text-red-400 truncate min-w-0">{saveError}</span>
         )}
-        <div className="flex-1 flex justify-center">
+        <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
           <ProfileSelector
             selectedProfile={selectedProfile}
             onSelect={setSelectedProfile}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -25,7 +25,7 @@ import { SoundSettings } from "./settings/SoundSettings";
 import { UpdateSettings } from "./settings/UpdateSettings";
 import { TmuxSettings } from "./settings/TmuxSettings";
 import { LoggingSettings } from "./settings/LoggingSettings";
-import { ProfileSelector } from "./settings/ProfileSelector";
+import { SettingsHeader } from "./settings/SettingsHeader";
 
 type TabId =
   | "session"
@@ -496,31 +496,13 @@ export function SettingsView({
 
   return (
     <div className="flex-1 flex flex-col overflow-hidden bg-surface-900">
-      {/* Header: ProfileSelector wraps onto its own row on mobile via basis-full so the Back affordance and title keep their space */}
-      <div
-        data-testid="settings-header"
-        className="bg-surface-850 border-b border-surface-700 shrink-0 flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2 md:flex-nowrap md:h-12 md:py-0"
-      >
-        <button
-          onClick={onClose}
-          className="text-brand-500 cursor-pointer text-sm shrink-0"
-        >
-          &larr; Back
-        </button>
-        <span className="text-sm font-semibold text-text-bright shrink-0">Settings</span>
-        {saving && (
-          <span className="text-xs text-text-dim shrink-0">Saving...</span>
-        )}
-        {saveError && (
-          <span className="text-xs text-red-400 truncate min-w-0">{saveError}</span>
-        )}
-        <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
-          <ProfileSelector
-            selectedProfile={selectedProfile}
-            onSelect={setSelectedProfile}
-          />
-        </div>
-      </div>
+      <SettingsHeader
+        onClose={onClose}
+        saving={saving}
+        saveError={saveError}
+        selectedProfile={selectedProfile}
+        onSelectProfile={setSelectedProfile}
+      />
 
       {/* Mobile tabs (horizontal scroll) */}
       <div className="md:hidden border-b border-surface-700 bg-surface-850 overflow-x-auto">

--- a/web/src/components/settings/ProfileSelector.tsx
+++ b/web/src/components/settings/ProfileSelector.tsx
@@ -107,12 +107,12 @@ export function ProfileSelector({ selectedProfile, onSelect }: Props) {
 
   return (
     <div className="relative" ref={panelRef}>
-      <div className="flex items-center gap-2">
+      <div className="flex items-center gap-2 flex-nowrap">
         <label className="text-sm font-medium text-text-secondary shrink-0">Profile</label>
         <select
           value={selectedProfile}
           onChange={(e) => onSelect(e.target.value)}
-          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-40"
+          className="bg-surface-900 border border-surface-700 rounded-md px-2 py-1 text-sm text-text-primary focus:border-brand-600 focus:outline-none w-32 sm:w-40 shrink"
         >
           {profiles.map((p) => (
             <option key={p.name} value={p.name}>

--- a/web/src/components/settings/SettingsHeader.tsx
+++ b/web/src/components/settings/SettingsHeader.tsx
@@ -1,0 +1,48 @@
+import { ProfileSelector } from "./ProfileSelector";
+
+interface Props {
+  onClose: () => void;
+  saving: boolean;
+  saveError: string | null;
+  selectedProfile: string;
+  onSelectProfile: (profile: string) => void;
+}
+
+// Settings header. ProfileSelector wraps onto its own row on mobile via
+// `basis-full` so the Back affordance and title keep their space; on md+
+// the wrapper switches to `basis-auto ml-auto` for a single-row layout
+// with the picker aligned right.
+export function SettingsHeader({
+  onClose,
+  saving,
+  saveError,
+  selectedProfile,
+  onSelectProfile,
+}: Props) {
+  return (
+    <div
+      data-testid="settings-header"
+      className="bg-surface-850 border-b border-surface-700 shrink-0 flex flex-wrap items-center gap-x-3 gap-y-2 px-4 py-2 md:flex-nowrap md:h-12 md:py-0"
+    >
+      <button
+        onClick={onClose}
+        className="text-brand-500 cursor-pointer text-sm shrink-0"
+      >
+        &larr; Back
+      </button>
+      <span className="text-sm font-semibold text-text-bright shrink-0">Settings</span>
+      {saving && (
+        <span className="text-xs text-text-dim shrink-0">Saving...</span>
+      )}
+      {saveError && (
+        <span className="text-xs text-red-400 truncate min-w-0">{saveError}</span>
+      )}
+      <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
+        <ProfileSelector
+          selectedProfile={selectedProfile}
+          onSelect={onSelectProfile}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/settings/SettingsHeader.tsx
+++ b/web/src/components/settings/SettingsHeader.tsx
@@ -30,12 +30,17 @@ export function SettingsHeader({
       >
         &larr; Back
       </button>
-      <span className="text-sm font-semibold text-text-bright shrink-0">Settings</span>
+      <span className="text-xs font-mono text-text-bright shrink-0">Settings</span>
       {saving && (
-        <span className="text-xs text-text-dim shrink-0">Saving...</span>
+        <span className="text-[11px] font-mono text-text-dim shrink-0">Saving...</span>
       )}
       {saveError && (
-        <span className="text-xs text-red-400 truncate min-w-0">{saveError}</span>
+        <span
+          data-testid="settings-header-save-error"
+          className="text-[11px] font-mono text-status-error truncate min-w-0"
+        >
+          {saveError}
+        </span>
       )}
       <div className="basis-full flex justify-center overflow-x-auto md:basis-auto md:ml-auto md:overflow-visible md:justify-end shrink-0">
         <ProfileSelector

--- a/web/src/components/settings/__tests__/SettingsHeader.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsHeader.test.tsx
@@ -6,7 +6,7 @@
 // desktop) live in `web/tests/mobile-settings-header.spec.ts`; this file
 // covers the conditional render branches and the back-button click path.
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 vi.mock("../../../lib/api", () => ({
@@ -47,16 +47,17 @@ describe("SettingsHeader", () => {
     expect(screen.getByText("Saving...")).toBeTruthy();
   });
 
-  it("does not render saveError message when saveError is null", () => {
+  it("does not render saveError span when saveError is null", () => {
     render(<SettingsHeader {...baseProps} saveError={null} />);
-    expect(screen.queryByText(/failed/i)).toBeNull();
+    expect(screen.queryByTestId("settings-header-save-error")).toBeNull();
   });
 
   it("renders saveError message when saveError is set", () => {
     render(
       <SettingsHeader {...baseProps} saveError="Save failed: network error" />,
     );
-    expect(screen.getByText("Save failed: network error")).toBeTruthy();
+    const errorSpan = screen.getByTestId("settings-header-save-error");
+    expect(errorSpan.textContent).toBe("Save failed: network error");
   });
 
   it("renders both Saving... and saveError together when both are set", () => {

--- a/web/src/components/settings/__tests__/SettingsHeader.test.tsx
+++ b/web/src/components/settings/__tests__/SettingsHeader.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+//
+// Contract test for the SettingsHeader extracted from SettingsView so the
+// header's transient render branches (`saving`, `saveError`) get hit by
+// vitest. The end-to-end layout assertions (two-row mobile, single-row
+// desktop) live in `web/tests/mobile-settings-header.spec.ts`; this file
+// covers the conditional render branches and the back-button click path.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+vi.mock("../../../lib/api", () => ({
+  fetchProfiles: vi.fn().mockResolvedValue([{ name: "default", is_default: true }]),
+  createProfile: vi.fn(),
+  renameProfile: vi.fn(),
+  deleteProfile: vi.fn(),
+}));
+
+import { SettingsHeader } from "../SettingsHeader";
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("SettingsHeader", () => {
+  const baseProps = {
+    onClose: () => {},
+    saving: false,
+    saveError: null as string | null,
+    selectedProfile: "default",
+    onSelectProfile: () => {},
+  };
+
+  it("renders Back button and Settings title", () => {
+    render(<SettingsHeader {...baseProps} />);
+    expect(screen.getByRole("button", { name: /Back/ })).toBeTruthy();
+    expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("does not render Saving... indicator when saving is false", () => {
+    render(<SettingsHeader {...baseProps} saving={false} />);
+    expect(screen.queryByText("Saving...")).toBeNull();
+  });
+
+  it("renders Saving... indicator when saving is true", () => {
+    render(<SettingsHeader {...baseProps} saving={true} />);
+    expect(screen.getByText("Saving...")).toBeTruthy();
+  });
+
+  it("does not render saveError message when saveError is null", () => {
+    render(<SettingsHeader {...baseProps} saveError={null} />);
+    expect(screen.queryByText(/failed/i)).toBeNull();
+  });
+
+  it("renders saveError message when saveError is set", () => {
+    render(
+      <SettingsHeader {...baseProps} saveError="Save failed: network error" />,
+    );
+    expect(screen.getByText("Save failed: network error")).toBeTruthy();
+  });
+
+  it("renders both Saving... and saveError together when both are set", () => {
+    // The header allows saveError to surface while a subsequent save is in
+    // flight; both branches should render side by side.
+    render(
+      <SettingsHeader
+        {...baseProps}
+        saving={true}
+        saveError="Save failed: network error"
+      />,
+    );
+    expect(screen.getByText("Saving...")).toBeTruthy();
+    expect(screen.getByText("Save failed: network error")).toBeTruthy();
+  });
+
+  it("calls onClose when the Back button is clicked", () => {
+    const onClose = vi.fn();
+    render(<SettingsHeader {...baseProps} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Back/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -93,6 +93,18 @@
       ]
     },
     {
+      "id": "settings.mobile-header",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/mobile-settings-header.spec.ts"
+      ],
+      "components": [
+        "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/ProfileSelector.tsx"
+      ]
+    },
+    {
       "id": "settings.theme-persistence-passphrase",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -101,7 +101,19 @@
       ],
       "components": [
         "web/src/components/SettingsView.tsx",
+        "web/src/components/settings/SettingsHeader.tsx",
         "web/src/components/settings/ProfileSelector.tsx"
+      ]
+    },
+    {
+      "id": "settings.header-branches",
+      "kind": "vitest",
+      "risk": "low",
+      "specs": [
+        "src/components/settings/__tests__/SettingsHeader.test.tsx"
+      ],
+      "components": [
+        "web/src/components/settings/SettingsHeader.tsx"
       ]
     },
     {

--- a/web/tests/mobile-settings-header.spec.ts
+++ b/web/tests/mobile-settings-header.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from "./helpers/mockedTest";
+import { devices } from "@playwright/test";
+
+// Anti-regression for #1430. The old header crammed Back + "Settings" title
+// + ProfileSelector into one h-12 row; ProfileSelector was wrapped in a
+// `flex-1 justify-center` div that squeezed the back affordance and title
+// down to the left edge at mobile widths. The fix makes the header use
+// flex-wrap so the ProfileSelector drops onto a second row below md, and
+// keeps a single-row layout (selector on the right) on md+.
+
+test.use({ ...devices["iPhone 13"] });
+
+test.describe("Mobile settings header (iPhone 13)", () => {
+  test("Back button and title sit on a row above the ProfileSelector", async ({ page }) => {
+    await page.goto("/settings");
+
+    const backBtn = page.getByRole("button", { name: /Back/ });
+    const profileLabel = page.getByText("Profile", { exact: true });
+
+    await expect(backBtn).toBeVisible();
+    await expect(profileLabel).toBeVisible();
+
+    const backBox = await backBtn.boundingBox();
+    const profileBox = await profileLabel.boundingBox();
+    expect(backBox).not.toBeNull();
+    expect(profileBox).not.toBeNull();
+    // ProfileSelector must wrap onto its own row, i.e. start at or below
+    // the bottom of the Back button (mobile two-row layout).
+    expect(profileBox!.y).toBeGreaterThanOrEqual(backBox!.y + backBox!.height - 1);
+  });
+
+  test("'Settings' title keeps clear separation from the Back button", async ({ page }) => {
+    await page.goto("/settings");
+    const backBtn = page.getByRole("button", { name: /Back/ });
+    const title = page.getByText("Settings", { exact: true }).first();
+    const backBox = await backBtn.boundingBox();
+    const titleBox = await title.boundingBox();
+    expect(backBox).not.toBeNull();
+    expect(titleBox).not.toBeNull();
+    // gap-x-3 on the header (12px); allow a small fudge for sub-pixel
+    // layout, anything above 6px proves the cramped-against-left-edge
+    // regression is gone.
+    expect(titleBox!.x - (backBox!.x + backBox!.width)).toBeGreaterThan(6);
+  });
+
+  test("settings header does not overflow horizontally at iPhone 13 width", async ({ page }) => {
+    await page.goto("/settings");
+    const header = page.getByTestId("settings-header");
+    await expect(header).toBeVisible();
+    const overflow = await header.evaluate((el) => ({
+      scrollWidth: el.scrollWidth,
+      clientWidth: el.clientWidth,
+    }));
+    expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+  });
+});
+
+test.describe("Mobile settings header (narrow 320px)", () => {
+  test.use({ viewport: { width: 320, height: 568 } });
+
+  test("header stays within viewport at 320px (5.4\" Android narrow case)", async ({ page }) => {
+    await page.goto("/settings");
+    const header = page.getByTestId("settings-header");
+    await expect(header).toBeVisible();
+    const headerBox = await header.boundingBox();
+    expect(headerBox).not.toBeNull();
+    // Header element must fit within the viewport width. Overflow inside
+    // the ProfileSelector row is allowed via overflow-x-auto, but the
+    // header container itself must not push past the viewport edge.
+    expect(headerBox!.width).toBeLessThanOrEqual(320);
+  });
+});


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Closes #1430

On mobile (`(pointer: coarse)`, iPhone 13 at 390px, and tighter Androids at 320px), the Settings header packed the Back button, the "Settings" title, optional saving/error text, and the `ProfileSelector` into a single `h-12` flex row. The `ProfileSelector` was wrapped in `flex-1 flex justify-center`, so it claimed the remaining width and squeezed the back affordance and title against the left edge of the viewport. At 390px the back arrow lost visual margin from the title; at 320px the title clipped.

The fix uses `flex-wrap` on the header container and puts the `ProfileSelector` wrapper on `basis-full` so it drops onto its own row below `md:`. On `md:` and up the wrapper switches to `basis-auto ml-auto`, restoring a single-row desktop layout with the picker aligned right (no more centred-flex-1 fight). `ProfileSelector` itself tightens to `flex-nowrap` and `w-32 sm:w-40` so the select stays within the second row on narrow viewports.

The sidebar interaction story raised in the issue (Settings replacing the workspace sidebar entirely on desktop) is out of scope here; this PR ships the mobile header fix only.

Anti-regression covered by a new mocked Playwright spec at iPhone 13 + 320px viewports.

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [x] Open Chrome DevTools, switch to iPhone 13 preset (390x844), navigate to `/settings`. Back button reads `← Back`, "Settings" title sits beside it with visible spacing, ProfileSelector sits centred on its own row below.
- [x] Resize the responsive DevTools to 320x568 (5.4" Android narrow). Header still fits within the viewport, no horizontal scrollbar on the header row.
- [x] Resize to 1280x800 (desktop). Header collapses to a single row: Back + title on the left, ProfileSelector flush to the right edge (no longer centred).
- [x] Tap Back at every viewport. Settings closes and returns to the previous route.
- [x] At iPhone 13, open the profile dropdown, switch profiles. Selection persists; no layout jump in the header.

## AI Usage

- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I made the design calls (two-row wrap vs moving the picker into the tab bar; sidebar question deferred), reviewed each commit, and ran the manual test steps above.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR fixes the mobile Settings header layout so it no longer crams the Back button, "Settings" title, status text, and ProfileSelector into a single row on narrow viewports. On phones the header now stacks into two rows so the Back button and title keep their spacing and the ProfileSelector drops below; on desktop (md+) the header returns to a single-row layout with the selector right-aligned. The header UI was extracted into a reusable component and tests were added to prevent regressions.

What changed, moved, added, removed:
- Moved inline header UI from SettingsView into a new SettingsHeader component.
- ProfileSelector sizing/behavior tightened (flex-nowrap, w-32 sm:w-40) to avoid claiming remaining width.
- Header layout made responsive via flex-wrap and changing wrapper basis (basis-full on mobile → basis-auto ml-auto on md+).
- Added Vitest unit tests for SettingsHeader and a Playwright spec exercising iPhone 13 and a 320px viewport.
- Updated coverage matrix to include the new test surfaces.
- Minor test and style tweaks (added data-testid for save-error span; removed an unused import).

Benefits:
- Prevents title clipping and preserves Back/title spacing on narrow phones (tested 390px and 320px).
- Cleaner, reusable header component improves maintainability.
- Automated unit and e2e tests reduce risk of regressions.

---

## Technical details

- New component: web/src/components/settings/SettingsHeader.tsx — props: onClose, saving, saveError, selectedProfile, onSelectProfile. Uses flex-wrap + responsive basis rules to stack on mobile and align on md+.
- SettingsView now imports and renders SettingsHeader instead of inline header markup.
- ProfileSelector changes: wrapper set to flex-nowrap; select width adjusted from w-40 → w-32 sm:w-40 to constrain width on small viewports.
- Tests:
  - Unit: web/src/components/settings/__tests__/SettingsHeader.test.tsx (Vitest + RTL) — covers Back click, saving state, save error visibility and combined states.
  - E2E: web/tests/mobile-settings-header.spec.ts (Playwright) — verifies wrapping, spacing (gap between Back and title), and no horizontal overflow on iPhone 13 and 320px.
- Tests/tools: added data-testid="settings-header-save-error" to make assertions robust; removed an unused import in the test file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1595?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->