### PR TITLE
test(web): theme switching and sidebar reorder user-story specs (#1405, #1419)

### DIFF
--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -432,6 +432,105 @@
       ]
     },
     {
+      "id": "sidebar.reorder-stationary-click",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-stationary-click-navigates.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-tiny-drag-noop",
+      "kind": "mocked-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/sidebar-reorder-tiny-drag-noop.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-click-after-drag-suppressed",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/sidebar-reorder-click-after-drag-suppressed.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-cross-group-noop",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-cross-group-noop.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-read-only",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-read-only.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-tap-navigates",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-mobile-tap-navigates.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-flick-scrolls",
+      "kind": "mocked-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/sidebar-reorder-mobile-flick-scrolls.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "sidebar.reorder-mobile-press-hold",
+      "kind": "mocked-playwright",
+      "risk": "high",
+      "specs": [
+        "tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
+      "id": "story.sidebar-reorder-reload-persists",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts"
+      ],
+      "components": [
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "sidebar.client-side-navigation",
       "kind": "mocked-playwright",
       "risk": "medium",
@@ -1272,6 +1371,54 @@
       ],
       "components": [
         "web/src/components/settings/ThemeSettings.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-theme-custom",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-custom.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/lib/theme.ts"
+      ]
+    },
+    {
+      "id": "story.settings-theme-custom-malformed",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx"
+      ]
+    },
+    {
+      "id": "story.settings-theme-color-mode",
+      "kind": "live-playwright",
+      "risk": "low",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-color-mode.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/hooks/useResolvedTheme.ts"
+      ]
+    },
+    {
+      "id": "story.settings-theme-failure-revert",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts"
+      ],
+      "components": [
+        "web/src/components/settings/ThemeSettings.tsx",
+        "web/src/components/SettingsView.tsx",
+        "web/src/hooks/useResolvedTheme.ts"
       ]
     },
     {

--- a/web/tests/helpers/sidebar.ts
+++ b/web/tests/helpers/sidebar.ts
@@ -1,4 +1,8 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { join } from "node:path";
 import type { Page } from "@playwright/test";
+import { resolveAoeBinary } from "./aoeServe";
 
 export async function clickSidebarSession(page: Page, title: string) {
   // Sidebar session rows are anchor tags (see WorkspaceSidebar.tsx). The
@@ -66,3 +70,98 @@ export async function openMobileSidebar(page: Page) {
     { timeout: 5_000 },
   );
 }
+
+/**
+ * Read the visible session-row titles in the sidebar, in DOM order.
+ *
+ * Scopes to the `.truncate` label span inside each row so a Wakeup or
+ * Plan chip on the same row can't be confused with the workspace
+ * title. Hoisted from `tests/live/workspace-ordering.spec.ts` so the
+ * reorder story specs can share the same accessor without redefining
+ * it per file.
+ */
+export async function readVisibleSessionTitles(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const rows = Array.from(
+      document.querySelectorAll<HTMLElement>(
+        "[data-testid='sidebar-session-row']",
+      ),
+    );
+    return rows
+      .map(
+        (r) =>
+          r.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+      )
+      .filter(Boolean);
+  });
+}
+
+/**
+ * Build a `seedFn` for `spawnAoeServe` that git-inits a project dir
+ * under the isolated HOME, then runs `aoe add` once per supplied
+ * title. The arrival order matters: the server prepends new workspace
+ * ids newest-first, so the seeded sidebar order in arrival sequence
+ * is `titles[-1]` at the top down to `titles[0]` at the bottom.
+ *
+ * Optional `subdir` lets callers seed multiple repos by pointing each
+ * `seedSessionsInRepo` call at a different directory; the cross-group
+ * reorder story chains two calls for that reason.
+ */
+export function seedSessionsInRepo(opts: {
+  titles: string[];
+  subdir?: string;
+  tool?: string;
+}): (seedEnv: {
+  home: string;
+  shimBin: string;
+  env: NodeJS.ProcessEnv;
+}) => void {
+  return ({ home, env }) => {
+    const binary = resolveAoeBinary();
+    const projectDir = join(home, opts.subdir ?? "repo");
+    mkdirSync(projectDir, { recursive: true });
+    spawnSync("git", ["init", "-q"], { cwd: projectDir });
+    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
+      cwd: projectDir,
+      env: {
+        ...env,
+        GIT_AUTHOR_NAME: "t",
+        GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t",
+        GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+    for (const title of opts.titles) {
+      const res = spawnSync(
+        binary,
+        ["add", projectDir, "-t", title, "-c", opts.tool ?? "claude"],
+        { env },
+      );
+      if (res.status !== 0) {
+        throw new Error(
+          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
+        );
+      }
+    }
+  };
+}
+
+/**
+ * Chain multiple repo seeds into a single `seedFn`. Cross-group
+ * reorder stories need at least two repos so dnd-kit's per-group
+ * SortableContext renders multiple drag boundaries; this helper runs
+ * each repo's `seedSessionsInRepo` in sequence under the same env.
+ */
+export function seedRepos(
+  repos: Array<{ titles: string[]; subdir: string; tool?: string }>,
+): (seedEnv: {
+  home: string;
+  shimBin: string;
+  env: NodeJS.ProcessEnv;
+}) => void {
+  const fns = repos.map((r) => seedSessionsInRepo(r));
+  return (seedEnv) => {
+    for (const fn of fns) fn(seedEnv);
+  };
+}
+

--- a/web/tests/helpers/sidebarMocks.ts
+++ b/web/tests/helpers/sidebarMocks.ts
@@ -1,0 +1,175 @@
+// Shared mocked-Playwright setup for the sidebar-reorder story specs
+// under `web/tests/sidebar-reorder-*.spec.ts` (#1419). The drag-to-
+// reorder UI sits on top of dnd-kit and a handful of REST endpoints;
+// the per-test specifics are just the input gesture + the assertion.
+// Extracted from `sidebar-drag-reorder.spec.ts` and trimmed to what
+// the story specs actually need.
+
+import type { Page, Route } from "@playwright/test";
+
+export interface MockSessionInput {
+  id: string;
+  title: string;
+  project_path: string;
+  branch: string | null;
+  /** ISO 8601 timestamp; controls newest-first default ordering. */
+  created_at?: string;
+}
+
+type MockSession = Required<MockSessionInput>;
+
+function fillCreatedAt(s: MockSessionInput, fallbackIndex: number): MockSession {
+  return {
+    ...s,
+    // Stagger fallback timestamps a day apart so a list seeded in
+    // arrival order has a deterministic newest-first sort if anything
+    // ever falls back to created_at.
+    created_at:
+      s.created_at ??
+      new Date(Date.UTC(2025, 0, 1 + fallbackIndex)).toISOString(),
+  };
+}
+
+function sessionResponse(s: MockSession) {
+  return {
+    id: s.id,
+    title: s.title,
+    project_path: s.project_path,
+    group_path: s.project_path,
+    tool: "claude",
+    status: "Idle",
+    yolo_mode: false,
+    created_at: s.created_at,
+    last_accessed_at: null,
+    idle_entered_at: null,
+    last_error: null,
+    branch: s.branch,
+    main_repo_path: null,
+    is_sandboxed: false,
+    has_terminal: true,
+    profile: "default",
+    workspace_repos: [],
+  };
+}
+
+/** Workspace id format used by the server: `<project_path>::<branch>`
+ *  for branched sessions, `<project_path>::__session__::<id>` for
+ *  ones without a branch. Mirrors `useWorkspaces.ts:31`. */
+export function workspaceId(s: { project_path: string; branch: string | null; id: string }): string {
+  return s.branch
+    ? `${s.project_path}::${s.branch}`
+    : `${s.project_path}::__session__::${s.id}`;
+}
+
+export interface SidebarMockHandle {
+  /** Recorded `PUT /api/workspace-ordering` bodies in arrival order. */
+  puts: Array<{ order?: string[] }>;
+  /** Override the fulfill response for the next PUT (used by the
+   *  failure-mode story). Reset after each call. */
+  nextPutResponse: { status?: number; body?: string } | null;
+  /** Override the read_only flag from `/api/about` (used by the
+   *  read-only story). */
+  readOnly: boolean;
+}
+
+export interface SidebarMockOptions {
+  sessions: MockSessionInput[];
+  /** Server-supplied workspace ordering (the full list, with each id
+   *  composed via `workspaceId`). Defaults to the input order. */
+  ordering?: string[];
+  /** Add `read_only: true` to the `/api/about` response. */
+  readOnly?: boolean;
+}
+
+/** Install routes for the surface the sidebar uses. Returns a handle
+ *  the test can read for captured PUT bodies and tweak the next PUT's
+ *  fulfill (for the failure-mode story). */
+export async function installSidebarMocks(
+  page: Page,
+  opts: SidebarMockOptions,
+): Promise<SidebarMockHandle> {
+  const filled = opts.sessions.map((s, i) => fillCreatedAt(s, i));
+  const handle: SidebarMockHandle = {
+    puts: [],
+    nextPutResponse: null,
+    readOnly: !!opts.readOnly,
+  };
+
+  const ordering = opts.ordering ?? filled.map((s) => workspaceId(s));
+
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: { sessions: filled.map(sessionResponse), workspace_ordering: ordering },
+    });
+  });
+  await page.route("**/api/workspace-ordering", (r: Route) => {
+    if (r.request().method() === "PUT") {
+      const body = r.request().postDataJSON() as { order?: string[] };
+      handle.puts.push(body ?? {});
+      const override = handle.nextPutResponse;
+      handle.nextPutResponse = null;
+      if (override) return r.fulfill(override);
+    }
+    return r.fulfill({ json: { order: [] } });
+  });
+  await page.route("**/api/about", (r) =>
+    r.fulfill({
+      json: {
+        read_only: handle.readOnly,
+        auth_mode: "none",
+        behind_tunnel: false,
+        profile: "default",
+      },
+    }),
+  );
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: [] }),
+    );
+  }
+  await page.route("**/api/docker/status", (r) =>
+    r.fulfill({ json: {} }),
+  );
+
+  return handle;
+}
+
+/** Standard three sessions in one repo, used by the activation /
+ *  suppression / mobile stories. Title -> branch -> id are aligned so
+ *  the test reads naturally. */
+export function threeSessionsInOneRepo(): MockSessionInput[] {
+  return [
+    {
+      id: "s-a",
+      title: "alpha",
+      project_path: "/tmp/repo",
+      branch: "feature/a",
+      created_at: "2025-03-01T00:00:00Z",
+    },
+    {
+      id: "s-b",
+      title: "beta",
+      project_path: "/tmp/repo",
+      branch: "feature/b",
+      created_at: "2025-02-01T00:00:00Z",
+    },
+    {
+      id: "s-c",
+      title: "gamma",
+      project_path: "/tmp/repo",
+      branch: "feature/c",
+      created_at: "2025-01-01T00:00:00Z",
+    },
+  ];
+}

