### PR TITLE
feat(cockpit): call experimental session/delete RPC before SIGTERM

### DIFF
--- a/cockpit-worker/test-shim/package-lock.json
+++ b/cockpit-worker/test-shim/package-lock.json
@@ -8,22 +8,22 @@
       "name": "aoe-cockpit-test-shim",
       "version": "0.0.1",
       "dependencies": {
-        "@agentclientprotocol/sdk": "^0.21.0"
+        "@agentclientprotocol/sdk": "^0.22.0"
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.21.0.tgz",
-      "integrity": "sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/@agentclientprotocol/sdk/-/sdk-0.22.1.tgz",
+      "integrity": "sha512-DfqXtl/8gO9NImq094MTaCXEU2vkhh6v7q/kT+9UjZxUqj8hYaya2OjLVIqn16MzNHcXEpShTR2RIauLSYeDQQ==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "peer": true,
       "funding": {

--- a/cockpit-worker/test-shim/package.json
+++ b/cockpit-worker/test-shim/package.json
@@ -5,6 +5,6 @@
   "type": "module",
   "private": true,
   "dependencies": {
-    "@agentclientprotocol/sdk": "^0.21.0"
+    "@agentclientprotocol/sdk": "^0.22.0"
   }
 }

--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -34,18 +34,57 @@ class ShimAgent {
     // assert the watchdog without waiting for CANCEL_ESCALATION_GRACE
     // to elapse.
     this._silentOrphanResolve = null;
+    this._installDeleteHandlerIfRequested();
   }
 
   async initialize(params) {
+    const agentCapabilities = {
+      loadSession: false,
+    };
+    // SHIM_DELETE_CAPABILITY=1 advertises sessionCapabilities.delete
+    // so the Rust client's session/delete dispatch path can be
+    // exercised end-to-end. Tests for #1404 toggle this; default off
+    // mirrors the negative-path adapters (aoe-agent, codex, opencode).
+    if (process.env.SHIM_DELETE_CAPABILITY === "1") {
+      agentCapabilities.sessionCapabilities = { delete: {} };
+    }
     return {
       protocolVersion: params.protocolVersion ?? acp.PROTOCOL_VERSION,
-      agentCapabilities: {
-        loadSession: false,
-      },
+      agentCapabilities,
       agentInfo: {
         name: "@agentclientprotocol/claude-agent-acp",
         version: "0.39.0",
       },
+    };
+  }
+
+  // Experimental session/delete handler installed only when
+  // SHIM_DELETE_CAPABILITY=1. Without the install, the SDK's request
+  // dispatcher returns -32601 method_not_found, which is the
+  // negative-path expectation aoe needs to test against (matches
+  // aoe-agent, codex, opencode behavior).
+  _installDeleteHandlerIfRequested() {
+    if (process.env.SHIM_DELETE_CAPABILITY !== "1") return;
+    // SHIM_DELETE_MODE controls the response shape so tests can drive
+    // the success / timeout / failure branches without spinning up
+    // distinct shim binaries. SHIM_DELETE_RECORD_FILE, when set,
+    // appends one line per call with the requested sessionId so tests
+    // assert the RPC actually fired.
+    this.unstable_deleteSession = async (params) => {
+      const mode = process.env.SHIM_DELETE_MODE ?? "success";
+      const recordFile = process.env.SHIM_DELETE_RECORD_FILE;
+      if (recordFile) {
+        const fs = await import("node:fs/promises");
+        await fs.appendFile(recordFile, `${params.sessionId}\n`);
+      }
+      if (mode === "slow") {
+        await new Promise((r) => setTimeout(r, 3000));
+        return {};
+      }
+      if (mode === "error") {
+        throw acp.RequestError.internalError({}, "shim deliberate failure");
+      }
+      return {};
     };
   }
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -445,6 +445,26 @@ Practical implications:
   `main`-branch case where there is no runner at all and every cockpit
   session takes the fresh-spawn branch on restart.
 
+## Session deletion
+
+When you delete a cockpit session, aoe first fires the experimental
+`session/delete` ACP request against the live worker (bounded by a
+2-second timeout) and then proceeds with the existing kill path
+(`session/cancel` for in-flight prompts, then SIGTERM on the runner,
+then on-disk cleanup). Adapters that advertise
+`sessionCapabilities.delete: {}` in their initialize response
+(claude-agent-acp 0.36+) use the request to release adapter-side
+persisted state, for example clearing the on-disk Claude session
+record so a recreated session id does not inherit prior transcripts.
+Adapters that do not advertise the capability (`aoe-agent`, `codex`,
+`opencode`, older `claude-agent-acp`) reply with JSON-RPC
+`-32601 method_not_found`; aoe treats that as expected and proceeds
+to SIGTERM without the operator noticing. A wedged adapter is bounded
+by the 2-second timeout, so delete never stalls the UI. Outcomes are
+logged under `target = "cockpit.acp"` in `debug.log`: success and
+unsupported land at `debug`, timeout and other errors at `warn`. See
+[#1404](https://github.com/agent-of-empires/agent-of-empires/issues/1404).
+
 ## Conversation persistence
 
 Cockpit transcripts survive page reloads, session switches, and

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -447,22 +447,24 @@ Practical implications:
 
 ## Session deletion
 
-When you delete a cockpit session, aoe first fires the experimental
-`session/delete` ACP request against the live worker (bounded by a
-2-second timeout) and then proceeds with the existing kill path
+When you delete a cockpit session, aoe opportunistically fires the
+experimental `session/delete` ACP request against the live worker
+(bounded by a 2-second timeout) whenever a stored ACP session id
+exists, and then proceeds with the existing kill path
 (`session/cancel` for in-flight prompts, then SIGTERM on the runner,
-then on-disk cleanup). Adapters that advertise
-`sessionCapabilities.delete: {}` in their initialize response
-(claude-agent-acp 0.36+) use the request to release adapter-side
-persisted state, for example clearing the on-disk Claude session
+then on-disk cleanup). aoe does not inspect the initialize-time
+capability flag: adapters that implement the method use the request
+to release adapter-side persisted state, for example
+`claude-agent-acp 0.37.0+` clearing the on-disk Claude session
 record so a recreated session id does not inherit prior transcripts.
-Adapters that do not advertise the capability (`aoe-agent`, `codex`,
+Adapters that do not implement the method (`aoe-agent`, `codex`,
 `opencode`, older `claude-agent-acp`) reply with JSON-RPC
-`-32601 method_not_found`; aoe treats that as expected and proceeds
-to SIGTERM without the operator noticing. A wedged adapter is bounded
-by the 2-second timeout, so delete never stalls the UI. Outcomes are
-logged under `target = "cockpit.acp"` in `debug.log`: success and
-unsupported land at `debug`, timeout and other errors at `warn`. See
+`-32601 method_not_found`; aoe logs that at `debug` and proceeds to
+SIGTERM. A wedged adapter is bounded by the 2-second timeout, so
+delete never stalls the UI. Outcomes are logged under
+`target = "cockpit.acp"` in `debug.log` with an `adapter=<agent_key>`
+field so operators can correlate behavior across adapters: success
+and `-32601` land at `debug`, timeout and other errors at `warn`. See
 [#1404](https://github.com/agent-of-empires/agent-of-empires/issues/1404).
 
 ## Conversation persistence

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -1531,9 +1531,9 @@ impl AcpClient {
     ///
     /// All outcomes are non-fatal. Adapters that don't implement the
     /// method return `-32601 method_not_found` and surface as
-    /// `Unsupported`; the supervisor proceeds to the existing kill
-    /// path either way. Bounded by `ACP_SESSION_DELETE_TIMEOUT` so a
-    /// wedged adapter cannot stall delete. See #1404.
+    /// `UnsupportedMethod`; the supervisor proceeds to the existing
+    /// kill path either way. Bounded by `ACP_SESSION_DELETE_TIMEOUT`
+    /// so a wedged adapter cannot stall delete. See #1404.
     pub async fn delete_session(&self, acp_session_id: String) -> DeleteSessionOutcome {
         let Some(cmd_tx) = self.cmd_tx.as_ref() else {
             return DeleteSessionOutcome::Failed("client not running".into());

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -16,6 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::Stdio;
 use std::sync::Arc;
 
+use agent_client_protocol::schema::ErrorCode;
 use agent_client_protocol::schema::{
     CancelNotification, ClientCapabilities, ContentBlock, CreateTerminalRequest,
     CreateTerminalResponse, FileSystemCapabilities, InitializeRequest, KillTerminalRequest,
@@ -28,7 +29,10 @@ use agent_client_protocol::schema::{
     TerminalOutputRequest, TerminalOutputResponse, TextContent, WaitForTerminalExitRequest,
     WaitForTerminalExitResponse, WriteTextFileRequest, WriteTextFileResponse,
 };
-use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo, Responder};
+use agent_client_protocol::{
+    Agent, ByteStreams, Client, ConnectionTo, JsonRpcRequest, JsonRpcResponse, Responder,
+};
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
@@ -184,6 +188,49 @@ pub(crate) fn classify_rate_limit_from_message(message: &str) -> Option<RateLimi
     })
 }
 
+/// Experimental `session/delete` ACP request. Adapters advertising
+/// `sessionCapabilities.delete: {}` (claude-agent-acp >= 0.36) handle
+/// this by releasing adapter-side state for the session (e.g. clearing
+/// the persisted Claude session record on disk). Other adapters reply
+/// with `-32601 method_not_found` and the supervisor falls through to
+/// the existing SIGTERM path. The Rust ACP schema crate (0.12) does
+/// not yet expose `SessionCapabilities.delete`, so the request type is
+/// defined here against the wire format from the TypeScript SDK. See
+/// #1404.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcRequest)]
+#[request(method = "session/delete", response = DeleteSessionResponse)]
+#[serde(rename_all = "camelCase")]
+struct DeleteSessionRequest {
+    session_id: agent_client_protocol::schema::SessionId,
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonRpcResponse)]
+struct DeleteSessionResponse {}
+
+/// Outcome of an experimental `session/delete` call. Every variant is
+/// non-fatal; the supervisor logs and proceeds to SIGTERM regardless.
+#[derive(Debug)]
+pub enum DeleteSessionOutcome {
+    /// Adapter accepted the request and returned a successful response.
+    Deleted,
+    /// Adapter returned JSON-RPC `-32601 method_not_found`. Expected on
+    /// adapters that don't advertise `sessionCapabilities.delete`
+    /// (`aoe-agent`, `codex`, `opencode`, older `claude-agent-acp`).
+    Unsupported,
+    /// The bounded wait elapsed before the adapter responded.
+    TimedOut,
+    /// Any other failure (non-`-32601` JSON-RPC error, transport drop,
+    /// dispatch channel closed). Carries the reason for the log line.
+    Failed(String),
+}
+
+/// Hard cap on the wait for `session/delete`. Adapters that succeed
+/// (claude-agent-acp clears a local file) complete in tens of ms; the
+/// timeout protects the delete path from a wedged adapter. Not a
+/// `CockpitConfig` field on purpose: this is best-effort experimental
+/// cleanup with no operator-visible failure mode.
+const ACP_SESSION_DELETE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
 /// Configuration for spawning an ACP agent.
 #[derive(Debug, Clone)]
 pub struct SpawnConfig {
@@ -236,6 +283,14 @@ enum ClientCmd {
     SetConfigOption {
         config_id: String,
         value: String,
+    },
+    /// Send the experimental `session/delete` RPC for the given ACP
+    /// session id and report the outcome via `respond_to`. Issued by
+    /// the supervisor before the existing shutdown path during cockpit
+    /// session deletion. See #1404.
+    DeleteSession {
+        acp_session_id: String,
+        respond_to: oneshot::Sender<DeleteSessionOutcome>,
     },
     Shutdown,
 }
@@ -1455,6 +1510,48 @@ impl AcpClient {
             .resolver
             .send(ApprovalResolutionMessage::Cancelled)
             .map_err(|_| AcpError::AgentExited)
+    }
+
+    /// Best-effort experimental `session/delete` RPC. Sent before
+    /// `shutdown` during cockpit session deletion so adapters that
+    /// persist session-side state (claude-agent-acp clears the on-disk
+    /// Claude session record) get a chance to clean up before SIGTERM.
+    ///
+    /// All outcomes are non-fatal. Adapters that don't implement the
+    /// method return `-32601 method_not_found` and surface as
+    /// `Unsupported`; the supervisor proceeds to the existing kill
+    /// path either way. Bounded by `ACP_SESSION_DELETE_TIMEOUT` so a
+    /// wedged adapter cannot stall delete. See #1404.
+    pub async fn delete_session(&self, acp_session_id: String) -> DeleteSessionOutcome {
+        let Some(cmd_tx) = self.cmd_tx.as_ref() else {
+            return DeleteSessionOutcome::Failed("client not running".into());
+        };
+        let (tx, rx) = oneshot::channel();
+        if cmd_tx
+            .send(ClientCmd::DeleteSession {
+                acp_session_id,
+                respond_to: tx,
+            })
+            .await
+            .is_err()
+        {
+            return DeleteSessionOutcome::Failed("connect task gone".into());
+        }
+        // Outer guard: the connect task wraps the request in its own
+        // `ACP_SESSION_DELETE_TIMEOUT`. Wait slightly longer here so
+        // the inner classification (Deleted/Unsupported/Failed) wins
+        // when the task is healthy, while still bounding the caller
+        // when the task is wedged.
+        match tokio::time::timeout(
+            ACP_SESSION_DELETE_TIMEOUT + std::time::Duration::from_millis(500),
+            rx,
+        )
+        .await
+        {
+            Ok(Ok(outcome)) => outcome,
+            Ok(Err(_)) => DeleteSessionOutcome::Failed("respond channel closed".into()),
+            Err(_) => DeleteSessionOutcome::TimedOut,
+        }
     }
 
     /// Shutdown the connection task and kill the subprocess.
@@ -3012,6 +3109,41 @@ fn extract_diff_from_locations(
     None
 }
 
+/// Dispatch the experimental `session/delete` RPC from the connect
+/// task's cmd_rx arm. The wait is detached via `tokio::spawn` so the
+/// cmd_rx select arm keeps polling other commands during the
+/// round-trip; the outcome is delivered to the caller via the
+/// `respond_to` oneshot. Bounded by `ACP_SESSION_DELETE_TIMEOUT` so a
+/// wedged adapter still resolves the oneshot in time for the caller's
+/// outer guard. See #1404.
+fn handle_delete_session_cmd(
+    connection: &ConnectionTo<Agent>,
+    acp_session_id: String,
+    respond_to: oneshot::Sender<DeleteSessionOutcome>,
+) {
+    let target = agent_client_protocol::schema::SessionId::from(acp_session_id);
+    let sent = connection.send_request(DeleteSessionRequest { session_id: target });
+    tokio::spawn(async move {
+        let outcome =
+            match tokio::time::timeout(ACP_SESSION_DELETE_TIMEOUT, sent.block_task()).await {
+                Ok(Ok(_resp)) => DeleteSessionOutcome::Deleted,
+                Ok(Err(err)) => {
+                    if err.code == ErrorCode::MethodNotFound {
+                        DeleteSessionOutcome::Unsupported
+                    } else {
+                        DeleteSessionOutcome::Failed(format!(
+                            "acp error {}: {}",
+                            i32::from(err.code),
+                            err.message
+                        ))
+                    }
+                }
+                Err(_) => DeleteSessionOutcome::TimedOut,
+            };
+        let _ = respond_to.send(outcome);
+    });
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn run_connection_task<W, R>(
     transport: ByteStreams<W, R>,
@@ -4018,6 +4150,16 @@ async fn run_connection_task<W, R>(
                                                 }
                                             });
                                         }
+                                        Some(ClientCmd::DeleteSession {
+                                            acp_session_id: target_id,
+                                            respond_to,
+                                        }) => {
+                                            handle_delete_session_cmd(
+                                                &connection,
+                                                target_id,
+                                                respond_to,
+                                            );
+                                        }
                                         Some(ClientCmd::Prompt(rejected_text)) => {
                                             // Surface the dropped prompt
                                             // to the UI so the user can
@@ -4154,6 +4296,12 @@ async fn run_connection_task<W, R>(
                                 }
                             }
                         });
