### PR TITLE
feat(cockpit): bump claude-agent-acp floor to 0.38.0 for Opus 4.8 support

### DIFF
--- a/cockpit-worker/test-shim/shim.mjs
+++ b/cockpit-worker/test-shim/shim.mjs
@@ -44,7 +44,7 @@ class ShimAgent {
       },
       agentInfo: {
         name: "@agentclientprotocol/claude-agent-acp",
-        version: "0.37.0",
+        version: "0.38.0",
       },
     };
   }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -79,7 +79,7 @@ RUN npm install -g @qwen-code/qwen-code
 # `gemini --acp`, `vibe-acp`) are already provided by their respective
 # CLIs above.
 RUN npm install -g \
-    @agentclientprotocol/claude-agent-acp@^0.37.0 \
+    @agentclientprotocol/claude-agent-acp@^0.38.0 \
     @zed-industries/codex-acp \
     pi-acp
 

--- a/docs/cockpit.md
+++ b/docs/cockpit.md
@@ -33,7 +33,7 @@ The wizard greys out the cockpit option for tools not in this set.
 
 | aoe tool   | Substrate B (cockpit)                                      | Auth                                   |
 |------------|------------------------------------------------------------|----------------------------------------|
-| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK, requires >=0.37.0) | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
+| `claude`   | `claude-agent-acp` (Zed adapter for the Claude SDK, requires >=0.38.0) | `claude /login` writes `~/.claude/credentials`; or `ANTHROPIC_API_KEY` |
 | `opencode` | `opencode acp` (native, SST)                               | `OPENCODE_API_KEY` env var; or provider-specific env (set up via `opencode auth`) |
 | `gemini`   | `gemini --acp` (native, Google)                            | `GEMINI_API_KEY` env var, OAuth via `gemini auth`, or Vertex `GOOGLE_API_KEY` |
 | `codex`    | `codex-acp` (Zed adapter, npm `@zed-industries/codex-acp`) | `OPENAI_API_KEY` env var, or ChatGPT login (local-only) |
@@ -531,7 +531,8 @@ Cockpit sessions render two extra selectors in the composer footer
 beside the mode pill when the ACP adapter advertises them: a model
 dropdown and a reasoning-effort selector. Both come from one wire
 mechanism, ACP `SessionUpdate::ConfigOptionUpdate`, stabilised
-upstream in `claude-agent-acp` v0.37.0. The adapter emits the full
+upstream in `claude-agent-acp` v0.37.0 (Opus 4.8 added in v0.38.0).
+The adapter emits the full
 snapshot of every selector (mode, model, reasoning effort, future
 categories) whenever any one of them changes; the cockpit replaces
 its cached list in full.
@@ -539,7 +540,7 @@ its cached list in full.
 ### When the pickers appear
 
 The pickers only render if the adapter publishes the matching
-category. `claude-agent-acp` v0.37.0+ advertises a model selector
+category. `claude-agent-acp` v0.38.0+ advertises a model selector
 for every session, and adds a reasoning-effort selector when the
 current model reports `supportsEffort=true`. Older adapters that
 emit no `config_option_update` show neither picker; this is by

--- a/docs/cockpit/multi-agent.md
+++ b/docs/cockpit/multi-agent.md
@@ -9,7 +9,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter, requires >=0.37.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.38.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |

--- a/docs/guides/sandbox.md
+++ b/docs/guides/sandbox.md
@@ -132,7 +132,7 @@ Example: `aoe-sandbox-a1b2c3d4`
 
 Cockpit-mode sessions can run inside the sandbox container. When both are enabled, the cockpit runner wraps the ACP agent in `docker exec`, so the adapter binary must exist inside the container. The published `aoe-sandbox` image bundles the npm-distributed ACP adapters for this:
 
-- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.37.0`, floor pin)
+- `claude-agent-acp` (`@agentclientprotocol/claude-agent-acp@^0.38.0`, floor pin)
 - `codex-acp` (`@zed-industries/codex-acp`)
 - `pi-acp`
 

--- a/src/cockpit/agent_compat.rs
+++ b/src/cockpit/agent_compat.rs
@@ -7,9 +7,10 @@
 //! single hook to call after `initialize` succeeds, instead of scattering
 //! ad-hoc semver checks at every spawn site.
 //!
-//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.37.0,
+//! Today only `ClaudeAgentAcp` carries a minimum version (>=0.38.0,
 //! required for `memory_recall` tool-call emission, native `cancelled`
-//! stop reason, and several other behaviors aoe builds on). Other agents
+//! stop reason, Opus 4.8 model availability, and several other behaviors
+//! aoe builds on). Other agents
 //! get a permissive policy (protocol check only). Long-term aoe should
 //! prefer ACP capability flags over package-version gating; until upstream
 //! exposes those, package versions are the only precise contract.
@@ -47,7 +48,7 @@ impl ExpectedAgent {
     /// separators, and the `.exe` / `.cmd` suffixes Windows shims add.
     /// Without this normalization a wrapped or Windows-installed
     /// `claude-agent-acp` would land in `Other` and silently bypass the
-    /// >=0.37.0 gate.
+    /// >=0.38.0 gate.
     pub fn from_command(command: &str) -> Self {
         // Scan every whitespace-separated token. The actual binary can
         // be the first token (`/usr/local/bin/claude-agent-acp`) but
@@ -55,7 +56,7 @@ impl ExpectedAgent {
         // (`bash claude-agent-acp`, `env -u FOO claude-agent-acp`,
         // `npx claude-agent-acp`, etc.). Match against the first token
         // that classifies as a known adapter so wrappers don't bypass
-        // the >=0.37.0 gate.
+        // the >=0.38.0 gate.
         command
             .split_whitespace()
             .find_map(|token| {
@@ -98,7 +99,7 @@ impl ExpectedAgent {
         match self {
             Self::ClaudeAgentAcp => CompatibilityPolicy {
                 expected_name: Some("@agentclientprotocol/claude-agent-acp"),
-                min_version: Some(semver::Version::new(0, 37, 0)),
+                min_version: Some(semver::Version::new(0, 38, 0)),
                 required_protocol: ProtocolVersion::V1,
                 fail_on_missing_agent_info: true,
             },
@@ -186,7 +187,7 @@ impl StartupError {
                 expected_package,
                 install_command,
             } => format!(
-                "Adapter did not report its package version. aoe requires {expected_package} >=0.37.0. Run: {install_command}",
+                "Adapter did not report its package version. aoe requires {expected_package} >=0.38.0. Run: {install_command}",
             ),
             Self::MismatchedAgentName {
                 expected,
@@ -384,12 +385,12 @@ mod tests {
             panic!()
         };
         assert_eq!(installed, "0.32.0");
-        assert_eq!(required, "0.37.0");
+        assert_eq!(required, "0.38.0");
     }
 
     #[test]
     fn claude_at_minimum_accepted() {
-        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.37.0");
+        let init = make_init("@agentclientprotocol/claude-agent-acp", "0.38.0");
         validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap();
     }
 
@@ -422,7 +423,7 @@ mod tests {
 
     #[test]
     fn claude_mismatched_name_rejected() {
-        let init = make_init("some-other-package", "0.37.0");
+        let init = make_init("some-other-package", "0.38.0");
         let err = validate(ExpectedAgent::ClaudeAgentAcp, &init).unwrap_err();
         assert_eq!(err.kind(), "mismatched_agent_name");
     }
@@ -505,7 +506,7 @@ mod tests {
         );
         // `npx`-style npm-package-spec invocations are out of scope:
         // npx itself resolves the package and the spawned binary's
-        // argv[0] is `claude-agent-acp`, not `claude-agent-acp@0.37.0`.
+        // argv[0] is `claude-agent-acp`, not `claude-agent-acp@0.38.0`.
         // The version-suffixed form would only show up if a user wired
         // it manually into AgentSpec.command, which is not a supported
         // configuration today.

--- a/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
+++ b/web/src/components/cockpit/__tests__/StartupErrorScreen.test.tsx
@@ -22,14 +22,14 @@ describe("StartupErrorScreen", () => {
           kind: "incompatible_agent_version",
           package_name: "@agentclientprotocol/claude-agent-acp",
           installed: "0.32.0",
-          required: "0.37.0",
+          required: "0.38.0",
           install_command:
             "npm install -g @agentclientprotocol/claude-agent-acp@latest",
         }}
       />,
     );
     expect(container.textContent).toContain("0.32.0");
-    expect(container.textContent).toContain("0.37.0");
+    expect(container.textContent).toContain("0.38.0");
     expect(container.textContent).toContain(
       "@agentclientprotocol/claude-agent-acp",
     );
@@ -81,14 +81,14 @@ describe("StartupErrorScreen", () => {
           kind: "unparseable_agent_version",
           package_name: "@agentclientprotocol/claude-agent-acp",
           raw_version: "not-semver",
-          required: "0.37.0",
+          required: "0.38.0",
           install_command:
             "npm install -g @agentclientprotocol/claude-agent-acp@latest",
         }}
       />,
     );
     expect(container.textContent).toContain("not-semver");
-    expect(container.textContent).toContain("0.37.0");
+    expect(container.textContent).toContain("0.38.0");
   });
 
   it("renders unsupported_protocol_version without an install command", () => {

--- a/web/src/lib/cockpitTypes.test.ts
+++ b/web/src/lib/cockpitTypes.test.ts
@@ -1862,7 +1862,7 @@ describe("CockpitState reducer / silent-orphan watchdog (#1240)", () => {
   });
 });
 
-describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
+describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.38.0)", () => {
   it("sets state.incompatibleAgent from the structured detail", () => {
     const next = applyEvent(emptyCockpitState(), {
       session_id: "s-1",
@@ -1873,7 +1873,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
             kind: "incompatible_agent_version",
             package_name: "@agentclientprotocol/claude-agent-acp",
             installed: "0.32.0",
-            required: "0.37.0",
+            required: "0.38.0",
             install_command:
               "npm install -g @agentclientprotocol/claude-agent-acp@latest",
           },
@@ -1884,7 +1884,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
     expect(next.incompatibleAgent?.kind).toBe("incompatible_agent_version");
     if (next.incompatibleAgent?.kind === "incompatible_agent_version") {
       expect(next.incompatibleAgent.installed).toBe("0.32.0");
-      expect(next.incompatibleAgent.required).toBe("0.37.0");
+      expect(next.incompatibleAgent.required).toBe("0.38.0");
     }
   });
 
@@ -1898,7 +1898,7 @@ describe("applyEvent / IncompatibleAgent (claude-agent-acp v0.37.0)", () => {
             kind: "incompatible_agent_version",
             package_name: "@agentclientprotocol/claude-agent-acp",
             installed: "0.32.0",
-            required: "0.37.0",
+            required: "0.38.0",
             install_command:
               "npm install -g @agentclientprotocol/claude-agent-acp@latest",
           },

--- a/web/tests/helpers/fakeAcpAgent.mjs
+++ b/web/tests/helpers/fakeAcpAgent.mjs
@@ -302,7 +302,7 @@ const INITIALIZE_RESULT = {
   },
   agentInfo: {
     name: "@agentclientprotocol/claude-agent-acp",
-    version: "0.37.0",
+    version: "0.38.0",
   },
   // No authMethods key at all. An empty array is interpreted by some
   // ACP client implementations as "auth methods listed but none

--- a/website/src/pages/docs/cockpit/multi-agent.md
+++ b/website/src/pages/docs/cockpit/multi-agent.md
@@ -13,7 +13,7 @@ are first-class but lighter on per-tool polish.
 
 | Agent | ACP entry | Install |
 |-------|-----------|---------|
-| Claude | `claude-agent-acp` (Zed adapter, requires >=0.37.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
+| Claude | `claude-agent-acp` (Zed adapter, requires >=0.38.0) | `npm install -g @agentclientprotocol/claude-agent-acp@latest` |
 | Codex (OpenAI) | `codex-acp` (Zed adapter) | `npm install -g @zed-industries/codex-acp` |
 | OpenCode (SST) | `opencode acp` (native) | `curl -fsSL https://opencode.ai/install \| bash` |
 | Gemini (Google) | `gemini --acp` (native) | `npm install -g @google/gemini-cli` |