--- a/web/tests/helpers/theme.ts
+++ b/web/tests/helpers/theme.ts
@@ -1,0 +1,117 @@
+// Shared helpers for theme-switching story specs (#1405).
+//
+// Two domains:
+//
+//   - `seedCustomTheme(home, name, body)` writes a TOML file into the
+//     isolated $HOME so that an `aoe serve` boot picks it up via
+//     `discover_custom_themes` (src/tui/styles/mod.rs:86). The themes
+//     directory lives at `${appDir}/themes/`, where `appDir` is
+//     `${home}/.agent-of-empires-dev` (macOS/Windows) or
+//     `${xdg}/agent-of-empires-dev/` (Linux). `appDirFor` in
+//     `aoeServe.ts` already mirrors that resolution.
+//
+//   - `readThemeFromDocument(page)` snapshots the four observable
+//     side-effects of `applyResolvedTheme` (web/src/lib/theme.ts:47):
+//     `dataset.theme`, `dataset.themeAppearance`, the `color-scheme`
+//     style, and one representative CSS variable. Used by the failure
+//     and color-mode stories to assert a precise "did NOT paint" state.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { Page } from "@playwright/test";
+import { appDirFor, resolveAoeBinary } from "./aoeServe";
+
+const MINIMAL_THEME_TOML = `appearance = "dark"
+
+background = "#11131c"
+border = "#2b2f3f"
+terminal_border = "#5fd7ff"
+selection = "#2b2f3f"
+session_selection = "#3c4154"
+title = "#c4b5fd"
+text = "#e6e8ee"
+dimmed = "#7a829a"
+hint = "#7a829a"
+running = "#5fd7af"
+waiting = "#ffd178"
+fresh_idle = "#ff8a5b"
+idle = "#7a829a"
+error = "#ff6b6b"
+terminal_active = "#5fd7ff"
+group = "#5fd7ff"
+search = "#fff59d"
+accent = "#c4b5fd"
+diff_add = "#5fd7af"
+diff_delete = "#ff6b6b"
+diff_modified = "#ffd178"
+diff_header = "#c4b5fd"
+help_key = "#c4b5fd"
+branch = "#5fd7ff"
+sandbox = "#c4b5fd"
+
+[syntax]
+shiki_theme = "github-dark"
+`;
+
+/** Body of a valid custom-theme TOML file. Custom themes deserialize as
+ *  the full `Theme` struct (TUI palette + syntax sub-table); a partial
+ *  body fails to parse and ends up filtered out by `load_custom_theme`. */
+export const VALID_CUSTOM_THEME_TOML = MINIMAL_THEME_TOML;
+
+/** Intentionally malformed TOML. Anything that doesn't satisfy the
+ *  `Theme` struct deserializer counts; this body trips a parse error,
+ *  so `load_custom_theme` returns `None` and the name is still listed
+ *  by `discover_custom_themes` (the discovery scan only looks at the
+ *  file stem, see src/tui/styles/mod.rs:97-108). */
+export const MALFORMED_CUSTOM_THEME_TOML = `appearance = "dark"
+this-is-not = "valid theme schema"
+[syntax
+shiki_theme = "missing closing bracket"
+`;
+
+export function customThemesDir(home: string, xdg: string): string {
+  const appDir = appDirFor(home, xdg, resolveAoeBinary());
+  return join(appDir, "themes");
+}
+
+/** Seed a `<name>.toml` file under the isolated app dir's `themes/`
+ *  directory. Caller passes both `home` and the per-test XDG path; the
+ *  resolution mirrors `appDirFor` so the same binary that the spec
+ *  resolves will discover the file on boot. */
+export function seedCustomTheme(
+  home: string,
+  xdg: string,
+  name: string,
+  body: string,
+): string {
+  const dir = customThemesDir(home, xdg);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, `${name}.toml`);
+  writeFileSync(path, body);
+  return path;
+}
+
+export interface ThemeDocumentSnapshot {
+  datasetTheme: string | undefined;
+  datasetAppearance: string | undefined;
+  colorScheme: string;
+  surface900: string;
+}
+
+/** Snapshot the observable side-effects of `applyResolvedTheme` on the
+ *  root element. Returning a strict shape (rather than asserting inline)
+ *  lets the failure-mode specs compare a single object against a
+ *  pre-change baseline without re-reading per-property. */
+export async function readThemeFromDocument(
+  page: Page,
+): Promise<ThemeDocumentSnapshot> {
+  return await page.evaluate(() => {
+    const root = document.documentElement;
+    return {
+      datasetTheme: root.dataset.theme,
+      datasetAppearance: root.dataset.themeAppearance,
+      colorScheme: root.style.colorScheme,
+      surface900: root.style.getPropertyValue("--color-surface-900").trim(),
+    };
+  });
+}

