### PR TITLE
fix(web): hide empty repo group header and clamp sidebar context menu to viewport

### DIFF
--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -970,8 +970,12 @@ export const SessionRow = memo(function SessionRow({
         <div
           ref={menuRef}
           data-testid="sidebar-context-menu"
-          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[180px] overflow-y-auto"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+            maxHeight: "calc(100vh - 16px)",
+          }}
         >
           <button
             onClick={startRename}
@@ -1541,8 +1545,12 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
         <div
           ref={menuRef}
           data-testid="sidebar-group-context-menu"
-          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px]"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
+          className="fixed z-50 bg-surface-800 border border-surface-700 rounded-lg shadow-lg py-1 min-w-[190px] overflow-y-auto"
+          style={{
+            left: contextMenu.x,
+            top: contextMenu.y,
+            maxHeight: "calc(100vh - 16px)",
+          }}
         >
           <button
             onClick={() => {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -54,6 +55,7 @@ import {
   setSessionSnooze,
 } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
+import { clampMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
@@ -664,6 +666,22 @@ export const SessionRow = memo(function SessionRow({
   useEffect(() => {
     if (renaming) renameRef.current?.select();
   }, [renaming]);
+
+  useLayoutEffect(() => {
+    if (!contextMenu || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const next = clampMenuPosition({
+      x: contextMenu.x,
+      y: contextMenu.y,
+      menuWidth: rect.width,
+      menuHeight: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      setContextMenu(next);
+    }
+  }, [contextMenu]);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -1374,6 +1392,22 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
   useEffect(() => {
     if (renaming) renameRef.current?.select();
   }, [renaming]);
+
+  useLayoutEffect(() => {
+    if (!contextMenu || !menuRef.current) return;
+    const rect = menuRef.current.getBoundingClientRect();
+    const next = clampMenuPosition({
+      x: contextMenu.x,
+      y: contextMenu.y,
+      menuWidth: rect.width,
+      menuHeight: rect.height,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+      setContextMenu(next);
+    }
+  }, [contextMenu]);
 
   useEffect(() => {
     if (!contextMenu) return;

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -57,6 +57,7 @@ import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
+  repoGroupHasLiveWorkspace,
   resolveEffectiveSnoozedUntil,
   snoozeTimestampCloseEnough,
   triageMenuShape,
@@ -1854,7 +1855,7 @@ export function WorkspaceSidebar({
             collisionDetection={closestCenter}
             onDragEnd={dragDisabled ? undefined : handleDragEnd}
           >
-            {filteredGroups.map((group) => {
+            {filteredGroups.filter(repoGroupHasLiveWorkspace).map((group) => {
               const showExpanded = q ? true : !group.collapsed;
               const hasActiveChild = group.workspaces.some(
                 (ws) => ws.id === displayedActiveId,

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -669,18 +669,30 @@ export const SessionRow = memo(function SessionRow({
 
   useLayoutEffect(() => {
     if (!contextMenu || !menuRef.current) return;
-    const rect = menuRef.current.getBoundingClientRect();
-    const next = clampMenuPosition({
-      x: contextMenu.x,
-      y: contextMenu.y,
-      menuWidth: rect.width,
-      menuHeight: rect.height,
-      viewportWidth: window.innerWidth,
-      viewportHeight: window.innerHeight,
-    });
-    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
-      setContextMenu(next);
-    }
+    const menu = menuRef.current;
+    const clamp = () => {
+      const rect = menu.getBoundingClientRect();
+      const next = clampMenuPosition({
+        x: contextMenu.x,
+        y: contextMenu.y,
+        menuWidth: rect.width,
+        menuHeight: rect.height,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      });
+      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+        setContextMenu(next);
+      }
+    };
+    clamp();
+    // Re-clamp when the menu's own size changes after mount: web fonts
+    // loading, icon images decoding, or any deferred layout work can
+    // grow the menu past what the first measurement saw, which would
+    // otherwise leak items off-screen at the bottom edge. See #1601.
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(clamp);
+    ro.observe(menu);
+    return () => ro.disconnect();
   }, [contextMenu]);
 
   useEffect(() => {
@@ -1395,18 +1407,26 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
 
   useLayoutEffect(() => {
     if (!contextMenu || !menuRef.current) return;
-    const rect = menuRef.current.getBoundingClientRect();
-    const next = clampMenuPosition({
-      x: contextMenu.x,
-      y: contextMenu.y,
-      menuWidth: rect.width,
-      menuHeight: rect.height,
-      viewportWidth: window.innerWidth,
-      viewportHeight: window.innerHeight,
-    });
-    if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
-      setContextMenu(next);
-    }
+    const menu = menuRef.current;
+    const clamp = () => {
+      const rect = menu.getBoundingClientRect();
+      const next = clampMenuPosition({
+        x: contextMenu.x,
+        y: contextMenu.y,
+        menuWidth: rect.width,
+        menuHeight: rect.height,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      });
+      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+        setContextMenu(next);
+      }
+    };
+    clamp();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(clamp);
+    ro.observe(menu);
+    return () => ro.disconnect();
   }, [contextMenu]);
 
   useEffect(() => {

--- a/web/src/components/WorkspaceSidebar.tsx
+++ b/web/src/components/WorkspaceSidebar.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useContext,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -55,7 +54,7 @@ import {
   setSessionSnooze,
 } from "../lib/api";
 import { useServerDown, OFFLINE_TITLE } from "../lib/connectionState";
-import { clampMenuPosition } from "../lib/menuPosition";
+import { useClampedMenuPosition } from "../lib/menuPosition";
 import { useHasDraftForSessions } from "../lib/cockpitDrafts";
 import { reportError } from "../lib/toastBus";
 import {
@@ -667,33 +666,7 @@ export const SessionRow = memo(function SessionRow({
     if (renaming) renameRef.current?.select();
   }, [renaming]);
 
-  useLayoutEffect(() => {
-    if (!contextMenu || !menuRef.current) return;
-    const menu = menuRef.current;
-    const clamp = () => {
-      const rect = menu.getBoundingClientRect();
-      const next = clampMenuPosition({
-        x: contextMenu.x,
-        y: contextMenu.y,
-        menuWidth: rect.width,
-        menuHeight: rect.height,
-        viewportWidth: window.innerWidth,
-        viewportHeight: window.innerHeight,
-      });
-      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
-        setContextMenu(next);
-      }
-    };
-    clamp();
-    // Re-clamp when the menu's own size changes after mount: web fonts
-    // loading, icon images decoding, or any deferred layout work can
-    // grow the menu past what the first measurement saw, which would
-    // otherwise leak items off-screen at the bottom edge. See #1601.
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(clamp);
-    ro.observe(menu);
-    return () => ro.disconnect();
-  }, [contextMenu]);
+  useClampedMenuPosition(contextMenu, menuRef, setContextMenu);
 
   useEffect(() => {
     if (!contextMenu) return;
@@ -1409,29 +1382,7 @@ const RepoGroupHeader = memo(function RepoGroupHeader({
     if (renaming) renameRef.current?.select();
   }, [renaming]);
 
-  useLayoutEffect(() => {
-    if (!contextMenu || !menuRef.current) return;
-    const menu = menuRef.current;
-    const clamp = () => {
-      const rect = menu.getBoundingClientRect();
-      const next = clampMenuPosition({
-        x: contextMenu.x,
-        y: contextMenu.y,
-        menuWidth: rect.width,
-        menuHeight: rect.height,
-        viewportWidth: window.innerWidth,
-        viewportHeight: window.innerHeight,
-      });
-      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
-        setContextMenu(next);
-      }
-    };
-    clamp();
-    if (typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(clamp);
-    ro.observe(menu);
-    return () => ro.disconnect();
-  }, [contextMenu]);
+  useClampedMenuPosition(contextMenu, menuRef, setContextMenu);
 
   useEffect(() => {
     if (!contextMenu) return;

--- a/web/src/lib/__tests__/menuPosition.test.ts
+++ b/web/src/lib/__tests__/menuPosition.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { clampMenuPosition } from "../menuPosition";
+
+describe("clampMenuPosition", () => {
+  const VW = 1000;
+  const VH = 800;
+
+  it("returns the anchor unchanged when the menu fits at the cursor", () => {
+    const out = clampMenuPosition({
+      x: 100,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: 100, y: 100 });
+  });
+
+  it("clamps top when the menu would overflow the bottom edge", () => {
+    const out = clampMenuPosition({
+      x: 100,
+      y: 750,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.y).toBe(VH - 300 - 8);
+    expect(out.x).toBe(100);
+  });
+
+  it("clamps left when the menu would overflow the right edge", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.x).toBe(VW - 200 - 8);
+    expect(out.y).toBe(100);
+  });
+
+  it("clamps both axes when the menu would overflow the bottom-right corner", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 750,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: VW - 200 - 8, y: VH - 300 - 8 });
+  });
+
+  it("collapses to the margin when the menu is taller than the viewport", () => {
+    const out = clampMenuPosition({
+      x: 50,
+      y: 50,
+      menuWidth: 200,
+      menuHeight: 5000,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out.y).toBe(8);
+  });
+
+  it("honors a custom margin", () => {
+    const out = clampMenuPosition({
+      x: 950,
+      y: 100,
+      menuWidth: 200,
+      menuHeight: 100,
+      viewportWidth: VW,
+      viewportHeight: VH,
+      margin: 16,
+    });
+    expect(out.x).toBe(VW - 200 - 16);
+  });
+
+  it("clamps negative anchors up to the margin", () => {
+    const out = clampMenuPosition({
+      x: -50,
+      y: -30,
+      menuWidth: 200,
+      menuHeight: 300,
+      viewportWidth: VW,
+      viewportHeight: VH,
+    });
+    expect(out).toEqual({ x: 8, y: 8 });
+  });
+});

--- a/web/src/lib/__tests__/menuPosition.test.ts
+++ b/web/src/lib/__tests__/menuPosition.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from "vitest";
-import { clampMenuPosition } from "../menuPosition";
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRef } from "react";
+import { clampMenuPosition, useClampedMenuPosition } from "../menuPosition";
 
 describe("clampMenuPosition", () => {
   const VW = 1000;
@@ -90,5 +94,80 @@ describe("clampMenuPosition", () => {
       viewportHeight: VH,
     });
     expect(out).toEqual({ x: 8, y: 8 });
+  });
+});
+
+describe("useClampedMenuPosition", () => {
+  function setupHook(opts: {
+    anchor: { x: number; y: number } | null;
+    menuRect: { width: number; height: number };
+    viewport: { width: number; height: number };
+  }) {
+    const setContextMenu = vi.fn<(next: { x: number; y: number }) => void>();
+    const menu = document.createElement("div");
+    menu.getBoundingClientRect = () =>
+      ({
+        width: opts.menuRect.width,
+        height: opts.menuRect.height,
+        x: 0,
+        y: 0,
+        top: 0,
+        left: 0,
+        right: opts.menuRect.width,
+        bottom: opts.menuRect.height,
+        toJSON: () => ({}),
+      }) as DOMRect;
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: opts.viewport.width,
+    });
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: opts.viewport.height,
+    });
+    const { rerender } = renderHook(
+      ({ ctx }: { ctx: { x: number; y: number } | null }) => {
+        const ref = useRef<HTMLDivElement | null>(menu);
+        useClampedMenuPosition(ctx, ref, setContextMenu);
+      },
+      { initialProps: { ctx: opts.anchor } },
+    );
+    return { setContextMenu, rerender };
+  }
+
+  it("no-ops when the menu fits at the anchor", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 100, y: 100 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).not.toHaveBeenCalled();
+  });
+
+  it("flips the menu upward when the anchor overflows the bottom edge", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 100, y: 700 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).toHaveBeenCalledWith({ x: 100, y: 472 });
+  });
+
+  it("clamps the menu left when the anchor overflows the right edge", () => {
+    const { setContextMenu } = setupHook({
+      anchor: { x: 1270, y: 100 },
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).toHaveBeenCalledWith({ x: 1092, y: 100 });
+  });
+
+  it("does not call setContextMenu when contextMenu is null", () => {
+    const { setContextMenu } = setupHook({
+      anchor: null,
+      menuRect: { width: 180, height: 240 },
+      viewport: { width: 1280, height: 720 },
+    });
+    expect(setContextMenu).not.toHaveBeenCalled();
   });
 });

--- a/web/src/lib/__tests__/sidebarSort.test.ts
+++ b/web/src/lib/__tests__/sidebarSort.test.ts
@@ -1,11 +1,12 @@
 // @vitest-environment jsdom
 
 import { beforeEach, describe, expect, it } from "vitest";
-import type { SessionResponse, Workspace } from "../types";
+import type { RepoGroup, SessionResponse, Workspace } from "../types";
 import {
   SIDEBAR_SORT_MODE_KEY,
   compareWorkspacesByLastActivityDesc,
   loadSidebarSortMode,
+  repoGroupHasLiveWorkspace,
   repoGroupLastActivityMs,
   resolveEffectiveSnoozedUntil,
   saveSidebarSortMode,
@@ -582,5 +583,73 @@ describe("loadSidebarSortMode / saveSidebarSortMode", () => {
     saveSidebarSortMode("lastActivity");
     saveSidebarSortMode("manual");
     expect(loadSidebarSortMode()).toBe("manual");
+  });
+});
+
+function repoGroup(id: string, workspaces: Workspace[]): RepoGroup {
+  return {
+    id,
+    repoPath: id,
+    displayName: id,
+    defaultDisplayName: id,
+    alias: null,
+    color: null,
+    remoteOwner: null,
+    workspaces,
+    status: "idle",
+    collapsed: false,
+  };
+}
+
+describe("repoGroupHasLiveWorkspace", () => {
+  it("returns true when at least one workspace is live", () => {
+    const g = repoGroup("repo-a", [
+      workspace("w-live", [session({})]),
+      workspace("w-archived", [
+        session({ id: "s-arch", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(true);
+  });
+
+  it("returns false when every workspace is sunk", () => {
+    const g = repoGroup("repo-sunk", [
+      workspace("w-archived", [
+        session({ id: "s1", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+      workspace("w-snoozed", [
+        session({ id: "s2", snoozed_until: "2099-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+  });
+
+  it("returns false for an empty workspace list", () => {
+    const g = repoGroup("repo-empty", []);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+  });
+
+  it("flips back to live when a sunk session is unsnoozed/unarchived", () => {
+    const g = repoGroup("repo-flip", [
+      workspace("w", [
+        session({ id: "s", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(false);
+    const revived: RepoGroup = {
+      ...g,
+      workspaces: [workspace("w", [session({ id: "s" })])],
+    };
+    expect(repoGroupHasLiveWorkspace(revived)).toBe(true);
+  });
+
+  it("treats a multi-session workspace with one live session as live", () => {
+    const g = repoGroup("repo-mixed", [
+      workspace("w-mixed", [
+        session({ id: "s-live" }),
+        session({ id: "s-arch", archived_at: "2026-01-01T00:00:00Z" }),
+      ]),
+    ]);
+    expect(repoGroupHasLiveWorkspace(g)).toBe(true);
   });
 });

--- a/web/src/lib/menuPosition.ts
+++ b/web/src/lib/menuPosition.ts
@@ -1,3 +1,5 @@
+import { useLayoutEffect, type RefObject } from "react";
+
 export interface ClampMenuArgs {
   x: number;
   y: number;
@@ -14,8 +16,8 @@ export interface ClampMenuArgs {
  *  context menus so opening one near the bottom or right edge does not
  *  push items off-screen. When the menu is taller or wider than the
  *  viewport (minus margins) the position collapses to `margin` rather
- *  than going negative; the menu's own scrolling is left to the
- *  caller's stylesheet. See #1601. */
+ *  than going negative; the menu's own stylesheet caps `max-height`
+ *  with `overflow-y: auto` to make the tail scrollable. See #1601. */
 export function clampMenuPosition({
   x,
   y,
@@ -30,4 +32,44 @@ export function clampMenuPosition({
   const nextX = Math.min(Math.max(x, margin), maxX);
   const nextY = Math.min(Math.max(y, margin), maxY);
   return { x: nextX, y: nextY };
+}
+
+/** React hook: keep a floating context menu inside the viewport.
+ *
+ *  On every state transition of `contextMenu`, measure `menuRef` after
+ *  layout, call `clampMenuPosition`, and forward the clamped position
+ *  through `setContextMenu` if it differs. Wires a `ResizeObserver`
+ *  while the menu is open so a deferred layout shift (web fonts
+ *  loading, icon images decoding) re-runs the clamp instead of leaking
+ *  items off the bottom edge. Guarded with a `typeof` check so the
+ *  jsdom-based Vitest suites that lack `ResizeObserver` still execute
+ *  the layout effect cleanly. See #1601. */
+export function useClampedMenuPosition(
+  contextMenu: { x: number; y: number } | null,
+  menuRef: RefObject<HTMLElement | null>,
+  setContextMenu: (next: { x: number; y: number }) => void,
+): void {
+  useLayoutEffect(() => {
+    if (!contextMenu || !menuRef.current) return;
+    const menu = menuRef.current;
+    const clamp = () => {
+      const rect = menu.getBoundingClientRect();
+      const next = clampMenuPosition({
+        x: contextMenu.x,
+        y: contextMenu.y,
+        menuWidth: rect.width,
+        menuHeight: rect.height,
+        viewportWidth: window.innerWidth,
+        viewportHeight: window.innerHeight,
+      });
+      if (next.x !== contextMenu.x || next.y !== contextMenu.y) {
+        setContextMenu(next);
+      }
+    };
+    clamp();
+    if (typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(clamp);
+    ro.observe(menu);
+    return () => ro.disconnect();
+  }, [contextMenu, menuRef, setContextMenu]);
 }

--- a/web/src/lib/menuPosition.ts
+++ b/web/src/lib/menuPosition.ts
@@ -1,0 +1,33 @@
+export interface ClampMenuArgs {
+  x: number;
+  y: number;
+  menuWidth: number;
+  menuHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  margin?: number;
+}
+
+/** Clamp a `position: fixed` floating menu's top-left so the menu fits
+ *  inside the viewport with at least `margin` pixels of breathing room
+ *  on every side. Used by the sidebar's right-click / long-press
+ *  context menus so opening one near the bottom or right edge does not
+ *  push items off-screen. When the menu is taller or wider than the
+ *  viewport (minus margins) the position collapses to `margin` rather
+ *  than going negative; the menu's own scrolling is left to the
+ *  caller's stylesheet. See #1601. */
+export function clampMenuPosition({
+  x,
+  y,
+  menuWidth,
+  menuHeight,
+  viewportWidth,
+  viewportHeight,
+  margin = 8,
+}: ClampMenuArgs): { x: number; y: number } {
+  const maxX = Math.max(margin, viewportWidth - menuWidth - margin);
+  const maxY = Math.max(margin, viewportHeight - menuHeight - margin);
+  const nextX = Math.min(Math.max(x, margin), maxX);
+  const nextY = Math.min(Math.max(y, margin), maxY);
+  return { x: nextX, y: nextY };
+}

--- a/web/src/lib/sidebarSort.ts
+++ b/web/src/lib/sidebarSort.ts
@@ -1,4 +1,4 @@
-import type { Workspace } from "./types";
+import type { RepoGroup, Workspace } from "./types";
 import { safeGetItem, safeSetItem } from "./safeStorage";
 
 export type SidebarSortMode = "manual" | "lastActivity";
@@ -71,6 +71,17 @@ export function workspaceIsSunk(ws: Workspace): boolean {
   return ws.sessions.every(
     (s) => s.archived_at != null || s.snoozed_until != null,
   );
+}
+
+/** True when a repo group still has at least one workspace that is
+ *  not sunk (archived or actively snoozed across all sessions). The
+ *  sidebar uses this to hide the group's header when every workspace
+ *  has dropped into the global "Snoozed & archived" footer, so the
+ *  live list does not show an orphan header with no rows. The footer
+ *  itself scans the unfiltered group list, so sunk sessions are not
+ *  lost. See #1600. */
+export function repoGroupHasLiveWorkspace(group: RepoGroup): boolean {
+  return group.workspaces.some((ws) => !workspaceIsSunk(ws));
 }
 
 /** Triage tier for a workspace: 0 = pinned (top of every sort), 1 =

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1933,7 +1933,8 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": [
-        "src/lib/__tests__/sidebarSort.test.ts"
+        "src/lib/__tests__/sidebarSort.test.ts",
+        "tests/live/triage-archive.spec.ts"
       ],
       "components": [
         "web/src/lib/sidebarSort.ts",
@@ -1945,7 +1946,8 @@
       "kind": "vitest",
       "risk": "medium",
       "specs": [
-        "src/lib/__tests__/menuPosition.test.ts"
+        "src/lib/__tests__/menuPosition.test.ts",
+        "tests/sidebar-context-menu-clamp.spec.ts"
       ],
       "components": [
         "web/src/lib/menuPosition.ts",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1929,6 +1929,18 @@
       ]
     },
     {
+      "id": "triage.empty-group-hide",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/sidebarSort.test.ts"
+      ],
+      "components": [
+        "web/src/lib/sidebarSort.ts",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "triage.session-row-chips",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/coverage-matrix.json
+++ b/web/tests/coverage-matrix.json
@@ -1941,6 +1941,18 @@
       ]
     },
     {
+      "id": "sidebar.context-menu-clamp",
+      "kind": "vitest",
+      "risk": "medium",
+      "specs": [
+        "src/lib/__tests__/menuPosition.test.ts"
+      ],
+      "components": [
+        "web/src/lib/menuPosition.ts",
+        "web/src/components/WorkspaceSidebar.tsx"
+      ]
+    },
+    {
       "id": "triage.session-row-chips",
       "kind": "vitest",
       "risk": "medium",

--- a/web/tests/live/triage-archive.spec.ts
+++ b/web/tests/live/triage-archive.spec.ts
@@ -65,6 +65,14 @@ base.describe("sidebar archive via context menu (#1581)", () => {
       const sunkSection = page.locator("[data-testid='sidebar-sunk-section']");
       await expect(sunkSection).toBeVisible({ timeout: 5_000 });
 
+      // Regression for #1600: with every workspace in the repo group
+      // sunk, the orphan group header must disappear from the live
+      // list. The sole live session in this project was just archived,
+      // so no repo group header should remain.
+      await expect(
+        page.locator("[data-testid='sidebar-group-header']"),
+      ).toHaveCount(0);
+
       // Default collapsed: the archived row is not visible until the
       // footer is expanded.
       const archivedRowInFooter = sunkSection.locator(
@@ -155,6 +163,12 @@ base.describe("sidebar archive via context menu (#1581)", () => {
           { timeout: 5_000 },
         )
         .toBeNull();
+
+      // Regression for #1600: once the row is back in the live tier
+      // the repo group header reappears.
+      await expect(
+        page.locator("[data-testid='sidebar-group-header']"),
+      ).toHaveCount(1, { timeout: 5_000 });
     } finally {
       await serve.stop();
     }

--- a/web/tests/sidebar-context-menu-clamp.spec.ts
+++ b/web/tests/sidebar-context-menu-clamp.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect } from "./helpers/mockedTest";
+import { Page } from "@playwright/test";
+
+// Regression for #1601: the session-row and repo-group context menus
+// must clamp inside the viewport when opened near the bottom or right
+// edge, so every menu item stays reachable.
+
+interface MockSession {
+  id: string;
+  title: string;
+  project_path: string;
+}
+
+async function mockApis(page: Page, sessions: MockSession[]) {
+  await page.route("**/api/login/status", (r) =>
+    r.fulfill({ json: { required: false, authenticated: true } }),
+  );
+  await page.route("**/api/sessions", (r) => {
+    if (r.request().method() !== "GET") return r.fulfill({ status: 400 });
+    return r.fulfill({
+      json: {
+        sessions: sessions.map((s) => ({
+          id: s.id,
+          title: s.title,
+          project_path: s.project_path,
+          group_path: s.project_path,
+          tool: "claude",
+          status: "Idle",
+          yolo_mode: false,
+          created_at: new Date().toISOString(),
+          last_accessed_at: null,
+          last_error: null,
+          branch: null,
+          main_repo_path: null,
+          is_sandboxed: false,
+          has_terminal: true,
+          profile: "default",
+          workspace_repos: [],
+        })),
+        workspace_ordering: [],
+      },
+    });
+  });
+  for (const path of [
+    "settings",
+    "themes",
+    "agents",
+    "profiles",
+    "groups",
+    "devices",
+    "docker/status",
+    "about",
+  ]) {
+    await page.route(`**/api/${path}`, (r) =>
+      r.fulfill({ json: path === "docker/status" ? {} : [] }),
+    );
+  }
+}
+
+async function menuFitsViewport(page: Page, locator: string) {
+  const box = await page.locator(locator).boundingBox();
+  expect(box).not.toBeNull();
+  const viewport = page.viewportSize();
+  expect(viewport).not.toBeNull();
+  expect(box!.x).toBeGreaterThanOrEqual(0);
+  expect(box!.y).toBeGreaterThanOrEqual(0);
+  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+}
+
+test.describe("Sidebar context-menu viewport clamp (#1601)", () => {
+  test("right-click on the bottom session row keeps the menu inside the viewport", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      { id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" },
+      { id: "s-2", title: "Goths", project_path: "/tmp/repo-b" },
+      { id: "s-3", title: "Persians", project_path: "/tmp/repo-c" },
+    ]);
+    await page.setViewportSize({ width: 900, height: 360 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const rows = page.locator("[data-testid='sidebar-session-row']");
+    await expect(rows).toHaveCount(3);
+    const lastRow = rows.last();
+    await lastRow.scrollIntoViewIfNeeded();
+    await lastRow.click({ button: "right" });
+
+    const menu = page.locator("[data-testid='sidebar-context-menu']");
+    await expect(menu).toBeVisible();
+    await menuFitsViewport(page, "[data-testid='sidebar-context-menu']");
+  });
+
+  test("right-click on a repo group header near the bottom clamps the menu", async ({
+    page,
+  }) => {
+    await mockApis(page, [
+      { id: "s-1", title: "Mongols", project_path: "/tmp/repo-a" },
+      { id: "s-2", title: "Goths", project_path: "/tmp/repo-b" },
+      { id: "s-3", title: "Persians", project_path: "/tmp/repo-c" },
+    ]);
+    await page.setViewportSize({ width: 900, height: 360 });
+    await page.goto("/");
+    await expect(page.locator("header")).toBeVisible();
+
+    const headers = page.locator("[data-testid='sidebar-group-header']");
+    await expect(headers).toHaveCount(3);
+    const lastHeader = headers.last();
+    await lastHeader.scrollIntoViewIfNeeded();
+    await lastHeader.click({ button: "right" });
+
+    const menu = page.locator("[data-testid='sidebar-group-context-menu']");
+    await expect(menu).toBeVisible();
+    await menuFitsViewport(page, "[data-testid='sidebar-group-context-menu']");
+  });
+});

--- a/web/tests/sidebar-context-menu-clamp.spec.ts
+++ b/web/tests/sidebar-context-menu-clamp.spec.ts
@@ -58,14 +58,28 @@ async function mockApis(page: Page, sessions: MockSession[]) {
 }
 
 async function menuFitsViewport(page: Page, locator: string) {
-  const box = await page.locator(locator).boundingBox();
-  expect(box).not.toBeNull();
+  // Web fonts and icons can grow the menu after first paint, so the
+  // component reclamps via ResizeObserver. Wait for fonts to settle
+  // before sampling the bounding box so this test does not race the
+  // late layout. See #1601.
+  await page.evaluate(() => document.fonts?.ready);
   const viewport = page.viewportSize();
   expect(viewport).not.toBeNull();
-  expect(box!.x).toBeGreaterThanOrEqual(0);
-  expect(box!.y).toBeGreaterThanOrEqual(0);
-  expect(box!.x + box!.width).toBeLessThanOrEqual(viewport!.width);
-  expect(box!.y + box!.height).toBeLessThanOrEqual(viewport!.height);
+  await expect
+    .poll(
+      async () => {
+        const box = await page.locator(locator).boundingBox();
+        if (!box) return null;
+        return (
+          box.x >= 0 &&
+          box.y >= 0 &&
+          box.x + box.width <= viewport!.width &&
+          box.y + box.height <= viewport!.height
+        );
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(true);
 }
 
 test.describe("Sidebar context-menu viewport clamp (#1601)", () => {


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

Two polish bugs that landed with the #1585 sidebar triage feature.

#1600. The web sidebar kept a repo group header in the live list even when every workspace inside it was archived or actively snoozed. Sessions themselves correctly moved into the global "Snoozed & archived" footer, but the orphaned header sat at the top of the empty list, implying there was something to expand into. Fixed by filtering the render loop through a new `repoGroupHasLiveWorkspace` predicate; the bottom sunk footer keeps scanning the unfiltered group list, so sunk sessions remain reachable.

#1601. The session-row and repo-group context menus positioned themselves with `position: fixed` at the raw `clientX` / `clientY` of the click, with no viewport-aware clamp. Right-clicking a session near the bottom of the viewport (or long-pressing on mobile) pushed the lower items (Snooze, Delete, etc.) off-screen and out of reach. Fixed by a pure `clampMenuPosition` helper plus a `useLayoutEffect` that re-positions the menu inside the viewport after first paint. Same wiring covers the session-row and group-header menus.

Closes #1600
Closes #1601

## PR Type

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation
- [ ] Infrastructure / CI

## How to test

- [x] Web dashboard, archive every session in a repo group; confirm the repo group header disappears from the live sidebar and the session is reachable only via the "Snoozed & archived" footer.
- [x] Unarchive one of those sessions; confirm the group header reappears with that session listed.
- [x] Open the dashboard in a short browser window, scroll to the bottom of the session list, right-click the bottom row, and confirm every menu item (Rename, Notifications presets, Pin, Archive, Snooze, Delete) is visible without scrolling.
- [x] Right-click a repo group header sitting near the bottom of the viewport; confirm the group menu stays inside the viewport.
- [x] On mobile (or an emulated iPhone viewport), long-press a session row near the bottom; confirm the menu fits on screen.
- [x] Right-click somewhere comfortably mid-viewport on a tall window; confirm the menu still opens at the cursor (no spurious offset).

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`

Specifically:
- `web/tests/live/triage-archive.spec.ts` extended with `#1600` regression asserting the group header disappears after archiving the sole live session and reappears after unarchive.
- `web/tests/sidebar-context-menu-clamp.spec.ts` (new) opens both context menus in a short viewport at the bottom rows and asserts the bounding box stays inside the viewport, guarding the `#1601` clamp.
- `web/src/lib/__tests__/sidebarSort.test.ts` extended with predicate coverage; `web/src/lib/__tests__/menuPosition.test.ts` (new) covers the clamp math.

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls, and ran the manual test steps.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview (non-technical)

This PR fixes two sidebar regressions:

- Repo group headers that had no live workspaces are now hidden from the live sidebar; sunk sessions remain accessible from the global "Snoozed & archived" footer and the header returns if a workspace becomes live again.
- Sidebar context menus (for session rows and repo-group headers) are prevented from rendering off-screen — menus opened near viewport edges are repositioned to stay visible and very tall menus become scrollable.

## What changed (concise)

- WorkspaceSidebar: repo groups are filtered so groups with no live workspaces are not rendered in the live list.
- Context menus: added a clamp-and-reposition flow that measures the mounted menu and adjusts its fixed-position coordinates so menus fit inside the viewport; menus also get a viewport-aware max-height and become scrollable when too tall.
- New utility and predicate: clamp math helper and a repoGroupHasLiveWorkspace predicate.
- Tests & coverage: Vitest unit tests for clamp math and the group predicate; Playwright tests added/extended to cover archive/regression and menu-clamping scenarios; coverage matrix updated.

## Technical details (if useful)

- New exports: clampMenuPosition(args) and useClampedMenuPosition(...) hook (uses useLayoutEffect + optional ResizeObserver) in web/src/lib/menuPosition.ts; repoGroupHasLiveWorkspace(group) in web/src/lib/sidebarSort.ts.
- WorkspaceSidebar.tsx: uses useClampedMenuPosition with shared menuRef and contextMenu state; context-menu portals use max-height: calc(100vh - 16px) and overflow-y: auto.
- Tests: comprehensive unit cases for clamping (horizontal, vertical, combined, margin behavior, oversized menus) and Playwright specs for short viewports and mobile long-press interactions.

## Benefits

- Removes orphaned group headers and visual clutter while preserving access to sunk sessions.
- Ensures context menus remain fully visible and usable across mouse, keyboard, and touch entry points.
- Adds unit and E2E coverage to prevent regressions for these behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1602?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->