### PR DESCRIPTION
**Note:** Claude handled the implementation and prose via back-and-forth. Idea, decisions, and everything else are mine. — @Seluj78

## Description

`claude-agent-acp` v0.38.0 dropped today, upgrading `@anthropic-ai/claude-agent-sdk` to `0.3.154` and adding native support for the new Opus 4.8 model. The adapter advertises Opus 4.8 in its dynamic `ConfigOptionUpdate` model selector once the install is at the new floor; aoe itself does not hardcode model lists, so the only thing aoe needs to do is gate its floor and refresh the documented baseline.

This PR bumps the version gate in `src/cockpit/agent_compat.rs` from `0.37.0` to `0.38.0`, mirroring the prior pattern from #1402 when 0.37.0 was first required. Users still on 0.37.0 will now see the structured `IncompatibleAgentVersion` startup error with a one-line `npm install -g @agentclientprotocol/claude-agent-acp@latest` upgrade nudge. The Docker sandbox image, sandbox guide, cockpit overview, and multi-agent table all advance to the same baseline so the documented floor matches the gate.

The v0.38.0 release notes also call out "removed handling of the hide Claude auth flag feature"; a quick grep across aoe shows no references to that flag, so no aoe cleanup is required there.

Closes: not tied to an existing issue. Filed as a proactive bump per "stay on top of upstream ACP releases".