--- a/web/tests/live/cockpit-stories/settings-theme-color-mode.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-color-mode.spec.ts
@@ -1,0 +1,117 @@
+// Color-mode field PATCHes but does NOT dispatch the theme repaint
+// event (#1405).
+//
+// ThemeSettings.tsx:34 early-returns from `save()` for any field other
+// than `name`, so only theme.name selections drive the dashboard
+// repaint. Color mode is a TUI-only setting (palette downsample for
+// 256-color terminals); a refactor that drops the early-return would
+// wastefully re-fetch /api/themes/<name> and dispatch
+// aoe:theme-picker-changed on every color-mode toggle, repainting the
+// dashboard on a TUI-only setting.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { settingsSelectByLabel } from "../../helpers/cockpit";
+
+base("color-mode change PATCHes but does not dispatch theme-picker-changed", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    // Capture both theme events before the SPA mounts so any dispatch
+    // is observable. addInitScript runs before any document script in
+    // each page (and survives reloads).
+    await page.addInitScript(() => {
+      const w = window as unknown as {
+        __pickerFired?: number;
+        __changedFired?: number;
+      };
+      w.__pickerFired = 0;
+      w.__changedFired = 0;
+      window.addEventListener("aoe:theme-picker-changed", () => {
+        w.__pickerFired = (w.__pickerFired ?? 0) + 1;
+      });
+      window.addEventListener("aoe:theme-changed", () => {
+        w.__changedFired = (w.__changedFired ?? 0) + 1;
+      });
+    });
+
+    await page.goto(`${serve.baseUrl}/settings/theme`);
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const colorMode = settingsSelectByLabel(page, "Color mode");
+    await expect(colorMode).toBeVisible({ timeout: 10_000 });
+
+    // useResolvedTheme fires aoe:theme-changed once on mount when its
+    // /api/theme/current resolves. Reset both counters AFTER mount so
+    // the assertion below targets only events the color-mode pick
+    // triggers.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () =>
+              (window as unknown as { __changedFired?: number })
+                .__changedFired ?? 0,
+          ),
+        { timeout: 5_000 },
+      )
+      .toBeGreaterThan(0);
+    await page.evaluate(() => {
+      const w = window as unknown as {
+        __pickerFired?: number;
+        __changedFired?: number;
+      };
+      w.__pickerFired = 0;
+      w.__changedFired = 0;
+    });
+
+    const before = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const initialMode = await colorMode.inputValue();
+    const nextMode = initialMode === "palette" ? "truecolor" : "palette";
+
+    await colorMode.selectOption(nextMode);
+    await expect(colorMode).toHaveValue(nextMode);
+
+    // The PATCH lands; this poll reads the persisted value back via
+    // GET /api/profiles/<name>/settings so a regression that drops the
+    // write surfaces here, not as a missing event later.
+    const profiles: Array<{ name: string; is_default?: boolean }> = await fetch(
+      `${serve.baseUrl}/api/profiles`,
+    ).then((r) => r.json());
+    const defaultProfile =
+      profiles.find((p) => p.is_default)?.name ?? profiles[0]?.name ?? "main";
+    const profileUrl = `${serve.baseUrl}/api/profiles/${encodeURIComponent(defaultProfile)}/settings`;
+    await expect(async () => {
+      const after = await fetch(profileUrl).then((r) => r.json());
+      expect(after?.theme?.color_mode).toBe(nextMode);
+    }).toPass({ timeout: 5_000 });
+
+    // The contract is "neither event fires for a color-mode change."
+    // A fixed 500ms wait is enough; the dispatch would have happened
+    // synchronously inside save().
+    await page.waitForTimeout(500);
+    const fired = await page.evaluate(() => ({
+      picker:
+        (window as unknown as { __pickerFired?: number }).__pickerFired ?? 0,
+      changed:
+        (window as unknown as { __changedFired?: number }).__changedFired ?? 0,
+    }));
+    expect(fired.picker).toBe(0);
+    expect(fired.changed).toBe(0);
+
+    const after = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    expect(after).toBe(before);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-custom-malformed.spec.ts
@@ -1,0 +1,72 @@
+// User story: a malformed custom theme TOML in `${appDir}/themes/`
+// does NOT break the settings dropdown; builtins still load and can be
+// picked (#1405).
+//
+// `discover_custom_themes` (src/tui/styles/mod.rs:86) scans by file
+// stem and surfaces the malformed name in /api/themes alongside the
+// builtins; `load_custom_theme` (mod.rs:124) returns None on parse
+// failure, so a user who selects the malformed entry gets the default
+// fallback palette. The user-observable contract this spec locks is
+// narrower: dropping a bad TOML in the dir must not 500 the settings
+// page or wipe the builtin list. Without this, a regression that
+// propagates the parse error up through `available_themes` would block
+// the entire theme picker.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+import {
+  MALFORMED_CUSTOM_THEME_TOML,
+  seedCustomTheme,
+} from "../../helpers/theme";
+
+const MALFORMED_NAME = "aoe-story-malformed";
+const SWITCH_TO = "dracula";
+
+base("malformed custom theme TOML does not break the dropdown", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      seedCustomTheme(home, xdg, MALFORMED_NAME, MALFORMED_CUSTOM_THEME_TOML);
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await openSettingsTab(page, "Theme");
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+
+    // Dropdown still populates: builtins are there and can be picked.
+    // We assert dracula specifically because the rest of the suite
+    // uses it as the switch-target; if the builtin set ever changes,
+    // pick any non-default builtin instead.
+    await expect
+      .poll(
+        async () =>
+          await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+            Array.from(sel.options).some((o) => o.value === target),
+          SWITCH_TO),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    // Switching to a builtin lands. The PATCH succeeds (the server
+    // does not validate names server-side; it would simply resolve
+    // through `resolve_theme`).
+    await themeSelect.selectOption(SWITCH_TO);
+    await expect(themeSelect).toHaveValue(SWITCH_TO);
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => document.documentElement.dataset.theme),
+        { timeout: 10_000 },
+      )
+      .toBe(SWITCH_TO);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-custom.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-custom.spec.ts
@@ -1,0 +1,79 @@
+// User story: a custom theme file in `${appDir}/themes/` is offered in
+// the settings dropdown and, when picked, applies its palette to the
+// dashboard (#1405).
+//
+// `discover_custom_themes` (src/tui/styles/mod.rs:86) scans the dir at
+// daemon startup; `GET /api/themes` returns the merged builtin + custom
+// list. Without this spec, a regression that drops the directory scan
+// (or renames the dir, or stops invoking it from `available_themes`)
+// would ship green: the existing settings-theme-select spec only
+// exercises builtins.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { openSettingsTab, settingsSelectByLabel } from "../../helpers/cockpit";
+import {
+  VALID_CUSTOM_THEME_TOML,
+  seedCustomTheme,
+} from "../../helpers/theme";
+
+const CUSTOM_NAME = "aoe-story-custom";
+
+base("custom theme TOML appears in the dropdown and applies on pick", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: ({ home, xdg }) => {
+      seedCustomTheme(home, xdg, CUSTOM_NAME, VALID_CUSTOM_THEME_TOML);
+    },
+  });
+
+  try {
+    await page.goto(`${serve.baseUrl}/settings`);
+    await openSettingsTab(page, "Theme");
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+
+    // The dropdown populates from /api/themes; poll for the custom
+    // entry rather than reading once. A non-zero option count alone is
+    // not enough since builtins always populate first.
+    await expect
+      .poll(
+        async () =>
+          await themeSelect.evaluate((sel: HTMLSelectElement, target) =>
+            Array.from(sel.options).some((o) => o.value === target),
+          CUSTOM_NAME),
+        { timeout: 10_000 },
+      )
+      .toBe(true);
+
+    await themeSelect.selectOption(CUSTOM_NAME);
+    await expect(themeSelect).toHaveValue(CUSTOM_NAME);
+
+    // applyResolvedTheme runs once the PATCH resolves and the picker
+    // refetches /api/themes/<custom>. The resolved payload's `name`
+    // matches the custom file's stem, so dataset.theme lands on it.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(() => document.documentElement.dataset.theme),
+        { timeout: 10_000 },
+      )
+      .toBe(CUSTOM_NAME);
+
+    // The custom TOML declares `background = "#11131c"`; the web
+    // projection maps theme.background to --color-surface-900. If a
+    // future refactor stops projecting custom theme palettes, this
+    // would fall back to whatever default the server resolves.
+    const surface = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+    expect(surface.toLowerCase()).toBe("#11131c");
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts
+++ b/web/tests/live/cockpit-stories/settings-theme-failure-revert.spec.ts
@@ -1,0 +1,119 @@
+// A failed PATCH must NOT silently change dataset.theme or fire the
+// repaint event (#1405, originally tracked in #1510).
+//
+// Before the fix, ThemeSettings.save() dispatched
+// aoe:theme-picker-changed immediately, then awaited the PATCH; the
+// dashboard repainted to the user's pick even when the server
+// rejected the write. On reload the page snapped back to the
+// persisted value and the user saw a silent revert. The fix at
+// ThemeSettings.tsx:34-37 gates the dispatch on `await result === true`.
+//
+// This spec spawns a real `aoe serve`, then intercepts
+// `PATCH /api/profiles/<name>/settings` from the browser side via
+// `page.route()` so the response is a 500 even though the rest of
+// the surface is real. Locks: dataset.theme does NOT change, and the
+// aoe:theme-picker-changed event never fires.
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe } from "../../helpers/aoeServe";
+import { settingsSelectByLabel } from "../../helpers/cockpit";
+
+base("PATCH 500 does not silently change dataset.theme or dispatch picker event", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+  });
+
+  try {
+    await page.addInitScript(() => {
+      const w = window as unknown as { __pickerFired?: number };
+      w.__pickerFired = 0;
+      window.addEventListener("aoe:theme-picker-changed", () => {
+        w.__pickerFired = (w.__pickerFired ?? 0) + 1;
+      });
+    });
+
+    // Reject the settings PATCH at the browser boundary. The rest of
+    // the surface (themes list, current theme, GETs against the
+    // profile) stays on the real serve so the rendering paths behave
+    // like production. Only the write path 500s.
+    await page.route(/.*\/api\/profiles\/[^/]+\/settings$/, (route) => {
+      if (route.request().method() === "PATCH") {
+        return route.fulfill({ status: 500, body: "boom" });
+      }
+      return route.continue();
+    });
+
+    await page.goto(`${serve.baseUrl}/settings/theme`);
+    await expect(page.getByRole("heading", { name: "Theme" })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const themeSelect = settingsSelectByLabel(page, "Theme");
+    await expect(themeSelect).toBeVisible({ timeout: 10_000 });
+    await expect
+      .poll(async () => themeSelect.locator("option").count(), {
+        timeout: 10_000,
+      })
+      .toBeGreaterThan(1);
+
+    // useResolvedTheme's mount-time apply runs before we pick. Wait
+    // for it to settle, then take the baseline and reset the picker
+    // counter so the assertion below targets only the pick attempt.
+    await expect
+      .poll(
+        async () =>
+          await page.evaluate(
+            () => document.documentElement.dataset.theme ?? "",
+          ),
+        { timeout: 5_000 },
+      )
+      .not.toBe("");
+    await page.evaluate(() => {
+      (window as unknown as { __pickerFired?: number }).__pickerFired = 0;
+    });
+    const datasetBefore = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const surfaceBefore = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+
+    const currentValue = await themeSelect.inputValue();
+    const optionValues = await themeSelect
+      .locator("option")
+      .evaluateAll((els) => (els as HTMLOptionElement[]).map((o) => o.value));
+    const next = optionValues.find((v) => v && v !== currentValue);
+    expect(next, "themes list must include at least two options").toBeDefined();
+
+    await themeSelect.selectOption(next!);
+
+    // Wait long enough that the PATCH round-trip would have settled.
+    // The save() awaits the PATCH; on the 500 it returns false and
+    // never dispatches the picker event. A short fixed wait is
+    // enough here since the contract is "never fires".
+    await page.waitForTimeout(600);
+
+    const picker = await page.evaluate(
+      () =>
+        (window as unknown as { __pickerFired?: number }).__pickerFired ?? 0,
+    );
+    expect(picker).toBe(0);
+
+    const datasetAfter = await page.evaluate(
+      () => document.documentElement.dataset.theme,
+    );
+    const surfaceAfter = await page.evaluate(() =>
+      document.documentElement.style
+        .getPropertyValue("--color-surface-900")
+        .trim(),
+    );
+    expect(datasetAfter).toBe(datasetBefore);
+    expect(surfaceAfter).toBe(surfaceBefore);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts
+++ b/web/tests/live/cockpit-stories/sidebar-reorder-reload-persists.spec.ts
@@ -1,0 +1,91 @@
+// User story: a sidebar drag-reorder survives a full page reload
+// (#1419). The live `workspace-ordering.spec.ts` round-trips one drag
+// and confirms `GET /api/sessions` returns the merged ordering, but
+// it does not refresh the page; a regression in the bootstrap path
+// that re-derives ordering from `created_at` instead of honoring the
+// server-supplied `workspace_ordering` would ship green there.
+//
+// This spec drags the bottom row to the top, awaits the PUT round-
+// trip, reloads the page, and asserts the new order paints from the
+// initial `GET /api/sessions` response (not after a delayed
+// client-side sort).
+
+import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions } from "../../helpers/aoeServe";
+import {
+  readVisibleSessionTitles,
+  seedSessionsInRepo,
+} from "../../helpers/sidebar";
+
+base("sidebar reorder persists across a full page reload", async ({ page }, testInfo) => {
+  const serve = await spawnAoeServe({
+    authMode: "none",
+    workerIndex: testInfo.workerIndex,
+    parallelIndex: testInfo.parallelIndex,
+    seedFn: seedSessionsInRepo({ titles: ["alpha", "beta", "gamma"] }),
+  });
+
+  try {
+    const seeded = await listSessions(serve.baseUrl);
+    expect(seeded).toHaveLength(3);
+
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto(`${serve.baseUrl}/`);
+
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 8_000 })
+      .toEqual(expect.arrayContaining(["alpha", "beta", "gamma"]));
+    const initial = await readVisibleSessionTitles(page);
+    expect(initial).toHaveLength(3);
+
+    const wrappers = page.locator(
+      "[aria-roledescription='Press and hold to reorder']",
+    );
+    await expect(wrappers).toHaveCount(3);
+
+    // Wait for the PUT so we know the server persisted before the
+    // reload. The route-attach captures it without altering response.
+    const putWait = page.waitForResponse(
+      (r) =>
+        r.url().endsWith("/api/workspace-ordering") &&
+        r.request().method() === "PUT" &&
+        r.status() < 400,
+      { timeout: 8_000 },
+    );
+
+    const sourceBox = await wrappers.nth(2).boundingBox();
+    const targetBox = await wrappers.nth(0).boundingBox();
+    if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+    await page.mouse.move(
+      sourceBox.x + sourceBox.width - 4,
+      sourceBox.y + sourceBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.waitForTimeout(250);
+    await page.mouse.move(
+      targetBox.x + targetBox.width / 2,
+      targetBox.y + targetBox.height / 2,
+      { steps: 12 },
+    );
+    await page.mouse.up();
+
+    await putWait;
+
+    const expectedAfter = [initial[2], initial[0], initial[1]];
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 4_000 })
+      .toEqual(expectedAfter);
+
+    // Reload the whole page. The new visual order must come from the
+    // initial server response, not from a delayed PUT or sort. Poll
+    // because the very first paint can briefly show the bootstrap
+    // shell before sessions land.
+    await page.reload();
+    await expect
+      .poll(() => readVisibleSessionTitles(page), { timeout: 8_000 })
+      .toEqual(expectedAfter);
+  } finally {
+    await serve.stop();
+  }
+});

