### PR TITLE
fix(server): bypass passphrase wall for loopback callers

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -239,6 +239,13 @@ state are always in sync.
 - **TUI status indicators**: a cockpit session that's healthy shows
   as Idle/Active in the TUI session list, since cockpit health is
   observed via the ACP event stream rather than tmux pane probing.
+- **`--auth=passphrase` daemons**: the local TUI attaches to a
+  same-host daemon without going through the passphrase exchange.
+  Loopback callers are treated as fs-trusted because the daemon's
+  serve files under `~/.agent-of-empires/serve.*` are already 0600,
+  so the filesystem permission boundary protects same-host access.
+  Remote callers proxied through a tunnel still hit the passphrase
+  wall as expected. See #1525.
 
 ### TUI cockpit view keybinds
 

--- a/src/cockpit/client/http.rs
+++ b/src/cockpit/client/http.rs
@@ -35,7 +35,12 @@ pub enum HttpError {
     SessionNotFound(String),
     #[error("daemon is read-only (started with --read-only); request refused")]
     ReadOnly,
-    #[error("authentication failed; check AOE_DAEMON_TOKEN or restart `aoe serve`")]
+    // The daemon may reject for several reasons: stale token, missing
+    // passphrase session, device binding mismatch. Pointing at
+    // `AOE_DAEMON_TOKEN` was misleading on `--auth=passphrase` and
+    // `--auth=none` daemons that never had a token in the first
+    // place. See #1525.
+    #[error("daemon rejected the request (401); restart `aoe serve` or check `--auth` mode")]
     Unauthorized,
     #[error("daemon returned HTTP {status}: {body}")]
     Server { status: StatusCode, body: String },
@@ -210,5 +215,24 @@ mod tests {
     fn auth_skips_bearer_when_no_token() {
         let client = HttpClient::new(endpoint("http://127.0.0.1:8080", None)).unwrap();
         assert!(client.endpoint().token.is_none());
+    }
+
+    // Regression test for #1525. The startup toast on a 401 from the
+    // cockpit endpoints folds in `HttpError::Unauthorized`'s Display.
+    // Previously that Display string hard-coded `AOE_DAEMON_TOKEN`,
+    // which made the toast actively misleading on `--auth=passphrase`
+    // and `--auth=none` daemons that never had a token. Pin the new
+    // wording so the env-var hint can't regress back in.
+    #[test]
+    fn unauthorized_display_omits_token_env_var() {
+        let rendered = HttpError::Unauthorized.to_string();
+        assert!(
+            !rendered.contains("AOE_DAEMON_TOKEN"),
+            "Unauthorized message must not pin diagnosis to a token env var that does not exist in passphrase or no-auth mode: {rendered}"
+        );
+        assert!(
+            rendered.contains("401"),
+            "Unauthorized message should still surface the underlying HTTP status: {rendered}"
+        );
     }
 }

--- a/src/server/auth.rs
+++ b/src/server/auth.rs
@@ -310,6 +310,46 @@ fn post_token_auth_action(
     }
 }
 
