### PR TITLE
fix(cockpit): stop iOS dictation duplicating dictated text in web composer

### DIFF
--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -295,6 +295,16 @@ An iPad with a Bluetooth keyboard (or any device that reports both
 the desktop Enter-to-send convention so hardware-keyboard typing
 feels natural. See #1129.
 
+### iOS Safari dictation
+
+Tapping the on-screen keyboard's mic icon to dictate into the composer
+commits each partial recognition exactly once. The composer detects
+WebKit's `insertReplacementText` burst, suspends its assistant-ui
+controlled-input flush for the duration so WebKit's dictation range
+pointer is not invalidated mid-utterance, then drains the final text
+into the composer state on blur (typically when you tap Send) or
+after a brief idle period. See #1431.
+
 ### Queued prompts (mid-turn + inactive session)
 
 The web composer keeps your messages around even when the session

--- a/web/src/components/cockpit/Composer.dictation.test.ts
+++ b/web/src/components/cockpit/Composer.dictation.test.ts
@@ -1,0 +1,119 @@
+// State-machine tests for the cockpit composer's iOS-dictation burst
+// detector added in #1431. The pure helper lets the burst matrix be
+// exercised without mounting the composer + the WebKit dictation
+// engine; the imperative wiring (refs, timers, composerRuntime.setText)
+// is in the component and exercised by the live Playwright spec.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DICTATION_BURST_TIMEOUT_MS,
+  decideDictationAction,
+  type DictationBurstState,
+} from "./Composer";
+
+const inactive: DictationBurstState = { active: false };
+
+describe("decideDictationAction (#1431)", () => {
+  it("inactive + insertReplacementText -> enter burst, suppress upstream, arm timeout", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "input",
+      inputType: "insertReplacementText",
+      nowMs: 1000,
+    });
+    expect(d.next).toEqual({ active: true, sinceMs: 1000 });
+    expect(d.suppressUpstreamChange).toBe(true);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBe(DICTATION_BURST_TIMEOUT_MS);
+  });
+
+  it("active + insertReplacementText -> stay in burst, suppress upstream, re-arm timeout", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "insertReplacementText",
+      nowMs: 1300,
+    });
+    expect(d.next).toEqual({ active: true, sinceMs: 1300 });
+    expect(d.suppressUpstreamChange).toBe(true);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBe(DICTATION_BURST_TIMEOUT_MS);
+  });
+
+  it("active + timeout -> exit burst, flush pending", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "timeout",
+      nowMs: 2300,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + blur -> exit burst, flush pending (Send tap fires blur first)", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, { kind: "blur" });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + non-replacement input -> exit burst, flush, do NOT suppress (let event through)", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "insertText",
+      nowMs: 1100,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(true);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("active + backspace -> exit burst, flush, do NOT suppress", () => {
+    const prev: DictationBurstState = { active: true, sinceMs: 1000 };
+    const d = decideDictationAction(prev, {
+      kind: "input",
+      inputType: "deleteContentBackward",
+      nowMs: 1100,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(true);
+    expect(d.suppressUpstreamChange).toBe(false);
+  });
+
+  it("inactive + regular insertText -> stay inactive, no-op", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "input",
+      inputType: "insertText",
+      nowMs: 1000,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.suppressUpstreamChange).toBe(false);
+    expect(d.flushPending).toBe(false);
+    expect(d.armTimeoutMs).toBeNull();
+  });
+
+  it("inactive + blur -> stay inactive, no flush", () => {
+    const d = decideDictationAction(inactive, { kind: "blur" });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(false);
+  });
+
+  it("inactive + timeout -> stay inactive, no flush (stale timer fired after blur)", () => {
+    const d = decideDictationAction(inactive, {
+      kind: "timeout",
+      nowMs: 5000,
+    });
+    expect(d.next).toEqual({ active: false });
+    expect(d.flushPending).toBe(false);
+  });
+
+  it("burst timeout is at least one second (must span typical breath pause)", () => {
+    expect(DICTATION_BURST_TIMEOUT_MS).toBeGreaterThanOrEqual(1000);
+  });
+});

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -95,6 +95,120 @@ export function decideBeforeInputAction(
   return "newline";
 }
 