--- a/web/tests/live/workspace-ordering.spec.ts
+++ b/web/tests/live/workspace-ordering.spec.ts
@@ -18,65 +18,12 @@
 // so the hold has to outlast the activation window without moving more
 // than 8px.
 
-import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
-import { join } from "node:path";
 import { test as base, expect } from "@playwright/test";
+import { spawnAoeServe, listSessions } from "../helpers/aoeServe";
 import {
-  spawnAoeServe,
-  listSessions,
-  resolveAoeBinary,
-} from "../helpers/aoeServe";
-
-function seedThreeSessionsInOneRepo(titles: [string, string, string]) {
-  return ({ home, env }: { home: string; shimBin: string; env: NodeJS.ProcessEnv }) => {
-    const binary = resolveAoeBinary();
-    const projectDir = join(home, "repo");
-    mkdirSync(projectDir, { recursive: true });
-    spawnSync("git", ["init", "-q"], { cwd: projectDir });
-    spawnSync("git", ["commit", "--allow-empty", "-q", "-m", "init"], {
-      cwd: projectDir,
-      env: {
-        ...env,
-        GIT_AUTHOR_NAME: "t",
-        GIT_AUTHOR_EMAIL: "t@t",
-        GIT_COMMITTER_NAME: "t",
-        GIT_COMMITTER_EMAIL: "t@t",
-      },
-    });
-    for (const title of titles) {
-      const res = spawnSync(
-        binary,
-        ["add", projectDir, "-t", title, "-c", "claude"],
-        { env },
-      );
-      if (res.status !== 0) {
-        throw new Error(
-          `aoe add failed for ${title}: status=${res.status} stderr=${res.stderr?.toString() ?? "<none>"}`,
-        );
-      }
-    }
-  };
-}
-
-async function readVisibleSessionTitles(page: import("@playwright/test").Page): Promise<string[]> {
-  return page.evaluate(() => {
-    const rows = Array.from(
-      document.querySelectorAll<HTMLElement>(
-        "[data-testid='sidebar-session-row']",
-      ),
-    );
-    // Scope to the label span specifically (see WorkspaceSidebar.tsx:587).
-    // A bare `[title]` selector can pick up a Wakeup or Plan chip if either
-    // ever renders on the row.
-    return rows
-      .map(
-        (r) =>
-          r.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
-      )
-      .filter(Boolean);
-  });
-}
+  readVisibleSessionTitles,
+  seedSessionsInRepo,
+} from "../helpers/sidebar";
 
 base.describe("workspace ordering live round-trip (#1220)", () => {
   base("press-and-hold drag reorders and round-trips PUT /api/workspace-ordering", async ({ page }, testInfo) => {
@@ -89,7 +36,7 @@ base.describe("workspace ordering live round-trip (#1220)", () => {
       authMode: "none",
       workerIndex: testInfo.workerIndex,
       parallelIndex: testInfo.parallelIndex,
-      seedFn: seedThreeSessionsInOneRepo(["alpha", "beta", "gamma"]),
+      seedFn: seedSessionsInRepo({ titles: ["alpha", "beta", "gamma"] }),
     });
 
     try {

--- a/web/tests/sidebar-reorder-click-after-drag-suppressed.spec.ts
+++ b/web/tests/sidebar-reorder-click-after-drag-suppressed.spec.ts
@@ -1,0 +1,56 @@
+// `useSuppressClickAfterDrag` (WorkspaceSidebar.tsx:274-290,
+// 356-371) swallows the synthetic click Chromium dispatches ~250ms
+// after `mouseup` on a drag. Without that, the dropped-on row would
+// receive a click and navigate, defeating the whole drag.
+//
+// This story drags gamma onto alpha's position and asserts that the
+// URL does NOT change to /session/s-a (alpha's id) even though the
+// click would have landed there.
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("click-after-drag suppression keeps the URL on the source row", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  // Start at "/" (no active session). The synthetic click after the
+  // drag release would try to land on alpha's row (the drop target);
+  // if the suppressor lets it through, the URL flips to /session/s-a.
+  // The contract is "URL stays at /".
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  const sourceBox = await wrappers.nth(2).boundingBox();
+  const targetBox = await wrappers.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+
+  // The drag fires one PUT. After release, the synthetic click would
+  // try to activate alpha (the row under the cursor); the suppressor
+  // swallows it so the URL stays on /.
+  await expect.poll(() => handle.puts.length, { timeout: 3_000 }).toBe(1);
+  await page.waitForTimeout(400);
+  expect(new URL(page.url()).pathname).toBe("/");
+});

--- a/web/tests/sidebar-reorder-cross-group-noop.spec.ts
+++ b/web/tests/sidebar-reorder-cross-group-noop.spec.ts
@@ -1,0 +1,73 @@
+// Drag is constrained to within one repo group: each repo's
+// `SortableContext` lives behind a separate boundary, so an `over.id`
+// that points into a different group's workspace list never matches
+// the active group's reorder logic (WorkspaceSidebar.tsx:1639-1664).
+//
+// Seeds two repos with three workspaces each, drags a row from group
+// A onto a row in group B, and asserts:
+//   - both groups' visual orders are unchanged
+//   - zero PUTs flew (handleDragEnd short-circuits at the `over.id`
+//     check, no `onReorderWorkspaces` call)
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  workspaceId,
+  type MockSessionInput,
+} from "./helpers/sidebarMocks";
+
+test("dragging a row onto a different repo group is a no-op", async ({ page }) => {
+  const repoA = "/tmp/repo-a";
+  const repoB = "/tmp/repo-b";
+  const sessions: MockSessionInput[] = [
+    { id: "a1", title: "alpha-a", project_path: repoA, branch: "feat/1" },
+    { id: "a2", title: "beta-a", project_path: repoA, branch: "feat/2" },
+    { id: "b1", title: "alpha-b", project_path: repoB, branch: "feat/1" },
+    { id: "b2", title: "beta-b", project_path: repoB, branch: "feat/2" },
+  ];
+  const handle = await installSidebarMocks(page, {
+    sessions,
+    ordering: sessions.map((s) => workspaceId(s)),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(4);
+
+  // First two wrappers belong to repo A, next two to repo B (the
+  // server-supplied ordering controls the render order). Drag the
+  // last A row onto the first B row.
+  const sourceBox = await wrappers.nth(1).boundingBox();
+  const targetBox = await wrappers.nth(2).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+  await page.mouse.up();
+
+  // Wait a frame so handleDragEnd has had a chance to fire on a
+  // regression that doesn't short-circuit cross-group.
+  await page.waitForTimeout(300);
+
+  const afterOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(afterOrder).toEqual(["alpha-a", "beta-a", "alpha-b", "beta-b"]);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-mobile-flick-scrolls.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-flick-scrolls.spec.ts
@@ -1,0 +1,77 @@
+// A fast vertical scroll-flick on the sidebar must NOT reorder a
+// row. TouchSensor `{ delay: 150, tolerance: 8 }` only promotes after
+// 150ms with movement under 8px; a flick that exceeds tolerance
+// before the delay elapses cancels the activation, so no drag starts
+// and no PUT fires (WorkspaceSidebar.tsx:1631, #1419).
+//
+// Real Playwright `page.touchscreen.tap` is single-finger and only
+// supports tap. To synthesize a multi-frame touchmove sequence we
+// dispatch raw TouchEvents from `page.evaluate`, per the AGENTS.md
+// "Legacy mobile/touch recipe".
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch flick on the sidebar does not reorder rows", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector('[data-testid="sidebar-session-row"]')
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const box = await rows.nth(0).boundingBox();
+  if (!box) throw new Error("row box missing");
+  const cx = box.x + box.width / 2;
+  const cy = box.y + box.height / 2;
+
+  // touchStart, then three quick vertical touchMoves well past the
+  // 8px tolerance, then touchEnd, all within ~60ms total wall time.
+  // The TouchSensor sees movement BEFORE the 150ms activation delay
+  // elapses and cancels activation. Driven via CDP so the events
+  // carry through to dnd-kit's document-level listeners the same way
+  // the press-hold recipe does.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: cx, y: cy, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 40, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 120, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchMove",
+    touchPoints: [{ x: cx, y: cy + 240, id: 1 }],
+  });
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+
+  await page.waitForTimeout(300);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-press-hold-reorders.spec.ts
@@ -1,0 +1,83 @@
+// A press-and-hold past the 150ms TouchSensor delay, followed by a
+// drag past 8px tolerance, DOES reorder on mobile
+// (WorkspaceSidebar.tsx:1631). Locks the activation path so the
+// mobile drag affordance does not silently break when the dnd-kit
+// dependency or its activation constraints change (#1419).
+//
+// Synthesizes TouchEvents from `page.evaluate` per the AGENTS.md
+// "Legacy mobile/touch recipe"; `page.touchscreen.tap` is single-
+// finger and does not satisfy the delay sensor cleanly.
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+  workspaceId,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch press-and-hold drag reorders the row and PUTs the new order", async ({ page }) => {
+  const sessions = threeSessionsInOneRepo();
+  const handle = await installSidebarMocks(page, { sessions });
+
+  await page.goto("/");
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector("[aria-roledescription='Press and hold to reorder']")
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const sourceBox = await wrappers.nth(2).boundingBox();
+  const targetBox = await wrappers.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+  const sx = sourceBox.x + sourceBox.width / 2;
+  const sy = sourceBox.y + sourceBox.height / 2;
+  const tx = targetBox.x + targetBox.width / 2;
+  const ty = targetBox.y + targetBox.height / 2;
+
+  // Drive real touch events through the Chrome DevTools Protocol.
+  // Playwright's `page.touchscreen` only exposes `tap`; raw
+  // `Input.dispatchTouchEvent` lets the test hold past the 150ms
+  // delay, then walk the touch across the sidebar one frame at a
+  // time so dnd-kit's TouchSensor activates and its collision
+  // detector resolves to the target row.
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchStart",
+    touchPoints: [{ x: sx, y: sy, id: 1 }],
+  });
+  await page.waitForTimeout(220);
+  const frames = 8;
+  for (let i = 1; i <= frames; i++) {
+    const t = i / frames;
+    const x = sx + (tx - sx) * t;
+    const y = sy + (ty - sy) * t;
+    await cdp.send("Input.dispatchTouchEvent", {
+      type: "touchMove",
+      touchPoints: [{ x, y, id: 1 }],
+    });
+    await page.waitForTimeout(20);
+  }
+  await cdp.send("Input.dispatchTouchEvent", {
+    type: "touchEnd",
+    touchPoints: [],
+  });
+
+  // One PUT body with gamma's id at the top of the flat order.
+  await expect.poll(() => handle.puts.length, { timeout: 4_000 }).toBe(1);
+  const sent = handle.puts[0]?.order ?? [];
+  expect(sent[0]).toBe(workspaceId(sessions[2]!));
+});

--- a/web/tests/sidebar-reorder-mobile-tap-navigates.spec.ts
+++ b/web/tests/sidebar-reorder-mobile-tap-navigates.spec.ts
@@ -1,0 +1,49 @@
+// On mobile a tap on a row must navigate, not reorder. dnd-kit's
+// TouchSensor has `{ delay: 150, tolerance: 8 }` activation
+// (WorkspaceSidebar.tsx:1631): a quick tap never crosses the 150ms
+// delay, so the sensor never promotes and the inner Link's click
+// runs as if the wrapper were not draggable (#1419).
+
+import { devices } from "@playwright/test";
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test.use({ ...devices["iPhone 13"] });
+
+test("touch tap on a row navigates", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.goto("/");
+  // On mobile the sidebar is initially closed; open it via the
+  // toggle so the rows have a visible bounding box. The dashboard
+  // exposes the toggle with accessible name "Toggle sidebar".
+  await page.getByRole("button", { name: "Toggle sidebar" }).click();
+
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  await page.waitForFunction(
+    () => {
+      const r = document
+        .querySelector('[data-testid="sidebar-session-row"]')
+        ?.getBoundingClientRect();
+      return !!r && r.x >= 0 && r.width > 0;
+    },
+    null,
+    { timeout: 5_000 },
+  );
+
+  const box = await rows.nth(1).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.touchscreen.tap(box.x + box.width / 2, box.y + box.height / 2);
+
+  await expect(page).toHaveURL(/\/session\/s-b$/, { timeout: 5_000 });
+
+  // No PUT fired; the gesture never started a drag.
+  await page.waitForTimeout(200);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-read-only.spec.ts
+++ b/web/tests/sidebar-reorder-read-only.spec.ts
@@ -1,0 +1,62 @@
+// Read-only viewers cannot drag rows: `useSortable({ disabled })` is
+// fed `dragOff = !!props.readOnly || !!props.dragDisabled`
+// (WorkspaceSidebar.tsx:389-391), `listeners` are not spread onto the
+// wrapper, and `aria-roledescription` is omitted (line 423-425). The
+// onDragEnd callback is also gated at the DndContext level
+// (line 1855). A press-and-hold attempt must produce no visual lift
+// and no PUT (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("read-only viewer cannot drag sidebar rows", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+    readOnly: true,
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  // The drag-enabled wrapper carries
+  // `aria-roledescription="Press and hold to reorder"`. In read-only
+  // mode the attribute is omitted; the row should not match at all.
+  const dragWrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect.poll(() => dragWrappers.count(), { timeout: 5_000 }).toBe(0);
+
+  // Locate the row a different way and attempt a drag anyway. If a
+  // future regression re-enables listeners on the wrapper, this
+  // gesture would surface as a PUT body or a visual ring.
+  const rows = page.getByTestId("sidebar-session-row");
+  await expect(rows).toHaveCount(3);
+  const sourceBox = await rows.nth(2).boundingBox();
+  const targetBox = await rows.nth(0).boundingBox();
+  if (!sourceBox || !targetBox) throw new Error("row box missing");
+
+  await page.mouse.move(
+    sourceBox.x + sourceBox.width - 4,
+    sourceBox.y + sourceBox.height / 2,
+  );
+  await page.mouse.down();
+  await page.waitForTimeout(250);
+  await page.mouse.move(
+    targetBox.x + targetBox.width / 2,
+    targetBox.y + targetBox.height / 2,
+    { steps: 12 },
+  );
+
+  // Visual feedback contract: no row gains the active-drag ring class.
+  // The check runs mid-gesture so a regression that wires listeners
+  // back up would still show the lift.
+  const ringedCount = await page.locator(".ring-2.ring-brand-500").count();
+  expect(ringedCount).toBe(0);
+
+  await page.mouse.up();
+  await page.waitForTimeout(300);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-stationary-click-navigates.spec.ts
+++ b/web/tests/sidebar-reorder-stationary-click-navigates.spec.ts
@@ -1,0 +1,38 @@
+// dnd-kit MouseSensor has `{ distance: 8 }` activation
+// (WorkspaceSidebar.tsx:1630). A press-and-release on a row WITHOUT
+// movement must not trigger reorder; it must navigate to the session
+// instead. Locks the desktop activation threshold from drifting
+// silently (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("stationary click on a row navigates without reordering", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  const box = await wrappers.nth(1).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.mouse.move(box.x + box.width - 4, box.y + box.height / 2);
+  await page.mouse.down();
+  await page.mouse.up();
+
+  // The Link inside SessionRow resolves to `/session/<id>`; the URL
+  // change is the user-observable contract here.
+  await expect(page).toHaveURL(/\/session\/s-b$/, { timeout: 5_000 });
+
+  await page.waitForTimeout(200);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/sidebar-reorder-tiny-drag-noop.spec.ts
+++ b/web/tests/sidebar-reorder-tiny-drag-noop.spec.ts
@@ -1,0 +1,57 @@
+// dnd-kit MouseSensor `{ distance: 8 }` rejects micro-movements
+// (WorkspaceSidebar.tsx:1630). Moving only 4px between mouse-down and
+// mouse-up must not start a drag; the order stays put and no PUT
+// flies. Locks the 8px threshold from drifting (#1419).
+
+import { test, expect } from "./helpers/mockedTest";
+import {
+  installSidebarMocks,
+  threeSessionsInOneRepo,
+} from "./helpers/sidebarMocks";
+
+test("4px movement does not start a drag", async ({ page }) => {
+  const handle = await installSidebarMocks(page, {
+    sessions: threeSessionsInOneRepo(),
+  });
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/");
+
+  const wrappers = page.locator(
+    "[aria-roledescription='Press and hold to reorder']",
+  );
+  await expect(wrappers).toHaveCount(3);
+
+  // Snapshot the visible order via the inner link text.
+  const beforeOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(beforeOrder).toEqual(["alpha", "beta", "gamma"]);
+
+  const box = await wrappers.nth(2).boundingBox();
+  if (!box) throw new Error("row box missing");
+  await page.mouse.move(box.x + box.width - 4, box.y + box.height / 2);
+  await page.mouse.down();
+  // 4px below the activation threshold; sensor should not promote.
+  await page.mouse.move(
+    box.x + box.width - 4,
+    box.y + box.height / 2 + 4,
+  );
+  await page.mouse.up();
+
+  // Give the sensor a tick; a regression that drops the threshold
+  // check would still fire onDragEnd inside this window.
+  await page.waitForTimeout(200);
+
+  const afterOrder = await wrappers.evaluateAll((els) =>
+    els.map(
+      (el) =>
+        el.querySelector("span.truncate[title]")?.getAttribute("title") ?? "",
+    ),
+  );
+  expect(afterOrder).toEqual(beforeOrder);
+  expect(handle.puts).toEqual([]);
+});

--- a/web/tests/wheel-scroll.spec.ts
+++ b/web/tests/wheel-scroll.spec.ts
@@ -90,7 +90,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     // enough headroom for CI runners under load (2s was tight enough
     // to flake on heavy parallel runs).
     await expect
-      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 5_000 })
+      .poll(() => countSeq(handle, WHEEL_DOWN_SEQ), { timeout: 10_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_UP_SEQ)).toBe(0);
   });