+                    }
+                    Some(ClientCmd::DeleteSession {
+                        acp_session_id: target_id,
+                        respond_to,
+                    }) => {
+                        handle_delete_session_cmd(&connection, target_id, respond_to);
                     }
                     Some(ClientCmd::SetConfigOption { config_id, value }) => {
                         info!(

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -202,6 +202,12 @@ pub(crate) fn classify_rate_limit_from_message(message: &str) -> Option<RateLimi
 #[serde(rename_all = "camelCase")]
 struct DeleteSessionRequest {
     session_id: agent_client_protocol::schema::SessionId,
+    /// Emit `_meta: {}` so adapters that validate against the strict
+    /// `unstable_session_delete` schema accept the request. Optional
+    /// in the TS schema, but a defensive default avoids `-32602
+    /// invalid_params` from future adapter validators.
+    #[serde(rename = "_meta")]
+    meta: serde_json::Value,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonRpcResponse)]
@@ -216,13 +222,19 @@ pub enum DeleteSessionOutcome {
     /// Adapter returned JSON-RPC `-32601 method_not_found`. Expected on
     /// adapters that don't advertise `sessionCapabilities.delete`
     /// (`aoe-agent`, `codex`, `opencode`, older `claude-agent-acp`).
-    Unsupported,
+    UnsupportedMethod,
     /// The bounded wait elapsed before the adapter responded.
     TimedOut,
     /// Any other failure (non-`-32601` JSON-RPC error, transport drop,
     /// dispatch channel closed). Carries the reason for the log line.
     Failed(String),
 }
+
+/// Adapter error messages flow through here verbatim. Cap at this many
+/// bytes before logging so a chatty or malicious adapter cannot bloat
+/// `debug.log`. 256 leaves room for the prefix while preserving the
+/// JSON-RPC error code and a useful slice of the message.
+const ACP_DELETE_ERROR_MSG_MAX: usize = 256;
 
 /// Hard cap on the wait for `session/delete`. Adapters that succeed
 /// (claude-agent-acp clears a local file) complete in tens of ms; the
@@ -1527,29 +1539,38 @@ impl AcpClient {
             return DeleteSessionOutcome::Failed("client not running".into());
         };
         let (tx, rx) = oneshot::channel();
-        if cmd_tx
-            .send(ClientCmd::DeleteSession {
-                acp_session_id,
-                respond_to: tx,
-            })
-            .await
-            .is_err()
-        {
-            return DeleteSessionOutcome::Failed("connect task gone".into());
-        }
-        // Outer guard: the connect task wraps the request in its own
-        // `ACP_SESSION_DELETE_TIMEOUT`. Wait slightly longer here so
-        // the inner classification (Deleted/Unsupported/Failed) wins
-        // when the task is healthy, while still bounding the caller
-        // when the task is wedged.
+        // Outer guard wraps BOTH the cmd_tx send AND the response wait.
+        // The mpsc send is `await`-able and can block if the connect
+        // task is wedged or the channel is saturated; without the
+        // guard a stalled worker would freeze the delete path
+        // indefinitely while the supervisor holds the per-instance
+        // lock at `sessions.rs:1361`. Wait slightly longer than the
+        // in-task `ACP_SESSION_DELETE_TIMEOUT` so the inner
+        // classification (Deleted/UnsupportedMethod/Failed) wins when
+        // the task is healthy.
+        let request = async {
+            if cmd_tx
+                .send(ClientCmd::DeleteSession {
+                    acp_session_id,
+                    respond_to: tx,
+                })
+                .await
+                .is_err()
+            {
+                return DeleteSessionOutcome::Failed("connect task gone".into());
+            }
+            match rx.await {
+                Ok(outcome) => outcome,
+                Err(_) => DeleteSessionOutcome::Failed("respond channel closed".into()),
+            }
+        };
         match tokio::time::timeout(
             ACP_SESSION_DELETE_TIMEOUT + std::time::Duration::from_millis(500),
-            rx,
+            request,
         )
         .await
         {
-            Ok(Ok(outcome)) => outcome,
-            Ok(Err(_)) => DeleteSessionOutcome::Failed("respond channel closed".into()),
+            Ok(outcome) => outcome,
             Err(_) => DeleteSessionOutcome::TimedOut,
         }
     }