+/// Decision for the entry of `run_passphrase_wall`: a request landed on
+/// the wall because the daemon is running in `--auth=passphrase` mode
+/// (token gate disabled, passphrase login active). The wall normally
+/// requires a session cookie + device binding for `/api/*` and `/ws`,
+/// redirects to `/login` otherwise, and step-up-elevates writes to
+/// persistent-config surfaces. Two conditions bypass that entire
+/// gauntlet: a login-bootstrap path (so the SPA can load assets and
+/// post to `/api/login`) and a loopback caller (so the local TUI can
+/// attach without a passphrase exchange).
+#[derive(Debug, PartialEq, Eq)]
+enum PassphraseWallEntryAction {
+    /// Path is in the login-bootstrap allow-list. Skip the wall so
+    /// `/login`, `/api/login`, static assets, etc. stay reachable
+    /// even without a session.
+    BypassExempt,
+    /// Caller is on loopback. fs-perm boundary on
+    /// `~/.agent-of-empires/serve.*` already protects same-host
+    /// access, so layering the passphrase factor on top adds friction
+    /// without strengthening the trust boundary. Mirrors the token-
+    /// auth path's `is_local_trusted` carve-out from #1168 so the
+    /// local TUI works against an `--auth=passphrase` daemon. See
+    /// #1525.
+    BypassLoopback,
+    /// Run the full session + device-binding + elevation flow.
+    Continue,
+}
+
+/// Resolve the entry decision for `run_passphrase_wall`. Extracted so
+/// the bypass policy is table-testable without standing up the full
+/// axum middleware. See #1525.
+fn passphrase_wall_entry_action(path: &str, client_ip: IpAddr) -> PassphraseWallEntryAction {
+    if is_login_session_exempt(path) {
+        return PassphraseWallEntryAction::BypassExempt;
+    }
+    if is_local_trusted(client_ip) {
+        return PassphraseWallEntryAction::BypassLoopback;
+    }
+    PassphraseWallEntryAction::Continue
+}
+
 /// Whether a request path + method needs an elevated login session
 /// (step-up auth, 15-minute passphrase confirmation window).
 ///
@@ -447,6 +487,16 @@ pub struct AuthenticatedSession(pub String);
 /// inside the token-auth path, but skips every token-cookie
 /// operation since there is no token to refresh.
 ///
+/// Loopback callers bypass the wall entirely (see
+/// [`passphrase_wall_entry_action`] / [`is_local_trusted`]). This
+/// mirrors the token-auth path's #1168 carve-out so the local TUI can
+/// attach to a same-host `--auth=passphrase` daemon without going
+/// through a passphrase exchange. The fs-perm boundary on
+/// `~/.agent-of-empires/serve.*` already protects same-host access,
+/// and remote callers proxied through a tunnel come in with the real
+/// remote IP via `resolve_client_ip`, so they still hit the wall as
+/// expected. See #1525.
+///
 /// Rate-limit lockout is intentionally not consulted here: the only
 /// authentication attempt that can fail in this path is the passphrase
 /// POST itself, and `/api/login` enforces `check_locked` /