@@ -108,7 +108,7 @@ test.describe("Terminal mouse-wheel scroll (desktop)", () => {
     await fireWheel(page, { deltaY: -120, times: 3 });
 
     await expect
-      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 5_000 })
+      .poll(() => countSeq(handle, WHEEL_UP_SEQ), { timeout: 10_000 })
       .toBeGreaterThan(0);
     expect(countSeq(handle, WHEEL_DOWN_SEQ)).toBe(0);
   });


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Lands the missing user-story Playwright coverage flagged by two open tracker issues. Pure test additions; no production code changes.

Closes #1405
Closes #1419

**#1405 (theme switching, 4 new live specs under `web/tests/live/cockpit-stories/`):**

- `settings-theme-custom.spec.ts`: a TOML file dropped into `${appDir}/themes/` appears in the dropdown and applies its palette when picked. Locks the `discover_custom_themes` / `available_themes` path.
- `settings-theme-custom-malformed.spec.ts`: a malformed TOML in the same directory does not break the dropdown; builtins still load and apply.
- `settings-theme-color-mode.spec.ts`: changing the color_mode field PATCHes but does not dispatch `aoe:theme-picker-changed` (locks the early-return at `ThemeSettings.tsx:34` so a refactor cannot accidentally repaint the dashboard on a TUI-only setting).
- `settings-theme-failure-revert.spec.ts`: a 500 on PATCH does not silently change `dataset.theme` or fire the picker event (locks the fix that landed in #1575 / #1510, browser-side route stub against a real serve so only the write path 500s).

Plus a small `web/tests/helpers/theme.ts` with `seedCustomTheme` + a couple of read accessors so the two custom-theme specs do not duplicate the TOML body or the appDir resolution.

**#1419 (sidebar drag-reorder, 9 new specs):**

Desktop activation + suppression (5 mocked):

- `sidebar-reorder-stationary-click-navigates.spec.ts`: a press-release with no movement still navigates (locks the `{distance: 8}` MouseSensor threshold).
- `sidebar-reorder-tiny-drag-noop.spec.ts`: a 4px drag stays below the activation threshold; row order unchanged, no PUT.
- `sidebar-reorder-click-after-drag-suppressed.spec.ts`: the synthetic click after a drag release does not navigate to the dropped-on row (locks `useSuppressClickAfterDrag`).
- `sidebar-reorder-cross-group-noop.spec.ts`: dragging a row onto a different repo group is a no-op (`handleDragEnd` short-circuits at the `over.id` check).
- `sidebar-reorder-read-only.spec.ts`: read-only viewers have no drag affordance and no PUT fires (locks `useSortable({ disabled })` and the missing aria-roledescription).

Mobile (3 mocked, `devices['iPhone 13']` viewport, CDP `Input.dispatchTouchEvent`):

- `sidebar-reorder-mobile-tap-navigates.spec.ts`: a tap on a row navigates; never enters the TouchSensor's 150ms delay window.
- `sidebar-reorder-mobile-flick-scrolls.spec.ts`: a fast vertical flick cancels TouchSensor activation; no PUT.
- `sidebar-reorder-mobile-press-hold-reorders.spec.ts`: press past 150ms then drag DOES reorder. This pins the touch synthesis recipe (CDP-driven `Input.dispatchTouchEvent` instead of synthetic `TouchEvent` dispatch) as the working approach for the 150ms delay sensor, which the issue explicitly flagged as an open question for the first spec to land.

Persistence (1 live):

- `sidebar-reorder-reload-persists.spec.ts`: after a drag, a full `page.reload()` reads back the server-supplied ordering and paints it before any client-side resort.

Plus `web/tests/helpers/sidebarMocks.ts` to hoist the mocked-Playwright session / ordering / read-only setup, and a small refactor that promotes `seedSessionsInRepo` + `readVisibleSessionTitles` from `tests/live/workspace-ordering.spec.ts` to `web/tests/helpers/sidebar.ts` so the new live story spec can share them.

11 new `coverage-matrix.json` entries cover the new specs; `tests/validate-coverage-matrix.mjs` passes.

## PR Type

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI
- [x] Tests

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary (no docs changes; behavior unchanged)
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## How to test

Run from `web/`:

- [ ] `npx playwright test sidebar-reorder --config=playwright.config.ts` passes all 8 mocked sidebar story specs (stationary click, tiny drag, click-after-drag, cross-group, read-only, mobile tap, mobile flick, mobile press-hold).
- [ ] `AOE_E2E_BINARY=$(realpath ../target/debug/aoe) npx playwright test cockpit-stories/settings-theme cockpit-stories/sidebar-reorder-reload-persists --config=playwright.live.config.ts` passes all 5 live story specs (custom theme, malformed custom, color-mode dispatch contract, PATCH failure, reload persistence).
- [ ] `node tests/validate-coverage-matrix.mjs` reports `Coverage matrix validation passed.`
- [ ] Existing `workspace-ordering` live spec still passes after the helper refactor: `AOE_E2E_BINARY=$(realpath ../target/debug/aoe) npx playwright test workspace-ordering --config=playwright.live.config.ts`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**

Investigation, scoping, and spec drafting handled by Claude under my direction. I picked the subset of stories to land in this PR (chiefly: skip the cross-surface terminal/shiki repaint stories and the deep-link-under-passphrase bug story, both worth a follow-up issue if they bite), pinned the CDP touch-event recipe as the answer to the issue's open question, and reviewed every commit before pushing.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds comprehensive Playwright test coverage for two features — theme switching and sidebar drag-and-drop reordering — across both mocked and live test environments. No production code changes are made; this is purely test infrastructure.

## What Was Added

**Theme Switching Tests (4 specs)**
- Custom theme loading and dropdown verification
- Malformed theme handling (ensure broken themes don't break the UI)
- Color-mode changes without triggering UI repaints
- Failure handling (500 errors revert changes silently)

**Sidebar Reorder Tests (9 specs)**
- Desktop mocked tests: stationary clicks navigate, tiny drags are ignored, click suppression after drag, cross-group drag prevention, read-only user restrictions
- Mobile mocked tests (iPhone 13): tap navigation, flick-scroll no-op, press-and-hold reordering using CDP touch events
- Live persistence test: verify reordered sidebar persists after page reload

**Test Helpers (3 new files)**
- `web/tests/helpers/theme.ts`: TOML seeding, theme document snapshots, constants for valid/malformed themes
- `web/tests/helpers/sidebarMocks.ts`: API mocking for sidebar sessions, workspace ordering, read-only mode
- Hoisted functions in `web/tests/helpers/sidebar.ts`: session seeding, visible title reading for reuse

**Coverage Matrix**
- 11 new entries documenting the new test surfaces

## What Was Refactored

- Hoisted `seedSessionsInRepo` and `readVisibleSessionTitles` helpers from `workspace-ordering.spec.ts` into shared `sidebar.ts` for reuse by new specs
- Refactored `workspace-ordering.spec.ts` to use the shared helpers (reduced from 58 lines to more concise usage)

## What Was Improved

- Increased poll timeout in `wheel-scroll.spec.ts` from 5s to 10s to reduce CI flakiness from increased test contention

## Benefits

- **Regression Protection**: Comprehensive coverage for theme customization and sidebar interactions ensures future changes don't break these features
- **Maintainability**: Hoisted helpers reduce duplication across test files
- **Mobile Coverage**: Touch event testing (via CDP) pins down mobile-specific behaviors like flick-scroll and press-hold gestures
- **Real-world Validation**: Live tests confirm end-to-end behavior including persistence and error handling
- **Improved CI Stability**: Adjusted timeout prevents timing-related failures as test suite grows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1597?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->