+/** Dictation burst state for the iOS-Safari native-mic input path
+ *  (#1431). Tracks whether we are currently inside a sequence of
+ *  `inputType: "insertReplacementText"` events, so the composer can
+ *  suppress assistant-ui's controlled-input cycle during the burst
+ *  and flush the buffered text into the runtime exactly once at the
+ *  end. */
+export type DictationBurstState =
+  | { active: false }
+  | { active: true; sinceMs: number };
+
+/** Event the composer feeds into {@link decideDictationAction}. The
+ *  helper only needs the discriminator + the current monotonic clock
+ *  reading; the imperative wiring lives in the component. */
+export type DictationEvent =
+  | { kind: "input"; inputType: string; nowMs: number }
+  | { kind: "timeout"; nowMs: number }
+  | { kind: "blur" };
+
+/** Decision returned by {@link decideDictationAction}. The component
+ *  applies the actions imperatively (refs, timers, `setText`); the
+ *  helper itself is pure so the burst-state matrix can be tested
+ *  without mounting the composer + the WebKit dictation engine. */
+export interface DictationDecision {
+  /** Next burst state to commit. */
+  next: DictationBurstState;
+  /** Caller should `preventDefault()` on the React `onChange` so that
+   *  `composeEventHandlers` skips assistant-ui's `setText` flush, which
+   *  would otherwise re-render the textarea's controlled `value` prop
+   *  and invalidate WebKit's dictation range pointer. */
+  suppressUpstreamChange: boolean;
+  /** Caller should flush the buffered textarea value into
+   *  `composerRuntime.setText` before clearing the burst. Set only on
+   *  the transition from `active` to inactive. */
+  flushPending: boolean;
+  /** Caller should (re)arm the burst timeout for this many ms from
+   *  now. Set only when entering or extending a burst. */
+  armTimeoutMs: number | null;
+}
+
+/** Window (ms) after the last `insertReplacementText` event before we
+ *  consider an iOS dictation burst finished and flush the buffered
+ *  text into assistant-ui state. Long enough to span a breath pause
+ *  between phrases in continuous dictation, short enough that the
+ *  user does not perceive lag between releasing the mic and the
+ *  composer state catching up. */
+export const DICTATION_BURST_TIMEOUT_MS = 1200;
+
+/** Pure decision helper for the iOS-dictation burst state machine
+ *  (#1431). The composer mirrors this state in refs and applies the
+ *  returned actions; tests exercise the matrix directly. */
+export function decideDictationAction(
+  prev: DictationBurstState,
+  ev: DictationEvent,
+): DictationDecision {
+  if (ev.kind === "blur") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  if (ev.kind === "timeout") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  // ev.kind === "input"
+  if (ev.inputType === "insertReplacementText") {
+    return {
+      next: { active: true, sinceMs: ev.nowMs },
+      suppressUpstreamChange: true,
+      flushPending: false,
+      armTimeoutMs: DICTATION_BURST_TIMEOUT_MS,
+    };
+  }
+  if (prev.active) {
+    // Non-replacement input while a burst is active: user typed a
+    // character, hit backspace, etc. End the burst, flush, and let
+    // this event flow through to assistant-ui normally.
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  return {
+    next: { active: false },
+    suppressUpstreamChange: false,
+    flushPending: false,
+    armTimeoutMs: null,
+  };
+}
+
 /** Wrapper class + inline style for the composer's outer <div>. When the
  *  soft keyboard is open we drop the bottom padding and apply a negative
  *  bottom margin equal to the App root's safe-area-inset-bottom so the
@@ -294,6 +408,47 @@ export function Composer({
   );
 
   const composerRuntime = useComposerRuntime();
+
+  // iOS Safari native dictation (#1431): WebKit fires `beforeinput`
+  // with `inputType: "insertReplacementText"` per partial recognition
+  // and tracks a private NSAttributedString range pointer into the
+  // textarea's text storage. Any JS write to `textarea.value` via the
+  // property setter invalidates that pointer, after which the next
+  // partial appends instead of replacing. assistant-ui's
+  // `ComposerPrimitive.Input` is fully controlled and re-renders on
+  // every `setText` (`@assistant-ui/react/.../ComposerInput.js`
+  // onChange runs `flushResourcesSync(() => setText(...))`), so the
+  // controlled-value reconciler re-writes the DOM value on every
+  // partial and dictation duplicates.
+  //
+  // Fix: detect the burst via `insertReplacementText`, suppress
+  // assistant-ui's onChange via `preventDefault` (radix's
+  // `composeEventHandlers` honours `event.defaultPrevented`), buffer
+  // the textarea value, and flush the buffer into `setText` once when
+  // the burst ends (timeout, blur, or non-replacement input).
+  const dictationStateRef = useRef<DictationBurstState>({ active: false });
+  const dictationBufferRef = useRef<string | null>(null);
+  const dictationTimerRef = useRef<number | null>(null);
+  const flushDictation = () => {
+    const buffered = dictationBufferRef.current;
+    dictationStateRef.current = { active: false };
+    dictationBufferRef.current = null;
+    if (dictationTimerRef.current !== null) {
+      window.clearTimeout(dictationTimerRef.current);
+      dictationTimerRef.current = null;
+    }
+    if (buffered !== null) {
+      composerRuntime.setText(buffered);
+    }
+  };
+  useEffect(() => {
+    return () => {
+      if (dictationTimerRef.current !== null) {
+        window.clearTimeout(dictationTimerRef.current);
+        dictationTimerRef.current = null;
+      }
+    };
+  }, []);
 
   // Context-primer prefill: when the parent passes a `primerPrefill`
   // payload (after the user clicked "Resume with prior context" on the
@@ -505,15 +660,64 @@ export function Composer({
                 // let the keydown matrix handle the platforms that do
                 // fire a real Enter keydown. See #1174.
                 const ne = e.nativeEvent as InputEvent;
-                const action = decideBeforeInputAction(
+                const newlineAction = decideBeforeInputAction(
                   ne.inputType,
                   ne.isComposing,
                   { isMobile },
                 );
-                if (action === "default") return;
-                e.preventDefault();
-                e.stopPropagation();
-                insertNewlineAtCaret(taRef);
+                if (newlineAction === "newline") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  insertNewlineAtCaret(taRef);
+                  return;
+                }
+                // iOS native dictation burst detection (#1431). Driven
+                // from `beforeinput` rather than `input` so the burst
+                // flag is set before assistant-ui's onChange (composed
+                // by radix) gets a chance to run and call `setText`.
+                const decision = decideDictationAction(
+                  dictationStateRef.current,
+                  { kind: "input", inputType: ne.inputType, nowMs: Date.now() },
+                );
+                if (decision.flushPending) {
+                  flushDictation();
+                }
+                dictationStateRef.current = decision.next;
+                if (decision.armTimeoutMs !== null) {
+                  if (dictationTimerRef.current !== null) {
+                    window.clearTimeout(dictationTimerRef.current);
+                  }
+                  dictationTimerRef.current = window.setTimeout(
+                    flushDictation,
+                    decision.armTimeoutMs,
+                  );
+                }
+              }}
+              onChange={(e) => {
+                // Suppress assistant-ui's controlled-input flush while
+                // an iOS dictation burst is active (#1431). Radix's
+                // `composeEventHandlers` (used by ComposerPrimitive.Input)
+                // skips the downstream handler when `defaultPrevented`
+                // is set on the SyntheticEvent. The buffered text is
+                // drained into `composerRuntime.setText` when the burst
+                // ends (timeout, blur, or non-replacement input).
+                if (dictationStateRef.current.active) {
+                  dictationBufferRef.current = e.currentTarget.value;
+                  e.preventDefault();
+                }
+              }}
+              onBlur={() => {
+                // Tapping Send (or anywhere outside the textarea) blurs
+                // the iOS soft-keyboard-owned field; flush the dictation
+                // buffer first so the pending text lands in
+                // assistant-ui state before the Send click reads it.
+                const decision = decideDictationAction(
+                  dictationStateRef.current,
+                  { kind: "blur" },
+                );
+                if (decision.flushPending) {
+                  flushDictation();
+                }
               }}
               onKeyDown={(e) => {
                 // Three-way Enter dispatch. See decideEnterAction for

--- a/web/src/components/cockpit/Composer.tsx
+++ b/web/src/components/cockpit/Composer.tsx
@@ -32,6 +32,15 @@ import type { CockpitState } from "../../lib/cockpitTypes";
 import { getDraft, setDraft } from "../../lib/cockpitDrafts";
 import { useMobileKeyboard } from "../../hooks/useMobileKeyboard";
 import { useAgentProfile } from "../../lib/agentProfileContext";
+import { useDictationBurstGuard } from "./useDictationBurstGuard";
+
+export {
+  DICTATION_BURST_TIMEOUT_MS,
+  decideDictationAction,
+  type DictationBurstState,
+  type DictationDecision,
+  type DictationEvent,
+} from "./useDictationBurstGuard";
 
 /** Decision returned by {@link decideEnterAction} for an Enter
  *  keystroke on the cockpit composer textarea.
@@ -93,120 +102,6 @@ export function decideBeforeInputAction(
     return "default";
   }
   return "newline";
-}
-
-/** Dictation burst state for the iOS-Safari native-mic input path
- *  (#1431). Tracks whether we are currently inside a sequence of
- *  `inputType: "insertReplacementText"` events, so the composer can
- *  suppress assistant-ui's controlled-input cycle during the burst
- *  and flush the buffered text into the runtime exactly once at the
- *  end. */
-export type DictationBurstState =
-  | { active: false }
-  | { active: true; sinceMs: number };
-
-/** Event the composer feeds into {@link decideDictationAction}. The
- *  helper only needs the discriminator + the current monotonic clock
- *  reading; the imperative wiring lives in the component. */
-export type DictationEvent =
-  | { kind: "input"; inputType: string; nowMs: number }
-  | { kind: "timeout"; nowMs: number }
-  | { kind: "blur" };
-
-/** Decision returned by {@link decideDictationAction}. The component
- *  applies the actions imperatively (refs, timers, `setText`); the
- *  helper itself is pure so the burst-state matrix can be tested
- *  without mounting the composer + the WebKit dictation engine. */
-export interface DictationDecision {
-  /** Next burst state to commit. */
-  next: DictationBurstState;
-  /** Caller should `preventDefault()` on the React `onChange` so that
-   *  `composeEventHandlers` skips assistant-ui's `setText` flush, which
-   *  would otherwise re-render the textarea's controlled `value` prop
-   *  and invalidate WebKit's dictation range pointer. */
-  suppressUpstreamChange: boolean;
-  /** Caller should flush the buffered textarea value into
-   *  `composerRuntime.setText` before clearing the burst. Set only on
-   *  the transition from `active` to inactive. */
-  flushPending: boolean;
-  /** Caller should (re)arm the burst timeout for this many ms from
-   *  now. Set only when entering or extending a burst. */
-  armTimeoutMs: number | null;
-}
-
-/** Window (ms) after the last `insertReplacementText` event before we
- *  consider an iOS dictation burst finished and flush the buffered
- *  text into assistant-ui state. Long enough to span a breath pause
- *  between phrases in continuous dictation, short enough that the
- *  user does not perceive lag between releasing the mic and the
- *  composer state catching up. */
-export const DICTATION_BURST_TIMEOUT_MS = 1200;
-
-/** Pure decision helper for the iOS-dictation burst state machine
- *  (#1431). The composer mirrors this state in refs and applies the
- *  returned actions; tests exercise the matrix directly. */
-export function decideDictationAction(
-  prev: DictationBurstState,
-  ev: DictationEvent,
-): DictationDecision {
-  if (ev.kind === "blur") {
-    if (!prev.active) {
-      return {
-        next: { active: false },
-        suppressUpstreamChange: false,
-        flushPending: false,
-        armTimeoutMs: null,
-      };
-    }
-    return {
-      next: { active: false },
-      suppressUpstreamChange: false,
-      flushPending: true,
-      armTimeoutMs: null,
-    };
-  }
-  if (ev.kind === "timeout") {
-    if (!prev.active) {
-      return {
-        next: { active: false },
-        suppressUpstreamChange: false,
-        flushPending: false,
-        armTimeoutMs: null,
-      };
-    }
-    return {
-      next: { active: false },
-      suppressUpstreamChange: false,
-      flushPending: true,
-      armTimeoutMs: null,
-    };
-  }
-  // ev.kind === "input"
-  if (ev.inputType === "insertReplacementText") {
-    return {
-      next: { active: true, sinceMs: ev.nowMs },
-      suppressUpstreamChange: true,
-      flushPending: false,
-      armTimeoutMs: DICTATION_BURST_TIMEOUT_MS,
-    };
-  }
-  if (prev.active) {
-    // Non-replacement input while a burst is active: user typed a
-    // character, hit backspace, etc. End the burst, flush, and let
-    // this event flow through to assistant-ui normally.
-    return {
-      next: { active: false },
-      suppressUpstreamChange: false,
-      flushPending: true,
-      armTimeoutMs: null,
-    };
-  }
-  return {
-    next: { active: false },
-    suppressUpstreamChange: false,
-    flushPending: false,
-    armTimeoutMs: null,
-  };
 }
 
 /** Wrapper class + inline style for the composer's outer <div>. When the
@@ -409,46 +304,16 @@ export function Composer({
 
   const composerRuntime = useComposerRuntime();
 
-  // iOS Safari native dictation (#1431): WebKit fires `beforeinput`
-  // with `inputType: "insertReplacementText"` per partial recognition
-  // and tracks a private NSAttributedString range pointer into the
-  // textarea's text storage. Any JS write to `textarea.value` via the
-  // property setter invalidates that pointer, after which the next
-  // partial appends instead of replacing. assistant-ui's
-  // `ComposerPrimitive.Input` is fully controlled and re-renders on
-  // every `setText` (`@assistant-ui/react/.../ComposerInput.js`
-  // onChange runs `flushResourcesSync(() => setText(...))`), so the
-  // controlled-value reconciler re-writes the DOM value on every
-  // partial and dictation duplicates.
-  //
-  // Fix: detect the burst via `insertReplacementText`, suppress
-  // assistant-ui's onChange via `preventDefault` (radix's
-  // `composeEventHandlers` honours `event.defaultPrevented`), buffer
-  // the textarea value, and flush the buffer into `setText` once when
-  // the burst ends (timeout, blur, or non-replacement input).
-  const dictationStateRef = useRef<DictationBurstState>({ active: false });
-  const dictationBufferRef = useRef<string | null>(null);
-  const dictationTimerRef = useRef<number | null>(null);
-  const flushDictation = () => {
-    const buffered = dictationBufferRef.current;
-    dictationStateRef.current = { active: false };
-    dictationBufferRef.current = null;
-    if (dictationTimerRef.current !== null) {
-      window.clearTimeout(dictationTimerRef.current);
-      dictationTimerRef.current = null;
-    }
-    if (buffered !== null) {
-      composerRuntime.setText(buffered);
-    }
-  };
-  useEffect(() => {
-    return () => {
-      if (dictationTimerRef.current !== null) {
-        window.clearTimeout(dictationTimerRef.current);
-        dictationTimerRef.current = null;
-      }
-    };
-  }, []);
+  // iOS Safari native dictation (#1431): WebKit fires `beforeinput` /
+  // `input` with `inputType: "insertReplacementText"` per partial
+  // recognition and tracks a private range pointer into the textarea
+  // that is invalidated by any controlled-value re-render. The guard
+  // suspends assistant-ui's `setText` flush for the burst, buffers the
+  // textarea value, and drains it back into the runtime once the burst
+  // ends (1200 ms timeout, blur, or non-replacement input).
+  const dictationGuard = useDictationBurstGuard((text) => {
+    composerRuntime.setText(text);
+  });
 
   // Context-primer prefill: when the parent passes a `primerPrefill`
   // payload (after the user clicked "Resume with prior context" on the
@@ -675,34 +540,15 @@ export function Composer({
                 // from `beforeinput` rather than `input` so the burst
                 // flag is set before assistant-ui's onChange (composed
                 // by radix) gets a chance to run and call `setText`.
-                const decision = decideDictationAction(
-                  dictationStateRef.current,
-                  { kind: "input", inputType: ne.inputType, nowMs: Date.now() },
-                );
-                if (decision.flushPending) {
-                  flushDictation();
-                }
-                dictationStateRef.current = decision.next;
-                if (decision.armTimeoutMs !== null) {
-                  if (dictationTimerRef.current !== null) {
-                    window.clearTimeout(dictationTimerRef.current);
-                  }
-                  dictationTimerRef.current = window.setTimeout(
-                    flushDictation,
-                    decision.armTimeoutMs,
-                  );
-                }
+                dictationGuard.observeInputType(ne.inputType, Date.now());
               }}
               onChange={(e) => {
                 // Suppress assistant-ui's controlled-input flush while
                 // an iOS dictation burst is active (#1431). Radix's
                 // `composeEventHandlers` (used by ComposerPrimitive.Input)
                 // skips the downstream handler when `defaultPrevented`
-                // is set on the SyntheticEvent. The buffered text is
-                // drained into `composerRuntime.setText` when the burst
-                // ends (timeout, blur, or non-replacement input).
-                if (dictationStateRef.current.active) {
-                  dictationBufferRef.current = e.currentTarget.value;
+                // is set on the SyntheticEvent.
+                if (dictationGuard.shouldSuppressUpstream(e.currentTarget.value)) {
                   e.preventDefault();
                 }
               }}
@@ -711,13 +557,7 @@ export function Composer({
                 // the iOS soft-keyboard-owned field; flush the dictation
                 // buffer first so the pending text lands in
                 // assistant-ui state before the Send click reads it.
-                const decision = decideDictationAction(
-                  dictationStateRef.current,
-                  { kind: "blur" },
-                );
-                if (decision.flushPending) {
-                  flushDictation();
-                }
+                dictationGuard.flushOnBlur();
               }}
               onKeyDown={(e) => {
                 // Three-way Enter dispatch. See decideEnterAction for

--- a/web/src/components/cockpit/useDictationBurstGuard.test.ts
+++ b/web/src/components/cockpit/useDictationBurstGuard.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+//
+// Imperative-side tests for useDictationBurstGuard, the iOS-Safari
+// dictation glue extracted from Composer.tsx (#1431). The pure
+// decideDictationAction matrix is covered separately by
+// Composer.dictation.test.ts; this file covers the hook wiring (refs,
+// burst timer, setText sink, unmount cleanup) without mounting the
+// whole composer + assistant-ui runtime.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import {
+  DICTATION_BURST_TIMEOUT_MS,
+  useDictationBurstGuard,
+} from "./useDictationBurstGuard";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+function renderGuard() {
+  const setText = vi.fn<(s: string) => void>();
+  const { result, unmount, rerender } = renderHook(() =>
+    useDictationBurstGuard(setText),
+  );
+  return { setText, result, unmount, rerender };
+}
+
+describe("useDictationBurstGuard (#1431)", () => {
+  it("non-replacement input outside a burst is a no-op", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("hello")).toBe(false);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("insertReplacementText enters a burst and suppresses upstream change", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("open the")).toBe(true);
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("buffers the latest textarea value across consecutive replacements", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    expect(result.current.shouldSuppressUpstream("open")).toBe(true);
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1100);
+    });
+    expect(result.current.shouldSuppressUpstream("open the")).toBe(true);
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1300);
+    });
+    expect(result.current.shouldSuppressUpstream("open the diff viewer")).toBe(
+      true,
+    );
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("flushes the buffered text into setText after the burst timeout fires", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("open the diff viewer");
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+    expect(setText).toHaveBeenCalledWith("open the diff viewer");
+    expect(result.current.shouldSuppressUpstream("any")).toBe(false);
+  });
+
+  it("re-arms the burst timer on each replacement so a long utterance does not flush mid-stream", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("open");
+    // Half-window passes, then another partial fires; the original
+    // timer must be cancelled and replaced.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS - 100);
+    });
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 2000);
+    });
+    result.current.shouldSuppressUpstream("open the");
+    // Original 1200 ms window has now elapsed since the first event,
+    // but the second event reset it; nothing should have flushed yet.
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(setText).not.toHaveBeenCalled();
+    // Once a full window passes since the second event, the flush fires.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("open the");
+  });
+
+  it("blur during an active burst flushes the buffer and clears the timer", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    act(() => {
+      result.current.flushOnBlur();
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello");
+    // The timer should be cleared by the flush; advancing past it must
+    // not double-fire setText.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 100);
+    });
+    expect(setText).toHaveBeenCalledTimes(1);
+  });
+
+  it("blur outside a burst is a no-op", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.flushOnBlur();
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("non-replacement input during a burst flushes, exits the burst, and stops suppressing", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    act(() => {
+      result.current.observeInputType("insertText", 1500);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello");
+    expect(result.current.shouldSuppressUpstream("hello!")).toBe(false);
+  });
+
+  it("does not call setText when the burst ends with an empty buffer (no shouldSuppressUpstream call between burst start and end)", () => {
+    const { setText, result } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    // Never captured a textarea value via shouldSuppressUpstream; the
+    // buffer ref stays null and the flush path skips setText.
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("unmount clears any armed timer to avoid a setText on an unmounted parent", () => {
+    const { setText, result, unmount } = renderGuard();
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    unmount();
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 100);
+    });
+    expect(setText).not.toHaveBeenCalled();
+  });
+
+  it("re-rendering the hook with the same setText reuses the burst state (refs survive re-render)", () => {
+    let calls = 0;
+    const setText = vi.fn<(s: string) => void>(() => {
+      calls += 1;
+    });
+    const { result, rerender } = renderHook(() =>
+      useDictationBurstGuard(setText),
+    );
+    act(() => {
+      result.current.observeInputType("insertReplacementText", 1000);
+    });
+    result.current.shouldSuppressUpstream("hello");
+    rerender();
+    // After the rerender the same burst is still active.
+    expect(result.current.shouldSuppressUpstream("hello world")).toBe(true);
+    act(() => {
+      vi.advanceTimersByTime(DICTATION_BURST_TIMEOUT_MS + 5);
+    });
+    expect(setText).toHaveBeenCalledExactlyOnceWith("hello world");
+    expect(calls).toBe(1);
+  });
+});

--- a/web/src/components/cockpit/useDictationBurstGuard.ts
+++ b/web/src/components/cockpit/useDictationBurstGuard.ts
@@ -1,0 +1,219 @@
+// Hook + pure state machine for the iOS-Safari native-mic dictation
+// path on the cockpit composer (#1431).
+//
+// WebKit fires `beforeinput` / `input` with `inputType:
+// "insertReplacementText"` per partial recognition. It tracks a
+// private NSAttributedString range pointer into the textarea's text
+// storage so the next partial replaces the prior one; any JS write to
+// `textarea.value` via the property setter invalidates that pointer,
+// after which the next partial appends instead of replacing.
+// assistant-ui's `ComposerPrimitive.Input` is fully controlled and
+// re-renders on every `setText`, so without this guard the
+// controlled-value reconciler re-writes the DOM value on every partial
+// and dictation duplicates.
+//
+// The guard detects the burst via the `insertReplacementText`
+// inputType, suspends the assistant-ui flush for its duration, buffers
+// the textarea value in a ref, and drains the buffer into `setText`
+// once when the burst ends (1200 ms timeout, blur, or non-replacement
+// input event).
+
+import { useEffect, useRef } from "react";
+
+/** Dictation burst state for the iOS-Safari native-mic input path
+ *  (#1431). Tracks whether we are currently inside a sequence of
+ *  `inputType: "insertReplacementText"` events. */
+export type DictationBurstState =
+  | { active: false }
+  | { active: true; sinceMs: number };
+
+/** Event the composer feeds into {@link decideDictationAction}. The
+ *  helper only needs the discriminator + the current monotonic clock
+ *  reading; the imperative wiring lives in the hook below. */
+export type DictationEvent =
+  | { kind: "input"; inputType: string; nowMs: number }
+  | { kind: "timeout"; nowMs: number }
+  | { kind: "blur" };
+
+/** Decision returned by {@link decideDictationAction}. The hook
+ *  applies the actions imperatively (refs, timers, `setText`); the
+ *  helper itself is pure so the burst-state matrix can be tested
+ *  without mounting the composer + the WebKit dictation engine. */
+export interface DictationDecision {
+  /** Next burst state to commit. */
+  next: DictationBurstState;
+  /** Caller should `preventDefault()` on the React `onChange` so that
+   *  radix's `composeEventHandlers` skips assistant-ui's downstream
+   *  `setText` flush, which would otherwise re-render the textarea's
+   *  controlled `value` prop and invalidate WebKit's dictation range
+   *  pointer. */
+  suppressUpstreamChange: boolean;
+  /** Caller should flush the buffered textarea value into `setText`
+   *  before clearing the burst. Set only on the transition from
+   *  `active` to inactive. */
+  flushPending: boolean;
+  /** Caller should (re)arm the burst timeout for this many ms from
+   *  now. Set only when entering or extending a burst. */
+  armTimeoutMs: number | null;
+}
+
+/** Window (ms) after the last `insertReplacementText` event before we
+ *  consider an iOS dictation burst finished and flush the buffered
+ *  text into assistant-ui state. Long enough to span a breath pause
+ *  between phrases in continuous dictation, short enough that the
+ *  user does not perceive lag between releasing the mic and the
+ *  composer state catching up. */
+export const DICTATION_BURST_TIMEOUT_MS = 1200;
+
+/** Pure decision helper for the iOS-dictation burst state machine
+ *  (#1431). The hook below mirrors this state in refs and applies the
+ *  returned actions; tests exercise the matrix directly. */
+export function decideDictationAction(
+  prev: DictationBurstState,
+  ev: DictationEvent,
+): DictationDecision {
+  if (ev.kind === "blur") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  if (ev.kind === "timeout") {
+    if (!prev.active) {
+      return {
+        next: { active: false },
+        suppressUpstreamChange: false,
+        flushPending: false,
+        armTimeoutMs: null,
+      };
+    }
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  if (ev.inputType === "insertReplacementText") {
+    return {
+      next: { active: true, sinceMs: ev.nowMs },
+      suppressUpstreamChange: true,
+      flushPending: false,
+      armTimeoutMs: DICTATION_BURST_TIMEOUT_MS,
+    };
+  }
+  if (prev.active) {
+    return {
+      next: { active: false },
+      suppressUpstreamChange: false,
+      flushPending: true,
+      armTimeoutMs: null,
+    };
+  }
+  return {
+    next: { active: false },
+    suppressUpstreamChange: false,
+    flushPending: false,
+    armTimeoutMs: null,
+  };
+}
+
+/** Imperative side of the dictation-burst guard. The component calls
+ *  the returned handlers from `onBeforeInput`, `onChange`, and
+ *  `onBlur`; the hook owns the burst state ref, the buffered text
+ *  ref, and the burst-timeout timer. */
+export interface DictationGuard {
+  /** Call from `onBeforeInput` with the native input event's
+   *  `inputType` and the current clock reading. Updates the burst
+   *  state, (re)arms or clears the burst timer, and flushes the
+   *  buffered text into `setText` if the burst is ending due to a
+   *  non-replacement input event. */
+  observeInputType: (inputType: string, nowMs: number) => void;
+  /** Call from `onChange` with the latest textarea value. Returns
+   *  `true` when the caller should `preventDefault()` on the
+   *  SyntheticEvent so that radix's `composeEventHandlers` skips the
+   *  downstream assistant-ui flush. */
+  shouldSuppressUpstream: (value: string) => boolean;
+  /** Call from `onBlur`. Flushes any pending burst into `setText`
+   *  before the focus shift can reach a Send-button click handler
+   *  that reads `composerRuntime.getState().text`. */
+  flushOnBlur: () => void;
+}
+
+/** Builds a {@link DictationGuard} bound to a single `setText` sink.
+ *  The hook owns three refs (state, buffered text, timer handle) and
+ *  one cleanup effect that clears the timer on unmount. */
+export function useDictationBurstGuard(
+  setText: (text: string) => void,
+): DictationGuard {
+  const stateRef = useRef<DictationBurstState>({ active: false });
+  const bufferRef = useRef<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const flush = () => {
+    const buffered = bufferRef.current;
+    stateRef.current = { active: false };
+    bufferRef.current = null;
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+    if (buffered !== null) {
+      setText(buffered);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  return {
+    observeInputType(inputType, nowMs) {
+      const decision = decideDictationAction(stateRef.current, {
+        kind: "input",
+        inputType,
+        nowMs,
+      });
+      if (decision.flushPending) {
+        flush();
+      }
+      stateRef.current = decision.next;
+      if (decision.armTimeoutMs !== null) {
+        if (timerRef.current !== null) {
+          window.clearTimeout(timerRef.current);
+        }
+        timerRef.current = window.setTimeout(flush, decision.armTimeoutMs);
+      }
+    },
+    shouldSuppressUpstream(value) {
+      if (stateRef.current.active) {
+        bufferRef.current = value;
+        return true;
+      }
+      return false;
+    },
+    flushOnBlur() {
+      const decision = decideDictationAction(stateRef.current, {
+        kind: "blur",
+      });
+      if (decision.flushPending) {
+        flush();
+      }
+    },
+  };
+}

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1704,6 +1704,28 @@
       ]
     },
     {
+      "id": "cockpit.story.composer-ios-dictation",
+      "kind": "live-playwright",
+      "risk": "medium",
+      "specs": [
+        "tests/live/cockpit-stories/composer-ios-dictation.spec.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
+      "id": "cockpit.composer-ios-dictation-state-machine",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/components/cockpit/Composer.dictation.test.ts"
+      ],
+      "components": [
+        "web/src/components/cockpit/Composer.tsx"
+      ]
+    },
+    {
       "id": "cockpit.story.composer-streamed-response",
       "kind": "live-playwright",
       "risk": "high",

--- a/web/tests/live/cockpit-stories/composer-ios-dictation.spec.ts
+++ b/web/tests/live/cockpit-stories/composer-ios-dictation.spec.ts
@@ -1,0 +1,222 @@
+// User story: iOS Safari native dictation into the cockpit composer
+// commits each partial recognition exactly once instead of re-appending
+// the prior partial on every event (#1431).
+//
+// The bug shape on real iOS: WebKit fires `beforeinput` + `input` with
+// `inputType: "insertReplacementText"` per partial. WebKit tracks a
+// private range pointer into the textarea's text storage, and any JS
+// write to `textarea.value` via the property setter invalidates that
+// pointer, so the next partial appends instead of replacing. The fix
+// detects the burst, suppresses assistant-ui's controlled-input flush
+// for the duration, buffers the textarea value, and drains the buffer
+// into `composerRuntime.setText` once at burst end (timeout, blur, or
+// a non-replacement input event).
+//
+// Chromium does not reproduce the WebKit pointer-reset itself, so this
+// spec exercises the new code path end-to-end and asserts the
+// observable invariants:
+//   - During the burst, assistant-ui state stays frozen (the localStorage
+//     draft, which mirrors composerRuntime state with a 250 ms debounce,
+//     does NOT update per replacement event).
+//   - After blur, the buffered text flushes into composerRuntime state,
+//     and the draft picks up the final dictated phrase exactly once.
+//   - The textarea still displays the final phrase exactly once with no
+//     duplication artifacts.
+
+import { test as base, expect } from "@playwright/test";
+import {
+  spawnAoeServe,
+  listSessions,
+  seedSessionViaAoeAdd,
+} from "../../helpers/aoeServe";
+import { waitForCockpitView, enableCockpitAndWait } from "../../helpers/cockpit";
+
+base(
+  "iOS dictation commits each partial exactly once, syncs on blur",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-ios-dictation" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find((s) => s.title === "story-ios-dictation");
+      if (!seeded) throw new Error("seeded session 'story-ios-dictation' missing");
+      const sessionId = seeded.id;
+
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+      await expect(composer).toBeFocused();
+
+      // Simulate the WebKit dictation emission shape. Each partial:
+      //   1. dispatch a cancelable `beforeinput` with
+      //      `inputType: "insertReplacementText"` so the composer's
+      //      `onBeforeInput` flips the burst flag.
+      //   2. set `textarea.value` via the native property setter, the
+      //      way WebKit would after the replacement is committed.
+      //   3. dispatch a non-cancelable `input` with the same inputType
+      //      so React's `onChange` runs and the composer's interceptor
+      //      can preventDefault on the composed assistant-ui handler.
+      const partials = [
+        "open",
+        "open the",
+        "open the diff",
+        "open the diff viewer",
+      ];
+      for (const partial of partials) {
+        await composer.evaluate((el, text) => {
+          const ta = el as HTMLTextAreaElement;
+          const beforeEvent = new InputEvent("beforeinput", {
+            bubbles: true,
+            cancelable: true,
+            inputType: "insertReplacementText",
+            data: text,
+          });
+          ta.dispatchEvent(beforeEvent);
+          const setter = Object.getOwnPropertyDescriptor(
+            HTMLTextAreaElement.prototype,
+            "value",
+          )?.set;
+          setter?.call(ta, text);
+          const inputEvent = new InputEvent("input", {
+            bubbles: true,
+            cancelable: false,
+            inputType: "insertReplacementText",
+            data: text,
+          });
+          ta.dispatchEvent(inputEvent);
+        }, partial);
+      }
+
+      // While the burst is active the composer should be holding the
+      // latest textarea value in its ref, NOT pushing it through
+      // composerRuntime. The localStorage draft mirrors composerRuntime
+      // state, so it should still be empty (or null) immediately after
+      // the burst events.
+      const draftKey = `cockpit:draft:${sessionId}`;
+      const draftMid = await page.evaluate(
+        (k) => localStorage.getItem(k),
+        draftKey,
+      );
+      expect(draftMid ?? "").toBe("");
+
+      // Textarea displays the final dictated phrase exactly once, no
+      // duplication artifacts from the simulated replacement chain.
+      await expect(composer).toHaveValue("open the diff viewer");
+
+      // Blur flushes the buffer into composerRuntime. The draft
+      // subscriber then writes the final phrase to localStorage on its
+      // 250 ms debounce.
+      await composer.blur();
+
+      await expect
+        .poll(
+          async () =>
+            await page.evaluate((k) => localStorage.getItem(k), draftKey),
+          { timeout: 5_000 },
+        )
+        .toBe("open the diff viewer");
+
+      await expect(composer).toHaveValue("open the diff viewer");
+    } finally {
+      await serve.stop();
+    }
+  },
+);
+
+base(
+  "regular typing after dictation is unaffected",
+  async ({ page }, testInfo) => {
+    const serve = await spawnAoeServe({
+      authMode: "none",
+      cockpit: true,
+      workerIndex: testInfo.workerIndex,
+      parallelIndex: testInfo.parallelIndex,
+      seedFn: seedSessionViaAoeAdd({ title: "story-ios-dictation-then-type" }),
+    });
+
+    try {
+      const sessions = await listSessions(serve.baseUrl);
+      const seeded = sessions.find(
+        (s) => s.title === "story-ios-dictation-then-type",
+      );
+      if (!seeded)
+        throw new Error("seeded session 'story-ios-dictation-then-type' missing");
+      const sessionId = seeded.id;
+
+      await enableCockpitAndWait(serve.baseUrl, sessionId);
+
+      await page.goto(`${serve.baseUrl}/session/${encodeURIComponent(sessionId)}`);
+      await waitForCockpitView(page);
+
+      const composer = page.getByRole("textbox", { name: /Send a message/i });
+      await composer.click();
+
+      // One dictation burst, then a real keystroke. The keystroke fires
+      // `beforeinput` + `input` with `inputType: "insertText"`, which
+      // should end the burst and let the keystroke flow normally to
+      // assistant-ui state. The final composer state must include both
+      // the dictated text and the appended keystroke text.
+      await composer.evaluate((el) => {
+        const ta = el as HTMLTextAreaElement;
+        ta.dispatchEvent(
+          new InputEvent("beforeinput", {
+            bubbles: true,
+            cancelable: true,
+            inputType: "insertReplacementText",
+            data: "hello",
+          }),
+        );
+        const setter = Object.getOwnPropertyDescriptor(
+          HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(ta, "hello");
+        ta.dispatchEvent(
+          new InputEvent("input", {
+            bubbles: true,
+            cancelable: false,
+            inputType: "insertReplacementText",
+            data: "hello",
+          }),
+        );
+      });
+
+      // Place the caret at end so the appended keystroke lands after
+      // the dictated text, mirroring what a real user would do.
+      await composer.evaluate((el) => {
+        const ta = el as HTMLTextAreaElement;
+        ta.setSelectionRange(ta.value.length, ta.value.length);
+      });
+
+      // Type a single character via Playwright; this simulates a real
+      // keyboard keystroke and exercises the burst-end-on-non-replacement
+      // branch of the state machine.
+      await composer.pressSequentially("!");
+
+      await expect(composer).toHaveValue("hello!");
+
+      await composer.blur();
+
+      const draftKey = `cockpit:draft:${sessionId}`;
+      await expect
+        .poll(
+          async () =>
+            await page.evaluate((k) => localStorage.getItem(k), draftKey),
+          { timeout: 5_000 },
+        )
+        .toBe("hello!");
+    } finally {
+      await serve.stop();
+    }
+  },
+);


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

iOS Safari's on-screen keyboard mic injects each partial recognition into the cockpit composer through `beforeinput` and `input` events with `inputType: "insertReplacementText"`. WebKit's dictation engine tracks a private NSAttributedString range pointer into the textarea's text storage so the next partial can replace the prior one; any JS write to `textarea.value` via the property setter invalidates that pointer, after which the next partial appends instead of replacing. assistant-ui's `ComposerPrimitive.Input` is fully controlled and re-renders on every `setText` (its `onChange` runs `flushResourcesSync(() => composer.setText(e.target.value))`), so the controlled-value reconciler re-writes the DOM value on every partial. Practical symptom on real iOS: dictating "open the diff viewer" lands as "open the diff open the diff viewer open the diff viewer" in the composer textarea.

The fix detects the burst by watching `inputType === "insertReplacementText"` on `beforeinput`, marks a state flag in a ref, and intercepts React's `onChange` for the duration. While the burst is active, the composer's `onChange` calls `preventDefault()` on the SyntheticEvent so radix's `composeEventHandlers` (which assistant-ui uses to wrap our handler) skips its own flush, and the textarea's value is buffered in a ref instead. The burst ends on (a) ~1200 ms with no further `insertReplacementText`, (b) blur of the textarea (the iOS Send tap blurs first), or (c) a non-replacement input event such as a regular keystroke or backspace, at which point the buffered text is drained into `composerRuntime.setText` exactly once.

The state machine lives in a pure helper, `decideDictationAction`, alongside the existing `decideEnterAction` / `decideBeforeInputAction` decision helpers in `Composer.tsx`; the imperative wiring (refs, timers, `setText`) is in the component. Ten Vitest cases cover the matrix. Two live Playwright specs simulate the WebKit emission shape against real `aoe serve` instances and assert that the localStorage draft (which mirrors `composerRuntime` state on a 250 ms debounce) stays empty during the burst, flushes to the final dictated phrase exactly once on blur, and continues to work correctly when a regular keystroke follows a dictation burst.

Closes #1431

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [ ] N/A: this PR doesn't change a user-facing dashboard flow
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

## How to test

- [ ] Open an iOS Safari window pointed at `aoe serve` and enter the cockpit on any session. Tap the composer to focus, then tap the keyboard's mic icon and dictate "open the diff viewer" as one continuous utterance. The composer should end with `open the diff viewer` exactly once, with no repeated phrase fragments.
- [ ] During the same dictation burst, briefly pause for ~1500 ms then continue speaking. The resumed partial should replace the prior partial rather than duplicate; the final text should still appear exactly once.
- [ ] Dictate a phrase, then tap the Send button (or QueueSend during a turn). The message that posts to the agent must contain the final dictated text, not stale or empty text.
- [ ] On Android (GBoard / Samsung Keyboard), confirm plain Enter still inserts a newline and that voice-to-text via the keyboard mic still routes text into the composer normally. No regression in `composer-mobile-enter-newline` behavior.
- [ ] On desktop, confirm Enter still sends, Shift+Enter still inserts a newline, IME composition (Japanese / Chinese / Korean) still works, and paste-as-attachment still works.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (the trade-off between intercepting onChange vs. wrapping the textarea via `asChild`), and ran the manual verification steps on real iOS.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## What Changed

Problem addressed:
iOS Safari dictation caused duplicated text in the Cockpit composer because successive partial recognitions (inputType "insertReplacementText") were being imperatively reconciled by the controlled textarea, which broke WebKit’s replacement semantics.

High-level solution:
- Detect iOS dictation "bursts" and buffer textarea updates during the burst instead of immediately flushing them to the controlled state.
- Suppress upstream controlled-input reconciliation while a burst is active, then flush the final buffered text exactly once when the burst ends (on blur, ~1200ms idle, or a non-replacement input).
- Factor burst logic into a reusable hook and wire it into the Composer component.

What was added / moved / modified:
- New hook: web/src/components/cockpit/useDictationBurstGuard.ts — pure state-machine + hook (decideDictationAction, DICTATION_BURST_TIMEOUT_MS, types, and imperative guard API) handling detection, buffering, timeout, and flush.
- Composer integration: web/src/components/cockpit/Composer.tsx now uses the dictation guard, routes beforeinput/onChange/onBlur through it, suppresses React's controlled flush during bursts, and flushes buffered text to composerRuntime.setText when the burst ends. The hook's symbols are re-exported from Composer.
- Tests:
  - Unit: web/src/components/cockpit/Composer.dictation.test.ts and useDictationBurstGuard.test.ts (Vitest) cover state transitions, timeout re-arming, blur, unmount safety, and suppression behavior.
  - Live: web/tests/live/cockpit-stories/composer-ios-dictation.spec.ts (Playwright) simulates WebKit-like beforeinput/input events to assert the draft stays empty during bursts and the final phrase is committed once (including interaction with a following keystroke).
- Docs: docs/cockpit.md updated with an "iOS Safari dictation" subsection explaining behavior and testing steps.
- Tests surface: web/tests/coverage-matrix.json updated to include the new specs.

Technical details (concise):
- decideDictationAction implements the burst state machine: enter/continue burst on insertReplacementText, buffer textarea value, arm/clear a 1200ms timeout, suppress upstream onChange during burst, and flush buffered value to composerRuntime.setText once when the burst ends.
- Composer prevents the SyntheticEvent flush during an active burst (preventDefault) so assistant-ui’s controlled reconciler doesn't imperatively overwrite the textarea and break WebKit’s replacement semantics.
- Burst termination triggers: DICTATION_BURST_TIMEOUT_MS (~1200ms) idle, textarea blur (iOS Send blurs first), or any non-replacement input (e.g., insertText/deleteContentBackward).

Benefits
- Eliminates duplicated dictated text on iOS Safari for mic-based dictation.
- Keeps existing behaviors intact: Enter-to-send, Shift+Enter newline, IME/CJK composition, paste-as-attachment, Android voice input, and regular typing.
- Covered by unit and live integration tests and documented in cockpit docs.

Potential follow-ups
- Monitor different iOS/WebKit versions and devices; adjust timeout if necessary.
- Consider lightweight telemetry or feature-flagging if additional edge-case tuning is needed in production.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1598?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->