@@ -463,8 +513,18 @@ async fn run_passphrase_wall(
     let path = request.uri().path().to_string();
     let method = request.method().clone();
 
-    if is_login_session_exempt(&path) {
-        return next.run(request).await;
+    match passphrase_wall_entry_action(&path, client_ip) {
+        PassphraseWallEntryAction::BypassExempt => return next.run(request).await,
+        PassphraseWallEntryAction::BypassLoopback => {
+            tracing::info!(
+                target: "auth.passphrase",
+                ip = %client_ip,
+                path = %path,
+                "loopback bypass: skipping passphrase factor in passphrase-only mode"
+            );
+            return next.run(request).await;
+        }
+        PassphraseWallEntryAction::Continue => {}
     }
 
     let session_id = super::login::extract_login_session(&request);
@@ -1024,6 +1084,63 @@ mod tests {
         assert_eq!(
             post_token_auth_action(true, false, remote),
             PostTokenAuthAction::RequireLogin
+        );
+    }
+
+    // Per-row coverage of the passphrase-wall entry policy added in
+    // #1525: a loopback caller should bypass the wall outright so the
+    // local TUI can attach to an `--auth=passphrase` daemon without a
+    // session, while remote callers continue to fall through to the
+    // session check. The login-bootstrap allow-list still wins over
+    // both regardless of IP so the SPA can fetch assets and POST to
+    // `/api/login` even when the network would otherwise be remote.
+    #[test]
+    fn passphrase_wall_entry_action_matrix() {
+        let loopback: IpAddr = "127.0.0.1".parse().unwrap();
+        let loopback_v6: IpAddr = "::1".parse().unwrap();
+        let remote: IpAddr = "100.64.0.5".parse().unwrap();
+
+        // Non-exempt path + loopback (IPv4 and IPv6): bypass the
+        // wall entirely. This is the #1525 fix: same-host TUI attach
+        // must not require a passphrase exchange.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/sessions", loopback),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/sessions/abc/cockpit/ws", loopback),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/api/settings", loopback_v6),
+            PassphraseWallEntryAction::BypassLoopback
+        );
+
+        // Non-exempt path + remote: run the full session check. This
+        // is the case the passphrase wall was built for; the bypass
+        // must not leak through here.
+        assert_eq!(
+            passphrase_wall_entry_action("/api/sessions", remote),
+            PassphraseWallEntryAction::Continue
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/sessions/abc/cockpit/ws", remote),
+            PassphraseWallEntryAction::Continue
+        );
+
+        // Login-bootstrap allow-list wins regardless of IP, so the
+        // SPA can pull assets and POST to `/api/login` from any peer.
+        assert_eq!(
+            passphrase_wall_entry_action("/login", remote),
+            PassphraseWallEntryAction::BypassExempt
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/api/login", remote),
+            PassphraseWallEntryAction::BypassExempt
+        );
+        assert_eq!(
+            passphrase_wall_entry_action("/assets/index.css", loopback),
+            PassphraseWallEntryAction::BypassExempt
         );
     }
 

--- a/tests/e2e/serve.rs
+++ b/tests/e2e/serve.rs
@@ -214,13 +214,17 @@ fn cli_serve_daemon_writes_marker_to_debug_log_not_serve_log() {
 /// branch is locked in CI rather than relying on manual smoke tests.
 ///
 /// Flow:
-///   1. GET `/api/about` without a session  -> 401 `login_required`
-///      (proves the wall actually blocks API traffic).
+///   1. GET `/api/about` from a simulated non-loopback caller (loopback
+///      socket + `X-Forwarded-For: 10.0.0.5`, which `resolve_client_ip`
+///      trusts because the socket itself is loopback) -> 401
+///      `login_required`. Proves the wall still blocks remote API
+///      traffic after the #1525 loopback bypass landed.
 ///   2. POST `/api/login` with the correct passphrase + a fresh
 ///      device-binding secret -> 200 with `Set-Cookie: aoe_session=`.
 ///   3. GET `/api/about` carrying the session cookie + binding header
-///      -> 200, body has `"auth_mode":"passphrase"` (proves both the
-///      wall handoff and the `/api/about` mode-derivation surface).
+///      (no XFF so the caller is loopback) -> 200, body has
+///      `"auth_mode":"passphrase"`. Proves both the wall handoff and
+///      the `/api/about` mode-derivation surface.
 #[test]
 #[serial]
 fn cli_serve_auth_passphrase_login_round_trip() {
@@ -267,9 +271,14 @@ fn cli_serve_auth_passphrase_login_round_trip() {
             .build()
             .map_err(|e| format!("build client: {e}"))?;
 
-        // 1. Unauthenticated GET must come back with 401 + login_required body.
+        // 1. Unauthenticated GET from a simulated remote caller must
+        //    come back with 401 + login_required body. The daemon
+        //    binds loopback, so `resolve_client_ip` trusts XFF; we
+        //    pin a non-loopback last-hop IP so the #1525 loopback
+        //    bypass does not fire.
         let about_unauth = client
             .get(format!("{base}/api/about"))
+            .header("x-forwarded-for", "10.0.0.5")
             .send()
             .await
             .map_err(|e| format!("GET /api/about (unauth): {e}"))?;
@@ -349,6 +358,109 @@ fn cli_serve_auth_passphrase_login_round_trip() {
 
     // Always tear the daemon down before asserting, so a failed assert
     // doesn't leak a process that owns the test port.
+    let _ = h.run_cli(&["serve", "--stop"]);
+
+    if let Err(e) = result {
+        panic!("{e}");
+    }
+}
+
+/// Regression test for #1525. With `--auth=passphrase` the daemon used
+/// to route loopback callers through the passphrase wall, breaking the
+/// local TUI cockpit attach: it had no session cookie + device binding
+/// to present so `/api/sessions/{id}/cockpit/replay` and the cockpit ws
+/// upgrade always 401'd. The fix mirrors the token-auth path's #1168
+/// carve-out and treats loopback as fs-trusted.
+///
+/// Flow:
+///   1. Start `aoe serve --daemon --auth=passphrase`.
+///   2. GET `/api/about` from 127.0.0.1 with no session cookie, no
+///      device binding, no XFF -> 200 with `"auth_mode":"passphrase"`.
+///      Without the bypass this would 401 `login_required`.
+///   3. GET `/api/sessions` from 127.0.0.1 -> 200 (proves the bypass
+///      covers the cockpit REST surface, not just `/api/about`).
+#[test]
+#[serial]
+fn cli_serve_auth_passphrase_loopback_bypass() {
+    let h = TuiTestHarness::new("serve_auth_passphrase_loopback");
+    let port = pick_free_port();
+    let port_s = port.to_string();
+
+    let start = h.run_cli(&[
+        "serve",
+        "--daemon",
+        "--port",
+        &port_s,
+        "--auth",
+        "passphrase",
+        "--passphrase",
+        "e2e-pass",
+    ]);
+    assert!(
+        start.status.success(),
+        "aoe serve --daemon --auth=passphrase failed.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&start.stdout),
+        String::from_utf8_lossy(&start.stderr),
+    );
+
+    assert!(
+        wait_for_port(port, Duration::from_secs(10)),
+        "daemon never bound port {}",
+        port
+    );
+
+    let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+    let result: Result<(), String> = rt.block_on(async {
+        let base = format!("http://127.0.0.1:{port}");
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(|e| format!("build client: {e}"))?;
+
+        // No cookie, no device binding, no XFF: the loopback bypass
+        // (#1525) lets the request through. Pre-fix this would have
+        // returned 401 login_required.
+        let about = client
+            .get(format!("{base}/api/about"))
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/about (loopback bypass): {e}"))?;
+        if !about.status().is_success() {
+            let s = about.status();
+            let b = about.text().await.unwrap_or_default();
+            return Err(format!(
+                "loopback /api/about should 200 under --auth=passphrase, got status={s} body={b}"
+            ));
+        }
+        let body: serde_json::Value = about
+            .json()
+            .await
+            .map_err(|e| format!("decode about body: {e}"))?;
+        if body.get("auth_mode").and_then(|v| v.as_str()) != Some("passphrase") {
+            return Err(format!(
+                "expected auth_mode=passphrase on loopback bypass, got {body}"
+            ));
+        }
+
+        // The cockpit REST surface lives under the same wall, so the
+        // bypass must extend to it. A successful 200 on `/api/sessions`
+        // from loopback without a session is what unblocks the local
+        // TUI cockpit attach in the issue report.
+        let sessions = client
+            .get(format!("{base}/api/sessions"))
+            .send()
+            .await
+            .map_err(|e| format!("GET /api/sessions (loopback bypass): {e}"))?;
+        if !sessions.status().is_success() {
+            let s = sessions.status();
+            let b = sessions.text().await.unwrap_or_default();
+            return Err(format!(
+                "loopback /api/sessions should 200 under --auth=passphrase, got status={s} body={b}"
+            ));
+        }
+
+        Ok(())
+    });
+
     let _ = h.run_cli(&["serve", "--stop"]);
 
     if let Err(e) = result {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

A local TUI cockpit attach against a same-host `aoe serve --auth=passphrase` daemon was returning 401 on every replay + ws upgrade. PR #1190 added the `is_local_trusted` loopback bypass to the token-auth branch for #1168, then #1160 introduced `--auth=passphrase`, which routes through `run_passphrase_wall` (a separate code path with no bypass). Same-host TUI users on the recommended LAN-behind-proxy auth mode were bricked on the cockpit-in-TUI flow.

This PR mirrors the #1168 carve-out inside the passphrase wall. A loopback caller already passes the filesystem-permission trust boundary on `~/.agent-of-empires/serve.*` (mode 0600), so layering the passphrase factor on top adds friction without strengthening the boundary. Remote callers proxied through a tunnel come in with the real remote IP via `resolve_client_ip` and continue to hit the wall as expected. The decision is extracted into a pure `passphrase_wall_entry_action` helper so the policy matrix is table-testable, the same way `post_token_auth_action` was extracted for #1168.

Two follow-ons in the same PR:

1. `HttpError::Unauthorized`'s Display string used to tell users to "check `AOE_DAEMON_TOKEN`" on any 401 from the cockpit endpoints. That hint is actively wrong on `--auth=passphrase` and `--auth=none` daemons that never had a token, so the toast steered users at a non-existent env var while the real fault went uninvestigated. Replaced with a mode-agnostic message.
2. `docs/cockpit.md` notes the new behavior in the TUI vs web dashboard section, including the threat-model reasoning so it doesn't read as an auth-weakening loophole.

Closes #1525

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow

**TUI / CLI (e2e test)**
- [x] Added or updated an e2e test under `tests/e2e/`

New `cli_serve_auth_passphrase_loopback_bypass` covers the bypass on `/api/about` and `/api/sessions` from 127.0.0.1 with no session cookie + device binding. The existing `cli_serve_auth_passphrase_login_round_trip` test asserted 401 on a no-cookie loopback GET; that returns 200 now, so step 1 was retargeted at a simulated remote caller via `X-Forwarded-For: 10.0.0.5` (the daemon binds loopback, so `resolve_client_ip` trusts the XFF header). Unit-level coverage comes from `passphrase_wall_entry_action_matrix` in `src/server/auth.rs::tests` (loopback v4/v6 → `BypassLoopback`, remote → `Continue`, login-bootstrap path → `BypassExempt` regardless of IP) and `unauthorized_display_omits_token_env_var` in `src/cockpit/client/http.rs::tests` (pins the new error string so the env-var hint can't regress back in).

## How to test

- [ ] Start a daemon: `aoe serve --daemon --host 127.0.0.1 --port 42041 --auth passphrase --passphrase test-pass`.
- [ ] From a separate terminal, open the TUI: `aoe`. Navigate to a session that's running in cockpit mode and press Enter. The cockpit transcript should render without the `startup failed: replay=authentication failed; ws=...` toast. Replay and ws traffic should both 200 / 101 in `~/.agent-of-empires/debug.log`.
- [ ] Confirm the remote path still rejects: `curl -i -H "X-Forwarded-For: 10.0.0.5" http://127.0.0.1:42041/api/about` returns `401 login_required`.
- [ ] Confirm the loopback path now passes: `curl -i http://127.0.0.1:42041/api/about` returns `200` with `"auth_mode":"passphrase"`.
- [ ] On any 401 that does occur (e.g. an actual stale session against a token-auth daemon), the TUI startup toast no longer mentions `AOE_DAEMON_TOKEN`.

## AI Usage

- [ ] No AI was used
- [x] AI was used
- [ ] This is fully AI-generated

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (notably: full bypass for loopback callers, skipping the elevation step-up consistent with the token-auth path; no token-embedded bootstrap URL change), and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified behavior of local TUI connections with passphrase authentication.

* **Bug Fixes**
  * Enhanced error messaging to provide actionable guidance during authentication issues.
  * Fixed passphrase authentication to correctly bypass requirements for same-host local connections while maintaining security for remote access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1596?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->