## PR Type

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor
- [x] Documentation
- [ ] Infrastructure / CI

## Checklist

- [x] New and existing tests pass
- [x] Documentation was updated where necessary
- [ ] For UI changes: included screenshot or recording

## Test Coverage Analysis

**Web dashboard / cockpit (Playwright user story)**
- [x] N/A: this PR doesn't change a user-facing dashboard flow
- [ ] Added or updated a Playwright spec under `web/tests/` and updated `web/tests/coverage-matrix.json`
- [ ] Skipped a test, because:

**TUI / CLI (e2e test)**
- [x] N/A: this PR doesn't change TUI rendering, a CLI subcommand, or session lifecycle
- [ ] Added or updated an e2e test under `tests/e2e/`
- [ ] Skipped a test, because:

The existing unit tests in `src/cockpit/agent_compat.rs` were updated in lockstep with the floor bump: `claude_at_minimum_accepted` now exercises `0.38.0`, `claude_below_minimum_rejected` asserts `required == "0.38.0"`, and `claude_above_minimum_accepted` continues to cover `0.38.1`. No new behavioral test is needed because the gate's behavior is unchanged; only the floor value moved.

## How to test

- [ ] Install `@agentclientprotocol/claude-agent-acp@0.37.0` (the previous floor) and try to start a cockpit session against the `claude` agent. Expect the `IncompatibleAgentVersion` startup error with `required: 0.38.0` and the `npm install -g @agentclientprotocol/claude-agent-acp@latest` install hint.
- [ ] Upgrade to `@agentclientprotocol/claude-agent-acp@0.38.0` (or later) and start a cockpit session against the `claude` agent. Expect the startup error to clear and the session to enter the normal cockpit view.
- [ ] In the composer footer model selector, confirm Opus 4.8 now appears in the dropdown (advertised by the v0.38.0 adapter).
- [ ] Build the sandbox image (`docker build -f docker/Dockerfile .`) and confirm it installs `@agentclientprotocol/claude-agent-acp@^0.38.0`.
- [ ] Spot-check `docs/cockpit.md`, `docs/cockpit/multi-agent.md`, and `docs/guides/sandbox.md` all reference the `0.38.0` floor.

## AI Usage

- [ ] No AI was used
- [x] AI was used

**AI Model/Tool used:** Claude (via Claude Code, agent-of-empires `/aoe-implement` skill)

**Any Additional AI Details you'd like to share:**
Investigation, plan, and implementation drafted by Claude under my direction. I reviewed each commit, made the design calls (bump the floor to 0.38.0 rather than just bumping the docs recommendation), and ran the validation sweep.

- [x] I am an AI Agent filling out this form (check box if true)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Overview

This PR raises the Cockpit compatibility floor for the Claude ACP adapter from 0.37.0 to 0.38.0 so the app requires claude-agent-acp >= 0.38.0 (which brings `@anthropic-ai/claude-agent-sdk` v0.3.154 and native Opus 4.8 support). The change is a coordinated version bump across runtime checks, tests, sandbox image, and documentation—no behavioral or API breaking changes.

## What changed (high-level)

- Docker sandbox now installs `@agentclientprotocol/claude-agent-acp`@^0.38.0.
- Runtime: src/cockpit/agent_compat.rs enforces minimum agent version 0.38.0 and updates the startup error message.
- Tests and fakes: unit tests, reducer tests, Playwright/frontend fixtures, and fake agent shims updated to report 0.38.0 so CI and local tests pass the new gate.
- Docs: updated references to require >=0.38.0 across cockpit docs, multi-agent docs, sandbox guide, and website docs.
- Notes: no additional aoe code cleanup was required for removal of the "hide Claude auth flag" behavior in v0.38.0.

## Key benefits

- Enables Opus 4.8 model support in the UI once the adapter meets the minimum version.
- Ensures a consistent, enforced version contract across runtime, tests, and docs to avoid compatibility surprises.
- Improves user guidance with an updated startup error message and aligned documentation.

## Technical details (concise)

- Files touched: Dockerfile, src/cockpit/agent_compat.rs (+tests), multiple documentation files, fake agent/test fixtures, frontend reducer/test updates.
- Change type: version requirement bump, test/fake updates, documentation sync. No public API changes.
- Verification: tests updated to assert rejection below 0.38.0 and acceptance at 0.38.0; instructions include verifying startup gating, Opus 4.8 visible in composer model selector, and sandbox builds installing the updated adapter.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/agent-of-empires/agent-of-empires/pull/1603?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->