@@ -3122,19 +3143,29 @@ fn handle_delete_session_cmd(
     respond_to: oneshot::Sender<DeleteSessionOutcome>,
 ) {
     let target = agent_client_protocol::schema::SessionId::from(acp_session_id);
-    let sent = connection.send_request(DeleteSessionRequest { session_id: target });
+    // `block_task()` is documented as safe to await from a spawned
+    // task: it waits on the per-request oneshot the main connection
+    // task feeds via its inbound pump, so the dispatch loop keeps
+    // running while this future is parked. The spawn here keeps the
+    // cmd_rx select arm responsive to other commands during the
+    // round-trip, mirroring the pattern used by SetMode /
+    // SetConfigOption.
+    let sent = connection.send_request(DeleteSessionRequest {
+        session_id: target,
+        meta: serde_json::Value::Object(serde_json::Map::new()),
+    });
     tokio::spawn(async move {
         let outcome =
             match tokio::time::timeout(ACP_SESSION_DELETE_TIMEOUT, sent.block_task()).await {
                 Ok(Ok(_resp)) => DeleteSessionOutcome::Deleted,
                 Ok(Err(err)) => {
                     if err.code == ErrorCode::MethodNotFound {
-                        DeleteSessionOutcome::Unsupported
+                        DeleteSessionOutcome::UnsupportedMethod
                     } else {
                         DeleteSessionOutcome::Failed(format!(
                             "acp error {}: {}",
                             i32::from(err.code),
-                            err.message
+                            truncate_for_log(&err.message, ACP_DELETE_ERROR_MSG_MAX)
                         ))
                     }
                 }
@@ -3142,6 +3173,24 @@ fn handle_delete_session_cmd(
             };
         let _ = respond_to.send(outcome);
     });
+}
+
+/// Defensive truncation of adapter-provided strings before they land
+/// in `debug.log`. A malformed or malicious adapter could emit a
+/// multi-megabyte message; this caps the allocation while preserving
+/// a useful prefix and respecting UTF-8 boundaries.
+fn truncate_for_log(s: &str, max_bytes: usize) -> String {
+    if s.len() <= max_bytes {
+        return s.to_string();
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(end + 3);
+    out.push_str(&s[..end]);
+    out.push_str("...");
+    out
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -3162,10 +3162,17 @@ fn handle_delete_session_cmd(
                     if err.code == ErrorCode::MethodNotFound {
                         DeleteSessionOutcome::UnsupportedMethod
                     } else {
+                        // Adapter error messages reach debug.log
+                        // verbatim. Run them through the existing
+                        // stderr secret scrubber so a leaked
+                        // `sk-...` / `Bearer ...` / GitHub PAT in
+                        // the adapter's own error string doesn't
+                        // land in operator logs, then cap length.
+                        let scrubbed = scrub_stderr_secrets(&err.message);
                         DeleteSessionOutcome::Failed(format!(
                             "acp error {}: {}",
                             i32::from(err.code),
-                            truncate_for_log(&err.message, ACP_DELETE_ERROR_MSG_MAX)
+                            truncate_for_log(&scrubbed, ACP_DELETE_ERROR_MSG_MAX)
                         ))
                     }
                 }

--- a/src/cockpit/acp_client.rs
+++ b/src/cockpit/acp_client.rs
@@ -5030,6 +5030,32 @@ mod tests {
         assert!(matches!(event, Event::ThinkingStarted));
     }
 
+    // truncate_for_log is the adapter-error sanitizer in the
+    // session/delete path: it caps a third-party-controlled string so
+    // a chatty adapter can't bloat debug.log, and must never panic on
+    // UTF-8 inputs. The cases below lock down the boundary semantics
+    // (no-op under cap, exact cap, multibyte cut) so a future change
+    // to the helper can't quietly regress the no-panic invariant.
+    #[test]
+    fn truncate_for_log_below_cap_returns_input() {
+        assert_eq!(truncate_for_log("hello", 64), "hello");
+    }
+
+    #[test]
+    fn truncate_for_log_at_exact_cap_returns_input() {
+        assert_eq!(truncate_for_log("hello", 5), "hello");
+    }
+
+    #[test]
+    fn truncate_for_log_cuts_on_utf8_boundary_without_panic() {
+        // "é" is two bytes (0xC3 0xA9). With max_bytes=5 the naive
+        // slice would land mid-codepoint; the helper must rewind to
+        // the previous char boundary (byte 4) before appending the
+        // ellipsis. "ééé" is 6 bytes total, so we expect "éé...".
+        let out = truncate_for_log("ééé", 5);
+        assert_eq!(out, "éé...");
+    }
+
     // -------------------------------------------------------------------
     // SilentOrphanWatchdog: pure-state-machine unit tests
     //

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -47,26 +47,52 @@ const RESPAWN_BACKOFF: Duration = Duration::from_millis(500);
 
 /// Look up the stored ACP session id for `session_id` and, if present,
 /// fire the experimental `session/delete` RPC against the live worker.
-/// Logs the outcome at a level matched to its severity; all outcomes
-/// are non-fatal and the caller proceeds to shutdown + SIGTERM. See
+/// Logs the outcome at a level matched to its severity, tagging with
+/// the adapter kind so operators can tell `claude-agent-acp` apart
+/// from `aoe-agent` / `codex` / `opencode` / future adapters in
+/// debug.log without bouncing through the registry. All outcomes are
+/// non-fatal and the caller proceeds to shutdown + SIGTERM. See
 /// `AcpClient::delete_session` and #1404.
 async fn try_session_delete(client: &AcpClient, session_id: &str) {
-    let acp_id = match super::worker_registry::load(session_id) {
-        Ok(Some(rec)) => rec.stored_acp_session_id,
-        Ok(None) => None,
-        Err(e) => {
-            debug!(
+    // worker_registry::load reads from disk (sync I/O). Offload to
+    // the blocking pool so we don't park a Tokio worker thread on a
+    // delete path that the supervisor holds the per-instance API
+    // lock through.
+    let session_id_owned = session_id.to_string();
+    let loaded =
+        tokio::task::spawn_blocking(move || super::worker_registry::load(&session_id_owned)).await;
+    let record = match loaded {
+        Ok(Ok(rec)) => rec,
+        Ok(Err(e)) => {
+            // Registry read failed (disk error, malformed JSON, etc.).
+            // Skipping `session/delete` here means we lose adapter-side
+            // cleanup for a session that may have a stored ACP id, so
+            // surface at warn even though shutdown still proceeds.
+            warn!(
                 target: "cockpit.acp",
                 session = %session_id,
                 "skipping session/delete: worker_registry load failed: {e}"
             );
             return;
         }
+        Err(e) => {
+            warn!(
+                target: "cockpit.acp",
+                session = %session_id,
+                "skipping session/delete: registry load task join failed: {e}"
+            );
+            return;
+        }
+    };
+    let (acp_id, adapter_kind) = match record {
+        Some(rec) => (rec.stored_acp_session_id, rec.agent_key),
+        None => (None, String::new()),
     };
     let Some(acp_id) = acp_id else {
         debug!(
             target: "cockpit.acp",
             session = %session_id,
+            adapter = %adapter_kind,
             "skipping session/delete: no stored ACP session id (pre-handshake or never assigned)"
         );
         return;
@@ -78,19 +104,22 @@ async fn try_session_delete(client: &AcpClient, session_id: &str) {
         DeleteSessionOutcome::Deleted => debug!(
             target: "cockpit.acp",
             session = %session_id,
+            adapter = %adapter_kind,
             acp_session_id = %acp_id,
             elapsed_ms,
             "session/delete RPC succeeded"
         ),
-        DeleteSessionOutcome::Unsupported => debug!(
+        DeleteSessionOutcome::UnsupportedMethod => debug!(
             target: "cockpit.acp",
             session = %session_id,
+            adapter = %adapter_kind,
             acp_session_id = %acp_id,
-            "adapter does not advertise session/delete; proceeding to SIGTERM"
+            "adapter does not support session/delete; proceeding to SIGTERM"
         ),
         DeleteSessionOutcome::TimedOut => warn!(
             target: "cockpit.acp",
             session = %session_id,
+            adapter = %adapter_kind,
             acp_session_id = %acp_id,
             elapsed_ms,
             "session/delete RPC timed out; proceeding to SIGTERM"
@@ -98,6 +127,7 @@ async fn try_session_delete(client: &AcpClient, session_id: &str) {
         DeleteSessionOutcome::Failed(msg) => warn!(
             target: "cockpit.acp",
             session = %session_id,
+            adapter = %adapter_kind,
             acp_session_id = %acp_id,
             elapsed_ms,
             "session/delete RPC failed: {msg}; proceeding to SIGTERM"

--- a/src/cockpit/supervisor.rs
+++ b/src/cockpit/supervisor.rs
@@ -29,7 +29,7 @@ use tokio::sync::{broadcast, mpsc, Mutex};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
-use super::acp_client::{AcpClient, AcpError, SpawnConfig};
+use super::acp_client::{AcpClient, AcpError, DeleteSessionOutcome, SpawnConfig};
 use super::agent_registry::{AgentRegistry, AgentSpec};
 use super::approvals::{ApprovalDecision, Nonce};
 use super::state::{CockpitSessionId, Event};
@@ -44,6 +44,66 @@ const RESTART_WINDOW: Duration = Duration::from_secs(60);
 /// Brief backoff before respawning an exited worker so we don't
 /// hot-loop when the agent process crashes immediately on startup.
 const RESPAWN_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Look up the stored ACP session id for `session_id` and, if present,
+/// fire the experimental `session/delete` RPC against the live worker.
+/// Logs the outcome at a level matched to its severity; all outcomes
+/// are non-fatal and the caller proceeds to shutdown + SIGTERM. See
+/// `AcpClient::delete_session` and #1404.
+async fn try_session_delete(client: &AcpClient, session_id: &str) {
+    let acp_id = match super::worker_registry::load(session_id) {
+        Ok(Some(rec)) => rec.stored_acp_session_id,
+        Ok(None) => None,
+        Err(e) => {
+            debug!(
+                target: "cockpit.acp",
+                session = %session_id,
+                "skipping session/delete: worker_registry load failed: {e}"
+            );
+            return;
+        }
+    };
+    let Some(acp_id) = acp_id else {
+        debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            "skipping session/delete: no stored ACP session id (pre-handshake or never assigned)"
+        );
+        return;
+    };
+    let started = Instant::now();
+    let outcome = client.delete_session(acp_id.clone()).await;
+    let elapsed_ms = started.elapsed().as_millis() as u64;
+    match &outcome {
+        DeleteSessionOutcome::Deleted => debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC succeeded"
+        ),
+        DeleteSessionOutcome::Unsupported => debug!(
+            target: "cockpit.acp",
+            session = %session_id,
+            acp_session_id = %acp_id,
+            "adapter does not advertise session/delete; proceeding to SIGTERM"
+        ),
+        DeleteSessionOutcome::TimedOut => warn!(
+            target: "cockpit.acp",
+            session = %session_id,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC timed out; proceeding to SIGTERM"
+        ),
+        DeleteSessionOutcome::Failed(msg) => warn!(
+            target: "cockpit.acp",
+            session = %session_id,
+            acp_session_id = %acp_id,
+            elapsed_ms,
+            "session/delete RPC failed: {msg}; proceeding to SIGTERM"
+        ),
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum SupervisorError {
@@ -1452,6 +1512,16 @@ impl<S: BroadcastSink> Supervisor<S> {
         if let Some(handle) = workers.remove(session_id) {
             // Worker is alive — tear it down.
             drop(workers);
+            // Best-effort experimental `session/delete` RPC before
+            // SIGTERM. Adapters that advertise
+            // `sessionCapabilities.delete: {}` (claude-agent-acp >= 0.36)
+            // release adapter-side persisted state here. Other
+            // adapters return -32601 and we proceed to the existing
+            // kill path either way. Bounded by
+            // `ACP_SESSION_DELETE_TIMEOUT` inside `delete_session`
+            // (~2s) so a wedged adapter cannot stall the user's
+            // delete. See #1404.
+            try_session_delete(&handle.client, session_id).await;
             let _ = handle.client.shutdown().await;
             handle.drain_task.abort();
             // SIGTERM the runner (if there is one) so the agent

--- a/tests/integration/cockpit_session_delete.rs
+++ b/tests/integration/cockpit_session_delete.rs
@@ -136,8 +136,8 @@ async fn session_delete_unsupported_when_capability_absent() {
     let _ = client.shutdown().await;
 
     assert!(
-        matches!(outcome, DeleteSessionOutcome::Unsupported),
-        "expected Unsupported; got {outcome:?}"
+        matches!(outcome, DeleteSessionOutcome::UnsupportedMethod),
+        "expected UnsupportedMethod; got {outcome:?}"
     );
 }
 

--- a/tests/integration/cockpit_session_delete.rs
+++ b/tests/integration/cockpit_session_delete.rs
@@ -1,0 +1,185 @@
+//! Experimental `session/delete` RPC dispatch coverage. See #1404.
+//!
+//! Exercises the round-trip from `AcpClient::delete_session` through
+//! the Rust ACP client, the JSON-RPC layer, and the test-shim's
+//! `unstable_deleteSession` handler. Tests cover:
+//!
+//! - Adapter advertising `sessionCapabilities.delete: {}` succeeds and
+//!   the shim records the call (matches claude-agent-acp 0.37+).
+//! - Adapter NOT advertising the capability returns `-32601`, surfaced
+//!   as `DeleteSessionOutcome::Unsupported` (matches aoe-agent, codex,
+//!   opencode, older claude-agent-acp).
+//! - Adapter handler that exceeds the bounded timeout surfaces as
+//!   `TimedOut`; the call does not hang the caller.
+
+use std::path::PathBuf;
+use std::time::Duration;
+
+use agent_of_empires::cockpit::acp_client::{AcpClient, DeleteSessionOutcome, SpawnConfig};
+use agent_of_empires::cockpit::agent_registry::AgentSpec;
+use agent_of_empires::cockpit::state::{CockpitSessionId, Event};
+
+use crate::common::{shim_path, shim_ready};
+
+fn spawn_config_with_shim_env(shim: PathBuf, env: Vec<(String, String)>) -> SpawnConfig {
+    SpawnConfig {
+        agent_key: "claude".into(),
+        spec: AgentSpec {
+            command: "node".into(),
+            args: vec![shim.to_string_lossy().to_string()],
+            description: "session/delete shim".into(),
+            env_allowlist: None,
+        },
+        cwd: std::env::temp_dir(),
+        additional_dirs: vec![],
+        provider_env: env,
+        socket_path: None,
+        stored_acp_session_id: None,
+        sandbox_info: None,
+        source_profile: None,
+    }
+}
+
+/// Drain events until a `Stopped` arrives or `deadline` elapses; returns
+/// the ACP session id assigned during the handshake so subsequent
+/// `delete_session` calls can target it.
+async fn drive_handshake_and_capture_session_id(
+    client: &mut AcpClient,
+    deadline: std::time::Instant,
+) -> Option<String> {
+    client
+        .send_prompt("hello")
+        .await
+        .expect("send_prompt should reach the shim");
+    let mut acp_session_id: Option<String> = None;
+    while std::time::Instant::now() < deadline {
+        let evt = match tokio::time::timeout(Duration::from_millis(200), client.next_event()).await
+        {
+            Ok(Some(evt)) => evt,
+            Ok(None) | Err(_) => continue,
+        };
+        if let Event::AcpSessionAssigned { acp_session_id: id } = &evt {
+            acp_session_id = Some(id.clone());
+        }
+        if matches!(evt, Event::Stopped { .. }) {
+            break;
+        }
+    }
+    acp_session_id
+}
+
+#[tokio::test]
+async fn session_delete_called_when_capability_advertised() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let temp = tempfile::tempdir().expect("tempdir");
+    let record_path = temp.path().join("delete-calls.log");
+    let config = spawn_config_with_shim_env(
+        shim_path(),
+        vec![
+            ("SHIM_DELETE_CAPABILITY".into(), "1".into()),
+            (
+                "SHIM_DELETE_RECORD_FILE".into(),
+                record_path.to_string_lossy().to_string(),
+            ),
+        ],
+    );
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-pos".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let outcome = client.delete_session(acp_id.clone()).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::Deleted),
+        "expected Deleted; got {outcome:?}"
+    );
+    let recorded =
+        std::fs::read_to_string(&record_path).expect("record file should exist after delete RPC");
+    assert!(
+        recorded.lines().any(|line| line == acp_id),
+        "shim should have recorded the deleted session id {acp_id} (file contents: {recorded:?})"
+    );
+}
+
+#[tokio::test]
+async fn session_delete_unsupported_when_capability_absent() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    // Without SHIM_DELETE_CAPABILITY the shim leaves
+    // unstable_deleteSession unset, so the SDK's dispatcher returns
+    // -32601 for `session/delete`. This is the steady-state shape for
+    // aoe-agent, codex, opencode.
+    let config = spawn_config_with_shim_env(shim_path(), vec![]);
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-neg".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let outcome = client.delete_session(acp_id).await;
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::Unsupported),
+        "expected Unsupported; got {outcome:?}"
+    );
+}
+
+#[tokio::test]
+async fn session_delete_timeout_does_not_hang() {
+    if let Err(reason) = shim_ready() {
+        eprintln!("skipping: {reason}");
+        return;
+    }
+    let config = spawn_config_with_shim_env(
+        shim_path(),
+        vec![
+            ("SHIM_DELETE_CAPABILITY".into(), "1".into()),
+            ("SHIM_DELETE_MODE".into(), "slow".into()),
+        ],
+    );
+
+    let mut client = AcpClient::spawn(config, CockpitSessionId("delete-slow".into()))
+        .await
+        .expect("spawn shim");
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(10);
+    let acp_id = drive_handshake_and_capture_session_id(&mut client, deadline)
+        .await
+        .expect("shim should assign an ACP session id during handshake");
+
+    let started = std::time::Instant::now();
+    let outcome = client.delete_session(acp_id).await;
+    let elapsed = started.elapsed();
+    let _ = client.shutdown().await;
+
+    assert!(
+        matches!(outcome, DeleteSessionOutcome::TimedOut),
+        "expected TimedOut; got {outcome:?}"
+    );
+    // ACP_SESSION_DELETE_TIMEOUT is 2s; the outer guard adds 500ms.
+    // The shim's slow path sleeps 3s, so the wait must surface as
+    // TimedOut well before the 3s mark. Cap at 3.4s to keep the
+    // assertion robust against scheduler slack.
+    assert!(
+        elapsed < Duration::from_millis(3400),
+        "delete_session should bound the wait; took {:?}",
+        elapsed
+    );
+}

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -30,6 +30,9 @@ mod worktree_integration;
 #[cfg(feature = "serve")]
 mod cockpit_acp_smoke;
 
+#[cfg(feature = "serve")]
+mod cockpit_session_delete;
+
 #[cfg(all(feature = "serve", debug_assertions))]
 mod cockpit_midturn_resume;
 


### PR DESCRIPTION
*AI disclosure: investigation and first-draft prose written by Claude (Opus 4.7). The framing, idea, the scope cut, and this disclosure line are mine (the human opening this).*

## Description

Before this change, deleting a cockpit session removed the worker
locally and SIGTERMed the runner, but the adapter never learned the
session was gone. For `claude-agent-acp` 0.37.0+ that means the
persisted Claude session record stayed on disk; a freshly-created
session id could inherit a deleted session's transcript. For
hypothetical adapters that pool resources (codex multi-session, future
Bedrock-shaped) it leaves cleanup aoe cannot observe.

This PR makes `Supervisor::shutdown` fire the experimental
`session/delete` ACP JSON-RPC opportunistically (bounded by a 2-second
timeout) before the existing kill path. The implementation is
blind-try: aoe does not inspect the initialize-time `sessionCapabilities.delete`
flag. The Rust ACP schema crate (`agent-client-protocol-schema 0.12`)
does not expose that field yet, so typed capability gating would
require swapping the typed `InitializeResponse` for a raw view across
every consumer; that is invasive for one experimental RPC. JSON-RPC
`-32601 method_not_found` is the equivalent runtime gate, classified
into `DeleteSessionOutcome::UnsupportedMethod` and logged at `debug`.
Other outcomes split as expected: `Deleted` at `debug`, `TimedOut`
and `Failed` at `warn`. Every log line carries `adapter=<agent_key>`
so operators can correlate behavior across `claude-agent-acp`,
`aoe-agent`, `codex`, `opencode`, and future adapters.

Hardening from in-house code review (consult + CodeRabbit) folded in:
the outer timeout guards the full `cmd_tx.send + rx.await` so a
saturated mpsc cannot stall the per-instance delete lock; the
adapter error message is scrubbed through `scrub_stderr_secrets` and
truncated to 256 UTF-8 bytes before formatting so adapter-controlled
strings cannot bloat or leak through `debug.log`; `_meta: {}` is
emitted on the request body to satisfy strict ACP validators;
`worker_registry::load` runs on the blocking pool so the delete path
does not park a Tokio worker on disk I/O; registry-load failures are
warned, not silently dropped at debug.

Tests cover the success path (capability advertised, adapter records
the call, outcome is `Deleted`), the steady-state aoe-agent / codex
/ opencode shape (capability absent, outcome is `UnsupportedMethod`),
and the bounded-timeout invariant (slow adapter, outcome is
`TimedOut` within ~2.5s wall clock). The test-shim's `@agentclientprotocol/sdk`
dependency is bumped from `^0.21.0` to `^0.22.0` because v0.21 does
not route `session/delete` to `unstable_deleteSession` and would
return -32601 regardless of handler installation. Existing cockpit
suite (15 tests) still passes against the bumped SDK.

Closes #1404

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [ ] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [x] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because: covered via three new integration tests under `tests/integration/cockpit_session_delete.rs` exercising the ACP round-trip end-to-end; a full e2e test would require driving the cockpit web UI which adds no signal over the integration coverage.

## How to test

- [ ] Build with `cargo build --features serve`; check that the binary still launches `aoe serve` without any new warnings.
- [ ] In `aoe serve`, create a cockpit session against `claude-agent-acp` 0.37.0+, send one prompt, then delete the session from the web dashboard. Watch `debug.log` for `target = "cockpit.acp"` lines including `adapter=claude` and `session/delete RPC succeeded`. Then look at `~/.claude/projects/` (or your Claude Agent SDK session store) and confirm the session file for the deleted session id is gone.
- [ ] Create a cockpit session against the bundled `aoe-agent`, send one prompt, then delete it. Confirm `debug.log` carries an `adapter=aoe-agent` line at `debug` level saying "adapter does not support session/delete; proceeding to SIGTERM" and that the existing kill path still tears down the worker and cleans the on-disk transcript.
- [ ] Confirm `cargo test --features serve --test integration cockpit_session_delete::` passes locally; the three test cases should be `Deleted`, `UnsupportedMethod`, and `TimedOut`.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude Code (Opus 4.7) via the `/aoe-implement` skill, with `/debate` consultation between `gemini-3.1-pro-preview` and `gpt-5.5` for the approach selection, and a follow-up review pass through CodeRabbit `--prompt-only`.

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. The debate flagged the blind-try-with-bounded-timeout shape, the deadlock risk in the connect-task pump, and the per-instance lock gap; CodeRabbit added the adapter-error scrubber requirement. I reviewed each commit, ran the manual test steps, and made the design calls (no config flag, no upstream patch dependency, no hard-coded skip list).

**NOTE:**
When responding to reviewer questions, please respond yourself rather than copy/pasting reviewer comments into an AI and pasting back its answer. We want to discuss with you, not your AI :)

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
High-level summary
- Adds a best-effort experimental session deletion step before terminating a live adapter: Supervisor now opportunistically calls an ACP session/delete RPC (bounded by a 2s outer timeout) during shutdown so adapters that implement it can release adapter-side session state instead of relying only on SIGTERM.
- Safe fallback and resilience: adapters that don't support the method continue to be terminated via the existing kill path; JSON-RPC MethodNotFound is treated as UnsupportedMethod and treated non‑fatally. Timeouts and other failures are logged but do not block shutdown.
- Tests, shim, docs and SDK bump: integration tests cover Deleted, UnsupportedMethod, and TimedOut scenarios via an updated test shim; the shim SDK dependency was bumped from ^0.21.0 to ^0.22.0; docs/cockpit.md documents the behavior.

Technical details
- New API: AcpClient::delete_session(acp_session_id: String) -> DeleteSessionOutcome { Deleted, UnsupportedMethod, TimedOut, Failed(String) }.
- Command/connection task changes: ClientCmd gains DeleteSession; connection task sends session/delete via a detached/blocking request, maps MethodNotFound to UnsupportedMethod, scrubs adapter stderr and truncates to 256 UTF-8 bytes for logs, and returns classification results. An outer timeout guards cmd_tx.send + rx.await to avoid mpsc saturation stalls.
- Supervisor integration: Supervisor::shutdown calls try_session_delete (which loads the stored ACP session id via spawn_blocking), logs outcomes with adapter=<agent_key> and elapsed time, then proceeds with existing handle.client.shutdown, runner SIGTERM, and registry teardown. Registry-load failures are warned rather than silently ignored.
- Test & shim: cockpit-worker/test-shim can advertise agentCapabilities.sessionCapabilities.delete via SHIM_DELETE_CAPABILITY and simulate success/slow/error via SHIM_DELETE_MODE; slow mode validates timeout handling; successful mode records deleted session ids to a file. Tests added in tests/integration/cockpit_session_delete.rs. The test binary conditionally includes the new tests under the serve feature.
- Docs: docs/cockpit.md adds a “Session deletion” section describing behavior, timeout, logging, and fallback.

Benefits
- Lets adapters proactively clean up persisted adapter-side session state (reducing stale or leaked state) instead of relying solely on process termination.
- Keeps shutdown bounded and non-blocking for API/UI flows by enforcing short timeouts and treating failures as non-fatal.
- Improves observability with classified outcomes and sanitized, size-bounded error logs for easier cross-adapter correlation.

Potential follow-ups
- Gate or negotiate calls on a stored sessionCapabilities.delete flag at call time (rather than a blind try) to avoid unnecessary RPCs.
- Surface capability and outcome information in UI/telemetry.
- Expand to other experimental session capabilities (out of scope for this PR).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->